### PR TITLE
refactor: extrai a lógica do TrailController para services

### DIFF
--- a/backend/src/controllers/TrailController.ts
+++ b/backend/src/controllers/TrailController.ts
@@ -9,8 +9,6 @@ import {
     questions,
     questionOptions,
     questionAnswers,
-    tags,
-    trailTags,
     achievements,
     userAchievements,
 } from "../../schema.ts";
@@ -56,32 +54,22 @@ import {
     conquistasDoUsuario,
     feedComunidade,
 } from "../services/achievement.service.ts";
+import { ehAdmin } from "../services/usuario.service.ts";
+import {
+    criarTrilha,
+    atualizarTrilha,
+    excluirTrilha,
+    listarTrilhas,
+    trilhasDoUsuario,
+    detalheDaTrilha,
+} from "../services/trail.service.ts";
 
 const QUIZ_MIN_ACERTOS = 4;
-
-async function ehAdmin(userId: string): Promise<boolean> {
-    const [u] = await db.select({ role: users.role }).from(users).where(eq(users.id, userId));
-    return u?.role === "admin";
-}
 
 export const createTrail = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const dados = createTrailSchema.parse(req.body);
-        const [trilha] = await db
-            .insert(trails)
-            .values({
-                name: dados.name,
-                trailLevel: dados.level,
-                description: dados.description,
-            })
-            .returning();
-        if (dados.tagIds?.length) {
-            await db
-                .insert(trailTags)
-                .values(dados.tagIds.map((tagId) => ({ trailId: trilha.id, tagId })))
-                .onConflictDoNothing();
-        }
-        res.status(201).json(trilha);
+        res.status(201).json(await criarTrilha(dados));
     } catch (err) {
         next(err);
     }
@@ -203,39 +191,7 @@ export const updateTrail = async (req: Request, res: Response, next: NextFunctio
     try {
         const trailId = String(req.params.id);
         const dados = updateTrailSchema.parse(req.body);
-
-        const sets: {
-            name?: string;
-            trailLevel?: "iniciante" | "intermediario" | "avancado";
-            description?: string;
-        } = {};
-        if (dados.name !== undefined) sets.name = dados.name;
-        if (dados.level !== undefined) sets.trailLevel = dados.level;
-        if (dados.description !== undefined) sets.description = dados.description;
-        if (Object.keys(sets).length === 0) {
-            return res.status(400).json({ erro: "Nada para atualizar" });
-        }
-
-        const [trilha] = await db.update(trails).set(sets).where(eq(trails.id, trailId)).returning({
-            id: trails.id,
-            name: trails.name,
-            trailLevel: trails.trailLevel,
-            description: trails.description,
-        });
-        if (!trilha) {
-            return res.status(404).json({ erro: "Trilha não encontrada" });
-        }
-
-        if (dados.tagIds !== undefined) {
-            await db.delete(trailTags).where(eq(trailTags.trailId, trailId));
-            if (dados.tagIds.length) {
-                await db
-                    .insert(trailTags)
-                    .values(dados.tagIds.map((tagId) => ({ trailId, tagId })))
-                    .onConflictDoNothing();
-            }
-        }
-        res.json(trilha);
+        res.json(await atualizarTrilha(trailId, dados));
     } catch (err) {
         next(err);
     }
@@ -244,44 +200,7 @@ export const updateTrail = async (req: Request, res: Response, next: NextFunctio
 // Exclui a trilha inteira (módulos, aulas, questões e progresso).
 export const deleteTrail = async (req: Request, res: Response, next: NextFunction) => {
     try {
-        const trailId = String(req.params.id);
-        const [trilha] = await db
-            .select({ id: trails.id })
-            .from(trails)
-            .where(eq(trails.id, trailId));
-        if (!trilha) {
-            return res.status(404).json({ erro: "Trilha não encontrada" });
-        }
-
-        await db.transaction(async (tx) => {
-            const ls = await tx
-                .select({ id: lessons.id })
-                .from(lessons)
-                .where(eq(lessons.trailId, trailId));
-            const lessonIds = ls.map((l) => l.id);
-            if (lessonIds.length) {
-                const qs = await tx
-                    .select({ id: questions.id })
-                    .from(questions)
-                    .where(inArray(questions.lessonId, lessonIds));
-                const qIds = qs.map((q) => q.id);
-                if (qIds.length) {
-                    await tx
-                        .delete(questionAnswers)
-                        .where(inArray(questionAnswers.questionId, qIds));
-                    await tx
-                        .delete(questionOptions)
-                        .where(inArray(questionOptions.questionId, qIds));
-                    await tx.delete(questions).where(inArray(questions.id, qIds));
-                }
-                await tx.delete(lessonProgress).where(inArray(lessonProgress.lessonId, lessonIds));
-                await tx.delete(lessons).where(inArray(lessons.id, lessonIds));
-            }
-            await tx.delete(modules).where(eq(modules.trailId, trailId));
-            await tx.delete(trailTags).where(eq(trailTags.trailId, trailId));
-            await tx.delete(trails).where(eq(trails.id, trailId));
-        });
-
+        await excluirTrilha(String(req.params.id));
         res.json({ ok: true });
     } catch (err) {
         next(err);
@@ -429,29 +348,7 @@ export const createQuestion = async (req: Request, res: Response, next: NextFunc
 
 export const listTrails = async (_req: Request, res: Response, next: NextFunction) => {
     try {
-        const lista = await db
-            .select({
-                id: trails.id,
-                name: trails.name,
-                trailLevel: trails.trailLevel,
-                description: trails.description,
-                totalLessons: count(lessons.id),
-            })
-            .from(trails)
-            .leftJoin(lessons, eq(lessons.trailId, trails.id))
-            .groupBy(trails.id);
-
-        const vinculos = await db
-            .select({ trailId: trailTags.trailId, id: tags.id, name: tags.name })
-            .from(trailTags)
-            .innerJoin(tags, eq(tags.id, trailTags.tagId));
-        const tagsPorTrilha = new Map<string, { id: string; name: string }[]>();
-        for (const v of vinculos) {
-            const arr = tagsPorTrilha.get(v.trailId) ?? [];
-            arr.push({ id: v.id, name: v.name });
-            tagsPorTrilha.set(v.trailId, arr);
-        }
-        res.json(lista.map((t) => ({ ...t, tags: tagsPorTrilha.get(t.id) ?? [] })));
+        res.json(await listarTrilhas());
     } catch (err) {
         next(err);
     }
@@ -463,45 +360,7 @@ export const getMyTrails = async (req: Request, res: Response, next: NextFunctio
         if (!userId) {
             return res.status(401).json({ erro: "Não autenticado" });
         }
-
-        const totais = await db
-            .select({ trailId: lessons.trailId, total: count(lessons.id) })
-            .from(lessons)
-            .groupBy(lessons.trailId);
-        const totalPorTrilha = new Map(totais.map((t) => [t.trailId, Number(t.total)]));
-
-        const feitas = await db
-            .select({ trailId: lessons.trailId, feitas: count(lessonProgress.id) })
-            .from(lessonProgress)
-            .innerJoin(lessons, eq(lessons.id, lessonProgress.lessonId))
-            .where(eq(lessonProgress.userId, userId))
-            .groupBy(lessons.trailId);
-
-        if (feitas.length === 0) {
-            return res.json([]);
-        }
-
-        const todasTrilhas = await db.select().from(trails);
-        const trilhaPorId = new Map(todasTrilhas.map((t) => [t.id, t]));
-
-        const resultado = feitas
-            .filter((f) => trilhaPorId.has(f.trailId))
-            .map((f) => {
-                const trilha = trilhaPorId.get(f.trailId)!;
-                const total = totalPorTrilha.get(f.trailId) ?? 0;
-                const concluidas = Number(f.feitas);
-                const pct = total > 0 ? Math.round((concluidas / total) * 100) : 0;
-                return {
-                    id: trilha.id,
-                    name: trilha.name,
-                    trailLevel: trilha.trailLevel,
-                    description: trilha.description,
-                    totalLessons: total,
-                    completedLessons: concluidas,
-                    progress: pct,
-                };
-            });
-        res.json(resultado);
+        res.json(await trilhasDoUsuario(userId));
     } catch (err) {
         next(err);
     }
@@ -511,78 +370,7 @@ export const getMyTrails = async (req: Request, res: Response, next: NextFunctio
 // Estado sequencial na trilha toda: done | current | locked.
 export const getTrail = async (req: Request, res: Response, next: NextFunction) => {
     try {
-        const userId = req.userId;
-        const trailId = String(req.params.id);
-
-        const [trilha] = await db.select().from(trails).where(eq(trails.id, trailId));
-        if (!trilha) {
-            return res.status(404).json({ erro: "Trilha não encontrada" });
-        }
-
-        const admin = await ehAdmin(userId!);
-
-        const mods = await db
-            .select()
-            .from(modules)
-            .where(eq(modules.trailId, trailId))
-            .orderBy(asc(modules.position));
-
-        // Aluno vê só aulas publicadas; admin vê todas (para gerenciar).
-        const todasAulas = await db
-            .select()
-            .from(lessons)
-            .where(eq(lessons.trailId, trailId))
-            .orderBy(asc(lessons.position));
-        const aulas = admin ? todasAulas : todasAulas.filter((a) => a.published);
-
-        const concluidas = new Set(
-            (
-                await db
-                    .select({ lessonId: lessonProgress.lessonId })
-                    .from(lessonProgress)
-                    .where(eq(lessonProgress.userId, userId!))
-            ).map((p) => p.lessonId),
-        );
-
-        // O estado segue a sequência das aulas PUBLICADAS. Rascunho (que só o admin vê)
-        // não entra na sequência: senão apareceria como "current" e o getLesson, que
-        // calcula o estado só com publicadas, o trataria como bloqueado (estados divergentes).
-        const ordenadas = mods.flatMap((m) =>
-            todasAulas
-                .filter((a) => a.moduleId === m.id && a.published)
-                .sort((a, b) => a.position - b.position),
-        );
-
-        const estadoPorAula = new Map<string, string>();
-        let achouCurrent = false;
-        for (const a of ordenadas) {
-            if (concluidas.has(a.id)) {
-                estadoPorAula.set(a.id, "done");
-            } else if (!achouCurrent) {
-                estadoPorAula.set(a.id, "current");
-                achouCurrent = true;
-            } else {
-                estadoPorAula.set(a.id, "locked");
-            }
-        }
-
-        const modulosComAulas = mods.map((m) => ({
-            id: m.id,
-            title: m.title,
-            position: m.position,
-            lessons: aulas
-                .filter((a) => a.moduleId === m.id)
-                .sort((a, b) => a.position - b.position)
-                .map((a) => ({
-                    id: a.id,
-                    title: a.title,
-                    position: a.position,
-                    published: a.published,
-                    state: estadoPorAula.get(a.id) ?? "locked",
-                })),
-        }));
-
-        res.json({ ...trilha, modules: modulosComAulas });
+        res.json(await detalheDaTrilha(String(req.params.id), req.userId!));
     } catch (err) {
         next(err);
     }

--- a/backend/src/controllers/TrailController.ts
+++ b/backend/src/controllers/TrailController.ts
@@ -46,6 +46,16 @@ import {
     atualizarLinguagem,
     excluirLinguagem,
 } from "../services/language.service.ts";
+import { calcularEstatisticas } from "../services/stats.service.ts";
+import {
+    listarConquistas,
+    criarConquista,
+    atualizarConquista,
+    excluirConquista,
+    verificarConquistas,
+    conquistasDoUsuario,
+    feedComunidade,
+} from "../services/achievement.service.ts";
 
 const QUIZ_MIN_ACERTOS = 4;
 
@@ -154,8 +164,7 @@ export const deleteLanguage = async (req: Request, res: Response, next: NextFunc
 // ===================== CONQUISTAS (catálogo, admin) =====================
 export const listAchievements = async (_req: Request, res: Response, next: NextFunction) => {
     try {
-        const lista = await db.select().from(achievements).orderBy(asc(achievements.threshold));
-        res.json(lista);
+        res.json(await listarConquistas());
     } catch (err) {
         next(err);
     }
@@ -164,15 +173,7 @@ export const listAchievements = async (_req: Request, res: Response, next: NextF
 export const createAchievement = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const dados = createAchievementSchema.parse(req.body);
-        const [existe] = await db
-            .select({ id: achievements.id })
-            .from(achievements)
-            .where(eq(achievements.name, dados.name));
-        if (existe) {
-            return res.status(409).json({ erro: "Já existe uma conquista com esse nome" });
-        }
-        const [a] = await db.insert(achievements).values(dados).returning();
-        res.status(201).json(a);
+        res.status(201).json(await criarConquista(dados));
     } catch (err) {
         next(err);
     }
@@ -182,22 +183,7 @@ export const updateAchievement = async (req: Request, res: Response, next: NextF
     try {
         const id = String(req.params.id);
         const dados = updateAchievementSchema.parse(req.body);
-        const [conflito] = await db
-            .select({ id: achievements.id })
-            .from(achievements)
-            .where(eq(achievements.name, dados.name));
-        if (conflito && conflito.id !== id) {
-            return res.status(409).json({ erro: "Já existe uma conquista com esse nome" });
-        }
-        const [a] = await db
-            .update(achievements)
-            .set(dados)
-            .where(eq(achievements.id, id))
-            .returning();
-        if (!a) {
-            return res.status(404).json({ erro: "Conquista não encontrada" });
-        }
-        res.json(a);
+        res.json(await atualizarConquista(id, dados));
     } catch (err) {
         next(err);
     }
@@ -205,11 +191,7 @@ export const updateAchievement = async (req: Request, res: Response, next: NextF
 
 export const deleteAchievement = async (req: Request, res: Response, next: NextFunction) => {
     try {
-        const id = String(req.params.id);
-        await db.transaction(async (tx) => {
-            await tx.delete(userAchievements).where(eq(userAchievements.achievementId, id));
-            await tx.delete(achievements).where(eq(achievements.id, id));
-        });
+        await excluirConquista(String(req.params.id));
         res.json({ ok: true });
     } catch (err) {
         next(err);
@@ -795,42 +777,6 @@ export const submitQuiz = async (req: Request, res: Response, next: NextFunction
     }
 };
 
-// Estatísticas base do usuário: XP (50 por aula + 10 por acerto), aulas e acertos.
-async function calcularEstatisticas(userId: string) {
-    const [aulas] = await db
-        .select({ n: count() })
-        .from(lessonProgress)
-        .where(eq(lessonProgress.userId, userId));
-    const [acertos] = await db
-        .select({ n: count() })
-        .from(questionAnswers)
-        .where(and(eq(questionAnswers.userId, userId), eq(questionAnswers.isCorrect, true)));
-    const lessonsCompleted = Number(aulas?.n ?? 0);
-    const questionsCorrect = Number(acertos?.n ?? 0);
-    return {
-        xp: lessonsCompleted * 50 + questionsCorrect * 10,
-        lessonsCompleted,
-        questionsCorrect,
-    };
-}
-
-// Desbloqueia (idempotente) as conquistas cujo critério o usuário já atingiu.
-async function verificarConquistas(userId: string) {
-    const stats = await calcularEstatisticas(userId);
-    const valor: Record<string, number> = {
-        xp_total: stats.xp,
-        lessons_completed: stats.lessonsCompleted,
-        questions_correct: stats.questionsCorrect,
-    };
-    const catalogo = await db.select().from(achievements);
-    const merecidas = catalogo.filter((a) => (valor[a.criteriaType] ?? 0) >= a.threshold);
-    if (merecidas.length === 0) return;
-    await db
-        .insert(userAchievements)
-        .values(merecidas.map((a) => ({ userId, achievementId: a.id })))
-        .onConflictDoNothing();
-}
-
 // XP total do usuário: 50 por aula concluída + 10 por questão acertada (primeira vez).
 export const getMyXp = async (req: Request, res: Response, next: NextFunction) => {
     try {
@@ -843,21 +789,7 @@ export const getMyXp = async (req: Request, res: Response, next: NextFunction) =
 // Catálogo de conquistas com a marcação do que o usuário já desbloqueou.
 export const getMyAchievements = async (req: Request, res: Response, next: NextFunction) => {
     try {
-        const userId = req.userId!;
-        await verificarConquistas(userId);
-        const catalogo = await db.select().from(achievements).orderBy(asc(achievements.threshold));
-        const ganhas = await db
-            .select()
-            .from(userAchievements)
-            .where(eq(userAchievements.userId, userId));
-        const quando = new Map(ganhas.map((g) => [g.achievementId, g.earnedAt]));
-        res.json(
-            catalogo.map((a) => ({
-                ...a,
-                earned: quando.has(a.id),
-                earnedAt: quando.get(a.id) ?? null,
-            })),
-        );
+        res.json(await conquistasDoUsuario(req.userId!));
     } catch (err) {
         next(err);
     }
@@ -914,19 +846,7 @@ export const getCommunityAchievements = async (
     next: NextFunction,
 ) => {
     try {
-        const lista = await db
-            .select({
-                name: users.name,
-                achievement: achievements.name,
-                icon: achievements.icon,
-                at: userAchievements.earnedAt,
-            })
-            .from(userAchievements)
-            .innerJoin(users, eq(users.id, userAchievements.userId))
-            .innerJoin(achievements, eq(achievements.id, userAchievements.achievementId))
-            .orderBy(desc(userAchievements.earnedAt))
-            .limit(10);
-        res.json(lista);
+        res.json(await feedComunidade());
     } catch (err) {
         next(err);
     }

--- a/backend/src/controllers/TrailController.ts
+++ b/backend/src/controllers/TrailController.ts
@@ -1,18 +1,4 @@
 import type { Request, Response, NextFunction } from "express";
-import { db } from "../../db.ts";
-import {
-    users,
-    trails,
-    modules,
-    lessons,
-    lessonProgress,
-    questions,
-    questionOptions,
-    questionAnswers,
-    achievements,
-    userAchievements,
-} from "../../schema.ts";
-import { eq, and, count, asc, desc, gte, inArray } from "drizzle-orm";
 import {
     createTrailSchema,
     createModuleSchema,
@@ -29,14 +15,9 @@ import {
     createAchievementSchema,
     updateAchievementSchema,
 } from "../schemas/trail.schemas.ts";
-import {
-    calcularStreak,
-    diasAtivosDoUsuario,
-    semanaAtividade,
-    streaksTodos,
-    hojeSaoPaulo,
-} from "../services/streak.ts";
-import { movimentacaoRanking } from "../services/ranking.ts";
+import { calcularStreak, diasAtivosDoUsuario, semanaAtividade } from "../services/streak.ts";
+import { rankingGlobal } from "../services/ranking.ts";
+import { atividadeRecente } from "../services/activity.service.ts";
 import { listarTags, criarTag, atualizarTag, excluirTag } from "../services/tag.service.ts";
 import {
     listarLinguagens,
@@ -62,7 +43,18 @@ import {
     detalheDaTrilha,
 } from "../services/trail.service.ts";
 import { detalheDaAula } from "../services/lesson.service.ts";
-import { QUIZ_MIN_ACERTOS, corrigirQuiz, conferirResposta } from "../services/quiz.service.ts";
+import { corrigirQuiz, conferirResposta } from "../services/quiz.service.ts";
+import {
+    criarModulo,
+    excluirModulo,
+    criarAula,
+    criarQuestao,
+    definirPublicacao,
+    estruturaDoEstudio,
+    aulaParaEdicao,
+    excluirAula,
+    salvarAulaEstudio,
+} from "../services/estudio.service.ts";
 
 export const createTrail = async (req: Request, res: Response, next: NextFunction) => {
     try {
@@ -209,24 +201,7 @@ export const createModule = async (req: Request, res: Response, next: NextFuncti
     try {
         const trailId = String(req.params.id);
         const dados = createModuleSchema.parse(req.body);
-
-        const [trilha] = await db
-            .select({ id: trails.id })
-            .from(trails)
-            .where(eq(trails.id, trailId));
-        if (!trilha) {
-            return res.status(404).json({ erro: "Trilha não encontrada" });
-        }
-
-        const [modulo] = await db
-            .insert(modules)
-            .values({
-                trailId,
-                title: dados.title,
-                position: dados.position,
-            })
-            .returning();
-        res.status(201).json(modulo);
+        res.status(201).json(await criarModulo(trailId, dados));
     } catch (err) {
         next(err);
     }
@@ -235,40 +210,7 @@ export const createModule = async (req: Request, res: Response, next: NextFuncti
 // Exclui um módulo e todas as suas aulas (questões, opções e progresso).
 export const deleteModule = async (req: Request, res: Response, next: NextFunction) => {
     try {
-        const moduleId = String(req.params.id);
-        const [modulo] = await db
-            .select({ id: modules.id })
-            .from(modules)
-            .where(eq(modules.id, moduleId));
-        if (!modulo) {
-            return res.status(404).json({ erro: "Módulo não encontrado" });
-        }
-        await db.transaction(async (tx) => {
-            const ls = await tx
-                .select({ id: lessons.id })
-                .from(lessons)
-                .where(eq(lessons.moduleId, moduleId));
-            const lessonIds = ls.map((l) => l.id);
-            if (lessonIds.length) {
-                const qs = await tx
-                    .select({ id: questions.id })
-                    .from(questions)
-                    .where(inArray(questions.lessonId, lessonIds));
-                const qIds = qs.map((q) => q.id);
-                if (qIds.length) {
-                    await tx
-                        .delete(questionAnswers)
-                        .where(inArray(questionAnswers.questionId, qIds));
-                    await tx
-                        .delete(questionOptions)
-                        .where(inArray(questionOptions.questionId, qIds));
-                    await tx.delete(questions).where(inArray(questions.id, qIds));
-                }
-                await tx.delete(lessonProgress).where(inArray(lessonProgress.lessonId, lessonIds));
-                await tx.delete(lessons).where(inArray(lessons.id, lessonIds));
-            }
-            await tx.delete(modules).where(eq(modules.id, moduleId));
-        });
+        await excluirModulo(String(req.params.id));
         res.json({ ok: true });
     } catch (err) {
         next(err);
@@ -279,26 +221,7 @@ export const createLesson = async (req: Request, res: Response, next: NextFuncti
     try {
         const moduleId = String(req.params.id);
         const dados = createLessonSchema.parse(req.body);
-
-        const [modulo] = await db
-            .select({ id: modules.id, trailId: modules.trailId })
-            .from(modules)
-            .where(eq(modules.id, moduleId));
-        if (!modulo) {
-            return res.status(404).json({ erro: "Módulo não encontrado" });
-        }
-
-        const [aula] = await db
-            .insert(lessons)
-            .values({
-                trailId: modulo.trailId,
-                moduleId,
-                title: dados.title,
-                content: dados.content,
-                position: dados.position,
-            })
-            .returning();
-        res.status(201).json(aula);
+        res.status(201).json(await criarAula(moduleId, dados));
     } catch (err) {
         next(err);
     }
@@ -308,37 +231,7 @@ export const createQuestion = async (req: Request, res: Response, next: NextFunc
     try {
         const lessonId = String(req.params.id);
         const dados = createQuestionSchema.parse(req.body);
-
-        const [aula] = await db
-            .select({ id: lessons.id })
-            .from(lessons)
-            .where(eq(lessons.id, lessonId));
-        if (!aula) {
-            return res.status(404).json({ erro: "Aula não encontrada" });
-        }
-
-        const criada = await db.transaction(async (tx) => {
-            const [questao] = await tx
-                .insert(questions)
-                .values({
-                    lessonId,
-                    statement: dados.statement,
-                    position: dados.position,
-                })
-                .returning();
-
-            await tx.insert(questionOptions).values(
-                dados.options.map((o, i) => ({
-                    questionId: questao.id,
-                    text: o.text,
-                    isCorrect: o.isCorrect,
-                    position: i + 1,
-                })),
-            );
-            return questao;
-        });
-
-        res.status(201).json(criada);
+        res.status(201).json(await criarQuestao(lessonId, dados));
     } catch (err) {
         next(err);
     }
@@ -415,42 +308,7 @@ export const getMyAchievements = async (req: Request, res: Response, next: NextF
 // Atividades recentes derivadas: aulas concluídas + conquistas desbloqueadas.
 export const getMyActivity = async (req: Request, res: Response, next: NextFunction) => {
     try {
-        const userId = req.userId!;
-        const aulas = await db
-            .select({ at: lessonProgress.completedAt, title: lessons.title })
-            .from(lessonProgress)
-            .innerJoin(lessons, eq(lessons.id, lessonProgress.lessonId))
-            .where(eq(lessonProgress.userId, userId))
-            .orderBy(desc(lessonProgress.completedAt))
-            .limit(15);
-        const conquistas = await db
-            .select({
-                at: userAchievements.earnedAt,
-                name: achievements.name,
-                icon: achievements.icon,
-            })
-            .from(userAchievements)
-            .innerJoin(achievements, eq(achievements.id, userAchievements.achievementId))
-            .where(eq(userAchievements.userId, userId))
-            .orderBy(desc(userAchievements.earnedAt))
-            .limit(15);
-        const itens = [
-            ...aulas.map((a) => ({
-                type: "lesson",
-                icon: "check",
-                text: `Concluiu a aula "${a.title}"`,
-                at: a.at,
-            })),
-            ...conquistas.map((c) => ({
-                type: "achievement",
-                icon: c.icon,
-                text: `Desbloqueou "${c.name}"`,
-                at: c.at,
-            })),
-        ]
-            .sort((x, y) => (x.at < y.at ? 1 : x.at > y.at ? -1 : 0))
-            .slice(0, 15);
-        res.json(itens);
+        res.json(await atividadeRecente(req.userId!));
     } catch (err) {
         next(err);
     }
@@ -474,100 +332,7 @@ export const getCommunityAchievements = async (
 export const getRanking = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const periodo = String(req.query.period ?? "all");
-        const dia = 24 * 60 * 60 * 1000;
-        const desde =
-            periodo === "week"
-                ? new Date(Date.now() - 7 * dia)
-                : periodo === "month"
-                  ? new Date(Date.now() - 30 * dia)
-                  : null;
-
-        const [usuarios, aulasTot, acertosTot, aulasPer, acertosPer, streaks] = await Promise.all([
-            db.select({ id: users.id, name: users.name, username: users.username }).from(users),
-            db
-                .select({ userId: lessonProgress.userId, n: count() })
-                .from(lessonProgress)
-                .groupBy(lessonProgress.userId),
-            db
-                .select({ userId: questionAnswers.userId, n: count() })
-                .from(questionAnswers)
-                .where(eq(questionAnswers.isCorrect, true))
-                .groupBy(questionAnswers.userId),
-            desde
-                ? db
-                      .select({ userId: lessonProgress.userId, n: count() })
-                      .from(lessonProgress)
-                      .where(gte(lessonProgress.completedAt, desde))
-                      .groupBy(lessonProgress.userId)
-                : Promise.resolve(null),
-            desde
-                ? db
-                      .select({ userId: questionAnswers.userId, n: count() })
-                      .from(questionAnswers)
-                      .where(
-                          and(
-                              eq(questionAnswers.isCorrect, true),
-                              gte(questionAnswers.answeredAt, desde),
-                          ),
-                      )
-                      .groupBy(questionAnswers.userId)
-                : Promise.resolve(null),
-            streaksTodos(),
-        ]);
-
-        const paraMapa = (arr: { userId: string; n: number }[] | null) =>
-            new Map((arr ?? []).map((a) => [a.userId, Number(a.n)]));
-        const at = paraMapa(aulasTot),
-            acT = paraMapa(acertosTot);
-        const aP = desde ? paraMapa(aulasPer) : at;
-        const acP = desde ? paraMapa(acertosPer) : acT;
-
-        const base = usuarios.map((u) => {
-            const totalXp = (at.get(u.id) ?? 0) * 50 + (acT.get(u.id) ?? 0) * 10;
-            const periodXp = (aP.get(u.id) ?? 0) * 50 + (acP.get(u.id) ?? 0) * 10;
-            return {
-                id: u.id,
-                name: u.name,
-                username: u.username,
-                totalXp,
-                periodXp,
-                level: Math.floor(totalXp / 500) + 1,
-                streak: streaks.get(u.id) ?? 0,
-                you: u.id === req.userId,
-            };
-        });
-        const ordenados = [...base]
-            .sort((a, b) => b.periodXp - a.periodXp)
-            .map((u, i) => ({ ...u, position: i + 1 }));
-        // Movimentação é calculada sobre o ranking geral (XP total).
-        const ordemGeral = [...base]
-            .sort((a, b) => b.totalXp - a.totalXp)
-            .map((u, i) => ({ id: u.id, position: i + 1 }));
-        const deltas = await movimentacaoRanking(hojeSaoPaulo(), ordemGeral);
-
-        const meu = ordenados.find((u) => u.you);
-        const me = meu
-            ? {
-                  position: meu.position,
-                  username: meu.username,
-                  xp: meu.periodXp,
-                  totalXp: meu.totalXp,
-                  level: meu.level,
-                  streak: meu.streak,
-                  delta: deltas.get(meu.id) ?? 0,
-              }
-            : null;
-        const rows = ordenados.slice(0, 20).map((u) => ({
-            position: u.position,
-            name: u.name,
-            username: u.username,
-            xp: u.periodXp,
-            level: u.level,
-            streak: u.streak,
-            delta: deltas.get(u.id) ?? 0,
-            you: u.you,
-        }));
-        res.json({ me, rows });
+        res.json(await rankingGlobal(periodo, req.userId));
     } catch (err) {
         next(err);
     }
@@ -605,17 +370,7 @@ export const setLessonPublished = async (req: Request, res: Response, next: Next
             return res.status(400).json({ erro: "Campo 'published' deve ser booleano" });
         }
 
-        const [aula] = await db
-            .update(lessons)
-            .set({ published })
-            .where(eq(lessons.id, lessonId))
-            .returning({ id: lessons.id, title: lessons.title, published: lessons.published });
-
-        if (!aula) {
-            return res.status(404).json({ erro: "Aula não encontrada" });
-        }
-
-        res.json(aula);
+        res.json(await definirPublicacao(lessonId, published));
     } catch (err) {
         next(err);
     }
@@ -626,42 +381,7 @@ export const setLessonPublished = async (req: Request, res: Response, next: Next
 // Estrutura do curso para o editor: módulos ordenados com suas aulas (inclui rascunhos).
 export const getTrailStudio = async (req: Request, res: Response, next: NextFunction) => {
     try {
-        const trailId = String(req.params.id);
-        const [trilha] = await db
-            .select({ id: trails.id, name: trails.name })
-            .from(trails)
-            .where(eq(trails.id, trailId));
-        if (!trilha) {
-            return res.status(404).json({ erro: "Trilha não encontrada" });
-        }
-
-        const mods = await db
-            .select()
-            .from(modules)
-            .where(eq(modules.trailId, trailId))
-            .orderBy(asc(modules.position));
-        const aulas = await db
-            .select({
-                id: lessons.id,
-                moduleId: lessons.moduleId,
-                title: lessons.title,
-                position: lessons.position,
-                published: lessons.published,
-            })
-            .from(lessons)
-            .where(eq(lessons.trailId, trailId))
-            .orderBy(asc(lessons.position));
-
-        res.json({
-            id: trilha.id,
-            name: trilha.name,
-            modules: mods.map((m) => ({
-                id: m.id,
-                title: m.title,
-                position: m.position,
-                lessons: aulas.filter((a) => a.moduleId === m.id),
-            })),
-        });
+        res.json(await estruturaDoEstudio(String(req.params.id)));
     } catch (err) {
         next(err);
     }
@@ -670,50 +390,7 @@ export const getTrailStudio = async (req: Request, res: Response, next: NextFunc
 // Aula completa para edição: inclui o gabarito e a dificuldade (só admin).
 export const getLessonStudio = async (req: Request, res: Response, next: NextFunction) => {
     try {
-        const lessonId = String(req.params.id);
-        const [aula] = await db.select().from(lessons).where(eq(lessons.id, lessonId));
-        if (!aula) {
-            return res.status(404).json({ erro: "Aula não encontrada" });
-        }
-
-        const qs = await db
-            .select()
-            .from(questions)
-            .where(eq(questions.lessonId, lessonId))
-            .orderBy(asc(questions.position));
-        const qIds = qs.map((q) => q.id);
-        const opts = qIds.length
-            ? await db
-                  .select()
-                  .from(questionOptions)
-                  .where(inArray(questionOptions.questionId, qIds))
-                  .orderBy(asc(questionOptions.position))
-            : [];
-
-        res.json({
-            id: aula.id,
-            moduleId: aula.moduleId,
-            title: aula.title,
-            content: aula.content,
-            contentBlocks:
-                aula.contentBlocks ?? (aula.content ? [{ type: "text", value: aula.content }] : []),
-            published: aula.published,
-            position: aula.position,
-            questions: qs.map((q) => ({
-                id: q.id,
-                statement: q.statement,
-                difficulty: q.difficulty,
-                position: q.position,
-                options: opts
-                    .filter((o) => o.questionId === q.id)
-                    .map((o) => ({
-                        id: o.id,
-                        text: o.text,
-                        isCorrect: o.isCorrect,
-                        position: o.position,
-                    })),
-            })),
-        });
+        res.json(await aulaParaEdicao(String(req.params.id)));
     } catch (err) {
         next(err);
     }
@@ -722,58 +399,12 @@ export const getLessonStudio = async (req: Request, res: Response, next: NextFun
 // Exclui uma aula e tudo que depende dela.
 export const deleteLesson = async (req: Request, res: Response, next: NextFunction) => {
     try {
-        const lessonId = String(req.params.id);
-        const [aula] = await db
-            .select({ id: lessons.id })
-            .from(lessons)
-            .where(eq(lessons.id, lessonId));
-        if (!aula) {
-            return res.status(404).json({ erro: "Aula não encontrada" });
-        }
-
-        await db.transaction(async (tx) => {
-            const qs = await tx
-                .select({ id: questions.id })
-                .from(questions)
-                .where(eq(questions.lessonId, lessonId));
-            const qIds = qs.map((q) => q.id);
-            if (qIds.length) {
-                await tx.delete(questionAnswers).where(inArray(questionAnswers.questionId, qIds));
-                await tx.delete(questionOptions).where(inArray(questionOptions.questionId, qIds));
-                await tx.delete(questions).where(inArray(questions.id, qIds));
-            }
-            await tx.delete(lessonProgress).where(eq(lessonProgress.lessonId, lessonId));
-            await tx.delete(lessons).where(eq(lessons.id, lessonId));
-        });
-
+        await excluirAula(String(req.params.id));
         res.json({ ok: true });
     } catch (err) {
         next(err);
     }
 };
-
-// Serializa os blocos em markdown (fallback para o aluno e para conteúdo legado).
-function blocosParaMarkdown(blocos: { type: string; value: string }[]): string {
-    return blocos
-        .map((b) => {
-            switch (b.type) {
-                case "code":
-                    return "```\n" + b.value + "\n```";
-                case "quote":
-                    return b.value
-                        .split("\n")
-                        .map((l) => "> " + l)
-                        .join("\n");
-                case "image":
-                    return `![imagem](${b.value})`;
-                case "video":
-                    return `[Vídeo](${b.value})`;
-                default:
-                    return b.value;
-            }
-        })
-        .join("\n\n");
-}
 
 // Salva a aula inteira (título, blocos de conteúdo e questões de uma vez). Substitui
 // as questões por completo. Valida o conteúdo apenas quando vai publicar.
@@ -781,86 +412,7 @@ export const saveLessonStudio = async (req: Request, res: Response, next: NextFu
     try {
         const lessonId = String(req.params.id);
         const dados = saveLessonStudioSchema.parse(req.body);
-
-        const [aula] = await db
-            .select({ id: lessons.id })
-            .from(lessons)
-            .where(eq(lessons.id, lessonId));
-        if (!aula) {
-            return res.status(404).json({ erro: "Aula não encontrada" });
-        }
-
-        if (dados.published) {
-            if (dados.questions.length < QUIZ_MIN_ACERTOS) {
-                return res.status(400).json({
-                    erro: `Para publicar, a aula precisa de ao menos ${QUIZ_MIN_ACERTOS} questões.`,
-                });
-            }
-            for (const [i, q] of dados.questions.entries()) {
-                if (q.statement.trim().length < 3) {
-                    return res
-                        .status(400)
-                        .json({ erro: `Questão ${i + 1}: enunciado muito curto.` });
-                }
-                if (q.options.filter((o) => o.text.trim().length > 0).length < 2) {
-                    return res
-                        .status(400)
-                        .json({ erro: `Questão ${i + 1}: precisa de ao menos 2 alternativas.` });
-                }
-                if (q.options.filter((o) => o.isCorrect).length !== 1) {
-                    return res.status(400).json({
-                        erro: `Questão ${i + 1}: marque exatamente uma alternativa correta.`,
-                    });
-                }
-            }
-        }
-
-        await db.transaction(async (tx) => {
-            const blocos = dados.contentBlocks ?? [];
-            await tx
-                .update(lessons)
-                .set({
-                    title: dados.title,
-                    contentBlocks: blocos,
-                    content: blocos.length ? blocosParaMarkdown(blocos) : null,
-                    ...(dados.published === undefined ? {} : { published: dados.published }),
-                })
-                .where(eq(lessons.id, lessonId));
-
-            const qs = await tx
-                .select({ id: questions.id })
-                .from(questions)
-                .where(eq(questions.lessonId, lessonId));
-            const qIds = qs.map((q) => q.id);
-            if (qIds.length) {
-                await tx.delete(questionAnswers).where(inArray(questionAnswers.questionId, qIds));
-                await tx.delete(questionOptions).where(inArray(questionOptions.questionId, qIds));
-                await tx.delete(questions).where(inArray(questions.id, qIds));
-            }
-
-            for (const [i, q] of dados.questions.entries()) {
-                const [nova] = await tx
-                    .insert(questions)
-                    .values({
-                        lessonId,
-                        statement: q.statement,
-                        difficulty: q.difficulty ?? "facil",
-                        position: i + 1,
-                    })
-                    .returning({ id: questions.id });
-                if (q.options.length) {
-                    await tx.insert(questionOptions).values(
-                        q.options.map((o, oi) => ({
-                            questionId: nova.id,
-                            text: o.text,
-                            isCorrect: o.isCorrect,
-                            position: oi + 1,
-                        })),
-                    );
-                }
-            }
-        });
-
+        await salvarAulaEstudio(lessonId, dados);
         res.json({ ok: true });
     } catch (err) {
         next(err);

--- a/backend/src/controllers/TrailController.ts
+++ b/backend/src/controllers/TrailController.ts
@@ -50,11 +50,9 @@ import {
     criarConquista,
     atualizarConquista,
     excluirConquista,
-    verificarConquistas,
     conquistasDoUsuario,
     feedComunidade,
 } from "../services/achievement.service.ts";
-import { ehAdmin } from "../services/usuario.service.ts";
 import {
     criarTrilha,
     atualizarTrilha,
@@ -63,9 +61,8 @@ import {
     trilhasDoUsuario,
     detalheDaTrilha,
 } from "../services/trail.service.ts";
-import { estadoDaAula, detalheDaAula } from "../services/lesson.service.ts";
-
-const QUIZ_MIN_ACERTOS = 4;
+import { detalheDaAula } from "../services/lesson.service.ts";
+import { QUIZ_MIN_ACERTOS, corrigirQuiz, conferirResposta } from "../services/quiz.service.ts";
 
 export const createTrail = async (req: Request, res: Response, next: NextFunction) => {
     try {
@@ -389,84 +386,9 @@ export const getLesson = async (req: Request, res: Response, next: NextFunction)
 // Recebe as respostas, corrige no servidor e conclui a aula se acertar o mínimo.
 export const submitQuiz = async (req: Request, res: Response, next: NextFunction) => {
     try {
-        const userId = req.userId!;
         const lessonId = String(req.params.id);
         const dados = submitQuizSchema.parse(req.body);
-
-        const [aula] = await db.select().from(lessons).where(eq(lessons.id, lessonId));
-        if (!aula) {
-            return res.status(404).json({ erro: "Aula não encontrada" });
-        }
-
-        if (!aula.published) {
-            return res.status(404).json({ erro: "Aula não encontrada" });
-        }
-
-        const estado = await estadoDaAula(userId, aula);
-        if (estado === "locked") {
-            return res.status(403).json({ erro: "Aula bloqueada. Conclua a aula anterior." });
-        }
-
-        const qs = await db
-            .select({ id: questions.id })
-            .from(questions)
-            .where(eq(questions.lessonId, lessonId));
-        const qIds = qs.map((q) => q.id);
-        if (qIds.length === 0) {
-            return res.status(400).json({ erro: "Esta aula não tem questões" });
-        }
-
-        const opts = await db
-            .select()
-            .from(questionOptions)
-            .where(inArray(questionOptions.questionId, qIds));
-        const corretaPorQuestao = new Map<string, string>();
-        for (const o of opts) {
-            if (o.isCorrect) corretaPorQuestao.set(o.questionId, o.id);
-        }
-
-        let acertos = 0;
-        for (const resp of dados.answers) {
-            if (corretaPorQuestao.get(resp.questionId) === resp.optionId) acertos++;
-        }
-
-        // Registra cada resposta uma única vez. A primeira conta para o XP por questão
-        // (10 cada); como não sobrescreve, errar e refazer não rende XP depois.
-        const idsValidos = new Set(opts.map((o) => o.id));
-        const qIdSet = new Set(qIds);
-        for (const resp of dados.answers) {
-            if (!qIdSet.has(resp.questionId) || !idsValidos.has(resp.optionId)) continue;
-            await db
-                .insert(questionAnswers)
-                .values({
-                    userId,
-                    questionId: resp.questionId,
-                    selectedOptionId: resp.optionId,
-                    isCorrect: corretaPorQuestao.get(resp.questionId) === resp.optionId,
-                })
-                .onConflictDoNothing();
-        }
-
-        const total = qIds.length;
-        const passou = acertos >= QUIZ_MIN_ACERTOS;
-
-        let aulaConcluida = false;
-        if (passou) {
-            const [existe] = await db
-                .select({ id: lessonProgress.id })
-                .from(lessonProgress)
-                .where(
-                    and(eq(lessonProgress.userId, userId), eq(lessonProgress.lessonId, lessonId)),
-                );
-            if (!existe) {
-                await db.insert(lessonProgress).values({ userId, lessonId });
-            }
-            aulaConcluida = true;
-        }
-
-        await verificarConquistas(userId);
-
-        res.json({ correct: acertos, total, passed: passou, lessonCompleted: aulaConcluida });
+        res.json(await corrigirQuiz(req.userId!, lessonId, dados));
     } catch (err) {
         next(err);
     }
@@ -666,46 +588,9 @@ export const getMyStreak = async (req: Request, res: Response, next: NextFunctio
 // continua sendo decidida no submitQuiz.
 export const checkAnswer = async (req: Request, res: Response, next: NextFunction) => {
     try {
-        const userId = req.userId!;
         const lessonId = String(req.params.id);
         const { questionId, optionId } = checkAnswerSchema.parse(req.body);
-
-        const [aula] = await db.select().from(lessons).where(eq(lessons.id, lessonId));
-        if (!aula) {
-            return res.status(404).json({ erro: "Aula não encontrada" });
-        }
-        if (!aula.published && !(await ehAdmin(userId))) {
-            return res.status(404).json({ erro: "Aula não encontrada" });
-        }
-
-        const estado = await estadoDaAula(userId, aula);
-        if (estado === "locked") {
-            return res.status(403).json({ erro: "Aula bloqueada. Conclua a aula anterior." });
-        }
-
-        // A questão precisa pertencer a esta aula.
-        const [questao] = await db
-            .select({ id: questions.id })
-            .from(questions)
-            .where(and(eq(questions.id, questionId), eq(questions.lessonId, lessonId)));
-        if (!questao) {
-            return res.status(404).json({ erro: "Questão não encontrada" });
-        }
-
-        const [correta] = await db
-            .select({ id: questionOptions.id })
-            .from(questionOptions)
-            .where(
-                and(
-                    eq(questionOptions.questionId, questionId),
-                    eq(questionOptions.isCorrect, true),
-                ),
-            );
-        if (!correta) {
-            return res.status(500).json({ erro: "Questão sem gabarito" });
-        }
-
-        res.json({ correct: correta.id === optionId, correctOptionId: correta.id });
+        res.json(await conferirResposta(req.userId!, lessonId, questionId, optionId));
     } catch (err) {
         next(err);
     }

--- a/backend/src/controllers/TrailController.ts
+++ b/backend/src/controllers/TrailController.ts
@@ -63,6 +63,7 @@ import {
     trilhasDoUsuario,
     detalheDaTrilha,
 } from "../services/trail.service.ts";
+import { estadoDaAula, detalheDaAula } from "../services/lesson.service.ts";
 
 const QUIZ_MIN_ACERTOS = 4;
 
@@ -376,104 +377,10 @@ export const getTrail = async (req: Request, res: Response, next: NextFunction) 
     }
 };
 
-// Calcula o estado (done/current/locked) de uma aula específica na trilha.
-async function estadoDaAula(userId: string, aula: typeof lessons.$inferSelect): Promise<string> {
-    // Só aulas publicadas entram na sequência (uma aula "em breve" não trava as próximas).
-    const irmas = await db
-        .select({ id: lessons.id, moduleId: lessons.moduleId, position: lessons.position })
-        .from(lessons)
-        .where(and(eq(lessons.trailId, aula.trailId), eq(lessons.published, true)));
-    const mods = await db
-        .select({ id: modules.id, position: modules.position })
-        .from(modules)
-        .where(eq(modules.trailId, aula.trailId));
-    const ordemModulo = new Map(mods.map((m) => [m.id, m.position]));
-
-    const ordenadas = [...irmas].sort((a, b) => {
-        const pm = (ordemModulo.get(a.moduleId) ?? 0) - (ordemModulo.get(b.moduleId) ?? 0);
-        return pm !== 0 ? pm : a.position - b.position;
-    });
-
-    const concluidas = new Set(
-        (
-            await db
-                .select({ lessonId: lessonProgress.lessonId })
-                .from(lessonProgress)
-                .where(eq(lessonProgress.userId, userId))
-        ).map((p) => p.lessonId),
-    );
-
-    let achouCurrent = false;
-    for (const a of ordenadas) {
-        if (concluidas.has(a.id)) {
-            if (a.id === aula.id) return "done";
-        } else if (!achouCurrent) {
-            achouCurrent = true;
-            if (a.id === aula.id) return "current";
-        } else if (a.id === aula.id) {
-            return "locked";
-        }
-    }
-    return "locked";
-}
-
 // Retorna a aula com conteúdo e questões SEM revelar a alternativa correta.
 export const getLesson = async (req: Request, res: Response, next: NextFunction) => {
     try {
-        const userId = req.userId!;
-        const lessonId = String(req.params.id);
-
-        const [aula] = await db.select().from(lessons).where(eq(lessons.id, lessonId));
-        if (!aula) {
-            return res.status(404).json({ erro: "Aula não encontrada" });
-        }
-
-        // Aula não publicada é invisível para o aluno; admin pode visualizar (preview).
-        const admin = await ehAdmin(userId);
-        if (!aula.published && !admin) {
-            return res.status(404).json({ erro: "Aula não encontrada" });
-        }
-
-        // Admin não é travado pelo bloqueio sequencial (pode pré-visualizar qualquer aula).
-        const estado = await estadoDaAula(userId, aula);
-        if (estado === "locked" && !admin) {
-            return res.status(403).json({ erro: "Aula bloqueada. Conclua a aula anterior." });
-        }
-
-        const qs = await db
-            .select()
-            .from(questions)
-            .where(eq(questions.lessonId, lessonId))
-            .orderBy(asc(questions.position));
-        const qIds = qs.map((q) => q.id);
-        const opts = qIds.length
-            ? await db
-                  .select()
-                  .from(questionOptions)
-                  .where(inArray(questionOptions.questionId, qIds))
-                  .orderBy(asc(questionOptions.position))
-            : [];
-
-        const questoes = qs.map((q) => ({
-            id: q.id,
-            statement: q.statement,
-            position: q.position,
-            // isCorrect deliberadamente omitido: o gabarito nunca vai para o cliente.
-            options: opts
-                .filter((o) => o.questionId === q.id)
-                .map((o) => ({ id: o.id, text: o.text, position: o.position })),
-        }));
-
-        res.json({
-            id: aula.id,
-            trailId: aula.trailId,
-            moduleId: aula.moduleId,
-            title: aula.title,
-            content: aula.content,
-            contentBlocks: aula.contentBlocks ?? null,
-            state: estado,
-            questions: questoes,
-        });
+        res.json(await detalheDaAula(String(req.params.id), req.userId!));
     } catch (err) {
         next(err);
     }

--- a/backend/src/controllers/TrailController.ts
+++ b/backend/src/controllers/TrailController.ts
@@ -11,11 +11,10 @@ import {
     questionAnswers,
     tags,
     trailTags,
-    languages,
     achievements,
     userAchievements,
 } from "../../schema.ts";
-import { eq, and, count, asc, desc, gte, inArray, sql } from "drizzle-orm";
+import { eq, and, count, asc, desc, gte, inArray } from "drizzle-orm";
 import {
     createTrailSchema,
     createModuleSchema,
@@ -40,6 +39,13 @@ import {
     hojeSaoPaulo,
 } from "../services/streak.ts";
 import { movimentacaoRanking } from "../services/ranking.ts";
+import { listarTags, criarTag, atualizarTag, excluirTag } from "../services/tag.service.ts";
+import {
+    listarLinguagens,
+    criarLinguagem,
+    atualizarLinguagem,
+    excluirLinguagem,
+} from "../services/language.service.ts";
 
 const QUIZ_MIN_ACERTOS = 4;
 
@@ -74,8 +80,7 @@ export const createTrail = async (req: Request, res: Response, next: NextFunctio
 // ===================== TAGS (categorias de trilha) =====================
 export const listTags = async (_req: Request, res: Response, next: NextFunction) => {
     try {
-        const lista = await db.select().from(tags).orderBy(asc(tags.name));
-        res.json(lista);
+        res.json(await listarTags());
     } catch (err) {
         next(err);
     }
@@ -84,15 +89,7 @@ export const listTags = async (_req: Request, res: Response, next: NextFunction)
 export const createTag = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const dados = createTagSchema.parse(req.body);
-        const [existe] = await db
-            .select({ id: tags.id })
-            .from(tags)
-            .where(eq(tags.name, dados.name));
-        if (existe) {
-            return res.status(409).json({ erro: "Já existe uma tag com esse nome" });
-        }
-        const [tag] = await db.insert(tags).values({ name: dados.name }).returning();
-        res.status(201).json(tag);
+        res.status(201).json(await criarTag(dados.name));
     } catch (err) {
         next(err);
     }
@@ -102,22 +99,7 @@ export const updateTag = async (req: Request, res: Response, next: NextFunction)
     try {
         const id = String(req.params.id);
         const dados = updateTagSchema.parse(req.body);
-        const [conflito] = await db
-            .select({ id: tags.id })
-            .from(tags)
-            .where(eq(tags.name, dados.name));
-        if (conflito && conflito.id !== id) {
-            return res.status(409).json({ erro: "Já existe uma tag com esse nome" });
-        }
-        const [tag] = await db
-            .update(tags)
-            .set({ name: dados.name })
-            .where(eq(tags.id, id))
-            .returning();
-        if (!tag) {
-            return res.status(404).json({ erro: "Tag não encontrada" });
-        }
-        res.json(tag);
+        res.json(await atualizarTag(id, dados.name));
     } catch (err) {
         next(err);
     }
@@ -125,11 +107,7 @@ export const updateTag = async (req: Request, res: Response, next: NextFunction)
 
 export const deleteTag = async (req: Request, res: Response, next: NextFunction) => {
     try {
-        const id = String(req.params.id);
-        await db.transaction(async (tx) => {
-            await tx.delete(trailTags).where(eq(trailTags.tagId, id));
-            await tx.delete(tags).where(eq(tags.id, id));
-        });
+        await excluirTag(String(req.params.id));
         res.json({ ok: true });
     } catch (err) {
         next(err);
@@ -139,8 +117,7 @@ export const deleteTag = async (req: Request, res: Response, next: NextFunction)
 // ===================== LINGUAGENS (canônicas do perfil) =====================
 export const listLanguages = async (_req: Request, res: Response, next: NextFunction) => {
     try {
-        const lista = await db.select().from(languages).orderBy(asc(languages.name));
-        res.json(lista);
+        res.json(await listarLinguagens());
     } catch (err) {
         next(err);
     }
@@ -149,15 +126,7 @@ export const listLanguages = async (_req: Request, res: Response, next: NextFunc
 export const createLanguage = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const dados = createLanguageSchema.parse(req.body);
-        const [existe] = await db
-            .select({ id: languages.id })
-            .from(languages)
-            .where(eq(languages.name, dados.name));
-        if (existe) {
-            return res.status(409).json({ erro: "Já existe uma linguagem com esse nome" });
-        }
-        const [lang] = await db.insert(languages).values({ name: dados.name }).returning();
-        res.status(201).json(lang);
+        res.status(201).json(await criarLinguagem(dados.name));
     } catch (err) {
         next(err);
     }
@@ -167,40 +136,7 @@ export const updateLanguage = async (req: Request, res: Response, next: NextFunc
     try {
         const id = String(req.params.id);
         const dados = updateLanguageSchema.parse(req.body);
-        const [atual] = await db
-            .select({ name: languages.name })
-            .from(languages)
-            .where(eq(languages.id, id));
-        if (!atual) {
-            return res.status(404).json({ erro: "Linguagem não encontrada" });
-        }
-        const [conflito] = await db
-            .select({ id: languages.id })
-            .from(languages)
-            .where(eq(languages.name, dados.name));
-        if (conflito && conflito.id !== id) {
-            return res.status(409).json({ erro: "Já existe uma linguagem com esse nome" });
-        }
-        const lang = await db.transaction(async (tx) => {
-            const [atualizada] = await tx
-                .update(languages)
-                .set({ name: dados.name })
-                .where(eq(languages.id, id))
-                .returning();
-            // Renomeou: propaga o novo nome para os perfis que usavam o antigo.
-            if (atual.name !== dados.name) {
-                await tx.execute(sql`
-                    UPDATE users
-                    SET languages = (
-                        SELECT jsonb_agg(CASE WHEN elem = ${JSON.stringify(atual.name)}::jsonb THEN ${JSON.stringify(dados.name)}::jsonb ELSE elem END)
-                        FROM jsonb_array_elements(languages) AS elem
-                    )
-                    WHERE languages @> ${JSON.stringify([atual.name])}::jsonb
-                `);
-            }
-            return atualizada;
-        });
-        res.json(lang);
+        res.json(await atualizarLinguagem(id, dados.name));
     } catch (err) {
         next(err);
     }
@@ -208,27 +144,7 @@ export const updateLanguage = async (req: Request, res: Response, next: NextFunc
 
 export const deleteLanguage = async (req: Request, res: Response, next: NextFunction) => {
     try {
-        const id = String(req.params.id);
-        const [lang] = await db
-            .select({ name: languages.name })
-            .from(languages)
-            .where(eq(languages.id, id));
-        if (!lang) {
-            return res.status(404).json({ erro: "Linguagem não encontrada" });
-        }
-        await db.transaction(async (tx) => {
-            await tx.delete(languages).where(eq(languages.id, id));
-            // Remove o nome dos perfis que a usavam, mantendo os dados padronizados.
-            await tx.execute(sql`
-                UPDATE users
-                SET languages = COALESCE((
-                    SELECT jsonb_agg(elem)
-                    FROM jsonb_array_elements(languages) AS elem
-                    WHERE elem <> ${JSON.stringify(lang.name)}::jsonb
-                ), '[]'::jsonb)
-                WHERE languages @> ${JSON.stringify([lang.name])}::jsonb
-            `);
-        });
+        await excluirLinguagem(String(req.params.id));
         res.json({ ok: true });
     } catch (err) {
         next(err);

--- a/backend/src/errors/AppError.ts
+++ b/backend/src/errors/AppError.ts
@@ -1,0 +1,14 @@
+/**
+ * Erro de domínio com status HTTP e mensagem própria.
+ * Os services lançam AppError para sinalizar 404/409/etc. sem depender
+ * de req/res; o middleware de erro converte em resposta JSON.
+ */
+export class AppError extends Error {
+    status: number;
+
+    constructor(status: number, message: string) {
+        super(message);
+        this.name = "AppError";
+        this.status = status;
+    }
+}

--- a/backend/src/middlewares/error.ts
+++ b/backend/src/middlewares/error.ts
@@ -1,7 +1,13 @@
 import type { Request, Response, NextFunction } from "express";
 import { ZodError } from "zod";
 import { env } from "../config/env.ts";
+import { AppError } from "../errors/AppError.ts";
 export function errorMiddleware(err: Error, _req: Request, res: Response, _next: NextFunction) {
+    // Erro de domínio lançado pelos services (404, 409, etc.)
+    if (err instanceof AppError) {
+        return res.status(err.status).json({ erro: err.message });
+    }
+
     // Se for erro do Zod
     if (err instanceof ZodError) {
         if (env.NODE_ENV !== "development") {

--- a/backend/src/services/achievement.service.ts
+++ b/backend/src/services/achievement.service.ts
@@ -1,0 +1,99 @@
+import { db } from "../../db.ts";
+import { achievements, userAchievements, users } from "../../schema.ts";
+import { eq, asc, desc } from "drizzle-orm";
+import type { z } from "zod";
+import type { createAchievementSchema } from "../schemas/trail.schemas.ts";
+import { AppError } from "../errors/AppError.ts";
+import { calcularEstatisticas } from "./stats.service.ts";
+
+type DadosConquista = z.infer<typeof createAchievementSchema>;
+
+// ===================== Catálogo (admin) =====================
+export async function listarConquistas() {
+    return db.select().from(achievements).orderBy(asc(achievements.threshold));
+}
+
+export async function criarConquista(dados: DadosConquista) {
+    const [existe] = await db
+        .select({ id: achievements.id })
+        .from(achievements)
+        .where(eq(achievements.name, dados.name));
+    if (existe) {
+        throw new AppError(409, "Já existe uma conquista com esse nome");
+    }
+    const [a] = await db.insert(achievements).values(dados).returning();
+    return a;
+}
+
+export async function atualizarConquista(id: string, dados: DadosConquista) {
+    const [conflito] = await db
+        .select({ id: achievements.id })
+        .from(achievements)
+        .where(eq(achievements.name, dados.name));
+    if (conflito && conflito.id !== id) {
+        throw new AppError(409, "Já existe uma conquista com esse nome");
+    }
+    const [a] = await db.update(achievements).set(dados).where(eq(achievements.id, id)).returning();
+    if (!a) {
+        throw new AppError(404, "Conquista não encontrada");
+    }
+    return a;
+}
+
+export async function excluirConquista(id: string) {
+    await db.transaction(async (tx) => {
+        await tx.delete(userAchievements).where(eq(userAchievements.achievementId, id));
+        await tx.delete(achievements).where(eq(achievements.id, id));
+    });
+}
+
+// ===================== Premiação automática =====================
+// Desbloqueia (idempotente) as conquistas cujo critério o usuário já atingiu.
+export async function verificarConquistas(userId: string) {
+    const stats = await calcularEstatisticas(userId);
+    const valor: Record<string, number> = {
+        xp_total: stats.xp,
+        lessons_completed: stats.lessonsCompleted,
+        questions_correct: stats.questionsCorrect,
+    };
+    const catalogo = await db.select().from(achievements);
+    const merecidas = catalogo.filter((a) => (valor[a.criteriaType] ?? 0) >= a.threshold);
+    if (merecidas.length === 0) return;
+    await db
+        .insert(userAchievements)
+        .values(merecidas.map((a) => ({ userId, achievementId: a.id })))
+        .onConflictDoNothing();
+}
+
+// Catálogo de conquistas com a marcação do que o usuário já desbloqueou.
+export async function conquistasDoUsuario(userId: string) {
+    await verificarConquistas(userId);
+    const catalogo = await db.select().from(achievements).orderBy(asc(achievements.threshold));
+    const ganhas = await db
+        .select()
+        .from(userAchievements)
+        .where(eq(userAchievements.userId, userId));
+    const quando = new Map(ganhas.map((g) => [g.achievementId, g.earnedAt]));
+    return catalogo.map((a) => ({
+        ...a,
+        earned: quando.has(a.id),
+        earnedAt: quando.get(a.id) ?? null,
+    }));
+}
+
+// ===================== Feed da comunidade =====================
+// Quem desbloqueou cada conquista, mais recentes primeiro.
+export async function feedComunidade() {
+    return db
+        .select({
+            name: users.name,
+            achievement: achievements.name,
+            icon: achievements.icon,
+            at: userAchievements.earnedAt,
+        })
+        .from(userAchievements)
+        .innerJoin(users, eq(users.id, userAchievements.userId))
+        .innerJoin(achievements, eq(achievements.id, userAchievements.achievementId))
+        .orderBy(desc(userAchievements.earnedAt))
+        .limit(10);
+}

--- a/backend/src/services/activity.service.ts
+++ b/backend/src/services/activity.service.ts
@@ -1,0 +1,41 @@
+import { db } from "../../db.ts";
+import { lessonProgress, lessons, userAchievements, achievements } from "../../schema.ts";
+import { eq, desc } from "drizzle-orm";
+
+// Atividades recentes derivadas: aulas concluídas + conquistas desbloqueadas.
+export async function atividadeRecente(userId: string) {
+    const aulas = await db
+        .select({ at: lessonProgress.completedAt, title: lessons.title })
+        .from(lessonProgress)
+        .innerJoin(lessons, eq(lessons.id, lessonProgress.lessonId))
+        .where(eq(lessonProgress.userId, userId))
+        .orderBy(desc(lessonProgress.completedAt))
+        .limit(15);
+    const conquistas = await db
+        .select({
+            at: userAchievements.earnedAt,
+            name: achievements.name,
+            icon: achievements.icon,
+        })
+        .from(userAchievements)
+        .innerJoin(achievements, eq(achievements.id, userAchievements.achievementId))
+        .where(eq(userAchievements.userId, userId))
+        .orderBy(desc(userAchievements.earnedAt))
+        .limit(15);
+    return [
+        ...aulas.map((a) => ({
+            type: "lesson",
+            icon: "check",
+            text: `Concluiu a aula "${a.title}"`,
+            at: a.at,
+        })),
+        ...conquistas.map((c) => ({
+            type: "achievement",
+            icon: c.icon,
+            text: `Desbloqueou "${c.name}"`,
+            at: c.at,
+        })),
+    ]
+        .sort((x, y) => (x.at < y.at ? 1 : x.at > y.at ? -1 : 0))
+        .slice(0, 15);
+}

--- a/backend/src/services/estudio.service.ts
+++ b/backend/src/services/estudio.service.ts
@@ -1,0 +1,354 @@
+import { db } from "../../db.ts";
+import {
+    trails,
+    modules,
+    lessons,
+    lessonProgress,
+    questions,
+    questionOptions,
+    questionAnswers,
+} from "../../schema.ts";
+import { eq, asc, inArray } from "drizzle-orm";
+import type { z } from "zod";
+import type {
+    createModuleSchema,
+    createLessonSchema,
+    createQuestionSchema,
+    saveLessonStudioSchema,
+} from "../schemas/trail.schemas.ts";
+import { AppError } from "../errors/AppError.ts";
+import { QUIZ_MIN_ACERTOS } from "./quiz.service.ts";
+
+type DadosModulo = z.infer<typeof createModuleSchema>;
+type DadosAula = z.infer<typeof createLessonSchema>;
+type DadosQuestao = z.infer<typeof createQuestionSchema>;
+type DadosSalvarAula = z.infer<typeof saveLessonStudioSchema>;
+
+export async function criarModulo(trailId: string, dados: DadosModulo) {
+    const [trilha] = await db.select({ id: trails.id }).from(trails).where(eq(trails.id, trailId));
+    if (!trilha) {
+        throw new AppError(404, "Trilha não encontrada");
+    }
+    const [modulo] = await db
+        .insert(modules)
+        .values({
+            trailId,
+            title: dados.title,
+            position: dados.position,
+        })
+        .returning();
+    return modulo;
+}
+
+// Exclui um módulo e todas as suas aulas (questões, opções e progresso).
+export async function excluirModulo(moduleId: string) {
+    const [modulo] = await db
+        .select({ id: modules.id })
+        .from(modules)
+        .where(eq(modules.id, moduleId));
+    if (!modulo) {
+        throw new AppError(404, "Módulo não encontrado");
+    }
+    await db.transaction(async (tx) => {
+        const ls = await tx
+            .select({ id: lessons.id })
+            .from(lessons)
+            .where(eq(lessons.moduleId, moduleId));
+        const lessonIds = ls.map((l) => l.id);
+        if (lessonIds.length) {
+            const qs = await tx
+                .select({ id: questions.id })
+                .from(questions)
+                .where(inArray(questions.lessonId, lessonIds));
+            const qIds = qs.map((q) => q.id);
+            if (qIds.length) {
+                await tx.delete(questionAnswers).where(inArray(questionAnswers.questionId, qIds));
+                await tx.delete(questionOptions).where(inArray(questionOptions.questionId, qIds));
+                await tx.delete(questions).where(inArray(questions.id, qIds));
+            }
+            await tx.delete(lessonProgress).where(inArray(lessonProgress.lessonId, lessonIds));
+            await tx.delete(lessons).where(inArray(lessons.id, lessonIds));
+        }
+        await tx.delete(modules).where(eq(modules.id, moduleId));
+    });
+}
+
+export async function criarAula(moduleId: string, dados: DadosAula) {
+    const [modulo] = await db
+        .select({ id: modules.id, trailId: modules.trailId })
+        .from(modules)
+        .where(eq(modules.id, moduleId));
+    if (!modulo) {
+        throw new AppError(404, "Módulo não encontrado");
+    }
+    const [aula] = await db
+        .insert(lessons)
+        .values({
+            trailId: modulo.trailId,
+            moduleId,
+            title: dados.title,
+            content: dados.content,
+            position: dados.position,
+        })
+        .returning();
+    return aula;
+}
+
+export async function criarQuestao(lessonId: string, dados: DadosQuestao) {
+    const [aula] = await db
+        .select({ id: lessons.id })
+        .from(lessons)
+        .where(eq(lessons.id, lessonId));
+    if (!aula) {
+        throw new AppError(404, "Aula não encontrada");
+    }
+    return db.transaction(async (tx) => {
+        const [questao] = await tx
+            .insert(questions)
+            .values({
+                lessonId,
+                statement: dados.statement,
+                position: dados.position,
+            })
+            .returning();
+
+        await tx.insert(questionOptions).values(
+            dados.options.map((o, i) => ({
+                questionId: questao.id,
+                text: o.text,
+                isCorrect: o.isCorrect,
+                position: i + 1,
+            })),
+        );
+        return questao;
+    });
+}
+
+// Publica ou despublica uma aula (admin).
+export async function definirPublicacao(lessonId: string, published: boolean) {
+    const [aula] = await db
+        .update(lessons)
+        .set({ published })
+        .where(eq(lessons.id, lessonId))
+        .returning({ id: lessons.id, title: lessons.title, published: lessons.published });
+    if (!aula) {
+        throw new AppError(404, "Aula não encontrada");
+    }
+    return aula;
+}
+
+// Estrutura do curso para o editor: módulos ordenados com suas aulas (inclui rascunhos).
+export async function estruturaDoEstudio(trailId: string) {
+    const [trilha] = await db
+        .select({ id: trails.id, name: trails.name })
+        .from(trails)
+        .where(eq(trails.id, trailId));
+    if (!trilha) {
+        throw new AppError(404, "Trilha não encontrada");
+    }
+
+    const mods = await db
+        .select()
+        .from(modules)
+        .where(eq(modules.trailId, trailId))
+        .orderBy(asc(modules.position));
+    const aulas = await db
+        .select({
+            id: lessons.id,
+            moduleId: lessons.moduleId,
+            title: lessons.title,
+            position: lessons.position,
+            published: lessons.published,
+        })
+        .from(lessons)
+        .where(eq(lessons.trailId, trailId))
+        .orderBy(asc(lessons.position));
+
+    return {
+        id: trilha.id,
+        name: trilha.name,
+        modules: mods.map((m) => ({
+            id: m.id,
+            title: m.title,
+            position: m.position,
+            lessons: aulas.filter((a) => a.moduleId === m.id),
+        })),
+    };
+}
+
+// Aula completa para edição: inclui o gabarito e a dificuldade (só admin).
+export async function aulaParaEdicao(lessonId: string) {
+    const [aula] = await db.select().from(lessons).where(eq(lessons.id, lessonId));
+    if (!aula) {
+        throw new AppError(404, "Aula não encontrada");
+    }
+
+    const qs = await db
+        .select()
+        .from(questions)
+        .where(eq(questions.lessonId, lessonId))
+        .orderBy(asc(questions.position));
+    const qIds = qs.map((q) => q.id);
+    const opts = qIds.length
+        ? await db
+              .select()
+              .from(questionOptions)
+              .where(inArray(questionOptions.questionId, qIds))
+              .orderBy(asc(questionOptions.position))
+        : [];
+
+    return {
+        id: aula.id,
+        moduleId: aula.moduleId,
+        title: aula.title,
+        content: aula.content,
+        contentBlocks:
+            aula.contentBlocks ?? (aula.content ? [{ type: "text", value: aula.content }] : []),
+        published: aula.published,
+        position: aula.position,
+        questions: qs.map((q) => ({
+            id: q.id,
+            statement: q.statement,
+            difficulty: q.difficulty,
+            position: q.position,
+            options: opts
+                .filter((o) => o.questionId === q.id)
+                .map((o) => ({
+                    id: o.id,
+                    text: o.text,
+                    isCorrect: o.isCorrect,
+                    position: o.position,
+                })),
+        })),
+    };
+}
+
+// Exclui uma aula e tudo que depende dela.
+export async function excluirAula(lessonId: string) {
+    const [aula] = await db
+        .select({ id: lessons.id })
+        .from(lessons)
+        .where(eq(lessons.id, lessonId));
+    if (!aula) {
+        throw new AppError(404, "Aula não encontrada");
+    }
+
+    await db.transaction(async (tx) => {
+        const qs = await tx
+            .select({ id: questions.id })
+            .from(questions)
+            .where(eq(questions.lessonId, lessonId));
+        const qIds = qs.map((q) => q.id);
+        if (qIds.length) {
+            await tx.delete(questionAnswers).where(inArray(questionAnswers.questionId, qIds));
+            await tx.delete(questionOptions).where(inArray(questionOptions.questionId, qIds));
+            await tx.delete(questions).where(inArray(questions.id, qIds));
+        }
+        await tx.delete(lessonProgress).where(eq(lessonProgress.lessonId, lessonId));
+        await tx.delete(lessons).where(eq(lessons.id, lessonId));
+    });
+}
+
+// Serializa os blocos em markdown (fallback para o aluno e para conteúdo legado).
+function blocosParaMarkdown(blocos: { type: string; value: string }[]): string {
+    return blocos
+        .map((b) => {
+            switch (b.type) {
+                case "code":
+                    return "```\n" + b.value + "\n```";
+                case "quote":
+                    return b.value
+                        .split("\n")
+                        .map((l) => "> " + l)
+                        .join("\n");
+                case "image":
+                    return `![imagem](${b.value})`;
+                case "video":
+                    return `[Vídeo](${b.value})`;
+                default:
+                    return b.value;
+            }
+        })
+        .join("\n\n");
+}
+
+// Salva a aula inteira (título, blocos de conteúdo e questões de uma vez). Substitui
+// as questões por completo. Valida o conteúdo apenas quando vai publicar.
+export async function salvarAulaEstudio(lessonId: string, dados: DadosSalvarAula) {
+    const [aula] = await db
+        .select({ id: lessons.id })
+        .from(lessons)
+        .where(eq(lessons.id, lessonId));
+    if (!aula) {
+        throw new AppError(404, "Aula não encontrada");
+    }
+
+    if (dados.published) {
+        if (dados.questions.length < QUIZ_MIN_ACERTOS) {
+            throw new AppError(
+                400,
+                `Para publicar, a aula precisa de ao menos ${QUIZ_MIN_ACERTOS} questões.`,
+            );
+        }
+        for (const [i, q] of dados.questions.entries()) {
+            if (q.statement.trim().length < 3) {
+                throw new AppError(400, `Questão ${i + 1}: enunciado muito curto.`);
+            }
+            if (q.options.filter((o) => o.text.trim().length > 0).length < 2) {
+                throw new AppError(400, `Questão ${i + 1}: precisa de ao menos 2 alternativas.`);
+            }
+            if (q.options.filter((o) => o.isCorrect).length !== 1) {
+                throw new AppError(
+                    400,
+                    `Questão ${i + 1}: marque exatamente uma alternativa correta.`,
+                );
+            }
+        }
+    }
+
+    await db.transaction(async (tx) => {
+        const blocos = dados.contentBlocks ?? [];
+        await tx
+            .update(lessons)
+            .set({
+                title: dados.title,
+                contentBlocks: blocos,
+                content: blocos.length ? blocosParaMarkdown(blocos) : null,
+                ...(dados.published === undefined ? {} : { published: dados.published }),
+            })
+            .where(eq(lessons.id, lessonId));
+
+        const qs = await tx
+            .select({ id: questions.id })
+            .from(questions)
+            .where(eq(questions.lessonId, lessonId));
+        const qIds = qs.map((q) => q.id);
+        if (qIds.length) {
+            await tx.delete(questionAnswers).where(inArray(questionAnswers.questionId, qIds));
+            await tx.delete(questionOptions).where(inArray(questionOptions.questionId, qIds));
+            await tx.delete(questions).where(inArray(questions.id, qIds));
+        }
+
+        for (const [i, q] of dados.questions.entries()) {
+            const [nova] = await tx
+                .insert(questions)
+                .values({
+                    lessonId,
+                    statement: q.statement,
+                    difficulty: q.difficulty ?? "facil",
+                    position: i + 1,
+                })
+                .returning({ id: questions.id });
+            if (q.options.length) {
+                await tx.insert(questionOptions).values(
+                    q.options.map((o, oi) => ({
+                        questionId: nova.id,
+                        text: o.text,
+                        isCorrect: o.isCorrect,
+                        position: oi + 1,
+                    })),
+                );
+            }
+        }
+    });
+}

--- a/backend/src/services/language.service.ts
+++ b/backend/src/services/language.service.ts
@@ -1,0 +1,79 @@
+import { db } from "../../db.ts";
+import { languages } from "../../schema.ts";
+import { eq, asc, sql } from "drizzle-orm";
+import { AppError } from "../errors/AppError.ts";
+
+export async function listarLinguagens() {
+    return db.select().from(languages).orderBy(asc(languages.name));
+}
+
+export async function criarLinguagem(nome: string) {
+    const [existe] = await db
+        .select({ id: languages.id })
+        .from(languages)
+        .where(eq(languages.name, nome));
+    if (existe) {
+        throw new AppError(409, "Já existe uma linguagem com esse nome");
+    }
+    const [lang] = await db.insert(languages).values({ name: nome }).returning();
+    return lang;
+}
+
+export async function atualizarLinguagem(id: string, nome: string) {
+    const [atual] = await db
+        .select({ name: languages.name })
+        .from(languages)
+        .where(eq(languages.id, id));
+    if (!atual) {
+        throw new AppError(404, "Linguagem não encontrada");
+    }
+    const [conflito] = await db
+        .select({ id: languages.id })
+        .from(languages)
+        .where(eq(languages.name, nome));
+    if (conflito && conflito.id !== id) {
+        throw new AppError(409, "Já existe uma linguagem com esse nome");
+    }
+    return db.transaction(async (tx) => {
+        const [atualizada] = await tx
+            .update(languages)
+            .set({ name: nome })
+            .where(eq(languages.id, id))
+            .returning();
+        // Renomeou: propaga o novo nome para os perfis que usavam o antigo.
+        if (atual.name !== nome) {
+            await tx.execute(sql`
+                UPDATE users
+                SET languages = (
+                    SELECT jsonb_agg(CASE WHEN elem = ${JSON.stringify(atual.name)}::jsonb THEN ${JSON.stringify(nome)}::jsonb ELSE elem END)
+                    FROM jsonb_array_elements(languages) AS elem
+                )
+                WHERE languages @> ${JSON.stringify([atual.name])}::jsonb
+            `);
+        }
+        return atualizada;
+    });
+}
+
+export async function excluirLinguagem(id: string) {
+    const [lang] = await db
+        .select({ name: languages.name })
+        .from(languages)
+        .where(eq(languages.id, id));
+    if (!lang) {
+        throw new AppError(404, "Linguagem não encontrada");
+    }
+    await db.transaction(async (tx) => {
+        await tx.delete(languages).where(eq(languages.id, id));
+        // Remove o nome dos perfis que a usavam, mantendo os dados padronizados.
+        await tx.execute(sql`
+            UPDATE users
+            SET languages = COALESCE((
+                SELECT jsonb_agg(elem)
+                FROM jsonb_array_elements(languages) AS elem
+                WHERE elem <> ${JSON.stringify(lang.name)}::jsonb
+            ), '[]'::jsonb)
+            WHERE languages @> ${JSON.stringify([lang.name])}::jsonb
+        `);
+    });
+}

--- a/backend/src/services/lesson.service.ts
+++ b/backend/src/services/lesson.service.ts
@@ -1,0 +1,104 @@
+import { db } from "../../db.ts";
+import { lessons, modules, lessonProgress, questions, questionOptions } from "../../schema.ts";
+import { eq, and, asc, inArray } from "drizzle-orm";
+import { AppError } from "../errors/AppError.ts";
+import { ehAdmin } from "./usuario.service.ts";
+
+// Calcula o estado (done/current/locked) de uma aula específica na trilha.
+export async function estadoDaAula(
+    userId: string,
+    aula: typeof lessons.$inferSelect,
+): Promise<string> {
+    // Só aulas publicadas entram na sequência (uma aula "em breve" não trava as próximas).
+    const irmas = await db
+        .select({ id: lessons.id, moduleId: lessons.moduleId, position: lessons.position })
+        .from(lessons)
+        .where(and(eq(lessons.trailId, aula.trailId), eq(lessons.published, true)));
+    const mods = await db
+        .select({ id: modules.id, position: modules.position })
+        .from(modules)
+        .where(eq(modules.trailId, aula.trailId));
+    const ordemModulo = new Map(mods.map((m) => [m.id, m.position]));
+
+    const ordenadas = [...irmas].sort((a, b) => {
+        const pm = (ordemModulo.get(a.moduleId) ?? 0) - (ordemModulo.get(b.moduleId) ?? 0);
+        return pm !== 0 ? pm : a.position - b.position;
+    });
+
+    const concluidas = new Set(
+        (
+            await db
+                .select({ lessonId: lessonProgress.lessonId })
+                .from(lessonProgress)
+                .where(eq(lessonProgress.userId, userId))
+        ).map((p) => p.lessonId),
+    );
+
+    let achouCurrent = false;
+    for (const a of ordenadas) {
+        if (concluidas.has(a.id)) {
+            if (a.id === aula.id) return "done";
+        } else if (!achouCurrent) {
+            achouCurrent = true;
+            if (a.id === aula.id) return "current";
+        } else if (a.id === aula.id) {
+            return "locked";
+        }
+    }
+    return "locked";
+}
+
+// Retorna a aula com conteúdo e questões SEM revelar a alternativa correta.
+export async function detalheDaAula(lessonId: string, userId: string) {
+    const [aula] = await db.select().from(lessons).where(eq(lessons.id, lessonId));
+    if (!aula) {
+        throw new AppError(404, "Aula não encontrada");
+    }
+
+    // Aula não publicada é invisível para o aluno; admin pode visualizar (preview).
+    const admin = await ehAdmin(userId);
+    if (!aula.published && !admin) {
+        throw new AppError(404, "Aula não encontrada");
+    }
+
+    // Admin não é travado pelo bloqueio sequencial (pode pré-visualizar qualquer aula).
+    const estado = await estadoDaAula(userId, aula);
+    if (estado === "locked" && !admin) {
+        throw new AppError(403, "Aula bloqueada. Conclua a aula anterior.");
+    }
+
+    const qs = await db
+        .select()
+        .from(questions)
+        .where(eq(questions.lessonId, lessonId))
+        .orderBy(asc(questions.position));
+    const qIds = qs.map((q) => q.id);
+    const opts = qIds.length
+        ? await db
+              .select()
+              .from(questionOptions)
+              .where(inArray(questionOptions.questionId, qIds))
+              .orderBy(asc(questionOptions.position))
+        : [];
+
+    const questoes = qs.map((q) => ({
+        id: q.id,
+        statement: q.statement,
+        position: q.position,
+        // isCorrect deliberadamente omitido: o gabarito nunca vai para o cliente.
+        options: opts
+            .filter((o) => o.questionId === q.id)
+            .map((o) => ({ id: o.id, text: o.text, position: o.position })),
+    }));
+
+    return {
+        id: aula.id,
+        trailId: aula.trailId,
+        moduleId: aula.moduleId,
+        title: aula.title,
+        content: aula.content,
+        contentBlocks: aula.contentBlocks ?? null,
+        state: estado,
+        questions: questoes,
+    };
+}

--- a/backend/src/services/quiz.service.ts
+++ b/backend/src/services/quiz.service.ts
@@ -1,0 +1,137 @@
+import { db } from "../../db.ts";
+import {
+    lessons,
+    questions,
+    questionOptions,
+    questionAnswers,
+    lessonProgress,
+} from "../../schema.ts";
+import { eq, and, inArray } from "drizzle-orm";
+import type { z } from "zod";
+import type { submitQuizSchema } from "../schemas/trail.schemas.ts";
+import { AppError } from "../errors/AppError.ts";
+import { estadoDaAula } from "./lesson.service.ts";
+import { ehAdmin } from "./usuario.service.ts";
+import { verificarConquistas } from "./achievement.service.ts";
+
+// Mínimo de acertos para concluir a aula (e de questões para poder publicá-la).
+export const QUIZ_MIN_ACERTOS = 4;
+
+type RespostasQuiz = z.infer<typeof submitQuizSchema>;
+
+// Recebe as respostas, corrige no servidor e conclui a aula se acertar o mínimo.
+export async function corrigirQuiz(userId: string, lessonId: string, dados: RespostasQuiz) {
+    const [aula] = await db.select().from(lessons).where(eq(lessons.id, lessonId));
+    if (!aula) {
+        throw new AppError(404, "Aula não encontrada");
+    }
+
+    if (!aula.published) {
+        throw new AppError(404, "Aula não encontrada");
+    }
+
+    const estado = await estadoDaAula(userId, aula);
+    if (estado === "locked") {
+        throw new AppError(403, "Aula bloqueada. Conclua a aula anterior.");
+    }
+
+    const qs = await db
+        .select({ id: questions.id })
+        .from(questions)
+        .where(eq(questions.lessonId, lessonId));
+    const qIds = qs.map((q) => q.id);
+    if (qIds.length === 0) {
+        throw new AppError(400, "Esta aula não tem questões");
+    }
+
+    const opts = await db
+        .select()
+        .from(questionOptions)
+        .where(inArray(questionOptions.questionId, qIds));
+    const corretaPorQuestao = new Map<string, string>();
+    for (const o of opts) {
+        if (o.isCorrect) corretaPorQuestao.set(o.questionId, o.id);
+    }
+
+    let acertos = 0;
+    for (const resp of dados.answers) {
+        if (corretaPorQuestao.get(resp.questionId) === resp.optionId) acertos++;
+    }
+
+    // Registra cada resposta uma única vez. A primeira conta para o XP por questão
+    // (10 cada); como não sobrescreve, errar e refazer não rende XP depois.
+    const idsValidos = new Set(opts.map((o) => o.id));
+    const qIdSet = new Set(qIds);
+    for (const resp of dados.answers) {
+        if (!qIdSet.has(resp.questionId) || !idsValidos.has(resp.optionId)) continue;
+        await db
+            .insert(questionAnswers)
+            .values({
+                userId,
+                questionId: resp.questionId,
+                selectedOptionId: resp.optionId,
+                isCorrect: corretaPorQuestao.get(resp.questionId) === resp.optionId,
+            })
+            .onConflictDoNothing();
+    }
+
+    const total = qIds.length;
+    const passou = acertos >= QUIZ_MIN_ACERTOS;
+
+    let aulaConcluida = false;
+    if (passou) {
+        const [existe] = await db
+            .select({ id: lessonProgress.id })
+            .from(lessonProgress)
+            .where(and(eq(lessonProgress.userId, userId), eq(lessonProgress.lessonId, lessonId)));
+        if (!existe) {
+            await db.insert(lessonProgress).values({ userId, lessonId });
+        }
+        aulaConcluida = true;
+    }
+
+    await verificarConquistas(userId);
+
+    return { correct: acertos, total, passed: passou, lessonCompleted: aulaConcluida };
+}
+
+// Confere uma única resposta sem revelar o gabarito das outras questões.
+// Não grava nada: a conclusão da aula continua sendo decidida no corrigirQuiz.
+export async function conferirResposta(
+    userId: string,
+    lessonId: string,
+    questionId: string,
+    optionId: string,
+) {
+    const [aula] = await db.select().from(lessons).where(eq(lessons.id, lessonId));
+    if (!aula) {
+        throw new AppError(404, "Aula não encontrada");
+    }
+    if (!aula.published && !(await ehAdmin(userId))) {
+        throw new AppError(404, "Aula não encontrada");
+    }
+
+    const estado = await estadoDaAula(userId, aula);
+    if (estado === "locked") {
+        throw new AppError(403, "Aula bloqueada. Conclua a aula anterior.");
+    }
+
+    // A questão precisa pertencer a esta aula.
+    const [questao] = await db
+        .select({ id: questions.id })
+        .from(questions)
+        .where(and(eq(questions.id, questionId), eq(questions.lessonId, lessonId)));
+    if (!questao) {
+        throw new AppError(404, "Questão não encontrada");
+    }
+
+    const [correta] = await db
+        .select({ id: questionOptions.id })
+        .from(questionOptions)
+        .where(and(eq(questionOptions.questionId, questionId), eq(questionOptions.isCorrect, true)));
+    if (!correta) {
+        throw new AppError(500, "Questão sem gabarito");
+    }
+
+    return { correct: correta.id === optionId, correctOptionId: correta.id };
+}

--- a/backend/src/services/ranking.ts
+++ b/backend/src/services/ranking.ts
@@ -1,6 +1,7 @@
-import { sql, eq } from "drizzle-orm";
+import { sql, eq, and, count, gte } from "drizzle-orm";
 import { db } from "../../db.ts";
-import { rankingSnapshots } from "../../schema.ts";
+import { rankingSnapshots, users, lessonProgress, questionAnswers } from "../../schema.ts";
+import { streaksTodos, hojeSaoPaulo } from "./streak.ts";
 
 // Grava o snapshot do dia (1x por dia, na primeira visualização) e devolve, por
 // usuário, quantas posições subiu (positivo) ou caiu (negativo) desde o último
@@ -49,4 +50,103 @@ export async function movimentacaoRanking(
         deltas.set(p.id, antes === undefined ? 0 : antes - p.position);
     }
     return deltas;
+}
+
+// Ranking global por XP. Liga e nível usam o XP total; o leaderboard usa o
+// período (week/month/all). XP = 50 por aula concluída + 10 por questão certa.
+export async function rankingGlobal(periodo: string, currentUserId: string | undefined) {
+    const dia = 24 * 60 * 60 * 1000;
+    const desde =
+        periodo === "week"
+            ? new Date(Date.now() - 7 * dia)
+            : periodo === "month"
+              ? new Date(Date.now() - 30 * dia)
+              : null;
+
+    const [usuarios, aulasTot, acertosTot, aulasPer, acertosPer, streaks] = await Promise.all([
+        db.select({ id: users.id, name: users.name, username: users.username }).from(users),
+        db
+            .select({ userId: lessonProgress.userId, n: count() })
+            .from(lessonProgress)
+            .groupBy(lessonProgress.userId),
+        db
+            .select({ userId: questionAnswers.userId, n: count() })
+            .from(questionAnswers)
+            .where(eq(questionAnswers.isCorrect, true))
+            .groupBy(questionAnswers.userId),
+        desde
+            ? db
+                  .select({ userId: lessonProgress.userId, n: count() })
+                  .from(lessonProgress)
+                  .where(gte(lessonProgress.completedAt, desde))
+                  .groupBy(lessonProgress.userId)
+            : Promise.resolve(null),
+        desde
+            ? db
+                  .select({ userId: questionAnswers.userId, n: count() })
+                  .from(questionAnswers)
+                  .where(
+                      and(
+                          eq(questionAnswers.isCorrect, true),
+                          gte(questionAnswers.answeredAt, desde),
+                      ),
+                  )
+                  .groupBy(questionAnswers.userId)
+            : Promise.resolve(null),
+        streaksTodos(),
+    ]);
+
+    const paraMapa = (arr: { userId: string; n: number }[] | null) =>
+        new Map((arr ?? []).map((a) => [a.userId, Number(a.n)]));
+    const at = paraMapa(aulasTot),
+        acT = paraMapa(acertosTot);
+    const aP = desde ? paraMapa(aulasPer) : at;
+    const acP = desde ? paraMapa(acertosPer) : acT;
+
+    const base = usuarios.map((u) => {
+        const totalXp = (at.get(u.id) ?? 0) * 50 + (acT.get(u.id) ?? 0) * 10;
+        const periodXp = (aP.get(u.id) ?? 0) * 50 + (acP.get(u.id) ?? 0) * 10;
+        return {
+            id: u.id,
+            name: u.name,
+            username: u.username,
+            totalXp,
+            periodXp,
+            level: Math.floor(totalXp / 500) + 1,
+            streak: streaks.get(u.id) ?? 0,
+            you: u.id === currentUserId,
+        };
+    });
+    const ordenados = [...base]
+        .sort((a, b) => b.periodXp - a.periodXp)
+        .map((u, i) => ({ ...u, position: i + 1 }));
+    // Movimentação é calculada sobre o ranking geral (XP total).
+    const ordemGeral = [...base]
+        .sort((a, b) => b.totalXp - a.totalXp)
+        .map((u, i) => ({ id: u.id, position: i + 1 }));
+    const deltas = await movimentacaoRanking(hojeSaoPaulo(), ordemGeral);
+
+    const meu = ordenados.find((u) => u.you);
+    const me = meu
+        ? {
+              position: meu.position,
+              username: meu.username,
+              xp: meu.periodXp,
+              totalXp: meu.totalXp,
+              level: meu.level,
+              streak: meu.streak,
+              delta: deltas.get(meu.id) ?? 0,
+          }
+        : null;
+    const rows = ordenados.slice(0, 20).map((u) => ({
+        position: u.position,
+        name: u.name,
+        username: u.username,
+        xp: u.periodXp,
+        level: u.level,
+        streak: u.streak,
+        delta: deltas.get(u.id) ?? 0,
+        you: u.you,
+    }));
+    return { me, rows };
 }

--- a/backend/src/services/stats.service.ts
+++ b/backend/src/services/stats.service.ts
@@ -1,0 +1,22 @@
+import { db } from "../../db.ts";
+import { lessonProgress, questionAnswers } from "../../schema.ts";
+import { eq, and, count } from "drizzle-orm";
+
+// Estatísticas base do usuário. XP = 50 por aula concluída + 10 por questão certa.
+export async function calcularEstatisticas(userId: string) {
+    const [aulas] = await db
+        .select({ n: count() })
+        .from(lessonProgress)
+        .where(eq(lessonProgress.userId, userId));
+    const [acertos] = await db
+        .select({ n: count() })
+        .from(questionAnswers)
+        .where(and(eq(questionAnswers.userId, userId), eq(questionAnswers.isCorrect, true)));
+    const lessonsCompleted = Number(aulas?.n ?? 0);
+    const questionsCorrect = Number(acertos?.n ?? 0);
+    return {
+        xp: lessonsCompleted * 50 + questionsCorrect * 10,
+        lessonsCompleted,
+        questionsCorrect,
+    };
+}

--- a/backend/src/services/tag.service.ts
+++ b/backend/src/services/tag.service.ts
@@ -1,0 +1,36 @@
+import { db } from "../../db.ts";
+import { tags, trailTags } from "../../schema.ts";
+import { eq, asc } from "drizzle-orm";
+import { AppError } from "../errors/AppError.ts";
+
+export async function listarTags() {
+    return db.select().from(tags).orderBy(asc(tags.name));
+}
+
+export async function criarTag(nome: string) {
+    const [existe] = await db.select({ id: tags.id }).from(tags).where(eq(tags.name, nome));
+    if (existe) {
+        throw new AppError(409, "Já existe uma tag com esse nome");
+    }
+    const [tag] = await db.insert(tags).values({ name: nome }).returning();
+    return tag;
+}
+
+export async function atualizarTag(id: string, nome: string) {
+    const [conflito] = await db.select({ id: tags.id }).from(tags).where(eq(tags.name, nome));
+    if (conflito && conflito.id !== id) {
+        throw new AppError(409, "Já existe uma tag com esse nome");
+    }
+    const [tag] = await db.update(tags).set({ name: nome }).where(eq(tags.id, id)).returning();
+    if (!tag) {
+        throw new AppError(404, "Tag não encontrada");
+    }
+    return tag;
+}
+
+export async function excluirTag(id: string) {
+    await db.transaction(async (tx) => {
+        await tx.delete(trailTags).where(eq(trailTags.tagId, id));
+        await tx.delete(tags).where(eq(tags.id, id));
+    });
+}

--- a/backend/src/services/trail.service.ts
+++ b/backend/src/services/trail.service.ts
@@ -1,0 +1,251 @@
+import { db } from "../../db.ts";
+import {
+    trails,
+    trailTags,
+    tags,
+    modules,
+    lessons,
+    lessonProgress,
+    questions,
+    questionOptions,
+    questionAnswers,
+} from "../../schema.ts";
+import { eq, asc, count, inArray } from "drizzle-orm";
+import type { z } from "zod";
+import type { createTrailSchema, updateTrailSchema } from "../schemas/trail.schemas.ts";
+import { AppError } from "../errors/AppError.ts";
+import { ehAdmin } from "./usuario.service.ts";
+
+type DadosCriarTrilha = z.infer<typeof createTrailSchema>;
+type DadosAtualizarTrilha = z.infer<typeof updateTrailSchema>;
+
+export async function criarTrilha(dados: DadosCriarTrilha) {
+    const [trilha] = await db
+        .insert(trails)
+        .values({
+            name: dados.name,
+            trailLevel: dados.level,
+            description: dados.description,
+        })
+        .returning();
+    if (dados.tagIds?.length) {
+        await db
+            .insert(trailTags)
+            .values(dados.tagIds.map((tagId) => ({ trailId: trilha.id, tagId })))
+            .onConflictDoNothing();
+    }
+    return trilha;
+}
+
+// Edita os dados da trilha (admin).
+export async function atualizarTrilha(trailId: string, dados: DadosAtualizarTrilha) {
+    const sets: {
+        name?: string;
+        trailLevel?: "iniciante" | "intermediario" | "avancado";
+        description?: string;
+    } = {};
+    if (dados.name !== undefined) sets.name = dados.name;
+    if (dados.level !== undefined) sets.trailLevel = dados.level;
+    if (dados.description !== undefined) sets.description = dados.description;
+    if (Object.keys(sets).length === 0) {
+        throw new AppError(400, "Nada para atualizar");
+    }
+
+    const [trilha] = await db.update(trails).set(sets).where(eq(trails.id, trailId)).returning({
+        id: trails.id,
+        name: trails.name,
+        trailLevel: trails.trailLevel,
+        description: trails.description,
+    });
+    if (!trilha) {
+        throw new AppError(404, "Trilha não encontrada");
+    }
+
+    if (dados.tagIds !== undefined) {
+        await db.delete(trailTags).where(eq(trailTags.trailId, trailId));
+        if (dados.tagIds.length) {
+            await db
+                .insert(trailTags)
+                .values(dados.tagIds.map((tagId) => ({ trailId, tagId })))
+                .onConflictDoNothing();
+        }
+    }
+    return trilha;
+}
+
+// Exclui a trilha inteira (módulos, aulas, questões e progresso).
+export async function excluirTrilha(trailId: string) {
+    const [trilha] = await db
+        .select({ id: trails.id })
+        .from(trails)
+        .where(eq(trails.id, trailId));
+    if (!trilha) {
+        throw new AppError(404, "Trilha não encontrada");
+    }
+
+    await db.transaction(async (tx) => {
+        const ls = await tx
+            .select({ id: lessons.id })
+            .from(lessons)
+            .where(eq(lessons.trailId, trailId));
+        const lessonIds = ls.map((l) => l.id);
+        if (lessonIds.length) {
+            const qs = await tx
+                .select({ id: questions.id })
+                .from(questions)
+                .where(inArray(questions.lessonId, lessonIds));
+            const qIds = qs.map((q) => q.id);
+            if (qIds.length) {
+                await tx.delete(questionAnswers).where(inArray(questionAnswers.questionId, qIds));
+                await tx.delete(questionOptions).where(inArray(questionOptions.questionId, qIds));
+                await tx.delete(questions).where(inArray(questions.id, qIds));
+            }
+            await tx.delete(lessonProgress).where(inArray(lessonProgress.lessonId, lessonIds));
+            await tx.delete(lessons).where(inArray(lessons.id, lessonIds));
+        }
+        await tx.delete(modules).where(eq(modules.trailId, trailId));
+        await tx.delete(trailTags).where(eq(trailTags.trailId, trailId));
+        await tx.delete(trails).where(eq(trails.id, trailId));
+    });
+}
+
+export async function listarTrilhas() {
+    const lista = await db
+        .select({
+            id: trails.id,
+            name: trails.name,
+            trailLevel: trails.trailLevel,
+            description: trails.description,
+            totalLessons: count(lessons.id),
+        })
+        .from(trails)
+        .leftJoin(lessons, eq(lessons.trailId, trails.id))
+        .groupBy(trails.id);
+
+    const vinculos = await db
+        .select({ trailId: trailTags.trailId, id: tags.id, name: tags.name })
+        .from(trailTags)
+        .innerJoin(tags, eq(tags.id, trailTags.tagId));
+    const tagsPorTrilha = new Map<string, { id: string; name: string }[]>();
+    for (const v of vinculos) {
+        const arr = tagsPorTrilha.get(v.trailId) ?? [];
+        arr.push({ id: v.id, name: v.name });
+        tagsPorTrilha.set(v.trailId, arr);
+    }
+    return lista.map((t) => ({ ...t, tags: tagsPorTrilha.get(t.id) ?? [] }));
+}
+
+// Trilhas em que o usuário já tem progresso, com percentual de conclusão.
+export async function trilhasDoUsuario(userId: string) {
+    const totais = await db
+        .select({ trailId: lessons.trailId, total: count(lessons.id) })
+        .from(lessons)
+        .groupBy(lessons.trailId);
+    const totalPorTrilha = new Map(totais.map((t) => [t.trailId, Number(t.total)]));
+
+    const feitas = await db
+        .select({ trailId: lessons.trailId, feitas: count(lessonProgress.id) })
+        .from(lessonProgress)
+        .innerJoin(lessons, eq(lessons.id, lessonProgress.lessonId))
+        .where(eq(lessonProgress.userId, userId))
+        .groupBy(lessons.trailId);
+
+    if (feitas.length === 0) {
+        return [];
+    }
+
+    const todasTrilhas = await db.select().from(trails);
+    const trilhaPorId = new Map(todasTrilhas.map((t) => [t.id, t]));
+
+    return feitas
+        .filter((f) => trilhaPorId.has(f.trailId))
+        .map((f) => {
+            const trilha = trilhaPorId.get(f.trailId)!;
+            const total = totalPorTrilha.get(f.trailId) ?? 0;
+            const concluidas = Number(f.feitas);
+            const pct = total > 0 ? Math.round((concluidas / total) * 100) : 0;
+            return {
+                id: trilha.id,
+                name: trilha.name,
+                trailLevel: trilha.trailLevel,
+                description: trilha.description,
+                totalLessons: total,
+                completedLessons: concluidas,
+                progress: pct,
+            };
+        });
+}
+
+// Retorna a trilha com módulos e aulas, cada aula com estado para o usuário.
+// Estado sequencial na trilha toda: done | current | locked.
+export async function detalheDaTrilha(trailId: string, userId: string) {
+    const [trilha] = await db.select().from(trails).where(eq(trails.id, trailId));
+    if (!trilha) {
+        throw new AppError(404, "Trilha não encontrada");
+    }
+
+    const admin = await ehAdmin(userId);
+
+    const mods = await db
+        .select()
+        .from(modules)
+        .where(eq(modules.trailId, trailId))
+        .orderBy(asc(modules.position));
+
+    // Aluno vê só aulas publicadas; admin vê todas (para gerenciar).
+    const todasAulas = await db
+        .select()
+        .from(lessons)
+        .where(eq(lessons.trailId, trailId))
+        .orderBy(asc(lessons.position));
+    const aulas = admin ? todasAulas : todasAulas.filter((a) => a.published);
+
+    const concluidas = new Set(
+        (
+            await db
+                .select({ lessonId: lessonProgress.lessonId })
+                .from(lessonProgress)
+                .where(eq(lessonProgress.userId, userId))
+        ).map((p) => p.lessonId),
+    );
+
+    // O estado segue a sequência das aulas PUBLICADAS. Rascunho (que só o admin vê)
+    // não entra na sequência: senão apareceria como "current" e o getLesson, que
+    // calcula o estado só com publicadas, o trataria como bloqueado (estados divergentes).
+    const ordenadas = mods.flatMap((m) =>
+        todasAulas
+            .filter((a) => a.moduleId === m.id && a.published)
+            .sort((a, b) => a.position - b.position),
+    );
+
+    const estadoPorAula = new Map<string, string>();
+    let achouCurrent = false;
+    for (const a of ordenadas) {
+        if (concluidas.has(a.id)) {
+            estadoPorAula.set(a.id, "done");
+        } else if (!achouCurrent) {
+            estadoPorAula.set(a.id, "current");
+            achouCurrent = true;
+        } else {
+            estadoPorAula.set(a.id, "locked");
+        }
+    }
+
+    const modulosComAulas = mods.map((m) => ({
+        id: m.id,
+        title: m.title,
+        position: m.position,
+        lessons: aulas
+            .filter((a) => a.moduleId === m.id)
+            .sort((a, b) => a.position - b.position)
+            .map((a) => ({
+                id: a.id,
+                title: a.title,
+                position: a.position,
+                published: a.published,
+                state: estadoPorAula.get(a.id) ?? "locked",
+            })),
+    }));
+
+    return { ...trilha, modules: modulosComAulas };
+}

--- a/backend/src/services/usuario.service.ts
+++ b/backend/src/services/usuario.service.ts
@@ -1,0 +1,9 @@
+import { db } from "../../db.ts";
+import { users } from "../../schema.ts";
+import { eq } from "drizzle-orm";
+
+// Indica se o usuário tem papel de administrador.
+export async function ehAdmin(userId: string): Promise<boolean> {
+    const [u] = await db.select({ role: users.role }).from(users).where(eq(users.id, userId));
+    return u?.role === "admin";
+}


### PR DESCRIPTION
Aplica a camada de services (opção B) tirando a lógica de dados de dentro do TrailController, que estava com mais de 1400 linhas misturando vários domínios.

Abordagem, de menor risco:
- Nova classe AppError(status, mensagem); o middleware de erro passa a renderizar a mensagem dela. Assim os services sinalizam 404/409 sem depender de req/res e a API mantém os mesmos status e corpo.
- Os controllers ficam finos: validam a requisição (Zod) e respondem. A lógica vai para services por domínio.
- As rotas não mudam (os controllers continuam exportando os mesmos nomes).

Feito até aqui:
- tags e linguagens (tag.service, language.service)
- conquistas e estatísticas (achievement.service, stats.service)

Em sequência, na mesma branch: trilhas, estúdio (módulos/aulas/questões) e quiz/ranking.

Os 28 testes de integração passam a cada etapa e o comportamento da API foi preservado.