### PR TITLE
Endurecimento de seguranca: rate limit, remocao de debug e lockout de conta

### DIFF
--- a/backend/app.ts
+++ b/backend/app.ts
@@ -1,9 +1,6 @@
 import { env } from "./src/config/env.ts";
 import express from "express";
-import type { Request, Response } from "express";
-import { db } from "./db.ts";
 import cookieParser from "cookie-parser";
-import { sql } from "drizzle-orm";
 import authRoutes from "./src/routes/auth.routes.ts";
 import userRoutes from "./src/routes/user.routes.ts";
 import { errorMiddleware } from "./src/middlewares/error.ts";
@@ -28,10 +25,5 @@ app.use(authRoutes);
 app.use(userRoutes);
 
 app.get("/health", (_req, res) => res.json({ status: "ok" }));
-
-app.get("/db-test", async (_req: Request, res: Response) => {
-    const result = await db.execute(sql`SELECT 1 + 1 AS result`);
-    res.json({ result: result.rows[0] });
-});
 
 app.use(errorMiddleware);

--- a/backend/drizzle/0004_complex_living_lightning.sql
+++ b/backend/drizzle/0004_complex_living_lightning.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "users" ADD COLUMN "failed_login_attempts" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "locked_until" timestamp with time zone;

--- a/backend/drizzle/meta/0004_snapshot.json
+++ b/backend/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,207 @@
+{
+  "id": "74b25e13-a893-4e03-a916-76fac5696d2a",
+  "prevId": "c022f4c8-6b49-471f-83ba-6e205d5038a7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.tokens": {
+      "name": "tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'refresh'"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tokens_user_id_users_id_fk": {
+          "name": "tokens_user_id_users_id_fk",
+          "tableFrom": "tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tokens_token_hash_unique": {
+          "name": "tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "failed_login_attempts": {
+          "name": "failed_login_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin",
+        "moderator"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1782488497322,
       "tag": "0003_fix_tokens_type",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1782499695129,
+      "tag": "0004_complex_living_lightning",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/schema.ts
+++ b/backend/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, uuid, varchar, date, timestamp, pgEnum } from "drizzle-orm/pg-core";
+import { pgTable, uuid, varchar, date, timestamp, pgEnum, integer } from "drizzle-orm/pg-core";
 
 export const userRole = pgEnum("user_role", ["user", "admin", "moderator"]);
 
@@ -14,6 +14,8 @@ export const users = pgTable("users", {
     updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
     emailVerifiedAt: timestamp("email_verified_at", { withTimezone: true}),
     role: userRole("role").default('user').notNull(),
+    failedLoginAttempts: integer("failed_login_attempts").default(0).notNull(),
+    lockedUntil: timestamp("locked_until", { withTimezone: true}),
 });
 
 export const tokens = pgTable("tokens", {

--- a/backend/src/controllers/AuthController.ts
+++ b/backend/src/controllers/AuthController.ts
@@ -11,6 +11,10 @@ import { emailService } from "../services/email.service.ts";
 
 const BCRYPT_COST = 10;
 
+// Lockout de conta: trava temporariamente após muitas senhas erradas.
+const MAX_TENTATIVAS = 5;
+const LOCKOUT_MS = 15 * 60 * 1000; // 15 minutos
+
 const JWT_SECRET = String(env.JWT_SECRET);
 
 if (!JWT_SECRET) {
@@ -74,6 +78,12 @@ export const login = async (req: Request, res: Response, next: NextFunction) => 
         const encontrados = await db.select().from(users).where(eq(users.email, dados.email));
         const user = encontrados[0];
 
+        // Conta travada? Recusa antes de gastar bcrypt. Mensagem genérica (igual ao
+        // rate limit) para não distinguir "travada" de "muitas tentativas por IP".
+        if (user?.lockedUntil && user.lockedUntil > new Date()) {
+            return res.status(429).json({ erro: "Muitas tentativas. Tente novamente mais tarde." });
+        }
+
         // Definimos qual hash será comparado. Se o usuário existir, usamos o dele.
         // Se não existir, usamos o DUMMY_HASH.
         const hashParaComparar = user ? user.passwordHash : DUMMY_HASH;
@@ -81,7 +91,28 @@ export const login = async (req: Request, res: Response, next: NextFunction) => 
         const senhaCorreta = await bcrypt.compare(dados.password, hashParaComparar);
 
         if (!user || !senhaCorreta) {
+            // Conta tentativas falhas só para usuário existente. Ao atingir o limite,
+            // trava por LOCKOUT_MS e zera o contador (a próxima janela começa limpa).
+            if (user) {
+                const tentativas = user.failedLoginAttempts + 1;
+                if (tentativas >= MAX_TENTATIVAS) {
+                    await db.update(users)
+                        .set({ failedLoginAttempts: 0, lockedUntil: new Date(Date.now() + LOCKOUT_MS) })
+                        .where(eq(users.id, user.id));
+                } else {
+                    await db.update(users)
+                        .set({ failedLoginAttempts: tentativas })
+                        .where(eq(users.id, user.id));
+                }
+            }
             return res.status(401).json({ erro: "Credenciais inválidas" });
+        }
+
+        // Senha correta: zera o contador se havia tentativas/lock pendentes.
+        if (user.failedLoginAttempts > 0 || user.lockedUntil) {
+            await db.update(users)
+                .set({ failedLoginAttempts: 0, lockedUntil: null })
+                .where(eq(users.id, user.id));
         }
 
         if (!user.emailVerifiedAt) {

--- a/backend/src/routes/auth.routes.ts
+++ b/backend/src/routes/auth.routes.ts
@@ -6,8 +6,8 @@ const router = Router();
 
 router.post("/login", loginLimiter, login);
 router.post("/register", loginLimiter, register);
-router.post("/refresh", refresh);
-router.post("/logout", logout);
-router.post("/verify-email", verifyEmail);
+router.post("/refresh",loginLimiter, refresh);
+router.post("/logout",loginLimiter, logout);
+router.post("/verify-email", loginLimiter, verifyEmail);
 
 export default router;  

--- a/backend/tests/auth.test.ts
+++ b/backend/tests/auth.test.ts
@@ -99,6 +99,84 @@ describe("POST /login", () => {
     });
 });
 
+describe("Lockout de conta", () => {
+    // Lê o estado de lockout direto do banco.
+    async function estadoLock(email: string) {
+        const { db } = await import("../db.ts");
+        const { users } = await import("../schema.ts");
+        const { eq } = await import("drizzle-orm");
+        const [u] = await db
+            .select({ tentativas: users.failedLoginAttempts, lockedUntil: users.lockedUntil })
+            .from(users)
+            .where(eq(users.email, email));
+        return u;
+    }
+
+    test("trava a conta com 429 após 5 senhas erradas", async () => {
+        const dados = novoUsuario();
+        await server.request("POST", "/register", { body: dados });
+        await verificarEmail(dados.email);
+
+        // 5 tentativas erradas: as 4 primeiras 401, a 5a trava
+        for (let i = 0; i < 5; i++) {
+            await server.request("POST", "/login", {
+                body: { email: dados.email, password: "errada999" },
+            });
+        }
+
+        // 6a tentativa (mesmo com a senha CERTA) deve bater no lock -> 429
+        const res = await server.request("POST", "/login", {
+            body: { email: dados.email, password: dados.password },
+        });
+        assert.equal(res.status, 429);
+
+        const estado = await estadoLock(dados.email);
+        assert.ok(estado.lockedUntil && estado.lockedUntil > new Date(), "lockedUntil deve estar no futuro");
+    });
+
+    test("login bem-sucedido zera o contador de tentativas", async () => {
+        const dados = novoUsuario();
+        await server.request("POST", "/register", { body: dados });
+        await verificarEmail(dados.email);
+
+        // 2 erros (abaixo do limite), depois acerta
+        await server.request("POST", "/login", { body: { email: dados.email, password: "errada1" } });
+        await server.request("POST", "/login", { body: { email: dados.email, password: "errada2" } });
+
+        let estado = await estadoLock(dados.email);
+        assert.equal(estado.tentativas, 2);
+
+        const ok = await server.request("POST", "/login", {
+            body: { email: dados.email, password: dados.password },
+        });
+        assert.equal(ok.status, 200);
+
+        estado = await estadoLock(dados.email);
+        assert.equal(estado.tentativas, 0);
+        assert.equal(estado.lockedUntil, null);
+    });
+
+    test("lockout expirado permite login novamente", async () => {
+        const dados = novoUsuario();
+        await server.request("POST", "/register", { body: dados });
+        await verificarEmail(dados.email);
+
+        // Trava manualmente com lockedUntil no PASSADO (simula lock expirado)
+        const { db } = await import("../db.ts");
+        const { users } = await import("../schema.ts");
+        const { eq } = await import("drizzle-orm");
+        await db.update(users)
+            .set({ lockedUntil: new Date(Date.now() - 1000), failedLoginAttempts: 5 })
+            .where(eq(users.email, dados.email));
+
+        // Lock no passado nao bloqueia: login com senha certa deve funcionar
+        const res = await server.request("POST", "/login", {
+            body: { email: dados.email, password: dados.password },
+        });
+        assert.equal(res.status, 200);
+    });
+});
+
 describe("POST /verify-email", () => {
     test("verifica email com token válido e libera o login", async () => {
         const dados = novoUsuario();


### PR DESCRIPTION
## Visão geral

Endurecimento de seguranca da autenticacao, a partir de uma auditoria focada em brute force, SQL injection e vazamento de dados. SQL injection nao apresentou problemas (todo acesso usa o query builder parametrizado do Drizzle).

## Correcoes de fraqueza (fix)

- Rate limit aplicado tambem em /refresh, /logout e /verify-email. Antes so login e register tinham limite, deixando /verify-email exposto a brute force de token.
- Remocao da rota de debug /db-test, que ficava publica sem autenticacao.

## Nova protecao (feat)

- Lockout temporario de conta: apos 5 senhas erradas, a conta trava por 15 minutos e responde 429 com mensagem generica.
- Complementa o rate limit por IP: protege contra ataque distribuido (varios IPs contra uma mesma conta).
- Lockout e temporario e destrava sozinho, para nao virar um vetor de DoS por travamento proposital.
- Contador de tentativas zera em login bem-sucedido.
- Colunas novas failed_login_attempts e locked_until na tabela users (migration 0004).

## Decisao registrada

A mensagem "verifique seu email" no login foi mantida de proposito. Ela revela que a senha esta correta, mas explorar isso exige vencer o bcrypt e o rate limit, o que e inviavel na pratica. O ganho de seguranca de remove-la nao compensa a piora de UX para o usuario legitimo.

## Testes

- 3 testes de integracao novos para o lockout (trava com 429, reset no sucesso, expiracao destrava).
- Suite total: 12 unitarios e 20 de integracao, todos passando. Typecheck limpo.

## Como testar

cd backend e bash tests/run-integration.sh
