### PR TITLE
Aulas: modulos, quiz e tela de aula

### DIFF
--- a/backend/drizzle/0006_conscious_cobalt_man.sql
+++ b/backend/drizzle/0006_conscious_cobalt_man.sql
@@ -1,0 +1,42 @@
+CREATE TABLE "modules" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"trail_id" uuid NOT NULL,
+	"title" varchar(255) NOT NULL,
+	"position" integer NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "question_answers" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"question_id" uuid NOT NULL,
+	"selected_option_id" uuid NOT NULL,
+	"is_correct" boolean NOT NULL,
+	"answered_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "question_answers_user_id_question_id_unique" UNIQUE("user_id","question_id")
+);
+--> statement-breakpoint
+CREATE TABLE "question_options" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"question_id" uuid NOT NULL,
+	"text" text NOT NULL,
+	"is_correct" boolean DEFAULT false NOT NULL,
+	"position" integer NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "questions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"lesson_id" uuid NOT NULL,
+	"statement" text NOT NULL,
+	"position" integer NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "lessons" ADD COLUMN "module_id" uuid NOT NULL;--> statement-breakpoint
+ALTER TABLE "modules" ADD CONSTRAINT "modules_trail_id_trails_id_fk" FOREIGN KEY ("trail_id") REFERENCES "public"."trails"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "question_answers" ADD CONSTRAINT "question_answers_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "question_answers" ADD CONSTRAINT "question_answers_question_id_questions_id_fk" FOREIGN KEY ("question_id") REFERENCES "public"."questions"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "question_answers" ADD CONSTRAINT "question_answers_selected_option_id_question_options_id_fk" FOREIGN KEY ("selected_option_id") REFERENCES "public"."question_options"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "question_options" ADD CONSTRAINT "question_options_question_id_questions_id_fk" FOREIGN KEY ("question_id") REFERENCES "public"."questions"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "questions" ADD CONSTRAINT "questions_lesson_id_lessons_id_fk" FOREIGN KEY ("lesson_id") REFERENCES "public"."lessons"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "lessons" ADD CONSTRAINT "lessons_module_id_modules_id_fk" FOREIGN KEY ("module_id") REFERENCES "public"."modules"("id") ON DELETE no action ON UPDATE no action;

--- a/backend/drizzle/0007_boring_elektra.sql
+++ b/backend/drizzle/0007_boring_elektra.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "lessons" ADD COLUMN "published" boolean DEFAULT false NOT NULL;

--- a/backend/drizzle/meta/0006_snapshot.json
+++ b/backend/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,698 @@
+{
+  "id": "60ae951f-b670-4b12-9da7-f47079537723",
+  "prevId": "3c600e26-28dc-4880-b90e-b4c6e7a23cbd",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.lessons_progress": {
+      "name": "lessons_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_progress_user_id_users_id_fk": {
+          "name": "lessons_progress_user_id_users_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_progress_lesson_id_lessons_id_fk": {
+          "name": "lessons_progress_lesson_id_lessons_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lessons_progress_user_id_lesson_id_unique": {
+          "name": "lessons_progress_user_id_lesson_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "lesson_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons": {
+      "name": "lessons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_trail_id_trails_id_fk": {
+          "name": "lessons_trail_id_trails_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_module_id_modules_id_fk": {
+          "name": "lessons_module_id_modules_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "modules",
+          "columnsFrom": [
+            "module_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.modules": {
+      "name": "modules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "modules_trail_id_trails_id_fk": {
+          "name": "modules_trail_id_trails_id_fk",
+          "tableFrom": "modules",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_answers": {
+      "name": "question_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_option_id": {
+          "name": "selected_option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_answers_user_id_users_id_fk": {
+          "name": "question_answers_user_id_users_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_question_id_questions_id_fk": {
+          "name": "question_answers_question_id_questions_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_selected_option_id_question_options_id_fk": {
+          "name": "question_answers_selected_option_id_question_options_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "question_options",
+          "columnsFrom": [
+            "selected_option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "question_answers_user_id_question_id_unique": {
+          "name": "question_answers_user_id_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_options": {
+      "name": "question_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_options_question_id_questions_id_fk": {
+          "name": "question_options_question_id_questions_id_fk",
+          "tableFrom": "question_options",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_lesson_id_lessons_id_fk": {
+          "name": "questions_lesson_id_lessons_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tokens": {
+      "name": "tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'refresh'"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tokens_user_id_users_id_fk": {
+          "name": "tokens_user_id_users_id_fk",
+          "tableFrom": "tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tokens_token_hash_unique": {
+          "name": "tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trails": {
+      "name": "trails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "trail_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "failed_login_attempts": {
+          "name": "failed_login_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.trail_level": {
+      "name": "trail_level",
+      "schema": "public",
+      "values": [
+        "iniciante",
+        "intermediario",
+        "avancado"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin",
+        "moderator"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/0007_snapshot.json
+++ b/backend/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,705 @@
+{
+  "id": "9c84fca3-7114-42d7-a1eb-36cd71a06102",
+  "prevId": "60ae951f-b670-4b12-9da7-f47079537723",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.lessons_progress": {
+      "name": "lessons_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_progress_user_id_users_id_fk": {
+          "name": "lessons_progress_user_id_users_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_progress_lesson_id_lessons_id_fk": {
+          "name": "lessons_progress_lesson_id_lessons_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lessons_progress_user_id_lesson_id_unique": {
+          "name": "lessons_progress_user_id_lesson_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "lesson_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons": {
+      "name": "lessons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_trail_id_trails_id_fk": {
+          "name": "lessons_trail_id_trails_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_module_id_modules_id_fk": {
+          "name": "lessons_module_id_modules_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "modules",
+          "columnsFrom": [
+            "module_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.modules": {
+      "name": "modules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "modules_trail_id_trails_id_fk": {
+          "name": "modules_trail_id_trails_id_fk",
+          "tableFrom": "modules",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_answers": {
+      "name": "question_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_option_id": {
+          "name": "selected_option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_answers_user_id_users_id_fk": {
+          "name": "question_answers_user_id_users_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_question_id_questions_id_fk": {
+          "name": "question_answers_question_id_questions_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_selected_option_id_question_options_id_fk": {
+          "name": "question_answers_selected_option_id_question_options_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "question_options",
+          "columnsFrom": [
+            "selected_option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "question_answers_user_id_question_id_unique": {
+          "name": "question_answers_user_id_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_options": {
+      "name": "question_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_options_question_id_questions_id_fk": {
+          "name": "question_options_question_id_questions_id_fk",
+          "tableFrom": "question_options",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_lesson_id_lessons_id_fk": {
+          "name": "questions_lesson_id_lessons_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tokens": {
+      "name": "tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'refresh'"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tokens_user_id_users_id_fk": {
+          "name": "tokens_user_id_users_id_fk",
+          "tableFrom": "tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tokens_token_hash_unique": {
+          "name": "tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trails": {
+      "name": "trails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "trail_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "failed_login_attempts": {
+          "name": "failed_login_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.trail_level": {
+      "name": "trail_level",
+      "schema": "public",
+      "values": [
+        "iniciante",
+        "intermediario",
+        "avancado"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin",
+        "moderator"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -43,6 +43,20 @@
       "when": 1782513013653,
       "tag": "0005_lush_stone_men",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1782601133603,
+      "tag": "0006_conscious_cobalt_man",
+      "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1782601928764,
+      "tag": "0007_boring_elektra",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/schema.ts
+++ b/backend/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, uuid, varchar, date, timestamp, pgEnum, integer, text, unique } from "drizzle-orm/pg-core";
+import { pgTable, uuid, varchar, date, timestamp, pgEnum, integer, text, unique, boolean } from "drizzle-orm/pg-core";
 
 export const userRole = pgEnum("user_role", ["user", "admin", "moderator"]);
 export const trailLevel = pgEnum("trail_level", ["iniciante", "intermediario", "avancado"]);
@@ -36,12 +36,22 @@ export const trails = pgTable("trails", {
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull()
 });
 
-export const lessons = pgTable("lessons", {
+export const modules = pgTable("modules", {
     id: uuid("id").primaryKey().defaultRandom(),
     trailId: uuid("trail_id").references(() => trails.id).notNull(),
     title: varchar("title", { length: 255 }).notNull(),
+    position: integer("position").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull()
+});
+
+export const lessons = pgTable("lessons", {
+    id: uuid("id").primaryKey().defaultRandom(),
+    trailId: uuid("trail_id").references(() => trails.id).notNull(),
+    moduleId: uuid("module_id").references(() => modules.id).notNull(),
+    title: varchar("title", { length: 255 }).notNull(),
     content: text("content"),
     position: integer("position").notNull(),
+    published: boolean("published").default(false).notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull()
 });
 
@@ -52,4 +62,31 @@ export const lessonProgress = pgTable("lessons_progress", {
     completedAt: timestamp("completed_at", { withTimezone: true }).defaultNow().notNull()
 }, (table) => [
     unique().on(table.userId, table.lessonId),
+]);
+
+export const questions = pgTable("questions", {
+    id: uuid("id").primaryKey().defaultRandom(),
+    lessonId: uuid("lesson_id").references(() => lessons.id).notNull(),
+    statement: text("statement").notNull(),
+    position: integer("position").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull()
+});
+
+export const questionOptions = pgTable("question_options", {
+    id: uuid("id").primaryKey().defaultRandom(),
+    questionId: uuid("question_id").references(() => questions.id).notNull(),
+    text: text("text").notNull(),
+    isCorrect: boolean("is_correct").default(false).notNull(),
+    position: integer("position").notNull()
+});
+
+export const questionAnswers = pgTable("question_answers", {
+    id: uuid("id").primaryKey().defaultRandom(),
+    userId: uuid("user_id").references(() => users.id).notNull(),
+    questionId: uuid("question_id").references(() => questions.id).notNull(),
+    selectedOptionId: uuid("selected_option_id").references(() => questionOptions.id).notNull(),
+    isCorrect: boolean("is_correct").notNull(),
+    answeredAt: timestamp("answered_at", { withTimezone: true }).defaultNow().notNull()
+}, (table) => [
+    unique().on(table.userId, table.questionId),
 ]);

--- a/backend/src/controllers/TrailController.ts
+++ b/backend/src/controllers/TrailController.ts
@@ -1,26 +1,52 @@
 import type { Request, Response, NextFunction } from "express";
 import { db } from "../../db.ts";
-import { trails, lessons, lessonProgress } from "../../schema.ts";
-import { eq, and, count, asc } from "drizzle-orm";
-import { createTrailSchema, createLessonSchema } from "../schemas/trail.schemas.ts";
+import {
+    users, trails, modules, lessons, lessonProgress,
+    questions, questionOptions, questionAnswers,
+} from "../../schema.ts";
+import { eq, and, count, asc, inArray } from "drizzle-orm";
+import {
+    createTrailSchema, createModuleSchema, createLessonSchema,
+    createQuestionSchema, submitQuizSchema,
+} from "../schemas/trail.schemas.ts";
+
+const QUIZ_MIN_ACERTOS = 4;
+
+async function ehAdmin(userId: string): Promise<boolean> {
+    const [u] = await db.select({ role: users.role }).from(users).where(eq(users.id, userId));
+    return u?.role === "admin";
+}
 
 export const createTrail = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const dados = createTrailSchema.parse(req.body);
-
         const [trilha] = await db.insert(trails).values({
             name: dados.name,
             trailLevel: dados.level,
-            description: dados.description
-        }).returning({
-            id: trails.id,
-            name: trails.name,
-            trailLevel: trails.trailLevel,
-            description: trails.description,
-            createdAt: trails.createdAt
-        });
-
+            description: dados.description,
+        }).returning();
         res.status(201).json(trilha);
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const createModule = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const trailId = String(req.params.id);
+        const dados = createModuleSchema.parse(req.body);
+
+        const [trilha] = await db.select({ id: trails.id }).from(trails).where(eq(trails.id, trailId));
+        if (!trilha) {
+            return res.status(404).json({ erro: "Trilha não encontrada" });
+        }
+
+        const [modulo] = await db.insert(modules).values({
+            trailId,
+            title: dados.title,
+            position: dados.position,
+        }).returning();
+        res.status(201).json(modulo);
     } catch (err) {
         next(err);
     }
@@ -28,28 +54,57 @@ export const createTrail = async (req: Request, res: Response, next: NextFunctio
 
 export const createLesson = async (req: Request, res: Response, next: NextFunction) => {
     try {
-        const trailId = String(req.params.id);
+        const moduleId = String(req.params.id);
         const dados = createLessonSchema.parse(req.body);
 
-        const [trilha] = await db.select({ id: trails.id }).from(trails).where(eq(trails.id, trailId));
-        if (!trilha) {
-            return res.status(404).json({ erro: "Trilha não encontrada" });
+        const [modulo] = await db.select({ id: modules.id, trailId: modules.trailId })
+            .from(modules).where(eq(modules.id, moduleId));
+        if (!modulo) {
+            return res.status(404).json({ erro: "Módulo não encontrado" });
         }
 
         const [aula] = await db.insert(lessons).values({
-            trailId,
+            trailId: modulo.trailId,
+            moduleId,
             title: dados.title,
             content: dados.content,
-            position: dados.position
-        }).returning({
-            id: lessons.id,
-            trailId: lessons.trailId,
-            title: lessons.title,
-            content: lessons.content,
-            position: lessons.position
+            position: dados.position,
+        }).returning();
+        res.status(201).json(aula);
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const createQuestion = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const lessonId = String(req.params.id);
+        const dados = createQuestionSchema.parse(req.body);
+
+        const [aula] = await db.select({ id: lessons.id }).from(lessons).where(eq(lessons.id, lessonId));
+        if (!aula) {
+            return res.status(404).json({ erro: "Aula não encontrada" });
+        }
+
+        const criada = await db.transaction(async (tx) => {
+            const [questao] = await tx.insert(questions).values({
+                lessonId,
+                statement: dados.statement,
+                position: dados.position,
+            }).returning();
+
+            await tx.insert(questionOptions).values(
+                dados.options.map((o, i) => ({
+                    questionId: questao.id,
+                    text: o.text,
+                    isCorrect: o.isCorrect,
+                    position: i + 1,
+                })),
+            );
+            return questao;
         });
 
-        res.status(201).json(aula);
+        res.status(201).json(criada);
     } catch (err) {
         next(err);
     }
@@ -63,39 +118,12 @@ export const listTrails = async (_req: Request, res: Response, next: NextFunctio
                 name: trails.name,
                 trailLevel: trails.trailLevel,
                 description: trails.description,
-                totalLessons: count(lessons.id)
+                totalLessons: count(lessons.id),
             })
             .from(trails)
             .leftJoin(lessons, eq(lessons.trailId, trails.id))
             .groupBy(trails.id);
-
         res.json(lista);
-    } catch (err) {
-        next(err);
-    }
-};
-
-export const getTrail = async (req: Request, res: Response, next: NextFunction) => {
-    try {
-        const trailId = String(req.params.id);
-
-        const [trilha] = await db.select().from(trails).where(eq(trails.id, trailId));
-        if (!trilha) {
-            return res.status(404).json({ erro: "Trilha não encontrada" });
-        }
-
-        const aulas = await db
-            .select({
-                id: lessons.id,
-                title: lessons.title,
-                content: lessons.content,
-                position: lessons.position
-            })
-            .from(lessons)
-            .where(eq(lessons.trailId, trailId))
-            .orderBy(asc(lessons.position));
-
-        res.json({ ...trilha, lessons: aulas });
     } catch (err) {
         next(err);
     }
@@ -108,14 +136,12 @@ export const getMyTrails = async (req: Request, res: Response, next: NextFunctio
             return res.status(401).json({ erro: "Não autenticado" });
         }
 
-        // Total de aulas por trilha
         const totais = await db
             .select({ trailId: lessons.trailId, total: count(lessons.id) })
             .from(lessons)
             .groupBy(lessons.trailId);
         const totalPorTrilha = new Map(totais.map((t) => [t.trailId, Number(t.total)]));
 
-        // Aulas concluídas pelo usuário, agrupadas por trilha
         const feitas = await db
             .select({ trailId: lessons.trailId, feitas: count(lessonProgress.id) })
             .from(lessonProgress)
@@ -127,7 +153,6 @@ export const getMyTrails = async (req: Request, res: Response, next: NextFunctio
             return res.json([]);
         }
 
-        // Busca os dados das trilhas que o usuário começou
         const todasTrilhas = await db.select().from(trails);
         const trilhaPorId = new Map(todasTrilhas.map((t) => [t.id, t]));
 
@@ -145,42 +170,246 @@ export const getMyTrails = async (req: Request, res: Response, next: NextFunctio
                     description: trilha.description,
                     totalLessons: total,
                     completedLessons: concluidas,
-                    progress: pct
+                    progress: pct,
                 };
             });
-
         res.json(resultado);
     } catch (err) {
         next(err);
     }
 };
 
-export const completeLesson = async (req: Request, res: Response, next: NextFunction) => {
+// Retorna a trilha com módulos e aulas, cada aula com estado para o usuário.
+// Estado sequencial na trilha toda: done | current | locked.
+export const getTrail = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const userId = req.userId;
-        if (!userId) {
-            return res.status(401).json({ erro: "Não autenticado" });
+        const trailId = String(req.params.id);
+
+        const [trilha] = await db.select().from(trails).where(eq(trails.id, trailId));
+        if (!trilha) {
+            return res.status(404).json({ erro: "Trilha não encontrada" });
         }
+
+        const admin = await ehAdmin(userId!);
+
+        const mods = await db.select().from(modules)
+            .where(eq(modules.trailId, trailId)).orderBy(asc(modules.position));
+
+        // Aluno vê só aulas publicadas; admin vê todas (para gerenciar).
+        const todasAulas = await db.select().from(lessons)
+            .where(eq(lessons.trailId, trailId)).orderBy(asc(lessons.position));
+        const aulas = admin ? todasAulas : todasAulas.filter((a) => a.published);
+
+        const concluidas = new Set(
+            (await db.select({ lessonId: lessonProgress.lessonId })
+                .from(lessonProgress)
+                .where(eq(lessonProgress.userId, userId!))
+            ).map((p) => p.lessonId),
+        );
+
+        // Ordem linear da trilha: por módulo (position) e, dentro, por aula (position).
+        const ordenadas = mods.flatMap((m) =>
+            aulas.filter((a) => a.moduleId === m.id).sort((a, b) => a.position - b.position),
+        );
+
+        const estadoPorAula = new Map<string, string>();
+        let achouCurrent = false;
+        for (const a of ordenadas) {
+            if (concluidas.has(a.id)) {
+                estadoPorAula.set(a.id, "done");
+            } else if (!achouCurrent) {
+                estadoPorAula.set(a.id, "current");
+                achouCurrent = true;
+            } else {
+                estadoPorAula.set(a.id, "locked");
+            }
+        }
+
+        const modulosComAulas = mods.map((m) => ({
+            id: m.id,
+            title: m.title,
+            position: m.position,
+            lessons: aulas
+                .filter((a) => a.moduleId === m.id)
+                .sort((a, b) => a.position - b.position)
+                .map((a) => ({
+                    id: a.id,
+                    title: a.title,
+                    position: a.position,
+                    published: a.published,
+                    state: estadoPorAula.get(a.id) ?? "locked",
+                })),
+        }));
+
+        res.json({ ...trilha, modules: modulosComAulas });
+    } catch (err) {
+        next(err);
+    }
+};
+
+// Calcula o estado (done/current/locked) de uma aula específica na trilha.
+async function estadoDaAula(userId: string, aula: typeof lessons.$inferSelect): Promise<string> {
+    // Só aulas publicadas entram na sequência (uma aula "em breve" não trava as próximas).
+    const irmas = await db.select({ id: lessons.id, moduleId: lessons.moduleId, position: lessons.position })
+        .from(lessons).where(and(eq(lessons.trailId, aula.trailId), eq(lessons.published, true)));
+    const mods = await db.select({ id: modules.id, position: modules.position })
+        .from(modules).where(eq(modules.trailId, aula.trailId));
+    const ordemModulo = new Map(mods.map((m) => [m.id, m.position]));
+
+    const ordenadas = [...irmas].sort((a, b) => {
+        const pm = (ordemModulo.get(a.moduleId) ?? 0) - (ordemModulo.get(b.moduleId) ?? 0);
+        return pm !== 0 ? pm : a.position - b.position;
+    });
+
+    const concluidas = new Set(
+        (await db.select({ lessonId: lessonProgress.lessonId })
+            .from(lessonProgress).where(eq(lessonProgress.userId, userId))
+        ).map((p) => p.lessonId),
+    );
+
+    let achouCurrent = false;
+    for (const a of ordenadas) {
+        if (concluidas.has(a.id)) {
+            if (a.id === aula.id) return "done";
+        } else if (!achouCurrent) {
+            achouCurrent = true;
+            if (a.id === aula.id) return "current";
+        } else if (a.id === aula.id) {
+            return "locked";
+        }
+    }
+    return "locked";
+}
+
+// Retorna a aula com conteúdo e questões SEM revelar a alternativa correta.
+export const getLesson = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const userId = req.userId!;
         const lessonId = String(req.params.id);
 
-        const [aula] = await db.select({ id: lessons.id }).from(lessons).where(eq(lessons.id, lessonId));
+        const [aula] = await db.select().from(lessons).where(eq(lessons.id, lessonId));
         if (!aula) {
             return res.status(404).json({ erro: "Aula não encontrada" });
         }
 
-        // Já concluída? (idempotência: não duplica, respeita o unique user+lesson)
-        const [existente] = await db
-            .select({ id: lessonProgress.id })
-            .from(lessonProgress)
-            .where(and(eq(lessonProgress.userId, userId), eq(lessonProgress.lessonId, lessonId)));
-
-        if (existente) {
-            return res.status(200).json({ mensagem: "Aula já concluída" });
+        // Aula não publicada é invisível para o aluno; admin pode visualizar.
+        if (!aula.published && !(await ehAdmin(userId))) {
+            return res.status(404).json({ erro: "Aula não encontrada" });
         }
 
-        await db.insert(lessonProgress).values({ userId, lessonId });
+        const estado = await estadoDaAula(userId, aula);
+        if (estado === "locked") {
+            return res.status(403).json({ erro: "Aula bloqueada. Conclua a aula anterior." });
+        }
 
-        res.status(201).json({ mensagem: "Aula concluída" });
+        const qs = await db.select().from(questions)
+            .where(eq(questions.lessonId, lessonId)).orderBy(asc(questions.position));
+        const qIds = qs.map((q) => q.id);
+        const opts = qIds.length
+            ? await db.select().from(questionOptions)
+                .where(inArray(questionOptions.questionId, qIds)).orderBy(asc(questionOptions.position))
+            : [];
+
+        const questoes = qs.map((q) => ({
+            id: q.id,
+            statement: q.statement,
+            position: q.position,
+            // isCorrect deliberadamente omitido: o gabarito nunca vai para o cliente.
+            options: opts
+                .filter((o) => o.questionId === q.id)
+                .map((o) => ({ id: o.id, text: o.text, position: o.position })),
+        }));
+
+        res.json({
+            id: aula.id,
+            trailId: aula.trailId,
+            moduleId: aula.moduleId,
+            title: aula.title,
+            content: aula.content,
+            state: estado,
+            questions: questoes,
+        });
+    } catch (err) {
+        next(err);
+    }
+};
+
+// Recebe as respostas, corrige no servidor e conclui a aula se acertar o mínimo.
+export const submitQuiz = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const userId = req.userId!;
+        const lessonId = String(req.params.id);
+        const dados = submitQuizSchema.parse(req.body);
+
+        const [aula] = await db.select().from(lessons).where(eq(lessons.id, lessonId));
+        if (!aula) {
+            return res.status(404).json({ erro: "Aula não encontrada" });
+        }
+
+        if (!aula.published) {
+            return res.status(404).json({ erro: "Aula não encontrada" });
+        }
+
+        const estado = await estadoDaAula(userId, aula);
+        if (estado === "locked") {
+            return res.status(403).json({ erro: "Aula bloqueada. Conclua a aula anterior." });
+        }
+
+        const qs = await db.select({ id: questions.id }).from(questions).where(eq(questions.lessonId, lessonId));
+        const qIds = qs.map((q) => q.id);
+        if (qIds.length === 0) {
+            return res.status(400).json({ erro: "Esta aula não tem questões" });
+        }
+
+        const opts = await db.select().from(questionOptions).where(inArray(questionOptions.questionId, qIds));
+        const corretaPorQuestao = new Map<string, string>();
+        for (const o of opts) {
+            if (o.isCorrect) corretaPorQuestao.set(o.questionId, o.id);
+        }
+
+        let acertos = 0;
+        for (const resp of dados.answers) {
+            if (corretaPorQuestao.get(resp.questionId) === resp.optionId) acertos++;
+        }
+        const total = qIds.length;
+        const passou = acertos >= QUIZ_MIN_ACERTOS;
+
+        let aulaConcluida = false;
+        if (passou) {
+            const [existe] = await db.select({ id: lessonProgress.id }).from(lessonProgress)
+                .where(and(eq(lessonProgress.userId, userId), eq(lessonProgress.lessonId, lessonId)));
+            if (!existe) {
+                await db.insert(lessonProgress).values({ userId, lessonId });
+            }
+            aulaConcluida = true;
+        }
+
+        res.json({ correct: acertos, total, passed: passou, lessonCompleted: aulaConcluida });
+    } catch (err) {
+        next(err);
+    }
+};
+
+// Publica ou despublica uma aula (admin). Body: { published: boolean }
+export const setLessonPublished = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const lessonId = String(req.params.id);
+        const { published } = req.body;
+        if (typeof published !== "boolean") {
+            return res.status(400).json({ erro: "Campo 'published' deve ser booleano" });
+        }
+
+        const [aula] = await db.update(lessons)
+            .set({ published })
+            .where(eq(lessons.id, lessonId))
+            .returning({ id: lessons.id, title: lessons.title, published: lessons.published });
+
+        if (!aula) {
+            return res.status(404).json({ erro: "Aula não encontrada" });
+        }
+
+        res.json(aula);
     } catch (err) {
         next(err);
     }

--- a/backend/src/routes/trail.routes.ts
+++ b/backend/src/routes/trail.routes.ts
@@ -2,23 +2,31 @@ import { Router } from "express";
 import { autenticar, exigirAdmin } from "../middlewares/auth.ts";
 import {
     createTrail,
+    createModule,
     createLesson,
+    createQuestion,
     listTrails,
     getTrail,
+    getLesson,
     getMyTrails,
-    completeLesson,
+    submitQuiz,
+    setLessonPublished,
 } from "../controllers/TrailController.ts";
 
 const router = Router();
 
 // Catálogo (admin cria, qualquer logado lê)
 router.post("/trails", autenticar, exigirAdmin, createTrail);
-router.post("/trails/:id/lessons", autenticar, exigirAdmin, createLesson);
+router.post("/trails/:id/modules", autenticar, exigirAdmin, createModule);
+router.post("/modules/:id/lessons", autenticar, exigirAdmin, createLesson);
+router.post("/lessons/:id/questions", autenticar, exigirAdmin, createQuestion);
+router.patch("/lessons/:id/published", autenticar, exigirAdmin, setLessonPublished);
 router.get("/trails", autenticar, listTrails);
 router.get("/trails/:id", autenticar, getTrail);
+router.get("/lessons/:id", autenticar, getLesson);
 
 // Progresso do aluno
 router.get("/me/trails", autenticar, getMyTrails);
-router.post("/lessons/:id/complete", autenticar, completeLesson);
+router.post("/lessons/:id/quiz", autenticar, submitQuiz);
 
 export default router;

--- a/backend/src/schemas/trail.schemas.ts
+++ b/backend/src/schemas/trail.schemas.ts
@@ -11,3 +11,32 @@ export const createLessonSchema = z.object({
     content: z.string().optional(),
     position: z.int().positive("A posição deve ser um número positivo")
 });
+
+export const createModuleSchema = z.object({
+    title: z.string().min(2, "Título deve ter ao menos 2 caracteres"),
+    position: z.int().positive("A posição deve ser um número positivo")
+});
+
+export const createQuestionSchema = z.object({
+    statement: z.string().min(3, "O enunciado deve ter ao menos 3 caracteres"),
+    position: z.int().positive("A posição deve ser um número positivo"),
+    options: z
+        .array(z.object({
+            text: z.string().min(1, "A alternativa não pode ser vazia"),
+            isCorrect: z.boolean()
+        }))
+        .min(2, "A questão precisa de ao menos 2 alternativas")
+        .refine(
+            (opts) => opts.filter((o) => o.isCorrect).length === 1,
+            "A questão precisa de exatamente uma alternativa correta"
+        )
+});
+
+export const submitQuizSchema = z.object({
+    answers: z
+        .array(z.object({
+            questionId: z.uuid("ID de questão inválido"),
+            optionId: z.uuid("ID de alternativa inválido")
+        }))
+        .min(1, "Envie ao menos uma resposta")
+});

--- a/backend/tests/auth.test.ts
+++ b/backend/tests/auth.test.ts
@@ -5,9 +5,10 @@ import { limparBanco } from "./helpers/db.ts";
 
 let server: Awaited<ReturnType<typeof startTestServer>>;
 
+let seq = 0;
 const novoUsuario = (over: Record<string, unknown> = {}) => ({
     name: "Maria Silva",
-    email: `maria_${Math.round(performance.now() * 1000)}@email.com`,
+    email: `maria_${++seq}_${Math.round(performance.now() * 1000)}@email.com`,
     password: "senhaforte123",
     birthDate: "1990-01-01",
     gender: "feminino",

--- a/backend/tests/helpers/db.ts
+++ b/backend/tests/helpers/db.ts
@@ -6,6 +6,6 @@ export async function limparBanco() {
     // CASCADE remove dependentes por FK; lista trails/lessons explicitamente
     // porque elas nao referenciam users e nao cairiam no cascade.
     await db.execute(
-        sql`TRUNCATE TABLE lessons_progress, lessons, trails, tokens, users RESTART IDENTITY CASCADE`,
+        sql`TRUNCATE TABLE question_answers, question_options, questions, lessons_progress, lessons, modules, trails, tokens, users RESTART IDENTITY CASCADE`,
     );
 }

--- a/backend/tests/trail.test.ts
+++ b/backend/tests/trail.test.ts
@@ -5,9 +5,11 @@ import { limparBanco } from "./helpers/db.ts";
 
 let server: Awaited<ReturnType<typeof startTestServer>>;
 
+// Contador incremental garante email único mesmo em criações no mesmo milissegundo.
+let seq = 0;
 const novoUsuario = (over: Record<string, unknown> = {}) => ({
     name: "Aluno Teste",
-    email: `aluno_${Math.round(performance.now() * 1000)}@email.com`,
+    email: `aluno_${++seq}_${Math.round(performance.now() * 1000)}@email.com`,
     password: "senhaforte123",
     birthDate: "1990-01-01",
     gender: "outro",
@@ -22,8 +24,8 @@ async function ajustarUsuario(email: string, campos: Record<string, unknown>) {
     await db.update(users).set(campos).where(eq(users.email, email));
 }
 
-async function criarUsuarioLogado(over: Record<string, unknown> = {}, admin = false) {
-    const dados = novoUsuario(over);
+async function criarUsuarioLogado(admin = false) {
+    const dados = novoUsuario();
     await server.request("POST", "/register", { body: dados });
     await ajustarUsuario(dados.email, { emailVerifiedAt: new Date(), ...(admin ? { role: "admin" } : {}) });
     const login = await server.request("POST", "/login", {
@@ -35,12 +37,10 @@ async function criarUsuarioLogado(over: Record<string, unknown> = {}, admin = fa
 function auth(token: string) {
     return { Authorization: `Bearer ${token}` };
 }
-
 async function get(path: string, token: string) {
     const res = await fetch(`${server.base}${path}`, { headers: auth(token) });
     return { status: res.status, body: await res.json().catch(() => null) };
 }
-
 async function post(path: string, token: string, body?: unknown) {
     const res = await fetch(`${server.base}${path}`, {
         method: "POST",
@@ -49,141 +49,183 @@ async function post(path: string, token: string, body?: unknown) {
     });
     return { status: res.status, body: await res.json().catch(() => null) };
 }
-
-async function criarTrilhaComAulas(adminToken: string, qtdAulas = 2) {
-    const trilha = await post("/trails", adminToken, {
-        name: "Logica de Programacao",
-        level: "iniciante",
-        description: "A base de qualquer linguagem de programacao.",
+async function patch(path: string, token: string, body?: unknown) {
+    const res = await fetch(`${server.base}${path}`, {
+        method: "PATCH",
+        headers: { ...auth(token), "Content-Type": "application/json" },
+        body: body ? JSON.stringify(body) : undefined,
     });
-    const lessonIds: string[] = [];
+    return { status: res.status, body: await res.json().catch(() => null) };
+}
+
+// Monta uma trilha completa: 1 modulo, N aulas, cada aula com 5 questoes (opcao B correta).
+async function montarTrilha(adminToken: string, qtdAulas = 2) {
+    const trilha = await post("/trails", adminToken, {
+        name: "Logica", level: "iniciante", description: "Base da programacao logica.",
+    });
+    const modulo = await post(`/trails/${trilha.body.id}/modules`, adminToken, {
+        title: "Modulo 1", position: 1,
+    });
+    const lessons: string[] = [];
     for (let i = 1; i <= qtdAulas; i++) {
-        const aula = await post(`/trails/${trilha.body.id}/lessons`, adminToken, {
-            title: `Aula ${i}`,
-            position: i,
+        const aula = await post(`/modules/${modulo.body.id}/lessons`, adminToken, {
+            title: `Aula ${i}`, position: i,
         });
-        lessonIds.push(aula.body.id);
+        for (let q = 1; q <= 5; q++) {
+            await post(`/lessons/${aula.body.id}/questions`, adminToken, {
+                statement: `Questao numero ${q}`, position: q,
+                options: [
+                    { text: "errada", isCorrect: false },
+                    { text: "certa", isCorrect: true },
+                ],
+            });
+        }
+        // Publica a aula para os alunos a verem.
+        await patch(`/lessons/${aula.body.id}/published`, adminToken, { published: true });
+        lessons.push(aula.body.id);
     }
-    return { trailId: trilha.body.id as string, lessonIds };
+    return { trailId: trilha.body.id as string, lessonIds: lessons };
+}
+
+// Responde o quiz de uma aula; acertos = quantas marcar certas (resto erradas).
+async function responderQuiz(token: string, lessonId: string, acertos: number) {
+    const aula = await get(`/lessons/${lessonId}`, token);
+    if (aula.status !== 200) return aula;
+    const answers = aula.body.questions.map((q: any, idx: number) => ({
+        questionId: q.id,
+        optionId: q.options.find((o: any) => o.position === (idx < acertos ? 2 : 1)).id,
+    }));
+    return post(`/lessons/${lessonId}/quiz`, token, { answers });
 }
 
 before(async () => { server = await startTestServer(); });
 after(async () => { await server.close(); });
 beforeEach(async () => { await limparBanco(); });
 
-describe("POST /trails", () => {
-    test("admin cria trilha (201)", async () => {
-        const { token } = await criarUsuarioLogado({}, true);
-        const res = await post("/trails", token, {
-            name: "Logica de Programacao",
-            level: "iniciante",
-            description: "A base de qualquer linguagem de programacao.",
+describe("Catalogo (admin)", () => {
+    test("admin cria trilha; comum recebe 403", async () => {
+        const admin = await criarUsuarioLogado(true);
+        const ok = await post("/trails", admin.token, {
+            name: "Trilha", level: "iniciante", description: "Descricao com dez caracteres.",
         });
-        assert.equal(res.status, 201);
-        assert.ok(res.body.id);
-    });
+        assert.equal(ok.status, 201);
 
-    test("usuario comum recebe 403", async () => {
-        const { token } = await criarUsuarioLogado();
-        const res = await post("/trails", token, {
-            name: "Logica de Programacao",
-            level: "iniciante",
-            description: "A base de qualquer linguagem de programacao.",
+        const comum = await criarUsuarioLogado();
+        const negado = await post("/trails", comum.token, {
+            name: "Trilha", level: "iniciante", description: "Descricao com dez caracteres.",
         });
-        assert.equal(res.status, 403);
+        assert.equal(negado.status, 403);
     });
 
     test("rejeita nivel invalido (400)", async () => {
-        const { token } = await criarUsuarioLogado({}, true);
-        const res = await post("/trails", token, {
-            name: "Trilha X",
-            level: "expert",
-            description: "Descricao valida com mais de dez caracteres.",
+        const admin = await criarUsuarioLogado(true);
+        const res = await post("/trails", admin.token, {
+            name: "Trilha", level: "expert", description: "Descricao com dez caracteres.",
+        });
+        assert.equal(res.status, 400);
+    });
+
+    test("rejeita questao sem exatamente uma correta (400)", async () => {
+        const admin = await criarUsuarioLogado(true);
+        const t = await post("/trails", admin.token, { name: "Trilha", level: "iniciante", description: "Descricao longa o suficiente." });
+        const m = await post(`/trails/${t.body.id}/modules`, admin.token, { title: "Modulo", position: 1 });
+        const a = await post(`/modules/${m.body.id}/lessons`, admin.token, { title: "Aula", position: 1 });
+        const res = await post(`/lessons/${a.body.id}/questions`, admin.token, {
+            statement: "Pergunta valida", position: 1,
+            options: [{ text: "a", isCorrect: true }, { text: "b", isCorrect: true }],
         });
         assert.equal(res.status, 400);
     });
 });
 
-describe("POST /trails/:id/lessons", () => {
-    test("admin cria aula numa trilha (201)", async () => {
-        const { token } = await criarUsuarioLogado({}, true);
-        const trilha = await post("/trails", token, {
-            name: "Trilha",
-            level: "iniciante",
-            description: "Descricao valida com mais de dez caracteres.",
-        });
-        const res = await post(`/trails/${trilha.body.id}/lessons`, token, {
-            title: "Variaveis",
-            position: 1,
-        });
-        assert.equal(res.status, 201);
-        assert.equal(res.body.position, 1);
-    });
-
-    test("404 ao criar aula em trilha inexistente", async () => {
-        const { token } = await criarUsuarioLogado({}, true);
-        const idFalso = "00000000-0000-0000-0000-000000000000";
-        const res = await post(`/trails/${idFalso}/lessons`, token, {
-            title: "Variaveis",
-            position: 1,
-        });
-        assert.equal(res.status, 404);
-    });
-});
-
-describe("GET /trails", () => {
-    test("lista o catalogo com o total de aulas", async () => {
-        const admin = await criarUsuarioLogado({}, true);
-        await criarTrilhaComAulas(admin.token, 3);
-
+describe("GET /lessons/:id (seguranca)", () => {
+    test("nao revela qual opcao e a correta", async () => {
+        const admin = await criarUsuarioLogado(true);
+        const { lessonIds } = await montarTrilha(admin.token, 1);
         const aluno = await criarUsuarioLogado();
-        const res = await get("/trails", aluno.token);
+
+        const res = await get(`/lessons/${lessonIds[0]}`, aluno.token);
         assert.equal(res.status, 200);
-        assert.equal(res.body.length, 1);
-        assert.equal(res.body[0].totalLessons, 3);
+        const temGabarito = res.body.questions.some(
+            (q: any) => q.options.some((o: any) => "isCorrect" in o),
+        );
+        assert.equal(temGabarito, false);
     });
 });
 
-describe("POST /lessons/:id/complete e GET /me/trails", () => {
-    test("marcar aula reflete no progresso (1 de 2 = 50%)", async () => {
-        const admin = await criarUsuarioLogado({}, true);
-        const { lessonIds } = await criarTrilhaComAulas(admin.token, 2);
+describe("Quiz e bloqueio sequencial", () => {
+    test("aula seguinte fica bloqueada ate concluir a anterior", async () => {
+        const admin = await criarUsuarioLogado(true);
+        const { trailId, lessonIds } = await montarTrilha(admin.token, 2);
         const aluno = await criarUsuarioLogado();
 
-        const c = await post(`/lessons/${lessonIds[0]}/complete`, aluno.token);
-        assert.equal(c.status, 201);
+        // Aula 2 comeca bloqueada
+        const bloqueada = await get(`/lessons/${lessonIds[1]}`, aluno.token);
+        assert.equal(bloqueada.status, 403);
 
-        const prog = await get("/me/trails", aluno.token);
-        assert.equal(prog.status, 200);
-        assert.equal(prog.body.length, 1);
-        assert.equal(prog.body[0].completedLessons, 1);
-        assert.equal(prog.body[0].progress, 50);
+        // Conclui a aula 1 com 5 acertos
+        const quiz = await responderQuiz(aluno.token, lessonIds[0], 5);
+        assert.equal(quiz.body.passed, true);
+        assert.equal(quiz.body.lessonCompleted, true);
+
+        // Aula 2 desbloqueia
+        const liberada = await get(`/lessons/${lessonIds[1]}`, aluno.token);
+        assert.equal(liberada.status, 200);
+
+        // Estados na trilha: 1 done, 1 current
+        const trilha = await get(`/trails/${trailId}`, aluno.token);
+        const estados = trilha.body.modules.flatMap((m: any) => m.lessons.map((l: any) => l.state));
+        assert.deepEqual(estados, ["done", "current"]);
     });
 
-    test("marcar a mesma aula duas vezes e idempotente", async () => {
-        const admin = await criarUsuarioLogado({}, true);
-        const { lessonIds } = await criarTrilhaComAulas(admin.token, 2);
+    test("menos de 4 acertos nao conclui a aula", async () => {
+        const admin = await criarUsuarioLogado(true);
+        const { lessonIds } = await montarTrilha(admin.token, 1);
         const aluno = await criarUsuarioLogado();
 
-        const primeira = await post(`/lessons/${lessonIds[0]}/complete`, aluno.token);
-        const segunda = await post(`/lessons/${lessonIds[0]}/complete`, aluno.token);
-        assert.equal(primeira.status, 201);
-        assert.equal(segunda.status, 200);
-
-        const prog = await get("/me/trails", aluno.token);
-        assert.equal(prog.body[0].completedLessons, 1);
+        const quiz = await responderQuiz(aluno.token, lessonIds[0], 2);
+        assert.equal(quiz.body.correct, 2);
+        assert.equal(quiz.body.passed, false);
+        assert.equal(quiz.body.lessonCompleted, false);
     });
 
-    test("o progresso de um aluno nao aparece para outro", async () => {
-        const admin = await criarUsuarioLogado({}, true);
-        const { lessonIds } = await criarTrilhaComAulas(admin.token, 2);
+    test("aula nao publicada fica invisivel para o aluno", async () => {
+        const admin = await criarUsuarioLogado(true);
+        const t = await post("/trails", admin.token, { name: "Trilha", level: "iniciante", description: "Descricao longa o suficiente." });
+        const m = await post(`/trails/${t.body.id}/modules`, admin.token, { title: "Modulo", position: 1 });
+        const a = await post(`/modules/${m.body.id}/lessons`, admin.token, { title: "Aula oculta", position: 1 });
+        // aula criada sem publicar (default false)
+
+        const aluno = await criarUsuarioLogado();
+        // Nao aparece na trilha
+        const trilha = await get(`/trails/${t.body.id}`, aluno.token);
+        const totalAulas = trilha.body.modules.flatMap((md: any) => md.lessons).length;
+        assert.equal(totalAulas, 0);
+        // Acesso direto retorna 404
+        const direto = await get(`/lessons/${a.body.id}`, aluno.token);
+        assert.equal(direto.status, 404);
+
+        // Admin enxerga a aula
+        const trilhaAdmin = await get(`/trails/${t.body.id}`, admin.token);
+        assert.equal(trilhaAdmin.body.modules[0].lessons.length, 1);
+
+        // Apos publicar, o aluno ve
+        await patch(`/lessons/${a.body.id}/published`, admin.token, { published: true });
+        const depois = await get(`/trails/${t.body.id}`, aluno.token);
+        assert.equal(depois.body.modules.flatMap((md: any) => md.lessons).length, 1);
+    });
+
+    test("o progresso de um aluno nao afeta outro", async () => {
+        const admin = await criarUsuarioLogado(true);
+        const { trailId, lessonIds } = await montarTrilha(admin.token, 2);
 
         const alunoA = await criarUsuarioLogado();
-        await post(`/lessons/${lessonIds[0]}/complete`, alunoA.token);
+        await responderQuiz(alunoA.token, lessonIds[0], 5);
 
         const alunoB = await criarUsuarioLogado();
-        const progB = await get("/me/trails", alunoB.token);
-        assert.equal(progB.status, 200);
-        assert.deepEqual(progB.body, []);
+        const trilhaB = await get(`/trails/${trailId}`, alunoB.token);
+        const estadosB = trilhaB.body.modules.flatMap((m: any) => m.lessons.map((l: any) => l.state));
+        // Para B nada foi concluido: primeira current, resto locked
+        assert.deepEqual(estadosB, ["current", "locked"]);
     });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { Login } from "./pages/Login";
 import { Register } from "./pages/Register";
 import { Home } from './pages/Home';
 import { Trilhas } from './pages/Trilhas';
+import { Aula } from './pages/Aula';
 import { VerifyEmail } from './pages/VerifyEmail';
 import { Placeholder } from './pages/Placeholder';
 
@@ -36,6 +37,13 @@ function AppRoutes() {
         element={
           <PrivateRoute>
             <Trilhas />
+          </PrivateRoute>
+        } />
+      <Route
+        path="/trilhas/:trailId/aula/:lessonId"
+        element={
+          <PrivateRoute>
+            <Aula />
           </PrivateRoute>
         } />
       <Route

--- a/frontend/src/components/Icons.tsx
+++ b/frontend/src/components/Icons.tsx
@@ -85,6 +85,35 @@ export const EyeOff = ({ size = 18 }: IconProps) => (
   </svg>
 );
 
+export const ChevronLeft = ({ size = 13 }: IconProps) => (
+  <svg {...base(size)} stroke="currentColor" strokeWidth="2.6" strokeLinecap="round" strokeLinejoin="round">
+    <polyline points="15 6 9 12 15 18" />
+  </svg>
+);
+
+export const X = ({ size = 13 }: IconProps) => (
+  <svg {...base(size)} stroke="currentColor" strokeWidth="3" strokeLinecap="round">
+    <line x1="6" y1="6" x2="18" y2="18" />
+    <line x1="18" y1="6" x2="6" y2="18" />
+  </svg>
+);
+
+export const Help = ({ size = 22 }: IconProps) => (
+  <svg {...base(size)} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <circle cx="12" cy="12" r="10" />
+    <path d="M9.1 9a3 3 0 1 1 4 2.8c-.9.4-1.6 1.2-1.6 2.2v.5" />
+    <line x1="12" y1="18" x2="12" y2="18" />
+  </svg>
+);
+
+export const Alert = ({ size = 34 }: IconProps) => (
+  <svg {...base(size)} stroke="currentColor" strokeWidth="2.6" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z" />
+    <line x1="12" y1="9" x2="12" y2="13" />
+    <line x1="12" y1="17" x2="12" y2="17" />
+  </svg>
+);
+
 /* Capelo de formatura — símbolo da marca */
 export const GradCap = ({ size = 19 }: IconProps) => (
   <svg width={size} height={size} viewBox="0 0 32 32" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">

--- a/frontend/src/pages/Aula/index.tsx
+++ b/frontend/src/pages/Aula/index.tsx
@@ -1,0 +1,291 @@
+import { useEffect, useState } from 'react';
+import { Link, useParams, useNavigate } from 'react-router-dom';
+import { useAuth } from '../../contexts/AuthContext';
+import { Logo } from '../../components/Logo';
+import { UserMenu } from '../../components/UserMenu';
+import { ThemeToggle } from '../../components/ThemeToggle';
+import { Flame, Check, Help, Alert, ChevronRight } from '../../components/Icons';
+import { getInitials } from '../../utils/initials';
+import { user } from '../../data/home';
+import {
+  obterTrilha,
+  obterAula,
+  enviarQuiz,
+  type TrailDetail,
+  type LessonDetail,
+  type QuizResult,
+} from '../../services/trails';
+
+const NAV = [
+  { label: 'Início', to: '/home' },
+  { label: 'Trilhas', to: '/trilhas' },
+  { label: 'Ranking', to: '/ranking' },
+  { label: 'Comunidade', to: '/comunidade' },
+];
+
+export function Aula() {
+  const { trailId, lessonId } = useParams();
+  const navigate = useNavigate();
+  const { user: authUser } = useAuth();
+  const displayName = authUser?.name ?? user.name;
+
+  const [trilha, setTrilha] = useState<TrailDetail | null>(null);
+  const [aula, setAula] = useState<LessonDetail | null>(null);
+  const [carregando, setCarregando] = useState(true);
+  const [erro, setErro] = useState('');
+
+  useEffect(() => {
+    let ativo = true;
+    async function carregar() {
+      setCarregando(true);
+      setErro('');
+      try {
+        const [t, a] = await Promise.all([
+          obterTrilha(trailId!),
+          obterAula(lessonId!),
+        ]);
+        if (!ativo) return;
+        setTrilha(t);
+        setAula(a);
+      } catch (err: any) {
+        if (!ativo) return;
+        setErro(
+          err.response?.status === 403
+            ? 'Esta aula está bloqueada. Conclua a aula anterior.'
+            : 'Não foi possível carregar a aula.',
+        );
+      } finally {
+        if (ativo) setCarregando(false);
+      }
+    }
+    carregar();
+    return () => { ativo = false; };
+  }, [trailId, lessonId]);
+
+  return (
+    <div className="home-shell">
+      <div className="home">
+        <header className="topbar">
+          <Logo variant="solid" size={20} />
+          <nav className="nav">
+            {NAV.map((item) => (
+              <Link
+                key={item.to}
+                to={item.to}
+                className={`nav__item${item.label === 'Trilhas' ? ' nav__item--active' : ''}`}
+              >
+                {item.label}
+              </Link>
+            ))}
+          </nav>
+          <div className="topbar__spacer" />
+          <div className="streak-pill"><Flame size={16} /> {user.streak}</div>
+          <ThemeToggle inline />
+          <UserMenu
+            initials={getInitials(displayName)}
+            level={user.level}
+            name={displayName}
+            email={authUser?.email}
+          />
+        </header>
+
+        {carregando && <p className="lesson__loading">Carregando aula...</p>}
+        {erro && !carregando && (
+          <div className="lesson__erro">
+            <p>{erro}</p>
+            <Link className="btn btn--accent" to={`/trilhas/${trailId}`}>Voltar para a trilha</Link>
+          </div>
+        )}
+
+        {!carregando && !erro && trilha && aula && (
+          <div className="lesson">
+            <SidebarTrilha trilha={trilha} aulaAtualId={aula.id} />
+            <ConteudoAula
+              trilha={trilha}
+              aula={aula}
+              onConcluir={() => navigate(`/trilhas/${trailId}`)}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SidebarTrilha({ trilha, aulaAtualId }: { trilha: TrailDetail; aulaAtualId: string }) {
+  const todas = trilha.modules.flatMap((m) => m.lessons);
+  const feitas = todas.filter((l) => l.state === 'done').length;
+  const total = todas.length;
+  const pct = total > 0 ? Math.round((feitas / total) * 100) : 0;
+
+  return (
+    <aside className="lesson__nav">
+      <div className="lesson__track">
+        <span className="lesson__track-icon">{'{}'}</span>
+        <div className="lesson__track-meta">
+          <div className="lesson__track-name">{trilha.name}</div>
+          <div className="lesson__track-sub">{feitas} de {total} aulas · {pct}%</div>
+        </div>
+      </div>
+      <div className="lesson__track-bar"><span style={{ width: `${pct}%` }} /></div>
+
+      {trilha.modules.map((m) => (
+        <div key={m.id} className="lesson__module">
+          <div className="lesson__module-title">{m.title}</div>
+          {m.lessons.map((l) => {
+            const estado = l.id === aulaAtualId ? 'current' : l.state;
+            return (
+              <Link
+                key={l.id}
+                to={`/trilhas/${trilha.id}/aula/${l.id}`}
+                className={`lesson__item lesson__item--${estado}${l.state === 'locked' ? ' lesson__item--disabled' : ''}`}
+              >
+                <span className="lesson__bullet">{l.state === 'done' ? <Check size={11} /> : null}</span>
+                <span className="lesson__item-name">{l.title}</span>
+              </Link>
+            );
+          })}
+        </div>
+      ))}
+    </aside>
+  );
+}
+
+function ConteudoAula({
+  trilha, aula, onConcluir,
+}: { trilha: TrailDetail; aula: LessonDetail; onConcluir: () => void }) {
+  return (
+    <main className="lesson__content">
+      <div className="lesson__crumb">
+        <span>{trilha.name}</span>
+        <span className="lesson__crumb-sep">/</span>
+        <span>{aula.title}</span>
+      </div>
+
+      <h1 className="lesson__title">{aula.title}</h1>
+
+      <hr className="rule lesson__rule" />
+
+      {aula.content
+        ? <p className="lesson__p">{aula.content}</p>
+        : <p className="lesson__p lesson__p--muted">Esta aula ainda não tem conteúdo escrito.</p>}
+
+      {aula.questions.length > 0 && <Quiz aula={aula} onConcluir={onConcluir} />}
+    </main>
+  );
+}
+
+function Quiz({ aula, onConcluir }: { aula: LessonDetail; onConcluir: () => void }) {
+  const total = aula.questions.length;
+  const [respostas, setRespostas] = useState<Record<string, string>>({});
+  const [enviando, setEnviando] = useState(false);
+  const [resultado, setResultado] = useState<QuizResult | null>(null);
+  const [erro, setErro] = useState('');
+
+  const todasRespondidas = aula.questions.every((q) => respostas[q.id]);
+
+  function selecionar(questionId: string, optionId: string) {
+    if (resultado) return;
+    setRespostas((r) => ({ ...r, [questionId]: optionId }));
+  }
+
+  async function enviar() {
+    if (!todasRespondidas || enviando) return;
+    setEnviando(true);
+    setErro('');
+    try {
+      const answers = aula.questions.map((q) => ({ questionId: q.id, optionId: respostas[q.id] }));
+      setResultado(await enviarQuiz(aula.id, answers));
+    } catch {
+      setErro('Não foi possível enviar o quiz. Tente novamente.');
+    } finally {
+      setEnviando(false);
+    }
+  }
+
+  function refazer() {
+    setRespostas({});
+    setResultado(null);
+  }
+
+  if (resultado) {
+    return (
+      <div className="quiz">
+        <div className="quiz__result">
+          <span
+            className="quiz__result-badge"
+            style={{ background: resultado.passed ? 'var(--success)' : 'var(--av-red)' }}
+          >
+            {resultado.passed ? <Check size={34} /> : <Alert size={34} />}
+          </span>
+          <div className="quiz__result-title">{resultado.passed ? 'Aula concluída!' : 'Quase lá!'}</div>
+          <div className="quiz__result-text">
+            {resultado.passed
+              ? 'Você dominou o conteúdo e desbloqueou a próxima aula.'
+              : 'Você precisa acertar pelo menos 4 questões. Revise o conteúdo e tente de novo.'}
+          </div>
+          <div className="quiz__score">
+            <span className="quiz__score-n" style={{ color: resultado.passed ? 'var(--success)' : 'var(--av-red)' }}>
+              {resultado.correct}
+            </span>
+            <span className="quiz__score-t">/ {resultado.total}</span>
+          </div>
+          <div className="quiz__result-actions">
+            <button className="btn btn--ghost" onClick={refazer}>Refazer quiz</button>
+            {resultado.passed && (
+              <button className="btn btn--accent" onClick={onConcluir}>Voltar para a trilha</button>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="quiz">
+      <div className="quiz__head">
+        <span className="quiz__icon"><Help size={22} /></span>
+        <div className="quiz__head-meta">
+          <div className="quiz__title">Pratique o que aprendeu</div>
+          <div className="quiz__sub">{total} questões · acerte ao menos 4 para concluir a aula</div>
+        </div>
+      </div>
+
+      {aula.questions.map((q, idx) => (
+        <div key={q.id} className="quiz__body">
+          <div className="quiz__q">
+            <span className="quiz__q-num">{idx + 1}</span>
+            <div className="quiz__q-text">{q.statement}</div>
+          </div>
+          <div className="quiz__options">
+            {q.options.map((o) => (
+              <button
+                key={o.id}
+                className={`quiz-opt${respostas[q.id] === o.id ? ' quiz-opt--selected' : ''}`}
+                onClick={() => selecionar(q.id, o.id)}
+              >
+                <span className="quiz-opt__label">{o.text}</span>
+                {respostas[q.id] === o.id && <ChevronRight size={14} />}
+              </button>
+            ))}
+          </div>
+        </div>
+      ))}
+
+      {erro && <div className="auth__alert">{erro}</div>}
+
+      <div className="quiz__foot">
+        <span className="quiz__hint">Responda todas as questões e envie.</span>
+        <div className="topbar__spacer" />
+        <button
+          className="btn btn--accent"
+          style={{ opacity: todasRespondidas ? 1 : 0.5 }}
+          disabled={!todasRespondidas || enviando}
+          onClick={enviar}
+        >
+          {enviando ? 'Enviando...' : 'Enviar respostas'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Trilhas/index.tsx
+++ b/frontend/src/pages/Trilhas/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { useTheme } from '../../contexts/ThemeContext';
 import { Logo } from '../../components/Logo';
@@ -9,7 +9,7 @@ import { Flame, Search, Play, ChevronRight } from '../../components/Icons';
 import { getInitials } from '../../utils/initials';
 import { user } from '../../data/home';
 import { trilhaFilters, type Trail, type TrailLevel } from '../../data/trails';
-import { listarTrilhas, listarMinhasTrilhas } from '../../services/trails';
+import { listarTrilhas, listarMinhasTrilhas, obterTrilha } from '../../services/trails';
 
 type TrailComId = Trail & { id: string };
 
@@ -49,7 +49,20 @@ function Metric({ value, label, accent }: { value: string; label: string; accent
 export function Trilhas() {
   const { user: authUser } = useAuth();
   const { theme } = useTheme();
+  const navigate = useNavigate();
   const tint = LEVEL_TINT[theme] ?? LEVEL_TINT.light;
+
+  // Abre a trilha indo para a primeira aula disponivel (current, ou a primeira).
+  async function abrirTrilha(trailId: string) {
+    try {
+      const detalhe = await obterTrilha(trailId);
+      const aulas = detalhe.modules.flatMap((m) => m.lessons);
+      const alvo = aulas.find((l) => l.state === 'current') ?? aulas[0];
+      if (alvo) navigate(`/trilhas/${trailId}/aula/${alvo.id}`);
+    } catch {
+      // se a trilha nao tiver aulas publicadas, nao navega
+    }
+  }
 
   const displayName = authUser?.name ?? user.name;
   const initials = getInitials(displayName);
@@ -191,7 +204,14 @@ export function Trilhas() {
               const completed = t.done >= t.lessons;
               const lv = tint[t.level];
               return (
-                <div key={t.id} className="track">
+                <div
+                  key={t.id}
+                  className="track track--clickable"
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => abrirTrilha(t.id)}
+                  onKeyDown={(e) => { if (e.key === 'Enter') abrirTrilha(t.id); }}
+                >
                   <div className="track__head">
                     <span
                       className="track__icon"

--- a/frontend/src/services/trails.ts
+++ b/frontend/src/services/trails.ts
@@ -55,3 +55,74 @@ export async function listarMinhasTrilhas() {
   const { data } = await api.get<TrailApi[]>('/me/trails');
   return data.map(adaptar);
 }
+
+export type LessonState = 'done' | 'current' | 'locked';
+
+export interface LessonRef {
+  id: string;
+  title: string;
+  position: number;
+  published?: boolean;
+  state: LessonState;
+}
+
+export interface ModuleWithLessons {
+  id: string;
+  title: string;
+  position: number;
+  lessons: LessonRef[];
+}
+
+export interface TrailDetail {
+  id: string;
+  name: string;
+  trailLevel: TrailApi['trailLevel'];
+  description: string;
+  modules: ModuleWithLessons[];
+}
+
+export async function obterTrilha(trailId: string) {
+  const { data } = await api.get<TrailDetail>(`/trails/${trailId}`);
+  return data;
+}
+
+export interface QuizOption {
+  id: string;
+  text: string;
+  position: number;
+}
+export interface QuizQuestion {
+  id: string;
+  statement: string;
+  position: number;
+  options: QuizOption[];
+}
+export interface LessonDetail {
+  id: string;
+  trailId: string;
+  moduleId: string;
+  title: string;
+  content: string | null;
+  state: LessonState;
+  questions: QuizQuestion[];
+}
+
+export async function obterAula(lessonId: string) {
+  const { data } = await api.get<LessonDetail>(`/lessons/${lessonId}`);
+  return data;
+}
+
+export interface QuizResult {
+  correct: number;
+  total: number;
+  passed: boolean;
+  lessonCompleted: boolean;
+}
+
+export async function enviarQuiz(
+  lessonId: string,
+  answers: { questionId: string; optionId: string }[],
+) {
+  const { data } = await api.post<QuizResult>(`/lessons/${lessonId}/quiz`, { answers });
+  return data;
+}

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -346,3 +346,107 @@
   .continue-card { flex-direction: column; align-items: flex-start; gap: 18px; }
   .track-grid { grid-template-columns: 1fr; }
 }
+
+/* ===================== TELA DE AULA ===================== */
+.lesson { display: grid; grid-template-columns: 288px 1fr; align-items: start; }
+.lesson__nav { align-self: stretch; background: var(--surface); border-right: 1px solid var(--border); padding: 22px 18px; }
+.lesson__track { display: flex; align-items: center; gap: 11px; padding: 0 6px 16px; }
+.lesson__track-icon { width: 38px; height: 38px; border-radius: var(--r-lg); flex-shrink: 0; display: flex; align-items: center; justify-content: center; font-family: var(--font-code); font-weight: 700; font-size: 15px; color: var(--accent); background: color-mix(in srgb, var(--accent) 14%, transparent); }
+.lesson__track-meta { min-width: 0; }
+.lesson__track-name { font-size: 15px; font-weight: 700; letter-spacing: -.01em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.lesson__track-sub { font-size: 12px; color: var(--muted); margin-top: 1px; }
+.lesson__track-bar { height: 6px; border-radius: 99px; background: var(--surface-2); overflow: hidden; margin: 0 6px 18px; }
+.lesson__track-bar span { display: block; height: 100%; border-radius: 99px; background: var(--accent); }
+.lesson__module { margin-bottom: 14px; }
+.lesson__module-title { font-size: 11px; font-weight: 700; letter-spacing: .07em; text-transform: uppercase; color: var(--muted); padding: 0 6px 8px; }
+.lesson__item { display: flex; align-items: center; gap: 10px; height: 36px; padding: 0 8px; border-radius: 9px; margin-bottom: 2px; }
+.lesson__bullet { width: 18px; height: 18px; border-radius: 50%; flex-shrink: 0; display: flex; align-items: center; justify-content: center; }
+.lesson__item-name { flex: 1; min-width: 0; font-size: 13.5px; font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.lesson__item--done .lesson__bullet { background: var(--success); color: #fff; }
+.lesson__item--todo .lesson__bullet, .lesson__item--locked .lesson__bullet { border: 1.5px solid var(--border-strong); }
+.lesson__item--locked .lesson__item-name { color: var(--muted); }
+.lesson__item--current { background: color-mix(in srgb, var(--accent) 12%, transparent); }
+.lesson__item--current .lesson__bullet { background: var(--accent); }
+.lesson__item--current .lesson__item-name { color: var(--accent); font-weight: 700; }
+
+.lesson__content { padding: 34px 44px 40px; max-width: 820px; }
+.lesson__crumb { display: flex; align-items: center; gap: 8px; margin-bottom: 14px; font-size: 13px; color: var(--muted); }
+.lesson__crumb-sep { opacity: .5; }
+.lesson__bookmark { margin-left: auto; color: var(--accent); display: flex; cursor: pointer; }
+.lesson__title { margin: 0; font-size: 32px; font-weight: 700; letter-spacing: -.025em; }
+.lesson__pager { display: flex; align-items: center; gap: 12px; margin: 18px 0 26px; }
+.lesson__pager-btn { flex: none; height: 42px; }
+.lesson__pager-count { font-size: 13px; color: var(--muted); }
+.lesson__rule { margin: 0 0 28px; }
+.lesson__h2 { margin: 0 0 12px; font-size: 22px; font-weight: 700; letter-spacing: -.01em; }
+.lesson__h2:not(:first-of-type) { margin-top: 4px; }
+.lesson__p { margin: 0 0 14px; font-size: 15.5px; line-height: 1.65; }
+.lesson__ul { margin: 0 0 24px; padding-left: 22px; font-size: 15.5px; line-height: 1.9; }
+.code-inline { font-family: var(--font-code); font-size: 13.5px; color: var(--accent); background: var(--surface-2); padding: 2px 7px; border-radius: 6px; }
+
+.codeblock { border-radius: 14px; overflow: hidden; border: 1px solid var(--border); margin: 0 0 26px; }
+.codeblock__bar { display: flex; align-items: center; gap: 9px; height: 38px; padding: 0 16px; background: var(--surface-2); border-bottom: 1px solid var(--border); }
+.codeblock__bar .dot { width: 9px; height: 9px; border-radius: 50%; }
+.codeblock__file { font-family: var(--font-code); font-size: 12px; color: var(--muted); margin-left: 6px; }
+.codeblock__run { font-family: var(--font-code); font-size: 12px; font-weight: 600; color: var(--accent); }
+.codeblock__code { margin: 0; padding: 18px 20px; background: var(--input); font-family: var(--font-code); font-size: 13.5px; line-height: 1.75; color: var(--text); overflow-x: auto; }
+.tok-num { color: #C2410C; }
+.tok-str { color: var(--success); }
+
+/* Quiz carrossel */
+.quiz { background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-2xl); padding: 26px; min-height: 330px; display: flex; flex-direction: column; }
+.quiz__head { display: flex; align-items: center; gap: 12px; margin-bottom: 16px; }
+.quiz__icon { width: 40px; height: 40px; border-radius: var(--r-lg); flex-shrink: 0; display: flex; align-items: center; justify-content: center; color: var(--accent); background: color-mix(in srgb, var(--accent) 13%, transparent); }
+.quiz__head-meta { flex: 1; }
+.quiz__title { font-size: 18px; font-weight: 700; letter-spacing: -.01em; }
+.quiz__sub { font-size: 13.5px; color: var(--muted); margin-top: 1px; }
+.quiz__counter { font-size: 13px; font-weight: 700; color: var(--accent); background: color-mix(in srgb, var(--accent) 12%, transparent); padding: 6px 12px; border-radius: 9px; }
+.quiz__dots { display: flex; gap: 6px; margin-bottom: 22px; }
+.quiz__dot { flex: 1; height: 6px; border-radius: 99px; background: var(--surface-2); }
+.quiz__dot--current { background: color-mix(in srgb, var(--accent) 40%, transparent); }
+.quiz__dot--done { background: var(--accent); }
+.quiz__body { flex: 1; display: flex; flex-direction: column; }
+.quiz__q { display: flex; gap: 12px; margin-bottom: 18px; }
+.quiz__q-num { width: 26px; height: 26px; border-radius: 8px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; font-size: 13px; font-weight: 700; color: #fff; background: var(--accent); }
+.quiz__q-text { font-size: 17px; font-weight: 600; line-height: 1.45; padding-top: 1px; }
+.quiz__options { display: flex; flex-direction: column; gap: 10px; }
+.quiz-opt { display: flex; align-items: center; gap: 13px; padding: 14px 16px; border-radius: var(--r-lg); cursor: pointer; background: var(--surface-2); border: 1.5px solid transparent; font-family: inherit; text-align: left; transition: background .12s, border-color .12s; }
+.quiz-opt:disabled { cursor: default; }
+.quiz-opt__badge { width: 26px; height: 26px; border-radius: 8px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; font-size: 13px; font-weight: 700; color: var(--muted); background: color-mix(in srgb, var(--muted) 22%, transparent); }
+.quiz-opt__label { flex: 1; font-size: 15px; font-weight: 500; color: var(--text); }
+.quiz-opt--selected { border-color: var(--accent); background: color-mix(in srgb, var(--accent) 12%, transparent); }
+.quiz-opt--selected .quiz-opt__badge { background: var(--accent); color: #fff; }
+.quiz-opt--correct { border-color: var(--success); background: var(--success-soft); }
+.quiz-opt--correct .quiz-opt__badge { background: var(--success); color: #fff; }
+.quiz-opt--correct .quiz-opt__label { color: var(--success); }
+.quiz-opt--wrong { border-color: var(--av-red); background: color-mix(in srgb, var(--av-red) 14%, transparent); }
+.quiz-opt--wrong .quiz-opt__badge { background: var(--av-red); color: #fff; }
+.quiz-opt--wrong .quiz-opt__label { color: var(--av-red); }
+.quiz-opt--dim .quiz-opt__label { color: var(--muted); }
+.quiz__feedback { display: flex; align-items: center; margin-top: 16px; padding: 12px 15px; border-radius: var(--r-lg); font-size: 14px; font-weight: 600; }
+.quiz__feedback--ok { background: var(--success-soft); color: var(--success); }
+.quiz__feedback--no { background: color-mix(in srgb, var(--av-red) 14%, transparent); color: var(--av-red); }
+.quiz__foot { display: flex; align-items: center; gap: 14px; margin-top: auto; padding-top: 24px; }
+.quiz__foot { border-top: 1px solid var(--border); margin-top: 24px; }
+.quiz__hint { font-size: 13.5px; color: var(--muted); }
+.quiz__result { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; text-align: center; padding: 14px 0; }
+.quiz__result-badge { width: 72px; height: 72px; border-radius: 50%; display: flex; align-items: center; justify-content: center; color: #fff; margin-bottom: 18px; }
+.quiz__result-title { font-size: 22px; font-weight: 700; letter-spacing: -.01em; }
+.quiz__result-text { font-size: 15px; color: var(--muted); margin-top: 7px; max-width: 360px; line-height: 1.5; }
+.quiz__score { display: flex; align-items: baseline; gap: 6px; margin: 22px 0 24px; }
+.quiz__score-n { font-size: 44px; font-weight: 700; letter-spacing: -.02em; line-height: 1; }
+.quiz__score-t { font-size: 20px; font-weight: 600; color: var(--muted); }
+.quiz__result-actions { display: flex; gap: 12px; }
+.quiz__result-actions .btn--ghost { flex: none; }
+
+
+/* Ajustes da tela de aula ao layout do projeto */
+.lesson { max-width: 1180px; margin: 0 auto; min-height: calc(100svh - 66px); }
+.lesson__item { text-decoration: none; }
+.lesson__item--disabled { pointer-events: none; opacity: .7; }
+.lesson__loading, .lesson__erro { padding: 40px 48px; text-align: center; color: var(--muted); }
+.lesson__erro { display: flex; flex-direction: column; align-items: center; gap: 16px; }
+.lesson__p--muted { color: var(--muted); font-style: italic; }
+.track--clickable { cursor: pointer; transition: border-color .15s ease, transform .05s ease; }
+.track--clickable:hover { border-color: var(--accent); }
+.track--clickable:active { transform: translateY(1px); }


### PR DESCRIPTION
## Visão geral

Fase 2 das trilhas: agrupa as aulas em modulos, adiciona o quiz de multipla escolha por aula e a tela onde o aluno estuda e responde.

## Backend

- Modulos agrupam as aulas dentro da trilha
- Aulas tem questoes de multipla escolha; o admin cria validando exatamente uma alternativa correta
- Quiz corrigido no servidor: acertar ao menos 4 de 5 conclui a aula. O gabarito nunca e enviado ao cliente
- Bloqueio sequencial: uma aula so abre depois de concluir a anterior
- Campo published por aula: aula nao publicada fica invisivel para o aluno e nao trava a sequencia; admin publica via PATCH
- GET /trails/:id retorna modulos e aulas com estado done/current/locked
- Testes de integracao para quiz, bloqueio, publicacao, seguranca do gabarito e isolamento entre alunos

## Frontend

- Tela de aula com sidebar de modulos e aulas, conteudo e quiz
- O quiz envia as respostas e mostra o resultado do servidor; o front nao conhece o gabarito
- Cards da tela de trilhas ficam clicaveis e abrem a primeira aula disponivel
- Servico ganha obterTrilha, obterAula e enviarQuiz; novos icones

## Como testar

Backend: cd backend e bash tests/run-integration.sh
Fluxo: como admin, montar trilha com modulo, aula e questoes e publicar a aula; como aluno, abrir a aula, responder o quiz e ver a aula concluir ao acertar 4 ou mais, com a proxima desbloqueando.