### PR TITLE
refactor: extrai a lógica de streak para um módulo puro e testável

### DIFF
--- a/backend/src/controllers/TrailController.ts
+++ b/backend/src/controllers/TrailController.ts
@@ -15,7 +15,7 @@ import {
     createAchievementSchema,
     updateAchievementSchema,
 } from "../schemas/trail.schemas.ts";
-import { calcularStreak, diasAtivosDoUsuario, semanaAtividade } from "../services/streak.ts";
+import { resumoSemana } from "../services/streak.ts";
 import { rankingGlobal } from "../services/ranking.ts";
 import { atividadeRecente } from "../services/activity.service.ts";
 import { listarTags, criarTag, atualizarTag, excluirTag } from "../services/tag.service.ts";
@@ -341,8 +341,7 @@ export const getRanking = async (req: Request, res: Response, next: NextFunction
 // Streak do usuário + os últimos 7 dias (para o card da home).
 export const getMyStreak = async (req: Request, res: Response, next: NextFunction) => {
     try {
-        const dias = await diasAtivosDoUsuario(req.userId!);
-        res.json({ streak: calcularStreak(dias), week: semanaAtividade(dias) });
+        res.json(await resumoSemana(req.userId!));
     } catch (err) {
         next(err);
     }

--- a/backend/src/controllers/UserController.ts
+++ b/backend/src/controllers/UserController.ts
@@ -7,7 +7,7 @@ import { users, languages as languagesTable } from "../../schema.ts";
 import { eq } from "drizzle-orm";
 import { updateMeSchema, completarPerfilSchema } from "../schemas/auth.schema.ts";
 import { UPLOADS_DIR, AVATARS_DIR, COVERS_DIR } from "../config/paths.ts";
-import { calcularStreak, diasAtivosDoUsuario } from "../services/streak.ts";
+import { streakDoUsuario } from "../services/streak.ts";
 import { calcularEstatisticas } from "../services/stats.service.ts";
 
 const publicUserColumns = {
@@ -49,7 +49,7 @@ export const getMe = async (req: Request, res: Response) => {
     // em vez de quebrar o perfil inteiro.
     let streak = 0;
     try {
-        streak = calcularStreak(await diasAtivosDoUsuario(userId));
+        streak = await streakDoUsuario(userId);
     } catch (e) {
         console.error("getMe: falha ao calcular streak", e);
     }

--- a/backend/src/domain/streak.test.ts
+++ b/backend/src/domain/streak.test.ts
@@ -1,0 +1,84 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { calcularStreak, semanaAtividade, diaAnterior } from "./streak.ts";
+
+const HOJE = "2026-07-01";
+
+describe("calcularStreak", () => {
+    test("sem dias ativos é 0", () => {
+        assert.equal(calcularStreak(new Set(), HOJE), 0);
+    });
+
+    test("só hoje conta 1", () => {
+        assert.equal(calcularStreak(new Set([HOJE]), HOJE), 1);
+    });
+
+    test("só ontem (sem hoje) ainda conta 1", () => {
+        assert.equal(calcularStreak(new Set(["2026-06-30"]), HOJE), 1);
+    });
+
+    test("hoje e ontem contam 2", () => {
+        assert.equal(calcularStreak(new Set(["2026-07-01", "2026-06-30"]), HOJE), 2);
+    });
+
+    test("sem hoje nem ontem é 0", () => {
+        assert.equal(calcularStreak(new Set(["2026-06-28"]), HOJE), 0);
+    });
+
+    test("buraco quebra a contagem", () => {
+        // hoje ativo, ontem não, anteontem ativo: só hoje conta
+        assert.equal(calcularStreak(new Set(["2026-07-01", "2026-06-29"]), HOJE), 1);
+    });
+
+    test("atravessa a virada de mês", () => {
+        assert.equal(calcularStreak(new Set(["2026-07-01", "2026-06-30", "2026-06-29"]), HOJE), 3);
+    });
+
+    test("atravessa a virada de ano", () => {
+        assert.equal(
+            calcularStreak(new Set(["2026-01-01", "2025-12-31", "2025-12-30"]), "2026-01-01"),
+            3,
+        );
+    });
+
+    test("dia no futuro é ignorado", () => {
+        assert.equal(calcularStreak(new Set(["2026-07-02", "2026-07-01"]), HOJE), 1);
+    });
+});
+
+describe("diaAnterior", () => {
+    test("dia comum", () => {
+        assert.equal(diaAnterior("2026-07-01"), "2026-06-30");
+    });
+
+    test("virada de ano", () => {
+        assert.equal(diaAnterior("2026-01-01"), "2025-12-31");
+    });
+
+    test("fevereiro em ano não bissexto", () => {
+        assert.equal(diaAnterior("2026-03-01"), "2026-02-28");
+    });
+
+    test("fevereiro em ano bissexto", () => {
+        assert.equal(diaAnterior("2024-03-01"), "2024-02-29");
+    });
+});
+
+describe("semanaAtividade", () => {
+    test("retorna 7 dias terminando em hoje", () => {
+        const semana = semanaAtividade(new Set([HOJE]), HOJE);
+        assert.equal(semana.length, 7);
+        assert.equal(semana[6].active, true); // último é hoje
+    });
+
+    test("marca ativos só nos dias da janela", () => {
+        const semana = semanaAtividade(new Set(["2026-07-01", "2026-06-29", "2026-05-01"]), HOJE);
+        // 07-01 e 06-29 caem nos últimos 7 dias; 05-01 não
+        assert.equal(semana.filter((d) => d.active).length, 2);
+    });
+
+    test("labels são iniciais de dia da semana", () => {
+        const semana = semanaAtividade(new Set(), HOJE);
+        assert.ok(semana.every((d) => "DSTQ".includes(d.label)));
+    });
+});

--- a/backend/src/domain/streak.ts
+++ b/backend/src/domain/streak.ts
@@ -1,0 +1,42 @@
+// Lógica pura de streak. Recebe os dias ativos (YYYY-MM-DD) e o "hoje" já resolvido,
+// então é determinística e testável, sem depender do relógio nem do fuso.
+
+const LETRAS = ["D", "S", "T", "Q", "Q", "S", "S"]; // domingo..sábado
+
+// Dia anterior a uma data YYYY-MM-DD, na aritmética UTC.
+export function diaAnterior(dia: string): string {
+    return new Date(Date.parse(dia + "T00:00:00Z") - 86400000).toISOString().slice(0, 10);
+}
+
+// Dias consecutivos terminando em hoje (ou ontem, se ainda não houve atividade hoje).
+export function calcularStreak(dias: Set<string>, hoje: string): number {
+    if (dias.size === 0) return 0;
+    let cursor = hoje;
+    if (!dias.has(cursor)) {
+        cursor = diaAnterior(cursor);
+        if (!dias.has(cursor)) return 0;
+    }
+    let n = 0;
+    while (dias.has(cursor)) {
+        n++;
+        cursor = diaAnterior(cursor);
+    }
+    return n;
+}
+
+// Últimos 7 dias (mais antigo -> hoje) com flag de atividade, para o card da home.
+export function semanaAtividade(
+    dias: Set<string>,
+    hoje: string,
+): { label: string; active: boolean }[] {
+    const ult7: string[] = [];
+    let cursor = hoje;
+    for (let i = 0; i < 7; i++) {
+        ult7.unshift(cursor);
+        cursor = diaAnterior(cursor);
+    }
+    return ult7.map((d) => ({
+        label: LETRAS[new Date(d + "T00:00:00Z").getUTCDay()],
+        active: dias.has(d),
+    }));
+}

--- a/backend/src/services/streak.ts
+++ b/backend/src/services/streak.ts
@@ -1,32 +1,13 @@
 import { sql } from "drizzle-orm";
 import { db } from "../../db.ts";
+import { calcularStreak, semanaAtividade } from "../domain/streak.ts";
 
 // Streak = dias corridos com atividade (questão respondida ou aula concluída).
-// O "dia" é calculado no fuso de São Paulo para bater com o usuário.
+// O "dia" é bucketizado no fuso de São Paulo para bater com o usuário.
 const TZ = "America/Sao_Paulo";
-const LETRAS = ["D", "S", "T", "Q", "Q", "S", "S"]; // domingo..sábado
 
-function diaAnterior(s: string): string {
-    return new Date(Date.parse(s + "T00:00:00Z") - 86400000).toISOString().slice(0, 10);
-}
 export function hojeSaoPaulo(): string {
     return new Date().toLocaleDateString("en-CA", { timeZone: TZ });
-}
-
-// Conta os dias consecutivos terminando hoje (ou ontem, se ainda não estudou hoje).
-export function calcularStreak(dias: Set<string>): number {
-    if (dias.size === 0) return 0;
-    let cursor = hojeSaoPaulo();
-    if (!dias.has(cursor)) {
-        cursor = diaAnterior(cursor);
-        if (!dias.has(cursor)) return 0;
-    }
-    let n = 0;
-    while (dias.has(cursor)) {
-        n++;
-        cursor = diaAnterior(cursor);
-    }
-    return n;
 }
 
 export async function diasAtivosDoUsuario(userId: string): Promise<Set<string>> {
@@ -38,7 +19,7 @@ export async function diasAtivosDoUsuario(userId: string): Promise<Set<string>> 
     return new Set((res.rows as { d: string }[]).map((r) => r.d));
 }
 
-// Calcula o streak de todos os usuários de uma vez (para o ranking).
+// Streak de todos os usuários de uma vez (para o ranking), medidos no mesmo hoje.
 export async function streaksTodos(): Promise<Map<string, number>> {
     const res = await db.execute(sql`
         SELECT user_id AS uid, to_char(answered_at AT TIME ZONE ${TZ}, 'YYYY-MM-DD') AS d FROM question_answers
@@ -54,21 +35,19 @@ export async function streaksTodos(): Promise<Map<string, number>> {
         }
         dias.add(row.d);
     }
+    const hoje = hojeSaoPaulo();
     const streaks = new Map<string, number>();
-    for (const [uid, dias] of porUsuario) streaks.set(uid, calcularStreak(dias));
+    for (const [uid, dias] of porUsuario) streaks.set(uid, calcularStreak(dias, hoje));
     return streaks;
 }
 
-// Últimos 7 dias (mais antigo -> hoje) com flag de atividade, para o card da home.
-export function semanaAtividade(dias: Set<string>): { label: string; active: boolean }[] {
-    const ult7: string[] = [];
-    let cursor = hojeSaoPaulo();
-    for (let i = 0; i < 7; i++) {
-        ult7.unshift(cursor);
-        cursor = diaAnterior(cursor);
-    }
-    return ult7.map((d) => ({
-        label: LETRAS[new Date(d + "T00:00:00Z").getUTCDay()],
-        active: dias.has(d),
-    }));
+// Orquestram fetch + relógio + cálculo puro para os endpoints.
+export async function streakDoUsuario(userId: string): Promise<number> {
+    return calcularStreak(await diasAtivosDoUsuario(userId), hojeSaoPaulo());
+}
+
+export async function resumoSemana(userId: string) {
+    const dias = await diasAtivosDoUsuario(userId);
+    const hoje = hojeSaoPaulo();
+    return { streak: calcularStreak(dias, hoje), week: semanaAtividade(dias, hoje) };
 }


### PR DESCRIPTION
## O que muda

Segundo passo do `domain/` de funções puras (depois do XP). As funções de streak (`calcularStreak`, `semanaAtividade`, `diaAnterior`) foram para `src/domain/streak.ts` e agora recebem o "hoje" como parâmetro, em vez de lerem o relógio por dentro. Com isso viram puras e determinísticas, e dá pra testar as bordas de verdade.

O `services/streak.ts` mantém o que é I/O (as queries e o `hojeSaoPaulo`) e passa a orquestrar: `streakDoUsuario` e `resumoSemana` compõem fetch + relógio + cálculo puro. Assim os controllers (`getMe`, `getMyStreak`) só chamam o service, sem tocar no relógio nem na função pura, alinhado com "services orquestram".

## Comportamento

Idêntico. Mesma regra de streak e mesmo card de semana. Refactor puro, sem migration e sem mudança de API. Bônus pequeno: no ranking, o streak de todos os usuários agora é medido no mesmo "hoje" (antes o relógio era lido por usuário dentro do loop).

## Testes

`src/domain/streak.test.ts`, rodando sem banco via `npm run test:unit`: só-hoje, só-ontem, buraco que quebra a contagem, virada de mês e de ano, dia no futuro ignorado, e o `diaAnterior` em fevereiro bissexto e não bissexto. Total agora: 43 testes unitários.

## Contexto

Próximos candidatos do combinado: correção de quiz (extrair a regra de aprovação e a contagem de acertos) e desbloqueio de conquista.
