### PR TITLE
Remove campo de foto de perfil do cadastro

### DIFF
--- a/frontend/src/pages/Register/index.tsx
+++ b/frontend/src/pages/Register/index.tsx
@@ -6,7 +6,7 @@ import { AuthBrand } from '../../components/auth/AuthBrand';
 import { FormField } from '../../components/FormField';
 import { SelectField } from '../../components/SelectField';
 import { Avatar } from '../../components/Avatar';
-import { Check, UserPlus, Plus } from '../../components/Icons';
+import { Check } from '../../components/Icons';
 import { formatPhone } from '../../utils/phone';
 
 const BENEFITS = [
@@ -92,17 +92,6 @@ export function Register() {
     <AuthShell brand={brand}>
       <h2 className="auth__title">Crie sua conta</h2>
       <p className="auth__subtitle">Leva menos de um minuto.</p>
-
-      <div className="photo-upload">
-        <button type="button" className="photo-upload__circle" aria-label="Adicionar foto">
-          <UserPlus size={26} />
-          <span className="photo-upload__badge"><Plus size={12} /></span>
-        </button>
-        <div>
-          <div className="photo-upload__title">Adicionar foto de perfil</div>
-          <div className="photo-upload__hint">PNG ou JPG, até 4 MB</div>
-        </div>
-      </div>
 
       {error && <div className="auth__alert">{error}</div>}
 

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -128,16 +128,6 @@
 .auth__terms { font-size: 12px; color: var(--muted); line-height: 1.5; text-align: center; margin: 14px 0 0; }
 .auth__terms .link { font-size: 12px; font-weight: 500; }
 
-.photo-upload { display: flex; align-items: center; gap: 15px; margin: 24px 0 22px; }
-.photo-upload__circle {
-  position: relative; width: 64px; height: 64px; flex-shrink: 0; border-radius: 50%; cursor: pointer;
-  background: color-mix(in srgb, var(--accent) 12%, var(--surface-2)); border: 2px dashed var(--border-strong); color: var(--accent);
-  display: flex; align-items: center; justify-content: center;
-}
-.photo-upload__badge { position: absolute; bottom: -3px; right: -3px; width: 24px; height: 24px; border-radius: 50%; background: var(--accent); border: 2px solid var(--surface); color: #fff; display: flex; align-items: center; justify-content: center; }
-.photo-upload__title { font-size: 14.5px; font-weight: 600; }
-.photo-upload__hint { font-size: 12.5px; color: var(--muted); margin-top: 2px; }
-
 /* ===================== AVATARES ===================== */
 .avatar { display: inline-flex; align-items: center; justify-content: center; border-radius: 50%; font-weight: 700; color: #fff; flex-shrink: 0; }
 .avatar--sm { width: 30px; height: 30px; font-size: 11px; }


### PR DESCRIPTION
## Visão geral

Remove o bloco "Adicionar foto de perfil" da tela de cadastro. O elemento era apenas visual, sem upload funcional ligado ao backend, entao foi retirado para a tela refletir so o que esta de fato implementado.

## Mudancas

- Remove o bloco photo-upload do componente de cadastro
- Remove os estilos .photo-upload do CSS, que ficaram sem uso
- Remove os imports de icones que so serviam a esse bloco

## Como testar

Abrir a tela de cadastro e confirmar que o formulario aparece sem o campo de foto, fluindo direto para os campos de nome, email, senha, data de nascimento, genero e telefone.