### PR TITLE
refactor: telas de admin usam o hook useRequisicao

### DIFF
--- a/frontend/src/pages/Configuracoes/index.tsx
+++ b/frontend/src/pages/Configuracoes/index.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Logo } from '../../components/Logo';
+import { useRequisicao } from '../../hooks/useRequisicao';
 import { Plus, Pencil, Trash, Check, IconeConquista, CHAVES_ICONE } from '../../components/Icons';
 import {
   listarTags,
@@ -50,26 +51,13 @@ function CrudList({
   atualizar,
   excluir,
 }: CrudListProps) {
-  const [itens, setItens] = useState<ItemCrud[]>([]);
-  const [carregando, setCarregando] = useState(true);
+  const { dados, carregando, erro: falhaCarga, recarregar } = useRequisicao(carregar, []);
+  const itens = dados ?? [];
   const [erro, setErro] = useState('');
   const [novo, setNovo] = useState('');
   const [criando, setCriando] = useState(false);
   const [editId, setEditId] = useState<string | null>(null);
   const [editNome, setEditNome] = useState('');
-
-  async function recarregar() {
-    try {
-      setItens(await carregar());
-    } catch {
-      setErro('Não foi possível carregar a lista.');
-    } finally {
-      setCarregando(false);
-    }
-  }
-  useEffect(() => {
-    recarregar();
-  }, []);
 
   async function adicionar() {
     const nome = novo.trim();
@@ -79,7 +67,7 @@ function CrudList({
     try {
       await criar(nome);
       setNovo('');
-      await recarregar();
+      recarregar();
     } catch (e) {
       setErro(msgErro(e) ?? 'Não foi possível adicionar.');
     } finally {
@@ -94,7 +82,7 @@ function CrudList({
     try {
       await atualizar(id, nome);
       setEditId(null);
-      await recarregar();
+      recarregar();
     } catch (e) {
       setErro(msgErro(e) ?? 'Não foi possível salvar.');
     }
@@ -105,7 +93,7 @@ function CrudList({
     setErro('');
     try {
       await excluir(item.id);
-      await recarregar();
+      recarregar();
     } catch {
       setErro('Não foi possível excluir.');
     }
@@ -137,7 +125,9 @@ function CrudList({
         </button>
       </div>
 
-      {erro && <div className="auth__alert">{erro}</div>}
+      {(erro || falhaCarga) && (
+        <div className="auth__alert">{erro || 'Não foi possível carregar a lista.'}</div>
+      )}
       {carregando && <p className="track__desc">Carregando...</p>}
       {!carregando && itens.length === 0 && <p className="track__desc">Nada cadastrado ainda.</p>}
 
@@ -225,25 +215,12 @@ const FORM_VAZIO = {
 
 // Seção de CRUD das conquistas (campos mais ricos: ícone, critério e valor).
 function ConquistasAdmin() {
-  const [itens, setItens] = useState<Achievement[]>([]);
-  const [carregando, setCarregando] = useState(true);
+  const { dados, carregando, erro: falhaCarga, recarregar } = useRequisicao(listarConquistas, []);
+  const itens = dados ?? [];
   const [erro, setErro] = useState('');
   const [editId, setEditId] = useState<string | null>(null);
   const [form, setForm] = useState(FORM_VAZIO);
   const [salvando, setSalvando] = useState(false);
-
-  async function recarregar() {
-    try {
-      setItens(await listarConquistas());
-    } catch {
-      setErro('Não foi possível carregar as conquistas.');
-    } finally {
-      setCarregando(false);
-    }
-  }
-  useEffect(() => {
-    recarregar();
-  }, []);
 
   function resetar() {
     setEditId(null);
@@ -258,7 +235,7 @@ function ConquistasAdmin() {
       if (editId) await atualizarConquista(editId, form);
       else await criarConquista(form);
       resetar();
-      await recarregar();
+      recarregar();
     } catch (e) {
       setErro(msgErro(e) ?? 'Não foi possível salvar a conquista.');
     } finally {
@@ -288,7 +265,7 @@ function ConquistasAdmin() {
     try {
       await excluirConquista(a.id);
       if (editId === a.id) resetar();
-      await recarregar();
+      recarregar();
     } catch {
       setErro('Não foi possível excluir a conquista.');
     }
@@ -379,7 +356,9 @@ function ConquistasAdmin() {
         </div>
       </div>
 
-      {erro && <div className="auth__alert">{erro}</div>}
+      {(erro || falhaCarga) && (
+        <div className="auth__alert">{erro || 'Não foi possível carregar as conquistas.'}</div>
+      )}
       {carregando && <p className="track__desc">Carregando...</p>}
       {!carregando && itens.length === 0 && (
         <p className="track__desc">Nenhuma conquista cadastrada ainda.</p>

--- a/frontend/src/pages/EstudioHome/index.tsx
+++ b/frontend/src/pages/EstudioHome/index.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { Logo } from '../../components/Logo';
 import { ChevronRight, Plus, Pencil, Trash } from '../../components/Icons';
+import { useRequisicao } from '../../hooks/useRequisicao';
 import {
   listarTrilhas,
   criarTrilha,
@@ -37,27 +38,20 @@ interface FormState {
 
 export function EstudioHome() {
   const navigate = useNavigate();
-  const [trilhas, setTrilhas] = useState<TrailComId[]>([]);
-  const [carregando, setCarregando] = useState(true);
+  const {
+    dados,
+    carregando,
+    erro: falhaCarga,
+    recarregar,
+  } = useRequisicao(
+    () => Promise.all([listarTrilhas(), listarTags()]).then(([tr, tg]) => ({ tr, tg })),
+    [],
+  );
+  const trilhas: TrailComId[] = dados?.tr ?? [];
+  const tagsDisp: Tag[] = dados?.tg ?? [];
   const [erro, setErro] = useState('');
   const [form, setForm] = useState<FormState | null>(null);
   const [salvando, setSalvando] = useState(false);
-  const [tagsDisp, setTagsDisp] = useState<Tag[]>([]);
-
-  async function carregar() {
-    try {
-      const [tr, tg] = await Promise.all([listarTrilhas(), listarTags()]);
-      setTrilhas(tr);
-      setTagsDisp(tg);
-    } catch {
-      setErro('Não foi possível carregar as trilhas.');
-    } finally {
-      setCarregando(false);
-    }
-  }
-  useEffect(() => {
-    carregar();
-  }, []);
 
   function novaTrilha() {
     setErro('');
@@ -96,7 +90,7 @@ export function EstudioHome() {
         });
       }
       setForm(null);
-      await carregar();
+      recarregar();
     } catch (e: unknown) {
       setErro(mensagemErro(e, 'Não foi possível salvar a trilha.'));
     } finally {
@@ -114,7 +108,7 @@ export function EstudioHome() {
     setErro('');
     try {
       await excluirTrilha(t.id);
-      await carregar();
+      recarregar();
     } catch {
       setErro('Não foi possível excluir a trilha.');
     }
@@ -224,7 +218,9 @@ export function EstudioHome() {
         )}
 
         {carregando && <p className="track__desc">Carregando...</p>}
-        {!form && erro && <div className="auth__alert">{erro}</div>}
+        {!form && (erro || falhaCarga) && (
+          <div className="auth__alert">{erro || 'Não foi possível carregar as trilhas.'}</div>
+        )}
         {!carregando && trilhas.length === 0 && !form && (
           <p className="track__desc">Nenhuma trilha cadastrada ainda.</p>
         )}


### PR DESCRIPTION
Continuação do Tier 2: Configurações (tags, linguagens, conquistas) e EstudioHome agora usam o hook useRequisicao, removendo a lógica de fetch/recarregar manual. Zera os avisos de set-state-in-effect e exhaustive-deps dessas telas (net -25 linhas). Frontend só; lint sem erros (restam avisos só de HMR/react-refresh, intencionais).