### PR TITLE
refactor: streak no contexto, consistente em todas as páginas

### DIFF
--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -7,7 +7,8 @@ interface User {
     email: string,
     gender: string,
     phone: string,
-    role?: 'user' | 'admin' | 'moderator'
+    role?: 'user' | 'admin' | 'moderator',
+    streak?: number
 }
 
 interface AuthContextData {
@@ -29,11 +30,32 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             const StoragedToken = localStorage.getItem('@App:accessToken');
             const storagedUser = localStorage.getItem('@App:user');
 
-            if (StoragedToken && storagedUser) {
-                setUser(JSON.parse(storagedUser));
-                api.defaults.headers.Authorization = `Bearer ${StoragedToken}`;
+            if (!StoragedToken) {
+                setLoading(false);
+                return;
             }
-            setLoading(false);
+
+            api.defaults.headers.Authorization = `Bearer ${StoragedToken}`;
+            // Mostra o cache na hora (sem tela de loading) e revalida com /me em
+            // segundo plano, trazendo streak/role/perfil atualizados.
+            if (storagedUser) {
+                setUser(JSON.parse(storagedUser));
+                setLoading(false);
+            }
+
+            try {
+                const { data } = await api.get('/me');
+                setUser(data);
+                localStorage.setItem('@App:user', JSON.stringify(data));
+            } catch (e) {
+                const status = (e as { response?: { status?: number } })?.response?.status;
+                if (status === 401) {
+                    localStorage.clear();
+                    setUser(null);
+                }
+            } finally {
+                setLoading(false);
+            }
         }
 
         loadStorageData();

--- a/frontend/src/pages/Aula/index.tsx
+++ b/frontend/src/pages/Aula/index.tsx
@@ -105,7 +105,7 @@ export function Aula() {
             ))}
           </nav>
           <div className="topbar__spacer" />
-          <div className="streak-pill"><Flame size={16} /> {user.streak}</div>
+          <div className="streak-pill"><Flame size={16} /> {authUser?.streak ?? 0}</div>
           <ThemeToggle inline />
           <UserMenu
             initials={getInitials(displayName)}

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -114,7 +114,7 @@ export function Home() {
             <span>Buscar exercício…</span>
           </div>
           <div className="streak-pill">
-            <Flame size={16} /> {streakInfo.streak}
+            <Flame size={16} /> {authUser?.streak ?? 0}
           </div>
           <ThemeToggle inline />
           <UserMenu

--- a/frontend/src/pages/Perfil/index.tsx
+++ b/frontend/src/pages/Perfil/index.tsx
@@ -227,7 +227,7 @@ export function Perfil() {
             <Search size={16} />
             <span>Buscar exercício…</span>
           </div>
-          <div className="streak-pill"><Flame size={16} /> {perfil?.streak ?? 0}</div>
+          <div className="streak-pill"><Flame size={16} /> {authUser?.streak ?? 0}</div>
           <ThemeToggle inline />
           <UserMenu initials={initials} level={nivel} name={displayName} email={authUser?.email} />
         </header>

--- a/frontend/src/pages/Ranking/index.tsx
+++ b/frontend/src/pages/Ranking/index.tsx
@@ -81,7 +81,7 @@ export function Ranking() {
           </nav>
           <div className="topbar__spacer" />
           <div className="searchbar"><Search size={16} /><span>Buscar exercício…</span></div>
-          <div className="streak-pill"><Flame size={16} /> {dados.me?.streak ?? 0}</div>
+          <div className="streak-pill"><Flame size={16} /> {authUser?.streak ?? 0}</div>
           <ThemeToggle inline />
           <UserMenu initials={getInitials(displayName)} level={nivel} name={displayName} email={authUser?.email} />
         </header>

--- a/frontend/src/pages/Trilhas/index.tsx
+++ b/frontend/src/pages/Trilhas/index.tsx
@@ -131,7 +131,7 @@ export function Trilhas() {
             <span>Buscar trilha…</span>
           </div>
           <div className="streak-pill">
-            <Flame size={16} /> {user.streak}
+            <Flame size={16} /> {authUser?.streak ?? 0}
           </div>
           <ThemeToggle inline />
           <UserMenu


### PR DESCRIPTION
## O que entra

A streak passou a vir do contexto (AuthContext), em vez de cada página buscar por conta própria ou usar um valor estático.

- O AuthContext agora tipa `streak` no usuário e revalida `/me` no carregamento: mostra o cache na hora (sem flash) e, se o token estiver inválido (401), faz logout limpo. O `/me` já devolvia a streak.
- Todos os pills de streak (Trilhas, Aula, Home, Perfil, Ranking) leem `authUser.streak`. Trilhas e Aula deixam de mostrar o valor estático e tudo fica numa fonte só, consistente.

Só frontend, sem mudança de backend (o `/me` já trazia a streak).
