### PR TITLE
feat: bloco de tabela no estúdio e fundo branco na aula

### DIFF
--- a/backend/src/schemas/trail.schemas.ts
+++ b/backend/src/schemas/trail.schemas.ts
@@ -88,7 +88,7 @@ export const saveLessonStudioSchema = z.object({
     contentBlocks: z
         .array(
             z.object({
-                type: z.enum(["text", "code", "image", "video", "quote"]),
+                type: z.enum(["text", "code", "image", "video", "quote", "table"]),
                 value: z.string(),
             }),
         )

--- a/backend/src/services/estudio.service.ts
+++ b/backend/src/services/estudio.service.ts
@@ -249,6 +249,22 @@ export async function excluirAula(lessonId: string) {
     });
 }
 
+// Converte o grid (JSON salvo pelo editor) em uma tabela markdown. 1ª linha = cabeçalho.
+function tabelaParaMarkdown(value: string): string {
+    try {
+        const grid = JSON.parse(value);
+        if (!Array.isArray(grid) || grid.length === 0) return "";
+        const celula = (c: unknown) => String(c ?? "").replace(/\|/g, "\\|").replace(/\n/g, " ");
+        const linha = (r: unknown[]) => "| " + r.map(celula).join(" | ") + " |";
+        const [cabecalho, ...corpo] = grid as unknown[][];
+        const separador = "| " + cabecalho.map(() => "---").join(" | ") + " |";
+        return [linha(cabecalho), separador, ...corpo.map(linha)].join("\n");
+    } catch (e) {
+        console.error("tabelaParaMarkdown: valor inválido", e);
+        return "";
+    }
+}
+
 // Serializa os blocos em markdown (fallback para o aluno e para conteúdo legado).
 function blocosParaMarkdown(blocos: { type: string; value: string }[]): string {
     return blocos
@@ -265,6 +281,8 @@ function blocosParaMarkdown(blocos: { type: string; value: string }[]): string {
                     return `![imagem](${b.value})`;
                 case "video":
                     return `[Vídeo](${b.value})`;
+                case "table":
+                    return tabelaParaMarkdown(b.value);
                 default:
                     return b.value;
             }

--- a/frontend/src/pages/Aula/index.tsx
+++ b/frontend/src/pages/Aula/index.tsx
@@ -20,6 +20,7 @@ import {
 import ReactMarkdown, { type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { statusErro } from '../../utils/erro';
+import { parseGrid } from '../../utils/tabela';
 
 const NAV = [
   { label: 'Início', to: '/home' },
@@ -269,6 +270,9 @@ function BlocosAula({ blocks }: { blocks: Bloco[] }) {
         if (b.type === 'quote') {
           return <blockquote key={i}>{b.value}</blockquote>;
         }
+        if (b.type === 'table') {
+          return <TabelaBloco key={i} value={b.value} />;
+        }
         return (
           <ReactMarkdown key={i} remarkPlugins={[remarkGfm]} components={md}>
             {b.value}
@@ -276,6 +280,33 @@ function BlocosAula({ blocks }: { blocks: Bloco[] }) {
         );
       })}
     </div>
+  );
+}
+
+// Renderiza um bloco de tabela. Herda o estilo de .lesson__md table; 1ª linha = cabeçalho.
+function TabelaBloco({ value }: { value: string }) {
+  const grid = parseGrid(value);
+  if (grid.length === 0) return null;
+  const [cabecalho, ...corpo] = grid;
+  return (
+    <table>
+      <thead>
+        <tr>
+          {cabecalho.map((c, j) => (
+            <th key={j}>{c}</th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {corpo.map((linha, i) => (
+          <tr key={i}>
+            {linha.map((c, j) => (
+              <td key={j}>{c}</td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
   );
 }
 

--- a/frontend/src/pages/Estudio/index.tsx
+++ b/frontend/src/pages/Estudio/index.tsx
@@ -17,6 +17,7 @@ import {
   type QuestionDifficulty,
   type BlocoTipo,
 } from '../../services/trails';
+import { parseGrid, serializeGrid } from '../../utils/tabela';
 
 const LETTERS = ['A', 'B', 'C', 'D', 'E', 'F'];
 
@@ -26,6 +27,7 @@ const BLOCO_TIPOS: { type: BlocoTipo; icon: string; label: string }[] = [
   { type: 'image', icon: '▣', label: 'Imagem' },
   { type: 'video', icon: '▷', label: 'Vídeo' },
   { type: 'quote', icon: '❝', label: 'Citação' },
+  { type: 'table', icon: '▦', label: 'Tabela' },
 ];
 const BLOCO_LABEL: Record<BlocoTipo, string> = {
   text: 'Texto',
@@ -33,6 +35,7 @@ const BLOCO_LABEL: Record<BlocoTipo, string> = {
   image: 'Imagem',
   video: 'Vídeo',
   quote: 'Citação',
+  table: 'Tabela',
 };
 const DIFFS: { value: QuestionDifficulty; label: string }[] = [
   { value: 'facil', label: 'Fácil' },
@@ -178,7 +181,15 @@ export function Estudio() {
 
   // ----- blocos de conteúdo -----
   function addBloco(type: BlocoTipo) {
-    setAula((a) => (a ? { ...a, contentBlocks: [...a.contentBlocks, { type, value: '' }] } : a));
+    // Tabela começa com um grid 2x2 (1ª linha = cabeçalho); os demais começam vazios.
+    const value =
+      type === 'table'
+        ? serializeGrid([
+            ['', ''],
+            ['', ''],
+          ])
+        : '';
+    setAula((a) => (a ? { ...a, contentBlocks: [...a.contentBlocks, { type, value }] } : a));
     sujo();
   }
   function setBloco(i: number, value: string) {
@@ -463,7 +474,9 @@ export function Estudio() {
                         <Trash size={15} />
                       </button>
                     </div>
-                    {b.type === 'image' || b.type === 'video' ? (
+                    {b.type === 'table' ? (
+                      <TabelaEditor value={b.value} onChange={(v) => setBloco(i, v)} />
+                    ) : b.type === 'image' || b.type === 'video' ? (
                       <input
                         className="block__input es-input"
                         value={b.value}
@@ -619,6 +632,69 @@ export function Estudio() {
           )}
         </div>
       )}
+    </div>
+  );
+}
+
+// Editor de tabela: grid de inputs com controles para adicionar/remover linhas e
+// colunas. A 1ª linha é o cabeçalho. Salva como JSON no value do bloco.
+function TabelaEditor({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  const grid = parseGrid(value);
+  const cols = grid[0]?.length ?? 0;
+
+  const setCell = (r: number, c: number, v: string) =>
+    onChange(
+      serializeGrid(
+        grid.map((row, ri) => (ri === r ? row.map((cell, ci) => (ci === c ? v : cell)) : row)),
+      ),
+    );
+  const addLinha = () => onChange(serializeGrid([...grid, Array(cols).fill('')]));
+  const removerLinha = () => {
+    if (grid.length > 1) onChange(serializeGrid(grid.slice(0, -1)));
+  };
+  const addColuna = () => onChange(serializeGrid(grid.map((row) => [...row, ''])));
+  const removerColuna = () => {
+    if (cols > 1) onChange(serializeGrid(grid.map((row) => row.slice(0, -1))));
+  };
+
+  return (
+    <div className="tbl-edit">
+      <div
+        className="tbl-edit__grid"
+        style={{ gridTemplateColumns: `repeat(${cols}, minmax(90px, 1fr))` }}
+      >
+        {grid.map((row, r) =>
+          row.map((cell, c) => (
+            <input
+              key={`${r}-${c}`}
+              className={`tbl-edit__cell${r === 0 ? ' tbl-edit__cell--head' : ''}`}
+              value={cell}
+              placeholder={r === 0 ? 'Cabeçalho' : ''}
+              onChange={(e) => setCell(r, c, e.target.value)}
+            />
+          )),
+        )}
+      </div>
+      <div className="tbl-edit__controls">
+        <span className="tbl-edit__hint">
+          {grid.length} {grid.length === 1 ? 'linha' : 'linhas'} × {cols}{' '}
+          {cols === 1 ? 'coluna' : 'colunas'} · 1ª linha é o cabeçalho
+        </span>
+        <div className="tbl-edit__actions">
+          <button type="button" className="tbl-edit__btn" onClick={removerColuna}>
+            − coluna
+          </button>
+          <button type="button" className="tbl-edit__btn" onClick={addColuna}>
+            + coluna
+          </button>
+          <button type="button" className="tbl-edit__btn" onClick={removerLinha}>
+            − linha
+          </button>
+          <button type="button" className="tbl-edit__btn" onClick={addLinha}>
+            + linha
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/services/trails.ts
+++ b/frontend/src/services/trails.ts
@@ -98,7 +98,7 @@ export interface QuizQuestion {
   position: number;
   options: QuizOption[];
 }
-export type BlocoTipo = 'text' | 'code' | 'image' | 'video' | 'quote';
+export type BlocoTipo = 'text' | 'code' | 'image' | 'video' | 'quote' | 'table';
 export interface Bloco {
   type: BlocoTipo;
   value: string;

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1657,6 +1657,10 @@
 .lesson__content {
   padding: 34px 44px 40px;
   max-width: 820px;
+  margin: 22px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 16px;
 }
 .lesson__crumb {
   display: flex;
@@ -2094,12 +2098,12 @@
   font-weight: 700;
 }
 .lesson__md blockquote {
-  border-left: 3px solid var(--accent);
+  border: 1px solid var(--border);
   margin: 0 0 18px;
-  padding: 4px 16px;
-  background: var(--surface-2);
-  border-radius: 0 8px 8px 0;
-  color: var(--muted);
+  padding: 10px 16px;
+  background: var(--input);
+  border-radius: 8px;
+  color: var(--text);
 }
 .lesson__md blockquote p {
   margin: 6px 0;
@@ -2122,6 +2126,67 @@
 }
 
 /* ===================== ESTÚDIO (admin) ===================== */
+.tbl-edit {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px;
+}
+.tbl-edit__grid {
+  display: grid;
+  gap: 1px;
+  background: var(--border-strong);
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  overflow: hidden;
+}
+.tbl-edit__cell {
+  border: none;
+  outline: none;
+  background: var(--input);
+  color: var(--text);
+  font-family: inherit;
+  font-size: 13.5px;
+  height: 40px;
+  padding: 0 10px;
+  width: 100%;
+}
+.tbl-edit__cell:focus {
+  background: color-mix(in srgb, var(--accent) 10%, var(--input));
+}
+.tbl-edit__cell--head {
+  font-weight: 700;
+  background: var(--surface-2);
+}
+.tbl-edit__controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.tbl-edit__actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.tbl-edit__hint {
+  font-size: 12px;
+  color: var(--muted);
+}
+.tbl-edit__btn {
+  padding: 5px 10px;
+  border-radius: 7px;
+  border: 1px solid var(--border-strong);
+  background: var(--surface);
+  color: var(--text);
+  font-size: 12.5px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.tbl-edit__btn:hover {
+  border-color: var(--accent);
+}
 .studio__bar {
   gap: 16px;
   height: 64px;

--- a/frontend/src/utils/tabela.ts
+++ b/frontend/src/utils/tabela.ts
@@ -1,0 +1,22 @@
+// Tabela do Estúdio: o grid é salvo como JSON (matriz de strings) no `value` do
+// bloco. A primeira linha é o cabeçalho. Estes helpers convertem entre o JSON e a
+// matriz, usados tanto pelo editor quanto pela visualização da aula.
+
+const GRID_PADRAO = [
+  ['', ''],
+  ['', ''],
+];
+
+export function parseGrid(value: string): string[][] {
+  try {
+    const g = JSON.parse(value);
+    if (Array.isArray(g) && g.length > 0 && g.every((r) => Array.isArray(r))) {
+      return g.map((r) => r.map((c) => String(c ?? '')));
+    }
+  } catch (e) {
+    console.warn('Tabela com valor inválido, começando vazia', e);
+  }
+  return GRID_PADRAO.map((r) => [...r]);
+}
+
+export const serializeGrid = (grid: string[][]): string => JSON.stringify(grid);


### PR DESCRIPTION
Adiciona um bloco de tabela no editor do estúdio: dá pra montar a tabela numa grade de células e ajustar a quantidade de linhas e colunas pelos botões, sendo a primeira linha o cabeçalho. Na aula a tabela aparece formatada.

Junto disso, o conteúdo da aula passou a ter fundo branco no lugar do bege, que estava difícil de ler, e a citação seguiu o mesmo padrão: fundo branco, sem a barra colorida na esquerda e com o texto escuro.

Testado localmente. tsc, lint e os 28 testes de integração passando.