### PR TITLE
Botao de mostrar/ocultar senha

### DIFF
--- a/frontend/src/components/FormField.tsx
+++ b/frontend/src/components/FormField.tsx
@@ -1,4 +1,5 @@
-import type { ChangeEvent, ReactNode } from 'react';
+import { useState, type ChangeEvent, type ReactNode } from 'react';
+import { Eye, EyeOff } from './Icons';
 
 interface FormFieldProps {
   label: string;
@@ -22,6 +23,11 @@ export function FormField({
   required = false,
   labelAddon,
 }: FormFieldProps) {
+  const [mostrarSenha, setMostrarSenha] = useState(false);
+  const ehSenha = type === 'password';
+  // Em campo de senha, o toggle alterna o type real entre password e text.
+  const tipoInput = ehSenha && mostrarSenha ? 'text' : type;
+
   return (
     <label className="field">
       {labelAddon ? (
@@ -32,15 +38,29 @@ export function FormField({
       ) : (
         <span className="field__label">{label}</span>
       )}
-      <input
-        className="input"
-        type={type}
-        placeholder={placeholder}
-        value={value}
-        onChange={onChange}
-        autoComplete={autoComplete}
-        required={required}
-      />
+      <div className={ehSenha ? 'input-wrap' : undefined}>
+        <input
+          className="input"
+          type={tipoInput}
+          placeholder={placeholder}
+          value={value}
+          onChange={onChange}
+          autoComplete={autoComplete}
+          required={required}
+        />
+        {ehSenha && (
+          <button
+            type="button"
+            className="input-toggle"
+            onClick={() => setMostrarSenha((v) => !v)}
+            aria-label={mostrarSenha ? 'Ocultar senha' : 'Mostrar senha'}
+            title={mostrarSenha ? 'Ocultar senha' : 'Mostrar senha'}
+            tabIndex={-1}
+          >
+            {mostrarSenha ? <EyeOff size={18} /> : <Eye size={18} />}
+          </button>
+        )}
+      </div>
     </label>
   );
 }

--- a/frontend/src/components/Icons.tsx
+++ b/frontend/src/components/Icons.tsx
@@ -65,6 +65,20 @@ export const Plus = ({ size = 12 }: IconProps) => (
   </svg>
 );
 
+export const Eye = ({ size = 18 }: IconProps) => (
+  <svg {...base(size)} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z" />
+    <circle cx="12" cy="12" r="3" />
+  </svg>
+);
+
+export const EyeOff = ({ size = 18 }: IconProps) => (
+  <svg {...base(size)} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20C5 20 1 12 1 12a18.5 18.5 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19M9.88 9.88a3 3 0 0 0 4.24 4.24" />
+    <line x1="1" y1="1" x2="23" y2="23" />
+  </svg>
+);
+
 /* Capelo de formatura — símbolo da marca */
 export const GradCap = ({ size = 19 }: IconProps) => (
   <svg width={size} height={size} viewBox="0 0 32 32" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -40,6 +40,15 @@
 }
 .input::placeholder { color: var(--muted); opacity: .8; }
 .input:focus { border-color: var(--accent); box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 16%, transparent); }
+.input-wrap { position: relative; }
+.input-wrap .input { padding-right: 44px; }
+.input-toggle {
+  position: absolute; top: 0; right: 0; height: 100%; width: 44px;
+  display: flex; align-items: center; justify-content: center;
+  background: none; border: none; cursor: pointer; color: var(--muted);
+  transition: color .15s ease;
+}
+.input-toggle:hover { color: var(--text); }
 .link { color: var(--accent); font-weight: 600; font-size: 13px; text-decoration: none; }
 .divider { display: flex; align-items: center; gap: 12px; color: var(--muted); font-size: 12.5px; margin: 18px 0; }
 .divider::before, .divider::after { content: ''; flex: 1; height: 1px; background: var(--border); }


### PR DESCRIPTION
## Visão geral

Adiciona um botao de olho nos campos de senha para o usuario poder ver o que digitou.

## Mudancas

- Toggle de visibilidade no FormField: quando o campo e do tipo senha, aparece um botao de olho que alterna entre ocultar e mostrar.
- Como Login e Cadastro usam o mesmo FormField, os dois ganham o recurso sem duplicacao.
- Icones Eye e EyeOff adicionados a biblioteca de icones.
- Acessibilidade: aria-label dinamico e o botao fica fora da ordem de tabulacao para nao atrapalhar a navegacao por teclado.

## Como testar

Abrir Login ou Cadastro, digitar uma senha e clicar no olho para mostrar/ocultar. Os demais campos nao tem o botao.