### PR TITLE
Build do deploy sem cache para evitar frontend desatualizado

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -89,8 +89,8 @@ jobs:
             git fetch origin main
             git checkout main
             git reset --hard origin/main
-            echo "==> Build das imagens"
-            docker compose -f docker-compose.prod.yml build
+            echo "==> Build das imagens (sem cache, para garantir bundle atualizado)"
+            docker compose -f docker-compose.prod.yml build --no-cache
             echo "==> Subindo o banco"
             docker compose -f docker-compose.prod.yml up -d db
             echo "==> Aplicando migrations (antes de subir o app novo)"


### PR DESCRIPTION
## Problema

Apos mergear uma mudanca de frontend, a producao continuou servindo o bundle antigo. O codigo estava correto na main e no servidor, mas o docker compose build reusou camadas de cache e nao reconstruiu os estaticos do frontend. Foi necessario um rebuild manual com --no-cache para corrigir.

## Correcao

Adiciona --no-cache ao build do deploy no pipeline. Assim cada deploy reconstroi as imagens do zero, garantindo que producao sempre reflita o ultimo commit.

## Custo

O deploy fica alguns segundos mais lento por reinstalar dependencias e rebuildar, mas passa a ser deterministico. Para um beta, a previsibilidade compensa.

## Como validar

No proximo deploy para a main, conferir que o bundle servido em producao muda de hash quando ha alteracao no frontend.