### PR TITLE
fix: login social verifica o email ao vincular conta já existente

### DIFF
--- a/backend/src/controllers/OAuthController.ts
+++ b/backend/src/controllers/OAuthController.ts
@@ -68,7 +68,6 @@ export const callbackOAuth = async (req: Request, res: Response) => {
     }
     if (!dados) return falhar("oauth_sem_email");
 
-    // Já existe essa identidade do provedor? Então é login: usa o dono dela.
     const [contaExistente] = await db
         .select()
         .from(oauthAccounts)
@@ -83,7 +82,6 @@ export const callbackOAuth = async (req: Request, res: Response) => {
     if (contaExistente) {
         [user] = await db.select().from(users).where(eq(users.id, contaExistente.userId));
     } else {
-        // Sem identidade ainda: vincula a uma conta com o mesmo email (verificado) ou cria.
         [user] = await db.select().from(users).where(eq(users.email, dados.email));
         if (!user) {
             [user] = await db
@@ -93,6 +91,13 @@ export const callbackOAuth = async (req: Request, res: Response) => {
                     email: dados.email,
                     emailVerifiedAt: new Date(),
                 })
+                .returning();
+        } else if (!user.emailVerifiedAt) {
+            // O provedor já confirmou o email, então marca a conta pré-existente como verificada.
+            [user] = await db
+                .update(users)
+                .set({ emailVerifiedAt: new Date() })
+                .where(eq(users.id, user.id))
                 .returning();
         }
         await db
@@ -106,7 +111,6 @@ export const callbackOAuth = async (req: Request, res: Response) => {
     const { accessToken, refreshToken } = await authService.gerarEGravarTokens(user.id);
     res.cookie("refreshToken", refreshToken, refreshCookieOpts);
 
-    // Conta de login social nova ainda não tem username nem nascimento/gênero/telefone.
     const precisaCompletar = !user.username || !user.birthDate || !user.gender || !user.phone;
     const destino = precisaCompletar ? "completar-perfil" : "home";
     res.redirect(`${env.FRONTEND_URL}/auth/callback#token=${accessToken}&destino=${destino}`);


### PR DESCRIPTION
## O que muda

Quando o login com Google ou GitHub vincula a uma conta que já existe mas ainda não verificou o email, a conta passa a ser marcada como verificada nesse momento. O provedor já confirma que o email é do usuário antes de devolver os dados (Google exige `email_verified`, GitHub busca o email verificado), então confiar nessa verificação é seguro.

## Por que

Antes, quem se cadastrava com email/senha e nunca clicava no link de verificação, e depois entrava com o Google usando o mesmo email, conseguia entrar pelo social mas continuava com o login por senha bloqueado ("Verifique seu email antes de entrar"). Agora a junção destrava isso.

## Também

Removi do `OAuthController` alguns comentários que só repetiam o que o código já dizia. Mantive os que explicam decisão de segurança (cookie Lax vs Strict).

## Como testar local

1. Cadastrar com email/senha e NÃO clicar no link de verificação.
2. Tentar logar com senha: deve barrar com "Verifique seu email antes de entrar".
3. Entrar com Google (ou GitHub) usando o MESMO email.
4. Conferir que o login por senha passa a funcionar (a conta ficou verificada).

## Escopo

Só backend, um arquivo, sem migration.
