### PR TITLE
refactor: centraliza a fórmula de XP e nível numa função pura

### DIFF
--- a/backend/src/domain/xp.test.ts
+++ b/backend/src/domain/xp.test.ts
@@ -1,0 +1,51 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { calcularXp, nivelPorXp } from "./xp.ts";
+
+describe("calcularXp", () => {
+    test("sem progresso vale 0", () => {
+        assert.equal(calcularXp({ aulas: 0, questoes: 0 }), 0);
+    });
+
+    test("cada aula concluída vale 50", () => {
+        assert.equal(calcularXp({ aulas: 1, questoes: 0 }), 50);
+        assert.equal(calcularXp({ aulas: 3, questoes: 0 }), 150);
+    });
+
+    test("cada questão certa vale 10", () => {
+        assert.equal(calcularXp({ aulas: 0, questoes: 1 }), 10);
+        assert.equal(calcularXp({ aulas: 0, questoes: 5 }), 50);
+    });
+
+    test("soma aulas e questões", () => {
+        assert.equal(calcularXp({ aulas: 2, questoes: 4 }), 140);
+    });
+
+    test("aula pesa mais que questão", () => {
+        assert.ok(calcularXp({ aulas: 1, questoes: 0 }) > calcularXp({ aulas: 0, questoes: 1 }));
+    });
+});
+
+describe("nivelPorXp", () => {
+    test("nível 1 com 0 de XP", () => {
+        assert.equal(nivelPorXp(0), 1);
+    });
+
+    test("um pouco antes do limite continua no mesmo nível", () => {
+        assert.equal(nivelPorXp(499), 1);
+    });
+
+    test("no limite exato sobe de nível", () => {
+        assert.equal(nivelPorXp(500), 2);
+        assert.equal(nivelPorXp(1000), 3);
+    });
+
+    test("nível não decresce quando o XP aumenta", () => {
+        let anterior = 1;
+        for (let xp = 0; xp <= 3000; xp += 37) {
+            const atual = nivelPorXp(xp);
+            assert.ok(atual >= anterior);
+            anterior = atual;
+        }
+    });
+});

--- a/backend/src/domain/xp.ts
+++ b/backend/src/domain/xp.ts
@@ -1,0 +1,12 @@
+// Regras de pontuação. Fonte única de XP e nível: /me, ranking e conquistas derivam daqui.
+export const XP_POR_AULA = 50;
+export const XP_POR_QUESTAO = 10;
+export const XP_POR_NIVEL = 500;
+
+export function calcularXp({ aulas, questoes }: { aulas: number; questoes: number }): number {
+    return aulas * XP_POR_AULA + questoes * XP_POR_QUESTAO;
+}
+
+export function nivelPorXp(xp: number): number {
+    return Math.floor(xp / XP_POR_NIVEL) + 1;
+}

--- a/backend/src/services/ranking.ts
+++ b/backend/src/services/ranking.ts
@@ -2,7 +2,7 @@ import { sql, eq, and, count, gte } from "drizzle-orm";
 import { db } from "../../db.ts";
 import { rankingSnapshots, users, lessonProgress, questionAnswers } from "../../schema.ts";
 import { streaksTodos, hojeSaoPaulo } from "./streak.ts";
-import { nivelPorXp } from "./stats.service.ts";
+import { calcularXp, nivelPorXp } from "../domain/xp.ts";
 
 // Grava o snapshot do dia (1x por dia, na primeira visualização) e devolve, por
 // usuário, quantas posições subiu (positivo) ou caiu (negativo) desde o último
@@ -54,7 +54,7 @@ export async function movimentacaoRanking(
 }
 
 // Ranking global por XP. Liga e nível usam o XP total; o leaderboard usa o
-// período (week/month/all). XP = 50 por aula concluída + 10 por questão certa.
+// período (week/month/all).
 export async function rankingGlobal(periodo: string, currentUserId: string | undefined) {
     const dia = 24 * 60 * 60 * 1000;
     const desde =
@@ -105,8 +105,8 @@ export async function rankingGlobal(periodo: string, currentUserId: string | und
     const acP = desde ? paraMapa(acertosPer) : acT;
 
     const base = usuarios.map((u) => {
-        const totalXp = (at.get(u.id) ?? 0) * 50 + (acT.get(u.id) ?? 0) * 10;
-        const periodXp = (aP.get(u.id) ?? 0) * 50 + (acP.get(u.id) ?? 0) * 10;
+        const totalXp = calcularXp({ aulas: at.get(u.id) ?? 0, questoes: acT.get(u.id) ?? 0 });
+        const periodXp = calcularXp({ aulas: aP.get(u.id) ?? 0, questoes: acP.get(u.id) ?? 0 });
         return {
             id: u.id,
             name: u.name,

--- a/backend/src/services/stats.service.ts
+++ b/backend/src/services/stats.service.ts
@@ -1,11 +1,9 @@
 import { db } from "../../db.ts";
 import { lessonProgress, questionAnswers } from "../../schema.ts";
 import { eq, and, count } from "drizzle-orm";
+import { calcularXp, nivelPorXp } from "../domain/xp.ts";
 
-// Nível derivado do XP. Fonte única da fórmula (usada aqui, no /me e no ranking).
-export const nivelPorXp = (xp: number) => Math.floor(xp / 500) + 1;
-
-// Estatísticas base do usuário. XP = 50 por aula concluída + 10 por questão certa.
+// Estatísticas base do usuário: conta o progresso no banco e deriva XP e nível.
 export async function calcularEstatisticas(userId: string) {
     const [aulas] = await db
         .select({ n: count() })
@@ -17,7 +15,7 @@ export async function calcularEstatisticas(userId: string) {
         .where(and(eq(questionAnswers.userId, userId), eq(questionAnswers.isCorrect, true)));
     const lessonsCompleted = Number(aulas?.n ?? 0);
     const questionsCorrect = Number(acertos?.n ?? 0);
-    const xp = lessonsCompleted * 50 + questionsCorrect * 10;
+    const xp = calcularXp({ aulas: lessonsCompleted, questoes: questionsCorrect });
     return {
         xp,
         level: nivelPorXp(xp),


### PR DESCRIPTION
## O que muda

A fórmula de XP (50 por aula concluída, 10 por questão certa) estava duplicada entre `stats.service.ts` e `ranking.ts`, e o cálculo de nível vivia no `stats`. Extraí tudo para `src/domain/xp.ts` como funções puras, sem dependência de banco ou framework: `calcularXp`, `nivelPorXp` e as constantes de pontuação.

Agora o `/me` (via `calcularEstatisticas`), o ranking e as conquistas derivam todos da mesma fonte. Antes, mudar a pontuação num lugar corria o risco de divergir do outro silenciosamente. O comentário no `stats` até dizia "fonte única", mas o `ranking` reimplementava os pesos inline.

## Comportamento

Idêntico. Mesmos pesos, mesma fórmula de nível. Refactor puro, sem migration e sem mudança de API.

## Testes

Novos testes unitários em `src/domain/xp.test.ts`, que rodam sem banco via `npm run test:unit`: pesos, soma, limites exatos de nível (499 vs 500) e monotonicidade. Lint, tsc e os testes de integração no CI cobrem o resto (stats e ranking já são exercidos contra Postgres real).

## Contexto

Primeiro passo do combinado de mover a lógica de gamificação com invariante para um `domain/` de funções puras. Próximos candidatos: streak (injetar o "hoje" pra ficar testável de forma determinística), correção de quiz e desbloqueio de conquista.
