### PR TITLE
chore: dependabot mirando a develop e actions atualizadas

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,15 +5,18 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    target-branch: "develop"
 
   - package-ecosystem: "npm"
     directory: "/frontend"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    target-branch: "develop"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    target-branch: "develop"

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -38,8 +38,8 @@ jobs:
       run:
         working-directory: backend
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
       - name: Instalar dependências
@@ -59,8 +59,8 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
       - name: Instalar dependências


### PR DESCRIPTION
Dois ajustes ligados aos PRs do Dependabot que entraram direto na main (#15 e #16), furando o fluxo develop.

- **dependabot.yml**: adiciona `target-branch: develop` nas três entradas (npm backend, npm frontend, github-actions). Assim os próximos PRs de dependência miram a develop e seguem develop→main. Observação: o Dependabot lê a config sempre da branch padrão (main), então isso só passa a valer quando este PR chegar na main.
- **pipeline.yml**: sobe `actions/checkout` para v7 e `actions/setup-node` para v6 na develop, que estava atrás da main por causa daqueles bumps diretos. Assim as duas branches convergem.

Sem mudança de comportamento de build/test, só versão das actions e config do bot.