### PR TITLE
feat: frontend dos simulados com revisão por tema

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,8 @@ import { EstudioHome } from './pages/EstudioHome';
 import { Configuracoes } from './pages/Configuracoes';
 import { Perfil } from './pages/Perfil';
 import { Ranking } from './pages/Ranking';
+import { Simulados } from './pages/Simulados';
+import { TentativaSimulado } from './pages/Simulados/Tentativa';
 import { VerifyEmail } from './pages/VerifyEmail';
 import { OAuthCallback } from './pages/OAuthCallback';
 import { CompletarPerfil } from './pages/CompletarPerfil';
@@ -95,6 +97,22 @@ function AppRoutes() {
           <AdminRoute>
             <Estudio />
           </AdminRoute>
+        }
+      />
+      <Route
+        path="/simulados"
+        element={
+          <PrivateRoute>
+            <Simulados />
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/simulados/tentativa/:attemptId"
+        element={
+          <PrivateRoute>
+            <TentativaSimulado />
+          </PrivateRoute>
         }
       />
       <Route

--- a/frontend/src/components/Icons.tsx
+++ b/frontend/src/components/Icons.tsx
@@ -385,3 +385,70 @@ export const GradCap = ({ size = 19 }: IconProps) => (
     <circle cx="27.5" cy="18.6" r="1.5" fill="currentColor" stroke="none" />
   </svg>
 );
+
+export const ClockExam = ({ size = 18 }: IconProps) => (
+  <svg
+    {...base(size)}
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <circle cx="12" cy="12" r="9" />
+    <path d="M12 7v5l3 2" />
+  </svg>
+);
+
+export const Info = ({ size = 17 }: IconProps) => (
+  <svg
+    {...base(size)}
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <circle cx="12" cy="12" r="10" />
+    <line x1="12" y1="11" x2="12" y2="16" />
+    <line x1="12" y1="8" x2="12" y2="8" />
+  </svg>
+);
+
+export const Redo = ({ size = 16 }: IconProps) => (
+  <svg
+    {...base(size)}
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M21 12a9 9 0 1 1-2.64-6.36" />
+    <polyline points="21 3 21 9 15 9" />
+  </svg>
+);
+
+export const Target = ({ size = 26 }: IconProps) => (
+  <svg
+    {...base(size)}
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <circle cx="12" cy="12" r="9" />
+    <circle cx="12" cy="12" r="5" />
+    <circle cx="12" cy="12" r="1.5" fill="currentColor" stroke="none" />
+  </svg>
+);
+
+export const BookOpen = ({ size = 13 }: IconProps) => (
+  <svg
+    {...base(size)}
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M12 6.5C10.5 5 8 4.5 3 4.8V19c5-.3 7.5.2 9 1.7" />
+    <path d="M12 6.5C13.5 5 16 4.5 21 4.8V19c-5-.3-7.5.2-9 1.7z" />
+  </svg>
+);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,4 @@
 /* Fundação do design system ensina.dev */
 @import './styles/tokens.css';
 @import './styles/app.css';
+@import './styles/simulado.css';

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -25,6 +25,7 @@ import type { Trail } from '../../data/trails';
 const NAV = [
   { label: 'Início', to: '/home' },
   { label: 'Trilhas', to: '/trilhas' },
+  { label: 'Simulados', to: '/simulados' },
   { label: 'Ranking', to: '/ranking' },
   { label: 'Comunidade', to: '/comunidade' },
 ];

--- a/frontend/src/pages/Ranking/index.tsx
+++ b/frontend/src/pages/Ranking/index.tsx
@@ -14,6 +14,7 @@ import { obterRanking, type RankingResposta, type RankingPeriodo } from '../../s
 const NAV = [
   { label: 'Início', to: '/home' },
   { label: 'Trilhas', to: '/trilhas' },
+  { label: 'Simulados', to: '/simulados' },
   { label: 'Ranking', to: '/ranking' },
   { label: 'Comunidade', to: '/comunidade' },
 ];

--- a/frontend/src/pages/Simulados/Prova.tsx
+++ b/frontend/src/pages/Simulados/Prova.tsx
@@ -1,0 +1,225 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { ClockExam, ChevronLeft, ChevronRight, Bookmark } from '../../components/Icons';
+import { salvarResposta, enviarTentativa, type TentativaEstado } from '../../services/simulados';
+
+const LETRAS = ['A', 'B', 'C', 'D', 'E', 'F'];
+
+function formatTempo(seg: number) {
+  const m = Math.floor(seg / 60);
+  const s = seg % 60;
+  return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+}
+
+export function Prova({ dados, onEnviado }: { dados: TentativaEstado; onEnviado: () => void }) {
+  const questions = dados.questions;
+  const total = questions.length;
+  const [current, setCurrent] = useState(0);
+  const [respostas, setRespostas] = useState<Record<string, string[]>>(() => {
+    const r: Record<string, string[]> = {};
+    for (const q of questions) r[q.id] = q.selected ?? [];
+    return r;
+  });
+  const [flags, setFlags] = useState<Set<number>>(new Set());
+  const [restante, setRestante] = useState(dados.remainingSeconds);
+  const [enviando, setEnviando] = useState(false);
+  const enviadoRef = useRef(false);
+
+  const q = questions[current];
+  const answeredCount = questions.filter((x) => (respostas[x.id]?.length ?? 0) > 0).length;
+  const progress = total ? Math.round((answeredCount / total) * 100) : 0;
+
+  async function persistir(questionId: string, optionIds: string[]) {
+    try {
+      await salvarResposta(dados.attemptId, questionId, optionIds);
+    } catch (e) {
+      console.error('Falha ao salvar resposta do simulado', e);
+    }
+  }
+
+  function marcar(optionId: string) {
+    const atual = respostas[q.id] ?? [];
+    const novo = q.multiple
+      ? atual.includes(optionId)
+        ? atual.filter((o) => o !== optionId)
+        : [...atual, optionId]
+      : [optionId];
+    setRespostas((prev) => ({ ...prev, [q.id]: novo }));
+    persistir(q.id, novo);
+  }
+
+  function alternarFlag() {
+    setFlags((f) => {
+      const n = new Set(f);
+      if (n.has(current)) n.delete(current);
+      else n.add(current);
+      return n;
+    });
+  }
+
+  const ir = (d: number) => setCurrent((c) => Math.max(0, Math.min(total - 1, c + d)));
+
+  async function enviar() {
+    if (enviadoRef.current) return;
+    enviadoRef.current = true;
+    setEnviando(true);
+    try {
+      await enviarTentativa(dados.attemptId);
+      onEnviado();
+    } catch (e) {
+      console.error('Falha ao enviar o simulado', e);
+      enviadoRef.current = false;
+      setEnviando(false);
+    }
+  }
+
+  function confirmarEnvio() {
+    const faltam = total - answeredCount;
+    const msg =
+      faltam > 0
+        ? `Você deixou ${faltam} questão(ões) em branco. Enviar mesmo assim?`
+        : 'Enviar o simulado para correção?';
+    if (window.confirm(msg)) enviar();
+  }
+
+  // Contagem regressiva a partir do expiresAt (fonte de verdade); auto-envia ao zerar.
+  const expiresMs = useMemo(() => new Date(dados.expiresAt).getTime(), [dados.expiresAt]);
+  useEffect(() => {
+    const tick = () => {
+      const s = Math.max(0, Math.round((expiresMs - Date.now()) / 1000));
+      setRestante(s);
+      if (s <= 0) enviar();
+    };
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [expiresMs]);
+
+  const urgente = restante <= 60;
+
+  return (
+    <>
+      <div className="exam-bar">
+        <span className="exam-bar__logo">
+          <ClockExam size={18} />
+        </span>
+        <div>
+          <div className="exam-bar__title">Simulado em andamento</div>
+          <div className="exam-bar__sub">{total} questões</div>
+        </div>
+        <div className="topbar__spacer" />
+        <div className="exam-bar__prog">
+          <div className="exam-bar__track">
+            <span style={{ width: `${progress}%` }} />
+          </div>
+          <span className="exam-bar__count">
+            {answeredCount} / {total}
+          </span>
+        </div>
+        <div className={`exam-bar__timer${urgente ? ' exam-bar__timer--urgent' : ''}`}>
+          <ClockExam size={17} />
+          <span>{formatTempo(restante)}</span>
+        </div>
+        <button
+          className="btn btn--ghost exam-bar__finish"
+          onClick={confirmarEnvio}
+          disabled={enviando}
+        >
+          Finalizar
+        </button>
+      </div>
+
+      <div className="exam-body">
+        <div className="card exam-q">
+          <div className="exam-q__meta">
+            <span className="exam-q__num">Questão {current + 1}</span>
+            {q.multiple && <span className="exam-q__tag">Selecione mais de uma</span>}
+            <div className="topbar__spacer" />
+            <button
+              className={`exam-q__flag${flags.has(current) ? ' exam-q__flag--on' : ''}`}
+              onClick={alternarFlag}
+            >
+              <Bookmark size={16} /> {flags.has(current) ? 'Marcada' : 'Marcar p/ revisar'}
+            </button>
+          </div>
+
+          <div className="exam-q__text">{q.statement}</div>
+
+          <div className="exam-q__options">
+            {q.options.map((o, i) => {
+              const on = (respostas[q.id] ?? []).includes(o.id);
+              return (
+                <button
+                  key={o.id}
+                  className={`exam-opt${on ? ' exam-opt--on' : ''}`}
+                  onClick={() => marcar(o.id)}
+                >
+                  <span className="exam-opt__badge">{LETRAS[i] ?? i + 1}</span>
+                  <span className="exam-opt__label">{o.text}</span>
+                </button>
+              );
+            })}
+          </div>
+
+          <div className="exam-q__foot">
+            <button
+              className="btn btn--ghost exam-q__nav"
+              onClick={() => ir(-1)}
+              disabled={current === 0}
+            >
+              <ChevronLeft size={14} /> Anterior
+            </button>
+            <div className="topbar__spacer" />
+            <span className="exam-q__saved">Resposta salva automaticamente</span>
+            <button
+              className="btn btn--accent exam-q__nav"
+              onClick={() => ir(1)}
+              disabled={current === total - 1}
+            >
+              Próxima <ChevronRight size={14} />
+            </button>
+          </div>
+        </div>
+
+        <div className="exam-side">
+          <div className="card">
+            <div className="exam-nav__title">Navegador</div>
+            <div className="exam-nav__grid">
+              {questions.map((x, i) => {
+                const isCur = i === current;
+                const isAns = (respostas[x.id]?.length ?? 0) > 0;
+                const isFlag = flags.has(i);
+                let cls = 'exam-nav__cell';
+                if (isFlag) cls += ' exam-nav__cell--flag';
+                else if (isAns) cls += ' exam-nav__cell--ans';
+                if (isCur) cls += ' exam-nav__cell--cur';
+                return (
+                  <button key={x.id} className={cls} onClick={() => setCurrent(i)}>
+                    {i + 1}
+                  </button>
+                );
+              })}
+            </div>
+            <div className="exam-nav__legend">
+              <div>
+                <span className="exam-nav__dot exam-nav__dot--ans" />
+                Respondida ({answeredCount})
+              </div>
+              <div>
+                <span className="exam-nav__dot exam-nav__dot--flag" />
+                Marcada ({flags.size})
+              </div>
+              <div>
+                <span className="exam-nav__dot exam-nav__dot--none" />
+                Em branco ({total - answeredCount})
+              </div>
+            </div>
+          </div>
+          <button className="exam-submit" onClick={confirmarEnvio} disabled={enviando}>
+            {enviando ? 'Enviando...' : 'Revisar e enviar'}
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/pages/Simulados/Resultado.tsx
+++ b/frontend/src/pages/Simulados/Resultado.tsx
@@ -1,0 +1,276 @@
+import { useNavigate } from 'react-router-dom';
+import { Check, X, Info, BookOpen, Trophy, Target, Redo } from '../../components/Icons';
+import type { TentativaEstado, QuestaoSimulado } from '../../services/simulados';
+
+const RING = 352;
+
+function mesmoConjunto(a: string[], b: string[]) {
+  if (a.length !== b.length) return false;
+  const s = new Set(a);
+  return b.every((x) => s.has(x));
+}
+function corretasDe(q: QuestaoSimulado) {
+  return q.options.filter((o) => o.isCorrect).map((o) => o.id);
+}
+function acertou(q: QuestaoSimulado) {
+  const corretas = corretasDe(q);
+  return corretas.length > 0 && mesmoConjunto(q.selected ?? [], corretas);
+}
+function textos(q: QuestaoSimulado, ids: string[]) {
+  return q.options
+    .filter((o) => ids.includes(o.id))
+    .map((o) => o.text)
+    .join(', ');
+}
+function faixa(pct: number) {
+  if (pct >= 80) return { fg: 'var(--success)', label: 'Forte' };
+  if (pct >= 70) return { fg: 'var(--accent)', label: 'Ok' };
+  if (pct >= 55) return { fg: 'var(--amber)', label: 'Reforçar' };
+  return { fg: 'var(--av-red)', label: 'Frágil' };
+}
+
+export function Resultado({ dados }: { dados: TentativaEstado }) {
+  const navigate = useNavigate();
+  const isPass = dados.passed === true;
+  const score = dados.score ?? 0;
+  const questions = dados.questions;
+  const total = questions.length;
+  const acertos = questions.filter(acertou).length;
+  const erros = total - acertos;
+  const erradas = questions.filter((q) => !acertou(q));
+  const temas = dados.temasARevisar ?? [];
+
+  const porTema = new Map<string, { acertos: number; total: number }>();
+  for (const q of questions) {
+    const tema = q.topic ?? 'Outros';
+    const t = porTema.get(tema) ?? { acertos: 0, total: 0 };
+    t.total++;
+    if (acertou(q)) t.acertos++;
+    porTema.set(tema, t);
+  }
+  const dominios = [...porTema.entries()]
+    .map(([name, v]) => ({ name, pct: v.total ? Math.round((v.acertos / v.total) * 100) : 0 }))
+    .sort((a, b) => a.pct - b.pct);
+
+  const ringOffset = Math.round(RING * (1 - score / 100));
+  const heroBg = isPass
+    ? 'linear-gradient(150deg, var(--success), color-mix(in srgb, var(--success) 52%, #06371f))'
+    : 'linear-gradient(150deg, #d9536b, #8a2f42)';
+  const titulo = isPass ? 'Aprovado! Mandou bem.' : 'Quase lá.';
+  const sub = isPass
+    ? 'Você atingiu a nota de corte. Revise os pontos abaixo pra chegar ainda mais confiante.'
+    : 'Faltou pouco pra nota de corte. Reforce os temas abaixo e tente de novo.';
+
+  return (
+    <div className="sim">
+      <div className="res-hero" style={{ background: heroBg }}>
+        <span className="res-hero__glow" />
+        <div className="res-hero__inner">
+          <div className="res-ring">
+            <svg
+              width="132"
+              height="132"
+              viewBox="0 0 132 132"
+              style={{ transform: 'rotate(-90deg)' }}
+            >
+              <circle
+                cx="66"
+                cy="66"
+                r="56"
+                fill="none"
+                stroke="rgba(255,255,255,.22)"
+                strokeWidth="12"
+              />
+              <circle
+                cx="66"
+                cy="66"
+                r="56"
+                fill="none"
+                stroke="#fff"
+                strokeWidth="12"
+                strokeLinecap="round"
+                strokeDasharray={RING}
+                strokeDashoffset={ringOffset}
+              />
+            </svg>
+            <div className="res-ring__center">
+              <div className="res-ring__pct">{score}%</div>
+              <div className="res-ring__cap">sua nota</div>
+            </div>
+          </div>
+
+          <div className="res-hero__meta">
+            <div className="res-badge">
+              {isPass ? <Check size={15} /> : <X size={13} />} {isPass ? 'Aprovado' : 'Reprovado'}
+            </div>
+            <div className="res-hero__title">{titulo}</div>
+            <div className="res-hero__sub">{sub}</div>
+          </div>
+
+          <div className="res-stats">
+            <div className="res-stat">
+              <div className="res-stat__v">{acertos}</div>
+              <div className="res-stat__l">acertos</div>
+            </div>
+            <div className="res-stat">
+              <div className="res-stat__v">{erros}</div>
+              <div className="res-stat__l">erros</div>
+            </div>
+            <div className="res-stat">
+              <div className="res-stat__v">{total}</div>
+              <div className="res-stat__l">questões</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="sim__grid">
+        <div className="sim__col">
+          <div className="card">
+            <div className="res-sec__title">Desempenho por tema</div>
+            <div className="res-sec__sub">Veja onde você foi bem e onde precisa reforçar.</div>
+            <div className="res-domains">
+              {dominios.map((d) => {
+                const c = faixa(d.pct);
+                return (
+                  <div key={d.name}>
+                    <div className="res-domain__row">
+                      <span className="res-domain__name">{d.name}</span>
+                      <span
+                        className="res-domain__tag"
+                        style={{
+                          color: c.fg,
+                          background: `color-mix(in srgb, ${c.fg} 12%, transparent)`,
+                        }}
+                      >
+                        {c.label}
+                      </span>
+                      <span className="res-domain__pct" style={{ color: c.fg }}>
+                        {d.pct}%
+                      </span>
+                    </div>
+                    <div className="res-domain__track">
+                      <span style={{ width: `${d.pct}%`, background: c.fg }} />
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          {erradas.length > 0 && (
+            <div className="card">
+              <div className="res-review__head">
+                <div className="res-sec__title">Revise o que você errou</div>
+                <div className="topbar__spacer" />
+                <span className="res-review__count">{erros} erradas</span>
+              </div>
+              <div className="res-sec__sub">
+                Confira a resposta certa, o porquê e o assunto de cada questão.
+              </div>
+              <div className="res-wrongs">
+                {erradas.map((q) => (
+                  <div key={q.id} className="res-wrong">
+                    <div className="res-wrong__meta">
+                      <span className="res-wrong__q">Questão {q.position}</span>
+                      {q.topic && <span className="res-wrong__domain">{q.topic}</span>}
+                    </div>
+                    <div className="res-wrong__text">{q.statement}</div>
+                    <div className="res-wrong__answers">
+                      <div className="res-ans res-ans--wrong">
+                        <span className="res-ans__icon res-ans__icon--wrong">
+                          <X size={12} />
+                        </span>
+                        <span className="res-ans__label">Sua resposta:</span>
+                        <span className="res-ans__val res-ans__val--wrong">
+                          {textos(q, q.selected ?? []) || 'em branco'}
+                        </span>
+                      </div>
+                      <div className="res-ans res-ans--right">
+                        <span className="res-ans__icon res-ans__icon--right">
+                          <Check size={12} />
+                        </span>
+                        <span className="res-ans__label">Correta:</span>
+                        <span className="res-ans__val res-ans__val--right">
+                          {textos(q, corretasDe(q))}
+                        </span>
+                      </div>
+                    </div>
+                    {q.explanation && (
+                      <div className="res-why">
+                        <span className="res-why__icon">
+                          <Info size={17} />
+                        </span>
+                        <div>
+                          <b>Por quê:</b> {q.explanation}
+                        </div>
+                      </div>
+                    )}
+                    {q.topic && (
+                      <div className="res-study">
+                        <span className="res-study__label">Estude:</span>
+                        <span className="res-study__chip">
+                          <BookOpen size={12} /> {q.topic}
+                        </span>
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+
+        <div className="sim__col">
+          <div className="card">
+            <div className="res-plan__title">Temas para revisar</div>
+            <div className="res-plan__sub">
+              {temas.length > 0
+                ? 'Priorize os assuntos onde você mais errou.'
+                : 'Você não errou nenhum tema. Excelente!'}
+            </div>
+            {temas.length > 0 && (
+              <div className="res-plan">
+                {temas.map((t) => (
+                  <div key={t.topic} className="res-plan-item">
+                    <span className="res-plan-item__icon">
+                      <BookOpen size={16} />
+                    </span>
+                    <div>
+                      <div className="res-plan-item__t">{t.topic}</div>
+                      <div className="res-plan-item__s">
+                        {t.erradas} de {t.total} erradas
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+            <button
+              className="btn btn--accent res-plan__redo"
+              onClick={() => navigate('/simulados')}
+            >
+              <Redo size={16} /> Refazer simulado
+            </button>
+          </div>
+
+          <div className={`res-seal res-seal--${isPass ? 'pass' : 'fail'}`}>
+            <span className="res-seal__icon">
+              {isPass ? <Trophy size={26} /> : <Target size={26} />}
+            </span>
+            <div>
+              <div className="res-seal__t">
+                {isPass ? 'Pronto pra prova' : 'Continue treinando'}
+              </div>
+              <div className="res-seal__s">
+                {isPass
+                  ? 'Seu desempenho está no nível de aprovação.'
+                  : 'Cada tentativa te deixa mais perto.'}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Simulados/SimTopbar.tsx
+++ b/frontend/src/pages/Simulados/SimTopbar.tsx
@@ -1,0 +1,49 @@
+import { Link } from 'react-router-dom';
+import { useAuth } from '../../contexts/AuthContext';
+import { Logo } from '../../components/Logo';
+import { UserMenu } from '../../components/UserMenu';
+import { ThemeToggle } from '../../components/ThemeToggle';
+import { Flame } from '../../components/Icons';
+import { getInitials } from '../../utils/initials';
+import { user as homeUser } from '../../data/home';
+
+const NAV = [
+  { label: 'Início', to: '/home' },
+  { label: 'Trilhas', to: '/trilhas' },
+  { label: 'Simulados', to: '/simulados' },
+  { label: 'Ranking', to: '/ranking' },
+  { label: 'Comunidade', to: '/comunidade' },
+];
+
+export function SimTopbar() {
+  const { user: authUser } = useAuth();
+  const displayName = authUser?.name ?? homeUser.name;
+
+  return (
+    <header className="topbar">
+      <Logo variant="solid" size={20} />
+      <nav className="nav">
+        {NAV.map((item) => (
+          <Link
+            key={item.to}
+            to={item.to}
+            className={`nav__item${item.to === '/simulados' ? ' nav__item--active' : ''}`}
+          >
+            {item.label}
+          </Link>
+        ))}
+      </nav>
+      <div className="topbar__spacer" />
+      <div className="streak-pill">
+        <Flame size={16} /> {authUser?.streak ?? 0}
+      </div>
+      <ThemeToggle inline />
+      <UserMenu
+        initials={getInitials(displayName)}
+        level={authUser?.level ?? 1}
+        name={displayName}
+        email={authUser?.email}
+      />
+    </header>
+  );
+}

--- a/frontend/src/pages/Simulados/Tentativa.tsx
+++ b/frontend/src/pages/Simulados/Tentativa.tsx
@@ -1,0 +1,38 @@
+import { useParams } from 'react-router-dom';
+import { useRequisicao } from '../../hooks/useRequisicao';
+import { SimTopbar } from './SimTopbar';
+import { Prova } from './Prova';
+import { Resultado } from './Resultado';
+import { obterTentativa } from '../../services/simulados';
+
+export function TentativaSimulado() {
+  const { attemptId = '' } = useParams();
+  const { dados, carregando, erro, recarregar } = useRequisicao(
+    () => obterTentativa(attemptId),
+    [attemptId],
+  );
+
+  return (
+    <div className="home-shell">
+      <div className="home">
+        <SimTopbar />
+        {carregando && (
+          <div className="sim">
+            <p className="sim-empty">Carregando simulado...</p>
+          </div>
+        )}
+        {erro && (
+          <div className="sim">
+            <p className="sim-empty">Não foi possível carregar a tentativa.</p>
+          </div>
+        )}
+        {dados &&
+          (dados.submitted ? (
+            <Resultado dados={dados} />
+          ) : (
+            <Prova dados={dados} onEnviado={recarregar} />
+          ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Simulados/index.tsx
+++ b/frontend/src/pages/Simulados/index.tsx
@@ -1,0 +1,249 @@
+import { useState, type ReactNode } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useRequisicao } from '../../hooks/useRequisicao';
+import { SimTopbar } from './SimTopbar';
+import { GradCap, Check, Play, Alert, ClockExam, Target, BookOpen } from '../../components/Icons';
+import {
+  listarSimulados,
+  historicoSimulados,
+  iniciarTentativa,
+  type TentativaHistorico,
+} from '../../services/simulados';
+
+function formatData(iso: string) {
+  return new Date(iso).toLocaleDateString('pt-BR', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+export function Simulados() {
+  const navigate = useNavigate();
+  const { dados, carregando } = useRequisicao(
+    () =>
+      Promise.all([listarSimulados(), historicoSimulados()]).then(([exams, historico]) => ({
+        exams,
+        historico,
+      })),
+    [],
+  );
+  const exams = dados?.exams ?? [];
+  const historico = dados?.historico ?? [];
+
+  const [slug, setSlug] = useState<string | null>(null);
+  const [iniciando, setIniciando] = useState(false);
+  const selecionado = exams.find((e) => e.slug === slug) ?? exams[0] ?? null;
+
+  async function iniciar() {
+    if (!selecionado || iniciando) return;
+    setIniciando(true);
+    try {
+      const t = await iniciarTentativa(selecionado.slug);
+      navigate(`/simulados/tentativa/${t.attemptId}`);
+    } catch (e) {
+      console.error('Falha ao iniciar simulado', e);
+      setIniciando(false);
+    }
+  }
+
+  return (
+    <div className="home-shell">
+      <div className="home">
+        <SimTopbar />
+        <div className="sim">
+          <div className="sim__head">
+            <h1 className="sim__title">Simulados de certificação</h1>
+            <p className="sim__sub">
+              Pratique com provas cronometradas no formato oficial e chegue confiante no dia do
+              exame.
+            </p>
+          </div>
+
+          {carregando ? (
+            <p className="sim-empty">Carregando simulados...</p>
+          ) : exams.length === 0 ? (
+            <p className="sim-empty">Nenhum simulado disponível ainda.</p>
+          ) : (
+            <div className="sim__grid">
+              <div className="sim__col">
+                <div className="sim__exams">
+                  {exams.map((e) => (
+                    <button
+                      key={e.slug}
+                      className={`exam-card${e.slug === selecionado?.slug ? ' exam-card--active' : ''}`}
+                      onClick={() => setSlug(e.slug)}
+                    >
+                      {e.slug === selecionado?.slug && (
+                        <span className="exam-card__check">
+                          <Check size={13} />
+                        </span>
+                      )}
+                      <div className="exam-card__top">
+                        <span className="exam-card__logo">
+                          <GradCap size={24} />
+                        </span>
+                        <div>
+                          <div className="exam-card__vendor">Certificação</div>
+                          <div className="exam-card__code">{e.name}</div>
+                        </div>
+                      </div>
+                      {e.description && <div className="exam-card__name">{e.description}</div>}
+                      <div className="exam-card__meta">
+                        <span>
+                          <b>{e.questionCount}</b> questões
+                        </span>
+                        <span>
+                          <b>{e.durationMinutes}</b> min
+                        </span>
+                        <span>
+                          <b>{e.passPercent}%</b> p/ passar
+                        </span>
+                      </div>
+                    </button>
+                  ))}
+                </div>
+
+                {selecionado && (
+                  <div className="card sim-rules">
+                    <div className="sim-rules__title">Como funciona o simulado</div>
+                    <div className="sim-rules__sub">
+                      Leia antes de começar. O cronômetro inicia assim que você iniciar.
+                    </div>
+                    <div className="sim-rules__grid">
+                      <Regra
+                        icon={<ClockExam size={18} />}
+                        t={`${selecionado.durationMinutes} minutos`}
+                        d="O cronômetro começa ao iniciar e não pausa até enviar."
+                      />
+                      <Regra
+                        icon={<Check size={17} />}
+                        t={`${selecionado.questionCount} questões`}
+                        d="Múltipla escolha; algumas pedem mais de uma resposta."
+                      />
+                      <Regra
+                        icon={<Target size={17} />}
+                        t={`${selecionado.passPercent}% para passar`}
+                        d="Cada questão vale igual; múltiplas contam tudo-ou-nada."
+                      />
+                      <Regra
+                        icon={<BookOpen size={17} />}
+                        t="Revisão ao final"
+                        d="Veja o que errou, o assunto de cada questão e o que revisar."
+                      />
+                    </div>
+                    <div className="sim-warn">
+                      <span className="sim-warn__icon">
+                        <Alert size={18} />
+                      </span>
+                      <div>
+                        <b>Uma vez iniciado, o cronômetro não para.</b> Se o tempo acabar, o
+                        simulado é enviado automaticamente com as respostas marcadas até ali.
+                      </div>
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              <div className="sim__col">
+                {selecionado && (
+                  <div className="card">
+                    <div className="sim-pick__label">Simulado selecionado</div>
+                    <div className="sim-pick__head">
+                      <span className="exam-card__logo">
+                        <GradCap size={22} />
+                      </span>
+                      <div>
+                        <div className="exam-card__vendor">Certificação</div>
+                        <div className="sim-pick__code">{selecionado.name}</div>
+                      </div>
+                    </div>
+                    <div className="sim-pick__rows">
+                      <Linha
+                        icon={<ClockExam size={18} />}
+                        label="Duração"
+                        value={`${selecionado.durationMinutes} min`}
+                      />
+                      <Linha
+                        icon={<Check size={18} />}
+                        label="Questões"
+                        value={`${selecionado.questionCount}`}
+                      />
+                      <Linha
+                        icon={<Target size={18} />}
+                        label="Aprovação"
+                        value={`${selecionado.passPercent}%`}
+                      />
+                    </div>
+                    <button className="sim-start" onClick={iniciar} disabled={iniciando}>
+                      <Play size={15} /> {iniciando ? 'Preparando...' : 'Iniciar simulado'}
+                    </button>
+                    <div className="sim-pick__note">O cronômetro só começa quando você inicia.</div>
+                  </div>
+                )}
+
+                <div className="card">
+                  <div className="sim-attempts__title">Suas últimas tentativas</div>
+                  {historico.length === 0 ? (
+                    <p className="sim-empty">Você ainda não fez nenhum simulado.</p>
+                  ) : (
+                    <div className="sim-attempts">
+                      {historico.slice(0, 5).map((a) => (
+                        <ItemTentativa
+                          key={a.attemptId}
+                          a={a}
+                          onClick={() => navigate(`/simulados/tentativa/${a.attemptId}`)}
+                        />
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Regra({ icon, t, d }: { icon: ReactNode; t: string; d: string }) {
+  return (
+    <div className="sim-rule">
+      <span className="sim-rule__icon">{icon}</span>
+      <div>
+        <div className="sim-rule__t">{t}</div>
+        <div className="sim-rule__d">{d}</div>
+      </div>
+    </div>
+  );
+}
+
+function Linha({ icon, label, value }: { icon: ReactNode; label: string; value: string }) {
+  return (
+    <div className="sim-pick__row">
+      <span className="sim-pick__row-icon">{icon}</span>
+      <span className="sim-pick__row-label">{label}</span>
+      <span className="sim-pick__row-val">{value}</span>
+    </div>
+  );
+}
+
+function ItemTentativa({ a, onClick }: { a: TentativaHistorico; onClick: () => void }) {
+  const enviado = a.submittedAt != null;
+  const ok = a.passed === true;
+  return (
+    <button className="sim-attempt" onClick={onClick}>
+      <span className={`sim-attempt__score sim-attempt__score--${ok ? 'ok' : 'no'}`}>
+        {enviado ? `${a.score}%` : '—'}
+      </span>
+      <div className="sim-attempt__id">
+        <div className="sim-attempt__exam">{a.simulado}</div>
+        <div className="sim-attempt__date">{formatData(a.startedAt)}</div>
+      </div>
+      <span className={`sim-attempt__verdict sim-attempt__verdict--${ok ? 'ok' : 'no'}`}>
+        {enviado ? (ok ? 'Aprovado' : 'Reprovado') : 'Em andamento'}
+      </span>
+    </button>
+  );
+}

--- a/frontend/src/pages/Trilhas/index.tsx
+++ b/frontend/src/pages/Trilhas/index.tsx
@@ -23,6 +23,7 @@ type TrailComId = Trail & { id: string };
 const NAV = [
   { label: 'Início', to: '/home' },
   { label: 'Trilhas', to: '/trilhas' },
+  { label: 'Simulados', to: '/simulados' },
   { label: 'Ranking', to: '/ranking' },
   { label: 'Comunidade', to: '/comunidade' },
 ];

--- a/frontend/src/services/simulados.ts
+++ b/frontend/src/services/simulados.ts
@@ -1,0 +1,91 @@
+import api from './api';
+
+export interface SimuladoResumo {
+  slug: string;
+  name: string;
+  description: string | null;
+  durationMinutes: number;
+  questionCount: number;
+  passPercent: number;
+}
+
+export interface OpcaoSimulado {
+  id: string;
+  text: string;
+  position: number;
+  isCorrect?: boolean; // só vem depois de enviar
+}
+
+export interface QuestaoSimulado {
+  id: string;
+  statement: string;
+  position: number;
+  multiple: boolean;
+  options: OpcaoSimulado[];
+  selected: string[];
+  topic?: string; // só depois de enviar
+  explanation?: string | null; // só depois de enviar
+}
+
+export interface TemaRevisar {
+  topic: string;
+  erradas: number;
+  total: number;
+}
+
+export interface TentativaEstado {
+  attemptId: string;
+  submitted: boolean;
+  expiresAt: string;
+  remainingSeconds: number;
+  score?: number;
+  passed?: boolean;
+  temasARevisar?: TemaRevisar[];
+  questions: QuestaoSimulado[];
+}
+
+export interface ResultadoEnvio {
+  acertos: number;
+  total: number;
+  score: number;
+  passed: boolean;
+}
+
+export interface TentativaHistorico {
+  attemptId: string;
+  simulado: string;
+  slug: string;
+  startedAt: string;
+  submittedAt: string | null;
+  score: number | null;
+  passed: boolean | null;
+}
+
+export async function listarSimulados() {
+  const { data } = await api.get<SimuladoResumo[]>('/simulados');
+  return data;
+}
+
+export async function iniciarTentativa(slug: string) {
+  const { data } = await api.post<TentativaEstado>(`/simulados/${slug}/attempts`);
+  return data;
+}
+
+export async function obterTentativa(attemptId: string) {
+  const { data } = await api.get<TentativaEstado>(`/simulado-attempts/${attemptId}`);
+  return data;
+}
+
+export async function salvarResposta(attemptId: string, questionId: string, optionIds: string[]) {
+  await api.put(`/simulado-attempts/${attemptId}/answers/${questionId}`, { optionIds });
+}
+
+export async function enviarTentativa(attemptId: string) {
+  const { data } = await api.post<ResultadoEnvio>(`/simulado-attempts/${attemptId}/submit`);
+  return data;
+}
+
+export async function historicoSimulados() {
+  const { data } = await api.get<TentativaHistorico[]>('/me/simulado-attempts');
+  return data;
+}

--- a/frontend/src/styles/simulado.css
+++ b/frontend/src/styles/simulado.css
@@ -1,0 +1,985 @@
+/* ensina.dev — estilos dos Simulados. Depende de tokens.css. */
+
+/* ===================== SIMULADOS ===================== */
+.sim {
+  padding: 26px;
+}
+.sim__head {
+  margin-bottom: 20px;
+}
+.sim__title {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+.sim__sub {
+  margin: 4px 0 0;
+  font-size: 14px;
+  color: var(--muted);
+}
+.sim__grid {
+  display: grid;
+  grid-template-columns: 1fr 336px;
+  gap: 24px;
+  align-items: start;
+}
+.sim__col {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  min-width: 0;
+}
+
+.sim__exams {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+.exam-card {
+  position: relative;
+  text-align: left;
+  background: var(--surface);
+  border: 1.5px solid var(--border);
+  border-radius: 16px;
+  padding: 18px;
+  cursor: pointer;
+  font-family: inherit;
+}
+.exam-card--active {
+  border-color: var(--accent);
+}
+.exam-card__check {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: var(--accent);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.exam-card__top {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.exam-card__logo {
+  width: 46px;
+  height: 46px;
+  border-radius: 12px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  background: var(--accent);
+}
+.exam-card__vendor {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--muted);
+}
+.exam-card__code {
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+.exam-card__name {
+  font-size: 13.5px;
+  font-weight: 600;
+  margin-top: 13px;
+}
+.exam-card__meta {
+  display: flex;
+  gap: 14px;
+  margin-top: 12px;
+  font-size: 12.5px;
+  color: var(--muted);
+}
+.exam-card__meta b {
+  color: var(--text);
+}
+
+.sim-rules {
+  padding: 22px 24px;
+}
+.sim-rules__title {
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+.sim-rules__sub {
+  font-size: 13.5px;
+  color: var(--muted);
+  margin-top: 4px;
+}
+.sim-rules__grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+  margin-top: 20px;
+}
+.sim-rule {
+  display: flex;
+  gap: 13px;
+  align-items: flex-start;
+}
+.sim-rule__icon {
+  width: 40px;
+  height: 40px;
+  border-radius: 11px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+}
+.sim-rule__t {
+  font-size: 14px;
+  font-weight: 600;
+}
+.sim-rule__d {
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--muted);
+  margin-top: 2px;
+}
+.sim-warn {
+  display: flex;
+  gap: 11px;
+  align-items: flex-start;
+  margin-top: 20px;
+  padding: 14px 16px;
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--amber) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--amber) 30%, transparent);
+}
+.sim-warn__icon {
+  color: #b7791f;
+  display: flex;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+.sim-warn div {
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.sim-pick__label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--muted);
+}
+.sim-pick__head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 10px;
+}
+.sim-pick__code {
+  font-size: 16px;
+  font-weight: 700;
+}
+.sim-pick__name {
+  font-size: 13px;
+  color: var(--muted);
+  margin-top: 8px;
+}
+.sim-pick__rows {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  margin-top: 16px;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+}
+.sim-pick__row {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  padding: 12px 14px;
+  background: var(--surface-2);
+}
+.sim-pick__row-icon {
+  color: var(--accent);
+  display: flex;
+}
+.sim-pick__row-label {
+  font-size: 13.5px;
+  color: var(--muted);
+  flex: 1;
+}
+.sim-pick__row-val {
+  font-size: 14px;
+  font-weight: 700;
+}
+.sim-start {
+  width: 100%;
+  height: 52px;
+  margin-top: 18px;
+  border: none;
+  border-radius: 13px;
+  background: var(--accent);
+  color: #fff;
+  font-family: inherit;
+  font-weight: 700;
+  font-size: 15.5px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 9px;
+  box-shadow: 0 10px 22px color-mix(in srgb, var(--accent) 30%, transparent);
+}
+.sim-start:disabled {
+  opacity: 0.7;
+  cursor: default;
+}
+.sim-pick__note {
+  font-size: 12px;
+  color: var(--muted);
+  text-align: center;
+  margin-top: 10px;
+}
+
+.sim-attempts__title {
+  font-size: 13px;
+  font-weight: 700;
+  margin-bottom: 12px;
+}
+.sim-attempts {
+  display: flex;
+  flex-direction: column;
+  gap: 11px;
+}
+.sim-attempt {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  width: 100%;
+  padding: 0;
+  background: none;
+  border: none;
+  text-align: left;
+  font-family: inherit;
+  cursor: pointer;
+}
+.sim-attempt__score {
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12.5px;
+  font-weight: 700;
+}
+.sim-attempt__score--ok {
+  color: var(--success);
+  background: var(--success-soft);
+}
+.sim-attempt__score--no {
+  color: var(--av-red);
+  background: color-mix(in srgb, var(--av-red) 15%, transparent);
+}
+.sim-attempt__id {
+  flex: 1;
+  min-width: 0;
+}
+.sim-attempt__exam {
+  font-size: 13.5px;
+  font-weight: 600;
+}
+.sim-attempt__date {
+  font-size: 12px;
+  color: var(--muted);
+}
+.sim-attempt__verdict {
+  font-size: 12px;
+  font-weight: 700;
+}
+.sim-attempt__verdict--ok {
+  color: var(--success);
+}
+.sim-attempt__verdict--no {
+  color: var(--av-red);
+}
+.sim-empty {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+/* Exam */
+.exam-bar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 14px 26px;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+}
+.exam-bar__logo {
+  width: 34px;
+  height: 34px;
+  border-radius: 9px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  background: #232f3e;
+}
+.exam-bar__title {
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  white-space: nowrap;
+}
+.exam-bar__sub {
+  font-size: 12px;
+  color: var(--muted);
+  white-space: nowrap;
+}
+.exam-bar__prog {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.exam-bar__track {
+  width: 180px;
+  height: 8px;
+  border-radius: 99px;
+  background: var(--surface-2);
+  overflow: hidden;
+}
+.exam-bar__track span {
+  display: block;
+  height: 100%;
+  border-radius: 99px;
+  background: var(--accent);
+}
+.exam-bar__count {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--muted);
+}
+.exam-bar__timer {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  height: 42px;
+  padding: 0 16px;
+  border-radius: 11px;
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  color: var(--accent);
+}
+.exam-bar__timer--urgent {
+  background: color-mix(in srgb, var(--av-red) 14%, transparent);
+  color: var(--av-red);
+}
+.exam-bar__timer span {
+  font-family: var(--font-code);
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+.exam-bar__finish {
+  flex: none;
+  height: 42px;
+}
+
+.exam-body {
+  display: grid;
+  grid-template-columns: 1fr 260px;
+  gap: 24px;
+  padding: 26px;
+  align-items: start;
+}
+.exam-q {
+  padding: 28px 30px;
+  min-width: 0;
+}
+.exam-q__meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 18px;
+}
+.exam-q__num {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  padding: 5px 12px;
+  border-radius: 8px;
+}
+.exam-q__tag {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--muted);
+  background: var(--surface-2);
+  padding: 5px 11px;
+  border-radius: 8px;
+}
+.exam-q__flag {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--muted);
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+}
+.exam-q__flag--on {
+  color: var(--amber);
+}
+.exam-q__text {
+  font-size: 19px;
+  font-weight: 600;
+  line-height: 1.5;
+  letter-spacing: -0.01em;
+}
+.exam-q__options {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 24px;
+}
+.exam-opt {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 16px 18px;
+  border-radius: 13px;
+  cursor: pointer;
+  background: var(--surface-2);
+  border: 1.5px solid transparent;
+  font-family: inherit;
+  text-align: left;
+}
+.exam-opt__badge {
+  width: 30px;
+  height: 30px;
+  border-radius: 9px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13.5px;
+  font-weight: 700;
+  color: var(--muted);
+  background: color-mix(in srgb, var(--muted) 20%, transparent);
+}
+.exam-opt__label {
+  font-size: 15px;
+  font-weight: 500;
+}
+.exam-opt--on {
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  border-color: var(--accent);
+}
+.exam-opt--on .exam-opt__badge {
+  background: var(--accent);
+  color: #fff;
+}
+.exam-opt--on .exam-opt__label {
+  color: var(--accent);
+}
+.exam-q__foot {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 28px;
+  padding-top: 22px;
+  border-top: 1px solid var(--border);
+}
+.exam-q__nav {
+  flex: none;
+  height: 46px;
+}
+.exam-q__saved {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.exam-side {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  position: sticky;
+  top: 26px;
+}
+.exam-nav__title {
+  font-size: 14px;
+  font-weight: 700;
+  margin-bottom: 14px;
+}
+.exam-nav__grid {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 7px;
+}
+.exam-nav__cell {
+  aspect-ratio: 1;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  color: var(--muted);
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  font-family: inherit;
+}
+.exam-nav__cell--ans {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+}
+.exam-nav__cell--flag {
+  background: color-mix(in srgb, var(--amber) 26%, transparent);
+  color: #b7791f;
+  border: 1px solid var(--amber);
+}
+.exam-nav__cell--cur {
+  background: var(--surface);
+  color: var(--accent);
+  border: 2px solid var(--accent);
+}
+.exam-nav__legend {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 16px;
+  padding-top: 14px;
+  border-top: 1px solid var(--border);
+}
+.exam-nav__legend div {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  font-size: 12.5px;
+  color: var(--muted);
+}
+.exam-nav__dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 4px;
+}
+.exam-nav__dot--ans {
+  background: var(--accent);
+}
+.exam-nav__dot--flag {
+  background: color-mix(in srgb, var(--amber) 26%, transparent);
+  border: 1px solid var(--amber);
+}
+.exam-nav__dot--none {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+}
+.exam-submit {
+  width: 100%;
+  height: 48px;
+  border: none;
+  border-radius: 13px;
+  background: var(--success);
+  color: #fff;
+  font-family: inherit;
+  font-weight: 700;
+  font-size: 14.5px;
+  cursor: pointer;
+}
+.exam-submit:disabled {
+  opacity: 0.7;
+  cursor: default;
+}
+
+/* Result */
+.res-hero {
+  position: relative;
+  overflow: hidden;
+  border-radius: 20px;
+  padding: 28px 30px;
+  margin-bottom: 18px;
+  color: #fff;
+}
+.res-hero__glow {
+  position: absolute;
+  width: 360px;
+  height: 360px;
+  border-radius: 50%;
+  top: -190px;
+  right: -70px;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.15), transparent 70%);
+  pointer-events: none;
+}
+.res-hero__inner {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 28px;
+}
+.res-ring {
+  position: relative;
+  width: 132px;
+  height: 132px;
+  flex-shrink: 0;
+}
+.res-ring__center {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+.res-ring__pct {
+  font-size: 34px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1;
+}
+.res-ring__cap {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.8);
+  margin-top: 2px;
+}
+.res-hero__meta {
+  flex: 1;
+  min-width: 0;
+}
+.res-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  height: 30px;
+  padding: 0 13px;
+  border-radius: 99px;
+  background: rgba(255, 255, 255, 0.2);
+  font-size: 13px;
+  font-weight: 700;
+}
+.res-hero__title {
+  font-size: 28px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin-top: 12px;
+}
+.res-hero__sub {
+  font-size: 15px;
+  color: rgba(255, 255, 255, 0.9);
+  margin-top: 6px;
+  line-height: 1.5;
+  max-width: 520px;
+}
+.res-stats {
+  display: flex;
+  gap: 10px;
+  flex-shrink: 0;
+}
+.res-stat {
+  background: rgba(255, 255, 255, 0.16);
+  border-radius: 13px;
+  padding: 14px 18px;
+  text-align: center;
+  min-width: 78px;
+}
+.res-stat__v {
+  font-size: 24px;
+  font-weight: 700;
+  line-height: 1;
+}
+.res-stat__l {
+  font-size: 11.5px;
+  color: rgba(255, 255, 255, 0.82);
+  margin-top: 3px;
+}
+
+.res-sec__title {
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+.res-sec__sub {
+  font-size: 13px;
+  color: var(--muted);
+  margin-top: 4px;
+  margin-bottom: 18px;
+}
+.res-domains {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.res-domain__row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+.res-domain__name {
+  font-size: 14px;
+  font-weight: 600;
+  flex: 1;
+}
+.res-domain__tag {
+  font-size: 12px;
+  font-weight: 700;
+  padding: 2px 9px;
+  border-radius: 6px;
+}
+.res-domain__pct {
+  font-size: 13px;
+  font-weight: 700;
+  width: 42px;
+  text-align: right;
+}
+.res-domain__track {
+  height: 8px;
+  border-radius: 99px;
+  background: var(--surface-2);
+  overflow: hidden;
+}
+.res-domain__track span {
+  display: block;
+  height: 100%;
+  border-radius: 99px;
+}
+
+.res-review__head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 4px;
+}
+.res-review__count {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--av-red);
+  background: color-mix(in srgb, var(--av-red) 12%, transparent);
+  padding: 4px 11px;
+  border-radius: 8px;
+}
+.res-wrongs {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.res-wrong {
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 18px 20px;
+}
+.res-wrong__meta {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin-bottom: 12px;
+}
+.res-wrong__q {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--muted);
+  background: var(--surface-2);
+  padding: 3px 10px;
+  border-radius: 7px;
+}
+.res-wrong__domain {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--muted);
+}
+.res-wrong__text {
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1.5;
+}
+.res-wrong__answers {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 14px;
+}
+.res-ans {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  padding: 11px 14px;
+  border-radius: 10px;
+}
+.res-ans--wrong {
+  background: color-mix(in srgb, var(--av-red) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--av-red) 35%, transparent);
+}
+.res-ans--right {
+  background: var(--success-soft);
+  border: 1px solid color-mix(in srgb, var(--success) 35%, transparent);
+}
+.res-ans__icon {
+  width: 24px;
+  height: 24px;
+  border-radius: 7px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+}
+.res-ans__icon--wrong {
+  background: var(--av-red);
+}
+.res-ans__icon--right {
+  background: var(--success);
+}
+.res-ans__label {
+  font-size: 13.5px;
+  color: var(--muted);
+}
+.res-ans__val {
+  font-size: 13.5px;
+  font-weight: 600;
+}
+.res-ans__val--wrong {
+  color: var(--av-red);
+}
+.res-ans__val--right {
+  color: var(--success);
+}
+.res-why {
+  display: flex;
+  gap: 10px;
+  margin-top: 14px;
+  padding: 13px 15px;
+  border-radius: 11px;
+  background: var(--surface-2);
+}
+.res-why__icon {
+  color: var(--accent);
+  flex-shrink: 0;
+  display: flex;
+  margin-top: 1px;
+}
+.res-why div {
+  font-size: 13px;
+  line-height: 1.55;
+}
+.res-study {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 12px;
+  flex-wrap: wrap;
+}
+.res-study__label {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--muted);
+}
+.res-study__chip {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 11%, transparent);
+  padding: 5px 11px;
+  border-radius: 8px;
+}
+
+.res-plan__title {
+  font-size: 15px;
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+.res-plan__sub {
+  font-size: 13px;
+  color: var(--muted);
+  line-height: 1.5;
+  margin-bottom: 16px;
+}
+.res-plan {
+  display: flex;
+  flex-direction: column;
+  gap: 11px;
+}
+.res-plan-item {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  padding: 13px 14px;
+  border-radius: 12px;
+  background: var(--surface-2);
+}
+.res-plan-item__icon {
+  width: 34px;
+  height: 34px;
+  border-radius: 10px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 13%, transparent);
+}
+.res-plan-item__t {
+  font-size: 13.5px;
+  font-weight: 600;
+}
+.res-plan-item__s {
+  font-size: 12px;
+  color: var(--muted);
+  margin-top: 1px;
+}
+.res-plan__redo {
+  width: 100%;
+  height: 46px;
+  margin-top: 16px;
+}
+.res-seal {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 20px;
+}
+.res-seal__icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 13px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.res-seal--pass .res-seal__icon {
+  color: var(--success);
+  background: var(--success-soft);
+}
+.res-seal--fail .res-seal__icon {
+  color: #b7791f;
+  background: color-mix(in srgb, var(--amber) 16%, transparent);
+}
+.res-seal__t {
+  font-size: 14px;
+  font-weight: 700;
+}
+.res-seal__s {
+  font-size: 12.5px;
+  color: var(--muted);
+  margin-top: 1px;
+}

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -24,6 +24,7 @@
 
   /* Cores de apoio (fixas nos dois temas) */
   --gold: #e0a82e;
+  --amber: #e0a82e;
   --silver: #a9aeb8;
   --bronze: #c77b3b;
   --av-blue: #5b8def;


### PR DESCRIPTION
## O que é

Frontend dos Simulados, no design da plataforma (referência do zip). Consome a API das fatias anteriores (#51/#52). Três telas:

- **Lista/briefing** (`/simulados`): cards de simulado (questões, tempo, corte), regras, "Iniciar" e as últimas tentativas.
- **Prova** (`/simulados/tentativa/:id`, em andamento): uma questão por vez, navegador lateral (respondida/marcada/em branco), suporte a resposta única e múltipla, autosave a cada marcação, cronômetro regressivo que auto-envia ao zerar.
- **Resultado** (mesma rota, após enviar): nota em anel, aprovado/reprovado, desempenho por tema e a revisão das erradas (sua resposta, a correta, o porquê e o assunto a estudar), além do painel de temas a revisar.

## Detalhes

- Reaproveita tokens e componentes existentes (Logo, UserMenu, ThemeToggle, Icons). Adicionei 5 ícones (ClockExam, Info, Redo, Target, BookOpen) e o token `--amber`.
- Entrada "Simulados" no menu (Home, Trilhas, Ranking).
- Sem gamificação, como combinado.
- Segurança: o gabarito só aparece na tela de resultado (o backend só envia isCorrect/justificativa após enviar).

## CSS

Os estilos do simulado ficaram em `styles/simulado.css` (importado no `index.css`), em vez de crescer o `app.css`.

## Como testar local

Precisa do backend com as migrações 0019/0020 e o seed. Subir o dev, migrar e rodar `node --env-file=.env scripts/seed-aws-ccp.ts`. Depois: entrar em Simulados, iniciar, responder, enviar e ver o resultado.

## Verificação

`tsc -b` + `vite build` verdes; lint sem erros (só warnings pré-existentes).
