### PR TITLE
feat: estúdio de administração de cursos e melhorias nas trilhas

### DIFF
--- a/backend/drizzle/0008_add_question_difficulty.sql
+++ b/backend/drizzle/0008_add_question_difficulty.sql
@@ -1,0 +1,2 @@
+CREATE TYPE "public"."question_difficulty" AS ENUM('facil', 'medio', 'dificil');--> statement-breakpoint
+ALTER TABLE "questions" ADD COLUMN "difficulty" "question_difficulty" DEFAULT 'facil' NOT NULL;

--- a/backend/drizzle/0009_lesson_content_blocks.sql
+++ b/backend/drizzle/0009_lesson_content_blocks.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "lessons" ADD COLUMN "content_blocks" jsonb;

--- a/backend/drizzle/0010_tags.sql
+++ b/backend/drizzle/0010_tags.sql
@@ -1,0 +1,16 @@
+CREATE TABLE "tags" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" varchar(60) NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "tags_name_unique" UNIQUE("name")
+);
+--> statement-breakpoint
+CREATE TABLE "trail_tags" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"trail_id" uuid NOT NULL,
+	"tag_id" uuid NOT NULL,
+	CONSTRAINT "trail_tags_trail_id_tag_id_unique" UNIQUE("trail_id","tag_id")
+);
+--> statement-breakpoint
+ALTER TABLE "trail_tags" ADD CONSTRAINT "trail_tags_trail_id_trails_id_fk" FOREIGN KEY ("trail_id") REFERENCES "public"."trails"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "trail_tags" ADD CONSTRAINT "trail_tags_tag_id_tags_id_fk" FOREIGN KEY ("tag_id") REFERENCES "public"."tags"("id") ON DELETE no action ON UPDATE no action;

--- a/backend/drizzle/meta/0008_snapshot.json
+++ b/backend/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,722 @@
+{
+  "id": "713d5c39-bc76-4a84-af41-1f72c832b94e",
+  "prevId": "9c84fca3-7114-42d7-a1eb-36cd71a06102",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.lessons_progress": {
+      "name": "lessons_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_progress_user_id_users_id_fk": {
+          "name": "lessons_progress_user_id_users_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_progress_lesson_id_lessons_id_fk": {
+          "name": "lessons_progress_lesson_id_lessons_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lessons_progress_user_id_lesson_id_unique": {
+          "name": "lessons_progress_user_id_lesson_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "lesson_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons": {
+      "name": "lessons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_trail_id_trails_id_fk": {
+          "name": "lessons_trail_id_trails_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_module_id_modules_id_fk": {
+          "name": "lessons_module_id_modules_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "modules",
+          "columnsFrom": [
+            "module_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.modules": {
+      "name": "modules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "modules_trail_id_trails_id_fk": {
+          "name": "modules_trail_id_trails_id_fk",
+          "tableFrom": "modules",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_answers": {
+      "name": "question_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_option_id": {
+          "name": "selected_option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_answers_user_id_users_id_fk": {
+          "name": "question_answers_user_id_users_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_question_id_questions_id_fk": {
+          "name": "question_answers_question_id_questions_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_selected_option_id_question_options_id_fk": {
+          "name": "question_answers_selected_option_id_question_options_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "question_options",
+          "columnsFrom": [
+            "selected_option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "question_answers_user_id_question_id_unique": {
+          "name": "question_answers_user_id_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_options": {
+      "name": "question_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_options_question_id_questions_id_fk": {
+          "name": "question_options_question_id_questions_id_fk",
+          "tableFrom": "question_options",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "question_difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'facil'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_lesson_id_lessons_id_fk": {
+          "name": "questions_lesson_id_lessons_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tokens": {
+      "name": "tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'refresh'"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tokens_user_id_users_id_fk": {
+          "name": "tokens_user_id_users_id_fk",
+          "tableFrom": "tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tokens_token_hash_unique": {
+          "name": "tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trails": {
+      "name": "trails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "trail_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "failed_login_attempts": {
+          "name": "failed_login_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.question_difficulty": {
+      "name": "question_difficulty",
+      "schema": "public",
+      "values": [
+        "facil",
+        "medio",
+        "dificil"
+      ]
+    },
+    "public.trail_level": {
+      "name": "trail_level",
+      "schema": "public",
+      "values": [
+        "iniciante",
+        "intermediario",
+        "avancado"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin",
+        "moderator"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/0009_snapshot.json
+++ b/backend/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,728 @@
+{
+  "id": "7d1c5382-1759-44f2-a944-597409d2e22f",
+  "prevId": "713d5c39-bc76-4a84-af41-1f72c832b94e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.lessons_progress": {
+      "name": "lessons_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_progress_user_id_users_id_fk": {
+          "name": "lessons_progress_user_id_users_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_progress_lesson_id_lessons_id_fk": {
+          "name": "lessons_progress_lesson_id_lessons_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lessons_progress_user_id_lesson_id_unique": {
+          "name": "lessons_progress_user_id_lesson_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "lesson_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons": {
+      "name": "lessons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_blocks": {
+          "name": "content_blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_trail_id_trails_id_fk": {
+          "name": "lessons_trail_id_trails_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_module_id_modules_id_fk": {
+          "name": "lessons_module_id_modules_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "modules",
+          "columnsFrom": [
+            "module_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.modules": {
+      "name": "modules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "modules_trail_id_trails_id_fk": {
+          "name": "modules_trail_id_trails_id_fk",
+          "tableFrom": "modules",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_answers": {
+      "name": "question_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_option_id": {
+          "name": "selected_option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_answers_user_id_users_id_fk": {
+          "name": "question_answers_user_id_users_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_question_id_questions_id_fk": {
+          "name": "question_answers_question_id_questions_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_selected_option_id_question_options_id_fk": {
+          "name": "question_answers_selected_option_id_question_options_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "question_options",
+          "columnsFrom": [
+            "selected_option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "question_answers_user_id_question_id_unique": {
+          "name": "question_answers_user_id_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_options": {
+      "name": "question_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_options_question_id_questions_id_fk": {
+          "name": "question_options_question_id_questions_id_fk",
+          "tableFrom": "question_options",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "question_difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'facil'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_lesson_id_lessons_id_fk": {
+          "name": "questions_lesson_id_lessons_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tokens": {
+      "name": "tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'refresh'"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tokens_user_id_users_id_fk": {
+          "name": "tokens_user_id_users_id_fk",
+          "tableFrom": "tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tokens_token_hash_unique": {
+          "name": "tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trails": {
+      "name": "trails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "trail_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "failed_login_attempts": {
+          "name": "failed_login_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.question_difficulty": {
+      "name": "question_difficulty",
+      "schema": "public",
+      "values": [
+        "facil",
+        "medio",
+        "dificil"
+      ]
+    },
+    "public.trail_level": {
+      "name": "trail_level",
+      "schema": "public",
+      "values": [
+        "iniciante",
+        "intermediario",
+        "avancado"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin",
+        "moderator"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/0010_snapshot.json
+++ b/backend/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,837 @@
+{
+  "id": "1ba5473b-9997-48c4-bbd4-2cfdbc3e638a",
+  "prevId": "7d1c5382-1759-44f2-a944-597409d2e22f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.lessons_progress": {
+      "name": "lessons_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_progress_user_id_users_id_fk": {
+          "name": "lessons_progress_user_id_users_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_progress_lesson_id_lessons_id_fk": {
+          "name": "lessons_progress_lesson_id_lessons_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lessons_progress_user_id_lesson_id_unique": {
+          "name": "lessons_progress_user_id_lesson_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "lesson_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons": {
+      "name": "lessons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_blocks": {
+          "name": "content_blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_trail_id_trails_id_fk": {
+          "name": "lessons_trail_id_trails_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_module_id_modules_id_fk": {
+          "name": "lessons_module_id_modules_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "modules",
+          "columnsFrom": [
+            "module_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.modules": {
+      "name": "modules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "modules_trail_id_trails_id_fk": {
+          "name": "modules_trail_id_trails_id_fk",
+          "tableFrom": "modules",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_answers": {
+      "name": "question_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_option_id": {
+          "name": "selected_option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_answers_user_id_users_id_fk": {
+          "name": "question_answers_user_id_users_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_question_id_questions_id_fk": {
+          "name": "question_answers_question_id_questions_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_selected_option_id_question_options_id_fk": {
+          "name": "question_answers_selected_option_id_question_options_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "question_options",
+          "columnsFrom": [
+            "selected_option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "question_answers_user_id_question_id_unique": {
+          "name": "question_answers_user_id_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_options": {
+      "name": "question_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_options_question_id_questions_id_fk": {
+          "name": "question_options_question_id_questions_id_fk",
+          "tableFrom": "question_options",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "question_difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'facil'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_lesson_id_lessons_id_fk": {
+          "name": "questions_lesson_id_lessons_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tokens": {
+      "name": "tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'refresh'"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tokens_user_id_users_id_fk": {
+          "name": "tokens_user_id_users_id_fk",
+          "tableFrom": "tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tokens_token_hash_unique": {
+          "name": "tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_tags": {
+      "name": "trail_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "trail_tags_trail_id_trails_id_fk": {
+          "name": "trail_tags_trail_id_trails_id_fk",
+          "tableFrom": "trail_tags",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trail_tags_tag_id_tags_id_fk": {
+          "name": "trail_tags_tag_id_tags_id_fk",
+          "tableFrom": "trail_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trail_tags_trail_id_tag_id_unique": {
+          "name": "trail_tags_trail_id_tag_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trail_id",
+            "tag_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trails": {
+      "name": "trails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "trail_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "failed_login_attempts": {
+          "name": "failed_login_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.question_difficulty": {
+      "name": "question_difficulty",
+      "schema": "public",
+      "values": [
+        "facil",
+        "medio",
+        "dificil"
+      ]
+    },
+    "public.trail_level": {
+      "name": "trail_level",
+      "schema": "public",
+      "values": [
+        "iniciante",
+        "intermediario",
+        "avancado"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin",
+        "moderator"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -57,6 +57,27 @@
       "when": 1782601928764,
       "tag": "0007_boring_elektra",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1782655657824,
+      "tag": "0008_add_question_difficulty",
+      "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1782659270682,
+      "tag": "0009_lesson_content_blocks",
+      "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1782660130102,
+      "tag": "0010_tags",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/schema.ts
+++ b/backend/schema.ts
@@ -1,7 +1,8 @@
-import { pgTable, uuid, varchar, date, timestamp, pgEnum, integer, text, unique, boolean } from "drizzle-orm/pg-core";
+import { pgTable, uuid, varchar, date, timestamp, pgEnum, integer, text, unique, boolean, jsonb } from "drizzle-orm/pg-core";
 
 export const userRole = pgEnum("user_role", ["user", "admin", "moderator"]);
 export const trailLevel = pgEnum("trail_level", ["iniciante", "intermediario", "avancado"]);
+export const questionDifficulty = pgEnum("question_difficulty", ["facil", "medio", "dificil"]);
 
 export const users = pgTable("users", {
     id: uuid("id").primaryKey().defaultRandom(),
@@ -50,6 +51,7 @@ export const lessons = pgTable("lessons", {
     moduleId: uuid("module_id").references(() => modules.id).notNull(),
     title: varchar("title", { length: 255 }).notNull(),
     content: text("content"),
+    contentBlocks: jsonb("content_blocks").$type<{ type: string; value: string }[]>(),
     position: integer("position").notNull(),
     published: boolean("published").default(false).notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull()
@@ -68,6 +70,7 @@ export const questions = pgTable("questions", {
     id: uuid("id").primaryKey().defaultRandom(),
     lessonId: uuid("lesson_id").references(() => lessons.id).notNull(),
     statement: text("statement").notNull(),
+    difficulty: questionDifficulty("difficulty").default("facil").notNull(),
     position: integer("position").notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull()
 });
@@ -89,4 +92,18 @@ export const questionAnswers = pgTable("question_answers", {
     answeredAt: timestamp("answered_at", { withTimezone: true }).defaultNow().notNull()
 }, (table) => [
     unique().on(table.userId, table.questionId),
+]);
+
+export const tags = pgTable("tags", {
+    id: uuid("id").primaryKey().defaultRandom(),
+    name: varchar("name", { length: 60 }).notNull().unique(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+});
+
+export const trailTags = pgTable("trail_tags", {
+    id: uuid("id").primaryKey().defaultRandom(),
+    trailId: uuid("trail_id").references(() => trails.id).notNull(),
+    tagId: uuid("tag_id").references(() => tags.id).notNull(),
+}, (table) => [
+    unique().on(table.trailId, table.tagId),
 ]);

--- a/backend/src/controllers/TrailController.ts
+++ b/backend/src/controllers/TrailController.ts
@@ -2,12 +2,13 @@ import type { Request, Response, NextFunction } from "express";
 import { db } from "../../db.ts";
 import {
     users, trails, modules, lessons, lessonProgress,
-    questions, questionOptions, questionAnswers,
+    questions, questionOptions, questionAnswers, tags, trailTags,
 } from "../../schema.ts";
 import { eq, and, count, asc, inArray } from "drizzle-orm";
 import {
     createTrailSchema, createModuleSchema, createLessonSchema,
-    createQuestionSchema, submitQuizSchema,
+    createQuestionSchema, submitQuizSchema, checkAnswerSchema,
+    saveLessonStudioSchema, updateTrailSchema, createTagSchema, updateTagSchema,
 } from "../schemas/trail.schemas.ts";
 
 const QUIZ_MIN_ACERTOS = 4;
@@ -25,7 +26,135 @@ export const createTrail = async (req: Request, res: Response, next: NextFunctio
             trailLevel: dados.level,
             description: dados.description,
         }).returning();
+        if (dados.tagIds?.length) {
+            await db.insert(trailTags).values(
+                dados.tagIds.map((tagId) => ({ trailId: trilha.id, tagId })),
+            ).onConflictDoNothing();
+        }
         res.status(201).json(trilha);
+    } catch (err) {
+        next(err);
+    }
+};
+
+// ===================== TAGS (categorias de trilha) =====================
+export const listTags = async (_req: Request, res: Response, next: NextFunction) => {
+    try {
+        const lista = await db.select().from(tags).orderBy(asc(tags.name));
+        res.json(lista);
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const createTag = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const dados = createTagSchema.parse(req.body);
+        const [existe] = await db.select({ id: tags.id }).from(tags).where(eq(tags.name, dados.name));
+        if (existe) {
+            return res.status(409).json({ erro: "Já existe uma tag com esse nome" });
+        }
+        const [tag] = await db.insert(tags).values({ name: dados.name }).returning();
+        res.status(201).json(tag);
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const updateTag = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const id = String(req.params.id);
+        const dados = updateTagSchema.parse(req.body);
+        const [conflito] = await db.select({ id: tags.id }).from(tags).where(eq(tags.name, dados.name));
+        if (conflito && conflito.id !== id) {
+            return res.status(409).json({ erro: "Já existe uma tag com esse nome" });
+        }
+        const [tag] = await db.update(tags).set({ name: dados.name }).where(eq(tags.id, id)).returning();
+        if (!tag) {
+            return res.status(404).json({ erro: "Tag não encontrada" });
+        }
+        res.json(tag);
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const deleteTag = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const id = String(req.params.id);
+        await db.transaction(async (tx) => {
+            await tx.delete(trailTags).where(eq(trailTags.tagId, id));
+            await tx.delete(tags).where(eq(tags.id, id));
+        });
+        res.json({ ok: true });
+    } catch (err) {
+        next(err);
+    }
+};
+
+// Edita os dados da trilha (admin).
+export const updateTrail = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const trailId = String(req.params.id);
+        const dados = updateTrailSchema.parse(req.body);
+
+        const sets: { name?: string; trailLevel?: "iniciante" | "intermediario" | "avancado"; description?: string } = {};
+        if (dados.name !== undefined) sets.name = dados.name;
+        if (dados.level !== undefined) sets.trailLevel = dados.level;
+        if (dados.description !== undefined) sets.description = dados.description;
+        if (Object.keys(sets).length === 0) {
+            return res.status(400).json({ erro: "Nada para atualizar" });
+        }
+
+        const [trilha] = await db.update(trails).set(sets).where(eq(trails.id, trailId))
+            .returning({ id: trails.id, name: trails.name, trailLevel: trails.trailLevel, description: trails.description });
+        if (!trilha) {
+            return res.status(404).json({ erro: "Trilha não encontrada" });
+        }
+
+        if (dados.tagIds !== undefined) {
+            await db.delete(trailTags).where(eq(trailTags.trailId, trailId));
+            if (dados.tagIds.length) {
+                await db.insert(trailTags).values(
+                    dados.tagIds.map((tagId) => ({ trailId, tagId })),
+                ).onConflictDoNothing();
+            }
+        }
+        res.json(trilha);
+    } catch (err) {
+        next(err);
+    }
+};
+
+// Exclui a trilha inteira (módulos, aulas, questões e progresso).
+export const deleteTrail = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const trailId = String(req.params.id);
+        const [trilha] = await db.select({ id: trails.id }).from(trails).where(eq(trails.id, trailId));
+        if (!trilha) {
+            return res.status(404).json({ erro: "Trilha não encontrada" });
+        }
+
+        await db.transaction(async (tx) => {
+            const ls = await tx.select({ id: lessons.id }).from(lessons).where(eq(lessons.trailId, trailId));
+            const lessonIds = ls.map((l) => l.id);
+            if (lessonIds.length) {
+                const qs = await tx.select({ id: questions.id }).from(questions).where(inArray(questions.lessonId, lessonIds));
+                const qIds = qs.map((q) => q.id);
+                if (qIds.length) {
+                    await tx.delete(questionAnswers).where(inArray(questionAnswers.questionId, qIds));
+                    await tx.delete(questionOptions).where(inArray(questionOptions.questionId, qIds));
+                    await tx.delete(questions).where(inArray(questions.id, qIds));
+                }
+                await tx.delete(lessonProgress).where(inArray(lessonProgress.lessonId, lessonIds));
+                await tx.delete(lessons).where(inArray(lessons.id, lessonIds));
+            }
+            await tx.delete(modules).where(eq(modules.trailId, trailId));
+            await tx.delete(trailTags).where(eq(trailTags.trailId, trailId));
+            await tx.delete(trails).where(eq(trails.id, trailId));
+        });
+
+        res.json({ ok: true });
     } catch (err) {
         next(err);
     }
@@ -47,6 +176,36 @@ export const createModule = async (req: Request, res: Response, next: NextFuncti
             position: dados.position,
         }).returning();
         res.status(201).json(modulo);
+    } catch (err) {
+        next(err);
+    }
+};
+
+// Exclui um módulo e todas as suas aulas (questões, opções e progresso).
+export const deleteModule = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const moduleId = String(req.params.id);
+        const [modulo] = await db.select({ id: modules.id }).from(modules).where(eq(modules.id, moduleId));
+        if (!modulo) {
+            return res.status(404).json({ erro: "Módulo não encontrado" });
+        }
+        await db.transaction(async (tx) => {
+            const ls = await tx.select({ id: lessons.id }).from(lessons).where(eq(lessons.moduleId, moduleId));
+            const lessonIds = ls.map((l) => l.id);
+            if (lessonIds.length) {
+                const qs = await tx.select({ id: questions.id }).from(questions).where(inArray(questions.lessonId, lessonIds));
+                const qIds = qs.map((q) => q.id);
+                if (qIds.length) {
+                    await tx.delete(questionAnswers).where(inArray(questionAnswers.questionId, qIds));
+                    await tx.delete(questionOptions).where(inArray(questionOptions.questionId, qIds));
+                    await tx.delete(questions).where(inArray(questions.id, qIds));
+                }
+                await tx.delete(lessonProgress).where(inArray(lessonProgress.lessonId, lessonIds));
+                await tx.delete(lessons).where(inArray(lessons.id, lessonIds));
+            }
+            await tx.delete(modules).where(eq(modules.id, moduleId));
+        });
+        res.json({ ok: true });
     } catch (err) {
         next(err);
     }
@@ -123,7 +282,17 @@ export const listTrails = async (_req: Request, res: Response, next: NextFunctio
             .from(trails)
             .leftJoin(lessons, eq(lessons.trailId, trails.id))
             .groupBy(trails.id);
-        res.json(lista);
+
+        const vinculos = await db
+            .select({ trailId: trailTags.trailId, id: tags.id, name: tags.name })
+            .from(trailTags).innerJoin(tags, eq(tags.id, trailTags.tagId));
+        const tagsPorTrilha = new Map<string, { id: string; name: string }[]>();
+        for (const v of vinculos) {
+            const arr = tagsPorTrilha.get(v.trailId) ?? [];
+            arr.push({ id: v.id, name: v.name });
+            tagsPorTrilha.set(v.trailId, arr);
+        }
+        res.json(lista.map((t) => ({ ...t, tags: tagsPorTrilha.get(t.id) ?? [] })));
     } catch (err) {
         next(err);
     }
@@ -208,9 +377,11 @@ export const getTrail = async (req: Request, res: Response, next: NextFunction) 
             ).map((p) => p.lessonId),
         );
 
-        // Ordem linear da trilha: por módulo (position) e, dentro, por aula (position).
+        // O estado segue a sequência das aulas PUBLICADAS. Rascunho (que só o admin vê)
+        // não entra na sequência: senão apareceria como "current" e o getLesson, que
+        // calcula o estado só com publicadas, o trataria como bloqueado (estados divergentes).
         const ordenadas = mods.flatMap((m) =>
-            aulas.filter((a) => a.moduleId === m.id).sort((a, b) => a.position - b.position),
+            todasAulas.filter((a) => a.moduleId === m.id && a.published).sort((a, b) => a.position - b.position),
         );
 
         const estadoPorAula = new Map<string, string>();
@@ -293,13 +464,15 @@ export const getLesson = async (req: Request, res: Response, next: NextFunction)
             return res.status(404).json({ erro: "Aula não encontrada" });
         }
 
-        // Aula não publicada é invisível para o aluno; admin pode visualizar.
-        if (!aula.published && !(await ehAdmin(userId))) {
+        // Aula não publicada é invisível para o aluno; admin pode visualizar (preview).
+        const admin = await ehAdmin(userId);
+        if (!aula.published && !admin) {
             return res.status(404).json({ erro: "Aula não encontrada" });
         }
 
+        // Admin não é travado pelo bloqueio sequencial (pode pré-visualizar qualquer aula).
         const estado = await estadoDaAula(userId, aula);
-        if (estado === "locked") {
+        if (estado === "locked" && !admin) {
             return res.status(403).json({ erro: "Aula bloqueada. Conclua a aula anterior." });
         }
 
@@ -327,6 +500,7 @@ export const getLesson = async (req: Request, res: Response, next: NextFunction)
             moduleId: aula.moduleId,
             title: aula.title,
             content: aula.content,
+            contentBlocks: aula.contentBlocks ?? null,
             state: estado,
             questions: questoes,
         });
@@ -372,6 +546,21 @@ export const submitQuiz = async (req: Request, res: Response, next: NextFunction
         for (const resp of dados.answers) {
             if (corretaPorQuestao.get(resp.questionId) === resp.optionId) acertos++;
         }
+
+        // Registra cada resposta uma única vez. A primeira conta para o XP por questão
+        // (10 cada); como não sobrescreve, errar e refazer não rende XP depois.
+        const idsValidos = new Set(opts.map((o) => o.id));
+        const qIdSet = new Set(qIds);
+        for (const resp of dados.answers) {
+            if (!qIdSet.has(resp.questionId) || !idsValidos.has(resp.optionId)) continue;
+            await db.insert(questionAnswers).values({
+                userId,
+                questionId: resp.questionId,
+                selectedOptionId: resp.optionId,
+                isCorrect: corretaPorQuestao.get(resp.questionId) === resp.optionId,
+            }).onConflictDoNothing();
+        }
+
         const total = qIds.length;
         const passou = acertos >= QUIZ_MIN_ACERTOS;
 
@@ -386,6 +575,67 @@ export const submitQuiz = async (req: Request, res: Response, next: NextFunction
         }
 
         res.json({ correct: acertos, total, passed: passou, lessonCompleted: aulaConcluida });
+    } catch (err) {
+        next(err);
+    }
+};
+
+// XP total do usuário: 50 por aula concluída + 10 por questão acertada (primeira vez).
+export const getMyXp = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const userId = req.userId!;
+        const [aulas] = await db.select({ n: count() }).from(lessonProgress)
+            .where(eq(lessonProgress.userId, userId));
+        const [acertos] = await db.select({ n: count() }).from(questionAnswers)
+            .where(and(eq(questionAnswers.userId, userId), eq(questionAnswers.isCorrect, true)));
+        const lessonsCompleted = Number(aulas?.n ?? 0);
+        const questionsCorrect = Number(acertos?.n ?? 0);
+        res.json({
+            xp: lessonsCompleted * 50 + questionsCorrect * 10,
+            lessonsCompleted,
+            questionsCorrect,
+        });
+    } catch (err) {
+        next(err);
+    }
+};
+
+// Verifica uma única resposta para o quiz em carrossel (feedback imediato), sem
+// expor o gabarito das outras questões. Não grava nada: a conclusão da aula
+// continua sendo decidida no submitQuiz.
+export const checkAnswer = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const userId = req.userId!;
+        const lessonId = String(req.params.id);
+        const { questionId, optionId } = checkAnswerSchema.parse(req.body);
+
+        const [aula] = await db.select().from(lessons).where(eq(lessons.id, lessonId));
+        if (!aula) {
+            return res.status(404).json({ erro: "Aula não encontrada" });
+        }
+        if (!aula.published && !(await ehAdmin(userId))) {
+            return res.status(404).json({ erro: "Aula não encontrada" });
+        }
+
+        const estado = await estadoDaAula(userId, aula);
+        if (estado === "locked") {
+            return res.status(403).json({ erro: "Aula bloqueada. Conclua a aula anterior." });
+        }
+
+        // A questão precisa pertencer a esta aula.
+        const [questao] = await db.select({ id: questions.id }).from(questions)
+            .where(and(eq(questions.id, questionId), eq(questions.lessonId, lessonId)));
+        if (!questao) {
+            return res.status(404).json({ erro: "Questão não encontrada" });
+        }
+
+        const [correta] = await db.select({ id: questionOptions.id }).from(questionOptions)
+            .where(and(eq(questionOptions.questionId, questionId), eq(questionOptions.isCorrect, true)));
+        if (!correta) {
+            return res.status(500).json({ erro: "Questão sem gabarito" });
+        }
+
+        res.json({ correct: correta.id === optionId, correctOptionId: correta.id });
     } catch (err) {
         next(err);
     }
@@ -410,6 +660,192 @@ export const setLessonPublished = async (req: Request, res: Response, next: Next
         }
 
         res.json(aula);
+    } catch (err) {
+        next(err);
+    }
+};
+
+// ===================== ESTÚDIO (admin) =====================
+
+// Estrutura do curso para o editor: módulos ordenados com suas aulas (inclui rascunhos).
+export const getTrailStudio = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const trailId = String(req.params.id);
+        const [trilha] = await db.select({ id: trails.id, name: trails.name })
+            .from(trails).where(eq(trails.id, trailId));
+        if (!trilha) {
+            return res.status(404).json({ erro: "Trilha não encontrada" });
+        }
+
+        const mods = await db.select().from(modules)
+            .where(eq(modules.trailId, trailId)).orderBy(asc(modules.position));
+        const aulas = await db.select({
+            id: lessons.id, moduleId: lessons.moduleId, title: lessons.title,
+            position: lessons.position, published: lessons.published,
+        }).from(lessons).where(eq(lessons.trailId, trailId)).orderBy(asc(lessons.position));
+
+        res.json({
+            id: trilha.id,
+            name: trilha.name,
+            modules: mods.map((m) => ({
+                id: m.id,
+                title: m.title,
+                position: m.position,
+                lessons: aulas.filter((a) => a.moduleId === m.id),
+            })),
+        });
+    } catch (err) {
+        next(err);
+    }
+};
+
+// Aula completa para edição: inclui o gabarito e a dificuldade (só admin).
+export const getLessonStudio = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const lessonId = String(req.params.id);
+        const [aula] = await db.select().from(lessons).where(eq(lessons.id, lessonId));
+        if (!aula) {
+            return res.status(404).json({ erro: "Aula não encontrada" });
+        }
+
+        const qs = await db.select().from(questions)
+            .where(eq(questions.lessonId, lessonId)).orderBy(asc(questions.position));
+        const qIds = qs.map((q) => q.id);
+        const opts = qIds.length
+            ? await db.select().from(questionOptions)
+                .where(inArray(questionOptions.questionId, qIds)).orderBy(asc(questionOptions.position))
+            : [];
+
+        res.json({
+            id: aula.id,
+            moduleId: aula.moduleId,
+            title: aula.title,
+            content: aula.content,
+            contentBlocks: aula.contentBlocks ?? (aula.content ? [{ type: "text", value: aula.content }] : []),
+            published: aula.published,
+            position: aula.position,
+            questions: qs.map((q) => ({
+                id: q.id,
+                statement: q.statement,
+                difficulty: q.difficulty,
+                position: q.position,
+                options: opts.filter((o) => o.questionId === q.id).map((o) => ({
+                    id: o.id, text: o.text, isCorrect: o.isCorrect, position: o.position,
+                })),
+            })),
+        });
+    } catch (err) {
+        next(err);
+    }
+};
+
+// Exclui uma aula e tudo que depende dela.
+export const deleteLesson = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const lessonId = String(req.params.id);
+        const [aula] = await db.select({ id: lessons.id }).from(lessons).where(eq(lessons.id, lessonId));
+        if (!aula) {
+            return res.status(404).json({ erro: "Aula não encontrada" });
+        }
+
+        await db.transaction(async (tx) => {
+            const qs = await tx.select({ id: questions.id }).from(questions).where(eq(questions.lessonId, lessonId));
+            const qIds = qs.map((q) => q.id);
+            if (qIds.length) {
+                await tx.delete(questionAnswers).where(inArray(questionAnswers.questionId, qIds));
+                await tx.delete(questionOptions).where(inArray(questionOptions.questionId, qIds));
+                await tx.delete(questions).where(inArray(questions.id, qIds));
+            }
+            await tx.delete(lessonProgress).where(eq(lessonProgress.lessonId, lessonId));
+            await tx.delete(lessons).where(eq(lessons.id, lessonId));
+        });
+
+        res.json({ ok: true });
+    } catch (err) {
+        next(err);
+    }
+};
+
+// Serializa os blocos em markdown (fallback para o aluno e para conteúdo legado).
+function blocosParaMarkdown(blocos: { type: string; value: string }[]): string {
+    return blocos.map((b) => {
+        switch (b.type) {
+            case "code": return "```\n" + b.value + "\n```";
+            case "quote": return b.value.split("\n").map((l) => "> " + l).join("\n");
+            case "image": return `![imagem](${b.value})`;
+            case "video": return `[Vídeo](${b.value})`;
+            default: return b.value;
+        }
+    }).join("\n\n");
+}
+
+// Salva a aula inteira (título, blocos de conteúdo e questões de uma vez). Substitui
+// as questões por completo. Valida o conteúdo apenas quando vai publicar.
+export const saveLessonStudio = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const lessonId = String(req.params.id);
+        const dados = saveLessonStudioSchema.parse(req.body);
+
+        const [aula] = await db.select({ id: lessons.id }).from(lessons).where(eq(lessons.id, lessonId));
+        if (!aula) {
+            return res.status(404).json({ erro: "Aula não encontrada" });
+        }
+
+        if (dados.published) {
+            if (dados.questions.length < QUIZ_MIN_ACERTOS) {
+                return res.status(400).json({ erro: `Para publicar, a aula precisa de ao menos ${QUIZ_MIN_ACERTOS} questões.` });
+            }
+            for (const [i, q] of dados.questions.entries()) {
+                if (q.statement.trim().length < 3) {
+                    return res.status(400).json({ erro: `Questão ${i + 1}: enunciado muito curto.` });
+                }
+                if (q.options.filter((o) => o.text.trim().length > 0).length < 2) {
+                    return res.status(400).json({ erro: `Questão ${i + 1}: precisa de ao menos 2 alternativas.` });
+                }
+                if (q.options.filter((o) => o.isCorrect).length !== 1) {
+                    return res.status(400).json({ erro: `Questão ${i + 1}: marque exatamente uma alternativa correta.` });
+                }
+            }
+        }
+
+        await db.transaction(async (tx) => {
+            const blocos = dados.contentBlocks ?? [];
+            await tx.update(lessons).set({
+                title: dados.title,
+                contentBlocks: blocos,
+                content: blocos.length ? blocosParaMarkdown(blocos) : null,
+                ...(dados.published === undefined ? {} : { published: dados.published }),
+            }).where(eq(lessons.id, lessonId));
+
+            const qs = await tx.select({ id: questions.id }).from(questions).where(eq(questions.lessonId, lessonId));
+            const qIds = qs.map((q) => q.id);
+            if (qIds.length) {
+                await tx.delete(questionAnswers).where(inArray(questionAnswers.questionId, qIds));
+                await tx.delete(questionOptions).where(inArray(questionOptions.questionId, qIds));
+                await tx.delete(questions).where(inArray(questions.id, qIds));
+            }
+
+            for (const [i, q] of dados.questions.entries()) {
+                const [nova] = await tx.insert(questions).values({
+                    lessonId,
+                    statement: q.statement,
+                    difficulty: q.difficulty ?? "facil",
+                    position: i + 1,
+                }).returning({ id: questions.id });
+                if (q.options.length) {
+                    await tx.insert(questionOptions).values(
+                        q.options.map((o, oi) => ({
+                            questionId: nova.id,
+                            text: o.text,
+                            isCorrect: o.isCorrect,
+                            position: oi + 1,
+                        })),
+                    );
+                }
+            }
+        });
+
+        res.json({ ok: true });
     } catch (err) {
         next(err);
     }

--- a/backend/src/routes/trail.routes.ts
+++ b/backend/src/routes/trail.routes.ts
@@ -2,31 +2,61 @@ import { Router } from "express";
 import { autenticar, exigirAdmin } from "../middlewares/auth.ts";
 import {
     createTrail,
+    updateTrail,
+    deleteTrail,
     createModule,
+    deleteModule,
     createLesson,
     createQuestion,
     listTrails,
     getTrail,
     getLesson,
     getMyTrails,
+    getMyXp,
     submitQuiz,
+    checkAnswer,
     setLessonPublished,
+    getTrailStudio,
+    getLessonStudio,
+    saveLessonStudio,
+    deleteLesson,
+    listTags,
+    createTag,
+    updateTag,
+    deleteTag,
 } from "../controllers/TrailController.ts";
 
 const router = Router();
 
 // Catálogo (admin cria, qualquer logado lê)
 router.post("/trails", autenticar, exigirAdmin, createTrail);
+router.patch("/trails/:id", autenticar, exigirAdmin, updateTrail);
+router.delete("/trails/:id", autenticar, exigirAdmin, deleteTrail);
+
+// Tags (categorias): leitura para qualquer logado; escrita só admin
+router.get("/tags", autenticar, listTags);
+router.post("/tags", autenticar, exigirAdmin, createTag);
+router.patch("/tags/:id", autenticar, exigirAdmin, updateTag);
+router.delete("/tags/:id", autenticar, exigirAdmin, deleteTag);
 router.post("/trails/:id/modules", autenticar, exigirAdmin, createModule);
 router.post("/modules/:id/lessons", autenticar, exigirAdmin, createLesson);
+router.delete("/modules/:id", autenticar, exigirAdmin, deleteModule);
 router.post("/lessons/:id/questions", autenticar, exigirAdmin, createQuestion);
 router.patch("/lessons/:id/published", autenticar, exigirAdmin, setLessonPublished);
 router.get("/trails", autenticar, listTrails);
 router.get("/trails/:id", autenticar, getTrail);
 router.get("/lessons/:id", autenticar, getLesson);
 
+// Estúdio (admin): edição de estrutura e conteúdo das aulas
+router.get("/trails/:id/studio", autenticar, exigirAdmin, getTrailStudio);
+router.get("/lessons/:id/studio", autenticar, exigirAdmin, getLessonStudio);
+router.put("/lessons/:id/studio", autenticar, exigirAdmin, saveLessonStudio);
+router.delete("/lessons/:id", autenticar, exigirAdmin, deleteLesson);
+
 // Progresso do aluno
 router.get("/me/trails", autenticar, getMyTrails);
+router.get("/me/xp", autenticar, getMyXp);
 router.post("/lessons/:id/quiz", autenticar, submitQuiz);
+router.post("/lessons/:id/quiz/check", autenticar, checkAnswer);
 
 export default router;

--- a/backend/src/schemas/trail.schemas.ts
+++ b/backend/src/schemas/trail.schemas.ts
@@ -4,7 +4,21 @@ export const createTrailSchema = z.object({
     name: z.string().min(2, "Nome deve ter ao menos 2 caracteres"),
     level: z.enum(["iniciante", "intermediario", "avancado"]),
     description: z.string().min(10, "A descrição deve ter ao menos 10 caracteres"),
+    tagIds: z.array(z.uuid()).optional(),
 });
+
+export const updateTrailSchema = z.object({
+    name: z.string().min(2, "Nome deve ter ao menos 2 caracteres").optional(),
+    level: z.enum(["iniciante", "intermediario", "avancado"]).optional(),
+    description: z.string().min(10, "A descrição deve ter ao menos 10 caracteres").optional(),
+    tagIds: z.array(z.uuid()).optional(),
+});
+
+export const createTagSchema = z.object({
+    name: z.string().min(2, "Nome deve ter ao menos 2 caracteres").max(60, "Nome muito longo"),
+});
+
+export const updateTagSchema = createTagSchema;
 
 export const createLessonSchema = z.object({
     title: z.string().min(3, "Título deve ter ao menos 3 caracteres"),
@@ -39,4 +53,29 @@ export const submitQuizSchema = z.object({
             optionId: z.uuid("ID de alternativa inválido")
         }))
         .min(1, "Envie ao menos uma resposta")
+});
+
+export const checkAnswerSchema = z.object({
+    questionId: z.uuid("ID de questão inválido"),
+    optionId: z.uuid("ID de alternativa inválido"),
+});
+
+// Salvar a aula inteira pelo Estúdio. Lenient para rascunho; a validação forte
+// (exatamente 1 correta, minimo de questoes) acontece no controller ao publicar.
+export const saveLessonStudioSchema = z.object({
+    title: z.string().min(3, "Título deve ter ao menos 3 caracteres"),
+    content: z.string().nullable().optional(),
+    contentBlocks: z.array(z.object({
+        type: z.enum(["text", "code", "image", "video", "quote"]),
+        value: z.string(),
+    })).optional(),
+    published: z.boolean().optional(),
+    questions: z.array(z.object({
+        statement: z.string(),
+        difficulty: z.enum(["facil", "medio", "dificil"]).optional(),
+        options: z.array(z.object({
+            text: z.string(),
+            isCorrect: z.boolean(),
+        })),
+    })),
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,9 @@ import { Register } from "./pages/Register";
 import { Home } from './pages/Home';
 import { Trilhas } from './pages/Trilhas';
 import { Aula } from './pages/Aula';
+import { Estudio } from './pages/Estudio';
+import { EstudioHome } from './pages/EstudioHome';
+import { Configuracoes } from './pages/Configuracoes';
 import { VerifyEmail } from './pages/VerifyEmail';
 import { Placeholder } from './pages/Placeholder';
 
@@ -14,6 +17,14 @@ function PrivateRoute({ children }: { children: React.JSX.Element }) {
   if (loading) return <div>Carregando...</div>;
 
   return isAuthenticated ? children : <Navigate to="/" />
+}
+
+function AdminRoute({ children }: { children: React.JSX.Element }) {
+  const { user, isAuthenticated, loading } = useAuth();
+
+  if (loading) return <div>Carregando...</div>;
+  if (!isAuthenticated) return <Navigate to="/" />;
+  return user?.role === 'admin' ? children : <Navigate to="/home" />;
 }
 
 function AppRoutes() {
@@ -45,6 +56,27 @@ function AppRoutes() {
           <PrivateRoute>
             <Aula />
           </PrivateRoute>
+        } />
+      <Route
+        path="/estudio"
+        element={
+          <AdminRoute>
+            <EstudioHome />
+          </AdminRoute>
+        } />
+      <Route
+        path="/configuracoes"
+        element={
+          <AdminRoute>
+            <Configuracoes />
+          </AdminRoute>
+        } />
+      <Route
+        path="/estudio/:trailId"
+        element={
+          <AdminRoute>
+            <Estudio />
+          </AdminRoute>
         } />
       <Route
         path="/ranking"

--- a/frontend/src/components/Icons.tsx
+++ b/frontend/src/components/Icons.tsx
@@ -114,6 +114,34 @@ export const Alert = ({ size = 34 }: IconProps) => (
   </svg>
 );
 
+export const Trash = ({ size = 16 }: IconProps) => (
+  <svg {...base(size)} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <polyline points="3 6 5 6 21 6" />
+    <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+    <line x1="10" y1="11" x2="10" y2="17" />
+    <line x1="14" y1="11" x2="14" y2="17" />
+  </svg>
+);
+
+export const Minus = ({ size = 14 }: IconProps) => (
+  <svg {...base(size)} stroke="currentColor" strokeWidth="3" strokeLinecap="round">
+    <line x1="6" y1="12" x2="18" y2="12" />
+  </svg>
+);
+
+export const ChevronDown = ({ size = 12 }: IconProps) => (
+  <svg {...base(size)} stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
+    <polyline points="6 9 12 15 18 9" />
+  </svg>
+);
+
+export const Pencil = ({ size = 15 }: IconProps) => (
+  <svg {...base(size)} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M12 20h9" />
+    <path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z" />
+  </svg>
+);
+
 /* Capelo de formatura — símbolo da marca */
 export const GradCap = ({ size = 19 }: IconProps) => (
   <svg width={size} height={size} viewBox="0 0 32 32" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">

--- a/frontend/src/components/UserMenu.tsx
+++ b/frontend/src/components/UserMenu.tsx
@@ -13,7 +13,7 @@ export function UserMenu({ initials, level, name, email }: UserMenuProps) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
   const navigate = useNavigate();
-  const { logout } = useAuth();
+  const { logout, user } = useAuth();
 
   // Fecha ao clicar fora ou pressionar Escape
   useEffect(() => {
@@ -84,6 +84,26 @@ export function UserMenu({ initials, level, name, email }: UserMenuProps) {
           >
             Meu progresso
           </button>
+          {user?.role === 'admin' && (
+            <button
+              type="button"
+              role="menuitem"
+              className="user-menu__item user-menu__item--accent"
+              onClick={() => go('/estudio')}
+            >
+              Estúdio
+            </button>
+          )}
+          {user?.role === 'admin' && (
+            <button
+              type="button"
+              role="menuitem"
+              className="user-menu__item"
+              onClick={() => go('/configuracoes')}
+            >
+              Configurações
+            </button>
+          )}
           <div className="user-menu__divider" />
           <button
             type="button"

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -6,7 +6,8 @@ interface User {
     name: string,
     email: string,
     gender: string,
-    phone: string
+    phone: string,
+    role?: 'user' | 'admin' | 'moderator'
 }
 
 interface AuthContextData {

--- a/frontend/src/pages/Aula/index.tsx
+++ b/frontend/src/pages/Aula/index.tsx
@@ -4,16 +4,18 @@ import { useAuth } from '../../contexts/AuthContext';
 import { Logo } from '../../components/Logo';
 import { UserMenu } from '../../components/UserMenu';
 import { ThemeToggle } from '../../components/ThemeToggle';
-import { Flame, Check, Help, Alert, ChevronRight } from '../../components/Icons';
+import { Flame, Check, Help, Alert, X } from '../../components/Icons';
 import { getInitials } from '../../utils/initials';
 import { user } from '../../data/home';
 import {
   obterTrilha,
   obterAula,
   enviarQuiz,
+  verificarResposta,
   type TrailDetail,
   type LessonDetail,
   type QuizResult,
+  type Bloco,
 } from '../../services/trails';
 import ReactMarkdown, { type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -117,7 +119,7 @@ export function Aula() {
         {erro && !carregando && (
           <div className="lesson__erro">
             <p>{erro}</p>
-            <Link className="btn btn--accent" to={`/trilhas/${trailId}`}>Voltar para a trilha</Link>
+            <Link className="btn btn--accent" to="/trilhas">Voltar para as trilhas</Link>
           </div>
         )}
 
@@ -127,7 +129,7 @@ export function Aula() {
             <ConteudoAula
               trilha={trilha}
               aula={aula}
-              onConcluir={() => navigate(`/trilhas/${trailId}`)}
+              onConcluir={() => navigate('/trilhas')}
             />
           </div>
         )}
@@ -190,41 +192,123 @@ function ConteudoAula({
 
       <hr className="rule lesson__rule" />
 
-      {aula.content
-        ? (
-          <div className="lesson__md">
-            <ReactMarkdown remarkPlugins={[remarkGfm]} components={md}>
-              {aula.content}
-            </ReactMarkdown>
-          </div>
-        )
-        : <p className="lesson__p lesson__p--muted">Esta aula ainda não tem conteúdo escrito.</p>}
+      {aula.contentBlocks && aula.contentBlocks.length > 0 ? (
+        <BlocosAula blocks={aula.contentBlocks} />
+      ) : aula.content ? (
+        <div className="lesson__md">
+          <ReactMarkdown remarkPlugins={[remarkGfm]} components={md}>
+            {aula.content}
+          </ReactMarkdown>
+        </div>
+      ) : (
+        <p className="lesson__p lesson__p--muted">Esta aula ainda não tem conteúdo escrito.</p>
+      )}
 
       {aula.questions.length > 0 && <Quiz aula={aula} onConcluir={onConcluir} />}
     </main>
   );
 }
 
+function embedVideo(url: string): string {
+  const yt = url.match(/(?:youtube\.com\/watch\?v=|youtu\.be\/)([\w-]+)/);
+  return yt ? `https://www.youtube.com/embed/${yt[1]}` : url;
+}
+
+// Renderiza o conteúdo da aula a partir dos blocos do Estúdio.
+function BlocosAula({ blocks }: { blocks: Bloco[] }) {
+  return (
+    <div className="lesson__md">
+      {blocks.map((b, i) => {
+        if (b.type === 'code') {
+          return (
+            <div key={i} className="codeblock">
+              <div className="codeblock__bar">
+                <span className="dot" style={{ background: '#ff5f57' }} />
+                <span className="dot" style={{ background: '#febc2e' }} />
+                <span className="dot" style={{ background: '#28c840' }} />
+              </div>
+              <pre className="codeblock__code">{b.value}</pre>
+            </div>
+          );
+        }
+        if (b.type === 'image') {
+          return b.value ? <img key={i} className="lesson__img" src={b.value} alt="" /> : null;
+        }
+        if (b.type === 'video') {
+          return b.value ? (
+            <div key={i} className="lesson__video">
+              <iframe src={embedVideo(b.value)} title="Vídeo" allowFullScreen style={{ border: 0 }} />
+            </div>
+          ) : null;
+        }
+        if (b.type === 'quote') {
+          return <blockquote key={i}>{b.value}</blockquote>;
+        }
+        return (
+          <ReactMarkdown key={i} remarkPlugins={[remarkGfm]} components={md}>
+            {b.value}
+          </ReactMarkdown>
+        );
+      })}
+    </div>
+  );
+}
+
+const LETTERS = ['A', 'B', 'C', 'D', 'E', 'F'];
+
+// Quiz em carrossel: uma questao por vez, com feedback imediato verificado no servidor.
 function Quiz({ aula, onConcluir }: { aula: LessonDetail; onConcluir: () => void }) {
   const total = aula.questions.length;
+  const [qIndex, setQIndex] = useState(0);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [checked, setChecked] = useState(false);
+  const [wasCorrect, setWasCorrect] = useState(false);
+  const [correctOptionId, setCorrectOptionId] = useState<string | null>(null);
   const [respostas, setRespostas] = useState<Record<string, string>>({});
+  const [verificando, setVerificando] = useState(false);
   const [enviando, setEnviando] = useState(false);
   const [resultado, setResultado] = useState<QuizResult | null>(null);
   const [erro, setErro] = useState('');
 
-  const todasRespondidas = aula.questions.every((q) => respostas[q.id]);
+  const q = aula.questions[qIndex];
+  const isLast = qIndex >= total - 1;
 
-  function selecionar(questionId: string, optionId: string) {
-    if (resultado) return;
-    setRespostas((r) => ({ ...r, [questionId]: optionId }));
+  function selecionar(optionId: string) {
+    if (checked) return;
+    setSelected(optionId);
   }
 
-  async function enviar() {
-    if (!todasRespondidas || enviando) return;
+  async function verificar() {
+    if (selected == null || checked || verificando) return;
+    setVerificando(true);
+    setErro('');
+    try {
+      const r = await verificarResposta(aula.id, q.id, selected);
+      setWasCorrect(r.correct);
+      setCorrectOptionId(r.correctOptionId);
+      setRespostas((prev) => ({ ...prev, [q.id]: selected }));
+      setChecked(true);
+    } catch {
+      setErro('Não foi possível verificar a resposta. Tente novamente.');
+    } finally {
+      setVerificando(false);
+    }
+  }
+
+  async function avancar() {
+    if (!isLast) {
+      setQIndex((i) => i + 1);
+      setSelected(null);
+      setChecked(false);
+      setWasCorrect(false);
+      setCorrectOptionId(null);
+      return;
+    }
+    if (enviando) return;
     setEnviando(true);
     setErro('');
     try {
-      const answers = aula.questions.map((q) => ({ questionId: q.id, optionId: respostas[q.id] }));
+      const answers = aula.questions.map((qq) => ({ questionId: qq.id, optionId: respostas[qq.id] }));
       setResultado(await enviarQuiz(aula.id, answers));
     } catch {
       setErro('Não foi possível enviar o quiz. Tente novamente.');
@@ -234,8 +318,32 @@ function Quiz({ aula, onConcluir }: { aula: LessonDetail; onConcluir: () => void
   }
 
   function refazer() {
+    setQIndex(0);
+    setSelected(null);
+    setChecked(false);
+    setWasCorrect(false);
+    setCorrectOptionId(null);
     setRespostas({});
     setResultado(null);
+    setErro('');
+  }
+
+  function classeOpcao(optionId: string) {
+    if (!checked) return `quiz-opt${selected === optionId ? ' quiz-opt--selected' : ''}`;
+    if (optionId === correctOptionId) return 'quiz-opt quiz-opt--correct';
+    if (optionId === selected) return 'quiz-opt quiz-opt--wrong';
+    return 'quiz-opt quiz-opt--dim';
+  }
+
+  function badge(optionId: string, i: number) {
+    if (checked && optionId === correctOptionId) return <Check size={13} />;
+    if (checked && optionId === selected) return <X size={12} />;
+    return LETTERS[i] ?? String(i + 1);
+  }
+
+  function letraCorreta() {
+    const idx = q.options.findIndex((o) => o.id === correctOptionId);
+    return LETTERS[idx] ?? '';
   }
 
   if (resultado) {
@@ -279,42 +387,72 @@ function Quiz({ aula, onConcluir }: { aula: LessonDetail; onConcluir: () => void
           <div className="quiz__title">Pratique o que aprendeu</div>
           <div className="quiz__sub">{total} questões · acerte ao menos 4 para concluir a aula</div>
         </div>
+        <span className="quiz__counter">{qIndex + 1} / {total}</span>
       </div>
 
-      {aula.questions.map((q, idx) => (
-        <div key={q.id} className="quiz__body">
-          <div className="quiz__q">
-            <span className="quiz__q-num">{idx + 1}</span>
-            <div className="quiz__q-text">{q.statement}</div>
-          </div>
-          <div className="quiz__options">
-            {q.options.map((o) => (
-              <button
-                key={o.id}
-                className={`quiz-opt${respostas[q.id] === o.id ? ' quiz-opt--selected' : ''}`}
-                onClick={() => selecionar(q.id, o.id)}
-              >
-                <span className="quiz-opt__label">{o.text}</span>
-                {respostas[q.id] === o.id && <ChevronRight size={14} />}
-              </button>
-            ))}
-          </div>
+      <div className="quiz__dots">
+        {aula.questions.map((qq, i) => {
+          let cls = 'quiz__dot';
+          if (i < qIndex || (i === qIndex && checked)) cls += ' quiz__dot--done';
+          else if (i === qIndex) cls += ' quiz__dot--current';
+          return <span key={qq.id} className={cls} />;
+        })}
+      </div>
+
+      <div className="quiz__body">
+        <div className="quiz__q">
+          <span className="quiz__q-num">{qIndex + 1}</span>
+          <div className="quiz__q-text">{q.statement}</div>
         </div>
-      ))}
 
-      {erro && <div className="auth__alert">{erro}</div>}
+        <div className="quiz__options">
+          {q.options.map((o, i) => (
+            <button
+              key={o.id}
+              className={classeOpcao(o.id)}
+              onClick={() => selecionar(o.id)}
+              disabled={checked}
+            >
+              <span className="quiz-opt__badge">{badge(o.id, i)}</span>
+              <span className="quiz-opt__label">{o.text}</span>
+            </button>
+          ))}
+        </div>
 
-      <div className="quiz__foot">
-        <span className="quiz__hint">Responda todas as questões e envie.</span>
-        <div className="topbar__spacer" />
-        <button
-          className="btn btn--accent"
-          style={{ opacity: todasRespondidas ? 1 : 0.5 }}
-          disabled={!todasRespondidas || enviando}
-          onClick={enviar}
-        >
-          {enviando ? 'Enviando...' : 'Enviar respostas'}
-        </button>
+        {checked && (
+          <div className={`quiz__feedback quiz__feedback--${wasCorrect ? 'ok' : 'no'}`}>
+            {wasCorrect
+              ? 'Correto! Mandou muito bem.'
+              : `Quase! A resposta certa é a alternativa ${letraCorreta()}.`}
+          </div>
+        )}
+
+        {erro && <div className="auth__alert">{erro}</div>}
+
+        <div className="quiz__foot">
+          <span className="quiz__hint">
+            {!checked
+              ? 'Selecione uma alternativa e verifique.'
+              : isLast
+                ? 'Veja seu desempenho na aula.'
+                : 'Siga para a próxima questão.'}
+          </span>
+          <div className="topbar__spacer" />
+          {!checked ? (
+            <button
+              className="btn btn--accent"
+              style={{ opacity: selected == null ? 0.5 : 1 }}
+              disabled={selected == null || verificando}
+              onClick={verificar}
+            >
+              {verificando ? 'Verificando...' : 'Verificar resposta'}
+            </button>
+          ) : (
+            <button className="btn btn--accent" disabled={enviando} onClick={avancar}>
+              {isLast ? (enviando ? 'Enviando...' : 'Ver resultado') : 'Próxima questão'}
+            </button>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/Configuracoes/index.tsx
+++ b/frontend/src/pages/Configuracoes/index.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Logo } from '../../components/Logo';
+import { Plus, Pencil, Trash, Check } from '../../components/Icons';
+import { listarTags, criarTag, atualizarTag, excluirTag, type Tag } from '../../services/trails';
+
+export function Configuracoes() {
+  const [tags, setTags] = useState<Tag[]>([]);
+  const [carregando, setCarregando] = useState(true);
+  const [erro, setErro] = useState('');
+  const [novo, setNovo] = useState('');
+  const [criando, setCriando] = useState(false);
+  const [editId, setEditId] = useState<string | null>(null);
+  const [editNome, setEditNome] = useState('');
+
+  async function carregar() {
+    try {
+      setTags(await listarTags());
+    } catch {
+      setErro('Não foi possível carregar as tags.');
+    } finally {
+      setCarregando(false);
+    }
+  }
+  useEffect(() => { carregar(); }, []);
+
+  async function adicionar() {
+    const nome = novo.trim();
+    if (!nome || criando) return;
+    setCriando(true);
+    setErro('');
+    try {
+      await criarTag(nome);
+      setNovo('');
+      await carregar();
+    } catch (e: any) {
+      setErro(e?.response?.data?.erro ?? 'Não foi possível criar a tag.');
+    } finally {
+      setCriando(false);
+    }
+  }
+
+  async function salvarEdicao(id: string) {
+    const nome = editNome.trim();
+    if (!nome) return;
+    setErro('');
+    try {
+      await atualizarTag(id, nome);
+      setEditId(null);
+      await carregar();
+    } catch (e: any) {
+      setErro(e?.response?.data?.erro ?? 'Não foi possível salvar a tag.');
+    }
+  }
+
+  async function excluir(t: Tag) {
+    if (!window.confirm(`Excluir a tag "${t.name}"? Ela será removida das trilhas que a usam.`)) return;
+    setErro('');
+    try {
+      await excluirTag(t.id);
+      await carregar();
+    } catch {
+      setErro('Não foi possível excluir a tag.');
+    }
+  }
+
+  return (
+    <div className="home">
+      <header className="topbar studio__bar">
+        <div className="studio__brand">
+          <Logo variant="solid" size={19} />
+          <span className="studio__badge">Configurações</span>
+        </div>
+        <span className="studio__divider" />
+        <div className="studio__crumb"><b>Tags de trilhas</b></div>
+        <div className="topbar__spacer" />
+        <Link className="btn btn--ghost studio__btn" to="/home">Voltar ao app</Link>
+      </header>
+
+      <div className="estudio-home">
+        <h1 className="estudio-home__title">Tags</h1>
+        <p className="estudio-home__sub">
+          Categorias para filtrar as trilhas (ex.: Fundamentos, Linguagens, Algoritmos). Você atribui as tags ao criar ou editar uma trilha no Estúdio.
+        </p>
+
+        <div className="estudio-form" style={{ display: 'flex', gap: 12, alignItems: 'center' }}>
+          <input
+            className="estudio-form__input"
+            style={{ margin: 0, flex: 1 }}
+            value={novo}
+            placeholder="Nome da nova tag"
+            onChange={(e) => setNovo(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') adicionar(); }}
+          />
+          <button className="btn btn--accent" style={{ flex: 'none' }} disabled={criando || !novo.trim()} onClick={adicionar}>
+            <Plus size={14} /> Adicionar
+          </button>
+        </div>
+
+        {erro && <div className="auth__alert">{erro}</div>}
+        {carregando && <p className="track__desc">Carregando...</p>}
+        {!carregando && tags.length === 0 && <p className="track__desc">Nenhuma tag cadastrada ainda.</p>}
+
+        <div className="estudio-home__list">
+          {tags.map((t) => (
+            <div key={t.id} className="estudio-home__card">
+              {editId === t.id ? (
+                <input
+                  className="estudio-form__input"
+                  style={{ margin: '8px 0 8px 14px', flex: 1 }}
+                  value={editNome}
+                  autoFocus
+                  onChange={(e) => setEditNome(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') salvarEdicao(t.id);
+                    if (e.key === 'Escape') setEditId(null);
+                  }}
+                />
+              ) : (
+                <div className="estudio-home__open" style={{ cursor: 'default' }}>
+                  <span className="chip--outline">{t.name}</span>
+                </div>
+              )}
+              <div className="estudio-home__actions">
+                {editId === t.id ? (
+                  <>
+                    <button className="estudio-home__act" onClick={() => salvarEdicao(t.id)} aria-label="Salvar"><Check size={15} /></button>
+                    <button className="estudio-home__act" onClick={() => setEditId(null)} aria-label="Cancelar">✕</button>
+                  </>
+                ) : (
+                  <>
+                    <button className="estudio-home__act" onClick={() => { setEditId(t.id); setEditNome(t.name); }} aria-label="Editar tag"><Pencil size={15} /></button>
+                    <button className="estudio-home__act estudio-home__act--danger" onClick={() => excluir(t)} aria-label="Excluir tag"><Trash size={15} /></button>
+                  </>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Estudio/index.tsx
+++ b/frontend/src/pages/Estudio/index.tsx
@@ -1,0 +1,466 @@
+import { useEffect, useRef, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { Logo } from '../../components/Logo';
+import { Eye, Trash, Plus, Minus, Check, ChevronRight } from '../../components/Icons';
+import {
+  obterEstudio,
+  obterAulaEstudio,
+  salvarAulaEstudio,
+  criarModulo,
+  criarAula,
+  excluirAula,
+  excluirModulo,
+  type StudioTrail,
+  type StudioLesson,
+  type StudioQuestion,
+  type QuestionDifficulty,
+  type BlocoTipo,
+} from '../../services/trails';
+
+const LETTERS = ['A', 'B', 'C', 'D', 'E', 'F'];
+
+const BLOCO_TIPOS: { type: BlocoTipo; icon: string; label: string }[] = [
+  { type: 'text', icon: '¶', label: 'Texto' },
+  { type: 'code', icon: '{}', label: 'Código' },
+  { type: 'image', icon: '▣', label: 'Imagem' },
+  { type: 'video', icon: '▷', label: 'Vídeo' },
+  { type: 'quote', icon: '❝', label: 'Citação' },
+];
+const BLOCO_LABEL: Record<BlocoTipo, string> = {
+  text: 'Texto',
+  code: '{ } Código',
+  image: 'Imagem',
+  video: 'Vídeo',
+  quote: 'Citação',
+};
+const DIFFS: { value: QuestionDifficulty; label: string }[] = [
+  { value: 'facil', label: 'Fácil' },
+  { value: 'medio', label: 'Médio' },
+  { value: 'dificil', label: 'Difícil' },
+];
+
+export function Estudio() {
+  const { trailId } = useParams();
+  const [outline, setOutline] = useState<StudioTrail | null>(null);
+  const [selId, setSelId] = useState<string | null>(null);
+  const selIdRef = useRef<string | null>(null);
+  const [aula, setAula] = useState<StudioLesson | null>(null);
+  const [carregando, setCarregando] = useState(true);
+  const [salvando, setSalvando] = useState(false);
+  const [salvo, setSalvo] = useState(false);
+  const [erro, setErro] = useState('');
+
+  async function carregarAula(id: string) {
+    selIdRef.current = id;
+    setSelId(id);
+    setErro('');
+    try {
+      setAula(await obterAulaEstudio(id));
+      setSalvo(true);
+    } catch {
+      setErro('Não foi possível carregar a aula.');
+    }
+  }
+
+  async function carregarOutline(prefer?: string | null) {
+    const o = await obterEstudio(trailId!);
+    setOutline(o);
+    const ids = o.modules.flatMap((m) => m.lessons).map((l) => l.id);
+    let alvo: string | null = null;
+    if (prefer && ids.includes(prefer)) alvo = prefer;
+    else if (prefer !== null && selIdRef.current && ids.includes(selIdRef.current)) alvo = selIdRef.current;
+    else alvo = ids[0] ?? null;
+    if (alvo) await carregarAula(alvo);
+    else {
+      setAula(null);
+      setSelId(null);
+      selIdRef.current = null;
+    }
+  }
+
+  useEffect(() => {
+    let ativo = true;
+    (async () => {
+      setCarregando(true);
+      try {
+        const o = await obterEstudio(trailId!);
+        if (!ativo) return;
+        setOutline(o);
+        const primeira = o.modules.flatMap((m) => m.lessons)[0]?.id ?? null;
+        if (primeira) await carregarAula(primeira);
+      } catch {
+        if (ativo) setErro('Não foi possível carregar o estúdio.');
+      } finally {
+        if (ativo) setCarregando(false);
+      }
+    })();
+    return () => { ativo = false; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [trailId]);
+
+  function sujo() { setSalvo(false); }
+
+  // ----- mutações estruturais (vão direto ao backend) -----
+  async function adicionarModulo() {
+    if (!outline) return;
+    const nome = window.prompt('Nome do módulo:');
+    if (!nome?.trim()) return;
+    try {
+      await criarModulo(outline.id, nome.trim(), outline.modules.length + 1);
+      await carregarOutline();
+    } catch { setErro('Não foi possível criar o módulo.'); }
+  }
+
+  async function adicionarAula(moduleId: string, qtd: number) {
+    try {
+      const nova = await criarAula(moduleId, 'Nova aula', qtd + 1);
+      await carregarOutline(nova.id);
+    } catch { setErro('Não foi possível criar a aula.'); }
+  }
+
+  async function excluir() {
+    if (!aula) return;
+    if (!window.confirm('Excluir esta aula? Essa ação não pode ser desfeita.')) return;
+    try {
+      await excluirAula(aula.id);
+      await carregarOutline(null);
+    } catch { setErro('Não foi possível excluir a aula.'); }
+  }
+
+  async function removerModulo(moduleId: string) {
+    if (!window.confirm('Excluir este módulo e todas as suas aulas? Essa ação não pode ser desfeita.')) return;
+    setErro('');
+    try {
+      await excluirModulo(moduleId);
+      await carregarOutline(null);
+    } catch { setErro('Não foi possível excluir o módulo.'); }
+  }
+
+  async function salvar(novoPublished?: boolean) {
+    if (!aula || salvando) return;
+    setSalvando(true);
+    setErro('');
+    try {
+      await salvarAulaEstudio(aula.id, {
+        title: aula.title,
+        contentBlocks: aula.contentBlocks,
+        published: novoPublished === undefined ? aula.published : novoPublished,
+        questions: aula.questions.map((q) => ({
+          statement: q.statement,
+          difficulty: q.difficulty,
+          options: q.options.map((o) => ({ text: o.text, isCorrect: o.isCorrect })),
+        })),
+      });
+      await carregarOutline(aula.id);
+    } catch (e: any) {
+      setErro(e?.response?.data?.erro ?? 'Não foi possível salvar.');
+    } finally {
+      setSalvando(false);
+    }
+  }
+
+  // ----- blocos de conteúdo -----
+  function addBloco(type: BlocoTipo) {
+    setAula((a) => (a ? { ...a, contentBlocks: [...a.contentBlocks, { type, value: '' }] } : a));
+    sujo();
+  }
+  function setBloco(i: number, value: string) {
+    setAula((a) => (a ? { ...a, contentBlocks: a.contentBlocks.map((b, j) => (j === i ? { ...b, value } : b)) } : a));
+    sujo();
+  }
+  function removerBloco(i: number) {
+    setAula((a) => (a ? { ...a, contentBlocks: a.contentBlocks.filter((_, j) => j !== i) } : a));
+    sujo();
+  }
+  function moverBloco(i: number, dir: -1 | 1) {
+    setAula((a) => {
+      if (!a) return a;
+      const arr = [...a.contentBlocks];
+      const j = i + dir;
+      if (j < 0 || j >= arr.length) return a;
+      [arr[i], arr[j]] = [arr[j], arr[i]];
+      return { ...a, contentBlocks: arr };
+    });
+    sujo();
+  }
+
+  // ----- edição local da aula -----
+  function setQuestion(qi: number, patch: Partial<StudioQuestion>) {
+    setAula((a) => (a ? { ...a, questions: a.questions.map((q, i) => (i === qi ? { ...q, ...patch } : q)) } : a));
+    sujo();
+  }
+  function setOption(qi: number, oi: number, patch: Partial<{ text: string; isCorrect: boolean }>) {
+    setAula((a) => (a ? {
+      ...a,
+      questions: a.questions.map((q, i) => (i !== qi ? q : { ...q, options: q.options.map((o, j) => (j === oi ? { ...o, ...patch } : o)) })),
+    } : a));
+    sujo();
+  }
+  function marcarCorreta(qi: number, oi: number) {
+    setAula((a) => (a ? {
+      ...a,
+      questions: a.questions.map((q, i) => (i !== qi ? q : { ...q, options: q.options.map((o, j) => ({ ...o, isCorrect: j === oi })) })),
+    } : a));
+    sujo();
+  }
+  function adicionarAlternativa(qi: number) {
+    setAula((a) => (a ? {
+      ...a,
+      questions: a.questions.map((q, i) => (i !== qi ? q : { ...q, options: [...q.options, { text: '', isCorrect: false }] })),
+    } : a));
+    sujo();
+  }
+  function removerAlternativa(qi: number, oi: number) {
+    setAula((a) => (a ? {
+      ...a,
+      questions: a.questions.map((q, i) => (i !== qi ? q : { ...q, options: q.options.filter((_, j) => j !== oi) })),
+    } : a));
+    sujo();
+  }
+  function adicionarQuestao() {
+    setAula((a) => (a ? {
+      ...a,
+      questions: [...a.questions, { statement: '', difficulty: 'facil', options: [{ text: '', isCorrect: true }, { text: '', isCorrect: false }] }],
+    } : a));
+    sujo();
+  }
+  function removerQuestao(qi: number) {
+    setAula((a) => (a ? { ...a, questions: a.questions.filter((_, i) => i !== qi) } : a));
+    sujo();
+  }
+
+  const totalMod = outline?.modules.length ?? 0;
+  const totalAulas = outline?.modules.reduce((s, m) => s + m.lessons.length, 0) ?? 0;
+  const moduloDaAula = aula ? outline?.modules.find((m) => m.id === aula.moduleId) : undefined;
+  const faltam = aula ? Math.max(0, 5 - aula.questions.length) : 0;
+
+  return (
+    <div className="home">
+      <header className="topbar studio__bar">
+        <div className="studio__brand">
+          <Logo variant="solid" size={19} />
+          <span className="studio__badge">Estúdio</span>
+        </div>
+        <span className="studio__divider" />
+        <div className="studio__crumb">
+          <Link to="/trilhas">Trilhas</Link>
+          <span className="studio__crumb-sep">/</span>
+          <b>{outline?.name ?? '...'}</b>
+        </div>
+        <div className="topbar__spacer" />
+        {aula && salvo && <span className="studio__saved"><i /> Rascunho salvo</span>}
+        {aula && (
+          <Link className="btn btn--ghost studio__btn" to={`/trilhas/${trailId}/aula/${aula.id}`}>
+            <Eye size={15} /> Pré-visualizar
+          </Link>
+        )}
+        <button className="btn btn--accent studio__btn" disabled={!aula || salvando} onClick={() => aula && salvar(!aula.published)}>
+          {salvando ? 'Salvando...' : aula?.published ? 'Despublicar' : 'Publicar'}
+        </button>
+      </header>
+
+      {carregando ? (
+        <p className="lesson__loading">Carregando estúdio...</p>
+      ) : (
+        <div className="studio">
+          <aside className="studio__nav">
+            <div className="studio__nav-head">
+              <span className="studio__nav-title">Estrutura do curso</span>
+              <span className="studio__nav-count">{totalMod} módulos · {totalAulas} aulas</span>
+            </div>
+
+            {outline?.modules.map((m) => (
+              <div key={m.id} className="studio-mod">
+                <div className="studio-mod__row" style={{ cursor: 'default' }}>
+                  <span className="studio-mod__chev" style={{ transform: 'rotate(90deg)' }}><ChevronRight size={13} /></span>
+                  <span className="studio-mod__num">{m.position}</span>
+                  <span className="studio-mod__title">{m.title}</span>
+                  <span className="studio-mod__count">{m.lessons.length} aulas</span>
+                  <button className="studio-mod__del" onClick={() => removerModulo(m.id)} aria-label="Excluir módulo"><Trash size={13} /></button>
+                </div>
+                <div className="studio-mod__lessons">
+                  {m.lessons.map((l) => {
+                    const estado = l.id === selId ? 'active' : l.published ? 'published' : 'draft';
+                    return (
+                      <div
+                        key={l.id}
+                        className={`studio-les studio-les--${estado}`}
+                        style={{ cursor: 'pointer' }}
+                        onClick={() => carregarAula(l.id)}
+                      >
+                        <span className="studio-les__dot">{l.published ? <Check size={11} /> : null}</span>
+                        <span className="studio-les__name">{l.title}</span>
+                        {l.id === selId && <span className="studio-les__tag">editando</span>}
+                      </div>
+                    );
+                  })}
+                  <button className="studio__add studio__add--ghost" onClick={() => adicionarAula(m.id, m.lessons.length)}>
+                    <Plus size={14} /> Adicionar aula
+                  </button>
+                </div>
+              </div>
+            ))}
+
+            <button className="studio__add studio__add--dashed" onClick={adicionarModulo}>
+              <Plus size={15} /> Adicionar módulo
+            </button>
+          </aside>
+
+          {aula ? (
+            <main className="studio__editor">
+              <div className="studio__meta">
+                <span className="studio__meta-mod">{moduloDaAula?.title ?? 'Módulo'}</span>
+                <span
+                  style={{
+                    fontSize: 11.5,
+                    fontWeight: 700,
+                    padding: '3px 9px',
+                    borderRadius: 6,
+                    color: aula.published ? 'var(--success)' : 'var(--muted)',
+                    background: aula.published ? 'var(--success-soft)' : 'var(--surface-2)',
+                  }}
+                >
+                  {aula.published ? 'Publicada' : 'Rascunho'}
+                </span>
+                <div className="topbar__spacer" />
+                <button className="studio__del" onClick={excluir}><Trash size={14} /> Excluir aula</button>
+              </div>
+
+              <label className="studio__label">Título da aula</label>
+              <div className="studio__title-field">
+                <input
+                  className="es-input"
+                  value={aula.title}
+                  onChange={(e) => { setAula({ ...aula, title: e.target.value }); sujo(); }}
+                />
+              </div>
+
+              <div className="studio__section">
+                <span className="studio__section-title">Conteúdo da aula</span>
+                <span className="studio__pill">{aula.contentBlocks.length} blocos</span>
+              </div>
+
+              <div className="studio__blocks">
+                {aula.contentBlocks.map((b, i) => (
+                  <div key={i} className="block">
+                    <div className="block__bar">
+                      <span className={`block__tag block__tag--${b.type}`}>{BLOCO_LABEL[b.type]}</span>
+                      <div className="topbar__spacer" />
+                      <button className="block__act" onClick={() => moverBloco(i, -1)} aria-label="Mover para cima">↑</button>
+                      <button className="block__act" onClick={() => moverBloco(i, 1)} aria-label="Mover para baixo">↓</button>
+                      <button className="block__act" onClick={() => removerBloco(i)} aria-label="Excluir bloco"><Trash size={15} /></button>
+                    </div>
+                    {b.type === 'image' || b.type === 'video' ? (
+                      <input
+                        className="block__input es-input"
+                        value={b.value}
+                        placeholder={b.type === 'image' ? 'URL da imagem (https://...)' : 'URL do vídeo (YouTube ou embed)'}
+                        onChange={(e) => setBloco(i, e.target.value)}
+                      />
+                    ) : (
+                      <textarea
+                        className={`block__edit es-input${b.type === 'code' ? ' block__edit--code' : ''}`}
+                        value={b.value}
+                        placeholder={b.type === 'code' ? 'Cole o código aqui' : b.type === 'quote' ? 'Texto da citação' : 'Escreva o texto'}
+                        onChange={(e) => setBloco(i, e.target.value)}
+                      />
+                    )}
+                  </div>
+                ))}
+                {aula.contentBlocks.length === 0 && (
+                  <p className="studio__section-sub" style={{ margin: 0 }}>Nenhum bloco ainda. Adicione conteúdo abaixo.</p>
+                )}
+              </div>
+
+              <div className="block-palette">
+                <div className="block-palette__label">Adicionar bloco de conteúdo</div>
+                <div className="block-palette__chips">
+                  {BLOCO_TIPOS.map((bt) => (
+                    <button key={bt.type} className="block-chip" onClick={() => addBloco(bt.type)}>
+                      <span className="block-chip__icon">{bt.icon}</span> {bt.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <div className="studio__section">
+                <span className="studio__section-title">Questões da aula</span>
+                <span className="studio__pill">{aula.questions.length} de 5</span>
+              </div>
+              <p className="studio__section-sub">Adicione 5 questões — o aluno precisa acertar ao menos 4 para concluir a aula.</p>
+
+              <div className="studio__questions">
+                {aula.questions.map((q, qi) => (
+                  <div key={qi} className="qcard">
+                    <div className="qcard__head">
+                      <span className="qcard__num">{qi + 1}</span>
+                      <span className="qcard__label">Questão {qi + 1}</span>
+                      <div className="topbar__spacer" />
+                      <select
+                        className="qcard__diff"
+                        value={q.difficulty}
+                        onChange={(e) => setQuestion(qi, { difficulty: e.target.value as QuestionDifficulty })}
+                      >
+                        {DIFFS.map((d) => <option key={d.value} value={d.value}>{d.label}</option>)}
+                      </select>
+                      <button className="qcard__del" onClick={() => removerQuestao(qi)} aria-label="Excluir questão"><Trash size={16} /></button>
+                    </div>
+
+                    <div className="qcard__field">
+                      <input
+                        className="es-input"
+                        value={q.statement}
+                        placeholder="Enunciado da questão"
+                        onChange={(e) => setQuestion(qi, { statement: e.target.value })}
+                      />
+                    </div>
+
+                    <div className="qcard__options">
+                      {q.options.map((o, oi) => (
+                        <div key={oi} className={`qopt${o.isCorrect ? ' qopt--correct' : ''}`}>
+                          <button className="qopt__radio" onClick={() => marcarCorreta(qi, oi)} aria-label="Marcar como correta">
+                            {o.isCorrect ? <Check size={12} /> : null}
+                          </button>
+                          <span className="qopt__letter">{LETTERS[oi] ?? oi + 1}</span>
+                          <input
+                            className="es-input"
+                            value={o.text}
+                            placeholder="Texto da alternativa"
+                            onChange={(e) => setOption(qi, oi, { text: e.target.value })}
+                          />
+                          {o.isCorrect && <span className="qopt__tag">correta</span>}
+                          <button className="qopt__remove" onClick={() => removerAlternativa(qi, oi)} aria-label="Remover alternativa"><Minus size={14} /></button>
+                        </div>
+                      ))}
+                    </div>
+
+                    <button className="studio__add studio__add--ghost" onClick={() => adicionarAlternativa(qi)}>
+                      <Plus size={14} /> Adicionar alternativa
+                    </button>
+                  </div>
+                ))}
+              </div>
+
+              {erro && <div className="auth__alert">{erro}</div>}
+
+              <button className="studio__add studio__add--dashed studio__add--lg" onClick={adicionarQuestao}>
+                <Plus size={16} /> Adicionar questão {faltam > 0 && <span className="studio__add-note">· faltam {faltam}</span>}
+              </button>
+
+              <div style={{ display: 'flex', gap: 12, marginTop: 18 }}>
+                <button className="btn btn--ghost" disabled={salvando} onClick={() => salvar()}>
+                  {salvando ? 'Salvando...' : 'Salvar'}
+                </button>
+              </div>
+            </main>
+          ) : (
+            <main className="studio__editor">
+              <p className="studio__section-sub">Selecione uma aula na esquerda ou adicione uma nova para começar.</p>
+              {erro && <div className="auth__alert">{erro}</div>}
+            </main>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/EstudioHome/index.tsx
+++ b/frontend/src/pages/EstudioHome/index.tsx
@@ -1,0 +1,205 @@
+import { useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { Logo } from '../../components/Logo';
+import { ChevronRight, Plus, Pencil, Trash } from '../../components/Icons';
+import {
+  listarTrilhas,
+  criarTrilha,
+  atualizarTrilha,
+  excluirTrilha,
+  listarTags,
+  type TrailLevelEnum,
+  type Tag,
+} from '../../services/trails';
+import type { Trail } from '../../data/trails';
+
+type TrailComId = Trail & { id: string };
+
+const LEVELS: { value: TrailLevelEnum; label: string }[] = [
+  { value: 'iniciante', label: 'Iniciante' },
+  { value: 'intermediario', label: 'Intermediário' },
+  { value: 'avancado', label: 'Avançado' },
+];
+const LABEL_TO_ENUM: Record<string, TrailLevelEnum> = {
+  'Iniciante': 'iniciante',
+  'Intermediário': 'intermediario',
+  'Avançado': 'avancado',
+};
+
+interface FormState {
+  id?: string;
+  name: string;
+  level: TrailLevelEnum;
+  description: string;
+  tagIds: string[];
+}
+
+export function EstudioHome() {
+  const navigate = useNavigate();
+  const [trilhas, setTrilhas] = useState<TrailComId[]>([]);
+  const [carregando, setCarregando] = useState(true);
+  const [erro, setErro] = useState('');
+  const [form, setForm] = useState<FormState | null>(null);
+  const [salvando, setSalvando] = useState(false);
+  const [tagsDisp, setTagsDisp] = useState<Tag[]>([]);
+
+  async function carregar() {
+    try {
+      const [tr, tg] = await Promise.all([listarTrilhas(), listarTags()]);
+      setTrilhas(tr);
+      setTagsDisp(tg);
+    } catch {
+      setErro('Não foi possível carregar as trilhas.');
+    } finally {
+      setCarregando(false);
+    }
+  }
+  useEffect(() => { carregar(); }, []);
+
+  function novaTrilha() {
+    setErro('');
+    setForm({ name: '', level: 'iniciante', description: '', tagIds: [] });
+  }
+  function editarTrilha(t: TrailComId) {
+    setErro('');
+    const tagIds = tagsDisp.filter((tg) => t.tags.includes(tg.name)).map((tg) => tg.id);
+    setForm({ id: t.id, name: t.name, level: LABEL_TO_ENUM[t.level] ?? 'iniciante', description: t.desc, tagIds });
+  }
+
+  async function salvar() {
+    if (!form || salvando) return;
+    setSalvando(true);
+    setErro('');
+    try {
+      if (form.id) {
+        await atualizarTrilha(form.id, { name: form.name, level: form.level, description: form.description, tagIds: form.tagIds });
+      } else {
+        await criarTrilha({ name: form.name, level: form.level, description: form.description, tagIds: form.tagIds });
+      }
+      setForm(null);
+      await carregar();
+    } catch (e: any) {
+      setErro(e?.response?.data?.erro ?? 'Não foi possível salvar a trilha.');
+    } finally {
+      setSalvando(false);
+    }
+  }
+
+  async function excluir(t: TrailComId) {
+    if (!window.confirm(`Excluir a trilha "${t.name}" e tudo dentro dela? Essa ação não pode ser desfeita.`)) return;
+    setErro('');
+    try {
+      await excluirTrilha(t.id);
+      await carregar();
+    } catch {
+      setErro('Não foi possível excluir a trilha.');
+    }
+  }
+
+  return (
+    <div className="home">
+      <header className="topbar studio__bar">
+        <div className="studio__brand">
+          <Logo variant="solid" size={19} />
+          <span className="studio__badge">Estúdio</span>
+        </div>
+        <span className="studio__divider" />
+        <div className="studio__crumb"><b>Painel do administrador</b></div>
+        <div className="topbar__spacer" />
+        <Link className="btn btn--ghost studio__btn" to="/home">Voltar ao app</Link>
+      </header>
+
+      <div className="estudio-home">
+        <div className="estudio-home__head">
+          <div>
+            <h1 className="estudio-home__title">Trilhas</h1>
+            <p className="estudio-home__sub">Escolha uma trilha para editar, ou crie uma nova.</p>
+          </div>
+          {!form && (
+            <button className="btn btn--accent" onClick={novaTrilha}><Plus size={14} /> Nova trilha</button>
+          )}
+        </div>
+
+        {form && (
+          <div className="estudio-form">
+            <div className="estudio-form__title">{form.id ? 'Editar trilha' : 'Nova trilha'}</div>
+            <label className="studio__label">Nome</label>
+            <input
+              className="estudio-form__input"
+              value={form.name}
+              placeholder="Ex.: Lógica de Programação"
+              onChange={(e) => setForm({ ...form, name: e.target.value })}
+            />
+            <label className="studio__label">Nível</label>
+            <select
+              className="estudio-form__input"
+              value={form.level}
+              onChange={(e) => setForm({ ...form, level: e.target.value as TrailLevelEnum })}
+            >
+              {LEVELS.map((l) => <option key={l.value} value={l.value}>{l.label}</option>)}
+            </select>
+            <label className="studio__label">Descrição</label>
+            <textarea
+              className="estudio-form__input estudio-form__textarea"
+              value={form.description}
+              placeholder="Descrição da trilha (mínimo 10 caracteres)"
+              onChange={(e) => setForm({ ...form, description: e.target.value })}
+            />
+            <label className="studio__label">Tags</label>
+            <div className="tag-picker">
+              {tagsDisp.length === 0 && <span className="tag-picker__empty">Nenhuma tag ainda. Crie em Configurações.</span>}
+              {tagsDisp.map((tg) => {
+                const ativa = form.tagIds.includes(tg.id);
+                return (
+                  <button
+                    key={tg.id}
+                    type="button"
+                    className={`tag-pick${ativa ? ' tag-pick--on' : ''}`}
+                    onClick={() => setForm({
+                      ...form,
+                      tagIds: ativa ? form.tagIds.filter((id) => id !== tg.id) : [...form.tagIds, tg.id],
+                    })}
+                  >
+                    {tg.name}
+                  </button>
+                );
+              })}
+            </div>
+            {erro && <div className="auth__alert">{erro}</div>}
+            <div className="estudio-form__actions">
+              <button className="btn btn--ghost" onClick={() => { setForm(null); setErro(''); }}>Cancelar</button>
+              <button className="btn btn--accent" disabled={salvando} onClick={salvar}>
+                {salvando ? 'Salvando...' : form.id ? 'Salvar' : 'Criar trilha'}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {carregando && <p className="track__desc">Carregando...</p>}
+        {!form && erro && <div className="auth__alert">{erro}</div>}
+        {!carregando && trilhas.length === 0 && !form && (
+          <p className="track__desc">Nenhuma trilha cadastrada ainda.</p>
+        )}
+
+        <div className="estudio-home__list">
+          {trilhas.map((t) => (
+            <div key={t.id} className="estudio-home__card">
+              <button className="estudio-home__open" onClick={() => navigate(`/estudio/${t.id}`)}>
+                <span className="estudio-home__glyph">{t.glyph}</span>
+                <div className="estudio-home__meta">
+                  <div className="estudio-home__name">{t.name}</div>
+                  <div className="estudio-home__info">{t.lessons} aulas · {t.level}</div>
+                </div>
+              </button>
+              <div className="estudio-home__actions">
+                <button className="estudio-home__act" onClick={() => editarTrilha(t)} aria-label="Editar trilha"><Pencil size={15} /></button>
+                <button className="estudio-home__act estudio-home__act--danger" onClick={() => excluir(t)} aria-label="Excluir trilha"><Trash size={15} /></button>
+                <button className="estudio-home__act" onClick={() => navigate(`/estudio/${t.id}`)} aria-label="Abrir trilha"><ChevronRight size={16} /></button>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -1,4 +1,5 @@
-import { Link } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { Logo } from '../../components/Logo';
 import { UserMenu } from '../../components/UserMenu';
@@ -9,12 +10,13 @@ import { getInitials } from '../../utils/initials';
 import {
   user,
   dailyChallenge,
-  trilhas,
   week,
   ranking,
   feed,
   MEDALS,
 } from '../../data/home';
+import { listarTrilhas, listarMinhasTrilhas, obterTrilha } from '../../services/trails';
+import type { Trail } from '../../data/trails';
 
 const NAV = [
   { label: 'Início', to: '/home' },
@@ -37,6 +39,48 @@ export function Home() {
 
   const displayName = authUser?.name ?? user.name;
   const initials = getInitials(displayName);
+
+  const navigate = useNavigate();
+  const [emAndamento, setEmAndamento] = useState<(Trail & { id: string })[]>([]);
+  const [disponiveis, setDisponiveis] = useState<(Trail & { id: string })[]>([]);
+  const [carregando, setCarregando] = useState(true);
+
+  useEffect(() => {
+    let ativo = true;
+    async function carregar() {
+      try {
+        const [todas, doUsuario] = await Promise.all([listarTrilhas(), listarMinhasTrilhas()]);
+        if (!ativo) return;
+        const comProgresso = todas.map((c) => ({
+          ...c,
+          done: doUsuario.find((m) => m.id === c.id)?.done ?? 0,
+        }));
+        setEmAndamento(comProgresso.filter((t) => t.done > 0 && t.done < t.lessons));
+        setDisponiveis(comProgresso);
+      } catch {
+        // silencioso: o resto da home continua aparecendo
+      } finally {
+        if (ativo) setCarregando(false);
+      }
+    }
+    carregar();
+    return () => { ativo = false; };
+  }, []);
+
+  // Abre a trilha na primeira aula disponivel (a atual, ou a primeira).
+  async function abrirTrilha(trailId: string) {
+    try {
+      const detalhe = await obterTrilha(trailId);
+      const aulas = detalhe.modules.flatMap((m) => m.lessons);
+      const alvo = aulas.find((l) => l.state === 'current') ?? aulas.find((l) => l.state !== 'locked');
+      navigate(alvo ? `/trilhas/${trailId}/aula/${alvo.id}` : '/trilhas');
+    } catch {
+      navigate('/trilhas');
+    }
+  }
+
+  const mostrandoEmAndamento = emAndamento.length > 0;
+  const listaTrilhas = (mostrandoEmAndamento ? emAndamento : disponiveis).slice(0, 4);
 
   return (
     <div className="home-shell">
@@ -125,36 +169,55 @@ export function Home() {
             {/* Trilhas */}
             <section>
               <div className="section-head">
-                <h2 className="section-title">Continue suas trilhas</h2>
-                <a className="link" href="#">Ver todas</a>
+                <h2 className="section-title">{mostrandoEmAndamento ? 'Continue suas trilhas' : 'Trilhas disponíveis'}</h2>
+                <Link className="link" to="/trilhas">Ver todas</Link>
               </div>
-              <div className="trilhas">
-                {trilhas.map((t) => (
-                  <div key={t.name} className="trilha">
-                    <div className="trilha__head">
-                      <span
-                        className="trilha__icon"
-                        style={{
-                          color: t.hue,
-                          background: `color-mix(in srgb, ${t.hue} 16%, transparent)`,
-                        }}
+              {carregando ? (
+                <p className="track__desc">Carregando trilhas...</p>
+              ) : listaTrilhas.length === 0 ? (
+                <p className="track__desc">Nenhuma trilha disponível ainda.</p>
+              ) : (
+                <div className="trilhas">
+                  {listaTrilhas.map((t) => {
+                    const pct = t.lessons > 0 ? Math.round((t.done / t.lessons) * 100) : 0;
+                    return (
+                      <div
+                        key={t.id}
+                        className="trilha"
+                        role="button"
+                        tabIndex={0}
+                        style={{ cursor: 'pointer' }}
+                        onClick={() => abrirTrilha(t.id)}
+                        onKeyDown={(e) => { if (e.key === 'Enter') abrirTrilha(t.id); }}
                       >
-                        {t.glyph}
-                      </span>
-                      <div className="trilha__meta">
-                        <div className="trilha__name">{t.name}</div>
-                        <div className="trilha__sub">{t.sub}</div>
+                        <div className="trilha__head">
+                          <span
+                            className="trilha__icon"
+                            style={{
+                              color: t.hue,
+                              background: `color-mix(in srgb, ${t.hue} 16%, transparent)`,
+                            }}
+                          >
+                            {t.glyph}
+                          </span>
+                          <div className="trilha__meta">
+                            <div className="trilha__name">{t.name}</div>
+                            <div className="trilha__sub">
+                              {t.done > 0 ? `${t.done} de ${t.lessons} aulas` : `${t.lessons} aulas · ${t.level}`}
+                            </div>
+                          </div>
+                        </div>
+                        <div className="progress">
+                          <div className="progress__track">
+                            <span className="progress__fill" style={{ width: `${pct}%` }} />
+                          </div>
+                          <span className="progress__pct">{pct}%</span>
+                        </div>
                       </div>
-                    </div>
-                    <div className="progress">
-                      <div className="progress__track">
-                        <span className="progress__fill" style={{ width: `${t.pct}%` }} />
-                      </div>
-                      <span className="progress__pct">{t.pct}%</span>
-                    </div>
-                  </div>
-                ))}
-              </div>
+                    );
+                  })}
+                </div>
+              )}
             </section>
           </main>
 

--- a/frontend/src/pages/Trilhas/index.tsx
+++ b/frontend/src/pages/Trilhas/index.tsx
@@ -8,8 +8,8 @@ import { ThemeToggle } from '../../components/ThemeToggle';
 import { Flame, Search, Play, ChevronRight } from '../../components/Icons';
 import { getInitials } from '../../utils/initials';
 import { user } from '../../data/home';
-import { trilhaFilters, type Trail, type TrailLevel } from '../../data/trails';
-import { listarTrilhas, listarMinhasTrilhas, obterTrilha } from '../../services/trails';
+import { type Trail, type TrailLevel } from '../../data/trails';
+import { listarTrilhas, listarMinhasTrilhas, obterTrilha, obterXp, listarTags, type Tag } from '../../services/trails';
 
 type TrailComId = Trail & { id: string };
 
@@ -57,10 +57,11 @@ export function Trilhas() {
     try {
       const detalhe = await obterTrilha(trailId);
       const aulas = detalhe.modules.flatMap((m) => m.lessons);
-      const alvo = aulas.find((l) => l.state === 'current') ?? aulas[0];
-      if (alvo) navigate(`/trilhas/${trailId}/aula/${alvo.id}`);
+      // nunca manda para uma aula bloqueada: prefere a atual, senao a primeira liberada.
+      const alvo = aulas.find((l) => l.state === 'current') ?? aulas.find((l) => l.state !== 'locked');
+      navigate(alvo ? `/trilhas/${trailId}/aula/${alvo.id}` : '/trilhas');
     } catch {
-      // se a trilha nao tiver aulas publicadas, nao navega
+      navigate('/trilhas');
     }
   }
 
@@ -71,16 +72,23 @@ export function Trilhas() {
   const [minhas, setMinhas] = useState<TrailComId[]>([]);
   const [carregando, setCarregando] = useState(true);
   const [erro, setErro] = useState('');
+  const [xp, setXp] = useState(0);
+  const [tagsDisp, setTagsDisp] = useState<Tag[]>([]);
+  const [filtro, setFiltro] = useState('Todas');
 
   useEffect(() => {
     async function carregar() {
       try {
-        const [todas, doUsuario] = await Promise.all([
+        const [todas, doUsuario, stats, tg] = await Promise.all([
           listarTrilhas(),
           listarMinhasTrilhas(),
+          obterXp(),
+          listarTags(),
         ]);
         setTrilhas(todas);
         setMinhas(doUsuario);
+        setXp(stats.xp);
+        setTagsDisp(tg);
       } catch {
         setErro('Não foi possível carregar as trilhas.');
       } finally {
@@ -97,6 +105,8 @@ export function Trilhas() {
 
   const aulasConcluidas = minhas.reduce((soma, t) => soma + t.done, 0);
   const emAndamento = minhas.filter((t) => t.done < t.lessons).length;
+
+  const trilhasFiltradas = filtro === 'Todas' ? trilhas : trilhas.filter((t) => t.tags.includes(filtro));
 
   return (
     <div className="home-shell">
@@ -147,7 +157,7 @@ export function Trilhas() {
               <span className="trilhas-page__divider" />
               <Metric value={String(aulasConcluidas)} label="aulas concluídas" />
               <span className="trilhas-page__divider" />
-              <Metric value={String(aulasConcluidas * 50)} label="XP em trilhas" accent />
+              <Metric value={String(xp)} label="XP em trilhas" accent />
             </div>
           </div>
 
@@ -170,7 +180,7 @@ export function Trilhas() {
                   </span>
                 </div>
               </div>
-              <button className="continue-card__btn">
+              <button className="continue-card__btn" onClick={() => abrirTrilha(continuar.id)}>
                 <Play size={13} /> Continuar aula
               </button>
             </div>
@@ -178,13 +188,17 @@ export function Trilhas() {
 
           {/* Filtros */}
           <div className="filters">
-            {trilhaFilters.map((f, i) => (
-              <button key={f} className={`filter${i === 0 ? ' filter--active' : ''}`}>
+            {['Todas', ...tagsDisp.map((t) => t.name)].map((f) => (
+              <button
+                key={f}
+                className={`filter${filtro === f ? ' filter--active' : ''}`}
+                onClick={() => setFiltro(f)}
+              >
                 {f}
               </button>
             ))}
             <div className="topbar__spacer" />
-            <span className="filters__count">{trilhas.length} trilhas</span>
+            <span className="filters__count">{trilhasFiltradas.length} trilhas</span>
           </div>
 
           {carregando && <p className="track__desc">Carregando trilhas...</p>}
@@ -195,7 +209,7 @@ export function Trilhas() {
 
           {/* Grade */}
           <div className="track-grid">
-            {trilhas.map((catalogo) => {
+            {trilhasFiltradas.map((catalogo) => {
               // Cruza o catalogo com o progresso do usuario (done vem de /me/trails).
               const progresso = minhas.find((m) => m.id === catalogo.id);
               const t = { ...catalogo, done: progresso?.done ?? 0 };
@@ -251,6 +265,16 @@ export function Trilhas() {
                       {t.tags.map((tag) => (
                         <span key={tag} className="chip--outline">{tag}</span>
                       ))}
+                      {authUser?.role === 'admin' && (
+                        <Link
+                          to={`/estudio/${t.id}`}
+                          className="chip--outline"
+                          style={{ textDecoration: 'none' }}
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          Editar
+                        </Link>
+                      )}
                     </div>
                     <span
                       className="track__cta"

--- a/frontend/src/services/trails.ts
+++ b/frontend/src/services/trails.ts
@@ -10,6 +10,7 @@ interface TrailApi {
   totalLessons: number;
   completedLessons?: number;
   progress?: number;
+  tags?: { id: string; name: string }[];
 }
 
 const LEVEL_LABEL: Record<TrailApi['trailLevel'], TrailLevel> = {
@@ -42,7 +43,7 @@ function adaptar(t: TrailApi): Trail & { id: string } {
     lessons: t.totalLessons,
     done: t.completedLessons ?? 0,
     desc: t.description,
-    tags: [level],
+    tags: t.tags?.map((tg) => tg.name) ?? [],
   };
 }
 
@@ -97,12 +98,19 @@ export interface QuizQuestion {
   position: number;
   options: QuizOption[];
 }
+export type BlocoTipo = 'text' | 'code' | 'image' | 'video' | 'quote';
+export interface Bloco {
+  type: BlocoTipo;
+  value: string;
+}
+
 export interface LessonDetail {
   id: string;
   trailId: string;
   moduleId: string;
   title: string;
   content: string | null;
+  contentBlocks: Bloco[] | null;
   state: LessonState;
   questions: QuizQuestion[];
 }
@@ -125,4 +133,156 @@ export async function enviarQuiz(
 ) {
   const { data } = await api.post<QuizResult>(`/lessons/${lessonId}/quiz`, { answers });
   return data;
+}
+
+export interface CheckResult {
+  correct: boolean;
+  correctOptionId: string;
+}
+
+// Verifica uma unica resposta (feedback imediato do quiz em carrossel). O gabarito
+// das outras questoes nao e exposto: o backend so revela a alternativa da questao enviada.
+export async function verificarResposta(
+  lessonId: string,
+  questionId: string,
+  optionId: string,
+) {
+  const { data } = await api.post<CheckResult>(`/lessons/${lessonId}/quiz/check`, {
+    questionId,
+    optionId,
+  });
+  return data;
+}
+
+// ===== Estúdio (admin) =====
+
+export type QuestionDifficulty = 'facil' | 'medio' | 'dificil';
+
+export interface StudioLessonRef {
+  id: string;
+  title: string;
+  position: number;
+  published: boolean;
+}
+export interface StudioModule {
+  id: string;
+  title: string;
+  position: number;
+  lessons: StudioLessonRef[];
+}
+export interface StudioTrail {
+  id: string;
+  name: string;
+  modules: StudioModule[];
+}
+
+export async function obterEstudio(trailId: string) {
+  const { data } = await api.get<StudioTrail>(`/trails/${trailId}/studio`);
+  return data;
+}
+
+export interface StudioOption {
+  id?: string;
+  text: string;
+  isCorrect: boolean;
+}
+export interface StudioQuestion {
+  id?: string;
+  statement: string;
+  difficulty: QuestionDifficulty;
+  options: StudioOption[];
+}
+export interface StudioLesson {
+  id: string;
+  moduleId: string;
+  title: string;
+  content: string | null;
+  contentBlocks: Bloco[];
+  published: boolean;
+  position: number;
+  questions: StudioQuestion[];
+}
+
+export async function obterAulaEstudio(lessonId: string) {
+  const { data } = await api.get<StudioLesson>(`/lessons/${lessonId}/studio`);
+  return data;
+}
+
+export interface SalvarAulaPayload {
+  title: string;
+  contentBlocks: Bloco[];
+  published?: boolean;
+  questions: {
+    statement: string;
+    difficulty: QuestionDifficulty;
+    options: { text: string; isCorrect: boolean }[];
+  }[];
+}
+export async function salvarAulaEstudio(lessonId: string, payload: SalvarAulaPayload) {
+  const { data } = await api.put(`/lessons/${lessonId}/studio`, payload);
+  return data;
+}
+
+export async function criarModulo(trailId: string, title: string, position: number) {
+  const { data } = await api.post<{ id: string }>(`/trails/${trailId}/modules`, { title, position });
+  return data;
+}
+export async function criarAula(moduleId: string, title: string, position: number) {
+  const { data } = await api.post<{ id: string }>(`/modules/${moduleId}/lessons`, { title, position });
+  return data;
+}
+export async function excluirAula(lessonId: string) {
+  await api.delete(`/lessons/${lessonId}`);
+}
+export async function excluirModulo(moduleId: string) {
+  await api.delete(`/modules/${moduleId}`);
+}
+
+export type TrailLevelEnum = 'iniciante' | 'intermediario' | 'avancado';
+
+export async function criarTrilha(payload: { name: string; level: TrailLevelEnum; description: string; tagIds?: string[] }) {
+  const { data } = await api.post<{ id: string }>('/trails', payload);
+  return data;
+}
+export async function atualizarTrilha(
+  id: string,
+  payload: { name?: string; level?: TrailLevelEnum; description?: string; tagIds?: string[] },
+) {
+  const { data } = await api.patch(`/trails/${id}`, payload);
+  return data;
+}
+export async function excluirTrilha(id: string) {
+  await api.delete(`/trails/${id}`);
+}
+
+export interface XpStats {
+  xp: number;
+  lessonsCompleted: number;
+  questionsCorrect: number;
+}
+export async function obterXp() {
+  const { data } = await api.get<XpStats>('/me/xp');
+  return data;
+}
+
+// ===== Tags (categorias de trilha) =====
+
+export interface Tag {
+  id: string;
+  name: string;
+}
+export async function listarTags() {
+  const { data } = await api.get<Tag[]>('/tags');
+  return data;
+}
+export async function criarTag(name: string) {
+  const { data } = await api.post<Tag>('/tags', { name });
+  return data;
+}
+export async function atualizarTag(id: string, name: string) {
+  const { data } = await api.patch<Tag>(`/tags/${id}`, { name });
+  return data;
+}
+export async function excluirTag(id: string) {
+  await api.delete(`/tags/${id}`);
 }

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -460,3 +460,142 @@
 .lesson__md hr { border: none; border-top: 1px solid var(--border); margin: 22px 0; }
 .lesson__md a { color: var(--accent); text-decoration: underline; }
 .codeblock__code code { background: none; padding: 0; color: inherit; font-size: inherit; border-radius: 0; }
+
+/* ===================== ESTÚDIO (admin) ===================== */
+.studio__bar { gap: 16px; height: 64px; padding: 0 22px; }
+.studio__brand { display: flex; align-items: center; gap: 10px; }
+.studio__badge { font-size: 12px; font-weight: 600; color: var(--accent); background: color-mix(in srgb, var(--accent) 13%, transparent); padding: 3px 9px; border-radius: 7px; }
+.studio__divider { width: 1px; height: 26px; background: var(--border); margin: 0 4px; }
+.studio__crumb { display: flex; align-items: center; gap: 8px; font-size: 14px; color: var(--muted); }
+.studio__crumb a { color: var(--muted); text-decoration: none; }
+.studio__crumb b { color: var(--text); font-weight: 600; }
+.studio__crumb-sep { opacity: .45; }
+.studio__saved { display: flex; align-items: center; gap: 7px; font-size: 13px; color: var(--muted); }
+.studio__saved i { width: 8px; height: 8px; border-radius: 50%; background: var(--success); }
+.studio__btn { flex: none; height: 40px; }
+
+.studio { display: grid; grid-template-columns: 312px 1fr; align-items: start; }
+
+.studio__nav { align-self: stretch; background: var(--surface); border-right: 1px solid var(--border); padding: 20px 16px; min-height: calc(100svh - 64px); }
+.studio__nav-head { display: flex; align-items: center; padding: 0 4px 14px; }
+.studio__nav-title { font-size: 11px; font-weight: 700; letter-spacing: .07em; text-transform: uppercase; color: var(--muted); }
+.studio__nav-count { margin-left: auto; font-size: 12px; color: var(--muted); }
+.studio-mod { margin-bottom: 8px; }
+.studio-mod__row { display: flex; align-items: center; gap: 9px; width: 100%; padding: 9px 10px; border-radius: 10px; background: var(--surface-2); border: none; font-family: inherit; }
+.studio-mod__chev { display: flex; color: var(--muted); }
+.studio-mod__num { width: 22px; height: 22px; border-radius: 6px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; font-family: var(--font-code); font-size: 11px; font-weight: 700; color: var(--accent); background: color-mix(in srgb, var(--accent) 13%, transparent); }
+.studio-mod__title { flex: 1; min-width: 0; font-size: 13.5px; font-weight: 600; text-align: left; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: var(--text); }
+.studio-mod__count { font-size: 11.5px; color: var(--muted); }
+.studio-mod__del { display: flex; align-items: center; justify-content: center; width: 24px; height: 24px; border-radius: 6px; background: none; border: none; color: var(--muted); cursor: pointer; flex-shrink: 0; }
+.studio-mod__del:hover { background: var(--surface); color: var(--av-red); }
+.studio-mod__lessons { padding: 6px 0 2px 14px; }
+.studio-les { display: flex; align-items: center; gap: 9px; height: 34px; padding: 0 9px; border-radius: 9px; margin-bottom: 1px; }
+.studio-les__dot { width: 18px; height: 18px; border-radius: 50%; flex-shrink: 0; display: flex; align-items: center; justify-content: center; border: 2px solid var(--border-strong); color: #fff; }
+.studio-les__name { flex: 1; min-width: 0; font-size: 13px; font-weight: 500; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.studio-les--published .studio-les__dot { background: var(--success); border-color: var(--success); }
+.studio-les--active { background: color-mix(in srgb, var(--accent) 12%, transparent); }
+.studio-les--active .studio-les__dot { border-color: var(--accent); }
+.studio-les--active .studio-les__name { color: var(--accent); font-weight: 700; }
+.studio-les__tag { font-size: 10px; font-weight: 700; color: var(--accent); text-transform: uppercase; letter-spacing: .04em; }
+
+.studio__add { display: flex; align-items: center; justify-content: center; gap: 8px; font-family: inherit; font-weight: 600; cursor: pointer; }
+.studio__add--ghost { width: 100%; height: 32px; margin-top: 2px; padding: 0 9px; border: none; background: transparent; border-radius: 9px; color: var(--accent); font-size: 13px; justify-content: flex-start; }
+.studio__add--dashed { width: 100%; height: 42px; margin-top: 8px; border-radius: 11px; border: 1.5px dashed var(--border-strong); background: transparent; color: var(--text); font-size: 13.5px; }
+.studio__add--lg { height: 50px; border-radius: 13px; font-size: 14px; }
+.studio__add-note { color: var(--muted); font-weight: 500; }
+
+.studio__editor { padding: 28px 36px 40px; max-width: 840px; }
+.studio__meta { display: flex; align-items: center; gap: 10px; margin-bottom: 18px; }
+.studio__meta-mod { font-size: 12px; font-weight: 700; color: var(--muted); text-transform: uppercase; letter-spacing: .06em; }
+.studio__del { display: flex; align-items: center; gap: 7px; height: 34px; padding: 0 13px; border-radius: 9px; border: 1px solid var(--border-strong); background: var(--surface); color: var(--muted); font-family: inherit; font-size: 13px; font-weight: 600; cursor: pointer; }
+.studio__label { display: block; font-size: 12px; font-weight: 600; color: var(--muted); text-transform: uppercase; letter-spacing: .05em; margin-bottom: 8px; }
+.studio__title-field { display: flex; align-items: center; height: 56px; padding: 0 18px; border-radius: 13px; border: 1px solid var(--border-strong); background: var(--input); margin-bottom: 26px; }
+.studio__title-field .es-input { flex: 1; font-size: 21px; font-weight: 700; letter-spacing: -.02em; }
+
+.es-input { border: none; outline: none; background: transparent; font-family: inherit; color: var(--text); width: 100%; }
+.es-input::placeholder { color: var(--muted); opacity: .7; }
+
+.studio__content { width: 100%; min-height: 220px; resize: vertical; padding: 16px 18px; border-radius: 13px; border: 1px solid var(--border-strong); background: var(--input); font-family: var(--font-code); font-size: 13.5px; line-height: 1.7; color: var(--text); margin-bottom: 34px; }
+
+.studio__section { display: flex; align-items: center; gap: 10px; margin-bottom: 14px; }
+.studio__section-title { font-size: 16px; font-weight: 700; letter-spacing: -.01em; }
+.studio__pill { font-size: 12px; color: var(--muted); background: var(--surface-2); padding: 2px 9px; border-radius: 6px; }
+.studio__section-sub { margin: -8px 0 16px; font-size: 13px; color: var(--muted); }
+
+.studio__questions { display: flex; flex-direction: column; gap: 14px; margin-bottom: 14px; }
+.qcard { border: 1px solid var(--border); border-radius: 15px; background: var(--surface); padding: 18px; }
+.qcard__head { display: flex; align-items: center; gap: 10px; margin-bottom: 14px; }
+.qcard__num { width: 26px; height: 26px; border-radius: 8px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; font-size: 13px; font-weight: 700; color: #fff; background: var(--accent); }
+.qcard__label { font-size: 13px; font-weight: 600; color: var(--muted); }
+.qcard__diff { height: 30px; padding: 0 11px; border-radius: 8px; border: 1px solid var(--border); background: var(--surface-2); font-family: inherit; font-size: 12.5px; font-weight: 600; color: var(--muted); cursor: pointer; }
+.qcard__del { display: flex; align-items: center; color: var(--muted); cursor: pointer; background: none; border: none; padding: 0; }
+.qcard__field { display: flex; align-items: center; height: 46px; padding: 0 14px; border-radius: 11px; border: 1px solid var(--border-strong); background: var(--input); margin-bottom: 14px; }
+.qcard__field .es-input { flex: 1; font-size: 14.5px; font-weight: 600; }
+.qcard__options { display: flex; flex-direction: column; gap: 8px; }
+.qopt { display: flex; align-items: center; gap: 11px; height: 44px; padding: 0 13px; border-radius: 11px; background: var(--surface-2); border: 1.5px solid transparent; }
+.qopt__radio { width: 22px; height: 22px; border-radius: 50%; flex-shrink: 0; display: flex; align-items: center; justify-content: center; border: 2px solid var(--border-strong); background: transparent; color: #fff; cursor: pointer; padding: 0; }
+.qopt__letter { width: 20px; font-size: 12.5px; font-weight: 700; color: var(--muted); }
+.qopt .es-input { flex: 1; font-size: 14px; font-weight: 500; }
+.qopt__remove { display: flex; color: var(--muted); opacity: .6; cursor: pointer; background: none; border: none; padding: 0; }
+.qopt--correct { background: var(--success-soft); border-color: var(--success); }
+.qopt--correct .qopt__radio { border-color: var(--success); background: var(--success); }
+.qopt--correct .qopt__letter { color: var(--success); }
+.qopt__tag { font-size: 11.5px; font-weight: 700; color: var(--success); text-transform: uppercase; letter-spacing: .04em; }
+
+/* Painel do Estúdio (lista de trilhas) */
+.estudio-home { max-width: 760px; margin: 0 auto; padding: 40px 32px; }
+.estudio-home__head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 22px; }
+.estudio-home__head .btn { flex: none; }
+.estudio-home__title { font-size: 26px; font-weight: 700; letter-spacing: -.02em; margin: 0; }
+.estudio-home__sub { margin: 6px 0 0; font-size: 14px; color: var(--muted); }
+.estudio-home__list { display: flex; flex-direction: column; gap: 10px; }
+.estudio-home__card { display: flex; align-items: center; border-radius: 14px; border: 1px solid var(--border); background: var(--surface); transition: border-color .15s ease; }
+.estudio-home__card:hover { border-color: var(--accent); }
+.estudio-home__open { flex: 1; min-width: 0; display: flex; align-items: center; gap: 14px; padding: 16px 18px; background: none; border: none; cursor: pointer; font-family: inherit; text-align: left; color: var(--text); }
+.estudio-home__glyph { width: 40px; height: 40px; border-radius: 11px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; font-family: var(--font-code); font-weight: 700; color: var(--accent); background: color-mix(in srgb, var(--accent) 14%, transparent); }
+.estudio-home__meta { flex: 1; min-width: 0; }
+.estudio-home__name { font-size: 15px; font-weight: 700; }
+.estudio-home__info { font-size: 12.5px; color: var(--muted); margin-top: 2px; }
+.estudio-home__actions { display: flex; align-items: center; gap: 2px; padding: 0 10px; }
+.estudio-home__act { display: flex; align-items: center; justify-content: center; width: 34px; height: 34px; border-radius: 9px; background: none; border: none; color: var(--muted); cursor: pointer; }
+.estudio-home__act:hover { background: var(--surface-2); color: var(--text); }
+.estudio-home__act--danger:hover { color: var(--av-red); }
+
+.estudio-form { border: 1px solid var(--border); border-radius: 14px; background: var(--surface); padding: 20px; margin-bottom: 20px; }
+.estudio-form__title { font-size: 16px; font-weight: 700; margin-bottom: 14px; }
+.estudio-form__input { width: 100%; height: 44px; padding: 0 14px; border-radius: 10px; border: 1px solid var(--border-strong); background: var(--input); font-family: inherit; font-size: 14px; color: var(--text); margin-bottom: 14px; }
+.estudio-form__textarea { height: auto; min-height: 90px; padding: 12px 14px; resize: vertical; line-height: 1.5; }
+.estudio-form__actions { display: flex; justify-content: flex-end; gap: 12px; }
+.estudio-form__actions .btn { flex: none; }
+
+.user-menu__item--accent { color: var(--accent); font-weight: 600; }
+
+/* Editor de blocos (Estúdio) */
+.studio__blocks { display: flex; flex-direction: column; gap: 12px; margin-bottom: 14px; }
+.block { border: 1px solid var(--border); border-radius: 13px; background: var(--surface); overflow: hidden; }
+.block__bar { display: flex; align-items: center; gap: 8px; height: 40px; padding: 0 10px; border-bottom: 1px solid var(--border); background: var(--surface-2); }
+.block__tag { font-size: 12px; font-weight: 700; padding: 3px 9px; border-radius: 6px; color: var(--muted); background: color-mix(in srgb, var(--muted) 20%, transparent); }
+.block__tag--code { color: var(--accent); background: color-mix(in srgb, var(--accent) 16%, transparent); }
+.block__act { display: flex; align-items: center; justify-content: center; min-width: 26px; height: 26px; border-radius: 7px; background: none; border: none; color: var(--muted); cursor: pointer; font-size: 14px; }
+.block__act:hover { background: var(--surface); color: var(--text); }
+.block__edit { min-height: 90px; resize: vertical; padding: 12px 14px; font-size: 14px; line-height: 1.6; }
+.block__edit--code { font-family: var(--font-code); font-size: 13px; }
+.block__input { height: 46px; padding: 0 14px; font-size: 14px; }
+
+.block-palette { border: 1.5px dashed var(--border-strong); border-radius: 13px; padding: 16px; margin-bottom: 8px; }
+.block-palette__label { font-size: 12.5px; font-weight: 600; color: var(--muted); text-align: center; margin-bottom: 12px; }
+.block-palette__chips { display: flex; gap: 9px; justify-content: center; flex-wrap: wrap; }
+.block-chip { display: flex; align-items: center; gap: 7px; height: 36px; padding: 0 14px; border-radius: 10px; background: var(--surface); border: 1px solid var(--border); font-family: inherit; font-size: 13px; font-weight: 600; cursor: pointer; color: var(--text); }
+.block-chip:hover { border-color: var(--accent); color: var(--accent); }
+.block-chip__icon { font-family: var(--font-code); font-size: 14px; }
+
+/* Conteúdo da aula em blocos (aluno) */
+.lesson__img { max-width: 100%; border-radius: 10px; margin: 0 0 22px; display: block; }
+.lesson__video { width: 100%; aspect-ratio: 16 / 9; margin: 0 0 22px; }
+.lesson__video iframe { width: 100%; height: 100%; border-radius: 10px; }
+
+/* Seletor de tags (Estúdio) */
+.tag-picker { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 14px; }
+.tag-pick { padding: 6px 12px; border-radius: 99px; border: 1px solid var(--border-strong); background: var(--surface); color: var(--muted); font-family: inherit; font-size: 13px; font-weight: 600; cursor: pointer; }
+.tag-pick--on { border-color: var(--accent); color: var(--accent); background: color-mix(in srgb, var(--accent) 12%, transparent); }
+.tag-picker__empty { font-size: 13px; color: var(--muted); }


### PR DESCRIPTION
Esta branch adiciona o Estúdio (área de administração de cursos) e melhorias nas trilhas. Testado localmente.

## Estúdio do administrador
- Painel em /estudio (restrito a admin) com a lista de trilhas.
- CRUD de trilha: criar, editar (nome, nível, descrição e tags) e excluir.
- Estrutura do curso: adicionar e excluir módulos e aulas.
- Editor de aula: título, editor de blocos de conteúdo (Texto, Código, Imagem, Vídeo, Citação) e editor de questões (enunciado, dificuldade, alternativas e marcação da correta).
- Publicar e despublicar aula. Publicar exige questões válidas.
- Acesso pelo menu do usuário (itens Estúdio e Configurações, só para admin).

## Quiz em carrossel
- Uma questão por vez com feedback imediato.
- A verificação acontece no servidor: o gabarito não é enviado ao cliente.

## XP
- 50 de XP por aula concluída e 10 por questão correta.
- Cada XP conta uma única vez; errar e refazer não rende XP de novo.
- Exibido em XP em trilhas.

## Tags e filtros
- Tabela de tags com aba de Configurações (/configuracoes) para o CRUD, restrita a admin.
- Tags atribuídas no formulário da trilha.
- Os filtros da página de trilhas passam a funcionar.

## Trilhas e Home
- Cards de trilha e botão Continuar aula abrem a aula correta.
- A Home mostra as trilhas em andamento do aluno ou, se não houver, as disponíveis.
- Conteúdo das aulas renderizado (markdown e blocos), com layout em largura total.

## Banco de dados (migrations)
- Coluna difficulty em questions.
- Coluna content_blocks (jsonb) em lessons.
- Tabelas tags e trail_tags.
O deploy aplica as migrations automaticamente.