### PR TITLE
feat: validação por campo no registro e rate limiter separado por endpoint

### DIFF
--- a/backend/src/middlewares/rateLimit.ts
+++ b/backend/src/middlewares/rateLimit.ts
@@ -1,10 +1,36 @@
 import rateLimit from "express-rate-limit";
 
-export const loginLimiter = rateLimit({
-    windowMs: 15 * 60 * 1000, //15 minutos em milissegundos
-    max: 10,
-    message: { erro: "Muitas tentativas. Tente novamente mais tarde." },
-    standardHeaders: true, // Envia headers RateLimit-* (É o padrão moderno de hoje)
-    legacyHeaders: false, // Não envia os headers antigos
-    skip: () => process.env.NODE_ENV === "test", // não limita durante os testes
-});
+// Cada endpoint sensível tem o seu próprio contador (instância separada), para um
+// não consumir o limite do outro. Antes login e cadastro dividiam o mesmo limiter,
+// então errar o cadastro algumas vezes travava também o login.
+const criarLimiter = (max: number, mensagem: string) =>
+    rateLimit({
+        windowMs: 15 * 60 * 1000, // 15 minutos
+        max,
+        message: { erro: mensagem },
+        standardHeaders: true, // headers RateLimit-* (padrão moderno)
+        legacyHeaders: false,
+        skip: () => process.env.NODE_ENV === "test", // não limita durante os testes
+    });
+
+export const loginLimiter = criarLimiter(
+    10,
+    "Muitas tentativas de login. Tente novamente em alguns minutos.",
+);
+
+export const registerLimiter = criarLimiter(
+    10,
+    "Muitas tentativas de cadastro. Tente novamente em alguns minutos.",
+);
+
+// Refresh é automático (rotação de token); precisa ser bem mais folgado para
+// não deslogar quem está usando o app normalmente.
+export const refreshLimiter = criarLimiter(
+    60,
+    "Muitas requisições. Tente novamente em alguns minutos.",
+);
+
+export const verifyEmailLimiter = criarLimiter(
+    20,
+    "Muitas tentativas. Tente novamente em alguns minutos.",
+);

--- a/backend/src/routes/auth.routes.ts
+++ b/backend/src/routes/auth.routes.ts
@@ -1,13 +1,18 @@
 import { Router } from "express";
 import { login, refresh, register, logout, verifyEmail } from "../controllers/AuthController.ts";
-import { loginLimiter } from "../middlewares/rateLimit.ts";
+import {
+    loginLimiter,
+    registerLimiter,
+    refreshLimiter,
+    verifyEmailLimiter,
+} from "../middlewares/rateLimit.ts";
 
 const router = Router();
 
 router.post("/login", loginLimiter, login);
-router.post("/register", loginLimiter, register);
-router.post("/refresh", loginLimiter, refresh);
-router.post("/logout", loginLimiter, logout);
-router.post("/verify-email", loginLimiter, verifyEmail);
+router.post("/register", registerLimiter, register);
+router.post("/refresh", refreshLimiter, refresh);
+router.post("/logout", refreshLimiter, logout);
+router.post("/verify-email", verifyEmailLimiter, verifyEmail);
 
 export default router;

--- a/backend/src/schemas/auth.schema.test.ts
+++ b/backend/src/schemas/auth.schema.test.ts
@@ -6,7 +6,7 @@ const usuarioValido = {
     name: "Maria Silva",
     username: "maria_silva",
     email: "maria@email.com",
-    password: "senhaforte123",
+    password: "Senhaforte123!",
     birthDate: "1990-01-01",
     gender: "feminino",
     phone: "(11) 98888-7777",
@@ -58,9 +58,24 @@ describe("registerSchema", () => {
         assert.equal(r.success, false);
     });
 
-    test("aceita senha no limite de 12 caracteres com número", () => {
-        const r = registerSchema.safeParse({ ...usuarioValido, password: "abcdefghij12" });
+    test("aceita senha no limite de 12 caracteres com todos os requisitos", () => {
+        const r = registerSchema.safeParse({ ...usuarioValido, password: "Abcdefgh123!" });
         assert.equal(r.success, true);
+    });
+
+    test("rejeita senha sem maiúscula", () => {
+        const r = registerSchema.safeParse({ ...usuarioValido, password: "senhaforte123!" });
+        assert.equal(r.success, false);
+    });
+
+    test("rejeita senha sem minúscula", () => {
+        const r = registerSchema.safeParse({ ...usuarioValido, password: "SENHAFORTE123!" });
+        assert.equal(r.success, false);
+    });
+
+    test("rejeita senha sem caractere especial", () => {
+        const r = registerSchema.safeParse({ ...usuarioValido, password: "Senhaforte123" });
+        assert.equal(r.success, false);
     });
 
     test("rejeita birthDate em formato errado", () => {

--- a/backend/src/schemas/auth.schema.ts
+++ b/backend/src/schemas/auth.schema.ts
@@ -13,7 +13,10 @@ export const registerSchema = z.object({
         .string()
         .min(12, "Senha deve ter ao menos 12 caracteres")
         .max(72)
-        .refine((s) => /[0-9]/.test(s), "A senha deve conter pelo menos um número"),
+        .refine((s) => /[a-z]/.test(s), "A senha deve conter uma letra minúscula")
+        .refine((s) => /[A-Z]/.test(s), "A senha deve conter uma letra maiúscula")
+        .refine((s) => /[0-9]/.test(s), "A senha deve conter pelo menos um número")
+        .refine((s) => /[^A-Za-z0-9]/.test(s), "A senha deve conter um caractere especial"),
     birthDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Data deve ser AAAA-MM-DD"),
     gender: z.string(),
     phone: z.string(),

--- a/backend/tests/auth.test.ts
+++ b/backend/tests/auth.test.ts
@@ -10,7 +10,7 @@ const novoUsuario = (over: Record<string, unknown> = {}) => ({
     name: "Maria Silva",
     email: `maria_${++seq}_${Math.round(performance.now() * 1000)}@email.com`,
     username: `maria_${seq}`,
-    password: "senhaforte123",
+    password: "Senhaforte123!",
     birthDate: "1990-01-01",
     gender: "feminino",
     phone: "(11) 98888-7777",

--- a/backend/tests/trail.test.ts
+++ b/backend/tests/trail.test.ts
@@ -11,7 +11,7 @@ const novoUsuario = (over: Record<string, unknown> = {}) => ({
     name: "Aluno Teste",
     email: `aluno_${++seq}_${Math.round(performance.now() * 1000)}@email.com`,
     username: `aluno_${seq}`,
-    password: "senhaforte123",
+    password: "Senhaforte123!",
     birthDate: "1990-01-01",
     gender: "outro",
     phone: "11999998888",

--- a/frontend/src/components/FormField.tsx
+++ b/frontend/src/components/FormField.tsx
@@ -11,6 +11,10 @@ interface FormFieldProps {
   required?: boolean;
   /** Conteúdo opcional à direita do label (ex.: link "Esqueceu a senha?"). */
   labelAddon?: ReactNode;
+  /** Mensagem de erro do campo; quando presente, destaca o input em vermelho. */
+  error?: string;
+  /** Conteúdo extra abaixo do input (ex.: checklist de requisitos da senha). */
+  children?: ReactNode;
 }
 
 export function FormField({
@@ -22,6 +26,8 @@ export function FormField({
   autoComplete,
   required = false,
   labelAddon,
+  error,
+  children,
 }: FormFieldProps) {
   const [mostrarSenha, setMostrarSenha] = useState(false);
   const ehSenha = type === 'password';
@@ -40,13 +46,14 @@ export function FormField({
       )}
       <div className={ehSenha ? 'input-wrap' : undefined}>
         <input
-          className="input"
+          className={`input${error ? ' input--error' : ''}`}
           type={tipoInput}
           placeholder={placeholder}
           value={value}
           onChange={onChange}
           autoComplete={autoComplete}
           required={required}
+          aria-invalid={error ? true : undefined}
         />
         {ehSenha && (
           <button
@@ -61,6 +68,8 @@ export function FormField({
           </button>
         )}
       </div>
+      {children}
+      {error && <span className="field__error">{error}</span>}
     </label>
   );
 }

--- a/frontend/src/components/SelectField.tsx
+++ b/frontend/src/components/SelectField.tsx
@@ -12,6 +12,7 @@ interface SelectFieldProps {
   options: Option[];
   placeholder?: string;
   required?: boolean;
+  error?: string;
 }
 
 export function SelectField({
@@ -21,11 +22,18 @@ export function SelectField({
   options,
   placeholder,
   required = false,
+  error,
 }: SelectFieldProps) {
   return (
     <label className="field">
       <span className="field__label">{label}</span>
-      <select className="input" value={value} onChange={onChange} required={required}>
+      <select
+        className={`input${error ? ' input--error' : ''}`}
+        value={value}
+        onChange={onChange}
+        required={required}
+        aria-invalid={error ? true : undefined}
+      >
         {placeholder && (
           <option value="" disabled>
             {placeholder}
@@ -37,6 +45,7 @@ export function SelectField({
           </option>
         ))}
       </select>
+      {error && <span className="field__error">{error}</span>}
     </label>
   );
 }

--- a/frontend/src/pages/Register/index.tsx
+++ b/frontend/src/pages/Register/index.tsx
@@ -28,7 +28,14 @@ type Erros = Record<string, string>;
 
 // Requisitos da senha (espelham o registerSchema do backend, que é a fonte de verdade).
 const SENHA_MIN = 12;
-const temNumero = (s: string) => /[0-9]/.test(s);
+const REGRAS_SENHA: { ok: (s: string) => boolean; label: string }[] = [
+  { ok: (s) => s.length >= SENHA_MIN, label: `Ao menos ${SENHA_MIN} caracteres` },
+  { ok: (s) => /[A-Z]/.test(s), label: 'Uma letra maiúscula' },
+  { ok: (s) => /[a-z]/.test(s), label: 'Uma letra minúscula' },
+  { ok: (s) => /[0-9]/.test(s), label: 'Um número' },
+  { ok: (s) => /[^A-Za-z0-9]/.test(s), label: 'Um caractere especial' },
+];
+const senhaValida = (s: string) => REGRAS_SENHA.every((r) => r.ok(s));
 
 export function Register() {
   const navigate = useNavigate();
@@ -59,8 +66,7 @@ export function Register() {
 
     if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim())) e.email = 'Email inválido';
 
-    if (password.length < SENHA_MIN) e.password = `Senha deve ter ao menos ${SENHA_MIN} caracteres`;
-    else if (!temNumero(password)) e.password = 'A senha deve conter pelo menos um número';
+    if (!senhaValida(password)) e.password = 'A senha não cumpre todos os requisitos';
 
     if (!/^\d{4}-\d{2}-\d{2}$/.test(birthDate)) e.birthDate = 'Informe sua data de nascimento';
     if (!gender) e.gender = 'Selecione o gênero';
@@ -98,10 +104,7 @@ export function Register() {
     }
   }
 
-  const reqsSenha = [
-    { ok: password.length >= SENHA_MIN, label: `Ao menos ${SENHA_MIN} caracteres` },
-    { ok: temNumero(password), label: 'Pelo menos um número' },
-  ];
+  const reqsSenha = REGRAS_SENHA.map((r) => ({ ok: r.ok(password), label: r.label }));
 
   const brand = (
     <AuthBrand glow="register">

--- a/frontend/src/pages/Register/index.tsx
+++ b/frontend/src/pages/Register/index.tsx
@@ -24,6 +24,12 @@ const GENDER_OPTIONS = [
   { value: 'prefiro_nao_dizer', label: 'Prefiro não dizer' },
 ];
 
+type Erros = Record<string, string>;
+
+// Requisitos da senha (espelham o registerSchema do backend, que é a fonte de verdade).
+const SENHA_MIN = 12;
+const temNumero = (s: string) => /[0-9]/.test(s);
+
 export function Register() {
   const navigate = useNavigate();
 
@@ -35,11 +41,40 @@ export function Register() {
   const [gender, setGender] = useState('');
   const [phone, setPhone] = useState('');
   const [error, setError] = useState('');
+  const [errors, setErrors] = useState<Erros>({});
   const [submitting, setSubmitting] = useState(false);
+
+  const limparErro = (campo: string) =>
+    setErrors((prev) => (prev[campo] ? { ...prev, [campo]: '' } : prev));
+
+  // Validação no cliente para dar feedback por campo; o backend valida de novo.
+  function validar(): Erros {
+    const e: Erros = {};
+    if (name.trim().length < 2) e.name = 'Nome deve ter ao menos 2 caracteres';
+
+    const u = username.trim();
+    if (u.length < 3) e.username = 'Usuário deve ter ao menos 3 caracteres';
+    else if (u.length > 20) e.username = 'Usuário deve ter no máximo 20 caracteres';
+    else if (!/^[a-zA-Z0-9_]+$/.test(u)) e.username = 'Use apenas letras, números e underscore';
+
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim())) e.email = 'Email inválido';
+
+    if (password.length < SENHA_MIN) e.password = `Senha deve ter ao menos ${SENHA_MIN} caracteres`;
+    else if (!temNumero(password)) e.password = 'A senha deve conter pelo menos um número';
+
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(birthDate)) e.birthDate = 'Informe sua data de nascimento';
+    if (!gender) e.gender = 'Selecione o gênero';
+    if (!phone.trim()) e.phone = 'Informe seu telefone';
+    return e;
+  }
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setError('');
+    const errs = validar();
+    setErrors(errs);
+    if (Object.keys(errs).length > 0) return;
+
     setSubmitting(true);
     try {
       await api.post('/register', {
@@ -53,11 +88,20 @@ export function Register() {
       });
       navigate('/');
     } catch (e: unknown) {
-      setError(mensagemErro(e, 'Erro ao criar conta. Tente novamente.'));
+      // Mapeia os erros conhecidos do backend (409) para o campo certo.
+      const msg = mensagemErro(e, 'Erro ao criar conta. Tente novamente.');
+      if (/usu[aá]rio/i.test(msg)) setErrors((prev) => ({ ...prev, username: msg }));
+      else if (/email/i.test(msg)) setErrors((prev) => ({ ...prev, email: msg }));
+      else setError(msg);
     } finally {
       setSubmitting(false);
     }
   }
+
+  const reqsSenha = [
+    { ok: password.length >= SENHA_MIN, label: `Ao menos ${SENHA_MIN} caracteres` },
+    { ok: temNumero(password), label: 'Pelo menos um número' },
+  ];
 
   const brand = (
     <AuthBrand glow="register">
@@ -107,22 +151,28 @@ export function Register() {
           label="Nome"
           placeholder="Seu nome"
           value={name}
-          onChange={(e) => setName(e.target.value)}
+          onChange={(e) => {
+            setName(e.target.value);
+            limparErro('name');
+          }}
           required
+          error={errors.name}
         />
         <FormField
           label="Nome de usuário"
           placeholder="seu_usuario"
           value={username}
-          onChange={(e) =>
+          onChange={(e) => {
             setUsername(
               e.target.value
                 .toLowerCase()
                 .replace(/[^a-z0-9_]/g, '')
                 .slice(0, 20),
-            )
-          }
+            );
+            limparErro('username');
+          }}
           required
+          error={errors.username}
         />
         <FormField
           label="E-mail"
@@ -130,33 +180,56 @@ export function Register() {
           autoComplete="email"
           placeholder="voce@email.com"
           value={email}
-          onChange={(e) => setEmail(e.target.value)}
+          onChange={(e) => {
+            setEmail(e.target.value);
+            limparErro('email');
+          }}
           required
+          error={errors.email}
         />
         <FormField
           label="Senha"
           type="password"
           autoComplete="new-password"
-          placeholder="mínimo 12 caracteres"
+          placeholder={`mínimo ${SENHA_MIN} caracteres`}
           value={password}
-          onChange={(e) => setPassword(e.target.value)}
+          onChange={(e) => {
+            setPassword(e.target.value);
+            limparErro('password');
+          }}
           required
-        />
+        >
+          <ul className="pw-reqs">
+            {reqsSenha.map((r) => (
+              <li key={r.label} className={`pw-reqs__item${r.ok ? ' pw-reqs__item--ok' : ''}`}>
+                <Check size={12} /> {r.label}
+              </li>
+            ))}
+          </ul>
+        </FormField>
         <FormField
           label="Data de nascimento"
           type="date"
           autoComplete="bday"
           value={birthDate}
-          onChange={(e) => setBirthDate(e.target.value)}
+          onChange={(e) => {
+            setBirthDate(e.target.value);
+            limparErro('birthDate');
+          }}
           required
+          error={errors.birthDate}
         />
         <SelectField
           label="Gênero"
           value={gender}
-          onChange={(e) => setGender(e.target.value)}
+          onChange={(e) => {
+            setGender(e.target.value);
+            limparErro('gender');
+          }}
           options={GENDER_OPTIONS}
           placeholder="Selecione"
           required
+          error={errors.gender}
         />
         <FormField
           label="Telefone"
@@ -164,8 +237,12 @@ export function Register() {
           autoComplete="tel"
           placeholder="(11) 98888-7777"
           value={phone}
-          onChange={(e) => setPhone(formatPhone(e.target.value))}
+          onChange={(e) => {
+            setPhone(formatPhone(e.target.value));
+            limparErro('phone');
+          }}
           required
+          error={errors.phone}
         />
         <button className="btn btn--accent btn--block" type="submit" disabled={submitting}>
           {submitting ? 'Criando conta...' : 'Criar conta grátis'}

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -161,6 +161,39 @@
 .input-toggle:hover {
   color: var(--text);
 }
+.input--error,
+.input--error:focus {
+  border-color: var(--av-red);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--av-red) 16%, transparent);
+}
+.field__error {
+  font-size: 12.5px;
+  color: var(--av-red);
+}
+.pw-reqs {
+  list-style: none;
+  margin: 2px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.pw-reqs__item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12.5px;
+  color: var(--muted);
+}
+.pw-reqs__item svg {
+  opacity: 0.35;
+}
+.pw-reqs__item--ok {
+  color: var(--success);
+}
+.pw-reqs__item--ok svg {
+  opacity: 1;
+}
 .link {
   color: var(--accent);
   font-weight: 600;


### PR DESCRIPTION
Resolve três pontos do registro/login.

## 1. Rate limiter (o bug)
Login e cadastro usavam a mesma instância de limiter, ou seja, um contador compartilhado por IP entre login, register, refresh, logout e verify-email. Errar o cadastro algumas vezes travava também o login. Agora cada endpoint tem sua própria instância (contador independente), via uma factory. O `/refresh` ficou mais folgado (60/15min) por ser automático e não poder deslogar quem está ativo.

## 2. Requisitos da senha no registro
Checklist ao vivo abaixo do campo, marcando conforme digita:
- Ao menos 12 caracteres
- Pelo menos um número

(Espelha o `registerSchema`, que exige justamente isso.)

## 3. Erros por campo
Validação no cliente espelhando as regras de cada campo (nome, usuário, email, senha, data, gênero, telefone), com mensagem específica embaixo do campo em vez do "Dados inválidos" genérico. O backend continua validando por baixo. Erros conhecidos do backend (usuário/email já em uso) são mapeados para o campo certo. `FormField` e `SelectField` ganharam suporte a `error`.

tsc/lint backend limpos, build do front OK e 28 testes de integração passando.