### PR TITLE
Trilhas de aprendizado: catalogo, progresso e tela

### DIFF
--- a/backend/app.ts
+++ b/backend/app.ts
@@ -3,6 +3,7 @@ import express from "express";
 import cookieParser from "cookie-parser";
 import authRoutes from "./src/routes/auth.routes.ts";
 import userRoutes from "./src/routes/user.routes.ts";
+import trailRoutes from "./src/routes/trail.routes.ts";
 import { errorMiddleware } from "./src/middlewares/error.ts";
 import helmet from "helmet";
 import cors from "cors";
@@ -23,6 +24,7 @@ app.use(cors({
 
 app.use(authRoutes);
 app.use(userRoutes);
+app.use(trailRoutes);
 
 app.get("/health", (_req, res) => res.json({ status: "ok" }));
 

--- a/backend/drizzle/0005_lush_stone_men.sql
+++ b/backend/drizzle/0005_lush_stone_men.sql
@@ -1,0 +1,29 @@
+CREATE TYPE "public"."trail_level" AS ENUM('iniciante', 'intermediario', 'avancado');--> statement-breakpoint
+CREATE TABLE "lessons_progress" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"lesson_id" uuid NOT NULL,
+	"completed_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "lessons_progress_user_id_lesson_id_unique" UNIQUE("user_id","lesson_id")
+);
+--> statement-breakpoint
+CREATE TABLE "lessons" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"trail_id" uuid NOT NULL,
+	"title" varchar(255) NOT NULL,
+	"content" text,
+	"position" integer NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "trails" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" varchar(255) NOT NULL,
+	"level" "trail_level" NOT NULL,
+	"description" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "lessons_progress" ADD CONSTRAINT "lessons_progress_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "lessons_progress" ADD CONSTRAINT "lessons_progress_lesson_id_lessons_id_fk" FOREIGN KEY ("lesson_id") REFERENCES "public"."lessons"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "lessons" ADD CONSTRAINT "lessons_trail_id_trails_id_fk" FOREIGN KEY ("trail_id") REFERENCES "public"."trails"("id") ON DELETE no action ON UPDATE no action;

--- a/backend/drizzle/meta/0005_snapshot.json
+++ b/backend/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,402 @@
+{
+  "id": "3c600e26-28dc-4880-b90e-b4c6e7a23cbd",
+  "prevId": "74b25e13-a893-4e03-a916-76fac5696d2a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.lessons_progress": {
+      "name": "lessons_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_progress_user_id_users_id_fk": {
+          "name": "lessons_progress_user_id_users_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_progress_lesson_id_lessons_id_fk": {
+          "name": "lessons_progress_lesson_id_lessons_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lessons_progress_user_id_lesson_id_unique": {
+          "name": "lessons_progress_user_id_lesson_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "lesson_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons": {
+      "name": "lessons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_trail_id_trails_id_fk": {
+          "name": "lessons_trail_id_trails_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tokens": {
+      "name": "tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'refresh'"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tokens_user_id_users_id_fk": {
+          "name": "tokens_user_id_users_id_fk",
+          "tableFrom": "tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tokens_token_hash_unique": {
+          "name": "tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trails": {
+      "name": "trails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "trail_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "failed_login_attempts": {
+          "name": "failed_login_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.trail_level": {
+      "name": "trail_level",
+      "schema": "public",
+      "values": [
+        "iniciante",
+        "intermediario",
+        "avancado"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin",
+        "moderator"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1782499695129,
       "tag": "0004_complex_living_lightning",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1782513013653,
+      "tag": "0005_lush_stone_men",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/schema.ts
+++ b/backend/schema.ts
@@ -1,6 +1,7 @@
-import { pgTable, uuid, varchar, date, timestamp, pgEnum, integer } from "drizzle-orm/pg-core";
+import { pgTable, uuid, varchar, date, timestamp, pgEnum, integer, text, unique } from "drizzle-orm/pg-core";
 
 export const userRole = pgEnum("user_role", ["user", "admin", "moderator"]);
+export const trailLevel = pgEnum("trail_level", ["iniciante", "intermediario", "avancado"]);
 
 export const users = pgTable("users", {
     id: uuid("id").primaryKey().defaultRandom(),
@@ -26,3 +27,29 @@ export const tokens = pgTable("tokens", {
     usedAt: timestamp("used_at", { withTimezone: true}),
     expiredAt: timestamp("expired_at", { withTimezone: true}).notNull()
 });
+
+export const trails = pgTable("trails", {
+    id: uuid("id").primaryKey().defaultRandom(),
+    name: varchar("name", { length: 255 }).notNull(),
+    trailLevel: trailLevel("level").notNull(),
+    description: text("description").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull()
+});
+
+export const lessons = pgTable("lessons", {
+    id: uuid("id").primaryKey().defaultRandom(),
+    trailId: uuid("trail_id").references(() => trails.id).notNull(),
+    title: varchar("title", { length: 255 }).notNull(),
+    content: text("content"),
+    position: integer("position").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull()
+});
+
+export const lessonProgress = pgTable("lessons_progress", {
+    id: uuid("id").primaryKey().defaultRandom(),
+    userId: uuid("user_id").references(() => users.id).notNull(),
+    lessonId: uuid("lesson_id").references(() => lessons.id).notNull(),
+    completedAt: timestamp("completed_at", { withTimezone: true }).defaultNow().notNull()
+}, (table) => [
+    unique().on(table.userId, table.lessonId),
+]);

--- a/backend/src/controllers/TrailController.ts
+++ b/backend/src/controllers/TrailController.ts
@@ -1,0 +1,187 @@
+import type { Request, Response, NextFunction } from "express";
+import { db } from "../../db.ts";
+import { trails, lessons, lessonProgress } from "../../schema.ts";
+import { eq, and, count, asc } from "drizzle-orm";
+import { createTrailSchema, createLessonSchema } from "../schemas/trail.schemas.ts";
+
+export const createTrail = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const dados = createTrailSchema.parse(req.body);
+
+        const [trilha] = await db.insert(trails).values({
+            name: dados.name,
+            trailLevel: dados.level,
+            description: dados.description
+        }).returning({
+            id: trails.id,
+            name: trails.name,
+            trailLevel: trails.trailLevel,
+            description: trails.description,
+            createdAt: trails.createdAt
+        });
+
+        res.status(201).json(trilha);
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const createLesson = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const trailId = String(req.params.id);
+        const dados = createLessonSchema.parse(req.body);
+
+        const [trilha] = await db.select({ id: trails.id }).from(trails).where(eq(trails.id, trailId));
+        if (!trilha) {
+            return res.status(404).json({ erro: "Trilha não encontrada" });
+        }
+
+        const [aula] = await db.insert(lessons).values({
+            trailId,
+            title: dados.title,
+            content: dados.content,
+            position: dados.position
+        }).returning({
+            id: lessons.id,
+            trailId: lessons.trailId,
+            title: lessons.title,
+            content: lessons.content,
+            position: lessons.position
+        });
+
+        res.status(201).json(aula);
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const listTrails = async (_req: Request, res: Response, next: NextFunction) => {
+    try {
+        const lista = await db
+            .select({
+                id: trails.id,
+                name: trails.name,
+                trailLevel: trails.trailLevel,
+                description: trails.description,
+                totalLessons: count(lessons.id)
+            })
+            .from(trails)
+            .leftJoin(lessons, eq(lessons.trailId, trails.id))
+            .groupBy(trails.id);
+
+        res.json(lista);
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const getTrail = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const trailId = String(req.params.id);
+
+        const [trilha] = await db.select().from(trails).where(eq(trails.id, trailId));
+        if (!trilha) {
+            return res.status(404).json({ erro: "Trilha não encontrada" });
+        }
+
+        const aulas = await db
+            .select({
+                id: lessons.id,
+                title: lessons.title,
+                content: lessons.content,
+                position: lessons.position
+            })
+            .from(lessons)
+            .where(eq(lessons.trailId, trailId))
+            .orderBy(asc(lessons.position));
+
+        res.json({ ...trilha, lessons: aulas });
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const getMyTrails = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const userId = req.userId;
+        if (!userId) {
+            return res.status(401).json({ erro: "Não autenticado" });
+        }
+
+        // Total de aulas por trilha
+        const totais = await db
+            .select({ trailId: lessons.trailId, total: count(lessons.id) })
+            .from(lessons)
+            .groupBy(lessons.trailId);
+        const totalPorTrilha = new Map(totais.map((t) => [t.trailId, Number(t.total)]));
+
+        // Aulas concluídas pelo usuário, agrupadas por trilha
+        const feitas = await db
+            .select({ trailId: lessons.trailId, feitas: count(lessonProgress.id) })
+            .from(lessonProgress)
+            .innerJoin(lessons, eq(lessons.id, lessonProgress.lessonId))
+            .where(eq(lessonProgress.userId, userId))
+            .groupBy(lessons.trailId);
+
+        if (feitas.length === 0) {
+            return res.json([]);
+        }
+
+        // Busca os dados das trilhas que o usuário começou
+        const todasTrilhas = await db.select().from(trails);
+        const trilhaPorId = new Map(todasTrilhas.map((t) => [t.id, t]));
+
+        const resultado = feitas
+            .filter((f) => trilhaPorId.has(f.trailId))
+            .map((f) => {
+                const trilha = trilhaPorId.get(f.trailId)!;
+                const total = totalPorTrilha.get(f.trailId) ?? 0;
+                const concluidas = Number(f.feitas);
+                const pct = total > 0 ? Math.round((concluidas / total) * 100) : 0;
+                return {
+                    id: trilha.id,
+                    name: trilha.name,
+                    trailLevel: trilha.trailLevel,
+                    description: trilha.description,
+                    totalLessons: total,
+                    completedLessons: concluidas,
+                    progress: pct
+                };
+            });
+
+        res.json(resultado);
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const completeLesson = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const userId = req.userId;
+        if (!userId) {
+            return res.status(401).json({ erro: "Não autenticado" });
+        }
+        const lessonId = String(req.params.id);
+
+        const [aula] = await db.select({ id: lessons.id }).from(lessons).where(eq(lessons.id, lessonId));
+        if (!aula) {
+            return res.status(404).json({ erro: "Aula não encontrada" });
+        }
+
+        // Já concluída? (idempotência: não duplica, respeita o unique user+lesson)
+        const [existente] = await db
+            .select({ id: lessonProgress.id })
+            .from(lessonProgress)
+            .where(and(eq(lessonProgress.userId, userId), eq(lessonProgress.lessonId, lessonId)));
+
+        if (existente) {
+            return res.status(200).json({ mensagem: "Aula já concluída" });
+        }
+
+        await db.insert(lessonProgress).values({ userId, lessonId });
+
+        res.status(201).json({ mensagem: "Aula concluída" });
+    } catch (err) {
+        next(err);
+    }
+};

--- a/backend/src/routes/trail.routes.ts
+++ b/backend/src/routes/trail.routes.ts
@@ -1,0 +1,24 @@
+import { Router } from "express";
+import { autenticar, exigirAdmin } from "../middlewares/auth.ts";
+import {
+    createTrail,
+    createLesson,
+    listTrails,
+    getTrail,
+    getMyTrails,
+    completeLesson,
+} from "../controllers/TrailController.ts";
+
+const router = Router();
+
+// Catálogo (admin cria, qualquer logado lê)
+router.post("/trails", autenticar, exigirAdmin, createTrail);
+router.post("/trails/:id/lessons", autenticar, exigirAdmin, createLesson);
+router.get("/trails", autenticar, listTrails);
+router.get("/trails/:id", autenticar, getTrail);
+
+// Progresso do aluno
+router.get("/me/trails", autenticar, getMyTrails);
+router.post("/lessons/:id/complete", autenticar, completeLesson);
+
+export default router;

--- a/backend/src/schemas/trail.schemas.ts
+++ b/backend/src/schemas/trail.schemas.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const createTrailSchema = z.object({
+    name: z.string().min(2, "Nome deve ter ao menos 2 caracteres"),
+    level: z.enum(["iniciante", "intermediario", "avancado"]),
+    description: z.string().min(10, "A descrição deve ter ao menos 10 caracteres"),
+});
+
+export const createLessonSchema = z.object({
+    title: z.string().min(3, "Título deve ter ao menos 3 caracteres"),
+    content: z.string().optional(),
+    position: z.int().positive("A posição deve ser um número positivo")
+});

--- a/backend/tests/helpers/db.ts
+++ b/backend/tests/helpers/db.ts
@@ -3,6 +3,9 @@ import { sql } from "drizzle-orm";
 
 /** Limpa as tabelas entre os testes, mantendo o schema. */
 export async function limparBanco() {
-    // TRUNCATE com CASCADE remove tokens (FK) junto; RESTART IDENTITY zera sequências.
-    await db.execute(sql`TRUNCATE TABLE tokens, users RESTART IDENTITY CASCADE`);
+    // CASCADE remove dependentes por FK; lista trails/lessons explicitamente
+    // porque elas nao referenciam users e nao cairiam no cascade.
+    await db.execute(
+        sql`TRUNCATE TABLE lessons_progress, lessons, trails, tokens, users RESTART IDENTITY CASCADE`,
+    );
 }

--- a/backend/tests/trail.test.ts
+++ b/backend/tests/trail.test.ts
@@ -1,0 +1,189 @@
+import { test, describe, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { startTestServer } from "./helpers/server.ts";
+import { limparBanco } from "./helpers/db.ts";
+
+let server: Awaited<ReturnType<typeof startTestServer>>;
+
+const novoUsuario = (over: Record<string, unknown> = {}) => ({
+    name: "Aluno Teste",
+    email: `aluno_${Math.round(performance.now() * 1000)}@email.com`,
+    password: "senhaforte123",
+    birthDate: "1990-01-01",
+    gender: "outro",
+    phone: "11999998888",
+    ...over,
+});
+
+async function ajustarUsuario(email: string, campos: Record<string, unknown>) {
+    const { db } = await import("../db.ts");
+    const { users } = await import("../schema.ts");
+    const { eq } = await import("drizzle-orm");
+    await db.update(users).set(campos).where(eq(users.email, email));
+}
+
+async function criarUsuarioLogado(over: Record<string, unknown> = {}, admin = false) {
+    const dados = novoUsuario(over);
+    await server.request("POST", "/register", { body: dados });
+    await ajustarUsuario(dados.email, { emailVerifiedAt: new Date(), ...(admin ? { role: "admin" } : {}) });
+    const login = await server.request("POST", "/login", {
+        body: { email: dados.email, password: dados.password },
+    });
+    return { email: dados.email, token: login.body.token };
+}
+
+function auth(token: string) {
+    return { Authorization: `Bearer ${token}` };
+}
+
+async function get(path: string, token: string) {
+    const res = await fetch(`${server.base}${path}`, { headers: auth(token) });
+    return { status: res.status, body: await res.json().catch(() => null) };
+}
+
+async function post(path: string, token: string, body?: unknown) {
+    const res = await fetch(`${server.base}${path}`, {
+        method: "POST",
+        headers: { ...auth(token), "Content-Type": "application/json" },
+        body: body ? JSON.stringify(body) : undefined,
+    });
+    return { status: res.status, body: await res.json().catch(() => null) };
+}
+
+async function criarTrilhaComAulas(adminToken: string, qtdAulas = 2) {
+    const trilha = await post("/trails", adminToken, {
+        name: "Logica de Programacao",
+        level: "iniciante",
+        description: "A base de qualquer linguagem de programacao.",
+    });
+    const lessonIds: string[] = [];
+    for (let i = 1; i <= qtdAulas; i++) {
+        const aula = await post(`/trails/${trilha.body.id}/lessons`, adminToken, {
+            title: `Aula ${i}`,
+            position: i,
+        });
+        lessonIds.push(aula.body.id);
+    }
+    return { trailId: trilha.body.id as string, lessonIds };
+}
+
+before(async () => { server = await startTestServer(); });
+after(async () => { await server.close(); });
+beforeEach(async () => { await limparBanco(); });
+
+describe("POST /trails", () => {
+    test("admin cria trilha (201)", async () => {
+        const { token } = await criarUsuarioLogado({}, true);
+        const res = await post("/trails", token, {
+            name: "Logica de Programacao",
+            level: "iniciante",
+            description: "A base de qualquer linguagem de programacao.",
+        });
+        assert.equal(res.status, 201);
+        assert.ok(res.body.id);
+    });
+
+    test("usuario comum recebe 403", async () => {
+        const { token } = await criarUsuarioLogado();
+        const res = await post("/trails", token, {
+            name: "Logica de Programacao",
+            level: "iniciante",
+            description: "A base de qualquer linguagem de programacao.",
+        });
+        assert.equal(res.status, 403);
+    });
+
+    test("rejeita nivel invalido (400)", async () => {
+        const { token } = await criarUsuarioLogado({}, true);
+        const res = await post("/trails", token, {
+            name: "Trilha X",
+            level: "expert",
+            description: "Descricao valida com mais de dez caracteres.",
+        });
+        assert.equal(res.status, 400);
+    });
+});
+
+describe("POST /trails/:id/lessons", () => {
+    test("admin cria aula numa trilha (201)", async () => {
+        const { token } = await criarUsuarioLogado({}, true);
+        const trilha = await post("/trails", token, {
+            name: "Trilha",
+            level: "iniciante",
+            description: "Descricao valida com mais de dez caracteres.",
+        });
+        const res = await post(`/trails/${trilha.body.id}/lessons`, token, {
+            title: "Variaveis",
+            position: 1,
+        });
+        assert.equal(res.status, 201);
+        assert.equal(res.body.position, 1);
+    });
+
+    test("404 ao criar aula em trilha inexistente", async () => {
+        const { token } = await criarUsuarioLogado({}, true);
+        const idFalso = "00000000-0000-0000-0000-000000000000";
+        const res = await post(`/trails/${idFalso}/lessons`, token, {
+            title: "Variaveis",
+            position: 1,
+        });
+        assert.equal(res.status, 404);
+    });
+});
+
+describe("GET /trails", () => {
+    test("lista o catalogo com o total de aulas", async () => {
+        const admin = await criarUsuarioLogado({}, true);
+        await criarTrilhaComAulas(admin.token, 3);
+
+        const aluno = await criarUsuarioLogado();
+        const res = await get("/trails", aluno.token);
+        assert.equal(res.status, 200);
+        assert.equal(res.body.length, 1);
+        assert.equal(res.body[0].totalLessons, 3);
+    });
+});
+
+describe("POST /lessons/:id/complete e GET /me/trails", () => {
+    test("marcar aula reflete no progresso (1 de 2 = 50%)", async () => {
+        const admin = await criarUsuarioLogado({}, true);
+        const { lessonIds } = await criarTrilhaComAulas(admin.token, 2);
+        const aluno = await criarUsuarioLogado();
+
+        const c = await post(`/lessons/${lessonIds[0]}/complete`, aluno.token);
+        assert.equal(c.status, 201);
+
+        const prog = await get("/me/trails", aluno.token);
+        assert.equal(prog.status, 200);
+        assert.equal(prog.body.length, 1);
+        assert.equal(prog.body[0].completedLessons, 1);
+        assert.equal(prog.body[0].progress, 50);
+    });
+
+    test("marcar a mesma aula duas vezes e idempotente", async () => {
+        const admin = await criarUsuarioLogado({}, true);
+        const { lessonIds } = await criarTrilhaComAulas(admin.token, 2);
+        const aluno = await criarUsuarioLogado();
+
+        const primeira = await post(`/lessons/${lessonIds[0]}/complete`, aluno.token);
+        const segunda = await post(`/lessons/${lessonIds[0]}/complete`, aluno.token);
+        assert.equal(primeira.status, 201);
+        assert.equal(segunda.status, 200);
+
+        const prog = await get("/me/trails", aluno.token);
+        assert.equal(prog.body[0].completedLessons, 1);
+    });
+
+    test("o progresso de um aluno nao aparece para outro", async () => {
+        const admin = await criarUsuarioLogado({}, true);
+        const { lessonIds } = await criarTrilhaComAulas(admin.token, 2);
+
+        const alunoA = await criarUsuarioLogado();
+        await post(`/lessons/${lessonIds[0]}/complete`, alunoA.token);
+
+        const alunoB = await criarUsuarioLogado();
+        const progB = await get("/me/trails", alunoB.token);
+        assert.equal(progB.status, 200);
+        assert.deepEqual(progB.body, []);
+    });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { AuthProvider, useAuth } from "./contexts/AuthContext";
 import { Login } from "./pages/Login";
 import { Register } from "./pages/Register";
 import { Home } from './pages/Home';
+import { Trilhas } from './pages/Trilhas';
 import { VerifyEmail } from './pages/VerifyEmail';
 import { Placeholder } from './pages/Placeholder';
 
@@ -34,7 +35,7 @@ function AppRoutes() {
         path="/trilhas"
         element={
           <PrivateRoute>
-            <Placeholder title="Trilhas" description="Em breve você poderá navegar por todas as trilhas de aprendizado aqui." />
+            <Trilhas />
           </PrivateRoute>
         } />
       <Route

--- a/frontend/src/components/Icons.tsx
+++ b/frontend/src/components/Icons.tsx
@@ -65,6 +65,12 @@ export const Plus = ({ size = 12 }: IconProps) => (
   </svg>
 );
 
+export const ChevronRight = ({ size = 15 }: IconProps) => (
+  <svg {...base(size)} stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
+    <polyline points="9 6 15 12 9 18" />
+  </svg>
+);
+
 /* Capelo de formatura — símbolo da marca */
 export const GradCap = ({ size = 19 }: IconProps) => (
   <svg width={size} height={size} viewBox="0 0 32 32" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">

--- a/frontend/src/data/trails.ts
+++ b/frontend/src/data/trails.ts
@@ -1,0 +1,48 @@
+/* Dados de exemplo (mock) das trilhas. Trocar pela API quando os endpoints existirem. */
+
+export type TrailLevel = 'Iniciante' | 'Intermediário' | 'Avançado';
+
+export interface Trail {
+  name: string;
+  glyph: string;
+  hue: string;
+  level: TrailLevel;
+  lessons: number;
+  done: number;
+  desc: string;
+  tags: string[];
+}
+
+export interface ContinueTrail {
+  name: string;
+  next: string;
+  pct: number;
+  done: number;
+  total: number;
+}
+
+export const continuar: ContinueTrail = {
+  name: 'Lógica de Programação',
+  next: 'Estruturas de repetição: while e for',
+  pct: 75,
+  done: 18,
+  total: 24,
+};
+
+export const trilhaFilters = [
+  'Todas',
+  'Fundamentos',
+  'Linguagens',
+  'Algoritmos',
+  'Back-end',
+  'Entrevistas',
+];
+
+export const trilhasFull: Trail[] = [
+  { name: 'Lógica de Programação', glyph: '{}', hue: '#2D6BF5', level: 'Iniciante', lessons: 24, done: 18, desc: 'Variáveis, condicionais, laços e funções, a base de qualquer linguagem.', tags: ['Fundamentos', 'Lógica'] },
+  { name: 'JavaScript Essencial', glyph: 'JS', hue: '#E0A82E', level: 'Iniciante', lessons: 30, done: 27, desc: 'Sintaxe, arrays, objetos e manipulação do DOM na prática.', tags: ['Linguagem', 'Web'] },
+  { name: 'Estruturas de Dados', glyph: '[]', hue: '#2E9E6B', level: 'Intermediário', lessons: 20, done: 7, desc: 'Listas, pilhas, filas, árvores e tabelas hash explicadas com código.', tags: ['Algoritmos', 'CS'] },
+  { name: 'Algoritmos', glyph: 'fx', hue: '#D9536B', level: 'Avançado', lessons: 20, done: 2, desc: 'Busca, ordenação, recursão e complexidade Big-O do zero.', tags: ['Algoritmos', 'Entrevistas'] },
+  { name: 'Python para Iniciantes', glyph: 'Py', hue: '#5B8DEF', level: 'Iniciante', lessons: 26, done: 0, desc: 'Comece a programar com uma das linguagens mais amigáveis.', tags: ['Linguagem'] },
+  { name: 'SQL & Bancos de Dados', glyph: 'DB', hue: '#9B6CD6', level: 'Intermediário', lessons: 18, done: 0, desc: 'Modelagem, consultas e joins para guardar e buscar dados.', tags: ['Back-end', 'Dados'] },
+];

--- a/frontend/src/data/trails.ts
+++ b/frontend/src/data/trails.ts
@@ -1,5 +1,3 @@
-/* Dados de exemplo (mock) das trilhas. Trocar pela API quando os endpoints existirem. */
-
 export type TrailLevel = 'Iniciante' | 'Intermediário' | 'Avançado';
 
 export interface Trail {
@@ -13,22 +11,6 @@ export interface Trail {
   tags: string[];
 }
 
-export interface ContinueTrail {
-  name: string;
-  next: string;
-  pct: number;
-  done: number;
-  total: number;
-}
-
-export const continuar: ContinueTrail = {
-  name: 'Lógica de Programação',
-  next: 'Estruturas de repetição: while e for',
-  pct: 75,
-  done: 18,
-  total: 24,
-};
-
 export const trilhaFilters = [
   'Todas',
   'Fundamentos',
@@ -36,13 +18,4 @@ export const trilhaFilters = [
   'Algoritmos',
   'Back-end',
   'Entrevistas',
-];
-
-export const trilhasFull: Trail[] = [
-  { name: 'Lógica de Programação', glyph: '{}', hue: '#2D6BF5', level: 'Iniciante', lessons: 24, done: 18, desc: 'Variáveis, condicionais, laços e funções, a base de qualquer linguagem.', tags: ['Fundamentos', 'Lógica'] },
-  { name: 'JavaScript Essencial', glyph: 'JS', hue: '#E0A82E', level: 'Iniciante', lessons: 30, done: 27, desc: 'Sintaxe, arrays, objetos e manipulação do DOM na prática.', tags: ['Linguagem', 'Web'] },
-  { name: 'Estruturas de Dados', glyph: '[]', hue: '#2E9E6B', level: 'Intermediário', lessons: 20, done: 7, desc: 'Listas, pilhas, filas, árvores e tabelas hash explicadas com código.', tags: ['Algoritmos', 'CS'] },
-  { name: 'Algoritmos', glyph: 'fx', hue: '#D9536B', level: 'Avançado', lessons: 20, done: 2, desc: 'Busca, ordenação, recursão e complexidade Big-O do zero.', tags: ['Algoritmos', 'Entrevistas'] },
-  { name: 'Python para Iniciantes', glyph: 'Py', hue: '#5B8DEF', level: 'Iniciante', lessons: 26, done: 0, desc: 'Comece a programar com uma das linguagens mais amigáveis.', tags: ['Linguagem'] },
-  { name: 'SQL & Bancos de Dados', glyph: 'DB', hue: '#9B6CD6', level: 'Intermediário', lessons: 18, done: 0, desc: 'Modelagem, consultas e joins para guardar e buscar dados.', tags: ['Back-end', 'Dados'] },
 ];

--- a/frontend/src/pages/Trilhas/index.tsx
+++ b/frontend/src/pages/Trilhas/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { useTheme } from '../../contexts/ThemeContext';
@@ -7,12 +8,10 @@ import { ThemeToggle } from '../../components/ThemeToggle';
 import { Flame, Search, Play, ChevronRight } from '../../components/Icons';
 import { getInitials } from '../../utils/initials';
 import { user } from '../../data/home';
-import {
-  trilhasFull,
-  trilhaFilters,
-  continuar,
-  type TrailLevel,
-} from '../../data/trails';
+import { trilhaFilters, type Trail, type TrailLevel } from '../../data/trails';
+import { listarTrilhas, listarMinhasTrilhas } from '../../services/trails';
+
+type TrailComId = Trail & { id: string };
 
 const NAV = [
   { label: 'Início', to: '/home' },
@@ -54,6 +53,37 @@ export function Trilhas() {
 
   const displayName = authUser?.name ?? user.name;
   const initials = getInitials(displayName);
+
+  const [trilhas, setTrilhas] = useState<TrailComId[]>([]);
+  const [minhas, setMinhas] = useState<TrailComId[]>([]);
+  const [carregando, setCarregando] = useState(true);
+  const [erro, setErro] = useState('');
+
+  useEffect(() => {
+    async function carregar() {
+      try {
+        const [todas, doUsuario] = await Promise.all([
+          listarTrilhas(),
+          listarMinhasTrilhas(),
+        ]);
+        setTrilhas(todas);
+        setMinhas(doUsuario);
+      } catch {
+        setErro('Não foi possível carregar as trilhas.');
+      } finally {
+        setCarregando(false);
+      }
+    }
+    carregar();
+  }, []);
+
+  // Card de destaque: a trilha em andamento mais avançada (mas nao concluida).
+  const continuar = minhas
+    .filter((t) => t.done > 0 && t.done < t.lessons)
+    .sort((a, b) => b.done / b.lessons - a.done / a.lessons)[0];
+
+  const aulasConcluidas = minhas.reduce((soma, t) => soma + t.done, 0);
+  const emAndamento = minhas.filter((t) => t.done < t.lessons).length;
 
   return (
     <div className="home-shell">
@@ -100,36 +130,38 @@ export function Trilhas() {
               </p>
             </div>
             <div className="trilhas-page__stats">
-              <Metric value="3" label="em andamento" />
+              <Metric value={String(emAndamento)} label="em andamento" />
               <span className="trilhas-page__divider" />
-              <Metric value="54" label="aulas concluídas" />
+              <Metric value={String(aulasConcluidas)} label="aulas concluídas" />
               <span className="trilhas-page__divider" />
-              <Metric value="2.640" label="XP em trilhas" accent />
+              <Metric value={String(aulasConcluidas * 50)} label="XP em trilhas" accent />
             </div>
           </div>
 
           {/* Continuar (destaque) */}
-          <div className="continue-card">
-            <span className="continue-card__glow" />
-            <div className="continue-card__body">
-              <div className="continue-card__kicker">Continuar de onde parou</div>
-              <h2 className="continue-card__title">{continuar.name}</h2>
-              <p className="continue-card__next">
-                Próxima aula · <b>{continuar.next}</b>
-              </p>
-              <div className="continue-card__progress">
-                <div className="continue-card__track">
-                  <span style={{ width: `${continuar.pct}%` }} />
+          {continuar && (
+            <div className="continue-card">
+              <span className="continue-card__glow" />
+              <div className="continue-card__body">
+                <div className="continue-card__kicker">Continuar de onde parou</div>
+                <h2 className="continue-card__title">{continuar.name}</h2>
+                <p className="continue-card__next">
+                  {continuar.done} de {continuar.lessons} aulas concluídas
+                </p>
+                <div className="continue-card__progress">
+                  <div className="continue-card__track">
+                    <span style={{ width: `${Math.round((continuar.done / continuar.lessons) * 100)}%` }} />
+                  </div>
+                  <span className="continue-card__pct">
+                    {Math.round((continuar.done / continuar.lessons) * 100)}% · {continuar.done}/{continuar.lessons}
+                  </span>
                 </div>
-                <span className="continue-card__pct">
-                  {continuar.pct}% · {continuar.done}/{continuar.total}
-                </span>
               </div>
+              <button className="continue-card__btn">
+                <Play size={13} /> Continuar aula
+              </button>
             </div>
-            <button className="continue-card__btn">
-              <Play size={13} /> Continuar aula
-            </button>
-          </div>
+          )}
 
           {/* Filtros */}
           <div className="filters">
@@ -139,18 +171,27 @@ export function Trilhas() {
               </button>
             ))}
             <div className="topbar__spacer" />
-            <span className="filters__count">{trilhasFull.length} trilhas</span>
+            <span className="filters__count">{trilhas.length} trilhas</span>
           </div>
+
+          {carregando && <p className="track__desc">Carregando trilhas...</p>}
+          {erro && <div className="auth__alert">{erro}</div>}
+          {!carregando && !erro && trilhas.length === 0 && (
+            <p className="track__desc">Nenhuma trilha disponível ainda.</p>
+          )}
 
           {/* Grade */}
           <div className="track-grid">
-            {trilhasFull.map((t) => {
-              const pct = Math.round((t.done / t.lessons) * 100);
+            {trilhas.map((catalogo) => {
+              // Cruza o catalogo com o progresso do usuario (done vem de /me/trails).
+              const progresso = minhas.find((m) => m.id === catalogo.id);
+              const t = { ...catalogo, done: progresso?.done ?? 0 };
+              const pct = t.lessons > 0 ? Math.round((t.done / t.lessons) * 100) : 0;
               const started = t.done > 0;
               const completed = t.done >= t.lessons;
               const lv = tint[t.level];
               return (
-                <div key={t.name} className="track">
+                <div key={t.id} className="track">
                   <div className="track__head">
                     <span
                       className="track__icon"

--- a/frontend/src/pages/Trilhas/index.tsx
+++ b/frontend/src/pages/Trilhas/index.tsx
@@ -1,0 +1,210 @@
+import { Link } from 'react-router-dom';
+import { useAuth } from '../../contexts/AuthContext';
+import { useTheme } from '../../contexts/ThemeContext';
+import { Logo } from '../../components/Logo';
+import { UserMenu } from '../../components/UserMenu';
+import { ThemeToggle } from '../../components/ThemeToggle';
+import { Flame, Search, Play, ChevronRight } from '../../components/Icons';
+import { getInitials } from '../../utils/initials';
+import { user } from '../../data/home';
+import {
+  trilhasFull,
+  trilhaFilters,
+  continuar,
+  type TrailLevel,
+} from '../../data/trails';
+
+const NAV = [
+  { label: 'Início', to: '/home' },
+  { label: 'Trilhas', to: '/trilhas' },
+  { label: 'Ranking', to: '/ranking' },
+  { label: 'Comunidade', to: '/comunidade' },
+];
+
+type Tint = { fg: string; bg: string };
+
+const LEVEL_TINT: Record<'light' | 'dark', Record<TrailLevel, Tint>> = {
+  light: {
+    Iniciante: { fg: '#1C8F5A', bg: '#E5F1EA' },
+    'Intermediário': { fg: '#B7791F', bg: '#FBF0D8' },
+    'Avançado': { fg: '#C2410C', bg: '#FBE6D8' },
+  },
+  dark: {
+    Iniciante: { fg: '#46D58F', bg: '#15271E' },
+    'Intermediário': { fg: '#E0A82E', bg: '#2A2310' },
+    'Avançado': { fg: '#F08A5D', bg: '#2A1810' },
+  },
+};
+
+function Metric({ value, label, accent }: { value: string; label: string; accent?: boolean }) {
+  return (
+    <div className="metric">
+      <div className="metric__value" style={accent ? { color: 'var(--accent)' } : undefined}>
+        {value}
+      </div>
+      <div className="metric__label">{label}</div>
+    </div>
+  );
+}
+
+export function Trilhas() {
+  const { user: authUser } = useAuth();
+  const { theme } = useTheme();
+  const tint = LEVEL_TINT[theme] ?? LEVEL_TINT.light;
+
+  const displayName = authUser?.name ?? user.name;
+  const initials = getInitials(displayName);
+
+  return (
+    <div className="home-shell">
+      <div className="home">
+        {/* Topbar */}
+        <header className="topbar">
+          <Logo variant="solid" size={20} />
+          <nav className="nav">
+            {NAV.map((item) => (
+              <Link
+                key={item.to}
+                to={item.to}
+                className={`nav__item${item.label === 'Trilhas' ? ' nav__item--active' : ''}`}
+              >
+                {item.label}
+              </Link>
+            ))}
+          </nav>
+          <div className="topbar__spacer" />
+          <div className="searchbar">
+            <Search size={16} />
+            <span>Buscar trilha…</span>
+          </div>
+          <div className="streak-pill">
+            <Flame size={16} /> {user.streak}
+          </div>
+          <ThemeToggle inline />
+          <UserMenu
+            initials={initials}
+            level={user.level}
+            name={displayName}
+            email={authUser?.email}
+          />
+        </header>
+
+        <div className="trilhas-page">
+          {/* Título + stats */}
+          <div className="trilhas-page__head">
+            <div>
+              <h1 className="trilhas-page__title">Trilhas de aprendizado</h1>
+              <p className="trilhas-page__sub">
+                Aprenda passo a passo, da lógica aos algoritmos. Conclua aulas para
+                subir de nível e ganhar XP.
+              </p>
+            </div>
+            <div className="trilhas-page__stats">
+              <Metric value="3" label="em andamento" />
+              <span className="trilhas-page__divider" />
+              <Metric value="54" label="aulas concluídas" />
+              <span className="trilhas-page__divider" />
+              <Metric value="2.640" label="XP em trilhas" accent />
+            </div>
+          </div>
+
+          {/* Continuar (destaque) */}
+          <div className="continue-card">
+            <span className="continue-card__glow" />
+            <div className="continue-card__body">
+              <div className="continue-card__kicker">Continuar de onde parou</div>
+              <h2 className="continue-card__title">{continuar.name}</h2>
+              <p className="continue-card__next">
+                Próxima aula · <b>{continuar.next}</b>
+              </p>
+              <div className="continue-card__progress">
+                <div className="continue-card__track">
+                  <span style={{ width: `${continuar.pct}%` }} />
+                </div>
+                <span className="continue-card__pct">
+                  {continuar.pct}% · {continuar.done}/{continuar.total}
+                </span>
+              </div>
+            </div>
+            <button className="continue-card__btn">
+              <Play size={13} /> Continuar aula
+            </button>
+          </div>
+
+          {/* Filtros */}
+          <div className="filters">
+            {trilhaFilters.map((f, i) => (
+              <button key={f} className={`filter${i === 0 ? ' filter--active' : ''}`}>
+                {f}
+              </button>
+            ))}
+            <div className="topbar__spacer" />
+            <span className="filters__count">{trilhasFull.length} trilhas</span>
+          </div>
+
+          {/* Grade */}
+          <div className="track-grid">
+            {trilhasFull.map((t) => {
+              const pct = Math.round((t.done / t.lessons) * 100);
+              const started = t.done > 0;
+              const completed = t.done >= t.lessons;
+              const lv = tint[t.level];
+              return (
+                <div key={t.name} className="track">
+                  <div className="track__head">
+                    <span
+                      className="track__icon"
+                      style={{
+                        color: t.hue,
+                        background: `color-mix(in srgb, ${t.hue} 16%, transparent)`,
+                      }}
+                    >
+                      {t.glyph}
+                    </span>
+                    <div className="track__meta">
+                      <div className="track__name">{t.name}</div>
+                      <div className="track__row">
+                        <span className="track__level" style={{ color: lv.fg, background: lv.bg }}>
+                          {t.level}
+                        </span>
+                        <span className="track__lessons">{t.lessons} aulas</span>
+                      </div>
+                    </div>
+                  </div>
+                  <p className="track__desc">{t.desc}</p>
+                  <div className="progress">
+                    <div className="progress__track">
+                      <span
+                        className="progress__fill"
+                        style={{
+                          width: `${pct}%`,
+                          background: started ? 'var(--accent)' : 'var(--surface-2)',
+                        }}
+                      />
+                    </div>
+                    <span className="progress__pct">{pct}%</span>
+                  </div>
+                  <hr className="rule" />
+                  <div className="track__foot">
+                    <div className="track__tags">
+                      {t.tags.map((tag) => (
+                        <span key={tag} className="chip--outline">{tag}</span>
+                      ))}
+                    </div>
+                    <span
+                      className="track__cta"
+                      style={{ color: started ? 'var(--accent)' : 'var(--text)' }}
+                    >
+                      {completed ? 'Revisar' : started ? 'Continuar' : 'Começar'}{' '}
+                      <ChevronRight size={15} />
+                    </span>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/services/trails.ts
+++ b/frontend/src/services/trails.ts
@@ -1,0 +1,57 @@
+import api from './api';
+import type { Trail, TrailLevel } from '../data/trails';
+
+// Formato cru vindo do backend.
+interface TrailApi {
+  id: string;
+  name: string;
+  trailLevel: 'iniciante' | 'intermediario' | 'avancado';
+  description: string;
+  totalLessons: number;
+  completedLessons?: number;
+  progress?: number;
+}
+
+const LEVEL_LABEL: Record<TrailApi['trailLevel'], TrailLevel> = {
+  iniciante: 'Iniciante',
+  intermediario: 'Intermediário',
+  avancado: 'Avançado',
+};
+
+// Cor de destaque do card derivada do nível (o banco nao guarda cor).
+const LEVEL_HUE: Record<TrailLevel, string> = {
+  Iniciante: '#2D6BF5',
+  'Intermediário': '#2E9E6B',
+  'Avançado': '#D9536B',
+};
+
+function glyphDoNome(name: string): string {
+  const limpo = name.replace(/[^A-Za-zÀ-ú ]/g, '').trim();
+  const partes = limpo.split(/\s+/).slice(0, 2);
+  return partes.map((p) => p[0]?.toUpperCase() ?? '').join('') || '{}';
+}
+
+function adaptar(t: TrailApi): Trail & { id: string } {
+  const level = LEVEL_LABEL[t.trailLevel] ?? 'Iniciante';
+  return {
+    id: t.id,
+    name: t.name,
+    glyph: glyphDoNome(t.name),
+    hue: LEVEL_HUE[level],
+    level,
+    lessons: t.totalLessons,
+    done: t.completedLessons ?? 0,
+    desc: t.description,
+    tags: [level],
+  };
+}
+
+export async function listarTrilhas() {
+  const { data } = await api.get<TrailApi[]>('/trails');
+  return data.map(adaptar);
+}
+
+export async function listarMinhasTrilhas() {
+  const { data } = await api.get<TrailApi[]>('/me/trails');
+  return data.map(adaptar);
+}

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -285,3 +285,55 @@
   .challenge__code { width: auto; border-left: none; border-top: 1px solid var(--border); }
   .trilhas { grid-template-columns: 1fr; }
 }
+
+/* ===================== TRILHAS ===================== */
+.trilhas-page { padding: 32px 48px; max-width: 1180px; margin: 0 auto; }
+.trilhas-page__head { display: flex; align-items: flex-end; gap: 14px; margin-bottom: 20px; }
+.trilhas-page__title { margin: 0; font-size: 24px; font-weight: 700; letter-spacing: -.02em; }
+.trilhas-page__sub { margin: 4px 0 0; font-size: 14px; color: var(--muted); max-width: 560px; }
+.trilhas-page__stats { display: flex; align-items: center; gap: 18px; margin-left: auto; }
+.trilhas-page__divider { width: 1px; align-self: stretch; background: var(--border); }
+.metric { text-align: right; }
+.metric__value { font-size: 20px; font-weight: 700; line-height: 1; }
+.metric__label { font-size: 12px; color: var(--muted); margin-top: 4px; }
+
+.continue-card { position: relative; overflow: hidden; display: flex; align-items: center; gap: 26px; border-radius: var(--r-2xl); padding: 26px 28px; margin-bottom: 24px; color: #fff; background: linear-gradient(150deg, var(--accent), color-mix(in srgb, var(--accent) 46%, #0A1430)); }
+.continue-card__glow { position: absolute; width: 320px; height: 320px; border-radius: 50%; top: -140px; right: -60px; background: radial-gradient(circle, rgba(255,255,255,.14), transparent 70%); pointer-events: none; }
+.continue-card__body { position: relative; flex: 1; min-width: 0; }
+.continue-card__kicker { font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: .08em; color: rgba(255,255,255,.8); line-height: 1; white-space: nowrap; }
+.continue-card__kicker::before { content: ''; display: inline-block; vertical-align: middle; width: 7px; height: 7px; border-radius: 50%; background: #fff; margin-right: 9px; position: relative; top: -1px; }
+.continue-card__title { margin: 10px 0 0; font-size: 23px; font-weight: 700; letter-spacing: -.015em; }
+.continue-card__next { margin: 6px 0 0; font-size: 14px; color: rgba(255,255,255,.85); }
+.continue-card__next b { color: #fff; }
+.continue-card__progress { display: flex; align-items: center; gap: 12px; margin-top: 18px; max-width: 430px; }
+.continue-card__track { flex: 1; height: 8px; border-radius: 99px; background: rgba(255,255,255,.25); overflow: hidden; }
+.continue-card__track span { display: block; height: 100%; border-radius: 99px; background: #fff; }
+.continue-card__pct { font-size: 13px; font-weight: 700; white-space: nowrap; }
+.continue-card__btn { position: relative; display: flex; align-items: center; gap: 9px; height: 50px; padding: 0 24px; border: none; border-radius: 13px; background: #fff; color: var(--accent); font-family: inherit; font-weight: 700; font-size: 15px; cursor: pointer; flex-shrink: 0; }
+
+.filters { display: flex; align-items: center; gap: 9px; margin-bottom: 18px; flex-wrap: wrap; }
+.filter { height: 34px; padding: 0 15px; border-radius: 99px; font-size: 13.5px; font-weight: 500; cursor: pointer; color: var(--muted); background: var(--surface); border: 1px solid var(--border); }
+.filter--active { color: #fff; font-weight: 600; background: var(--accent); border-color: var(--accent); }
+.filters__count { font-size: 13px; color: var(--muted); }
+
+.track-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
+.track { display: flex; flex-direction: column; background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-xl); padding: 18px; }
+.track__head { display: flex; align-items: center; gap: 12px; }
+.track__icon { width: 46px; height: 46px; border-radius: var(--r-lg); flex-shrink: 0; display: flex; align-items: center; justify-content: center; font-family: var(--font-code); font-weight: 700; font-size: 16px; }
+.track__meta { min-width: 0; flex: 1; }
+.track__name { font-size: 15.5px; font-weight: 600; letter-spacing: -.01em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.track__row { display: flex; align-items: center; gap: 7px; margin-top: 3px; }
+.track__level { font-size: 12px; font-weight: 700; padding: 2px 8px; border-radius: 6px; }
+.track__lessons { font-size: 12.5px; color: var(--muted); }
+.track__desc { margin: 13px 0 0; font-size: 13px; line-height: 1.5; color: var(--muted); min-height: 39px; }
+.track__foot { display: flex; align-items: center; gap: 8px; }
+.track__tags { display: flex; gap: 6px; }
+.track__cta { display: inline-flex; align-items: center; gap: 6px; margin-left: auto; font-size: 13.5px; font-weight: 600; cursor: pointer; }
+
+@media (max-width: 900px) {
+  .trilhas-page { padding: 24px; }
+  .trilhas-page__head { flex-direction: column; align-items: flex-start; }
+  .trilhas-page__stats { margin-left: 0; }
+  .continue-card { flex-direction: column; align-items: flex-start; gap: 18px; }
+  .track-grid { grid-template-columns: 1fr; }
+}


### PR DESCRIPTION
## Visão geral

Primeira fase das trilhas de aprendizado: catalogo de trilhas e aulas criado por admin, progresso por aluno e a tela que consome tudo isso.

## Backend

- Tabelas trails, lessons e lessons_progress (migration 0005), com unique em (user_id, lesson_id) para o progresso ser idempotente
- Admin cria trilhas e aulas; qualquer usuario logado le o catalogo
- GET /trails lista o catalogo com o total de aulas
- GET /trails/:id retorna a trilha com as aulas em ordem
- GET /me/trails calcula o progresso por trilha a partir das aulas concluidas
- POST /lessons/:id/complete marca conclusao sem duplicar
- Progresso isolado por usuario: um aluno nao ve o do outro
- Testes de integracao cobrindo criacao, RBAC, contagem, progresso, idempotencia e isolamento

## Frontend

- Tela de trilhas com card de continuar, filtros e a grade de trilhas com nivel, progresso e tags
- Servico que busca o catalogo e o progresso e adapta o formato da API para a tela
- Estados de carregando, erro e vazio
- Cor e sigla de cada trilha derivadas no front, ja que nao sao guardadas no banco

## Decisoes

- O catalogo e compartilhado por todos; o que e privado e o progresso de cada aluno
- Inscricao e derivada do progresso, sem tabela de inscricao
- Os filtros da tela ainda sao estaticos; serao ligados a uma busca real depois

## Como testar

Backend: cd backend e bash tests/run-integration.sh
Fluxo: logar como admin, criar uma trilha e aulas, depois logar como aluno, concluir uma aula e ver o progresso na tela de trilhas.