### PR TITLE
Verificacao de email, deploy de producao e testes do backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .env
+.env.*
+!.env.*.example
 # Logs
 logs
 *.log

--- a/backend/.env.prod.example
+++ b/backend/.env.prod.example
@@ -1,0 +1,22 @@
+# Template do ambiente de PRODUÇÃO.
+# Copie para .env.prod no servidor e preencha com valores reais.
+# NÃO comite o .env.prod (ele é ignorado pelo git).
+
+# Ambiente
+NODE_ENV=production
+PORT=3001
+
+# URL do frontend (usada no CORS e no link de verificação de email)
+FRONTEND_URL=https://ensinadev.com.br
+
+# Segredo do JWT — gere com: openssl rand -base64 32
+JWT_SECRET=TROQUE_POR_UM_SEGREDO_FORTE_DE_32+_CARACTERES
+
+# Postgres (usado pelo container do banco)
+POSTGRES_USER=ensinadev
+POSTGRES_PASSWORD=TROQUE_POR_UMA_SENHA_FORTE
+POSTGRES_DB=estudos
+
+# Conexão do backend ao banco — host "db" é o nome do serviço no compose.
+# Usuário/senha/base devem bater com os POSTGRES_* acima.
+DATABASE_URL=postgres://ensinadev:TROQUE_POR_UMA_SENHA_FORTE@db:5432/estudos

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,16 @@
+# Imagem de produção do backend (Node 22, sem watch)
+FROM node:22-alpine
+
+WORKDIR /app
+
+# Instala as dependências (inclui drizzle-kit, usado para migrations em prod)
+COPY package*.json ./
+RUN npm ci
+
+# Copia o restante do código
+COPY . .
+
+EXPOSE 3001
+
+# Sobe o servidor lendo as variáveis do ambiente do container (não do .env)
+CMD ["node", "index.ts"]

--- a/backend/app.ts
+++ b/backend/app.ts
@@ -1,0 +1,37 @@
+import { env } from "./src/config/env.ts";
+import express from "express";
+import type { Request, Response } from "express";
+import { db } from "./db.ts";
+import cookieParser from "cookie-parser";
+import { sql } from "drizzle-orm";
+import authRoutes from "./src/routes/auth.routes.ts";
+import userRoutes from "./src/routes/user.routes.ts";
+import { errorMiddleware } from "./src/middlewares/error.ts";
+import helmet from "helmet";
+import cors from "cors";
+
+export const app = express();
+
+app.set("trust proxy", 1);
+
+app.use(cookieParser());
+app.use(express.json());
+app.use(helmet());
+app.use(cors({
+    origin: env.NODE_ENV === "production"
+    ? env.FRONTEND_URL
+    : true,
+    credentials: true,
+}));
+
+app.use(authRoutes);
+app.use(userRoutes);
+
+app.get("/health", (_req, res) => res.json({ status: "ok" }));
+
+app.get("/db-test", async (_req: Request, res: Response) => {
+    const result = await db.execute(sql`SELECT 1 + 1 AS result`);
+    res.json({ result: result.rows[0] });
+});
+
+app.use(errorMiddleware);

--- a/backend/db.ts
+++ b/backend/db.ts
@@ -3,8 +3,10 @@ import pg from "pg";
 import { env } from "./src/config/env.ts";
 
 const pool = new pg.Pool({
-    connectionString: process.env.DATABASE_URL,
-    ssl: env.NODE_ENV === "production" ? { rejectUnauthorized: false } : false,
+    connectionString: env.DATABASE_URL,
+    // SSL controlado por variável própria: o Postgres em container (mesma rede
+    // Docker) não fala SSL. Ligar só quando o banco for remoto/gerenciado.
+    ssl: env.DB_SSL ? { rejectUnauthorized: false } : false,
 });
 
 export const db = drizzle(pool);

--- a/backend/drizzle/0003_fix_tokens_type.sql
+++ b/backend/drizzle/0003_fix_tokens_type.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "tokens" ADD COLUMN IF NOT EXISTS "type" varchar(50) DEFAULT 'refresh' NOT NULL;

--- a/backend/drizzle/meta/0003_snapshot.json
+++ b/backend/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,194 @@
+{
+  "id": "c022f4c8-6b49-471f-83ba-6e205d5038a7",
+  "prevId": "2f429a79-2252-42db-9994-03edcddd1c32",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.tokens": {
+      "name": "tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'refresh'"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tokens_user_id_users_id_fk": {
+          "name": "tokens_user_id_users_id_fk",
+          "tableFrom": "tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tokens_token_hash_unique": {
+          "name": "tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin",
+        "moderator"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1782476502755,
       "tag": "0002_cloudy_lady_mastermind",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1782488497322,
+      "tag": "0003_fix_tokens_type",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -1,41 +1,7 @@
 import { env } from "./src/config/env.ts";
-import express from "express";
-import type { Request, Response } from "express";
-import { db } from "./db.ts";
-import cookieParser from "cookie-parser";
-import { sql } from "drizzle-orm";
-import authRoutes from "./src/routes/auth.routes.ts";
-import userRoutes from "./src/routes/user.routes.ts";
-import { errorMiddleware } from "./src/middlewares/error.ts";
-import helmet from "helmet";
-import cors from "cors";
+import { app } from "./app.ts";
 
 const PORT = Number(env.PORT) || 3001;
-const app = express();
-
-app.set("trust proxy", 1);
-
-app.use(cookieParser());
-app.use(express.json());
-app.use(helmet());
-app.use(cors({
-    origin: env.NODE_ENV === "production"
-    ? env.FRONTEND_URL
-    : true,
-    credentials: true,
-}));
-
-app.use(authRoutes);
-app.use(userRoutes);
-
-app.get("/health", (_req, res) => res.json({ status: "ok" }));
-
-app.get("/db-test", async (_req: Request, res: Response) => {
-    const result = await db.execute(sql`SELECT 1 + 1 AS result`);
-    res.json({ result: result.rows[0] });
-});
-
-app.use(errorMiddleware);
 
 app.listen(PORT, "0.0.0.0", () => {
     console.log(`Server is running on port ${PORT}`);

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -20,7 +20,7 @@ app.use(express.json());
 app.use(helmet());
 app.use(cors({
     origin: env.NODE_ENV === "production"
-    ? "https://meusite.com"
+    ? env.FRONTEND_URL
     : true,
     credentials: true,
 }));

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test --test-concurrency=1 'src/**/*.test.ts' 'tests/**/*.test.ts'",
+    "test:unit": "node --test 'src/**/*.test.ts'",
     "dev": "node --watch --env-file=.env index.ts"
   },
   "keywords": [],

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -6,6 +6,7 @@ const envSchema = z.object({
     PORT: z.string().default("3001"),
     NODE_ENV: z.enum(["development", "test", "production"]).default("development"),
     FRONTEND_URL: z.string().url().default("http://localhost:5173"),
+    DB_SSL: z.string().optional().transform((v) => v === "true"),
 });
 
 // Valida os dados e lança erro se tiver algo errado.

--- a/backend/src/middlewares/rateLimit.ts
+++ b/backend/src/middlewares/rateLimit.ts
@@ -6,4 +6,5 @@ export const loginLimiter = rateLimit({
     message: { erro: "Muitas tentativas. Tente novamente mais tarde." },
     standardHeaders: true, // Envia headers RateLimit-* (É o padrão moderno de hoje)
     legacyHeaders: false, // Não envia os headers antigos
+    skip: () => process.env.NODE_ENV === "test", // não limita durante os testes
 });

--- a/backend/src/schemas/auth.schema.test.ts
+++ b/backend/src/schemas/auth.schema.test.ts
@@ -1,0 +1,76 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema, loginSchema } from "./auth.schema.ts";
+
+const usuarioValido = {
+    name: "Maria Silva",
+    email: "maria@email.com",
+    password: "senhaforte123",
+    birthDate: "1990-01-01",
+    gender: "feminino",
+    phone: "(11) 98888-7777",
+};
+
+describe("registerSchema", () => {
+    test("aceita um cadastro válido", () => {
+        const r = registerSchema.safeParse(usuarioValido);
+        assert.equal(r.success, true);
+    });
+
+    test("rejeita nome com menos de 2 caracteres", () => {
+        const r = registerSchema.safeParse({ ...usuarioValido, name: "M" });
+        assert.equal(r.success, false);
+    });
+
+    test("rejeita email inválido", () => {
+        const r = registerSchema.safeParse({ ...usuarioValido, email: "naoehemail" });
+        assert.equal(r.success, false);
+    });
+
+    test("rejeita senha com menos de 12 caracteres", () => {
+        const r = registerSchema.safeParse({ ...usuarioValido, password: "abc123" });
+        assert.equal(r.success, false);
+    });
+
+    test("rejeita senha sem número", () => {
+        const r = registerSchema.safeParse({ ...usuarioValido, password: "senhasemnumero" });
+        assert.equal(r.success, false);
+    });
+
+    test("rejeita senha com mais de 72 caracteres", () => {
+        const r = registerSchema.safeParse({ ...usuarioValido, password: "a1" + "x".repeat(72) });
+        assert.equal(r.success, false);
+    });
+
+    test("aceita senha no limite de 12 caracteres com número", () => {
+        const r = registerSchema.safeParse({ ...usuarioValido, password: "abcdefghij12" });
+        assert.equal(r.success, true);
+    });
+
+    test("rejeita birthDate em formato errado", () => {
+        const r = registerSchema.safeParse({ ...usuarioValido, birthDate: "01/01/1990" });
+        assert.equal(r.success, false);
+    });
+
+    test("rejeita quando faltam campos obrigatórios", () => {
+        const r = registerSchema.safeParse({ name: "Maria", email: "maria@email.com" });
+        assert.equal(r.success, false);
+    });
+});
+
+describe("loginSchema", () => {
+    test("aceita email e senha válidos", () => {
+        const r = loginSchema.safeParse({ email: "maria@email.com", password: "x" });
+        assert.equal(r.success, true);
+    });
+
+    test("rejeita email inválido", () => {
+        const r = loginSchema.safeParse({ email: "invalido", password: "x" });
+        assert.equal(r.success, false);
+    });
+
+    test("rejeita senha vazia", () => {
+        const r = loginSchema.safeParse({ email: "maria@email.com", password: "" });
+        assert.equal(r.success, false);
+    });
+});

--- a/backend/tests/auth.test.ts
+++ b/backend/tests/auth.test.ts
@@ -1,0 +1,234 @@
+import { test, describe, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { startTestServer, extractRefreshCookie } from "./helpers/server.ts";
+import { limparBanco } from "./helpers/db.ts";
+
+let server: Awaited<ReturnType<typeof startTestServer>>;
+
+const novoUsuario = (over: Record<string, unknown> = {}) => ({
+    name: "Maria Silva",
+    email: `maria_${Math.round(performance.now() * 1000)}@email.com`,
+    password: "senhaforte123",
+    birthDate: "1990-01-01",
+    gender: "feminino",
+    phone: "(11) 98888-7777",
+    ...over,
+});
+
+// Marca o email como verificado direto no banco, para testar o login.
+async function verificarEmail(email: string) {
+    const { db } = await import("../db.ts");
+    const { users } = await import("../schema.ts");
+    const { eq } = await import("drizzle-orm");
+    await db.update(users).set({ emailVerifiedAt: new Date() }).where(eq(users.email, email));
+}
+
+before(async () => { server = await startTestServer(); });
+after(async () => { await server.close(); });
+beforeEach(async () => { await limparBanco(); });
+
+describe("POST /register", () => {
+    test("cria usuário com os campos obrigatórios e retorna 201", async () => {
+        const dados = novoUsuario();
+        const res = await server.request("POST", "/register", { body: dados });
+
+        assert.equal(res.status, 201);
+        assert.equal(res.body.user.email, dados.email);
+        // Não deve vazar hash de senha nem logar automaticamente (fluxo hard)
+        assert.equal(res.body.user.passwordHash, undefined);
+        assert.equal(res.body.token, undefined);
+        assert.equal(extractRefreshCookie(res.setCookie), null);
+    });
+
+    test("rejeita cadastro sem campos obrigatórios (400)", async () => {
+        const res = await server.request("POST", "/register", {
+            body: { name: "X", email: "x@email.com", password: "senhaforte123" },
+        });
+        assert.equal(res.status, 400);
+    });
+
+    test("rejeita email duplicado", async () => {
+        const dados = novoUsuario();
+        await server.request("POST", "/register", { body: dados });
+        const res = await server.request("POST", "/register", { body: dados });
+        assert.ok(res.status >= 400);
+    });
+});
+
+describe("POST /login", () => {
+    test("bloqueia login com email não verificado (403)", async () => {
+        const dados = novoUsuario();
+        await server.request("POST", "/register", { body: dados });
+
+        const res = await server.request("POST", "/login", {
+            body: { email: dados.email, password: dados.password },
+        });
+        assert.equal(res.status, 403);
+        assert.equal(extractRefreshCookie(res.setCookie), null);
+    });
+
+    test("permite login após verificar o email (200 + cookie)", async () => {
+        const dados = novoUsuario();
+        await server.request("POST", "/register", { body: dados });
+        await verificarEmail(dados.email);
+
+        const res = await server.request("POST", "/login", {
+            body: { email: dados.email, password: dados.password },
+        });
+        assert.equal(res.status, 200);
+        assert.ok(res.body.token, "deve retornar access token");
+        assert.ok(extractRefreshCookie(res.setCookie), "deve setar cookie de refresh");
+    });
+
+    test("rejeita senha errada (401)", async () => {
+        const dados = novoUsuario();
+        await server.request("POST", "/register", { body: dados });
+        await verificarEmail(dados.email);
+
+        const res = await server.request("POST", "/login", {
+            body: { email: dados.email, password: "senhaerrada999" },
+        });
+        assert.equal(res.status, 401);
+    });
+
+    test("rejeita usuário inexistente (401)", async () => {
+        const res = await server.request("POST", "/login", {
+            body: { email: "naoexiste@email.com", password: "senhaforte123" },
+        });
+        assert.equal(res.status, 401);
+    });
+});
+
+describe("POST /verify-email", () => {
+    test("verifica email com token válido e libera o login", async () => {
+        const dados = novoUsuario();
+        // Captura o token puro interceptando o emailService via log não é trivial;
+        // então geramos um token de verificação diretamente pelo service.
+        await server.request("POST", "/register", { body: dados });
+
+        const { authService } = await import("../src/services/auth.service.ts");
+        const { db } = await import("../db.ts");
+        const { users } = await import("../schema.ts");
+        const { eq } = await import("drizzle-orm");
+        const [u] = await db.select({ id: users.id }).from(users).where(eq(users.email, dados.email));
+        const token = await authService.gerarTokenVerificacao(u.id);
+
+        const res = await server.request("POST", "/verify-email", { body: { token } });
+        assert.equal(res.status, 200);
+
+        // Agora o login deve funcionar
+        const login = await server.request("POST", "/login", {
+            body: { email: dados.email, password: dados.password },
+        });
+        assert.equal(login.status, 200);
+    });
+
+    test("rejeita token inválido (400)", async () => {
+        const res = await server.request("POST", "/verify-email", { body: { token: "lixoinvalido" } });
+        assert.equal(res.status, 400);
+    });
+
+    test("rejeita reuso do mesmo token (400)", async () => {
+        const dados = novoUsuario();
+        await server.request("POST", "/register", { body: dados });
+        const { authService } = await import("../src/services/auth.service.ts");
+        const { db } = await import("../db.ts");
+        const { users } = await import("../schema.ts");
+        const { eq } = await import("drizzle-orm");
+        const [u] = await db.select({ id: users.id }).from(users).where(eq(users.email, dados.email));
+        const token = await authService.gerarTokenVerificacao(u.id);
+
+        await server.request("POST", "/verify-email", { body: { token } });
+        const segundo = await server.request("POST", "/verify-email", { body: { token } });
+        assert.equal(segundo.status, 400);
+    });
+});
+
+// Helper: registra, verifica e loga, devolvendo o cookie de refresh.
+async function usuarioLogado(dados = novoUsuario()) {
+    await server.request("POST", "/register", { body: dados });
+    await verificarEmail(dados.email as string);
+    const login = await server.request("POST", "/login", {
+        body: { email: dados.email, password: dados.password },
+    });
+    return { dados, cookie: extractRefreshCookie(login.setCookie), token: login.body.token };
+}
+
+describe("POST /refresh", () => {
+    test("renova o token com cookie válido (200 + novo cookie)", async () => {
+        const { cookie } = await usuarioLogado();
+        const res = await server.request("POST", "/refresh", { cookie: cookie! });
+        assert.equal(res.status, 200);
+        assert.ok(res.body.token);
+        assert.ok(extractRefreshCookie(res.setCookie));
+    });
+
+    test("sem cookie retorna 401 (não 500)", async () => {
+        const res = await server.request("POST", "/refresh", {});
+        assert.equal(res.status, 401);
+    });
+
+    test("detecta reuso de token rotacionado", async () => {
+        const { cookie } = await usuarioLogado();
+        // Primeiro refresh: consome o cookie original e gera um novo
+        const r1 = await server.request("POST", "/refresh", { cookie: cookie! });
+        assert.equal(r1.status, 200);
+        // Reusar o cookie ORIGINAL (já rotacionado) deve falhar
+        const r2 = await server.request("POST", "/refresh", { cookie: cookie! });
+        assert.equal(r2.status, 401);
+    });
+});
+
+describe("POST /logout", () => {
+    test("revoga o refresh token (refresh posterior falha)", async () => {
+        const { cookie } = await usuarioLogado();
+        const out = await server.request("POST", "/logout", { cookie: cookie! });
+        assert.equal(out.status, 204);
+
+        const res = await server.request("POST", "/refresh", { cookie: cookie! });
+        assert.equal(res.status, 401);
+    });
+});
+
+// Promove um usuário a admin direto no banco.
+async function promoverAdmin(email: string) {
+    const { db } = await import("../db.ts");
+    const { users } = await import("../schema.ts");
+    const { eq } = await import("drizzle-orm");
+    await db.update(users).set({ role: "admin" }).where(eq(users.email, email));
+}
+
+describe("GET /users (RBAC)", () => {
+    test("usuário comum recebe 403", async () => {
+        const { token } = await usuarioLogado();
+        const res = await fetch(`${server.base}/users`, {
+            headers: { Authorization: `Bearer ${token}` },
+        });
+        assert.equal(res.status, 403);
+    });
+
+    test("admin recebe 200 e a lista não expõe passwordHash", async () => {
+        const dados = novoUsuario();
+        await server.request("POST", "/register", { body: dados });
+        await verificarEmail(dados.email);
+        await promoverAdmin(dados.email);
+        const login = await server.request("POST", "/login", {
+            body: { email: dados.email, password: dados.password },
+        });
+
+        const res = await fetch(`${server.base}/users`, {
+            headers: { Authorization: `Bearer ${login.body.token}` },
+        });
+        assert.equal(res.status, 200);
+        const lista = await res.json();
+        assert.ok(Array.isArray(lista));
+        for (const u of lista) {
+            assert.equal(u.passwordHash, undefined, "passwordHash não deve vazar");
+        }
+    });
+
+    test("sem token retorna 401", async () => {
+        const res = await fetch(`${server.base}/users`);
+        assert.equal(res.status, 401);
+    });
+});

--- a/backend/tests/helpers/db.ts
+++ b/backend/tests/helpers/db.ts
@@ -1,0 +1,8 @@
+import { db } from "../../db.ts";
+import { sql } from "drizzle-orm";
+
+/** Limpa as tabelas entre os testes, mantendo o schema. */
+export async function limparBanco() {
+    // TRUNCATE com CASCADE remove tokens (FK) junto; RESTART IDENTITY zera sequências.
+    await db.execute(sql`TRUNCATE TABLE tokens, users RESTART IDENTITY CASCADE`);
+}

--- a/backend/tests/helpers/server.ts
+++ b/backend/tests/helpers/server.ts
@@ -1,0 +1,56 @@
+import type { AddressInfo } from "node:net";
+import type { Server } from "node:http";
+
+/**
+ * Sobe o app numa porta efêmera e devolve uma função `request` baseada em fetch.
+ * O app é importado dinamicamente para garantir que as variáveis de ambiente
+ * de teste (DATABASE_URL etc.) já estejam definidas antes de o db.ts conectar.
+ */
+export async function startTestServer() {
+    const { app } = await import("../../app.ts");
+
+    const server: Server = await new Promise((resolve) => {
+        const s = app.listen(0, () => resolve(s));
+    });
+
+    const { port } = server.address() as AddressInfo;
+    const base = `http://127.0.0.1:${port}`;
+
+    async function request(
+        method: string,
+        path: string,
+        options: { body?: unknown; cookie?: string } = {},
+    ) {
+        const headers: Record<string, string> = {};
+        if (options.body !== undefined) headers["Content-Type"] = "application/json";
+        if (options.cookie) headers["Cookie"] = options.cookie;
+
+        const res = await fetch(`${base}${path}`, {
+            method,
+            headers,
+            body: options.body !== undefined ? JSON.stringify(options.body) : undefined,
+        });
+
+        const setCookie = res.headers.get("set-cookie");
+        let json: any = null;
+        const text = await res.text();
+        if (text) {
+            try { json = JSON.parse(text); } catch { json = text; }
+        }
+
+        return { status: res.status, body: json, setCookie };
+    }
+
+    async function close() {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+
+    return { request, close, base };
+}
+
+/** Extrai o valor do refreshToken de um header Set-Cookie. */
+export function extractRefreshCookie(setCookie: string | null): string | null {
+    if (!setCookie) return null;
+    const match = setCookie.match(/refreshToken=([^;]+)/);
+    return match ? `refreshToken=${match[1]}` : null;
+}

--- a/backend/tests/run-integration.sh
+++ b/backend/tests/run-integration.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Sobe um Postgres efêmero, aplica as migrations e roda os testes de integração.
+# Uso: bash tests/run-integration.sh
+set -euo pipefail
+
+CONTAINER="ensinadev_pg_test"
+PORT=55433
+export DATABASE_URL="postgres://test:test@localhost:${PORT}/testdb"
+export JWT_SECRET="test_secret_com_pelo_menos_32_caracteres_aqui_ok"
+export NODE_ENV="test"
+export FRONTEND_URL="http://localhost:5173"
+export DB_SSL="false"
+
+cleanup() {
+  docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "==> Subindo Postgres de teste (porta ${PORT})"
+docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+docker run -d --rm --name "$CONTAINER" \
+  -e POSTGRES_USER=test -e POSTGRES_PASSWORD=test -e POSTGRES_DB=testdb \
+  -p ${PORT}:5432 postgres:16-alpine >/dev/null
+
+echo "==> Aguardando o banco aceitar conexões"
+for i in $(seq 1 30); do
+  docker exec "$CONTAINER" pg_isready -U test -d testdb >/dev/null 2>&1 && break
+  sleep 1
+done
+
+echo "==> Aplicando migrations"
+npx drizzle-kit migrate >/dev/null
+
+echo "==> Rodando testes de integração"
+node --test --test-concurrency=1 'tests/**/*.test.ts'

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,0 +1,15 @@
+ensinadev.com.br, www.ensinadev.com.br {
+	# API: tudo sob /api vai para o backend, removendo o prefixo /api
+	handle_path /api/* {
+		reverse_proxy backend:3001
+	}
+
+	# Frontend: arquivos estáticos do build do Vite
+	handle {
+		root * /srv
+		try_files {path} /index.html
+		file_server
+	}
+
+	encode gzip
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,42 @@
+services:
+  caddy:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+      args:
+        VITE_API_URL: https://ensinadev.com.br/api
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./deploy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      - backend
+
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    env_file:
+      - ./backend/.env.prod
+    depends_on:
+      - db
+    expose:
+      - "3001"
+
+  db:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    env_file:
+      - ./backend/.env.prod
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+volumes:
+  pgdata:
+  caddy_data:
+  caddy_config:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,19 @@
+# Build de produção do frontend (Vite) servido pelo Caddy
+# Estágio 1: build dos arquivos estáticos
+FROM node:22-alpine AS build
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+
+# VITE_API_URL é injetado no build (variável de build-time do Vite)
+ARG VITE_API_URL
+ENV VITE_API_URL=$VITE_API_URL
+RUN npm run build
+
+# Estágio 2: imagem final só com os estáticos, servidos pelo Caddy
+FROM caddy:2-alpine
+COPY --from=build /app/dist /srv


### PR DESCRIPTION
## Visão geral

Segunda leva desde o beta. Traz a verificação de email, os arquivos de deploy de produção com HTTPS e uma suíte de testes para o backend. Também corrige uma divergência de migration que quebrava bancos novos.

## Verificação de email

- Token de verificação gerado no cadastro, validado por hash e tipo
- Endpoint de confirmação que marca o email como verificado
- Login bloqueado enquanto o email não for confirmado
- Página de verificação no frontend que lê o token da URL e chama a API

## Deploy de produção

- Dockerfile de produção do backend e build estático do frontend
- Caddy como reverse proxy com HTTPS automatico e roteamento de /api para o backend
- docker-compose.prod.yml com volumes persistentes
- CORS de produção passa a usar FRONTEND_URL
- SSL do banco controlado por variável própria, já que o Postgres roda em container na mesma rede

## Correção de migration

- O schema definia tokens.type, mas nenhuma migration criava a coluna. Um banco novo subia sem ela e o cadastro falhava.
- Adicionada migration idempotente que cria a coluna se ela não existir, sem afetar bancos que já a possuem.

## Testes

- Testes unitarios dos schemas de validação (politica de senha, email, campos obrigatorios)
- Testes de integração das rotas de autenticação contra um Postgres efemero: registro, login com bloqueio por verificação, verificação de email, refresh com rotação e detecção de reuso, logout e controle de acesso de administrador
- App separado do listen para permitir os testes
- Rate limiter desativado em ambiente de teste

## Como testar

1. Unitarios, sem banco: cd backend e npm run test:unit
2. Integração, sobe o banco sozinho: cd backend e bash tests/run-integration.sh

## Notas para o deploy

- A migration nova sera aplicada no proximo deploy. Como e idempotente, e segura no banco de produção que ja recebeu a coluna manualmente.
- O envio de email segue registrando o link no log com o prefixo VERIFY-LINK. Para liberar usuarios do beta, basta filtrar o log por esse prefixo.
