### PR TITLE
fix: corrige deploy que não recriava os containers em produção

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -94,7 +94,7 @@ jobs:
             echo "==> Subindo o banco"
             docker compose -f docker-compose.prod.yml up -d db
             echo "==> Aplicando migrations (antes de subir o app novo)"
-            docker compose -f docker-compose.prod.yml run --rm backend npx drizzle-kit migrate
+            docker compose -f docker-compose.prod.yml run --rm -T backend npx drizzle-kit migrate </dev/null
             echo "==> Subindo backend e proxy (forcando recriacao p/ usar a imagem nova)"
             docker compose -f docker-compose.prod.yml up -d --force-recreate --no-deps backend caddy
             echo "==> Limpando imagens antigas"


### PR DESCRIPTION
## Problema
O deploy passava verde no CI, mas a VPS nunca rodava as imagens novas. Confirmado na VPS: containers com 37h de vida enquanto as imagens `:latest` tinham minutos.

## Causa
O job manda o script pra VPS com `ssh ... bash -s <<'DEPLOY'` (o script vem pelo stdin). A linha de migration `docker compose run --rm backend ...` lê o stdin e consome o resto do script, então o `up -d --force-recreate` e o `docker image prune` nunca rodam. A migration termina, o bash chega no fim do stdin e sai com 0, deixando o job verde com os containers antigos.

No log do deploy isso fica claro: a saída termina exatamente em `migrations applied successfully!`, sem nenhuma linha de recriação depois.

## Correção
Adiciona `-T` (sem TTY) e `</dev/null` (isola o stdin) na migration, o mesmo padrão que já usamos nos testes de integração. Assim a migration não come o script e a recriação dos containers volta a rodar.

## Efeito
Quando esta correção chegar na main, o deploy já recria os containers e conserta a produção sozinho (build + migrate + force-recreate rodando de verdade).