### PR TITLE
feat: backend de simulados no formato da prova AWS

### DIFF
--- a/backend/app.ts
+++ b/backend/app.ts
@@ -4,6 +4,7 @@ import cookieParser from "cookie-parser";
 import authRoutes from "./src/routes/auth.routes.ts";
 import userRoutes from "./src/routes/user.routes.ts";
 import trailRoutes from "./src/routes/trail.routes.ts";
+import simuladoRoutes from "./src/routes/simulado.routes.ts";
 import { errorMiddleware } from "./src/middlewares/error.ts";
 import helmet from "helmet";
 import cors from "cors";
@@ -41,6 +42,7 @@ app.use(
 app.use(authRoutes);
 app.use(userRoutes);
 app.use(trailRoutes);
+app.use(simuladoRoutes);
 
 app.get("/health", (_req, res) => res.json({ status: "ok" }));
 

--- a/backend/drizzle/0019_simulados.sql
+++ b/backend/drizzle/0019_simulados.sql
@@ -1,0 +1,65 @@
+CREATE TABLE "simulado_attempt_answers" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"attempt_id" uuid NOT NULL,
+	"question_id" uuid NOT NULL,
+	"option_id" uuid NOT NULL,
+	CONSTRAINT "simulado_attempt_answers_attempt_id_question_id_option_id_unique" UNIQUE("attempt_id","question_id","option_id")
+);
+--> statement-breakpoint
+CREATE TABLE "simulado_attempt_questions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"attempt_id" uuid NOT NULL,
+	"question_id" uuid NOT NULL,
+	"position" integer NOT NULL,
+	CONSTRAINT "simulado_attempt_questions_attempt_id_question_id_unique" UNIQUE("attempt_id","question_id")
+);
+--> statement-breakpoint
+CREATE TABLE "simulado_attempts" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"simulado_id" uuid NOT NULL,
+	"started_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"submitted_at" timestamp with time zone,
+	"score" integer,
+	"passed" boolean
+);
+--> statement-breakpoint
+CREATE TABLE "simulado_options" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"question_id" uuid NOT NULL,
+	"text" text NOT NULL,
+	"is_correct" boolean DEFAULT false NOT NULL,
+	"position" integer NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "simulado_questions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"simulado_id" uuid NOT NULL,
+	"statement" text NOT NULL,
+	"explanation" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "simulados" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"slug" varchar(80) NOT NULL,
+	"name" varchar(160) NOT NULL,
+	"description" text,
+	"duration_minutes" integer NOT NULL,
+	"question_count" integer NOT NULL,
+	"pass_percent" integer NOT NULL,
+	"published" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "simulados_slug_unique" UNIQUE("slug")
+);
+--> statement-breakpoint
+ALTER TABLE "simulado_attempt_answers" ADD CONSTRAINT "simulado_attempt_answers_attempt_id_simulado_attempts_id_fk" FOREIGN KEY ("attempt_id") REFERENCES "public"."simulado_attempts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "simulado_attempt_answers" ADD CONSTRAINT "simulado_attempt_answers_question_id_simulado_questions_id_fk" FOREIGN KEY ("question_id") REFERENCES "public"."simulado_questions"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "simulado_attempt_answers" ADD CONSTRAINT "simulado_attempt_answers_option_id_simulado_options_id_fk" FOREIGN KEY ("option_id") REFERENCES "public"."simulado_options"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "simulado_attempt_questions" ADD CONSTRAINT "simulado_attempt_questions_attempt_id_simulado_attempts_id_fk" FOREIGN KEY ("attempt_id") REFERENCES "public"."simulado_attempts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "simulado_attempt_questions" ADD CONSTRAINT "simulado_attempt_questions_question_id_simulado_questions_id_fk" FOREIGN KEY ("question_id") REFERENCES "public"."simulado_questions"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "simulado_attempts" ADD CONSTRAINT "simulado_attempts_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "simulado_attempts" ADD CONSTRAINT "simulado_attempts_simulado_id_simulados_id_fk" FOREIGN KEY ("simulado_id") REFERENCES "public"."simulados"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "simulado_options" ADD CONSTRAINT "simulado_options_question_id_simulado_questions_id_fk" FOREIGN KEY ("question_id") REFERENCES "public"."simulado_questions"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "simulado_questions" ADD CONSTRAINT "simulado_questions_simulado_id_simulados_id_fk" FOREIGN KEY ("simulado_id") REFERENCES "public"."simulados"("id") ON DELETE no action ON UPDATE no action;

--- a/backend/drizzle/meta/0019_snapshot.json
+++ b/backend/drizzle/meta/0019_snapshot.json
@@ -1,0 +1,1673 @@
+{
+  "id": "58aca13c-42af-44e4-844e-978657c90bfd",
+  "prevId": "a9971ad8-201c-46f4-b495-b5277ee704e1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.achievements": {
+      "name": "achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "criteria_type": {
+          "name": "criteria_type",
+          "type": "achievement_criteria",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "achievements_name_unique": {
+          "name": "achievements_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.languages": {
+      "name": "languages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "languages_name_unique": {
+          "name": "languages_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons_progress": {
+      "name": "lessons_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_progress_user_id_users_id_fk": {
+          "name": "lessons_progress_user_id_users_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_progress_lesson_id_lessons_id_fk": {
+          "name": "lessons_progress_lesson_id_lessons_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lessons_progress_user_id_lesson_id_unique": {
+          "name": "lessons_progress_user_id_lesson_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "lesson_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons": {
+      "name": "lessons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_blocks": {
+          "name": "content_blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_trail_id_trails_id_fk": {
+          "name": "lessons_trail_id_trails_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_module_id_modules_id_fk": {
+          "name": "lessons_module_id_modules_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "modules",
+          "columnsFrom": [
+            "module_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.modules": {
+      "name": "modules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "modules_trail_id_trails_id_fk": {
+          "name": "modules_trail_id_trails_id_fk",
+          "tableFrom": "modules",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_accounts": {
+      "name": "oauth_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_accounts_user_id_users_id_fk": {
+          "name": "oauth_accounts_user_id_users_id_fk",
+          "tableFrom": "oauth_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_accounts_provider_provider_id_unique": {
+          "name": "oauth_accounts_provider_provider_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "provider_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_answers": {
+      "name": "question_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_option_id": {
+          "name": "selected_option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_answers_user_id_users_id_fk": {
+          "name": "question_answers_user_id_users_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_question_id_questions_id_fk": {
+          "name": "question_answers_question_id_questions_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_selected_option_id_question_options_id_fk": {
+          "name": "question_answers_selected_option_id_question_options_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "question_options",
+          "columnsFrom": [
+            "selected_option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "question_answers_user_id_question_id_unique": {
+          "name": "question_answers_user_id_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_options": {
+      "name": "question_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_options_question_id_questions_id_fk": {
+          "name": "question_options_question_id_questions_id_fk",
+          "tableFrom": "question_options",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "question_difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'facil'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_lesson_id_lessons_id_fk": {
+          "name": "questions_lesson_id_lessons_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ranking_snapshots": {
+      "name": "ranking_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ranking_snapshots_user_id_users_id_fk": {
+          "name": "ranking_snapshots_user_id_users_id_fk",
+          "tableFrom": "ranking_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ranking_snapshots_user_id_snapshot_date_unique": {
+          "name": "ranking_snapshots_user_id_snapshot_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "snapshot_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_attempt_answers": {
+      "name": "simulado_attempt_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_attempt_answers_attempt_id_simulado_attempts_id_fk": {
+          "name": "simulado_attempt_answers_attempt_id_simulado_attempts_id_fk",
+          "tableFrom": "simulado_attempt_answers",
+          "tableTo": "simulado_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempt_answers_question_id_simulado_questions_id_fk": {
+          "name": "simulado_attempt_answers_question_id_simulado_questions_id_fk",
+          "tableFrom": "simulado_attempt_answers",
+          "tableTo": "simulado_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempt_answers_option_id_simulado_options_id_fk": {
+          "name": "simulado_attempt_answers_option_id_simulado_options_id_fk",
+          "tableFrom": "simulado_attempt_answers",
+          "tableTo": "simulado_options",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulado_attempt_answers_attempt_id_question_id_option_id_unique": {
+          "name": "simulado_attempt_answers_attempt_id_question_id_option_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "attempt_id",
+            "question_id",
+            "option_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_attempt_questions": {
+      "name": "simulado_attempt_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_attempt_questions_attempt_id_simulado_attempts_id_fk": {
+          "name": "simulado_attempt_questions_attempt_id_simulado_attempts_id_fk",
+          "tableFrom": "simulado_attempt_questions",
+          "tableTo": "simulado_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempt_questions_question_id_simulado_questions_id_fk": {
+          "name": "simulado_attempt_questions_question_id_simulado_questions_id_fk",
+          "tableFrom": "simulado_attempt_questions",
+          "tableTo": "simulado_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulado_attempt_questions_attempt_id_question_id_unique": {
+          "name": "simulado_attempt_questions_attempt_id_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "attempt_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_attempts": {
+      "name": "simulado_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "simulado_id": {
+          "name": "simulado_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passed": {
+          "name": "passed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_attempts_user_id_users_id_fk": {
+          "name": "simulado_attempts_user_id_users_id_fk",
+          "tableFrom": "simulado_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempts_simulado_id_simulados_id_fk": {
+          "name": "simulado_attempts_simulado_id_simulados_id_fk",
+          "tableFrom": "simulado_attempts",
+          "tableTo": "simulados",
+          "columnsFrom": [
+            "simulado_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_options": {
+      "name": "simulado_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_options_question_id_simulado_questions_id_fk": {
+          "name": "simulado_options_question_id_simulado_questions_id_fk",
+          "tableFrom": "simulado_options",
+          "tableTo": "simulado_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_questions": {
+      "name": "simulado_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "simulado_id": {
+          "name": "simulado_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_questions_simulado_id_simulados_id_fk": {
+          "name": "simulado_questions_simulado_id_simulados_id_fk",
+          "tableFrom": "simulado_questions",
+          "tableTo": "simulados",
+          "columnsFrom": [
+            "simulado_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulados": {
+      "name": "simulados",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_count": {
+          "name": "question_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pass_percent": {
+          "name": "pass_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulados_slug_unique": {
+          "name": "simulados_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tokens": {
+      "name": "tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'refresh'"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tokens_user_id_users_id_fk": {
+          "name": "tokens_user_id_users_id_fk",
+          "tableFrom": "tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tokens_token_hash_unique": {
+          "name": "tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_tags": {
+      "name": "trail_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "trail_tags_trail_id_trails_id_fk": {
+          "name": "trail_tags_trail_id_trails_id_fk",
+          "tableFrom": "trail_tags",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trail_tags_tag_id_tags_id_fk": {
+          "name": "trail_tags_tag_id_tags_id_fk",
+          "tableFrom": "trail_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trail_tags_trail_id_tag_id_unique": {
+          "name": "trail_tags_trail_id_tag_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trail_id",
+            "tag_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trails": {
+      "name": "trails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "trail_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_achievements": {
+      "name": "user_achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "achievement_id": {
+          "name": "achievement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_achievements_user_id_users_id_fk": {
+          "name": "user_achievements_user_id_users_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_achievements_achievement_id_achievements_id_fk": {
+          "name": "user_achievements_achievement_id_achievements_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "achievements",
+          "columnsFrom": [
+            "achievement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_achievements_user_id_achievement_id_unique": {
+          "name": "user_achievements_user_id_achievement_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "achievement_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occupation": {
+          "name": "occupation",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github": {
+          "name": "github",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin": {
+          "name": "linkedin",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "failed_login_attempts": {
+          "name": "failed_login_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.achievement_criteria": {
+      "name": "achievement_criteria",
+      "schema": "public",
+      "values": [
+        "xp_total",
+        "lessons_completed",
+        "questions_correct"
+      ]
+    },
+    "public.question_difficulty": {
+      "name": "question_difficulty",
+      "schema": "public",
+      "values": [
+        "facil",
+        "medio",
+        "dificil"
+      ]
+    },
+    "public.trail_level": {
+      "name": "trail_level",
+      "schema": "public",
+      "values": [
+        "iniciante",
+        "intermediario",
+        "avancado"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin",
+        "moderator"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1782832261914,
       "tag": "0018_oauth_accounts",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1782917350761,
+      "tag": "0019_simulados",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/schema.ts
+++ b/backend/schema.ts
@@ -233,3 +233,87 @@ export const trailTags = pgTable(
     },
     (table) => [unique().on(table.trailId, table.tagId)],
 );
+
+// Prova cronometrada com banco de questões próprio, separado das aulas.
+export const simulados = pgTable("simulados", {
+    id: uuid("id").primaryKey().defaultRandom(),
+    slug: varchar("slug", { length: 80 }).notNull().unique(),
+    name: varchar("name", { length: 160 }).notNull(),
+    description: text("description"),
+    durationMinutes: integer("duration_minutes").notNull(),
+    questionCount: integer("question_count").notNull(),
+    passPercent: integer("pass_percent").notNull(),
+    published: boolean("published").default(false).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+});
+
+export const simuladoQuestions = pgTable("simulado_questions", {
+    id: uuid("id").primaryKey().defaultRandom(),
+    simuladoId: uuid("simulado_id")
+        .references(() => simulados.id)
+        .notNull(),
+    statement: text("statement").notNull(),
+    explanation: text("explanation"),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+});
+
+export const simuladoOptions = pgTable("simulado_options", {
+    id: uuid("id").primaryKey().defaultRandom(),
+    questionId: uuid("question_id")
+        .references(() => simuladoQuestions.id)
+        .notNull(),
+    text: text("text").notNull(),
+    isCorrect: boolean("is_correct").default(false).notNull(),
+    position: integer("position").notNull(),
+});
+
+// Uma execução do simulado por um usuário (sessão cronometrada).
+export const simuladoAttempts = pgTable("simulado_attempts", {
+    id: uuid("id").primaryKey().defaultRandom(),
+    userId: uuid("user_id")
+        .references(() => users.id)
+        .notNull(),
+    simuladoId: uuid("simulado_id")
+        .references(() => simulados.id)
+        .notNull(),
+    startedAt: timestamp("started_at", { withTimezone: true }).defaultNow().notNull(),
+    expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+    submittedAt: timestamp("submitted_at", { withTimezone: true }),
+    score: integer("score"),
+    passed: boolean("passed"),
+});
+
+// Snapshot das questões sorteadas para a tentativa (ordem fixa, sobrevive a
+// mudanças no banco de questões).
+export const simuladoAttemptQuestions = pgTable(
+    "simulado_attempt_questions",
+    {
+        id: uuid("id").primaryKey().defaultRandom(),
+        attemptId: uuid("attempt_id")
+            .references(() => simuladoAttempts.id)
+            .notNull(),
+        questionId: uuid("question_id")
+            .references(() => simuladoQuestions.id)
+            .notNull(),
+        position: integer("position").notNull(),
+    },
+    (table) => [unique().on(table.attemptId, table.questionId)],
+);
+
+// Opções marcadas pelo usuário (uma linha por opção: é o que permite multi-seleção).
+export const simuladoAttemptAnswers = pgTable(
+    "simulado_attempt_answers",
+    {
+        id: uuid("id").primaryKey().defaultRandom(),
+        attemptId: uuid("attempt_id")
+            .references(() => simuladoAttempts.id)
+            .notNull(),
+        questionId: uuid("question_id")
+            .references(() => simuladoQuestions.id)
+            .notNull(),
+        optionId: uuid("option_id")
+            .references(() => simuladoOptions.id)
+            .notNull(),
+    },
+    (table) => [unique().on(table.attemptId, table.questionId, table.optionId)],
+);

--- a/backend/scripts/seed-aws-ccp.ts
+++ b/backend/scripts/seed-aws-ccp.ts
@@ -1,0 +1,700 @@
+// Seed do simulado AWS Certified Cloud Practitioner (questões 4 a 50 do gabarito
+// comentado). Idempotente: se o simulado já tiver questões, não faz nada.
+//
+// Rodar em dev:  node --env-file=.env scripts/seed-aws-ccp.ts
+// Rodar em prod: docker compose -f docker-compose.prod.yml exec -T backend \
+//                  node --env-file=.env.prod scripts/seed-aws-ccp.ts
+import { db } from "../db.ts";
+import { simulados, simuladoQuestions, simuladoOptions } from "../schema.ts";
+import { eq, count } from "drizzle-orm";
+
+const SLUG = "aws-cloud-practitioner";
+
+type Questao = { statement: string; explanation: string; options: [string, boolean][] };
+
+const QUESTOES: Questao[] = [
+    {
+        statement: "Quais tarefas são responsabilidades da AWS? (Selecione DUAS opções.)",
+        explanation:
+            "A AWS é responsável pela segurança da nuvem (hardware, virtualização, infraestrutura física). Grupos de segurança, usuários IAM e treinamento são responsabilidades do cliente (segurança na nuvem).",
+        options: [
+            ["Configuração de grupos de segurança em instâncias do Amazon EC2", false],
+            ["Manutenção da infraestrutura de virtualização", true],
+            ["Configuração de dispositivos de infraestrutura da AWS", true],
+            ["Criação de usuários e grupos do IAM", false],
+            ["Treinamento de funcionários da empresa sobre como usar os serviços da AWS", false],
+        ],
+    },
+    {
+        statement:
+            "Um engenheiro de nuvem está executando uma instância EC2 e deseja armazenar dados em um recurso anexado à instância. Qual serviço deve ser utilizado?",
+        explanation:
+            "O EBS é o armazenamento em bloco persistente que se anexa a uma instância EC2. O armazenamento de instância é efêmero, o S3 é de objetos via API e sub-rede é rede.",
+        options: [
+            ["Volume do Amazon Elastic Block Store (Amazon EBS)", true],
+            ["Armazenamento de instância", false],
+            ["Bucket do Amazon S3", false],
+            ["Sub-rede", false],
+        ],
+    },
+    {
+        statement:
+            "Qual componente da nuvem privada virtual (VPC) controla o tráfego de entrada e saída para instâncias do Amazon EC2?",
+        explanation:
+            "O grupo de segurança atua no nível da instância (firewall stateful). A Network ACL controla tráfego no nível da sub-rede; como o enunciado fala em instâncias EC2, a resposta é grupo de segurança.",
+        options: [
+            ["Lista de controle de acesso de rede", false],
+            ["Sub-rede", false],
+            ["Gateway de internet", false],
+            ["Grupo de segurança", true],
+        ],
+    },
+    {
+        statement:
+            "Qual opção de preço do Amazon EC2 reduz o custo quando você assume um compromisso de gasto por hora com uma família de instâncias?",
+        explanation:
+            'A palavra-chave é "compromisso de gasto por hora" com uma família de instâncias, definição do EC2 Instance Savings Plans. As Reservadas comprometem-se com configuração específica de instância.',
+        options: [
+            ["Instâncias reservadas", false],
+            ["Savings Plans da instância do EC2", true],
+            ["Instâncias spot", false],
+            ["Hosts dedicados", false],
+        ],
+    },
+    {
+        statement: "Qual das afirmações a seguir melhor descreve as Zonas de Disponibilidade?",
+        explanation:
+            "Uma AZ é um ou mais data centers isolados dentro de uma Região. A opção sobre localização geográfica descreve uma Região; as demais descrevem a origem e os edge locations do CloudFront.",
+        options: [
+            ["Uma parte totalmente isolada da infraestrutura global da AWS", true],
+            [
+                "Uma localização geográfica separada com vários locais isolados uns dos outros",
+                false,
+            ],
+            ["O servidor do qual o Amazon CloudFront obtém os arquivos", false],
+            [
+                "Um site que o Amazon CloudFront usa para armazenar em cache cópias de conteúdo para entrega mais rápida",
+                false,
+            ],
+        ],
+    },
+    {
+        statement: "Quais ações você pode executar no Amazon Route 53? (Selecione DUAS opções.)",
+        explanation:
+            "O Route 53 é o DNS da AWS: gerencia registros DNS e roteia solicitações para recursos na AWS e externos. Monitorar é CloudWatch, automatizar é CloudFormation e conformidade é o AWS Artifact.",
+        options: [
+            ["Gerenciar registros DNS para nomes de domínio", true],
+            ["Conectar solicitações de usuários à infraestrutura na AWS e fora da AWS", true],
+            [
+                "Monitorar as aplicações e responder a alterações de desempenho em todo o sistema",
+                false,
+            ],
+            ["Automatizar a implantação de cargas de trabalho no ambiente AWS", false],
+            [
+                "Acessar relatórios de segurança e conformidade da AWS e selecionar contratos on-line",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Qual categoria do AWS Trusted Advisor inclui verificações para baixa utilização de instâncias do Amazon EC2?",
+        explanation:
+            "O Trusted Advisor sinaliza instâncias EC2 subutilizadas (baixa utilização) na categoria de otimização de custos.",
+        options: [
+            ["Segurança", false],
+            ["Desempenho", false],
+            ["Tolerância a falhas", false],
+            ["Otimização de custos", true],
+        ],
+    },
+    {
+        statement:
+            "Qual ferramenta realiza ações de automação para serviços e aplicações da AWS por meio de scripts?",
+        explanation:
+            "A AWS CLI automatiza e gerencia serviços via linha de comando/scripts. QLDB é banco ledger, Redshift é data warehouse e Snowball é transferência física de dados.",
+        options: [
+            ["Amazon QLDB", false],
+            ["Amazon Redshift", false],
+            ["AWS Command Line Interface", true],
+            ["AWS Snowball", false],
+        ],
+    },
+    {
+        statement: "Qual serviço é usado para transferência até 100 PB de dados para a AWS?",
+        explanation:
+            "O Snowmobile move até ~100 PB por unidade (escala de exabytes). O Snowball move dezenas de TB. Neptune é banco de grafos, DeepRacer é ML e CloudFront é CDN.",
+        options: [
+            ["Amazon Neptune", false],
+            ["AWS Snowmobile", true],
+            ["AWS DeepRacer", false],
+            ["Amazon CloudFront", false],
+        ],
+    },
+    {
+        statement: "Qual afirmação melhor descreve o Elastic Load Balancing?",
+        explanation:
+            "Definição exata do ELB. As outras opções descrevem o ElastiCache, o Trusted Advisor/CloudWatch e o EC2 Auto Scaling.",
+        options: [
+            [
+                "Um serviço que permite criar, configurar, gerenciar e dimensionar na nuvem um ambiente de cache ou em memória distribuído",
+                false,
+            ],
+            [
+                "Um serviço que fornece dados para monitorar aplicações, otimizar a utilização dos recursos e responder a mudanças sistêmicas de desempenho",
+                false,
+            ],
+            [
+                "Um serviço que monitora aplicações e automaticamente adiciona ou remove capacidade dos Resource Groups em resposta a mudanças na demanda",
+                false,
+            ],
+            [
+                "Um serviço que distribui o tráfego de entrada entre vários destinos, como instâncias do Amazon EC2",
+                true,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço apresenta revisão de detalhes de atividades de usuário e chamadas de API que ocorreram no ambiente AWS?",
+        explanation:
+            "O CloudTrail registra chamadas de API e atividades de usuário (auditoria/governança). CloudWatch monitora desempenho e Inspector avalia vulnerabilidades.",
+        options: [
+            ["AWS Trusted Advisor", false],
+            ["AWS CloudTrail", true],
+            ["Amazon CloudWatch", false],
+            ["Amazon Inspector", false],
+        ],
+    },
+    {
+        statement:
+            "Qual componente ou serviço estabelece uma conexão privada dedicada entre o data center on-premises e a nuvem privada virtual (VPC)?",
+        explanation:
+            "O Direct Connect cria um link físico dedicado (sem internet pública). O Gateway Privado Virtual é apenas o lado AWS de uma VPN/Direct Connect.",
+        options: [
+            ["Gateway privado virtual", false],
+            ["AWS Direct Connect", true],
+            ["Amazon CloudFront", false],
+            ["Gateway de internet", false],
+        ],
+    },
+    {
+        statement: "Qual declaração descreve melhor o Amazon GuardDuty?",
+        explanation:
+            "GuardDuty é detecção de ameaças baseada em ML. As outras opções descrevem o AWS Shield (DDoS), o Inspector e o AWS WAF.",
+        options: [
+            [
+                "Um serviço que protege as aplicações contra ataques distribuídos de negação de serviço (DDoS)",
+                false,
+            ],
+            [
+                "Um serviço que verifica as aplicações quanto a vulnerabilidades de segurança e desvios das práticas recomendadas de segurança",
+                false,
+            ],
+            ["Um serviço que monitora as solicitações de rede para aplicações web", false],
+            [
+                "Um serviço que realiza detecção inteligente de ameaças na infraestrutura e nos recursos da AWS",
+                true,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço permite consolidar e gerenciar várias contas AWS em um local central?",
+        explanation:
+            "O Organizations centraliza várias contas (faturamento consolidado, SCPs). KMS gerencia chaves, Artifact dá relatórios de conformidade e IAM gerencia identidades dentro de uma conta.",
+        options: [
+            ["AWS Organizations", true],
+            ["AWS Key Management Service (AWS KMS)", false],
+            ["AWS Artifact", false],
+            ["AWS Identity and Access Management (IAM)", false],
+        ],
+    },
+    {
+        statement: "Qual ação pode ser executada no Amazon CloudFront?",
+        explanation:
+            "O CloudFront é a CDN da AWS (edge locations). As outras opções descrevem a VPC, o CloudFormation e nuvem híbrida (Outposts/Direct Connect).",
+        options: [
+            [
+                "Provisão de uma seção isolada da nuvem AWS para iniciar recursos em uma rede virtual definida por alguém",
+                false,
+            ],
+            ["Provisão de recursos usando linguagens de programação ou um arquivo de texto", false],
+            ["Entregar conteúdo aos clientes por uma rede global de locais de borda", true],
+            ["Executar a infraestrutura em uma abordagem de nuvem híbrida", false],
+        ],
+    },
+    {
+        statement:
+            "Um desenvolvedor de aplicação deseja armazenar dados em um banco de dados de chave-valor. Qual serviço deve ser utilizado?",
+        explanation:
+            "O DynamoDB é o banco NoSQL chave-valor. Aurora e RDS são relacionais e DocumentDB é orientado a documentos.",
+        options: [
+            ["Amazon DynamoDB", true],
+            ["Amazon Aurora", false],
+            ["Amazon RDS", false],
+            ["Amazon DocumentDB", false],
+        ],
+    },
+    {
+        statement: "Qual serviço permite implantar e dimensionar rapidamente aplicações na AWS?",
+        explanation:
+            "O Beanstalk (PaaS) faz deploy e escala automático (provisiona EC2, Load Balancer, Auto Scaling). Snowball é transferência de dados, Outposts é on-premises e CloudFront é CDN.",
+        options: [
+            ["AWS Snowball", false],
+            ["AWS Outposts", false],
+            ["AWS Elastic Beanstalk", true],
+            ["Amazon CloudFront", false],
+        ],
+    },
+    {
+        statement: "Qual serviço executa aplicações em contêineres na AWS?",
+        explanation:
+            "O EKS roda contêineres com Kubernetes. Aurora é banco, SageMaker é ML e Redshift é data warehouse.",
+        options: [
+            ["Amazon Elastic Kubernetes Service (Amazon EKS)", true],
+            ["Amazon Aurora", false],
+            ["Amazon SageMaker", false],
+            ["Amazon Redshift", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço permite criar fluxos de trabalho necessários para a revisão humana das previsões de machine learning?",
+        explanation:
+            "O Amazon A2I (Augmented AI) é o serviço de human-in-the-loop. Aurora é banco, Lex faz chatbots e Textract extrai texto de documentos.",
+        options: [
+            ["Amazon Augmented AI", true],
+            ["Amazon Aurora", false],
+            ["Amazon Lex", false],
+            ["Amazon Textract", false],
+        ],
+    },
+    {
+        statement: "Qual declaração descreve melhor o AWS Marketplace?",
+        explanation:
+            "O Marketplace é a loja/catálogo de software de terceiros (ISVs). As outras opções descrevem suporte, o Trusted Advisor e o AWS Support enterprise.",
+        options: [
+            [
+                "Um recurso que pode responder a perguntas sobre práticas recomendadas e ajudar na solução de problemas",
+                false,
+            ],
+            [
+                "Uma ferramenta on-line que inspeciona o ambiente AWS e faz recomendações em tempo real de acordo com as práticas recomendadas da AWS",
+                false,
+            ],
+            [
+                "Um recurso que oferece orientação, revisões de arquitetura e comunicação contínua com sua empresa durante o planejamento, a implantação e a otimização das aplicações",
+                false,
+            ],
+            [
+                "Um catálogo digital que inclui milhares de ofertas de software de fornecedores independentes de software",
+                true,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Qual estratégia de migração envolve alterar a forma como uma aplicação é arquitetada e desenvolvida, normalmente usando recursos nativos da nuvem?",
+        explanation:
+            "Refatorar (re-architecting) reescreve a aplicação para recursos cloud-native. Replatform faz ajustes pequenos, Repurchase troca por SaaS e Rehost é o lift-and-shift.",
+        options: [
+            ["Redefinir plataforma", false],
+            ["Recomprar", false],
+            ["Refatorar", true],
+            ["Redefinir hospedagem", false],
+        ],
+    },
+    {
+        statement:
+            "Um engenheiro de nuvem deseja armazenar dados em um volume anexado a uma instância do Amazon EC2. Qual serviço deve ser utilizado?",
+        explanation:
+            'Palavra-chave: "volume anexado" = armazenamento em bloco = EBS. S3 é objetos via API, ElastiCache é cache e Lambda é serverless.',
+        options: [
+            ["Amazon Elastic Block Store (Amazon EBS)", true],
+            ["Amazon Simple Storage Service (Amazon S3)", false],
+            ["Amazon ElastiCache", false],
+            ["AWS Lambda", false],
+        ],
+    },
+    {
+        statement:
+            "Qual perspectiva do AWS Cloud Adoption Framework se concentra na recuperação de cargas de trabalho de TI para atender aos requisitos dos stakeholders da empresa?",
+        explanation:
+            "A perspectiva de Operações cuida de executar, monitorar e recuperar cargas de trabalho. As demais perspectivas tratam de governança, pessoas e negócio.",
+        options: [
+            ["Perspectiva de governança", false],
+            ["Perspectiva de pessoas", false],
+            ["Perspectiva de negócio", false],
+            ["Perspectiva de operações", true],
+        ],
+    },
+    {
+        statement:
+            "Qual pilar do AWS Well-Architected Framework tem foco em usar recursos de computação de maneiras que atendam aos requisitos do sistema?",
+        explanation:
+            "Eficiência de Desempenho trata de usar recursos computacionais adequados à demanda. Confiabilidade é recuperação, Segurança é proteção e Excelência Operacional é executar/melhorar processos.",
+        options: [
+            ["Confiabilidade", false],
+            ["Segurança", false],
+            ["Excelência operacional", false],
+            ["Eficiência de desempenho", true],
+        ],
+    },
+    {
+        statement:
+            "Na storage class S3 Intelligent-Tiering, o Amazon S3 move objetos entre um nível de acesso frequente e um nível de acesso pouco frequente. Quais classes de armazenamento são usadas? (Selecione DUAS opções.)",
+        explanation:
+            "O Intelligent-Tiering move objetos entre o tier de acesso frequente (S3 Standard) e o de acesso infrequente (S3 Standard-IA). As demais são classes de arquivamento separadas.",
+        options: [
+            ["S3 One Zone – IA", false],
+            ["S3 Glacier Flexible Retrieval", false],
+            ["S3 Standard-IA", true],
+            ["S3 Standard", true],
+            ["S3 Glacier Deep Archive", false],
+        ],
+    },
+    {
+        statement:
+            "Um desenvolvedor de aplicação deseja enviar e receber mensagens entre componentes distribuídos de aplicações. Qual serviço deve ser utilizado?",
+        explanation:
+            "O SQS é o serviço de filas que desacopla componentes distribuídos. Snowball é transferência, ElastiCache é cache e Route 53 é DNS.",
+        options: [
+            ["AWS Snowball", false],
+            ["Amazon ElastiCache", false],
+            ["Amazon Route 53", false],
+            ["Amazon Simple Queue Service (Amazon SQS)", true],
+        ],
+    },
+    {
+        statement:
+            "Quais recomendações estão incluídas nas verificações do AWS Trusted Advisor? (Selecione DUAS respostas.)",
+        explanation:
+            "Verificações clássicas de Segurança do Trusted Advisor: buckets S3 abertos e MFA no root. Interrupções é o Health Dashboard, patches é Systems Manager/Inspector e número de usuários não é verificação.",
+        options: [
+            ["Permissões de bucket do Amazon S3", true],
+            ["Interrupções de produtos da AWS para serviços", false],
+            ["Uso de autenticação multifator (MFA) no usuário raiz da conta da AWS", true],
+            ["Patches de software disponíveis para instâncias Amazon EC2", false],
+            ["Número de usuários na conta", false],
+        ],
+    },
+    {
+        statement:
+            "Qual princípio de design da arquitetura da Nuvem AWS é compatível com a distribuição de cargas de trabalho em várias zonas de disponibilidade?",
+        explanation:
+            "Distribuir cargas em múltiplas AZs é projetar para falhas (alta disponibilidade). Automação reduz esforço manual, agilidade é velocidade e elasticidade é escalar conforme demanda.",
+        options: [
+            ["Implementação de automação", false],
+            ["Design para agilidade", false],
+            ["Design à prova de falhas", true],
+            ["Implementação de elasticidade", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa tem um servidor de aplicações em execução em uma instância Amazon EC2. O servidor precisa acessar o conteúdo em um bucket privado do Amazon S3. Qual é a abordagem recomendada?",
+        explanation:
+            "Prática recomendada: IAM role anexada à instância, sem credenciais codificadas. Peering de VPC conecta VPCs; chaves codificadas ou armazenadas devem ser evitadas.",
+        options: [
+            [
+                "Crie uma IAM role com as permissões apropriadas e associe a role à instância EC2.",
+                true,
+            ],
+            [
+                "Configure uma conexão de peering de VPC para permitir a comunicação privada entre a instância EC2 e o bucket do S3.",
+                false,
+            ],
+            [
+                "Crie uma chave de acesso compartilhada e configure a instância EC2 para usar a chave codificada.",
+                false,
+            ],
+            ["Configure a aplicação para ler uma chave de acesso de uma fonte segura.", false],
+        ],
+    },
+    {
+        statement:
+            "Quais recursos ou serviços relacionados à segurança a AWS oferece? (Selecione DUAS respostas.)",
+        explanation:
+            'Verificações de segurança do Trusted Advisor e criptografia são recursos reais. "Compliance completa com PCI" é falso (responsabilidade compartilhada); pentest automatizado e detecção de direitos autorais não são serviços oferecidos.',
+        options: [
+            ["Compliance completa com PCI para aplicações do cliente executadas na AWS", false],
+            ["Verificações de segurança do AWS Trusted Advisor", true],
+            ["Criptografia dos dados", true],
+            ["Teste de penetração automatizado", false],
+            ["Detecção de conteúdo protegido por direitos autorais do Amazon S3", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa precisa de acesso ininterrupto por telefone, e-mail e chat. O tempo de resposta deverá ser inferior a uma hora se um sistema de produção tiver uma interrupção de serviço. Qual plano do AWS Support atende a esse requisito pelo MENOR custo?",
+        explanation:
+            "Suporte 24/7 por telefone/chat e resposta menor que 1 h para produção inoperante começa no plano Business. Developer não tem telefone nem esse SLA; Enterprise atende mas custa mais.",
+        options: [
+            ["AWS Basic Support", false],
+            ["AWS Developer Support", false],
+            ["AWS Business Support", true],
+            ["AWS Enterprise Support", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa está hospedando um site estático por meio de um único bucket do Amazon S3. Qual produto da AWS atingirá latência mais baixa e alta velocidade de transferência?",
+        explanation:
+            "O CloudFront (CDN) entrega conteúdo de edge locations próximas, reduzindo latência. Beanstalk é deploy, DAX acelera o DynamoDB e Route 53 é DNS.",
+        options: [
+            ["AWS Elastic Beanstalk", false],
+            ["Amazon DynamoDB Accelerator (DAX)", false],
+            ["Amazon Route 53", false],
+            ["Amazon CloudFront", true],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa precisa monitorar e receber alertas sobre eventos de login do Console de Gerenciamento da AWS que envolvem o usuário raiz da conta. Qual produto da AWS a empresa deve usar?",
+        explanation:
+            "O CloudWatch cria o alarme que dispara o alerta (alimentado pelo CloudTrail). Config avalia conformidade, Trusted Advisor faz recomendações e IAM gerencia identidades.",
+        options: [
+            ["Amazon CloudWatch", true],
+            ["AWS Config", false],
+            ["AWS Trusted Advisor", false],
+            ["AWS Identity and Access Management (IAM)", false],
+        ],
+    },
+    {
+        statement:
+            "Qual das opções a seguir descreve uma melhor prática de segurança que pode ser implementada usando o AWS Identity and Access Management (IAM)?",
+        explanation:
+            "Princípio do menor privilégio (least privilege). As demais são práticas ruins: desativar console para todos, gerar chaves para cada usuário e armazenar credenciais em EC2 (o correto é usar IAM roles).",
+        options: [
+            ["Desativar o acesso ao Console de Gerenciamento da AWS para todos os usuários", false],
+            ["Gerar chaves secretas para cada usuário do IAM", false],
+            [
+                "Conceder permissões a usuários que precisam executar apenas uma tarefa específica",
+                true,
+            ],
+            ["Armazenar credenciais da AWS em instâncias Amazon EC2", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer uma conexão privada dedicada entre suas operações locais e a Nuvem AWS. Qual recurso ou produto da AWS fornecerá essa conexão?",
+        explanation:
+            "O Direct Connect cria um link físico dedicado (sem internet). VPN e VPN endpoint usam a internet pública; PrivateLink conecta serviços/VPCs dentro da AWS.",
+        options: [
+            ["AWS VPN", false],
+            ["AWS PrivateLink", false],
+            ["VPN endpoint", false],
+            ["AWS Direct Connect", true],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa exige isolamento físico de suas instâncias Amazon EC2 das instâncias de outros clientes. Qual opção de compra de instâncias atende a esse requisito?",
+        explanation:
+            "Palavra-chave: isolamento físico. O Dedicated Host fornece um servidor físico inteiro dedicado. Reservadas, On-Demand e Spot são modelos de preço em hardware compartilhado.",
+        options: [
+            ["Hosts dedicados", true],
+            ["Instâncias reservadas", false],
+            ["Instâncias On-Demand", false],
+            ["Instâncias Spot", false],
+        ],
+    },
+    {
+        statement:
+            "Qual das seguintes opções é uma responsabilidade da AWS de acordo com o modelo de responsabilidade compartilhada da AWS?",
+        explanation:
+            "A AWS é responsável pela segurança da nuvem (infraestrutura física). Projetar DR, atualizar SO convidado e configurar recursos são responsabilidades do cliente.",
+        options: [
+            ["Projetar a aplicação de um cliente para recuperação de desastres", false],
+            [
+                "Atualizar os sistemas operacionais convidados em instâncias Amazon EC2 implantadas",
+                false,
+            ],
+            ["Configurar novos recursos em uma conta da AWS", false],
+            ["Proteger a infraestrutura física", true],
+        ],
+    },
+    {
+        statement:
+            "Quais recursos ou produtos da AWS são compatíveis com a replicação de dados em todas as regiões AWS? (Selecione DUAS respostas.)",
+        explanation:
+            "S3 (Cross-Region Replication) e RDS (réplicas de leitura entre regiões) replicam dados entre regiões. EBS é por AZ, Instance Store é efêmero/local e Storage Gateway é híbrido.",
+        options: [
+            ["Amazon S3", true],
+            ["Amazon Elastic Block Store (Amazon EBS)", false],
+            ["Amazon EC2 Instance store", false],
+            ["Amazon Storage Gateway", false],
+            ["Amazon RDS", true],
+        ],
+    },
+    {
+        statement:
+            "Qual modelo de preço do Amazon EC2 se ajusta com base na oferta e na demanda de instâncias EC2?",
+        explanation:
+            "As Spot usam capacidade ociosa e o preço varia conforme oferta e demanda. On-Demand tem preço fixo; reservadas e conversíveis têm preço fixo com compromisso de prazo.",
+        options: [
+            ["Instâncias On-Demand", false],
+            ["Instâncias reservadas", false],
+            ["Instâncias Spot", true],
+            ["Instâncias reservadas conversíveis", false],
+        ],
+    },
+    {
+        statement:
+            "Qual produto da AWS pode criar um alarme que envia uma notificação quando um limite de faturamento é excedido?",
+        explanation:
+            "Os billing alarms são criados no CloudWatch (métrica EstimatedCharges + notificação via SNS). CloudTrail apenas audita chamadas de API; Trusted Advisor recomenda; QuickSight é BI.",
+        options: [
+            ["AWS Trusted Advisor", false],
+            ["AWS CloudTrail", false],
+            ["Amazon CloudWatch", true],
+            ["Amazon QuickSight", false],
+        ],
+    },
+    {
+        statement:
+            "Qual produto da AWS fornece uma solução de armazenamento de arquivos compartilhado, simples e escalável para uso com servidores locais e instâncias Amazon EC2?",
+        explanation:
+            "Palavra-chave: armazenamento de arquivos compartilhado (NFS, montável em várias instâncias). AMS é operações, Glacier é arquivamento e EBS é bloco anexado a uma única instância.",
+        options: [
+            ["AWS Managed Services (AMS)", false],
+            ["Amazon S3 Glacier", false],
+            ["Amazon Elastic Block Store (Amazon EBS)", false],
+            ["Amazon Elastic File System (Amazon EFS)", true],
+        ],
+    },
+    {
+        statement:
+            "Quais das opções a seguir são vantagens da Nuvem AWS? (Selecione DUAS respostas.)",
+        explanation:
+            "A AWS cuida da manutenção da infraestrutura e do planejamento de capacidade dos servidores físicos. Segurança das aplicações do cliente, desenvolvimento e planejamento de custos são do cliente.",
+        options: [
+            ["A AWS gerencia a manutenção da infraestrutura de nuvem", true],
+            ["A AWS gerencia a segurança de aplicações criadas na AWS", false],
+            ["A AWS gerencia o planejamento de capacidade para servidores físicos", true],
+            ["A AWS gerencia o desenvolvimento de aplicações na AWS", false],
+            ["A AWS gerencia o planejamento de custos para servidores virtuais", false],
+        ],
+    },
+    {
+        statement:
+            "Quais das seguintes opções são benefícios da Nuvem AWS? (Selecione DUAS respostas.)",
+        explanation:
+            'Trocar CapEx por OpEx e ganhar agilidade são benefícios clássicos da nuvem. "Segurança na nuvem" é do cliente e não é um benefício; equipe de TI maior e fatura fixa são falsos.',
+        options: [
+            ["As empresas precisam de uma equipe de TI maior", false],
+            ["As despesas de capital são substituídas por despesas variáveis", true],
+            [
+                "Os clientes recebem a mesma fatura mensal, independentemente de quais recursos eles usam",
+                false,
+            ],
+            ["As empresas ganham maior agilidade", true],
+            ["A AWS é responsável pela segurança na nuvem", false],
+        ],
+    },
+    {
+        statement: "Qual das opções a seguir é uma vantagem do faturamento consolidado na AWS?",
+        explanation:
+            "O faturamento consolidado junta o uso de todas as contas, atingindo descontos por volume mais cedo. Permissões é IAM; várias faturas é o oposto; marcação de recursos não tem relação.",
+        options: [
+            ["Qualificação de preços por volume", true],
+            ["Permissões de acesso compartilhado", false],
+            ["Várias faturas para cada conta", false],
+            ["Eliminação da necessidade de marcar recursos", false],
+        ],
+    },
+    {
+        statement:
+            "Qual aspecto da infraestrutura da AWS fornece implementação global de computação e armazenamento?",
+        explanation:
+            "As Regiões espalhadas pelo mundo dão o alcance global. Várias AZs em uma região dão disponibilidade regional. Tags e Resource Groups organizam recursos.",
+        options: [
+            ["Várias zonas de disponibilidade em uma região da AWS", false],
+            ["Várias regiões AWS", true],
+            ["Tags", false],
+            ["Resource Groups", false],
+        ],
+    },
+    {
+        statement: "Qual declaração é VERDADEIRA sobre o AWS Lambda?",
+        explanation:
+            "Essência do serverless: paga-se só pelo tempo de execução. As demais contradizem o modelo (pagar antecipado, configurar/provisionar servidores).",
+        options: [
+            ["A empresa paga apenas pelo tempo de computação durante a execução do código", true],
+            [
+                "Para usar o AWS Lambda, uma empresa precisa pagar antecipadamente pelo tempo estimado de computação",
+                false,
+            ],
+            [
+                "Para usar o AWS Lambda, uma empresa precisa configurar os servidores que executam o código",
+                false,
+            ],
+            ["A primeira etapa ao usar o AWS Lambda é provisionar um servidor", false],
+        ],
+    },
+    {
+        statement:
+            "Qual princípio da arquitetura da Nuvem AWS afirma que os sistemas devem reduzir as interdependências?",
+        explanation:
+            '"Reduzir interdependências" = acoplamento fraco (loose coupling), via SQS, Load Balancer etc. "Serviços, não servidores" é sobre serverless; escalabilidade e automação tratam de outros aspectos.',
+        options: [
+            ["Escalabilidade", false],
+            ["Serviços, não servidores", false],
+            ["Automação", false],
+            ["Acoplamento fraco", true],
+        ],
+    },
+];
+
+async function seed() {
+    let [simulado] = await db.select().from(simulados).where(eq(simulados.slug, SLUG));
+    if (!simulado) {
+        [simulado] = await db
+            .insert(simulados)
+            .values({
+                slug: SLUG,
+                name: "AWS Certified Cloud Practitioner",
+                description:
+                    "Simulado no formato da prova CLF-C02: 90 minutos, corte de 70%. Mistura resposta única e múltipla.",
+                durationMinutes: 90,
+                questionCount: 65,
+                passPercent: 70,
+                published: true,
+            })
+            .returning();
+        console.log(`Simulado criado: ${simulado.slug}`);
+    }
+
+    const [{ n }] = await db
+        .select({ n: count() })
+        .from(simuladoQuestions)
+        .where(eq(simuladoQuestions.simuladoId, simulado.id));
+    if (Number(n) > 0) {
+        console.log(`Simulado já tem ${n} questões, nada a fazer.`);
+        return;
+    }
+
+    for (const q of QUESTOES) {
+        const [questao] = await db
+            .insert(simuladoQuestions)
+            .values({ simuladoId: simulado.id, statement: q.statement, explanation: q.explanation })
+            .returning();
+        await db.insert(simuladoOptions).values(
+            q.options.map(([text, isCorrect], i) => ({
+                questionId: questao.id,
+                text,
+                isCorrect,
+                position: i + 1,
+            })),
+        );
+    }
+    console.log(`Seed concluído: ${QUESTOES.length} questões inseridas.`);
+}
+
+seed()
+    .then(() => process.exit(0))
+    .catch((e) => {
+        console.error("Falha no seed:", e);
+        process.exit(1);
+    });

--- a/backend/src/controllers/SimuladoController.ts
+++ b/backend/src/controllers/SimuladoController.ts
@@ -1,0 +1,66 @@
+import type { Request, Response, NextFunction } from "express";
+import { salvarRespostaSchema } from "../schemas/simulado.schema.ts";
+import {
+    listarSimulados,
+    iniciarTentativa,
+    estadoDaTentativa,
+    salvarResposta,
+    enviarTentativa,
+    historicoDoUsuario,
+} from "../services/simulado.service.ts";
+
+export const listSimulados = async (_req: Request, res: Response, next: NextFunction) => {
+    try {
+        res.json(await listarSimulados());
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const startAttempt = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        res.status(201).json(await iniciarTentativa(req.userId!, String(req.params.slug)));
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const getAttempt = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        res.json(await estadoDaTentativa(req.userId!, String(req.params.id)));
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const saveAnswer = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const { optionIds } = salvarRespostaSchema.parse(req.body);
+        res.json(
+            await salvarResposta(
+                req.userId!,
+                String(req.params.id),
+                String(req.params.questionId),
+                optionIds,
+            ),
+        );
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const submitAttempt = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        res.json(await enviarTentativa(req.userId!, String(req.params.id)));
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const getMyAttempts = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        res.json(await historicoDoUsuario(req.userId!));
+    } catch (err) {
+        next(err);
+    }
+};

--- a/backend/src/domain/simulado.test.ts
+++ b/backend/src/domain/simulado.test.ts
@@ -1,0 +1,96 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { corrigirSimulado, questaoCorreta } from "./simulado.ts";
+
+describe("questaoCorreta", () => {
+    test("resposta única certa", () => {
+        assert.equal(questaoCorreta(new Set(["a"]), new Set(["a"])), true);
+    });
+
+    test("resposta única errada", () => {
+        assert.equal(questaoCorreta(new Set(["b"]), new Set(["a"])), false);
+    });
+
+    test("múltipla completa acerta", () => {
+        assert.equal(questaoCorreta(new Set(["a", "b"]), new Set(["a", "b"])), true);
+    });
+
+    test("múltipla parcial não conta", () => {
+        assert.equal(questaoCorreta(new Set(["a"]), new Set(["a", "b"])), false);
+    });
+
+    test("múltipla com opção a mais não conta", () => {
+        assert.equal(questaoCorreta(new Set(["a", "b", "c"]), new Set(["a", "b"])), false);
+    });
+
+    test("em branco não conta", () => {
+        assert.equal(questaoCorreta(new Set(), new Set(["a"])), false);
+    });
+
+    test("questão sem gabarito nunca é correta", () => {
+        assert.equal(questaoCorreta(new Set(["a"]), new Set()), false);
+    });
+});
+
+describe("corrigirSimulado", () => {
+    const questoes = [
+        { id: "q1", corretas: new Set(["a"]) },
+        { id: "q2", corretas: new Set(["a", "b"]) },
+        { id: "q3", corretas: new Set(["c"]) },
+    ];
+
+    test("tudo certo é 100 e passa", () => {
+        const r = corrigirSimulado(
+            questoes,
+            new Map([
+                ["q1", new Set(["a"])],
+                ["q2", new Set(["a", "b"])],
+                ["q3", new Set(["c"])],
+            ]),
+            70,
+        );
+        assert.deepEqual(r, { acertos: 3, total: 3, score: 100, passed: true });
+    });
+
+    test("multi parcial reprova a questão", () => {
+        const r = corrigirSimulado(
+            questoes,
+            new Map([
+                ["q1", new Set(["a"])],
+                ["q2", new Set(["a"])], // faltou b
+                ["q3", new Set(["c"])],
+            ]),
+            70,
+        );
+        assert.equal(r.acertos, 2);
+        assert.equal(r.score, 67);
+        assert.equal(r.passed, false);
+    });
+
+    test("questões sem resposta contam como erro", () => {
+        const r = corrigirSimulado(questoes, new Map(), 70);
+        assert.deepEqual(r, { acertos: 0, total: 3, score: 0, passed: false });
+    });
+
+    test("corte exato de 70 passa", () => {
+        const dez = Array.from({ length: 10 }, (_, i) => ({
+            id: `q${i}`,
+            corretas: new Set([`o${i}`]),
+        }));
+        const respostas = new Map(
+            dez.slice(0, 7).map((q) => [q.id, new Set([`o${q.id.slice(1)}`])]),
+        );
+        const r = corrigirSimulado(dez, respostas, 70);
+        assert.equal(r.score, 70);
+        assert.equal(r.passed, true);
+    });
+
+    test("simulado vazio não passa", () => {
+        assert.deepEqual(corrigirSimulado([], new Map(), 70), {
+            acertos: 0,
+            total: 0,
+            score: 0,
+            passed: false,
+        });
+    });
+});

--- a/backend/src/domain/simulado.ts
+++ b/backend/src/domain/simulado.ts
@@ -1,0 +1,26 @@
+// Por questão é tudo-ou-nada: o conjunto marcado tem que ser exatamente o correto.
+// Vale para resposta única e múltipla.
+
+function mesmosConjuntos(a: Set<string>, b: Set<string>): boolean {
+    if (a.size !== b.size) return false;
+    for (const x of a) if (!b.has(x)) return false;
+    return true;
+}
+
+export function questaoCorreta(marcadas: Set<string>, corretas: Set<string>): boolean {
+    return corretas.size > 0 && mesmosConjuntos(marcadas, corretas);
+}
+
+export function corrigirSimulado(
+    questoes: { id: string; corretas: Set<string> }[],
+    respostas: Map<string, Set<string>>,
+    passPercent: number,
+): { acertos: number; total: number; score: number; passed: boolean } {
+    let acertos = 0;
+    for (const q of questoes) {
+        if (questaoCorreta(respostas.get(q.id) ?? new Set(), q.corretas)) acertos++;
+    }
+    const total = questoes.length;
+    const score = total === 0 ? 0 : Math.round((acertos / total) * 100);
+    return { acertos, total, score, passed: total > 0 && score >= passPercent };
+}

--- a/backend/src/routes/simulado.routes.ts
+++ b/backend/src/routes/simulado.routes.ts
@@ -1,0 +1,21 @@
+import { Router } from "express";
+import { autenticar } from "../middlewares/auth.ts";
+import {
+    listSimulados,
+    startAttempt,
+    getAttempt,
+    saveAnswer,
+    submitAttempt,
+    getMyAttempts,
+} from "../controllers/SimuladoController.ts";
+
+const router = Router();
+
+router.get("/simulados", autenticar, listSimulados);
+router.get("/me/simulado-attempts", autenticar, getMyAttempts);
+router.post("/simulados/:slug/attempts", autenticar, startAttempt);
+router.get("/simulado-attempts/:id", autenticar, getAttempt);
+router.put("/simulado-attempts/:id/answers/:questionId", autenticar, saveAnswer);
+router.post("/simulado-attempts/:id/submit", autenticar, submitAttempt);
+
+export default router;

--- a/backend/src/schemas/simulado.schema.ts
+++ b/backend/src/schemas/simulado.schema.ts
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+// Vazio limpa a resposta; várias opções cobrem as questões de múltipla resposta.
+export const salvarRespostaSchema = z.object({
+    optionIds: z.array(z.uuid()).max(10),
+});

--- a/backend/src/services/simulado.service.ts
+++ b/backend/src/services/simulado.service.ts
@@ -1,0 +1,292 @@
+import { db } from "../../db.ts";
+import {
+    simulados,
+    simuladoQuestions,
+    simuladoOptions,
+    simuladoAttempts,
+    simuladoAttemptQuestions,
+    simuladoAttemptAnswers,
+} from "../../schema.ts";
+import { eq, and, sql, inArray, desc, isNull } from "drizzle-orm";
+import { AppError } from "../errors/AppError.ts";
+import { corrigirSimulado } from "../domain/simulado.ts";
+
+function agrupar(pares: [string, string][]): Map<string, Set<string>> {
+    const mapa = new Map<string, Set<string>>();
+    for (const [chave, valor] of pares) {
+        let conjunto = mapa.get(chave);
+        if (!conjunto) {
+            conjunto = new Set();
+            mapa.set(chave, conjunto);
+        }
+        conjunto.add(valor);
+    }
+    return mapa;
+}
+
+export async function listarSimulados() {
+    return db
+        .select({
+            slug: simulados.slug,
+            name: simulados.name,
+            description: simulados.description,
+            durationMinutes: simulados.durationMinutes,
+            questionCount: simulados.questionCount,
+            passPercent: simulados.passPercent,
+        })
+        .from(simulados)
+        .where(eq(simulados.published, true))
+        .orderBy(simulados.name);
+}
+
+export async function iniciarTentativa(userId: string, slug: string) {
+    const [simulado] = await db
+        .select()
+        .from(simulados)
+        .where(and(eq(simulados.slug, slug), eq(simulados.published, true)));
+    if (!simulado) throw new AppError(404, "Simulado não encontrado");
+
+    const agora = new Date();
+
+    // Se já existe uma tentativa em aberto e dentro do prazo, retoma em vez de criar outra.
+    const [emAberto] = await db
+        .select()
+        .from(simuladoAttempts)
+        .where(
+            and(
+                eq(simuladoAttempts.userId, userId),
+                eq(simuladoAttempts.simuladoId, simulado.id),
+                isNull(simuladoAttempts.submittedAt),
+            ),
+        )
+        .orderBy(desc(simuladoAttempts.startedAt))
+        .limit(1);
+    if (emAberto && emAberto.expiresAt > agora) {
+        return estadoDaTentativa(userId, emAberto.id);
+    }
+
+    const sorteadas = await db
+        .select({ id: simuladoQuestions.id })
+        .from(simuladoQuestions)
+        .where(eq(simuladoQuestions.simuladoId, simulado.id))
+        .orderBy(sql`random()`)
+        .limit(simulado.questionCount);
+    if (sorteadas.length === 0) throw new AppError(409, "Simulado ainda não tem questões");
+
+    const expiresAt = new Date(agora.getTime() + simulado.durationMinutes * 60 * 1000);
+    const attemptId = await db.transaction(async (tx) => {
+        const [attempt] = await tx
+            .insert(simuladoAttempts)
+            .values({ userId, simuladoId: simulado.id, expiresAt })
+            .returning({ id: simuladoAttempts.id });
+        await tx.insert(simuladoAttemptQuestions).values(
+            sorteadas.map((q, i) => ({
+                attemptId: attempt.id,
+                questionId: q.id,
+                position: i + 1,
+            })),
+        );
+        return attempt.id;
+    });
+
+    return estadoDaTentativa(userId, attemptId);
+}
+
+// O gabarito (isCorrect e a justificativa) só é revelado depois de enviar.
+export async function estadoDaTentativa(userId: string, attemptId: string) {
+    const [attempt] = await db
+        .select()
+        .from(simuladoAttempts)
+        .where(and(eq(simuladoAttempts.id, attemptId), eq(simuladoAttempts.userId, userId)));
+    if (!attempt) throw new AppError(404, "Tentativa não encontrada");
+
+    const enviado = attempt.submittedAt !== null;
+
+    const questoes = await db
+        .select({
+            id: simuladoQuestions.id,
+            statement: simuladoQuestions.statement,
+            explanation: simuladoQuestions.explanation,
+            position: simuladoAttemptQuestions.position,
+        })
+        .from(simuladoAttemptQuestions)
+        .innerJoin(simuladoQuestions, eq(simuladoQuestions.id, simuladoAttemptQuestions.questionId))
+        .where(eq(simuladoAttemptQuestions.attemptId, attemptId))
+        .orderBy(simuladoAttemptQuestions.position);
+
+    const questionIds = questoes.map((q) => q.id);
+    const opcoes = questionIds.length
+        ? await db
+              .select()
+              .from(simuladoOptions)
+              .where(inArray(simuladoOptions.questionId, questionIds))
+              .orderBy(simuladoOptions.position)
+        : [];
+    const respostas = await db
+        .select()
+        .from(simuladoAttemptAnswers)
+        .where(eq(simuladoAttemptAnswers.attemptId, attemptId));
+    const marcadas = agrupar(respostas.map((r) => [r.questionId, r.optionId]));
+
+    const questions = questoes.map((q) => {
+        const opcoesDaQuestao = opcoes.filter((o) => o.questionId === q.id);
+        return {
+            id: q.id,
+            statement: q.statement,
+            position: q.position,
+            // multi-resposta é derivado do gabarito; só expomos o booleano (a contagem
+            // exata já está no enunciado, ex.: "selecione DUAS").
+            multiple: opcoesDaQuestao.filter((o) => o.isCorrect).length > 1,
+            options: opcoesDaQuestao.map((o) => ({
+                id: o.id,
+                text: o.text,
+                position: o.position,
+                ...(enviado ? { isCorrect: o.isCorrect } : {}),
+            })),
+            selected: [...(marcadas.get(q.id) ?? [])],
+            ...(enviado ? { explanation: q.explanation } : {}),
+        };
+    });
+
+    const restanteMs = attempt.expiresAt.getTime() - Date.now();
+    return {
+        attemptId: attempt.id,
+        submitted: enviado,
+        expiresAt: attempt.expiresAt,
+        remainingSeconds: enviado ? 0 : Math.max(0, Math.floor(restanteMs / 1000)),
+        ...(enviado ? { score: attempt.score, passed: attempt.passed } : {}),
+        questions,
+    };
+}
+
+export async function salvarResposta(
+    userId: string,
+    attemptId: string,
+    questionId: string,
+    optionIds: string[],
+) {
+    const [attempt] = await db
+        .select()
+        .from(simuladoAttempts)
+        .where(and(eq(simuladoAttempts.id, attemptId), eq(simuladoAttempts.userId, userId)));
+    if (!attempt) throw new AppError(404, "Tentativa não encontrada");
+    if (attempt.submittedAt) throw new AppError(409, "Simulado já enviado");
+    if (attempt.expiresAt <= new Date()) throw new AppError(409, "Tempo esgotado");
+
+    const [pertence] = await db
+        .select({ id: simuladoAttemptQuestions.id })
+        .from(simuladoAttemptQuestions)
+        .where(
+            and(
+                eq(simuladoAttemptQuestions.attemptId, attemptId),
+                eq(simuladoAttemptQuestions.questionId, questionId),
+            ),
+        );
+    if (!pertence) throw new AppError(404, "Questão não faz parte da tentativa");
+
+    // As opções precisam ser desta questão (não deixa marcar opção de outra).
+    let validas: string[] = [];
+    if (optionIds.length > 0) {
+        const encontradas = await db
+            .select({ id: simuladoOptions.id })
+            .from(simuladoOptions)
+            .where(
+                and(
+                    eq(simuladoOptions.questionId, questionId),
+                    inArray(simuladoOptions.id, optionIds),
+                ),
+            );
+        validas = encontradas.map((o) => o.id);
+        if (validas.length !== new Set(optionIds).size) {
+            throw new AppError(400, "Opção inválida para esta questão");
+        }
+    }
+
+    await db.transaction(async (tx) => {
+        await tx
+            .delete(simuladoAttemptAnswers)
+            .where(
+                and(
+                    eq(simuladoAttemptAnswers.attemptId, attemptId),
+                    eq(simuladoAttemptAnswers.questionId, questionId),
+                ),
+            );
+        if (validas.length > 0) {
+            await tx
+                .insert(simuladoAttemptAnswers)
+                .values(validas.map((optionId) => ({ attemptId, questionId, optionId })));
+        }
+    });
+    return { ok: true };
+}
+
+// Pontua só o que estava salvo, então envio após o prazo vale como auto-envio.
+export async function enviarTentativa(userId: string, attemptId: string) {
+    const [attempt] = await db
+        .select()
+        .from(simuladoAttempts)
+        .where(and(eq(simuladoAttempts.id, attemptId), eq(simuladoAttempts.userId, userId)));
+    if (!attempt) throw new AppError(404, "Tentativa não encontrada");
+    if (attempt.submittedAt) throw new AppError(409, "Simulado já enviado");
+
+    const [simulado] = await db
+        .select({ passPercent: simulados.passPercent })
+        .from(simulados)
+        .where(eq(simulados.id, attempt.simuladoId));
+    if (!simulado) throw new AppError(404, "Simulado não encontrado");
+
+    const linhasQ = await db
+        .select({ questionId: simuladoAttemptQuestions.questionId })
+        .from(simuladoAttemptQuestions)
+        .where(eq(simuladoAttemptQuestions.attemptId, attemptId));
+    const questionIds = linhasQ.map((q) => q.questionId);
+
+    const corretasRows = questionIds.length
+        ? await db
+              .select({ questionId: simuladoOptions.questionId, id: simuladoOptions.id })
+              .from(simuladoOptions)
+              .where(
+                  and(
+                      inArray(simuladoOptions.questionId, questionIds),
+                      eq(simuladoOptions.isCorrect, true),
+                  ),
+              )
+        : [];
+    const respostasRows = await db
+        .select()
+        .from(simuladoAttemptAnswers)
+        .where(eq(simuladoAttemptAnswers.attemptId, attemptId));
+
+    const corretasPorQuestao = agrupar(corretasRows.map((r) => [r.questionId, r.id]));
+    const respostasPorQuestao = agrupar(respostasRows.map((r) => [r.questionId, r.optionId]));
+    const questoes = questionIds.map((id) => ({
+        id,
+        corretas: corretasPorQuestao.get(id) ?? new Set<string>(),
+    }));
+
+    const resultado = corrigirSimulado(questoes, respostasPorQuestao, simulado.passPercent);
+
+    await db
+        .update(simuladoAttempts)
+        .set({ submittedAt: new Date(), score: resultado.score, passed: resultado.passed })
+        .where(eq(simuladoAttempts.id, attemptId));
+
+    return resultado;
+}
+
+export async function historicoDoUsuario(userId: string) {
+    return db
+        .select({
+            attemptId: simuladoAttempts.id,
+            simulado: simulados.name,
+            slug: simulados.slug,
+            startedAt: simuladoAttempts.startedAt,
+            submittedAt: simuladoAttempts.submittedAt,
+            score: simuladoAttempts.score,
+            passed: simuladoAttempts.passed,
+        })
+        .from(simuladoAttempts)
+        .innerJoin(simulados, eq(simulados.id, simuladoAttempts.simuladoId))
+        .where(eq(simuladoAttempts.userId, userId))
+        .orderBy(desc(simuladoAttempts.startedAt));
+}

--- a/backend/tests/helpers/db.ts
+++ b/backend/tests/helpers/db.ts
@@ -6,6 +6,6 @@ export async function limparBanco() {
     // CASCADE remove dependentes por FK; lista trails/lessons explicitamente
     // porque elas nao referenciam users e nao cairiam no cascade.
     await db.execute(
-        sql`TRUNCATE TABLE question_answers, question_options, questions, lessons_progress, lessons, modules, trails, tokens, users RESTART IDENTITY CASCADE`,
+        sql`TRUNCATE TABLE simulado_attempt_answers, simulado_attempt_questions, simulado_attempts, simulado_options, simulado_questions, simulados, question_answers, question_options, questions, lessons_progress, lessons, modules, trails, tokens, users RESTART IDENTITY CASCADE`,
     );
 }

--- a/backend/tests/simulado.test.ts
+++ b/backend/tests/simulado.test.ts
@@ -1,0 +1,230 @@
+import { test, describe, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { startTestServer } from "./helpers/server.ts";
+import { limparBanco } from "./helpers/db.ts";
+
+let server: Awaited<ReturnType<typeof startTestServer>>;
+
+let seq = 0;
+const novoUsuario = (over: Record<string, unknown> = {}) => ({
+    name: "Aluno Teste",
+    email: `sim_${++seq}_${Math.round(performance.now() * 1000)}@email.com`,
+    username: `sim_${seq}`,
+    password: "Senhaforte123!",
+    birthDate: "1990-01-01",
+    gender: "outro",
+    phone: "11999998888",
+    ...over,
+});
+
+async function ajustarUsuario(email: string, campos: Record<string, unknown>) {
+    const { db } = await import("../db.ts");
+    const { users } = await import("../schema.ts");
+    const { eq } = await import("drizzle-orm");
+    await db.update(users).set(campos).where(eq(users.email, email));
+}
+
+async function criarUsuarioLogado() {
+    const dados = novoUsuario();
+    await server.request("POST", "/register", { body: dados });
+    await ajustarUsuario(dados.email, { emailVerifiedAt: new Date() });
+    const login = await server.request("POST", "/login", {
+        body: { email: dados.email, password: dados.password },
+    });
+    return { email: dados.email, token: login.body.token as string };
+}
+
+function auth(token: string) {
+    return { Authorization: `Bearer ${token}` };
+}
+async function get(path: string, token: string) {
+    const res = await fetch(`${server.base}${path}`, { headers: auth(token) });
+    return { status: res.status, body: await res.json().catch(() => null) };
+}
+async function post(path: string, token: string, body?: unknown) {
+    const res = await fetch(`${server.base}${path}`, {
+        method: "POST",
+        headers: { ...auth(token), "Content-Type": "application/json" },
+        body: body ? JSON.stringify(body) : undefined,
+    });
+    return { status: res.status, body: await res.json().catch(() => null) };
+}
+async function put(path: string, token: string, body?: unknown) {
+    const res = await fetch(`${server.base}${path}`, {
+        method: "PUT",
+        headers: { ...auth(token), "Content-Type": "application/json" },
+        body: body ? JSON.stringify(body) : undefined,
+    });
+    return { status: res.status, body: await res.json().catch(() => null) };
+}
+
+// Cria um simulado com 3 questões (2 de resposta única, 1 de múltipla) direto no
+// banco, já que a criação de simulado é por seed/admin (não há endpoint público).
+async function montarSimulado(over: Record<string, unknown> = {}) {
+    const { db } = await import("../db.ts");
+    const { simulados, simuladoQuestions, simuladoOptions } = await import("../schema.ts");
+    const [s] = await db
+        .insert(simulados)
+        .values({
+            slug: `ccp-${++seq}`,
+            name: "AWS CCP Teste",
+            durationMinutes: 90,
+            questionCount: 3,
+            passPercent: 70,
+            published: true,
+            ...over,
+        })
+        .returning();
+
+    const corretas: Record<string, string[]> = {};
+
+    async function criarQuestao(gabarito: boolean[]) {
+        const [q] = await db
+            .insert(simuladoQuestions)
+            .values({ simuladoId: s.id, statement: "Enunciado", explanation: "Porque sim." })
+            .returning();
+        const opcoes = await db
+            .insert(simuladoOptions)
+            .values(
+                gabarito.map((isCorrect, i) => ({
+                    questionId: q.id,
+                    text: `opcao ${i + 1}`,
+                    isCorrect,
+                    position: i + 1,
+                })),
+            )
+            .returning();
+        corretas[q.id] = opcoes.filter((o) => o.isCorrect).map((o) => o.id);
+        return q.id;
+    }
+
+    await criarQuestao([true, false]); // única
+    await criarQuestao([false, true]); // única
+    const multiId = await criarQuestao([true, true, false]); // múltipla (2 corretas)
+
+    return { slug: s.slug as string, corretas, multiId };
+}
+
+before(async () => {
+    server = await startTestServer();
+});
+after(async () => {
+    await server.close();
+});
+beforeEach(async () => {
+    await limparBanco();
+});
+
+describe("Simulado: início e segurança", () => {
+    test("inicia a tentativa sem vazar o gabarito", async () => {
+        const aluno = await criarUsuarioLogado();
+        const { slug } = await montarSimulado();
+
+        const r = await post(`/simulados/${slug}/attempts`, aluno.token);
+        assert.equal(r.status, 201);
+        assert.equal(r.body.questions.length, 3);
+        assert.ok(r.body.remainingSeconds > 0);
+        assert.equal(r.body.submitted, false);
+
+        const vazou = r.body.questions.some((q: any) =>
+            q.options.some((o: any) => "isCorrect" in o),
+        );
+        assert.equal(vazou, false);
+        assert.equal(
+            r.body.questions.some((q: any) => "explanation" in q),
+            false,
+        );
+    });
+
+    test("outro usuário não acessa a tentativa alheia", async () => {
+        const dono = await criarUsuarioLogado();
+        const { slug } = await montarSimulado();
+        const criada = await post(`/simulados/${slug}/attempts`, dono.token);
+
+        const intruso = await criarUsuarioLogado();
+        const r = await get(`/simulado-attempts/${criada.body.attemptId}`, intruso.token);
+        assert.equal(r.status, 404);
+    });
+
+    test("simulado inexistente retorna 404", async () => {
+        const aluno = await criarUsuarioLogado();
+        const r = await post(`/simulados/nao-existe/attempts`, aluno.token);
+        assert.equal(r.status, 404);
+    });
+});
+
+describe("Simulado: responder, enviar e corrigir", () => {
+    test("gabaritando, passa com 100 e revela o gabarito", async () => {
+        const aluno = await criarUsuarioLogado();
+        const { slug, corretas } = await montarSimulado();
+
+        const attempt = await post(`/simulados/${slug}/attempts`, aluno.token);
+        const id = attempt.body.attemptId;
+
+        for (const q of attempt.body.questions) {
+            await put(`/simulado-attempts/${id}/answers/${q.id}`, aluno.token, {
+                optionIds: corretas[q.id],
+            });
+        }
+
+        const envio = await post(`/simulado-attempts/${id}/submit`, aluno.token);
+        assert.equal(envio.status, 200);
+        assert.equal(envio.body.score, 100);
+        assert.equal(envio.body.passed, true);
+
+        // Depois de enviar, o gabarito aparece.
+        const revisao = await get(`/simulado-attempts/${id}`, aluno.token);
+        assert.equal(revisao.body.submitted, true);
+        assert.ok(revisao.body.questions[0].options.some((o: any) => "isCorrect" in o));
+    });
+
+    test("marcar só uma opção da múltipla reprova aquela questão", async () => {
+        const aluno = await criarUsuarioLogado();
+        const { slug, corretas, multiId } = await montarSimulado();
+
+        const attempt = await post(`/simulados/${slug}/attempts`, aluno.token);
+        const id = attempt.body.attemptId;
+
+        for (const q of attempt.body.questions) {
+            const marcar = q.id === multiId ? [corretas[q.id][0]] : corretas[q.id];
+            await put(`/simulado-attempts/${id}/answers/${q.id}`, aluno.token, {
+                optionIds: marcar,
+            });
+        }
+
+        const envio = await post(`/simulado-attempts/${id}/submit`, aluno.token);
+        assert.equal(envio.body.correct ?? envio.body.acertos, 2);
+        assert.equal(envio.body.score, 67);
+        assert.equal(envio.body.passed, false);
+    });
+
+    test("não deixa enviar duas vezes", async () => {
+        const aluno = await criarUsuarioLogado();
+        const { slug } = await montarSimulado();
+        const attempt = await post(`/simulados/${slug}/attempts`, aluno.token);
+        const id = attempt.body.attemptId;
+
+        await post(`/simulado-attempts/${id}/submit`, aluno.token);
+        const segundo = await post(`/simulado-attempts/${id}/submit`, aluno.token);
+        assert.equal(segundo.status, 409);
+    });
+
+    test("histórico lista a tentativa enviada", async () => {
+        const aluno = await criarUsuarioLogado();
+        const { slug, corretas } = await montarSimulado();
+        const attempt = await post(`/simulados/${slug}/attempts`, aluno.token);
+        const id = attempt.body.attemptId;
+        for (const q of attempt.body.questions) {
+            await put(`/simulado-attempts/${id}/answers/${q.id}`, aluno.token, {
+                optionIds: corretas[q.id],
+            });
+        }
+        await post(`/simulado-attempts/${id}/submit`, aluno.token);
+
+        const hist = await get(`/me/simulado-attempts`, aluno.token);
+        assert.equal(hist.status, 200);
+        assert.equal(hist.body.length, 1);
+        assert.equal(hist.body[0].passed, true);
+        assert.equal(hist.body[0].score, 100);
+    });
+});


### PR DESCRIPTION
## O que é

Primeira fatia do sistema de Simulados: prova cronometrada no formato da AWS (90 min, corte 70%, resposta única e múltipla). Backend completo; frontend e as questões que faltam para 65 vêm nas próximas fatias.

## Modelo

Banco de questões próprio, separado das aulas (`simulados`, `simulado_questions`, `simulado_options`). Cada tentativa (`simulado_attempts`) sorteia as questões, guarda um snapshot do que caiu (`simulado_attempt_questions`) e as marcações do usuário (`simulado_attempt_answers`, uma linha por opção, o que permite múltipla resposta). Migração `0019`, tudo aditivo.

## Fluxo e endpoints (todos autenticados)

- `GET /simulados` — catálogo
- `POST /simulados/:slug/attempts` — inicia (ou retoma uma em aberto), sorteia e crava o prazo
- `GET /simulado-attempts/:id` — estado, para retomar; gabarito só depois de enviar
- `PUT /simulado-attempts/:id/answers/:questionId` — salva as marcações (autosave)
- `POST /simulado-attempts/:id/submit` — corrige e grava nota/aprovação
- `GET /me/simulado-attempts` — histórico

## Correção

Função pura (`domain/simulado.ts`): por questão é tudo-ou-nada (marcar exatamente o conjunto certo), `score = acertos/total`, passa com >= 70%. Pontua só o que estava salvo, então envio após o prazo vale como auto-envio.

## Segurança

`isCorrect` e a justificativa nunca vão para o front antes de enviar. Sorteio e correção no servidor. A tentativa é escopada ao dono (outro usuário recebe 404).

## Conteúdo

Seed idempotente das 47 questões do gabarito comentado (Q4 a 50) em `scripts/seed-aws-ccp.ts`. A Q10 foi corrigida de "alta" para "baixa utilização" (o enunciado original divergia do gabarito). Rodar em dev: `node --env-file=.env scripts/seed-aws-ccp.ts`.

## Testes

- Unitários da correção: única, múltipla parcial, corte exato de 70, em branco, sem gabarito.
- Integração do fluxo: início sem vazar gabarito, 404 para tentativa alheia, gabaritar e passar, múltipla parcial reprovando a questão, bloqueio de envio duplo, histórico.
- Validei o seed num Postgres efêmero: 47 questões, 8 de múltipla, 0 sem gabarito, idempotente na 2a rodada.

## Gamificação

Sem impacto: o simulado tem histórico próprio e não mexe em XP, streak nem ranking, como combinado.
