### PR TITLE
feat: nível real do usuário em todas as telas

### DIFF
--- a/backend/src/controllers/UserController.ts
+++ b/backend/src/controllers/UserController.ts
@@ -8,6 +8,7 @@ import { eq } from "drizzle-orm";
 import { updateMeSchema } from "../schemas/auth.schema.ts";
 import { UPLOADS_DIR, AVATARS_DIR, COVERS_DIR } from "../config/paths.ts";
 import { calcularStreak, diasAtivosDoUsuario } from "../services/streak.ts";
+import { calcularEstatisticas } from "../services/stats.service.ts";
 
 const publicUserColumns = {
     id: users.id,
@@ -44,14 +45,23 @@ export const getMe = async (req: Request, res: Response) => {
         return res.status(404).json({ erro: "Usuário não encontrado" });
     }
 
+    // streak e nível são derivados: se falharem, logamos e seguimos com o fallback
+    // em vez de quebrar o perfil inteiro.
     let streak = 0;
     try {
         streak = calcularStreak(await diasAtivosDoUsuario(userId));
-    } catch {
-        // streak é derivado; se falhar, não quebra o perfil
+    } catch (e) {
+        console.error("getMe: falha ao calcular streak", e);
     }
 
-    res.json({ ...user, streak });
+    let level = 1;
+    try {
+        level = (await calcularEstatisticas(userId)).level;
+    } catch (e) {
+        console.error("getMe: falha ao calcular nível", e);
+    }
+
+    res.json({ ...user, streak, level });
 };
 
 // Atualiza o próprio perfil (campos editáveis). Não toca em campos sensíveis.

--- a/backend/src/services/ranking.ts
+++ b/backend/src/services/ranking.ts
@@ -2,6 +2,7 @@ import { sql, eq, and, count, gte } from "drizzle-orm";
 import { db } from "../../db.ts";
 import { rankingSnapshots, users, lessonProgress, questionAnswers } from "../../schema.ts";
 import { streaksTodos, hojeSaoPaulo } from "./streak.ts";
+import { nivelPorXp } from "./stats.service.ts";
 
 // Grava o snapshot do dia (1x por dia, na primeira visualização) e devolve, por
 // usuário, quantas posições subiu (positivo) ou caiu (negativo) desde o último
@@ -112,7 +113,7 @@ export async function rankingGlobal(periodo: string, currentUserId: string | und
             username: u.username,
             totalXp,
             periodXp,
-            level: Math.floor(totalXp / 500) + 1,
+            level: nivelPorXp(totalXp),
             streak: streaks.get(u.id) ?? 0,
             you: u.id === currentUserId,
         };

--- a/backend/src/services/stats.service.ts
+++ b/backend/src/services/stats.service.ts
@@ -2,6 +2,9 @@ import { db } from "../../db.ts";
 import { lessonProgress, questionAnswers } from "../../schema.ts";
 import { eq, and, count } from "drizzle-orm";
 
+// Nível derivado do XP. Fonte única da fórmula (usada aqui, no /me e no ranking).
+export const nivelPorXp = (xp: number) => Math.floor(xp / 500) + 1;
+
 // Estatísticas base do usuário. XP = 50 por aula concluída + 10 por questão certa.
 export async function calcularEstatisticas(userId: string) {
     const [aulas] = await db
@@ -14,8 +17,10 @@ export async function calcularEstatisticas(userId: string) {
         .where(and(eq(questionAnswers.userId, userId), eq(questionAnswers.isCorrect, true)));
     const lessonsCompleted = Number(aulas?.n ?? 0);
     const questionsCorrect = Number(acertos?.n ?? 0);
+    const xp = lessonsCompleted * 50 + questionsCorrect * 10;
     return {
-        xp: lessonsCompleted * 50 + questionsCorrect * 10,
+        xp,
+        level: nivelPorXp(xp),
         lessonsCompleted,
         questionsCorrect,
     };

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -9,6 +9,7 @@ interface User {
   phone: string;
   role?: 'user' | 'admin' | 'moderator';
   streak?: number;
+  level?: number;
 }
 
 interface AuthContextData {

--- a/frontend/src/pages/Aula/index.tsx
+++ b/frontend/src/pages/Aula/index.tsx
@@ -119,7 +119,7 @@ export function Aula() {
           <ThemeToggle inline />
           <UserMenu
             initials={getInitials(displayName)}
-            level={user.level}
+            level={authUser?.level ?? 1}
             name={displayName}
             email={authUser?.email}
           />

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -134,7 +134,7 @@ export function Home() {
           <ThemeToggle inline />
           <UserMenu
             initials={initials}
-            level={user.level}
+            level={authUser?.level ?? 1}
             name={displayName}
             email={authUser?.email}
           />

--- a/frontend/src/pages/Perfil/index.tsx
+++ b/frontend/src/pages/Perfil/index.tsx
@@ -95,7 +95,7 @@ function lerArquivo(file: File): Promise<string> {
 export function Perfil() {
   const { user: authUser } = useAuth();
   const [perfil, setPerfil] = useState<PerfilData | null>(null);
-  const [xp, setXp] = useState({ xp: 0, lessonsCompleted: 0, questionsCorrect: 0 });
+  const [xp, setXp] = useState({ xp: 0, level: 1, lessonsCompleted: 0, questionsCorrect: 0 });
   const [carregando, setCarregando] = useState(true);
   const [linguagens, setLinguagens] = useState<string[]>([]);
   const [conquistas, setConquistas] = useState<MinhaConquista[]>([]);
@@ -234,7 +234,7 @@ export function Perfil() {
 
   const displayName = perfil?.name ?? authUser?.name ?? homeUser.name;
   const initials = getInitials(displayName);
-  const nivel = Math.floor(xp.xp / 500) + 1;
+  const nivel = xp.level;
   const langsVisiveis = editando ? draft.languages : (perfil?.languages ?? []);
   const langsDisponiveis = linguagens.filter((l) => !draft.languages.includes(l));
   const fotoUrl = urlImagem(perfil?.avatarUrl);

--- a/frontend/src/pages/Trilhas/index.tsx
+++ b/frontend/src/pages/Trilhas/index.tsx
@@ -145,7 +145,7 @@ export function Trilhas() {
           <ThemeToggle inline />
           <UserMenu
             initials={initials}
-            level={user.level}
+            level={authUser?.level ?? 1}
             name={displayName}
             email={authUser?.email}
           />

--- a/frontend/src/services/trails.ts
+++ b/frontend/src/services/trails.ts
@@ -264,6 +264,7 @@ export async function excluirTrilha(id: string) {
 
 export interface XpStats {
   xp: number;
+  level: number;
   lessonsCompleted: number;
   questionsCorrect: number;
 }


### PR DESCRIPTION
O nível aparecia fixo (Lv7) vindo do mock em Home, Trilhas e Aula, enquanto Perfil e Ranking já mostravam o real (derivado do XP). Agora:

- O `/me` passa a retornar `level` (derivado do XP), o `AuthContext` carrega e Home/Trilhas/Aula usam `authUser.level`.
- A fórmula `floor(xp/500)+1` foi centralizada no helper `nivelPorXp` (stats.service), usada pelo `/me`, pelas estatísticas e pelo ranking, pra não divergir.
- O Perfil passa a usar o `level` que vem do `/me/xp`, sem recalcular.
- Os catches derivados (streak e nível) no `getMe` agora logam o erro em vez de engolir.

28 testes de integração passam, tsc/lint do backend limpos e build do front OK.