### PR TITLE
deploy: leva a correção do pipeline para a main (recria os containers em prod)

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -94,7 +94,7 @@ jobs:
             echo "==> Subindo o banco"
             docker compose -f docker-compose.prod.yml up -d db
             echo "==> Aplicando migrations (antes de subir o app novo)"
-            docker compose -f docker-compose.prod.yml run --rm backend npx drizzle-kit migrate
+            docker compose -f docker-compose.prod.yml run --rm -T backend npx drizzle-kit migrate </dev/null
             echo "==> Subindo backend e proxy (forcando recriacao p/ usar a imagem nova)"
             docker compose -f docker-compose.prod.yml up -d --force-recreate --no-deps backend caddy
             echo "==> Limpando imagens antigas"


### PR DESCRIPTION
Sobe para a main a correção do deploy (#28). Hoje os deploys atualizam o git e reconstroem as imagens, mas a migration via `docker compose run` consome o stdin do heredoc e o `up --force-recreate` nunca roda, então os containers em produção ficam parados na imagem antiga (confirmado: containers com 37h, backend sem as rotas `/api/ranking` e `/api/me/streak`, que respondem 404).

Com o `-T </dev/null` na migration, ao mergear este PR o deploy roda inteiro e recria os containers com o código atual, fazendo as páginas de ranking e trilhas voltarem a funcionar.