### PR TITLE
CI e CD com GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,77 @@
+name: CI
+
+on:
+  push:
+    branches: [develop, main]
+  pull_request:
+    branches: [develop, main]
+
+jobs:
+  backend-tests:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: testdb
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U test -d testdb"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgres://test:test@localhost:5432/testdb
+      JWT_SECRET: ci_secret_com_pelo_menos_32_caracteres_aqui_ok
+      NODE_ENV: test
+      FRONTEND_URL: http://localhost:5173
+      DB_SSL: "false"
+
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Instalar dependências
+        run: npm ci
+
+      - name: Typecheck
+        run: npx tsc --noEmit
+
+      - name: Testes unitários
+        run: npm run test:unit
+
+      - name: Aplicar migrations no banco de teste
+        run: npx drizzle-kit migrate
+
+      - name: Testes de integração
+        run: node --test --test-concurrency=1 'tests/**/*.test.ts'
+
+  frontend-build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Instalar dependências
+        run: npm ci
+
+      - name: Typecheck e build
+        run: npm run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,47 @@
+name: Deploy
+
+# Dispara no merge/push para a main e atualiza o servidor de produção via SSH.
+on:
+  push:
+    branches: [main]
+
+# Evita dois deploys simultâneos pisando um no outro.
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configurar chave SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          echo "76.13.174.73 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILDPyeTPCOu8dACmJrgFeI04EGjZkKVwN3lu5145uH8k" >> ~/.ssh/known_hosts
+
+      - name: Deploy no servidor
+        run: |
+          ssh -i ~/.ssh/deploy_key ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} bash -s <<'DEPLOY'
+            set -e
+            cd ${{ secrets.DEPLOY_PATH }}
+            echo "==> Atualizando código (main)"
+            git fetch origin main
+            git checkout main
+            git reset --hard origin/main
+            echo "==> Rebuild e subida dos containers"
+            docker compose -f docker-compose.prod.yml up -d --build
+            echo "==> Aplicando migrations"
+            docker compose -f docker-compose.prod.yml exec -T backend npx drizzle-kit migrate
+            echo "==> Limpando imagens antigas"
+            docker image prune -f
+            echo "==> Deploy concluido"
+          DEPLOY
+
+      - name: Verificar saúde do site
+        run: |
+          sleep 5
+          code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 20 https://ensinadev.com.br/api/health)
+          echo "Health check retornou: $code"
+          test "$code" = "200"


### PR DESCRIPTION
## Visão geral

Adiciona automação de CI e CD com GitHub Actions. Este PR contém apenas os dois workflows.

## CI (ci.yml)

Roda a cada push e pull request para develop e main:

- Typecheck do backend
- Testes unitarios dos schemas de validação
- Testes de integração das rotas de autenticação, com um Postgres provisionado pelo runner
- Typecheck e build do frontend

O CI ja foi exercitado na develop e passou nos dois jobs.

## CD (deploy.yml)

Dispara no push para a main. Conecta no servidor por SSH usando uma chave dedicada de deploy e:

- Atualiza o codigo para o estado da main
- Reconstroi e sobe os containers de produção
- Aplica as migrations
- Faz um health check no site ao final

A chave de deploy e dedicada (separada da chave pessoal) e foi instalada no servidor. Os dados de acesso ficam em GitHub Secrets, nao no codigo.

## Observação

Ao mergear este PR, o workflow de deploy roda pela primeira vez e atualiza o servidor de produção automaticamente. O arquivo de variaveis de ambiente do servidor fica fora do controle de versao e nao e afetado pelo deploy.
