### PR TITLE
feat: perfil, conquistas, comunidade, ranking e streak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ dist
 dist-ssr
 *.local
 
+# Imagens enviadas pelos usuarios (geradas em runtime)
+backend/uploads/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+uploads
+.env
+.env.*
+!.env.*.example
+*.log

--- a/backend/app.ts
+++ b/backend/app.ts
@@ -7,12 +7,17 @@ import trailRoutes from "./src/routes/trail.routes.ts";
 import { errorMiddleware } from "./src/middlewares/error.ts";
 import helmet from "helmet";
 import cors from "cors";
+import { UPLOADS_DIR } from "./src/config/paths.ts";
 
 export const app = express();
 
 app.set("trust proxy", 1);
 
 app.use(cookieParser());
+// Uploads de imagem trafegam como data URL (base64) em JSON e precisam de um
+// limite maior que o padrao. Aplicado so nessas rotas; o json global segue enxuto.
+app.use("/me/avatar", express.json({ limit: "6mb" }));
+app.use("/me/cover", express.json({ limit: "6mb" }));
 app.use(express.json());
 app.use(helmet());
 app.use(cors({
@@ -21,6 +26,13 @@ app.use(cors({
     : true,
     credentials: true,
 }));
+
+// Imagens enviadas pelos usuarios. Libera o carregamento cross-origin para o
+// front (em dev fica em outra origem que o backend).
+app.use("/uploads", (_req, res, next) => {
+    res.setHeader("Cross-Origin-Resource-Policy", "cross-origin");
+    next();
+}, express.static(UPLOADS_DIR));
 
 app.use(authRoutes);
 app.use(userRoutes);

--- a/backend/drizzle/0011_user_username.sql
+++ b/backend/drizzle/0011_user_username.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "users" ADD COLUMN "username" varchar(20);--> statement-breakpoint
+ALTER TABLE "users" ADD CONSTRAINT "users_username_unique" UNIQUE("username");

--- a/backend/drizzle/0012_user_profile_fields.sql
+++ b/backend/drizzle/0012_user_profile_fields.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "users" ADD COLUMN "bio" text;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "location" varchar(120);--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "occupation" varchar(120);--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "languages" jsonb;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "github" varchar(200);--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "linkedin" varchar(200);

--- a/backend/drizzle/0013_add_avatar_cover.sql
+++ b/backend/drizzle/0013_add_avatar_cover.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "users" ADD COLUMN "avatar_url" varchar(300);--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "cover_url" varchar(300);

--- a/backend/drizzle/0014_languages_table.sql
+++ b/backend/drizzle/0014_languages_table.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "languages" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" varchar(60) NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "languages_name_unique" UNIQUE("name")
+);
+--> statement-breakpoint
+INSERT INTO "languages" ("name") VALUES
+('JavaScript'),('TypeScript'),('Python'),('Java'),('C#'),('C++'),('C'),('Go'),('Rust'),('Ruby'),('PHP'),('Swift'),('Kotlin'),('Dart'),('Scala'),('R'),('SQL'),('HTML'),('CSS'),('Shell'),('Lua'),('Elixir'),('Haskell'),('Clojure'),('Objective-C'),('Perl')
+ON CONFLICT ("name") DO NOTHING;

--- a/backend/drizzle/0015_achievements.sql
+++ b/backend/drizzle/0015_achievements.sql
@@ -1,0 +1,31 @@
+CREATE TYPE "public"."achievement_criteria" AS ENUM('xp_total', 'lessons_completed', 'questions_correct');--> statement-breakpoint
+CREATE TABLE "achievements" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" varchar(80) NOT NULL,
+	"description" varchar(200) NOT NULL,
+	"icon" varchar(30) NOT NULL,
+	"criteria_type" "achievement_criteria" NOT NULL,
+	"threshold" integer NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "achievements_name_unique" UNIQUE("name")
+);
+--> statement-breakpoint
+CREATE TABLE "user_achievements" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"achievement_id" uuid NOT NULL,
+	"earned_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "user_achievements_user_id_achievement_id_unique" UNIQUE("user_id","achievement_id")
+);
+--> statement-breakpoint
+ALTER TABLE "user_achievements" ADD CONSTRAINT "user_achievements_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_achievements" ADD CONSTRAINT "user_achievements_achievement_id_achievements_id_fk" FOREIGN KEY ("achievement_id") REFERENCES "public"."achievements"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+INSERT INTO "achievements" ("name","description","icon","criteria_type","threshold") VALUES
+('Primeiros passos','Conclua sua primeira aula','trophy','lessons_completed',1),
+('Ritmo de estudo','Conclua 5 aulas','flame','lessons_completed',5),
+('Maratonista','Conclua 10 aulas','medal','lessons_completed',10),
+('Pontaria','Acerte 25 questões','check','questions_correct',25),
+('Centurião','Acerte 100 questões','check','questions_correct',100),
+('Em ascensão','Alcance 500 XP','star','xp_total',500),
+('Veterano','Alcance 2000 XP','star','xp_total',2000)
+ON CONFLICT ("name") DO NOTHING;

--- a/backend/drizzle/meta/0011_snapshot.json
+++ b/backend/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,850 @@
+{
+  "id": "13a98089-7402-4b03-82db-3827e5ee68f1",
+  "prevId": "1ba5473b-9997-48c4-bbd4-2cfdbc3e638a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.lessons_progress": {
+      "name": "lessons_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_progress_user_id_users_id_fk": {
+          "name": "lessons_progress_user_id_users_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_progress_lesson_id_lessons_id_fk": {
+          "name": "lessons_progress_lesson_id_lessons_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lessons_progress_user_id_lesson_id_unique": {
+          "name": "lessons_progress_user_id_lesson_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "lesson_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons": {
+      "name": "lessons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_blocks": {
+          "name": "content_blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_trail_id_trails_id_fk": {
+          "name": "lessons_trail_id_trails_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_module_id_modules_id_fk": {
+          "name": "lessons_module_id_modules_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "modules",
+          "columnsFrom": [
+            "module_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.modules": {
+      "name": "modules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "modules_trail_id_trails_id_fk": {
+          "name": "modules_trail_id_trails_id_fk",
+          "tableFrom": "modules",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_answers": {
+      "name": "question_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_option_id": {
+          "name": "selected_option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_answers_user_id_users_id_fk": {
+          "name": "question_answers_user_id_users_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_question_id_questions_id_fk": {
+          "name": "question_answers_question_id_questions_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_selected_option_id_question_options_id_fk": {
+          "name": "question_answers_selected_option_id_question_options_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "question_options",
+          "columnsFrom": [
+            "selected_option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "question_answers_user_id_question_id_unique": {
+          "name": "question_answers_user_id_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_options": {
+      "name": "question_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_options_question_id_questions_id_fk": {
+          "name": "question_options_question_id_questions_id_fk",
+          "tableFrom": "question_options",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "question_difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'facil'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_lesson_id_lessons_id_fk": {
+          "name": "questions_lesson_id_lessons_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tokens": {
+      "name": "tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'refresh'"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tokens_user_id_users_id_fk": {
+          "name": "tokens_user_id_users_id_fk",
+          "tableFrom": "tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tokens_token_hash_unique": {
+          "name": "tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_tags": {
+      "name": "trail_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "trail_tags_trail_id_trails_id_fk": {
+          "name": "trail_tags_trail_id_trails_id_fk",
+          "tableFrom": "trail_tags",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trail_tags_tag_id_tags_id_fk": {
+          "name": "trail_tags_tag_id_tags_id_fk",
+          "tableFrom": "trail_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trail_tags_trail_id_tag_id_unique": {
+          "name": "trail_tags_trail_id_tag_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trail_id",
+            "tag_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trails": {
+      "name": "trails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "trail_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "failed_login_attempts": {
+          "name": "failed_login_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.question_difficulty": {
+      "name": "question_difficulty",
+      "schema": "public",
+      "values": [
+        "facil",
+        "medio",
+        "dificil"
+      ]
+    },
+    "public.trail_level": {
+      "name": "trail_level",
+      "schema": "public",
+      "values": [
+        "iniciante",
+        "intermediario",
+        "avancado"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin",
+        "moderator"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/0012_snapshot.json
+++ b/backend/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,886 @@
+{
+  "id": "78e86557-5408-4185-8d5a-cc8cca17dd0d",
+  "prevId": "13a98089-7402-4b03-82db-3827e5ee68f1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.lessons_progress": {
+      "name": "lessons_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_progress_user_id_users_id_fk": {
+          "name": "lessons_progress_user_id_users_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_progress_lesson_id_lessons_id_fk": {
+          "name": "lessons_progress_lesson_id_lessons_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lessons_progress_user_id_lesson_id_unique": {
+          "name": "lessons_progress_user_id_lesson_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "lesson_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons": {
+      "name": "lessons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_blocks": {
+          "name": "content_blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_trail_id_trails_id_fk": {
+          "name": "lessons_trail_id_trails_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_module_id_modules_id_fk": {
+          "name": "lessons_module_id_modules_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "modules",
+          "columnsFrom": [
+            "module_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.modules": {
+      "name": "modules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "modules_trail_id_trails_id_fk": {
+          "name": "modules_trail_id_trails_id_fk",
+          "tableFrom": "modules",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_answers": {
+      "name": "question_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_option_id": {
+          "name": "selected_option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_answers_user_id_users_id_fk": {
+          "name": "question_answers_user_id_users_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_question_id_questions_id_fk": {
+          "name": "question_answers_question_id_questions_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_selected_option_id_question_options_id_fk": {
+          "name": "question_answers_selected_option_id_question_options_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "question_options",
+          "columnsFrom": [
+            "selected_option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "question_answers_user_id_question_id_unique": {
+          "name": "question_answers_user_id_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_options": {
+      "name": "question_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_options_question_id_questions_id_fk": {
+          "name": "question_options_question_id_questions_id_fk",
+          "tableFrom": "question_options",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "question_difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'facil'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_lesson_id_lessons_id_fk": {
+          "name": "questions_lesson_id_lessons_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tokens": {
+      "name": "tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'refresh'"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tokens_user_id_users_id_fk": {
+          "name": "tokens_user_id_users_id_fk",
+          "tableFrom": "tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tokens_token_hash_unique": {
+          "name": "tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_tags": {
+      "name": "trail_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "trail_tags_trail_id_trails_id_fk": {
+          "name": "trail_tags_trail_id_trails_id_fk",
+          "tableFrom": "trail_tags",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trail_tags_tag_id_tags_id_fk": {
+          "name": "trail_tags_tag_id_tags_id_fk",
+          "tableFrom": "trail_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trail_tags_trail_id_tag_id_unique": {
+          "name": "trail_tags_trail_id_tag_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trail_id",
+            "tag_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trails": {
+      "name": "trails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "trail_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occupation": {
+          "name": "occupation",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github": {
+          "name": "github",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin": {
+          "name": "linkedin",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "failed_login_attempts": {
+          "name": "failed_login_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.question_difficulty": {
+      "name": "question_difficulty",
+      "schema": "public",
+      "values": [
+        "facil",
+        "medio",
+        "dificil"
+      ]
+    },
+    "public.trail_level": {
+      "name": "trail_level",
+      "schema": "public",
+      "values": [
+        "iniciante",
+        "intermediario",
+        "avancado"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin",
+        "moderator"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/0013_snapshot.json
+++ b/backend/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,898 @@
+{
+  "id": "e9c20132-c38b-49bf-94b2-76cec95619d2",
+  "prevId": "78e86557-5408-4185-8d5a-cc8cca17dd0d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.lessons_progress": {
+      "name": "lessons_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_progress_user_id_users_id_fk": {
+          "name": "lessons_progress_user_id_users_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_progress_lesson_id_lessons_id_fk": {
+          "name": "lessons_progress_lesson_id_lessons_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lessons_progress_user_id_lesson_id_unique": {
+          "name": "lessons_progress_user_id_lesson_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "lesson_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons": {
+      "name": "lessons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_blocks": {
+          "name": "content_blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_trail_id_trails_id_fk": {
+          "name": "lessons_trail_id_trails_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_module_id_modules_id_fk": {
+          "name": "lessons_module_id_modules_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "modules",
+          "columnsFrom": [
+            "module_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.modules": {
+      "name": "modules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "modules_trail_id_trails_id_fk": {
+          "name": "modules_trail_id_trails_id_fk",
+          "tableFrom": "modules",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_answers": {
+      "name": "question_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_option_id": {
+          "name": "selected_option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_answers_user_id_users_id_fk": {
+          "name": "question_answers_user_id_users_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_question_id_questions_id_fk": {
+          "name": "question_answers_question_id_questions_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_selected_option_id_question_options_id_fk": {
+          "name": "question_answers_selected_option_id_question_options_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "question_options",
+          "columnsFrom": [
+            "selected_option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "question_answers_user_id_question_id_unique": {
+          "name": "question_answers_user_id_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_options": {
+      "name": "question_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_options_question_id_questions_id_fk": {
+          "name": "question_options_question_id_questions_id_fk",
+          "tableFrom": "question_options",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "question_difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'facil'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_lesson_id_lessons_id_fk": {
+          "name": "questions_lesson_id_lessons_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tokens": {
+      "name": "tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'refresh'"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tokens_user_id_users_id_fk": {
+          "name": "tokens_user_id_users_id_fk",
+          "tableFrom": "tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tokens_token_hash_unique": {
+          "name": "tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_tags": {
+      "name": "trail_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "trail_tags_trail_id_trails_id_fk": {
+          "name": "trail_tags_trail_id_trails_id_fk",
+          "tableFrom": "trail_tags",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trail_tags_tag_id_tags_id_fk": {
+          "name": "trail_tags_tag_id_tags_id_fk",
+          "tableFrom": "trail_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trail_tags_trail_id_tag_id_unique": {
+          "name": "trail_tags_trail_id_tag_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trail_id",
+            "tag_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trails": {
+      "name": "trails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "trail_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occupation": {
+          "name": "occupation",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github": {
+          "name": "github",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin": {
+          "name": "linkedin",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "failed_login_attempts": {
+          "name": "failed_login_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.question_difficulty": {
+      "name": "question_difficulty",
+      "schema": "public",
+      "values": [
+        "facil",
+        "medio",
+        "dificil"
+      ]
+    },
+    "public.trail_level": {
+      "name": "trail_level",
+      "schema": "public",
+      "values": [
+        "iniciante",
+        "intermediario",
+        "avancado"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin",
+        "moderator"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/0014_snapshot.json
+++ b/backend/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,939 @@
+{
+  "id": "3c8bea74-1a58-4a85-bec5-5232c311a1f5",
+  "prevId": "e9c20132-c38b-49bf-94b2-76cec95619d2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.languages": {
+      "name": "languages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "languages_name_unique": {
+          "name": "languages_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons_progress": {
+      "name": "lessons_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_progress_user_id_users_id_fk": {
+          "name": "lessons_progress_user_id_users_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_progress_lesson_id_lessons_id_fk": {
+          "name": "lessons_progress_lesson_id_lessons_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lessons_progress_user_id_lesson_id_unique": {
+          "name": "lessons_progress_user_id_lesson_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "lesson_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons": {
+      "name": "lessons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_blocks": {
+          "name": "content_blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_trail_id_trails_id_fk": {
+          "name": "lessons_trail_id_trails_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_module_id_modules_id_fk": {
+          "name": "lessons_module_id_modules_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "modules",
+          "columnsFrom": [
+            "module_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.modules": {
+      "name": "modules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "modules_trail_id_trails_id_fk": {
+          "name": "modules_trail_id_trails_id_fk",
+          "tableFrom": "modules",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_answers": {
+      "name": "question_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_option_id": {
+          "name": "selected_option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_answers_user_id_users_id_fk": {
+          "name": "question_answers_user_id_users_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_question_id_questions_id_fk": {
+          "name": "question_answers_question_id_questions_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_selected_option_id_question_options_id_fk": {
+          "name": "question_answers_selected_option_id_question_options_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "question_options",
+          "columnsFrom": [
+            "selected_option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "question_answers_user_id_question_id_unique": {
+          "name": "question_answers_user_id_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_options": {
+      "name": "question_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_options_question_id_questions_id_fk": {
+          "name": "question_options_question_id_questions_id_fk",
+          "tableFrom": "question_options",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "question_difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'facil'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_lesson_id_lessons_id_fk": {
+          "name": "questions_lesson_id_lessons_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tokens": {
+      "name": "tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'refresh'"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tokens_user_id_users_id_fk": {
+          "name": "tokens_user_id_users_id_fk",
+          "tableFrom": "tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tokens_token_hash_unique": {
+          "name": "tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_tags": {
+      "name": "trail_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "trail_tags_trail_id_trails_id_fk": {
+          "name": "trail_tags_trail_id_trails_id_fk",
+          "tableFrom": "trail_tags",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trail_tags_tag_id_tags_id_fk": {
+          "name": "trail_tags_tag_id_tags_id_fk",
+          "tableFrom": "trail_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trail_tags_trail_id_tag_id_unique": {
+          "name": "trail_tags_trail_id_tag_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trail_id",
+            "tag_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trails": {
+      "name": "trails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "trail_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occupation": {
+          "name": "occupation",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github": {
+          "name": "github",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin": {
+          "name": "linkedin",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "failed_login_attempts": {
+          "name": "failed_login_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.question_difficulty": {
+      "name": "question_difficulty",
+      "schema": "public",
+      "values": [
+        "facil",
+        "medio",
+        "dificil"
+      ]
+    },
+    "public.trail_level": {
+      "name": "trail_level",
+      "schema": "public",
+      "values": [
+        "iniciante",
+        "intermediario",
+        "avancado"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin",
+        "moderator"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/0015_snapshot.json
+++ b/backend/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,1089 @@
+{
+  "id": "e85dfe01-09ba-4fc6-a6bc-e9198a8f7f9d",
+  "prevId": "3c8bea74-1a58-4a85-bec5-5232c311a1f5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.achievements": {
+      "name": "achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "criteria_type": {
+          "name": "criteria_type",
+          "type": "achievement_criteria",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "achievements_name_unique": {
+          "name": "achievements_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.languages": {
+      "name": "languages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "languages_name_unique": {
+          "name": "languages_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons_progress": {
+      "name": "lessons_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_progress_user_id_users_id_fk": {
+          "name": "lessons_progress_user_id_users_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_progress_lesson_id_lessons_id_fk": {
+          "name": "lessons_progress_lesson_id_lessons_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lessons_progress_user_id_lesson_id_unique": {
+          "name": "lessons_progress_user_id_lesson_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "lesson_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons": {
+      "name": "lessons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_blocks": {
+          "name": "content_blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_trail_id_trails_id_fk": {
+          "name": "lessons_trail_id_trails_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_module_id_modules_id_fk": {
+          "name": "lessons_module_id_modules_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "modules",
+          "columnsFrom": [
+            "module_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.modules": {
+      "name": "modules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "modules_trail_id_trails_id_fk": {
+          "name": "modules_trail_id_trails_id_fk",
+          "tableFrom": "modules",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_answers": {
+      "name": "question_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_option_id": {
+          "name": "selected_option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_answers_user_id_users_id_fk": {
+          "name": "question_answers_user_id_users_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_question_id_questions_id_fk": {
+          "name": "question_answers_question_id_questions_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_selected_option_id_question_options_id_fk": {
+          "name": "question_answers_selected_option_id_question_options_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "question_options",
+          "columnsFrom": [
+            "selected_option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "question_answers_user_id_question_id_unique": {
+          "name": "question_answers_user_id_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_options": {
+      "name": "question_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_options_question_id_questions_id_fk": {
+          "name": "question_options_question_id_questions_id_fk",
+          "tableFrom": "question_options",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "question_difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'facil'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_lesson_id_lessons_id_fk": {
+          "name": "questions_lesson_id_lessons_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tokens": {
+      "name": "tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'refresh'"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tokens_user_id_users_id_fk": {
+          "name": "tokens_user_id_users_id_fk",
+          "tableFrom": "tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tokens_token_hash_unique": {
+          "name": "tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_tags": {
+      "name": "trail_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "trail_tags_trail_id_trails_id_fk": {
+          "name": "trail_tags_trail_id_trails_id_fk",
+          "tableFrom": "trail_tags",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trail_tags_tag_id_tags_id_fk": {
+          "name": "trail_tags_tag_id_tags_id_fk",
+          "tableFrom": "trail_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trail_tags_trail_id_tag_id_unique": {
+          "name": "trail_tags_trail_id_tag_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trail_id",
+            "tag_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trails": {
+      "name": "trails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "trail_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_achievements": {
+      "name": "user_achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "achievement_id": {
+          "name": "achievement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_achievements_user_id_users_id_fk": {
+          "name": "user_achievements_user_id_users_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_achievements_achievement_id_achievements_id_fk": {
+          "name": "user_achievements_achievement_id_achievements_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "achievements",
+          "columnsFrom": [
+            "achievement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_achievements_user_id_achievement_id_unique": {
+          "name": "user_achievements_user_id_achievement_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "achievement_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occupation": {
+          "name": "occupation",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github": {
+          "name": "github",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin": {
+          "name": "linkedin",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "failed_login_attempts": {
+          "name": "failed_login_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.achievement_criteria": {
+      "name": "achievement_criteria",
+      "schema": "public",
+      "values": [
+        "xp_total",
+        "lessons_completed",
+        "questions_correct"
+      ]
+    },
+    "public.question_difficulty": {
+      "name": "question_difficulty",
+      "schema": "public",
+      "values": [
+        "facil",
+        "medio",
+        "dificil"
+      ]
+    },
+    "public.trail_level": {
+      "name": "trail_level",
+      "schema": "public",
+      "values": [
+        "iniciante",
+        "intermediario",
+        "avancado"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin",
+        "moderator"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -78,6 +78,41 @@
       "when": 1782660130102,
       "tag": "0010_tags",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1782662202042,
+      "tag": "0011_user_username",
+      "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1782662580398,
+      "tag": "0012_user_profile_fields",
+      "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1782664253120,
+      "tag": "0013_add_avatar_cover",
+      "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1782665200264,
+      "tag": "0014_languages_table",
+      "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1782667002593,
+      "tag": "0015_achievements",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/schema.ts
+++ b/backend/schema.ts
@@ -7,11 +7,20 @@ export const questionDifficulty = pgEnum("question_difficulty", ["facil", "medio
 export const users = pgTable("users", {
     id: uuid("id").primaryKey().defaultRandom(),
     name: varchar("name", { length: 255 }).notNull(),
+    username: varchar("username", { length: 20 }).unique(),
     email: varchar("email", { length: 255 }).notNull().unique(),
     passwordHash: varchar("password_hash", { length: 255 }).notNull(),
     birthDate: date("birth_date").notNull(),
     gender: varchar("gender", { length: 50 }).notNull(),
     phone: varchar("phone", { length: 20 }).notNull(),
+    bio: text("bio"),
+    location: varchar("location", { length: 120 }),
+    occupation: varchar("occupation", { length: 120 }),
+    languages: jsonb("languages").$type<string[]>(),
+    github: varchar("github", { length: 200 }),
+    linkedin: varchar("linkedin", { length: 200 }),
+    avatarUrl: varchar("avatar_url", { length: 300 }),
+    coverUrl: varchar("cover_url", { length: 300 }),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
     emailVerifiedAt: timestamp("email_verified_at", { withTimezone: true}),
@@ -99,6 +108,37 @@ export const tags = pgTable("tags", {
     name: varchar("name", { length: 60 }).notNull().unique(),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
 });
+
+// Conjunto canonico de linguagens do perfil (gerenciado pelo admin em Configuracoes).
+export const languages = pgTable("languages", {
+    id: uuid("id").primaryKey().defaultRandom(),
+    name: varchar("name", { length: 60 }).notNull().unique(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+});
+
+// Conquistas: catalogo gerenciado pelo admin. Desbloqueiam sozinhas quando o
+// aluno atinge o limite (threshold) do criterio escolhido.
+export const achievementCriteria = pgEnum("achievement_criteria", ["xp_total", "lessons_completed", "questions_correct"]);
+
+export const achievements = pgTable("achievements", {
+    id: uuid("id").primaryKey().defaultRandom(),
+    name: varchar("name", { length: 80 }).notNull().unique(),
+    description: varchar("description", { length: 200 }).notNull(),
+    icon: varchar("icon", { length: 30 }).notNull(),
+    criteriaType: achievementCriteria("criteria_type").notNull(),
+    threshold: integer("threshold").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+});
+
+// Conquistas ja desbloqueadas por cada usuario (guarda quando foi pra montar o feed).
+export const userAchievements = pgTable("user_achievements", {
+    id: uuid("id").primaryKey().defaultRandom(),
+    userId: uuid("user_id").references(() => users.id).notNull(),
+    achievementId: uuid("achievement_id").references(() => achievements.id).notNull(),
+    earnedAt: timestamp("earned_at", { withTimezone: true }).defaultNow().notNull(),
+}, (table) => [
+    unique().on(table.userId, table.achievementId),
+]);
 
 export const trailTags = pgTable("trail_tags", {
     id: uuid("id").primaryKey().defaultRandom(),

--- a/backend/src/config/paths.ts
+++ b/backend/src/config/paths.ts
@@ -1,0 +1,7 @@
+import path from "node:path";
+
+// Diretorio onde ficam as imagens enviadas pelos usuarios (foto e capa do perfil).
+// process.cwd() e /app tanto em dev (npm run dev) quanto em prod (node index.ts).
+export const UPLOADS_DIR = path.join(process.cwd(), "uploads");
+export const AVATARS_DIR = path.join(UPLOADS_DIR, "avatars");
+export const COVERS_DIR = path.join(UPLOADS_DIR, "covers");

--- a/backend/src/controllers/AuthController.ts
+++ b/backend/src/controllers/AuthController.ts
@@ -28,6 +28,14 @@ export const register = async (req: Request, res: Response, next: NextFunction) 
         // Validação dos dados que chegam
         const dados = registerSchema.parse(req.body);
 
+        // Username normalizado (minúsculo) e único. O regex no schema já barra
+        // qualquer caractere fora de [a-zA-Z0-9_], então é seguro contra injection.
+        const username = dados.username.toLowerCase();
+        const [existeUsername] = await db.select({ id: users.id }).from(users).where(eq(users.username, username));
+        if (existeUsername) {
+            return res.status(409).json({ erro: "Esse nome de usuário já está em uso" });
+        }
+
         // Criptografia da senha
         const passwordHash = await bcrypt.hash(dados.password, BCRYPT_COST);
 
@@ -36,18 +44,20 @@ export const register = async (req: Request, res: Response, next: NextFunction) 
             // Cria o usuário
             const [usuarioCriado] = await tx.insert(users).values({
                 name: dados.name,
+                username,
                 email:dados.email,
                 passwordHash,
                 birthDate: dados.birthDate,
                 gender: dados.gender,
                 phone: dados.phone
-            }).returning({ 
-                id: users.id, 
-                name: users.name, 
-                email: users.email, 
-                birthDate: users.birthDate, 
-                gender: users.gender, 
-                phone: users.phone 
+            }).returning({
+                id: users.id,
+                name: users.name,
+                username: users.username,
+                email: users.email,
+                birthDate: users.birthDate,
+                gender: users.gender,
+                phone: users.phone
             });
 
             const verificationToken = await authService.gerarTokenVerificacao(usuarioCriado.id, tx);

--- a/backend/src/controllers/TrailController.ts
+++ b/backend/src/controllers/TrailController.ts
@@ -2,14 +2,18 @@ import type { Request, Response, NextFunction } from "express";
 import { db } from "../../db.ts";
 import {
     users, trails, modules, lessons, lessonProgress,
-    questions, questionOptions, questionAnswers, tags, trailTags,
+    questions, questionOptions, questionAnswers, tags, trailTags, languages,
+    achievements, userAchievements,
 } from "../../schema.ts";
-import { eq, and, count, asc, inArray } from "drizzle-orm";
+import { eq, and, count, asc, desc, gte, inArray, sql } from "drizzle-orm";
 import {
     createTrailSchema, createModuleSchema, createLessonSchema,
     createQuestionSchema, submitQuizSchema, checkAnswerSchema,
     saveLessonStudioSchema, updateTrailSchema, createTagSchema, updateTagSchema,
+    createLanguageSchema, updateLanguageSchema,
+    createAchievementSchema, updateAchievementSchema,
 } from "../schemas/trail.schemas.ts";
+import { calcularStreak, diasAtivosDoUsuario, semanaAtividade, streaksTodos } from "../services/streak.ts";
 
 const QUIZ_MIN_ACERTOS = 4;
 
@@ -85,6 +89,144 @@ export const deleteTag = async (req: Request, res: Response, next: NextFunction)
         await db.transaction(async (tx) => {
             await tx.delete(trailTags).where(eq(trailTags.tagId, id));
             await tx.delete(tags).where(eq(tags.id, id));
+        });
+        res.json({ ok: true });
+    } catch (err) {
+        next(err);
+    }
+};
+
+// ===================== LINGUAGENS (canônicas do perfil) =====================
+export const listLanguages = async (_req: Request, res: Response, next: NextFunction) => {
+    try {
+        const lista = await db.select().from(languages).orderBy(asc(languages.name));
+        res.json(lista);
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const createLanguage = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const dados = createLanguageSchema.parse(req.body);
+        const [existe] = await db.select({ id: languages.id }).from(languages).where(eq(languages.name, dados.name));
+        if (existe) {
+            return res.status(409).json({ erro: "Já existe uma linguagem com esse nome" });
+        }
+        const [lang] = await db.insert(languages).values({ name: dados.name }).returning();
+        res.status(201).json(lang);
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const updateLanguage = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const id = String(req.params.id);
+        const dados = updateLanguageSchema.parse(req.body);
+        const [atual] = await db.select({ name: languages.name }).from(languages).where(eq(languages.id, id));
+        if (!atual) {
+            return res.status(404).json({ erro: "Linguagem não encontrada" });
+        }
+        const [conflito] = await db.select({ id: languages.id }).from(languages).where(eq(languages.name, dados.name));
+        if (conflito && conflito.id !== id) {
+            return res.status(409).json({ erro: "Já existe uma linguagem com esse nome" });
+        }
+        const lang = await db.transaction(async (tx) => {
+            const [atualizada] = await tx.update(languages).set({ name: dados.name }).where(eq(languages.id, id)).returning();
+            // Renomeou: propaga o novo nome para os perfis que usavam o antigo.
+            if (atual.name !== dados.name) {
+                await tx.execute(sql`
+                    UPDATE users
+                    SET languages = (
+                        SELECT jsonb_agg(CASE WHEN elem = ${JSON.stringify(atual.name)}::jsonb THEN ${JSON.stringify(dados.name)}::jsonb ELSE elem END)
+                        FROM jsonb_array_elements(languages) AS elem
+                    )
+                    WHERE languages @> ${JSON.stringify([atual.name])}::jsonb
+                `);
+            }
+            return atualizada;
+        });
+        res.json(lang);
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const deleteLanguage = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const id = String(req.params.id);
+        const [lang] = await db.select({ name: languages.name }).from(languages).where(eq(languages.id, id));
+        if (!lang) {
+            return res.status(404).json({ erro: "Linguagem não encontrada" });
+        }
+        await db.transaction(async (tx) => {
+            await tx.delete(languages).where(eq(languages.id, id));
+            // Remove o nome dos perfis que a usavam, mantendo os dados padronizados.
+            await tx.execute(sql`
+                UPDATE users
+                SET languages = COALESCE((
+                    SELECT jsonb_agg(elem)
+                    FROM jsonb_array_elements(languages) AS elem
+                    WHERE elem <> ${JSON.stringify(lang.name)}::jsonb
+                ), '[]'::jsonb)
+                WHERE languages @> ${JSON.stringify([lang.name])}::jsonb
+            `);
+        });
+        res.json({ ok: true });
+    } catch (err) {
+        next(err);
+    }
+};
+
+// ===================== CONQUISTAS (catálogo, admin) =====================
+export const listAchievements = async (_req: Request, res: Response, next: NextFunction) => {
+    try {
+        const lista = await db.select().from(achievements).orderBy(asc(achievements.threshold));
+        res.json(lista);
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const createAchievement = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const dados = createAchievementSchema.parse(req.body);
+        const [existe] = await db.select({ id: achievements.id }).from(achievements).where(eq(achievements.name, dados.name));
+        if (existe) {
+            return res.status(409).json({ erro: "Já existe uma conquista com esse nome" });
+        }
+        const [a] = await db.insert(achievements).values(dados).returning();
+        res.status(201).json(a);
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const updateAchievement = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const id = String(req.params.id);
+        const dados = updateAchievementSchema.parse(req.body);
+        const [conflito] = await db.select({ id: achievements.id }).from(achievements).where(eq(achievements.name, dados.name));
+        if (conflito && conflito.id !== id) {
+            return res.status(409).json({ erro: "Já existe uma conquista com esse nome" });
+        }
+        const [a] = await db.update(achievements).set(dados).where(eq(achievements.id, id)).returning();
+        if (!a) {
+            return res.status(404).json({ erro: "Conquista não encontrada" });
+        }
+        res.json(a);
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const deleteAchievement = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const id = String(req.params.id);
+        await db.transaction(async (tx) => {
+            await tx.delete(userAchievements).where(eq(userAchievements.achievementId, id));
+            await tx.delete(achievements).where(eq(achievements.id, id));
         });
         res.json({ ok: true });
     } catch (err) {
@@ -574,27 +716,184 @@ export const submitQuiz = async (req: Request, res: Response, next: NextFunction
             aulaConcluida = true;
         }
 
+        await verificarConquistas(userId);
+
         res.json({ correct: acertos, total, passed: passou, lessonCompleted: aulaConcluida });
     } catch (err) {
         next(err);
     }
 };
 
+// Estatísticas base do usuário: XP (50 por aula + 10 por acerto), aulas e acertos.
+async function calcularEstatisticas(userId: string) {
+    const [aulas] = await db.select({ n: count() }).from(lessonProgress)
+        .where(eq(lessonProgress.userId, userId));
+    const [acertos] = await db.select({ n: count() }).from(questionAnswers)
+        .where(and(eq(questionAnswers.userId, userId), eq(questionAnswers.isCorrect, true)));
+    const lessonsCompleted = Number(aulas?.n ?? 0);
+    const questionsCorrect = Number(acertos?.n ?? 0);
+    return { xp: lessonsCompleted * 50 + questionsCorrect * 10, lessonsCompleted, questionsCorrect };
+}
+
+// Desbloqueia (idempotente) as conquistas cujo critério o usuário já atingiu.
+async function verificarConquistas(userId: string) {
+    const stats = await calcularEstatisticas(userId);
+    const valor: Record<string, number> = {
+        xp_total: stats.xp,
+        lessons_completed: stats.lessonsCompleted,
+        questions_correct: stats.questionsCorrect,
+    };
+    const catalogo = await db.select().from(achievements);
+    const merecidas = catalogo.filter((a) => (valor[a.criteriaType] ?? 0) >= a.threshold);
+    if (merecidas.length === 0) return;
+    await db.insert(userAchievements)
+        .values(merecidas.map((a) => ({ userId, achievementId: a.id })))
+        .onConflictDoNothing();
+}
+
 // XP total do usuário: 50 por aula concluída + 10 por questão acertada (primeira vez).
 export const getMyXp = async (req: Request, res: Response, next: NextFunction) => {
     try {
+        res.json(await calcularEstatisticas(req.userId!));
+    } catch (err) {
+        next(err);
+    }
+};
+
+// Catálogo de conquistas com a marcação do que o usuário já desbloqueou.
+export const getMyAchievements = async (req: Request, res: Response, next: NextFunction) => {
+    try {
         const userId = req.userId!;
-        const [aulas] = await db.select({ n: count() }).from(lessonProgress)
-            .where(eq(lessonProgress.userId, userId));
-        const [acertos] = await db.select({ n: count() }).from(questionAnswers)
-            .where(and(eq(questionAnswers.userId, userId), eq(questionAnswers.isCorrect, true)));
-        const lessonsCompleted = Number(aulas?.n ?? 0);
-        const questionsCorrect = Number(acertos?.n ?? 0);
-        res.json({
-            xp: lessonsCompleted * 50 + questionsCorrect * 10,
-            lessonsCompleted,
-            questionsCorrect,
-        });
+        await verificarConquistas(userId);
+        const catalogo = await db.select().from(achievements).orderBy(asc(achievements.threshold));
+        const ganhas = await db.select().from(userAchievements).where(eq(userAchievements.userId, userId));
+        const quando = new Map(ganhas.map((g) => [g.achievementId, g.earnedAt]));
+        res.json(catalogo.map((a) => ({
+            ...a,
+            earned: quando.has(a.id),
+            earnedAt: quando.get(a.id) ?? null,
+        })));
+    } catch (err) {
+        next(err);
+    }
+};
+
+// Atividades recentes derivadas: aulas concluídas + conquistas desbloqueadas.
+export const getMyActivity = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const userId = req.userId!;
+        const aulas = await db
+            .select({ at: lessonProgress.completedAt, title: lessons.title })
+            .from(lessonProgress)
+            .innerJoin(lessons, eq(lessons.id, lessonProgress.lessonId))
+            .where(eq(lessonProgress.userId, userId))
+            .orderBy(desc(lessonProgress.completedAt))
+            .limit(15);
+        const conquistas = await db
+            .select({ at: userAchievements.earnedAt, name: achievements.name, icon: achievements.icon })
+            .from(userAchievements)
+            .innerJoin(achievements, eq(achievements.id, userAchievements.achievementId))
+            .where(eq(userAchievements.userId, userId))
+            .orderBy(desc(userAchievements.earnedAt))
+            .limit(15);
+        const itens = [
+            ...aulas.map((a) => ({ type: "lesson", icon: "check", text: `Concluiu a aula "${a.title}"`, at: a.at })),
+            ...conquistas.map((c) => ({ type: "achievement", icon: c.icon, text: `Desbloqueou "${c.name}"`, at: c.at })),
+        ]
+            .sort((x, y) => (x.at < y.at ? 1 : x.at > y.at ? -1 : 0))
+            .slice(0, 15);
+        res.json(itens);
+    } catch (err) {
+        next(err);
+    }
+};
+
+// Feed da comunidade: quem desbloqueou cada conquista, mais recentes primeiro.
+export const getCommunityAchievements = async (_req: Request, res: Response, next: NextFunction) => {
+    try {
+        const lista = await db
+            .select({
+                name: users.name,
+                achievement: achievements.name,
+                icon: achievements.icon,
+                at: userAchievements.earnedAt,
+            })
+            .from(userAchievements)
+            .innerJoin(users, eq(users.id, userAchievements.userId))
+            .innerJoin(achievements, eq(achievements.id, userAchievements.achievementId))
+            .orderBy(desc(userAchievements.earnedAt))
+            .limit(10);
+        res.json(lista);
+    } catch (err) {
+        next(err);
+    }
+};
+
+// Ranking global por XP. Liga e nível usam o XP total; o leaderboard usa o
+// período (week/month/all). XP = 50 por aula concluída + 10 por questão certa.
+export const getRanking = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const periodo = String(req.query.period ?? "all");
+        const dia = 24 * 60 * 60 * 1000;
+        const desde = periodo === "week" ? new Date(Date.now() - 7 * dia)
+            : periodo === "month" ? new Date(Date.now() - 30 * dia)
+            : null;
+
+        const [usuarios, aulasTot, acertosTot, aulasPer, acertosPer, streaks] = await Promise.all([
+            db.select({ id: users.id, name: users.name, username: users.username }).from(users),
+            db.select({ userId: lessonProgress.userId, n: count() }).from(lessonProgress).groupBy(lessonProgress.userId),
+            db.select({ userId: questionAnswers.userId, n: count() }).from(questionAnswers)
+                .where(eq(questionAnswers.isCorrect, true)).groupBy(questionAnswers.userId),
+            desde
+                ? db.select({ userId: lessonProgress.userId, n: count() }).from(lessonProgress)
+                    .where(gte(lessonProgress.completedAt, desde)).groupBy(lessonProgress.userId)
+                : Promise.resolve(null),
+            desde
+                ? db.select({ userId: questionAnswers.userId, n: count() }).from(questionAnswers)
+                    .where(and(eq(questionAnswers.isCorrect, true), gte(questionAnswers.answeredAt, desde))).groupBy(questionAnswers.userId)
+                : Promise.resolve(null),
+            streaksTodos(),
+        ]);
+
+        const paraMapa = (arr: { userId: string; n: number }[] | null) =>
+            new Map((arr ?? []).map((a) => [a.userId, Number(a.n)]));
+        const at = paraMapa(aulasTot), acT = paraMapa(acertosTot);
+        const aP = desde ? paraMapa(aulasPer) : at;
+        const acP = desde ? paraMapa(acertosPer) : acT;
+
+        const ordenados = usuarios
+            .map((u) => {
+                const totalXp = (at.get(u.id) ?? 0) * 50 + (acT.get(u.id) ?? 0) * 10;
+                const periodXp = (aP.get(u.id) ?? 0) * 50 + (acP.get(u.id) ?? 0) * 10;
+                return {
+                    id: u.id, name: u.name, username: u.username,
+                    totalXp, periodXp, level: Math.floor(totalXp / 500) + 1,
+                    streak: streaks.get(u.id) ?? 0,
+                    you: u.id === req.userId,
+                };
+            })
+            .sort((a, b) => b.periodXp - a.periodXp)
+            .map((u, i) => ({ ...u, position: i + 1 }));
+
+        const meu = ordenados.find((u) => u.you);
+        const me = meu
+            ? { position: meu.position, username: meu.username, xp: meu.periodXp, totalXp: meu.totalXp, level: meu.level, streak: meu.streak }
+            : null;
+        const rows = ordenados.slice(0, 20).map((u) => ({
+            position: u.position, name: u.name, username: u.username,
+            xp: u.periodXp, level: u.level, streak: u.streak, you: u.you,
+        }));
+        res.json({ me, rows });
+    } catch (err) {
+        next(err);
+    }
+};
+
+// Streak do usuário + os últimos 7 dias (para o card da home).
+export const getMyStreak = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const dias = await diasAtivosDoUsuario(req.userId!);
+        res.json({ streak: calcularStreak(dias), week: semanaAtividade(dias) });
     } catch (err) {
         next(err);
     }

--- a/backend/src/controllers/UserController.ts
+++ b/backend/src/controllers/UserController.ts
@@ -1,15 +1,30 @@
-import type { Request, Response } from "express";
+import type { Request, Response, NextFunction } from "express";
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import { writeFile, mkdir, unlink } from "node:fs/promises";
 import { db } from "../../db.ts";
-import { users } from "../../schema.ts";
+import { users, languages as languagesTable } from "../../schema.ts";
 import { eq } from "drizzle-orm";
+import { updateMeSchema } from "../schemas/auth.schema.ts";
+import { UPLOADS_DIR, AVATARS_DIR, COVERS_DIR } from "../config/paths.ts";
+import { calcularStreak, diasAtivosDoUsuario } from "../services/streak.ts";
 
 const publicUserColumns = {
     id: users.id,
     name: users.name,
+    username: users.username,
     email: users.email,
     birthDate: users.birthDate,
     gender: users.gender,
     phone: users.phone,
+    bio: users.bio,
+    location: users.location,
+    occupation: users.occupation,
+    languages: users.languages,
+    github: users.github,
+    linkedin: users.linkedin,
+    avatarUrl: users.avatarUrl,
+    coverUrl: users.coverUrl,
     role: users.role,
     createdAt: users.createdAt
 };
@@ -29,8 +44,120 @@ export const getMe = async (req: Request, res: Response) => {
         return res.status(404).json({ erro: "Usuário não encontrado" });
     }
 
-    res.json(user);
+    let streak = 0;
+    try {
+        streak = calcularStreak(await diasAtivosDoUsuario(userId));
+    } catch {
+        // streak é derivado; se falhar, não quebra o perfil
+    }
+
+    res.json({ ...user, streak });
 }
+
+// Atualiza o próprio perfil (campos editáveis). Não toca em campos sensíveis.
+export const updateMe = async (req: Request, res: Response, next: NextFunction) => {
+    const userId = req.userId;
+    if (!userId) {
+        return res.status(401).json({ erro: "Não autenticado" });
+    }
+    try {
+        const dados = updateMeSchema.parse(req.body);
+        // Linguagens precisam existir no conjunto canonico (gerenciado no admin),
+        // pra manter os dados padronizados para analises futuras.
+        if (dados.languages && dados.languages.length > 0) {
+            const validas = await db.select({ name: languagesTable.name }).from(languagesTable);
+            const conjunto = new Set(validas.map((l) => l.name));
+            const invalida = dados.languages.find((l) => !conjunto.has(l));
+            if (invalida) {
+                return res.status(400).json({ erro: `Linguagem inválida: ${invalida}` });
+            }
+        }
+        const sets: {
+            bio?: string; location?: string; occupation?: string;
+            languages?: string[]; github?: string; linkedin?: string;
+        } = {};
+        if (dados.bio !== undefined) sets.bio = dados.bio;
+        if (dados.location !== undefined) sets.location = dados.location;
+        if (dados.occupation !== undefined) sets.occupation = dados.occupation;
+        if (dados.languages !== undefined) sets.languages = dados.languages;
+        if (dados.github !== undefined) sets.github = dados.github;
+        if (dados.linkedin !== undefined) sets.linkedin = dados.linkedin;
+        if (Object.keys(sets).length === 0) {
+            return res.status(400).json({ erro: "Nada para atualizar" });
+        }
+        const [user] = await db.update(users).set(sets).where(eq(users.id, userId)).returning(publicUserColumns);
+        res.json(user);
+    } catch (err) {
+        next(err);
+    }
+};
+
+const MIME_EXT: Record<string, string> = {
+    "image/png": "png",
+    "image/jpeg": "jpg",
+    "image/jpg": "jpg",
+    "image/webp": "webp",
+};
+const MAX_IMG_BYTES = 4 * 1024 * 1024; // 4MB
+
+type ResultadoImagem = { ok: true; url: string } | { ok: false; erro: string };
+
+// Decodifica uma data URL (base64) e grava em disco com nome aleatorio. O nome
+// nunca vem do cliente, entao nao ha risco de path traversal nem sobrescrita.
+async function salvarImagem(dataUrl: unknown, destDir: string, urlBase: string): Promise<ResultadoImagem> {
+    if (typeof dataUrl !== "string") return { ok: false, erro: "Imagem ausente" };
+    const m = /^data:([^;]+);base64,(.+)$/s.exec(dataUrl);
+    if (!m) return { ok: false, erro: "Formato de imagem invalido" };
+    const ext = MIME_EXT[m[1].toLowerCase()];
+    if (!ext) return { ok: false, erro: "Use uma imagem PNG, JPG ou WEBP" };
+    const buffer = Buffer.from(m[2], "base64");
+    if (buffer.length === 0) return { ok: false, erro: "Imagem vazia" };
+    if (buffer.length > MAX_IMG_BYTES) return { ok: false, erro: "Imagem muito grande (maximo 4MB)" };
+    await mkdir(destDir, { recursive: true });
+    const nome = `${randomUUID()}.${ext}`;
+    await writeFile(path.join(destDir, nome), buffer);
+    return { ok: true, url: `${urlBase}/${nome}` };
+}
+
+// Remove (best-effort) o arquivo local antigo ao trocar a imagem, evitando orfaos.
+async function removerArquivoLocal(url: string | null) {
+    if (!url || !url.startsWith("/uploads/")) return;
+    try {
+        await unlink(path.join(UPLOADS_DIR, url.slice("/uploads/".length)));
+    } catch {
+        // arquivo ja removido ou inexistente: ignora
+    }
+}
+
+export const uploadAvatar = async (req: Request, res: Response, next: NextFunction) => {
+    const userId = req.userId;
+    if (!userId) return res.status(401).json({ erro: "Nao autenticado" });
+    try {
+        const r = await salvarImagem(req.body?.image, AVATARS_DIR, "/uploads/avatars");
+        if (!r.ok) return res.status(400).json({ erro: r.erro });
+        const [atual] = await db.select({ avatarUrl: users.avatarUrl }).from(users).where(eq(users.id, userId));
+        const [user] = await db.update(users).set({ avatarUrl: r.url }).where(eq(users.id, userId)).returning(publicUserColumns);
+        await removerArquivoLocal(atual?.avatarUrl ?? null);
+        res.json(user);
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const uploadCover = async (req: Request, res: Response, next: NextFunction) => {
+    const userId = req.userId;
+    if (!userId) return res.status(401).json({ erro: "Nao autenticado" });
+    try {
+        const r = await salvarImagem(req.body?.image, COVERS_DIR, "/uploads/covers");
+        if (!r.ok) return res.status(400).json({ erro: r.erro });
+        const [atual] = await db.select({ coverUrl: users.coverUrl }).from(users).where(eq(users.id, userId));
+        const [user] = await db.update(users).set({ coverUrl: r.url }).where(eq(users.id, userId)).returning(publicUserColumns);
+        await removerArquivoLocal(atual?.coverUrl ?? null);
+        res.json(user);
+    } catch (err) {
+        next(err);
+    }
+};
 
 export const listUsers = async (_req: Request, res: Response) => {
     const allUsers = await db.select(publicUserColumns).from(users);

--- a/backend/src/middlewares/error.ts
+++ b/backend/src/middlewares/error.ts
@@ -26,6 +26,16 @@ export function errorMiddleware(
         return res.status(409).json({ erro: err.message });
     }
 
+    // Erros que ja carregam um status HTTP (ex.: body-parser: corpo grande -> 413,
+    // JSON malformado -> 400). Sem isso, cairiam no 500 generico abaixo.
+    const status = (err as { status?: number; statusCode?: number }).status
+        ?? (err as { status?: number; statusCode?: number }).statusCode;
+    if (typeof status === "number" && status >= 400 && status < 500) {
+        return res.status(status).json({
+            erro: status === 413 ? "Arquivo muito grande" : "Requisição inválida"
+        });
+    }
+
     // Erro genérico
     console.error("Erro inesperado: ", err);
     return res.status(500).json({ erro: "Erro interno do servidor" });

--- a/backend/src/routes/trail.routes.ts
+++ b/backend/src/routes/trail.routes.ts
@@ -24,6 +24,19 @@ import {
     createTag,
     updateTag,
     deleteTag,
+    listLanguages,
+    createLanguage,
+    updateLanguage,
+    deleteLanguage,
+    listAchievements,
+    createAchievement,
+    updateAchievement,
+    deleteAchievement,
+    getMyAchievements,
+    getMyActivity,
+    getCommunityAchievements,
+    getRanking,
+    getMyStreak,
 } from "../controllers/TrailController.ts";
 
 const router = Router();
@@ -38,6 +51,18 @@ router.get("/tags", autenticar, listTags);
 router.post("/tags", autenticar, exigirAdmin, createTag);
 router.patch("/tags/:id", autenticar, exigirAdmin, updateTag);
 router.delete("/tags/:id", autenticar, exigirAdmin, deleteTag);
+
+// Linguagens do perfil: leitura para qualquer logado; escrita só admin
+router.get("/languages", autenticar, listLanguages);
+router.post("/languages", autenticar, exigirAdmin, createLanguage);
+router.patch("/languages/:id", autenticar, exigirAdmin, updateLanguage);
+router.delete("/languages/:id", autenticar, exigirAdmin, deleteLanguage);
+
+// Conquistas: leitura para qualquer logado; escrita só admin
+router.get("/achievements", autenticar, listAchievements);
+router.post("/achievements", autenticar, exigirAdmin, createAchievement);
+router.patch("/achievements/:id", autenticar, exigirAdmin, updateAchievement);
+router.delete("/achievements/:id", autenticar, exigirAdmin, deleteAchievement);
 router.post("/trails/:id/modules", autenticar, exigirAdmin, createModule);
 router.post("/modules/:id/lessons", autenticar, exigirAdmin, createLesson);
 router.delete("/modules/:id", autenticar, exigirAdmin, deleteModule);
@@ -56,6 +81,11 @@ router.delete("/lessons/:id", autenticar, exigirAdmin, deleteLesson);
 // Progresso do aluno
 router.get("/me/trails", autenticar, getMyTrails);
 router.get("/me/xp", autenticar, getMyXp);
+router.get("/me/achievements", autenticar, getMyAchievements);
+router.get("/me/activity", autenticar, getMyActivity);
+router.get("/me/streak", autenticar, getMyStreak);
+router.get("/community/achievements", autenticar, getCommunityAchievements);
+router.get("/ranking", autenticar, getRanking);
 router.post("/lessons/:id/quiz", autenticar, submitQuiz);
 router.post("/lessons/:id/quiz/check", autenticar, checkAnswer);
 

--- a/backend/src/routes/user.routes.ts
+++ b/backend/src/routes/user.routes.ts
@@ -1,9 +1,12 @@
 import { Router } from "express";
 import { autenticar, exigirAdmin } from "../middlewares/auth.ts";
-import { getMe, listUsers } from "../controllers/UserController.ts";
+import { getMe, updateMe, uploadAvatar, uploadCover, listUsers } from "../controllers/UserController.ts";
 const router = Router();
 
 router.get("/me", autenticar, getMe);
+router.patch("/me", autenticar, updateMe);
+router.post("/me/avatar", autenticar, uploadAvatar);
+router.post("/me/cover", autenticar, uploadCover);
 router.get("/users", autenticar, exigirAdmin, listUsers);
 
 export default router;

--- a/backend/src/schemas/auth.schema.test.ts
+++ b/backend/src/schemas/auth.schema.test.ts
@@ -4,6 +4,7 @@ import { registerSchema, loginSchema } from "./auth.schema.ts";
 
 const usuarioValido = {
     name: "Maria Silva",
+    username: "maria_silva",
     email: "maria@email.com",
     password: "senhaforte123",
     birthDate: "1990-01-01",
@@ -24,6 +25,21 @@ describe("registerSchema", () => {
 
     test("rejeita email inválido", () => {
         const r = registerSchema.safeParse({ ...usuarioValido, email: "naoehemail" });
+        assert.equal(r.success, false);
+    });
+
+    test("rejeita username com caracteres inválidos", () => {
+        const r = registerSchema.safeParse({ ...usuarioValido, username: "maria silva" });
+        assert.equal(r.success, false);
+    });
+
+    test("rejeita username muito curto", () => {
+        const r = registerSchema.safeParse({ ...usuarioValido, username: "ab" });
+        assert.equal(r.success, false);
+    });
+
+    test("rejeita username muito longo", () => {
+        const r = registerSchema.safeParse({ ...usuarioValido, username: "a".repeat(21) });
         assert.equal(r.success, false);
     });
 

--- a/backend/src/schemas/auth.schema.ts
+++ b/backend/src/schemas/auth.schema.ts
@@ -2,6 +2,11 @@ import { z } from "zod";
 
 export const registerSchema = z.object({
   name: z.string().min(2, "Nome deve ter ao menos 2 caracteres"),
+  username: z.string()
+    .trim()
+    .min(3, "Usuário deve ter ao menos 3 caracteres")
+    .max(20, "Usuário deve ter no máximo 20 caracteres")
+    .regex(/^[a-zA-Z0-9_]+$/, "Use apenas letras, números e underscore"),
   email: z.email("Email inválido"),
   password: z.string().min(12, "Senha deve ter ao menos 12 caracteres").max(72).refine((s) => /[0-9]/.test(s), "A senha deve conter pelo menos um número"),
   birthDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Data deve ser AAAA-MM-DD"),
@@ -16,4 +21,13 @@ export const loginSchema = z.object({
 
 export const refreshSchema = z.object({
   refreshToken: z.string().min(1, "Refresh Token é obrigatório.")
+});
+
+export const updateMeSchema = z.object({
+  bio: z.string().max(500, "A bio deve ter no máximo 500 caracteres").optional(),
+  location: z.string().max(120).optional(),
+  occupation: z.string().max(120).optional(),
+  languages: z.array(z.string().min(1).max(60)).max(20).optional(),
+  github: z.string().max(200).optional(),
+  linkedin: z.string().max(200).optional(),
 });

--- a/backend/src/schemas/trail.schemas.ts
+++ b/backend/src/schemas/trail.schemas.ts
@@ -20,6 +20,22 @@ export const createTagSchema = z.object({
 
 export const updateTagSchema = createTagSchema;
 
+export const createLanguageSchema = z.object({
+    name: z.string().min(1, "Nome obrigatório").max(60, "Nome muito longo"),
+});
+
+export const updateLanguageSchema = createLanguageSchema;
+
+export const createAchievementSchema = z.object({
+    name: z.string().min(2, "Nome obrigatório").max(80, "Nome muito longo"),
+    description: z.string().min(2, "Descrição obrigatória").max(200, "Descrição muito longa"),
+    icon: z.enum(["trophy", "flame", "star", "check", "medal", "bookmark"]),
+    criteriaType: z.enum(["xp_total", "lessons_completed", "questions_correct"]),
+    threshold: z.int().positive("O valor deve ser positivo"),
+});
+
+export const updateAchievementSchema = createAchievementSchema;
+
 export const createLessonSchema = z.object({
     title: z.string().min(3, "Título deve ter ao menos 3 caracteres"),
     content: z.string().optional(),

--- a/backend/src/services/streak.ts
+++ b/backend/src/services/streak.ts
@@ -1,0 +1,74 @@
+import { sql } from "drizzle-orm";
+import { db } from "../../db.ts";
+
+// Streak = dias corridos com atividade (questão respondida ou aula concluída).
+// O "dia" é calculado no fuso de São Paulo para bater com o usuário.
+const TZ = "America/Sao_Paulo";
+const LETRAS = ["D", "S", "T", "Q", "Q", "S", "S"]; // domingo..sábado
+
+function diaAnterior(s: string): string {
+    return new Date(Date.parse(s + "T00:00:00Z") - 86400000).toISOString().slice(0, 10);
+}
+function hojeLocal(): string {
+    return new Date().toLocaleDateString("en-CA", { timeZone: TZ });
+}
+
+// Conta os dias consecutivos terminando hoje (ou ontem, se ainda não estudou hoje).
+export function calcularStreak(dias: Set<string>): number {
+    if (dias.size === 0) return 0;
+    let cursor = hojeLocal();
+    if (!dias.has(cursor)) {
+        cursor = diaAnterior(cursor);
+        if (!dias.has(cursor)) return 0;
+    }
+    let n = 0;
+    while (dias.has(cursor)) {
+        n++;
+        cursor = diaAnterior(cursor);
+    }
+    return n;
+}
+
+export async function diasAtivosDoUsuario(userId: string): Promise<Set<string>> {
+    const res = await db.execute(sql`
+        SELECT DISTINCT to_char(answered_at AT TIME ZONE ${TZ}, 'YYYY-MM-DD') AS d FROM question_answers WHERE user_id = ${userId}
+        UNION
+        SELECT DISTINCT to_char(completed_at AT TIME ZONE ${TZ}, 'YYYY-MM-DD') AS d FROM lessons_progress WHERE user_id = ${userId}
+    `);
+    return new Set((res.rows as { d: string }[]).map((r) => r.d));
+}
+
+// Calcula o streak de todos os usuários de uma vez (para o ranking).
+export async function streaksTodos(): Promise<Map<string, number>> {
+    const res = await db.execute(sql`
+        SELECT user_id AS uid, to_char(answered_at AT TIME ZONE ${TZ}, 'YYYY-MM-DD') AS d FROM question_answers
+        UNION
+        SELECT user_id AS uid, to_char(completed_at AT TIME ZONE ${TZ}, 'YYYY-MM-DD') AS d FROM lessons_progress
+    `);
+    const porUsuario = new Map<string, Set<string>>();
+    for (const row of res.rows as { uid: string; d: string }[]) {
+        let dias = porUsuario.get(row.uid);
+        if (!dias) {
+            dias = new Set();
+            porUsuario.set(row.uid, dias);
+        }
+        dias.add(row.d);
+    }
+    const streaks = new Map<string, number>();
+    for (const [uid, dias] of porUsuario) streaks.set(uid, calcularStreak(dias));
+    return streaks;
+}
+
+// Últimos 7 dias (mais antigo -> hoje) com flag de atividade, para o card da home.
+export function semanaAtividade(dias: Set<string>): { label: string; active: boolean }[] {
+    const ult7: string[] = [];
+    let cursor = hojeLocal();
+    for (let i = 0; i < 7; i++) {
+        ult7.unshift(cursor);
+        cursor = diaAnterior(cursor);
+    }
+    return ult7.map((d) => ({
+        label: LETRAS[new Date(d + "T00:00:00Z").getUTCDay()],
+        active: dias.has(d),
+    }));
+}

--- a/backend/tests/auth.test.ts
+++ b/backend/tests/auth.test.ts
@@ -9,6 +9,7 @@ let seq = 0;
 const novoUsuario = (over: Record<string, unknown> = {}) => ({
     name: "Maria Silva",
     email: `maria_${++seq}_${Math.round(performance.now() * 1000)}@email.com`,
+    username: `maria_${seq}`,
     password: "senhaforte123",
     birthDate: "1990-01-01",
     gender: "feminino",

--- a/backend/tests/trail.test.ts
+++ b/backend/tests/trail.test.ts
@@ -10,6 +10,7 @@ let seq = 0;
 const novoUsuario = (over: Record<string, unknown> = {}) => ({
     name: "Aluno Teste",
     email: `aluno_${++seq}_${Math.round(performance.now() * 1000)}@email.com`,
+    username: `aluno_${seq}`,
     password: "senhaforte123",
     birthDate: "1990-01-01",
     gender: "outro",

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,6 +23,8 @@ services:
     restart: unless-stopped
     env_file:
       - ./backend/.env.prod
+    volumes:
+      - uploads:/app/uploads
     depends_on:
       - db
     expose:
@@ -40,3 +42,4 @@ volumes:
   pgdata:
   caddy_data:
   caddy_config:
+  uploads:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,8 @@ import { Aula } from './pages/Aula';
 import { Estudio } from './pages/Estudio';
 import { EstudioHome } from './pages/EstudioHome';
 import { Configuracoes } from './pages/Configuracoes';
+import { Perfil } from './pages/Perfil';
+import { Ranking } from './pages/Ranking';
 import { VerifyEmail } from './pages/VerifyEmail';
 import { Placeholder } from './pages/Placeholder';
 
@@ -82,7 +84,7 @@ function AppRoutes() {
         path="/ranking"
         element={
           <PrivateRoute>
-            <Placeholder title="Ranking" description="Em breve o ranking global completo aparecerá aqui." />
+            <Ranking />
           </PrivateRoute>
         } />
       <Route
@@ -96,7 +98,7 @@ function AppRoutes() {
         path="/perfil"
         element={
           <PrivateRoute>
-            <Placeholder title="Perfil" description="Em breve você poderá ver e editar seus dados de perfil aqui." />
+            <Perfil />
           </PrivateRoute>
         } />
       <Route

--- a/frontend/src/components/Icons.tsx
+++ b/frontend/src/components/Icons.tsx
@@ -142,6 +142,85 @@ export const Pencil = ({ size = 15 }: IconProps) => (
   </svg>
 );
 
+export const AtSign = ({ size = 14 }: IconProps) => (
+  <svg {...base(size)} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <circle cx="12" cy="12" r="4" />
+    <path d="M16 8v5a3 3 0 0 0 6 0v-1a10 10 0 1 0-3.9 7.9" />
+  </svg>
+);
+
+export const MapPin = ({ size = 14 }: IconProps) => (
+  <svg {...base(size)} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M21 10c0 7-9 12-9 12s-9-5-9-12a9 9 0 0 1 18 0z" />
+    <circle cx="12" cy="10" r="3" />
+  </svg>
+);
+
+export const Briefcase = ({ size = 14 }: IconProps) => (
+  <svg {...base(size)} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <rect x="2" y="7" width="20" height="14" rx="2" />
+    <path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16" />
+  </svg>
+);
+
+export const Calendar = ({ size = 14 }: IconProps) => (
+  <svg {...base(size)} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <rect x="3" y="4" width="18" height="18" rx="2" />
+    <line x1="3" y1="10" x2="21" y2="10" />
+    <line x1="8" y1="2" x2="8" y2="6" />
+    <line x1="16" y1="2" x2="16" y2="6" />
+  </svg>
+);
+
+export const Github = ({ size = 15 }: IconProps) => (
+  <svg {...base(size)} fill="currentColor">
+    <path d="M12 2a10 10 0 0 0-3.16 19.49c.5.09.68-.22.68-.48v-1.7c-2.78.6-3.37-1.34-3.37-1.34-.45-1.16-1.11-1.47-1.11-1.47-.91-.62.07-.6.07-.6 1 .07 1.53 1.03 1.53 1.03.9 1.53 2.36 1.09 2.94.83.09-.65.35-1.09.63-1.34-2.22-.25-4.55-1.11-4.55-4.94 0-1.09.39-1.98 1.03-2.68-.1-.25-.45-1.27.1-2.65 0 0 .84-.27 2.75 1.02a9.5 9.5 0 0 1 5 0c1.91-1.29 2.75-1.02 2.75-1.02.55 1.38.2 2.4.1 2.65.64.7 1.03 1.59 1.03 2.68 0 3.84-2.34 4.69-4.57 4.94.36.31.68.92.68 1.85v2.74c0 .27.18.59.69.48A10 10 0 0 0 12 2z" />
+  </svg>
+);
+
+export const Linkedin = ({ size = 15 }: IconProps) => (
+  <svg {...base(size)} fill="currentColor">
+    <path d="M4.98 3.5a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5zM3 9h4v12H3zM10 9h3.8v1.7h.05c.53-.95 1.83-1.95 3.76-1.95 4.02 0 4.76 2.5 4.76 5.76V21h-4v-5c0-1.19-.02-2.72-1.7-2.72-1.7 0-1.96 1.3-1.96 2.64V21h-4z" />
+  </svg>
+);
+
+export const Camera = ({ size = 15 }: IconProps) => (
+  <svg {...base(size)} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z" />
+    <circle cx="12" cy="13" r="4" />
+  </svg>
+);
+
+export const Star = ({ size = 16 }: IconProps) => (
+  <svg {...base(size)} fill="currentColor">
+    <path d="M12 2l2.94 5.96 6.58.96-4.76 4.64 1.12 6.56L12 17.77l-5.88 3.09 1.12-6.56L2.5 8.92l6.58-.96z" />
+  </svg>
+);
+
+export const Medal = ({ size = 16 }: IconProps) => (
+  <svg {...base(size)} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M8.5 8.5 6 2M15.5 8.5 18 2M9 2h6" />
+    <circle cx="12" cy="15" r="6" />
+    <path d="M12 12.4l.93 1.9 2.07.3-1.5 1.46.35 2.06L12 17.15l-1.85.97.35-2.06-1.5-1.46 2.07-.3z" fill="currentColor" stroke="none" />
+  </svg>
+);
+
+// Mapeia a chave de ícone (guardada na conquista) para o componente.
+export const CHAVES_ICONE = ['trophy', 'flame', 'star', 'check', 'medal', 'bookmark'] as const;
+const MAPA_ICONE = { trophy: Trophy, flame: Flame, star: Star, check: Check, medal: Medal, bookmark: Bookmark };
+
+export function IconeConquista({ chave, size = 18 }: { chave: string; size?: number }) {
+  const C = MAPA_ICONE[chave as keyof typeof MAPA_ICONE] ?? Trophy;
+  return <C size={size} />;
+}
+
+export const Lock = ({ size = 14 }: IconProps) => (
+  <svg {...base(size)} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <rect x="4" y="11" width="16" height="10" rx="2" />
+    <path d="M8 11V7a4 4 0 0 1 8 0v4" />
+  </svg>
+);
+
 /* Capelo de formatura — símbolo da marca */
 export const GradCap = ({ size = 19 }: IconProps) => (
   <svg width={size} height={size} viewBox="0 0 32 32" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">

--- a/frontend/src/pages/Configuracoes/index.tsx
+++ b/frontend/src/pages/Configuracoes/index.tsx
@@ -1,11 +1,37 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Logo } from '../../components/Logo';
-import { Plus, Pencil, Trash, Check } from '../../components/Icons';
-import { listarTags, criarTag, atualizarTag, excluirTag, type Tag } from '../../services/trails';
+import { Plus, Pencil, Trash, Check, IconeConquista, CHAVES_ICONE } from '../../components/Icons';
+import {
+  listarTags, criarTag, atualizarTag, excluirTag,
+  listarLinguagens, criarLinguagem, atualizarLinguagem, excluirLinguagem,
+  listarConquistas, criarConquista, atualizarConquista, excluirConquista,
+  type Achievement, type CriterioConquista,
+} from '../../services/trails';
 
-export function Configuracoes() {
-  const [tags, setTags] = useState<Tag[]>([]);
+function msgErro(e: unknown): string | undefined {
+  return (e as { response?: { data?: { erro?: string } } })?.response?.data?.erro;
+}
+
+interface ItemCrud {
+  id: string;
+  name: string;
+}
+
+interface CrudListProps {
+  titulo: string;
+  descricao: string;
+  placeholder: string;
+  confirmarExclusao: (item: ItemCrud) => string;
+  carregar: () => Promise<ItemCrud[]>;
+  criar: (name: string) => Promise<unknown>;
+  atualizar: (id: string, name: string) => Promise<unknown>;
+  excluir: (id: string) => Promise<unknown>;
+}
+
+// Seção genérica de CRUD por nome (usada para Tags e Linguagens).
+function CrudList({ titulo, descricao, placeholder, confirmarExclusao, carregar, criar, atualizar, excluir }: CrudListProps) {
+  const [itens, setItens] = useState<ItemCrud[]>([]);
   const [carregando, setCarregando] = useState(true);
   const [erro, setErro] = useState('');
   const [novo, setNovo] = useState('');
@@ -13,16 +39,16 @@ export function Configuracoes() {
   const [editId, setEditId] = useState<string | null>(null);
   const [editNome, setEditNome] = useState('');
 
-  async function carregar() {
+  async function recarregar() {
     try {
-      setTags(await listarTags());
+      setItens(await carregar());
     } catch {
-      setErro('Não foi possível carregar as tags.');
+      setErro('Não foi possível carregar a lista.');
     } finally {
       setCarregando(false);
     }
   }
-  useEffect(() => { carregar(); }, []);
+  useEffect(() => { recarregar(); }, []);
 
   async function adicionar() {
     const nome = novo.trim();
@@ -30,11 +56,11 @@ export function Configuracoes() {
     setCriando(true);
     setErro('');
     try {
-      await criarTag(nome);
+      await criar(nome);
       setNovo('');
-      await carregar();
-    } catch (e: any) {
-      setErro(e?.response?.data?.erro ?? 'Não foi possível criar a tag.');
+      await recarregar();
+    } catch (e) {
+      setErro(msgErro(e) ?? 'Não foi possível adicionar.');
     } finally {
       setCriando(false);
     }
@@ -45,25 +71,223 @@ export function Configuracoes() {
     if (!nome) return;
     setErro('');
     try {
-      await atualizarTag(id, nome);
+      await atualizar(id, nome);
       setEditId(null);
-      await carregar();
-    } catch (e: any) {
-      setErro(e?.response?.data?.erro ?? 'Não foi possível salvar a tag.');
+      await recarregar();
+    } catch (e) {
+      setErro(msgErro(e) ?? 'Não foi possível salvar.');
     }
   }
 
-  async function excluir(t: Tag) {
-    if (!window.confirm(`Excluir a tag "${t.name}"? Ela será removida das trilhas que a usam.`)) return;
+  async function remover(item: ItemCrud) {
+    if (!window.confirm(confirmarExclusao(item))) return;
     setErro('');
     try {
-      await excluirTag(t.id);
-      await carregar();
+      await excluir(item.id);
+      await recarregar();
     } catch {
-      setErro('Não foi possível excluir a tag.');
+      setErro('Não foi possível excluir.');
     }
   }
 
+  return (
+    <section style={{ marginBottom: 40 }}>
+      <h1 className="estudio-home__title">{titulo}</h1>
+      <p className="estudio-home__sub">{descricao}</p>
+
+      <div className="estudio-form" style={{ display: 'flex', gap: 12, alignItems: 'center' }}>
+        <input
+          className="estudio-form__input"
+          style={{ margin: 0, flex: 1 }}
+          value={novo}
+          placeholder={placeholder}
+          onChange={(e) => setNovo(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter') adicionar(); }}
+        />
+        <button className="btn btn--accent" style={{ flex: 'none' }} disabled={criando || !novo.trim()} onClick={adicionar}>
+          <Plus size={14} /> Adicionar
+        </button>
+      </div>
+
+      {erro && <div className="auth__alert">{erro}</div>}
+      {carregando && <p className="track__desc">Carregando...</p>}
+      {!carregando && itens.length === 0 && <p className="track__desc">Nada cadastrado ainda.</p>}
+
+      <div className="estudio-home__list">
+        {itens.map((item) => (
+          <div key={item.id} className="estudio-home__card">
+            {editId === item.id ? (
+              <input
+                className="estudio-form__input"
+                style={{ margin: '8px 0 8px 14px', flex: 1 }}
+                value={editNome}
+                autoFocus
+                onChange={(e) => setEditNome(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') salvarEdicao(item.id);
+                  if (e.key === 'Escape') setEditId(null);
+                }}
+              />
+            ) : (
+              <div className="estudio-home__open" style={{ cursor: 'default' }}>
+                <span className="chip--outline">{item.name}</span>
+              </div>
+            )}
+            <div className="estudio-home__actions">
+              {editId === item.id ? (
+                <>
+                  <button className="estudio-home__act" onClick={() => salvarEdicao(item.id)} aria-label="Salvar"><Check size={15} /></button>
+                  <button className="estudio-home__act" onClick={() => setEditId(null)} aria-label="Cancelar">✕</button>
+                </>
+              ) : (
+                <>
+                  <button className="estudio-home__act" onClick={() => { setEditId(item.id); setEditNome(item.name); }} aria-label="Editar"><Pencil size={15} /></button>
+                  <button className="estudio-home__act estudio-home__act--danger" onClick={() => remover(item)} aria-label="Excluir"><Trash size={15} /></button>
+                </>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+const CRITERIOS: { value: CriterioConquista; label: string }[] = [
+  { value: 'lessons_completed', label: 'Aulas concluídas' },
+  { value: 'questions_correct', label: 'Questões certas' },
+  { value: 'xp_total', label: 'XP total' },
+];
+const rotuloCriterio = (c: CriterioConquista) => CRITERIOS.find((x) => x.value === c)?.label ?? c;
+
+const FORM_VAZIO = { name: '', description: '', icon: 'trophy', criteriaType: 'lessons_completed' as CriterioConquista, threshold: 1 };
+
+// Seção de CRUD das conquistas (campos mais ricos: ícone, critério e valor).
+function ConquistasAdmin() {
+  const [itens, setItens] = useState<Achievement[]>([]);
+  const [carregando, setCarregando] = useState(true);
+  const [erro, setErro] = useState('');
+  const [editId, setEditId] = useState<string | null>(null);
+  const [form, setForm] = useState(FORM_VAZIO);
+  const [salvando, setSalvando] = useState(false);
+
+  async function recarregar() {
+    try {
+      setItens(await listarConquistas());
+    } catch {
+      setErro('Não foi possível carregar as conquistas.');
+    } finally {
+      setCarregando(false);
+    }
+  }
+  useEffect(() => { recarregar(); }, []);
+
+  function resetar() { setEditId(null); setForm(FORM_VAZIO); }
+
+  async function salvar() {
+    if (!form.name.trim() || !form.description.trim() || form.threshold < 1 || salvando) return;
+    setSalvando(true);
+    setErro('');
+    try {
+      if (editId) await atualizarConquista(editId, form);
+      else await criarConquista(form);
+      resetar();
+      await recarregar();
+    } catch (e) {
+      setErro(msgErro(e) ?? 'Não foi possível salvar a conquista.');
+    } finally {
+      setSalvando(false);
+    }
+  }
+
+  function editar(a: Achievement) {
+    setEditId(a.id);
+    setForm({ name: a.name, description: a.description, icon: a.icon, criteriaType: a.criteriaType, threshold: a.threshold });
+  }
+
+  async function remover(a: Achievement) {
+    if (!window.confirm(`Excluir a conquista "${a.name}"? Ela será removida dos perfis que a desbloquearam.`)) return;
+    setErro('');
+    try {
+      await excluirConquista(a.id);
+      if (editId === a.id) resetar();
+      await recarregar();
+    } catch {
+      setErro('Não foi possível excluir a conquista.');
+    }
+  }
+
+  return (
+    <section style={{ marginBottom: 40 }}>
+      <h1 className="estudio-home__title">Conquistas</h1>
+      <p className="estudio-home__sub">
+        Desbloqueiam sozinhas quando o aluno atinge o critério (ex.: concluir 5 aulas, acertar 100 questões, alcançar 500 XP).
+      </p>
+
+      <div className="conq-form">
+        <input
+          className="estudio-form__input"
+          style={{ margin: 0 }}
+          value={form.name}
+          placeholder="Nome (ex.: Maratonista)"
+          onChange={(e) => setForm({ ...form, name: e.target.value })}
+        />
+        <input
+          className="estudio-form__input"
+          style={{ margin: 0 }}
+          value={form.description}
+          placeholder="Descrição (ex.: Conclua 10 aulas)"
+          onChange={(e) => setForm({ ...form, description: e.target.value })}
+        />
+        <div className="conq-form__row">
+          <select className="estudio-form__input" style={{ margin: 0 }} value={form.icon} onChange={(e) => setForm({ ...form, icon: e.target.value })}>
+            {CHAVES_ICONE.map((k) => <option key={k} value={k}>{k}</option>)}
+          </select>
+          <select className="estudio-form__input" style={{ margin: 0 }} value={form.criteriaType} onChange={(e) => setForm({ ...form, criteriaType: e.target.value as CriterioConquista })}>
+            {CRITERIOS.map((c) => <option key={c.value} value={c.value}>{c.label}</option>)}
+          </select>
+          <input
+            className="estudio-form__input"
+            style={{ margin: 0, width: 110 }}
+            type="number"
+            min={1}
+            value={form.threshold}
+            placeholder="Valor"
+            onChange={(e) => setForm({ ...form, threshold: Math.max(1, Number(e.target.value) || 1) })}
+          />
+          <button className="btn btn--accent" style={{ flex: 'none' }} disabled={salvando || !form.name.trim() || !form.description.trim()} onClick={salvar}>
+            {editId ? <><Check size={14} /> Salvar</> : <><Plus size={14} /> Adicionar</>}
+          </button>
+          {editId && <button className="btn btn--ghost" style={{ flex: 'none' }} onClick={resetar}>Cancelar</button>}
+        </div>
+      </div>
+
+      {erro && <div className="auth__alert">{erro}</div>}
+      {carregando && <p className="track__desc">Carregando...</p>}
+      {!carregando && itens.length === 0 && <p className="track__desc">Nenhuma conquista cadastrada ainda.</p>}
+
+      <div className="estudio-home__list">
+        {itens.map((a) => (
+          <div key={a.id} className="estudio-home__card">
+            <div className="conq-item">
+              <span className="conq-item__icon"><IconeConquista chave={a.icon} size={18} /></span>
+              <div>
+                <div className="conq-item__name">{a.name}</div>
+                <div className="conq-item__sub">{a.description} · {rotuloCriterio(a.criteriaType)} ≥ {a.threshold}</div>
+              </div>
+            </div>
+            <div className="estudio-home__actions">
+              <button className="estudio-home__act" onClick={() => editar(a)} aria-label="Editar"><Pencil size={15} /></button>
+              <button className="estudio-home__act estudio-home__act--danger" onClick={() => remover(a)} aria-label="Excluir"><Trash size={15} /></button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function Configuracoes() {
   return (
     <div className="home">
       <header className="topbar studio__bar">
@@ -72,71 +296,35 @@ export function Configuracoes() {
           <span className="studio__badge">Configurações</span>
         </div>
         <span className="studio__divider" />
-        <div className="studio__crumb"><b>Tags de trilhas</b></div>
+        <div className="studio__crumb"><b>Tags, linguagens e conquistas</b></div>
         <div className="topbar__spacer" />
         <Link className="btn btn--ghost studio__btn" to="/home">Voltar ao app</Link>
       </header>
 
       <div className="estudio-home">
-        <h1 className="estudio-home__title">Tags</h1>
-        <p className="estudio-home__sub">
-          Categorias para filtrar as trilhas (ex.: Fundamentos, Linguagens, Algoritmos). Você atribui as tags ao criar ou editar uma trilha no Estúdio.
-        </p>
+        <CrudList
+          titulo="Tags"
+          descricao="Categorias para filtrar as trilhas (ex.: Fundamentos, Linguagens, Algoritmos). Você atribui as tags ao criar ou editar uma trilha no Estúdio."
+          placeholder="Nome da nova tag"
+          confirmarExclusao={(t) => `Excluir a tag "${t.name}"? Ela será removida das trilhas que a usam.`}
+          carregar={listarTags}
+          criar={criarTag}
+          atualizar={atualizarTag}
+          excluir={excluirTag}
+        />
 
-        <div className="estudio-form" style={{ display: 'flex', gap: 12, alignItems: 'center' }}>
-          <input
-            className="estudio-form__input"
-            style={{ margin: 0, flex: 1 }}
-            value={novo}
-            placeholder="Nome da nova tag"
-            onChange={(e) => setNovo(e.target.value)}
-            onKeyDown={(e) => { if (e.key === 'Enter') adicionar(); }}
-          />
-          <button className="btn btn--accent" style={{ flex: 'none' }} disabled={criando || !novo.trim()} onClick={adicionar}>
-            <Plus size={14} /> Adicionar
-          </button>
-        </div>
+        <CrudList
+          titulo="Linguagens"
+          descricao="Conjunto fixo de linguagens que aparecem no perfil. Padronizar evita variações como JS, Javascript e javascript, mantendo os dados limpos para análises."
+          placeholder="Nome da nova linguagem"
+          confirmarExclusao={(l) => `Excluir a linguagem "${l.name}"? Ela será removida dos perfis que a usam.`}
+          carregar={listarLinguagens}
+          criar={criarLinguagem}
+          atualizar={atualizarLinguagem}
+          excluir={excluirLinguagem}
+        />
 
-        {erro && <div className="auth__alert">{erro}</div>}
-        {carregando && <p className="track__desc">Carregando...</p>}
-        {!carregando && tags.length === 0 && <p className="track__desc">Nenhuma tag cadastrada ainda.</p>}
-
-        <div className="estudio-home__list">
-          {tags.map((t) => (
-            <div key={t.id} className="estudio-home__card">
-              {editId === t.id ? (
-                <input
-                  className="estudio-form__input"
-                  style={{ margin: '8px 0 8px 14px', flex: 1 }}
-                  value={editNome}
-                  autoFocus
-                  onChange={(e) => setEditNome(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') salvarEdicao(t.id);
-                    if (e.key === 'Escape') setEditId(null);
-                  }}
-                />
-              ) : (
-                <div className="estudio-home__open" style={{ cursor: 'default' }}>
-                  <span className="chip--outline">{t.name}</span>
-                </div>
-              )}
-              <div className="estudio-home__actions">
-                {editId === t.id ? (
-                  <>
-                    <button className="estudio-home__act" onClick={() => salvarEdicao(t.id)} aria-label="Salvar"><Check size={15} /></button>
-                    <button className="estudio-home__act" onClick={() => setEditId(null)} aria-label="Cancelar">✕</button>
-                  </>
-                ) : (
-                  <>
-                    <button className="estudio-home__act" onClick={() => { setEditId(t.id); setEditNome(t.name); }} aria-label="Editar tag"><Pencil size={15} /></button>
-                    <button className="estudio-home__act estudio-home__act--danger" onClick={() => excluir(t)} aria-label="Excluir tag"><Trash size={15} /></button>
-                  </>
-                )}
-              </div>
-            </div>
-          ))}
-        </div>
+        <ConquistasAdmin />
       </div>
     </div>
   );

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -7,15 +7,13 @@ import { ThemeToggle } from '../../components/ThemeToggle';
 import { Avatar } from '../../components/Avatar';
 import { Flame, Search, Bookmark, Play } from '../../components/Icons';
 import { getInitials } from '../../utils/initials';
+import { tempoRelativo } from '../../utils/tempo';
 import {
   user,
   dailyChallenge,
-  week,
-  ranking,
-  feed,
   MEDALS,
 } from '../../data/home';
-import { listarTrilhas, listarMinhasTrilhas, obterTrilha } from '../../services/trails';
+import { listarTrilhas, listarMinhasTrilhas, obterTrilha, obterFeedConquistas, obterRanking, obterStreak, type FeedConquista, type RankingRow, type StreakInfo } from '../../services/trails';
 import type { Trail } from '../../data/trails';
 
 const NAV = [
@@ -24,6 +22,8 @@ const NAV = [
   { label: 'Ranking', to: '/ranking' },
   { label: 'Comunidade', to: '/comunidade' },
 ];
+
+const CORES_FEED = ['#2D6BF5', '#E0655A', '#3DAE6B', '#E0A82E', '#8B5CF6'];
 
 function Stat({ value, label }: { value: string; label: string }) {
   return (
@@ -44,6 +44,9 @@ export function Home() {
   const [emAndamento, setEmAndamento] = useState<(Trail & { id: string })[]>([]);
   const [disponiveis, setDisponiveis] = useState<(Trail & { id: string })[]>([]);
   const [carregando, setCarregando] = useState(true);
+  const [feedComunidade, setFeedComunidade] = useState<FeedConquista[]>([]);
+  const [rankingGlobal, setRankingGlobal] = useState<RankingRow[]>([]);
+  const [streakInfo, setStreakInfo] = useState<StreakInfo>({ streak: 0, week: [] });
 
   useEffect(() => {
     let ativo = true;
@@ -65,6 +68,12 @@ export function Home() {
     }
     carregar();
     return () => { ativo = false; };
+  }, []);
+
+  useEffect(() => {
+    obterFeedConquistas().then(setFeedComunidade).catch(() => {});
+    obterRanking().then((r) => setRankingGlobal(r.rows)).catch(() => {});
+    obterStreak().then(setStreakInfo).catch(() => {});
   }, []);
 
   // Abre a trilha na primeira aula disponivel (a atual, ou a primeira).
@@ -105,7 +114,7 @@ export function Home() {
             <span>Buscar exercício…</span>
           </div>
           <div className="streak-pill">
-            <Flame size={16} /> {user.streak}
+            <Flame size={16} /> {streakInfo.streak}
           </div>
           <ThemeToggle inline />
           <UserMenu
@@ -228,17 +237,17 @@ export function Home() {
               <div className="streak">
                 <span className="streak__icon"><Flame size={24} /></span>
                 <div>
-                  <div className="streak__count">{user.streak} dias</div>
+                  <div className="streak__count">{streakInfo.streak} dias</div>
                   <div className="streak__label">de streak seguido</div>
                 </div>
               </div>
               <div className="week">
-                {week.map((d, i) => (
+                {streakInfo.week.map((d, i) => (
                   <div key={i} className="week__day">
-                    <span className={`week__dot${d.on ? ' week__dot--on' : ''}`}>
-                      {d.on ? '✓' : ''}
+                    <span className={`week__dot${d.active ? ' week__dot--on' : ''}`}>
+                      {d.active ? '✓' : ''}
                     </span>
-                    <span className="week__letter">{d.d}</span>
+                    <span className="week__letter">{d.label}</span>
                   </div>
                 ))}
               </div>
@@ -251,22 +260,24 @@ export function Home() {
             <div className="card">
               <div className="card__head">
                 <h3 className="card__title">Ranking global</h3>
-                <a className="link" href="#">Ver tudo</a>
+                <Link className="link" to="/ranking">Ver tudo</Link>
               </div>
-              {ranking.map((p) => (
-                <div key={p.r} className={`rank-row${p.you ? ' rank-row--you' : ''}`}>
-                  <span className="rank-row__pos" style={{ color: MEDALS[p.r] || 'var(--muted)' }}>
-                    {p.r}
+              {rankingGlobal.length === 0 ? (
+                <p className="track__desc">Ranking ainda vazio.</p>
+              ) : rankingGlobal.slice(0, 5).map((p) => (
+                <div key={p.position} className={`rank-row${p.you ? ' rank-row--you' : ''}`}>
+                  <span className="rank-row__pos" style={{ color: MEDALS[p.position] || 'var(--muted)' }}>
+                    {p.position}
                   </span>
                   <Avatar
-                    initials={p.initials}
-                    background={p.you ? 'var(--accent)' : p.color}
-                    color={!p.you && p.r === 1 ? '#3a2a00' : '#fff'}
+                    initials={getInitials(p.name)}
+                    background={p.you ? 'var(--accent)' : CORES_FEED[p.position % CORES_FEED.length]}
+                    color={!p.you && p.position === 1 ? '#3a2a00' : '#fff'}
                   />
                   <span className={`rank-row__name${p.you ? ' rank-row__name--you' : ''}`}>
                     {p.name}
                   </span>
-                  <span className="rank-row__pts">{p.pts}</span>
+                  <span className="rank-row__pts">{p.xp}</span>
                 </div>
               ))}
             </div>
@@ -274,18 +285,22 @@ export function Home() {
             {/* Comunidade */}
             <div className="card">
               <h3 className="card__title card__title--mb">Comunidade</h3>
-              <div className="feed">
-                {feed.map((f, i) => (
-                  <div key={i} className="feed__item">
-                    <Avatar initials={f.initials} background={f.color} />
-                    <p className="feed__text">
-                      <b>{f.name}</b>{' '}
-                      <span className="feed__muted">{f.text}</span>{' '}
-                      <span className="feed__time">· {f.time}</span>
-                    </p>
-                  </div>
-                ))}
-              </div>
+              {feedComunidade.length === 0 ? (
+                <p className="track__desc">Ainda não há conquistas na comunidade.</p>
+              ) : (
+                <div className="feed">
+                  {feedComunidade.map((f, i) => (
+                    <div key={i} className="feed__item">
+                      <Avatar initials={getInitials(f.name)} background={CORES_FEED[i % CORES_FEED.length]} />
+                      <p className="feed__text">
+                        <b>{f.name}</b>{' '}
+                        <span className="feed__muted">desbloqueou {f.achievement}</span>{' '}
+                        <span className="feed__time">· {tempoRelativo(f.at)}</span>
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              )}
             </div>
           </aside>
         </div>

--- a/frontend/src/pages/Perfil/index.tsx
+++ b/frontend/src/pages/Perfil/index.tsx
@@ -13,7 +13,7 @@ import { getInitials } from '../../utils/initials';
 import { tempoRelativo } from '../../utils/tempo';
 import { user as homeUser } from '../../data/home';
 import {
-  obterXp, listarLinguagens, obterMinhasConquistas, obterAtividades,
+  obterXp, listarLinguagens, obterMinhasConquistas, obterAtividades, obterRanking,
   type MinhaConquista, type Atividade,
 } from '../../services/trails';
 
@@ -85,6 +85,7 @@ export function Perfil() {
   const [conquistas, setConquistas] = useState<MinhaConquista[]>([]);
   const [verTodasConquistas, setVerTodasConquistas] = useState(false);
   const [atividades, setAtividades] = useState<Atividade[]>([]);
+  const [posicao, setPosicao] = useState<number | null>(null);
   const [editando, setEditando] = useState(false);
   const [draft, setDraft] = useState<Editavel>({ bio: '', location: '', occupation: '', languages: [], github: '', linkedin: '' });
   const [salvando, setSalvando] = useState(false);
@@ -98,12 +99,13 @@ export function Perfil() {
     let ativo = true;
     async function carregar() {
       try {
-        const [me, stats, langs, conq, ativ] = await Promise.all([
+        const [me, stats, langs, conq, ativ, rank] = await Promise.all([
           api.get<PerfilData>('/me'),
           obterXp(),
           listarLinguagens().catch(() => []),
           obterMinhasConquistas().catch(() => []),
           obterAtividades().catch(() => []),
+          obterRanking().catch(() => null),
         ]);
         if (!ativo) return;
         setPerfil(me.data);
@@ -111,6 +113,7 @@ export function Perfil() {
         setLinguagens(langs.map((l) => l.name));
         setConquistas(conq);
         setAtividades(ativ);
+        setPosicao(rank?.me?.position ?? null);
       } catch {
         if (ativo) setErro('Não foi possível carregar o perfil.');
       } finally {
@@ -299,7 +302,7 @@ export function Perfil() {
               <div className="pf-stats">
                 <Stat value={String(perfil.streak)} label="dias de streak" icon={<Flame size={18} />} />
                 <Stat value={xp.xp.toLocaleString('pt-BR')} label="XP total" />
-                <Stat value="—" label="no ranking global" />
+                <Stat value={posicao ? `#${posicao}` : '—'} label="no ranking global" />
                 <Stat value={String(xp.questionsCorrect)} label="exercícios resolvidos" />
                 <Stat value={String(xp.lessonsCompleted)} label="aulas concluídas" />
               </div>

--- a/frontend/src/pages/Perfil/index.tsx
+++ b/frontend/src/pages/Perfil/index.tsx
@@ -1,0 +1,509 @@
+import { useEffect, useRef, useState, type ChangeEvent, type ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+import api from '../../services/api';
+import { useAuth } from '../../contexts/AuthContext';
+import { Logo } from '../../components/Logo';
+import { UserMenu } from '../../components/UserMenu';
+import { ThemeToggle } from '../../components/ThemeToggle';
+import {
+  Flame, Search, Pencil, Check, X, Camera,
+  AtSign, MapPin, Briefcase, Calendar, Github, Linkedin, IconeConquista,
+} from '../../components/Icons';
+import { getInitials } from '../../utils/initials';
+import { tempoRelativo } from '../../utils/tempo';
+import { user as homeUser } from '../../data/home';
+import {
+  obterXp, listarLinguagens, obterMinhasConquistas, obterAtividades,
+  type MinhaConquista, type Atividade,
+} from '../../services/trails';
+
+const NAV = [
+  { label: 'Início', to: '/home' },
+  { label: 'Trilhas', to: '/trilhas' },
+  { label: 'Ranking', to: '/ranking' },
+  { label: 'Comunidade', to: '/comunidade' },
+];
+
+interface PerfilData {
+  id: string;
+  name: string;
+  username: string | null;
+  email: string;
+  bio: string | null;
+  location: string | null;
+  occupation: string | null;
+  languages: string[] | null;
+  github: string | null;
+  linkedin: string | null;
+  avatarUrl: string | null;
+  coverUrl: string | null;
+  streak: number;
+  createdAt: string;
+  role?: string;
+}
+
+interface Editavel {
+  bio: string;
+  location: string;
+  occupation: string;
+  languages: string[];
+  github: string;
+  linkedin: string;
+}
+
+function membroDesde(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '—';
+  const s = d.toLocaleDateString('pt-BR', { month: 'long', year: 'numeric' });
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+// As imagens sao servidas pelo backend; em dev ele fica em outra origem que o front.
+const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:3001';
+function urlImagem(p: string | null | undefined): string | null {
+  if (!p) return null;
+  return p.startsWith('http') ? p : `${API_BASE}${p}`;
+}
+const TIPOS_IMG = ['image/png', 'image/jpeg', 'image/webp'];
+const MAX_IMG = 4 * 1024 * 1024; // 4MB
+
+function lerArquivo(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(new Error('Falha ao ler o arquivo'));
+    reader.readAsDataURL(file);
+  });
+}
+
+export function Perfil() {
+  const { user: authUser } = useAuth();
+  const [perfil, setPerfil] = useState<PerfilData | null>(null);
+  const [xp, setXp] = useState({ xp: 0, lessonsCompleted: 0, questionsCorrect: 0 });
+  const [carregando, setCarregando] = useState(true);
+  const [linguagens, setLinguagens] = useState<string[]>([]);
+  const [conquistas, setConquistas] = useState<MinhaConquista[]>([]);
+  const [verTodasConquistas, setVerTodasConquistas] = useState(false);
+  const [atividades, setAtividades] = useState<Atividade[]>([]);
+  const [editando, setEditando] = useState(false);
+  const [draft, setDraft] = useState<Editavel>({ bio: '', location: '', occupation: '', languages: [], github: '', linkedin: '' });
+  const [salvando, setSalvando] = useState(false);
+  const [erro, setErro] = useState('');
+  const [enviandoFoto, setEnviandoFoto] = useState(false);
+  const [enviandoCapa, setEnviandoCapa] = useState(false);
+  const inputFoto = useRef<HTMLInputElement>(null);
+  const inputCapa = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    let ativo = true;
+    async function carregar() {
+      try {
+        const [me, stats, langs, conq, ativ] = await Promise.all([
+          api.get<PerfilData>('/me'),
+          obterXp(),
+          listarLinguagens().catch(() => []),
+          obterMinhasConquistas().catch(() => []),
+          obterAtividades().catch(() => []),
+        ]);
+        if (!ativo) return;
+        setPerfil(me.data);
+        setXp(stats);
+        setLinguagens(langs.map((l) => l.name));
+        setConquistas(conq);
+        setAtividades(ativ);
+      } catch {
+        if (ativo) setErro('Não foi possível carregar o perfil.');
+      } finally {
+        if (ativo) setCarregando(false);
+      }
+    }
+    carregar();
+    return () => { ativo = false; };
+  }, []);
+
+  function editar() {
+    if (!perfil) return;
+    setErro('');
+    setDraft({
+      bio: perfil.bio ?? '',
+      location: perfil.location ?? '',
+      occupation: perfil.occupation ?? '',
+      languages: (perfil.languages ?? []).filter((l) => linguagens.includes(l)),
+      github: perfil.github ?? '',
+      linkedin: perfil.linkedin ?? '',
+    });
+    setEditando(true);
+  }
+
+  function cancelar() {
+    setEditando(false);
+    setErro('');
+  }
+
+  async function salvar() {
+    if (salvando) return;
+    setSalvando(true);
+    setErro('');
+    try {
+      const { data } = await api.patch<PerfilData>('/me', draft);
+      setPerfil(data);
+      setEditando(false);
+    } catch (e) {
+      const msg = (e as { response?: { data?: { erro?: string } } })?.response?.data?.erro;
+      setErro(msg ?? 'Não foi possível salvar as alterações.');
+    } finally {
+      setSalvando(false);
+    }
+  }
+
+  async function enviarImagem(file: File, rota: '/me/avatar' | '/me/cover', setBusy: (v: boolean) => void) {
+    if (!TIPOS_IMG.includes(file.type)) {
+      setErro('Use uma imagem PNG, JPG ou WEBP.');
+      return;
+    }
+    if (file.size > MAX_IMG) {
+      setErro('Imagem muito grande (máximo 4MB).');
+      return;
+    }
+    setBusy(true);
+    setErro('');
+    try {
+      const dataUrl = await lerArquivo(file);
+      const { data } = await api.post<PerfilData>(rota, { image: dataUrl });
+      setPerfil(data);
+    } catch (e) {
+      const msg = (e as { response?: { data?: { erro?: string } } })?.response?.data?.erro;
+      setErro(msg ?? 'Não foi possível enviar a imagem.');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function onPickFoto(e: ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    e.target.value = '';
+    if (file) enviarImagem(file, '/me/avatar', setEnviandoFoto);
+  }
+
+  function onPickCapa(e: ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    e.target.value = '';
+    if (file) enviarImagem(file, '/me/cover', setEnviandoCapa);
+  }
+
+  function addLang(v: string) {
+    if (!v || draft.languages.includes(v)) return;
+    setDraft((d) => ({ ...d, languages: [...d.languages, v] }));
+  }
+
+  function removeLang(i: number) {
+    setDraft((d) => ({ ...d, languages: d.languages.filter((_, idx) => idx !== i) }));
+  }
+
+  const displayName = perfil?.name ?? authUser?.name ?? homeUser.name;
+  const initials = getInitials(displayName);
+  const nivel = Math.floor(xp.xp / 500) + 1;
+  const langsVisiveis = editando ? draft.languages : (perfil?.languages ?? []);
+  const langsDisponiveis = linguagens.filter((l) => !draft.languages.includes(l));
+  const fotoUrl = urlImagem(perfil?.avatarUrl);
+  const capaUrl = urlImagem(perfil?.coverUrl);
+  const conquistasGanhas = conquistas.filter((c) => c.earned);
+
+  return (
+    <div className="home-shell">
+      <div className="home">
+        <header className="topbar">
+          <Logo variant="solid" size={20} />
+          <nav className="nav">
+            {NAV.map((item) => (
+              <Link key={item.to} to={item.to} className="nav__item">{item.label}</Link>
+            ))}
+          </nav>
+          <div className="topbar__spacer" />
+          <div className="searchbar">
+            <Search size={16} />
+            <span>Buscar exercício…</span>
+          </div>
+          <div className="streak-pill"><Flame size={16} /> {perfil?.streak ?? 0}</div>
+          <ThemeToggle inline />
+          <UserMenu initials={initials} level={nivel} name={displayName} email={authUser?.email} />
+        </header>
+
+        {carregando ? (
+          <p className="track__desc" style={{ padding: '40px 26px' }}>Carregando perfil...</p>
+        ) : !perfil ? (
+          <p className="track__desc" style={{ padding: '40px 26px' }}>{erro || 'Perfil não encontrado.'}</p>
+        ) : (
+          <div className="pf">
+            <div className="pf-card">
+              <div
+                className="pf-banner"
+                style={capaUrl ? { backgroundImage: `url(${capaUrl})`, backgroundSize: 'cover', backgroundPosition: 'center' } : undefined}
+              >
+                {!capaUrl && (
+                  <>
+                    <span className="pf-banner__glow pf-banner__glow--a" />
+                    <span className="pf-banner__glow pf-banner__glow--b" />
+                  </>
+                )}
+                {editando && (
+                  <button
+                    type="button"
+                    className="pf-banner__edit"
+                    onClick={() => inputCapa.current?.click()}
+                    disabled={enviandoCapa}
+                  >
+                    <Camera size={14} /> {enviandoCapa ? 'Enviando...' : 'Trocar capa'}
+                  </button>
+                )}
+                <input ref={inputCapa} type="file" accept="image/png,image/jpeg,image/webp" hidden onChange={onPickCapa} />
+              </div>
+              <div className="pf-head">
+                <div className="pf-avatar-wrap">
+                  <div className="pf-avatar" style={{ width: 104, height: 104, fontSize: 38, border: '4px solid var(--surface)' }}>
+                    {fotoUrl ? <img src={fotoUrl} alt={perfil.name} /> : initials}
+                  </div>
+                  {editando && (
+                    <button
+                      type="button"
+                      className="pf-avatar-wrap__cam"
+                      onClick={() => inputFoto.current?.click()}
+                      disabled={enviandoFoto}
+                      aria-label="Trocar foto"
+                    >
+                      <Camera size={14} />
+                    </button>
+                  )}
+                  <input ref={inputFoto} type="file" accept="image/png,image/jpeg,image/webp" hidden onChange={onPickFoto} />
+                </div>
+                <div className="pf-id">
+                  <div className="pf-id__row">
+                    <span className="pf-id__name">{perfil.name}</span>
+                    <span className="pf-id__level">Nível {nivel}</span>
+                  </div>
+                  <div className="pf-id__user">@{perfil.username ?? 'sem_usuario'}</div>
+                </div>
+                {!editando ? (
+                  <div className="pf-actions">
+                    <button className="btn btn--accent pf-actions__btn" onClick={editar}><Pencil size={14} /> Editar perfil</button>
+                  </div>
+                ) : (
+                  <div className="pf-actions">
+                    <button className="btn btn--ghost pf-actions__btn" onClick={cancelar}>Cancelar</button>
+                    <button className="pf-save" disabled={salvando} onClick={salvar}>
+                      <Check size={15} /> {salvando ? 'Salvando...' : 'Salvar alterações'}
+                    </button>
+                  </div>
+                )}
+              </div>
+              <div className="pf-stats">
+                <Stat value={String(perfil.streak)} label="dias de streak" icon={<Flame size={18} />} />
+                <Stat value={xp.xp.toLocaleString('pt-BR')} label="XP total" />
+                <Stat value="—" label="no ranking global" />
+                <Stat value={String(xp.questionsCorrect)} label="exercícios resolvidos" />
+                <Stat value={String(xp.lessonsCompleted)} label="aulas concluídas" />
+              </div>
+            </div>
+
+            <div className="pf-grid">
+              <div className="pf-col">
+                <div className="card">
+                  <h3 className="card__title card__title--mb">Sobre</h3>
+                  {!editando ? (
+                    <p className="pf-bio">{perfil.bio || 'Sem descrição ainda.'}</p>
+                  ) : (
+                    <textarea
+                      className="pf-textarea"
+                      value={draft.bio}
+                      maxLength={500}
+                      placeholder="Conte um pouco sobre você"
+                      onChange={(e) => setDraft({ ...draft, bio: e.target.value })}
+                    />
+                  )}
+                </div>
+
+                <div className="card">
+                  <h3 className="card__title card__title--mb">Informações</h3>
+                  <div className="pf-fields">
+                    <Campo icon={<AtSign size={14} />} label="Usuário" value={perfil.username ? `@${perfil.username}` : '—'} />
+                    <CampoEdit
+                      icon={<MapPin size={14} />} label="Localização" value={perfil.location}
+                      editando={editando} draft={draft.location} placeholder="Cidade, País"
+                      onChange={(v) => setDraft({ ...draft, location: v })}
+                    />
+                    <CampoEdit
+                      icon={<Briefcase size={14} />} label="Função" value={perfil.occupation}
+                      editando={editando} draft={draft.occupation} placeholder="Ex: Estudante de programação"
+                      onChange={(v) => setDraft({ ...draft, occupation: v })}
+                    />
+                    <Campo icon={<Calendar size={14} />} label="Membro desde" value={membroDesde(perfil.createdAt)} />
+
+                    <div>
+                      <div className="pf-field__label">Linguagens</div>
+                      <div className="pf-langs">
+                        {langsVisiveis.map((l, i) => (
+                          <span key={l + i} className="pf-lang">
+                            {l}
+                            {editando && (
+                              <button className="pf-lang__x" onClick={() => removeLang(i)} aria-label={`Remover ${l}`}><X size={11} /></button>
+                            )}
+                          </span>
+                        ))}
+                        {editando && langsDisponiveis.length > 0 && (
+                          <select
+                            className="pf-lang-add"
+                            value=""
+                            onChange={(e) => addLang(e.target.value)}
+                          >
+                            <option value="" disabled>+ Adicionar</option>
+                            {langsDisponiveis.map((l) => (
+                              <option key={l} value={l}>{l}</option>
+                            ))}
+                          </select>
+                        )}
+                        {!editando && langsVisiveis.length === 0 && (
+                          <span className="pf-field__value" style={{ color: 'var(--muted)' }}>—</span>
+                        )}
+                      </div>
+                    </div>
+
+                    <div>
+                      <div className="pf-field__label">Links</div>
+                      <div className="pf-links">
+                        <LinkEdit
+                          icon={<Github size={15} />} value={perfil.github}
+                          editando={editando} draft={draft.github} placeholder="github.com/voce"
+                          onChange={(v) => setDraft({ ...draft, github: v })}
+                        />
+                        <LinkEdit
+                          icon={<Linkedin size={15} />} value={perfil.linkedin}
+                          editando={editando} draft={draft.linkedin} placeholder="linkedin.com/in/voce"
+                          onChange={(v) => setDraft({ ...draft, linkedin: v })}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div className="pf-col">
+                <div className="card">
+                  <div className="card__head">
+                    <h3 className="card__title">Conquistas</h3>
+                    {conquistasGanhas.length > 6 && (
+                      <button
+                        type="button"
+                        className="link"
+                        style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer', font: 'inherit' }}
+                        onClick={() => setVerTodasConquistas((v) => !v)}
+                      >
+                        {verTodasConquistas ? 'Ver menos' : 'Ver todas'}
+                      </button>
+                    )}
+                  </div>
+                  {conquistasGanhas.length === 0 ? (
+                    <p className="track__desc">Nenhuma conquista desbloqueada.</p>
+                  ) : (
+                    <div className="pf-badges">
+                      {(verTodasConquistas ? conquistasGanhas : conquistasGanhas.slice(0, 6)).map((c) => (
+                        <div key={c.id} className="pf-badge">
+                          <span className="pf-badge__icon"><IconeConquista chave={c.icon} size={24} /></span>
+                          <div className="pf-badge__name">{c.name}</div>
+                          <div className="pf-badge__sub">{c.description}</div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+                <div className="card">
+                  <h3 className="card__title card__title--mb">Atividade recente</h3>
+                  {atividades.length === 0 ? (
+                    <p className="track__desc">Nenhuma atividade ainda. Conclua uma aula para começar.</p>
+                  ) : (
+                    <div className="pf-timeline">
+                      {atividades.map((a, i) => (
+                        <div key={i} className="pf-act">
+                          <span className={`pf-act__icon pf-act__icon--${a.type === 'achievement' ? 'accent' : 'green'}`}>
+                            <IconeConquista chave={a.icon} size={14} />
+                          </span>
+                          <div className="pf-act__body">
+                            <div className="pf-act__text">{a.text}</div>
+                            <div className="pf-act__time">{tempoRelativo(a.at)}</div>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            {erro && <div className="auth__alert" style={{ marginTop: 16 }}>{erro}</div>}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Stat({ value, label, icon }: { value: string; label: string; icon?: ReactNode }) {
+  return (
+    <div className="pf-stat">
+      <div className="pf-stat__value">{icon && <span className="pf-stat__icon">{icon}</span>}{value}</div>
+      <div className="pf-stat__label">{label}</div>
+    </div>
+  );
+}
+
+function Campo({ icon, label, value }: { icon: ReactNode; label: string; value: string }) {
+  return (
+    <div>
+      <div className="pf-field__label"><span className="pf-field__icon">{icon}</span>{label}</div>
+      <div className="pf-field__value">{value}</div>
+    </div>
+  );
+}
+
+interface CampoEditProps {
+  icon: ReactNode;
+  label: string;
+  value: string | null;
+  editando: boolean;
+  draft: string;
+  placeholder?: string;
+  onChange: (v: string) => void;
+}
+
+function CampoEdit({ icon, label, value, editando, draft, placeholder, onChange }: CampoEditProps) {
+  return (
+    <div>
+      <div className="pf-field__label"><span className="pf-field__icon">{icon}</span>{label}</div>
+      {!editando ? (
+        <div className="pf-field__value">{value || '—'}</div>
+      ) : (
+        <input className="pf-input" value={draft} placeholder={placeholder} onChange={(e) => onChange(e.target.value)} />
+      )}
+    </div>
+  );
+}
+
+interface LinkEditProps {
+  icon: ReactNode;
+  value: string | null;
+  editando: boolean;
+  draft: string;
+  placeholder?: string;
+  onChange: (v: string) => void;
+}
+
+function LinkEdit({ icon, value, editando, draft, placeholder, onChange }: LinkEditProps) {
+  if (!editando) {
+    return <div className="pf-link"><span className="pf-link__icon">{icon}</span>{value || '—'}</div>;
+  }
+  return (
+    <div className="pf-link-edit">
+      <span className="pf-link__icon">{icon}</span>
+      <input className="pf-input pf-input--bare" value={draft} placeholder={placeholder} onChange={(e) => onChange(e.target.value)} />
+    </div>
+  );
+}

--- a/frontend/src/pages/Ranking/index.tsx
+++ b/frontend/src/pages/Ranking/index.tsx
@@ -1,0 +1,230 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useAuth } from '../../contexts/AuthContext';
+import { Logo } from '../../components/Logo';
+import { UserMenu } from '../../components/UserMenu';
+import { ThemeToggle } from '../../components/ThemeToggle';
+import { Avatar } from '../../components/Avatar';
+import { Flame, Search, Trophy, Check, Lock } from '../../components/Icons';
+import { getInitials } from '../../utils/initials';
+import { user as homeUser } from '../../data/home';
+import { obterRanking, type RankingResposta, type RankingPeriodo } from '../../services/trails';
+
+const NAV = [
+  { label: 'Início', to: '/home' },
+  { label: 'Trilhas', to: '/trilhas' },
+  { label: 'Ranking', to: '/ranking' },
+  { label: 'Comunidade', to: '/comunidade' },
+];
+const CORES = ['#5B8DEF', '#E0655A', '#2E9E6B', '#E0A82E', '#8B5CF6'];
+const MEDAL: Record<number, string> = { 1: 'var(--gold)', 2: 'var(--silver)', 3: 'var(--bronze)' };
+const PODIO: Record<number, { size: number; font: number; pedestal: number }> = {
+  1: { size: 76, font: 27, pedestal: 132 },
+  2: { size: 62, font: 22, pedestal: 104 },
+  3: { size: 58, font: 20, pedestal: 88 },
+};
+const PERIODOS: { label: string; value: RankingPeriodo }[] = [
+  { label: 'Semana', value: 'week' },
+  { label: 'Mês', value: 'month' },
+  { label: 'Geral', value: 'all' },
+];
+const LIGAS = [
+  { name: 'Bronze', color: '#C77B3B', threshold: 0 },
+  { name: 'Prata', color: '#A9AEB8', threshold: 1500 },
+  { name: 'Ouro', color: '#E0A82E', threshold: 3500 },
+  { name: 'Platina', color: '#3FBEC6', threshold: 6000 },
+  { name: 'Diamante', color: '#56C5E8', threshold: 10000 },
+];
+
+function ligaAtual(totalXp: number): number {
+  let idx = 0;
+  for (let i = 0; i < LIGAS.length; i++) if (totalXp >= LIGAS[i].threshold) idx = i;
+  return idx;
+}
+const fmtXp = (n: number) => n.toLocaleString('pt-BR');
+
+export function Ranking() {
+  const { user: authUser } = useAuth();
+  const [period, setPeriod] = useState<RankingPeriodo>('all');
+  const [dados, setDados] = useState<RankingResposta>({ me: null, rows: [] });
+  const [carregando, setCarregando] = useState(true);
+
+  useEffect(() => {
+    let ativo = true;
+    setCarregando(true);
+    obterRanking(period)
+      .then((r) => { if (ativo) setDados(r); })
+      .catch(() => { if (ativo) setDados({ me: null, rows: [] }); })
+      .finally(() => { if (ativo) setCarregando(false); });
+    return () => { ativo = false; };
+  }, [period]);
+
+  const displayName = authUser?.name ?? homeUser.name;
+  const totalXp = dados.me?.totalXp ?? 0;
+  const nivel = dados.me?.level ?? 1;
+  const ligaIdx = ligaAtual(totalXp);
+  const liga = LIGAS[ligaIdx];
+  const progresso = (ligaIdx / (LIGAS.length - 1)) * 72 + 14; // % da linha preenchida
+
+  const podio = [dados.rows[1], dados.rows[0], dados.rows[2]]; // [#2, #1, #3]
+  const tabela = dados.rows.slice(3);
+
+  return (
+    <div className="home-shell">
+      <div className="home">
+        <header className="topbar">
+          <Logo variant="solid" size={20} />
+          <nav className="nav">
+            {NAV.map((item) => (
+              <Link key={item.to} to={item.to} className={`nav__item${item.to === '/ranking' ? ' nav__item--active' : ''}`}>{item.label}</Link>
+            ))}
+          </nav>
+          <div className="topbar__spacer" />
+          <div className="searchbar"><Search size={16} /><span>Buscar exercício…</span></div>
+          <div className="streak-pill"><Flame size={16} /> {dados.me?.streak ?? 0}</div>
+          <ThemeToggle inline />
+          <UserMenu initials={getInitials(displayName)} level={nivel} name={displayName} email={authUser?.email} />
+        </header>
+
+        <div className="rk">
+          <div className="rk-head">
+            <div>
+              <div className="rk-head__title-row">
+                <h1 className="rk-title">Ranking global</h1>
+                <span className="rk-league-badge"><Trophy size={13} /> Liga {liga.name}</span>
+              </div>
+              <p className="rk-sub">Classificação por XP. Resolva exercícios e conclua aulas para subir.</p>
+            </div>
+            <div className="seg">
+              {PERIODOS.map((p) => (
+                <button key={p.value} className={`seg__item${period === p.value ? ' seg__item--active' : ''}`} onClick={() => setPeriod(p.value)}>{p.label}</button>
+              ))}
+            </div>
+          </div>
+
+          {/* Ligas */}
+          <div className="leagues">
+            <div className="leagues__head">
+              <h3 className="card__title">Ligas</h3>
+              <span className="leagues__rule">Sua liga depende do XP total acumulado</span>
+            </div>
+            <div className="leagues__track">
+              <span className="leagues__line" />
+              <span className="leagues__line leagues__line--progress" style={{ width: `${progresso}%` }} />
+              <div className="leagues__grid">
+                {LIGAS.map((g, i) => {
+                  const done = i < ligaIdx;
+                  const current = i === ligaIdx;
+                  const locked = i > ligaIdx;
+                  return (
+                    <div key={g.name} className="league" style={{ opacity: locked ? 0.7 : 1 }}>
+                      <div
+                        className="league__emblem"
+                        style={{
+                          background: locked ? 'var(--surface-2)' : g.color,
+                          color: locked ? 'var(--muted)' : g.name === 'Ouro' ? '#5a3d00' : '#fff',
+                          boxShadow: current ? '0 0 0 4px color-mix(in srgb, var(--accent) 32%, transparent)' : 'none',
+                        }}
+                      >
+                        <svg width="26" height="26" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2 L19.5 9 L12 22 L4.5 9 Z" opacity=".92" /><path d="M4.5 9 L19.5 9 L12 2 Z" opacity=".6" /></svg>
+                        {done && <span className="league__seal league__seal--done"><Check size={11} /></span>}
+                        {locked && <span className="league__seal league__seal--lock"><Lock size={10} /></span>}
+                      </div>
+                      <div className="league__name" style={{ color: locked ? 'var(--muted)' : 'var(--text)', fontWeight: current ? 700 : 600 }}>{g.name}</div>
+                      {current ? <span className="league__here">Você está aqui</span> : <span className="league__xp">{fmtXp(g.threshold)} XP</span>}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+
+          {/* Pódio */}
+          {dados.rows.length > 0 && (
+            <div className="podium">
+              <span className="podium__glow" />
+              <div className="podium__grid">
+                {podio.map((p, slot) => {
+                  if (!p) return <div className="podium__col" key={slot} />;
+                  const meta = PODIO[p.position] ?? PODIO[3];
+                  const cor = MEDAL[p.position] ?? 'var(--muted)';
+                  return (
+                    <div key={p.position} className="podium__col">
+                      {p.position === 1 && (
+                        <svg className="podium__crown" width="26" height="26" viewBox="0 0 24 24" fill="var(--gold)"><path d="M3 7l4 4 5-7 5 7 4-4-1.5 12h-15z" /></svg>
+                      )}
+                      <div className="podium__avatar-wrap">
+                        <div
+                          className="podium__avatar"
+                          style={{ width: meta.size, height: meta.size, fontSize: meta.font, background: p.you ? 'var(--accent)' : CORES[p.position % CORES.length], color: '#fff', borderColor: cor }}
+                        >
+                          {getInitials(p.name)}
+                        </div>
+                        <span className="podium__rank" style={{ background: cor }}>{p.position}</span>
+                      </div>
+                      <div className="podium__name">{p.you ? 'Você' : p.name}</div>
+                      <div className="podium__xp">{fmtXp(p.xp)} XP</div>
+                      <div
+                        className="podium__pedestal"
+                        style={{ height: meta.pedestal, background: `linear-gradient(180deg, color-mix(in srgb, ${cor} 28%, var(--surface)), color-mix(in srgb, ${cor} 10%, var(--surface)))`, color: `color-mix(in srgb, ${cor} 80%, var(--text))` }}
+                      >
+                        {p.position}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {/* Sua posição */}
+          {dados.me && (
+            <div className="rk-you">
+              <span className="rk-you__label">Sua posição</span>
+              <span className="rk-you__rank">#{dados.me.position}</span>
+              <Avatar initials={getInitials(displayName)} background="var(--accent)" />
+              <div className="rk-you__id">
+                <div className="rk-you__name">Você</div>
+                <div className="rk-you__user">@{dados.me.username ?? 'voce'}</div>
+              </div>
+              <span className="rk-you__streak"><Flame size={15} /> {dados.me.streak} dias</span>
+              <span className="rk-you__xp">{fmtXp(dados.me.xp)} XP</span>
+            </div>
+          )}
+
+          {/* Tabela */}
+          <div className="card" style={{ padding: 0, overflow: 'hidden' }}>
+            <div className="rk-table__head">
+              <div>#</div><div>Estudante</div><div>Streak</div><div>Nível</div><div className="rk-right">XP</div>
+            </div>
+            {carregando ? (
+              <p className="track__desc" style={{ padding: '18px 20px' }}>Carregando ranking...</p>
+            ) : tabela.length === 0 ? (
+              <p className="track__desc" style={{ padding: '18px 20px' }}>
+                {dados.rows.length === 0 ? 'Ninguém pontuou ainda. Conclua aulas para aparecer aqui.' : 'Sem mais posições por enquanto.'}
+              </p>
+            ) : (
+              tabela.map((r) => (
+                <div key={r.position} className={`rk-row${r.you ? ' rk-row--you' : ''}`}>
+                  <div className="rk-row__rank">
+                    <span style={{ color: MEDAL[r.position] || 'var(--text)' }}>{r.position}</span>
+                  </div>
+                  <div className="rk-row__student">
+                    <Avatar initials={getInitials(r.name)} background={r.you ? 'var(--accent)' : CORES[r.position % CORES.length]} />
+                    <div className="rk-row__id">
+                      <div className="rk-row__name" style={{ fontWeight: r.you ? 700 : 600 }}>{r.you ? 'Você' : r.name}</div>
+                      <div className="rk-row__user">@{r.username ?? 'usuario'}</div>
+                    </div>
+                  </div>
+                  <div className="rk-row__streak"><Flame size={14} />{r.streak}</div>
+                  <div><span className="rk-row__level">Lv {r.level}</span></div>
+                  <div className="rk-row__xp" style={{ color: r.you ? 'var(--accent)' : 'var(--text)' }}>{fmtXp(r.xp)}</div>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Register/index.tsx
+++ b/frontend/src/pages/Register/index.tsx
@@ -27,6 +27,7 @@ export function Register() {
   const navigate = useNavigate();
 
   const [name, setName] = useState('');
+  const [username, setUsername] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [birthDate, setBirthDate] = useState('');
@@ -42,6 +43,7 @@ export function Register() {
     try {
       await api.post('/register', {
         name,
+        username,
         email: email.trim(),
         password,
         birthDate,
@@ -97,10 +99,17 @@ export function Register() {
 
       <form className="form" onSubmit={handleSubmit} noValidate>
         <FormField
-          label="Nome de usuário"
-          placeholder="seu_nome"
+          label="Nome"
+          placeholder="Seu nome"
           value={name}
           onChange={(e) => setName(e.target.value)}
+          required
+        />
+        <FormField
+          label="Nome de usuário"
+          placeholder="seu_usuario"
+          value={username}
+          onChange={(e) => setUsername(e.target.value.toLowerCase().replace(/[^a-z0-9_]/g, '').slice(0, 20))}
           required
         />
         <FormField

--- a/frontend/src/services/trails.ts
+++ b/frontend/src/services/trails.ts
@@ -286,3 +286,136 @@ export async function atualizarTag(id: string, name: string) {
 export async function excluirTag(id: string) {
   await api.delete(`/tags/${id}`);
 }
+
+// ===== Linguagens (canônicas do perfil) =====
+
+export interface Language {
+  id: string;
+  name: string;
+}
+export async function listarLinguagens() {
+  const { data } = await api.get<Language[]>('/languages');
+  return data;
+}
+export async function criarLinguagem(name: string) {
+  const { data } = await api.post<Language>('/languages', { name });
+  return data;
+}
+export async function atualizarLinguagem(id: string, name: string) {
+  const { data } = await api.patch<Language>(`/languages/${id}`, { name });
+  return data;
+}
+export async function excluirLinguagem(id: string) {
+  await api.delete(`/languages/${id}`);
+}
+
+// ===== Conquistas =====
+
+export type CriterioConquista = 'xp_total' | 'lessons_completed' | 'questions_correct';
+
+export interface Achievement {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+  criteriaType: CriterioConquista;
+  threshold: number;
+}
+export interface MinhaConquista extends Achievement {
+  earned: boolean;
+  earnedAt: string | null;
+}
+export interface PayloadConquista {
+  name: string;
+  description: string;
+  icon: string;
+  criteriaType: CriterioConquista;
+  threshold: number;
+}
+
+export async function listarConquistas() {
+  const { data } = await api.get<Achievement[]>('/achievements');
+  return data;
+}
+export async function criarConquista(payload: PayloadConquista) {
+  const { data } = await api.post<Achievement>('/achievements', payload);
+  return data;
+}
+export async function atualizarConquista(id: string, payload: PayloadConquista) {
+  const { data } = await api.patch<Achievement>(`/achievements/${id}`, payload);
+  return data;
+}
+export async function excluirConquista(id: string) {
+  await api.delete(`/achievements/${id}`);
+}
+export async function obterMinhasConquistas() {
+  const { data } = await api.get<MinhaConquista[]>('/me/achievements');
+  return data;
+}
+
+// ===== Atividades recentes =====
+
+export interface Atividade {
+  type: string;
+  icon: string;
+  text: string;
+  at: string;
+}
+export async function obterAtividades() {
+  const { data } = await api.get<Atividade[]>('/me/activity');
+  return data;
+}
+
+// Feed da comunidade: quem desbloqueou cada conquista.
+export interface FeedConquista {
+  name: string;
+  achievement: string;
+  icon: string;
+  at: string;
+}
+export async function obterFeedConquistas() {
+  const { data } = await api.get<FeedConquista[]>('/community/achievements');
+  return data;
+}
+
+// Ranking global por XP.
+export type RankingPeriodo = 'week' | 'month' | 'all';
+export interface RankingRow {
+  position: number;
+  name: string;
+  username: string | null;
+  xp: number;
+  level: number;
+  streak: number;
+  you: boolean;
+}
+export interface RankingMe {
+  position: number;
+  username: string | null;
+  xp: number;
+  totalXp: number;
+  level: number;
+  streak: number;
+}
+export interface RankingResposta {
+  me: RankingMe | null;
+  rows: RankingRow[];
+}
+export async function obterRanking(period: RankingPeriodo = 'all') {
+  const { data } = await api.get<RankingResposta>('/ranking', { params: { period } });
+  return data;
+}
+
+// Streak (dias seguidos de estudo) + os últimos 7 dias.
+export interface DiaSemana {
+  label: string;
+  active: boolean;
+}
+export interface StreakInfo {
+  streak: number;
+  week: DiaSemana[];
+}
+export async function obterStreak() {
+  const { data } = await api.get<StreakInfo>('/me/streak');
+  return data;
+}

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -599,3 +599,142 @@
 .tag-pick { padding: 6px 12px; border-radius: 99px; border: 1px solid var(--border-strong); background: var(--surface); color: var(--muted); font-family: inherit; font-size: 13px; font-weight: 600; cursor: pointer; }
 .tag-pick--on { border-color: var(--accent); color: var(--accent); background: color-mix(in srgb, var(--accent) 12%, transparent); }
 .tag-picker__empty { font-size: 13px; color: var(--muted); }
+
+/* ===================== PERFIL ===================== */
+.pf { padding: 28px 48px 36px; max-width: 1600px; margin: 0 auto; }
+.pf-avatar { border-radius: 50%; background: var(--accent); color: #fff; display: flex; align-items: center; justify-content: center; font-weight: 700; overflow: hidden; box-shadow: 0 6px 18px rgba(0,0,0,.14); }
+.pf-avatar img { width: 100%; height: 100%; object-fit: cover; }
+.pf-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-2xl); overflow: hidden; margin-bottom: 20px; }
+.pf-banner { position: relative; height: 132px; background: linear-gradient(150deg, var(--accent), color-mix(in srgb, var(--accent) 46%, #0A1430)); }
+.pf-banner__glow { position: absolute; border-radius: 50%; pointer-events: none; }
+.pf-banner__glow--a { width: 280px; height: 280px; top: -150px; right: 40px; background: radial-gradient(circle, rgba(255,255,255,.16), transparent 70%); }
+.pf-banner__glow--b { width: 200px; height: 200px; bottom: -120px; left: -30px; background: radial-gradient(circle, rgba(0,0,0,.18), transparent 70%); }
+.pf-head { display: flex; align-items: flex-end; gap: 20px; padding: 0 26px 22px; margin-top: -46px; }
+.pf-avatar-wrap { position: relative; flex-shrink: 0; }
+.pf-id { flex: 1; min-width: 0; padding-bottom: 4px; }
+.pf-id__row { display: flex; align-items: center; gap: 10px; }
+.pf-id__name { font-size: 24px; font-weight: 700; letter-spacing: -.02em; }
+.pf-id__level { font-size: 11.5px; font-weight: 700; color: var(--accent); background: color-mix(in srgb, var(--accent) 13%, transparent); padding: 3px 9px; border-radius: 7px; }
+.pf-id__user { font-size: 14px; color: var(--muted); margin-top: 3px; font-family: var(--font-code); }
+.pf-actions { display: flex; gap: 10px; padding-bottom: 4px; }
+.pf-actions__btn { flex: none; height: 42px; }
+.pf-save { display: flex; align-items: center; gap: 8px; height: 42px; padding: 0 20px; border-radius: 11px; border: none; background: var(--success); color: #fff; font-family: inherit; font-weight: 600; font-size: 14px; cursor: pointer; }
+.pf-stats { display: grid; grid-template-columns: repeat(5, 1fr); border-top: 1px solid var(--border); }
+.pf-stat { padding: 16px 20px; border-right: 1px solid var(--border); }
+.pf-stat:last-child { border-right: none; }
+.pf-stat__value { display: flex; align-items: center; gap: 6px; font-size: 22px; font-weight: 700; letter-spacing: -.01em; }
+.pf-stat__icon { display: flex; color: var(--accent); }
+.pf-stat__label { font-size: 12.5px; color: var(--muted); margin-top: 2px; }
+.pf-grid { display: grid; grid-template-columns: 340px 1fr; gap: 20px; align-items: start; }
+.pf-col { display: flex; flex-direction: column; gap: 20px; }
+.pf-bio { margin: 0; font-size: 14px; line-height: 1.6; }
+.pf-textarea { width: 100%; box-sizing: border-box; height: 104px; resize: none; border: 1px solid var(--border-strong); background: var(--input); border-radius: 11px; padding: 11px 13px; font-family: inherit; font-size: 14px; line-height: 1.55; color: var(--text); outline: none; }
+.pf-fields { display: flex; flex-direction: column; gap: 15px; }
+.pf-field__label { display: flex; align-items: center; gap: 8px; font-size: 12px; font-weight: 600; color: var(--muted); text-transform: uppercase; letter-spacing: .04em; margin-bottom: 6px; }
+.pf-field__icon { display: flex; color: var(--muted); }
+.pf-field__value { font-size: 14px; font-weight: 500; }
+.pf-input { width: 100%; box-sizing: border-box; height: 42px; border: 1px solid var(--border-strong); background: var(--input); border-radius: 10px; padding: 0 12px; font-family: inherit; font-size: 14px; color: var(--text); outline: none; }
+.pf-input--bare { height: auto; border: none; background: transparent; border-radius: 0; padding: 0; flex: 1; font-size: 13.5px; }
+.pf-langs { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
+.pf-lang { display: flex; align-items: center; gap: 6px; font-size: 13px; font-weight: 600; color: var(--accent); background: color-mix(in srgb, var(--accent) 12%, transparent); padding: 6px 11px; border-radius: 8px; }
+.pf-lang__x { display: flex; border: none; background: transparent; color: var(--accent); opacity: .7; cursor: pointer; padding: 0; }
+.pf-lang-add { min-width: 150px; height: 32px; border: 1px dashed var(--border-strong); background: var(--surface-2); border-radius: 8px; padding: 0 11px; font-family: inherit; font-size: 13px; font-weight: 600; color: var(--text); outline: none; cursor: pointer; }
+.pf-links { display: flex; flex-direction: column; gap: 8px; }
+.pf-link { display: flex; align-items: center; gap: 9px; font-size: 13.5px; font-weight: 500; color: var(--accent); }
+.pf-link__icon { color: var(--muted); display: flex; }
+.pf-link-edit { display: flex; align-items: center; gap: 9px; height: 42px; padding: 0 12px; border: 1px solid var(--border-strong); background: var(--input); border-radius: 10px; }
+.pf-avatar-wrap__cam { position: absolute; right: 2px; bottom: 2px; width: 30px; height: 30px; border-radius: 50%; border: 2px solid var(--surface); background: var(--accent); color: #fff; display: flex; align-items: center; justify-content: center; cursor: pointer; padding: 0; }
+.pf-avatar-wrap__cam:disabled { opacity: .6; cursor: default; }
+.pf-banner__edit { position: absolute; top: 12px; right: 12px; display: flex; align-items: center; gap: 7px; height: 34px; padding: 0 13px; border-radius: 9px; border: 1px solid rgba(255,255,255,.4); background: rgba(0,0,0,.32); color: #fff; font-family: inherit; font-size: 13px; font-weight: 600; cursor: pointer; }
+.pf-banner__edit:disabled { opacity: .7; cursor: default; }
+
+/* Conquistas (badges) no perfil */
+.pf-badges { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; }
+.pf-badge { border: 1px solid var(--border); border-radius: 14px; padding: 24px 16px; text-align: center; background: var(--surface-2); }
+.pf-badge--locked { opacity: .5; filter: grayscale(1); }
+.pf-badge__icon { display: inline-flex; align-items: center; justify-content: center; width: 56px; height: 56px; border-radius: 50%; background: color-mix(in srgb, var(--accent) 14%, transparent); color: var(--accent); margin-bottom: 12px; }
+.pf-badge__name { font-size: 15px; font-weight: 700; letter-spacing: -.01em; }
+.pf-badge__sub { font-size: 12.5px; color: var(--muted); margin-top: 3px; line-height: 1.4; }
+
+/* Atividade recente (timeline) no perfil */
+.pf-timeline { display: flex; flex-direction: column; gap: 14px; }
+.pf-act { display: flex; gap: 12px; align-items: flex-start; }
+.pf-act__icon { flex: none; width: 30px; height: 30px; border-radius: 50%; display: flex; align-items: center; justify-content: center; color: #fff; }
+.pf-act__icon--green { background: var(--success); }
+.pf-act__icon--accent { background: var(--accent); }
+.pf-act__body { flex: 1; min-width: 0; }
+.pf-act__text { font-size: 13.5px; line-height: 1.4; }
+.pf-act__time { font-size: 12px; color: var(--muted); margin-top: 1px; }
+
+/* Form de conquistas no admin (Configurações) */
+.conq-form { display: flex; flex-direction: column; gap: 10px; margin: 14px 0 4px; }
+.conq-form__row { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
+.conq-item { display: flex; align-items: center; gap: 12px; padding: 8px 0 8px 14px; flex: 1; }
+.conq-item__icon { display: inline-flex; align-items: center; justify-content: center; width: 34px; height: 34px; border-radius: 9px; background: color-mix(in srgb, var(--accent) 14%, transparent); color: var(--accent); flex: none; }
+.conq-item__name { font-size: 14px; font-weight: 600; }
+.conq-item__sub { font-size: 12.5px; color: var(--muted); margin-top: 1px; }
+
+/* ===================== RANKING ===================== */
+.rk { padding: 28px 48px 40px; max-width: 1600px; margin: 0 auto; }
+.rk-head { display: flex; align-items: flex-start; gap: 16px; margin-bottom: 18px; }
+.rk-head__title-row { display: flex; align-items: center; gap: 11px; }
+.rk-title { margin: 0; font-size: 24px; font-weight: 700; letter-spacing: -.02em; }
+.rk-league-badge { display: flex; align-items: center; gap: 6px; font-size: 12.5px; font-weight: 700; color: #B7791F; background: color-mix(in srgb, var(--gold) 18%, transparent); padding: 4px 11px; border-radius: 8px; }
+.rk-sub { margin: 4px 0 0; font-size: 14px; color: var(--muted); }
+
+.seg { display: flex; gap: 3px; margin-left: auto; background: var(--surface); border: 1px solid var(--border); border-radius: 11px; padding: 3px; }
+.seg__item { padding: 7px 15px; border: none; background: transparent; border-radius: 8px; font-family: inherit; font-size: 13px; font-weight: 600; color: var(--muted); cursor: pointer; }
+.seg__item--active { background: var(--accent); color: #fff; }
+
+.leagues { background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-xl); padding: 18px 24px 20px; margin-bottom: 18px; }
+.leagues__head { display: flex; align-items: center; margin-bottom: 18px; }
+.leagues__rule { margin-left: auto; font-size: 12.5px; color: var(--muted); }
+.leagues__track { position: relative; padding: 0 4px; }
+.leagues__line { position: absolute; left: 14%; right: 14%; top: 27px; height: 3px; border-radius: 9px; background: var(--border); }
+.leagues__line--progress { right: auto; background: var(--accent); }
+.leagues__grid { position: relative; display: grid; grid-template-columns: repeat(5, 1fr); }
+.league { display: flex; flex-direction: column; align-items: center; gap: 9px; }
+.league__emblem { position: relative; width: 56px; height: 56px; border-radius: 50%; display: flex; align-items: center; justify-content: center; border: 3px solid var(--surface); }
+.league__seal { position: absolute; bottom: -3px; right: -3px; width: 20px; height: 20px; border-radius: 50%; border: 2px solid var(--surface); display: flex; align-items: center; justify-content: center; }
+.league__seal--done { background: var(--success); color: #fff; }
+.league__seal--lock { background: var(--surface-2); color: var(--muted); }
+.league__name { font-size: 13.5px; }
+.league__here { font-size: 10.5px; font-weight: 700; color: var(--accent); text-transform: uppercase; letter-spacing: .05em; background: color-mix(in srgb, var(--accent) 13%, transparent); padding: 2px 8px; border-radius: 6px; }
+.league__xp { font-size: 11.5px; color: var(--muted); font-family: var(--font-code); }
+
+.podium { position: relative; overflow: hidden; border-radius: var(--r-2xl); padding: 30px 30px 0; margin-bottom: 18px; background: linear-gradient(160deg, color-mix(in srgb, var(--accent) 18%, var(--surface)), var(--surface)); border: 1px solid var(--border); }
+.podium__glow { position: absolute; width: 340px; height: 340px; border-radius: 50%; top: -180px; left: 50%; transform: translateX(-50%); background: radial-gradient(circle, color-mix(in srgb, var(--accent) 16%, transparent), transparent 70%); pointer-events: none; }
+.podium__grid { position: relative; display: grid; grid-template-columns: 1fr 1fr 1fr; align-items: end; gap: 16px; max-width: 660px; margin: 0 auto; }
+.podium__col { display: flex; flex-direction: column; align-items: center; }
+.podium__crown { margin-bottom: 6px; }
+.podium__avatar-wrap { position: relative; margin-bottom: 12px; }
+.podium__avatar { border-radius: 50%; display: flex; align-items: center; justify-content: center; font-weight: 700; border: 3px solid; box-shadow: 0 6px 16px rgba(0,0,0,.12); }
+.podium__rank { position: absolute; bottom: -7px; left: 50%; transform: translateX(-50%); width: 24px; height: 24px; border-radius: 50%; color: #fff; display: flex; align-items: center; justify-content: center; font-size: 12px; font-weight: 700; border: 2px solid var(--surface); }
+.podium__name { font-size: 14.5px; font-weight: 700; letter-spacing: -.01em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
+.podium__xp { font-family: var(--font-code); font-size: 13px; font-weight: 500; color: var(--accent); margin-top: 2px; }
+.podium__pedestal { width: 100%; margin-top: 14px; border-radius: 12px 12px 0 0; display: flex; align-items: flex-start; justify-content: center; padding-top: 12px; font-size: 30px; font-weight: 700; }
+
+.rk-you { display: flex; align-items: center; gap: 16px; padding: 15px 20px; border-radius: 14px; margin-bottom: 18px; background: color-mix(in srgb, var(--accent) 12%, var(--surface)); border: 1.5px solid color-mix(in srgb, var(--accent) 45%, transparent); }
+.rk-you__label { font-size: 12px; font-weight: 700; color: var(--accent); text-transform: uppercase; letter-spacing: .05em; }
+.rk-you__rank { font-size: 22px; font-weight: 700; color: var(--accent); }
+.rk-you__id { flex: 1; min-width: 0; }
+.rk-you__name { font-size: 15px; font-weight: 700; }
+.rk-you__user { font-size: 12.5px; color: var(--muted); font-family: var(--font-code); }
+.rk-you__xp { font-family: var(--font-code); font-size: 16px; font-weight: 700; color: var(--accent); }
+
+.rk-table__head { display: grid; grid-template-columns: 64px 1fr 110px 90px 120px; align-items: center; padding: 11px 20px; font-size: 11.5px; font-weight: 700; color: var(--muted); text-transform: uppercase; letter-spacing: .05em; border-bottom: 1px solid var(--border); background: var(--surface-2); }
+.rk-right { text-align: right; }
+.rk-row { display: grid; grid-template-columns: 64px 1fr 110px 90px 120px; align-items: center; padding: 12px 20px; border-bottom: 1px solid var(--border); }
+.rk-row:last-child { border-bottom: none; }
+.rk-row--you { background: color-mix(in srgb, var(--accent) 10%, transparent); }
+.rk-row__rank { display: flex; align-items: center; gap: 7px; }
+.rk-row__rank > span:first-child { font-size: 15px; font-weight: 700; }
+.rk-row__student { display: flex; align-items: center; gap: 12px; min-width: 0; }
+.rk-row__id { min-width: 0; }
+.rk-row__name { font-size: 14.5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.rk-row__user { font-size: 12px; color: var(--muted); font-family: var(--font-code); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.rk-row__level { font-size: 12.5px; font-weight: 700; color: var(--accent); background: color-mix(in srgb, var(--accent) 12%, transparent); padding: 3px 9px; border-radius: 7px; }
+.rk-row__xp { font-family: var(--font-code); font-size: 14.5px; font-weight: 700; text-align: right; }
+.rk-row__streak { display: flex; align-items: center; gap: 6px; font-size: 13.5px; font-weight: 600; color: var(--text); }
+.rk-row__streak svg { color: var(--accent); }
+.rk-you__streak { display: flex; align-items: center; gap: 7px; font-size: 14px; font-weight: 600; color: var(--accent); }

--- a/frontend/src/utils/tempo.ts
+++ b/frontend/src/utils/tempo.ts
@@ -1,0 +1,13 @@
+// Formata uma data ISO como tempo relativo curto em pt-BR (ex.: "há 2 d").
+export function tempoRelativo(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  const min = Math.floor((Date.now() - d.getTime()) / 60000);
+  if (min < 1) return 'agora';
+  if (min < 60) return `há ${min} min`;
+  const h = Math.floor(min / 60);
+  if (h < 24) return `há ${h} h`;
+  const dias = Math.floor(h / 24);
+  if (dias < 30) return `há ${dias} d`;
+  return d.toLocaleDateString('pt-BR');
+}


### PR DESCRIPTION
## O que entra

Cadastro com nome de usuário único e validado.

Perfil novo: bio, localização, função, linguagens, links, foto e capa. As imagens sobem pro servidor (salvas em disco e servidas por URL).

Linguagens viraram um conjunto canônico com CRUD no admin, pra padronizar os dados.

Conquistas com CRUD no admin e desbloqueio automático por critério (XP, aulas concluídas, questões certas). O perfil mostra as conquistas do usuário e a home mostra quem desbloqueou cada uma.

Ranking global por XP com filtro de período (semana, mês, geral), pódio, ligas e a sua posição, que também aparece no perfil.

Streak de dias seguidos de estudo (fuso de São Paulo) no perfil, na home e no ranking.

Configurações do admin reúne tags, linguagens e conquistas.

## Banco

Migrations novas, da 0011 à 0015 (username, campos de perfil, foto e capa, tabela de linguagens, tabela de conquistas). Precisam rodar no deploy.

## Produção

Volume nomeado `uploads` adicionado no docker-compose.prod.yml pra foto e capa sobreviverem aos deploys.

## Testes

Unitários e de integração passando. Os fixtures de cadastro foram ajustados para o novo nome de usuário.
