### PR TITLE
feat: CRUD admin de simulados no backend

### DIFF
--- a/backend/src/controllers/SimuladoController.ts
+++ b/backend/src/controllers/SimuladoController.ts
@@ -1,5 +1,10 @@
 import type { Request, Response, NextFunction } from "express";
-import { salvarRespostaSchema } from "../schemas/simulado.schema.ts";
+import {
+    salvarRespostaSchema,
+    createSimuladoSchema,
+    updateSimuladoSchema,
+    simuladoQuestionSchema,
+} from "../schemas/simulado.schema.ts";
 import {
     listarSimulados,
     iniciarTentativa,
@@ -7,6 +12,14 @@ import {
     salvarResposta,
     enviarTentativa,
     historicoDoUsuario,
+    listarSimuladosAdmin,
+    detalheSimuladoAdmin,
+    criarSimulado,
+    atualizarSimulado,
+    excluirSimulado,
+    criarQuestaoSimulado,
+    atualizarQuestaoSimulado,
+    excluirQuestaoSimulado,
 } from "../services/simulado.service.ts";
 
 export const listSimulados = async (_req: Request, res: Response, next: NextFunction) => {
@@ -60,6 +73,83 @@ export const submitAttempt = async (req: Request, res: Response, next: NextFunct
 export const getMyAttempts = async (req: Request, res: Response, next: NextFunction) => {
     try {
         res.json(await historicoDoUsuario(req.userId!));
+    } catch (err) {
+        next(err);
+    }
+};
+
+// ===================== ADMIN =====================
+export const adminListSimulados = async (_req: Request, res: Response, next: NextFunction) => {
+    try {
+        res.json(await listarSimuladosAdmin());
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const adminGetSimulado = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        res.json(await detalheSimuladoAdmin(String(req.params.slug)));
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const createSimulado = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        res.status(201).json(await criarSimulado(createSimuladoSchema.parse(req.body)));
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const updateSimulado = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        res.json(
+            await atualizarSimulado(String(req.params.slug), updateSimuladoSchema.parse(req.body)),
+        );
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const deleteSimulado = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        res.json(await excluirSimulado(String(req.params.slug)));
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const createSimuladoQuestion = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        res.status(201).json(
+            await criarQuestaoSimulado(
+                String(req.params.slug),
+                simuladoQuestionSchema.parse(req.body),
+            ),
+        );
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const updateSimuladoQuestion = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        res.json(
+            await atualizarQuestaoSimulado(
+                String(req.params.id),
+                simuladoQuestionSchema.parse(req.body),
+            ),
+        );
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const deleteSimuladoQuestion = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        res.json(await excluirQuestaoSimulado(String(req.params.id)));
     } catch (err) {
         next(err);
     }

--- a/backend/src/routes/simulado.routes.ts
+++ b/backend/src/routes/simulado.routes.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { autenticar } from "../middlewares/auth.ts";
+import { autenticar, exigirAdmin } from "../middlewares/auth.ts";
 import {
     listSimulados,
     startAttempt,
@@ -7,6 +7,14 @@ import {
     saveAnswer,
     submitAttempt,
     getMyAttempts,
+    adminListSimulados,
+    adminGetSimulado,
+    createSimulado,
+    updateSimulado,
+    deleteSimulado,
+    createSimuladoQuestion,
+    updateSimuladoQuestion,
+    deleteSimuladoQuestion,
 } from "../controllers/SimuladoController.ts";
 
 const router = Router();
@@ -17,5 +25,15 @@ router.post("/simulados/:slug/attempts", autenticar, startAttempt);
 router.get("/simulado-attempts/:id", autenticar, getAttempt);
 router.put("/simulado-attempts/:id/answers/:questionId", autenticar, saveAnswer);
 router.post("/simulado-attempts/:id/submit", autenticar, submitAttempt);
+
+// Admin: CRUD de simulados e questões
+router.get("/admin/simulados", autenticar, exigirAdmin, adminListSimulados);
+router.post("/simulados", autenticar, exigirAdmin, createSimulado);
+router.get("/admin/simulados/:slug", autenticar, exigirAdmin, adminGetSimulado);
+router.patch("/simulados/:slug", autenticar, exigirAdmin, updateSimulado);
+router.delete("/simulados/:slug", autenticar, exigirAdmin, deleteSimulado);
+router.post("/simulados/:slug/questions", autenticar, exigirAdmin, createSimuladoQuestion);
+router.patch("/simulado-questions/:id", autenticar, exigirAdmin, updateSimuladoQuestion);
+router.delete("/simulado-questions/:id", autenticar, exigirAdmin, deleteSimuladoQuestion);
 
 export default router;

--- a/backend/src/schemas/simulado.schema.ts
+++ b/backend/src/schemas/simulado.schema.ts
@@ -4,3 +4,44 @@ import { z } from "zod";
 export const salvarRespostaSchema = z.object({
     optionIds: z.array(z.uuid()).max(10),
 });
+
+export const createSimuladoSchema = z.object({
+    slug: z
+        .string()
+        .trim()
+        .min(3, "O slug deve ter ao menos 3 caracteres")
+        .max(80)
+        .regex(/^[a-z0-9-]+$/, "Use apenas minúsculas, números e hífen"),
+    name: z.string().trim().min(3, "O nome deve ter ao menos 3 caracteres").max(160),
+    description: z.string().max(2000).optional(),
+    durationMinutes: z.int().positive("A duração deve ser positiva"),
+    questionCount: z.int().positive("A quantidade de questões deve ser positiva"),
+    passPercent: z.int().min(0).max(100),
+    published: z.boolean().default(false),
+});
+
+export const updateSimuladoSchema = z.object({
+    name: z.string().trim().min(3).max(160).optional(),
+    description: z.string().max(2000).optional(),
+    durationMinutes: z.int().positive().optional(),
+    questionCount: z.int().positive().optional(),
+    passPercent: z.int().min(0).max(100).optional(),
+    published: z.boolean().optional(),
+});
+
+// Questão de simulado: aceita múltipla resposta, então exige ao menos uma correta.
+export const simuladoQuestionSchema = z.object({
+    statement: z.string().trim().min(3, "O enunciado deve ter ao menos 3 caracteres"),
+    topic: z.string().trim().max(60).optional(),
+    explanation: z.string().max(2000).optional(),
+    options: z
+        .array(
+            z.object({
+                text: z.string().trim().min(1, "A alternativa não pode ser vazia"),
+                isCorrect: z.boolean(),
+            }),
+        )
+        .min(2, "A questão precisa de ao menos 2 alternativas")
+        .max(6, "No máximo 6 alternativas")
+        .refine((opts) => opts.some((o) => o.isCorrect), "Marque ao menos uma alternativa correta"),
+});

--- a/backend/src/services/simulado.service.ts
+++ b/backend/src/services/simulado.service.ts
@@ -7,7 +7,7 @@ import {
     simuladoAttemptQuestions,
     simuladoAttemptAnswers,
 } from "../../schema.ts";
-import { eq, and, sql, inArray, desc, isNull } from "drizzle-orm";
+import { eq, and, sql, inArray, desc, isNull, count } from "drizzle-orm";
 import { AppError } from "../errors/AppError.ts";
 import { corrigirSimulado, questaoCorreta, resumoPorTema } from "../domain/simulado.ts";
 
@@ -304,4 +304,217 @@ export async function historicoDoUsuario(userId: string) {
         .innerJoin(simulados, eq(simulados.id, simuladoAttempts.simuladoId))
         .where(eq(simuladoAttempts.userId, userId))
         .orderBy(desc(simuladoAttempts.startedAt));
+}
+
+// ===================== ADMIN (CRUD) =====================
+
+type DadosSimulado = {
+    slug: string;
+    name: string;
+    description?: string;
+    durationMinutes: number;
+    questionCount: number;
+    passPercent: number;
+    published: boolean;
+};
+type DadosSimuladoUpdate = Partial<Omit<DadosSimulado, "slug">>;
+type DadosQuestao = {
+    statement: string;
+    topic?: string;
+    explanation?: string;
+    options: { text: string; isCorrect: boolean }[];
+};
+
+async function simuladoPorSlug(slug: string) {
+    const [s] = await db.select().from(simulados).where(eq(simulados.slug, slug));
+    if (!s) throw new AppError(404, "Simulado não encontrado");
+    return s;
+}
+
+export async function listarSimuladosAdmin() {
+    return db
+        .select({
+            slug: simulados.slug,
+            name: simulados.name,
+            durationMinutes: simulados.durationMinutes,
+            questionCount: simulados.questionCount,
+            passPercent: simulados.passPercent,
+            published: simulados.published,
+            questoes: count(simuladoQuestions.id),
+        })
+        .from(simulados)
+        .leftJoin(simuladoQuestions, eq(simuladoQuestions.simuladoId, simulados.id))
+        .groupBy(simulados.id)
+        .orderBy(simulados.name);
+}
+
+export async function criarSimulado(dados: DadosSimulado) {
+    const [existe] = await db
+        .select({ id: simulados.id })
+        .from(simulados)
+        .where(eq(simulados.slug, dados.slug));
+    if (existe) throw new AppError(409, "Já existe um simulado com esse slug");
+    const [s] = await db.insert(simulados).values(dados).returning();
+    return s;
+}
+
+export async function atualizarSimulado(slug: string, dados: DadosSimuladoUpdate) {
+    const s = await simuladoPorSlug(slug);
+    if (Object.keys(dados).length === 0) throw new AppError(400, "Nada para atualizar");
+    const [atualizado] = await db
+        .update(simulados)
+        .set(dados)
+        .where(eq(simulados.id, s.id))
+        .returning();
+    return atualizado;
+}
+
+export async function excluirSimulado(slug: string) {
+    const s = await simuladoPorSlug(slug);
+    await db.transaction(async (tx) => {
+        const tentativas = await tx
+            .select({ id: simuladoAttempts.id })
+            .from(simuladoAttempts)
+            .where(eq(simuladoAttempts.simuladoId, s.id));
+        const attemptIds = tentativas.map((t) => t.id);
+        if (attemptIds.length) {
+            await tx
+                .delete(simuladoAttemptAnswers)
+                .where(inArray(simuladoAttemptAnswers.attemptId, attemptIds));
+            await tx
+                .delete(simuladoAttemptQuestions)
+                .where(inArray(simuladoAttemptQuestions.attemptId, attemptIds));
+            await tx.delete(simuladoAttempts).where(eq(simuladoAttempts.simuladoId, s.id));
+        }
+        const questoes = await tx
+            .select({ id: simuladoQuestions.id })
+            .from(simuladoQuestions)
+            .where(eq(simuladoQuestions.simuladoId, s.id));
+        const questionIds = questoes.map((q) => q.id);
+        if (questionIds.length) {
+            await tx
+                .delete(simuladoOptions)
+                .where(inArray(simuladoOptions.questionId, questionIds));
+            await tx.delete(simuladoQuestions).where(eq(simuladoQuestions.simuladoId, s.id));
+        }
+        await tx.delete(simulados).where(eq(simulados.id, s.id));
+    });
+    return { ok: true };
+}
+
+// Simulado com o banco de questões inteiro (com gabarito), para a edição no admin.
+export async function detalheSimuladoAdmin(slug: string) {
+    const s = await simuladoPorSlug(slug);
+    const questoes = await db
+        .select()
+        .from(simuladoQuestions)
+        .where(eq(simuladoQuestions.simuladoId, s.id))
+        .orderBy(simuladoQuestions.createdAt);
+    const questionIds = questoes.map((q) => q.id);
+    const opcoes = questionIds.length
+        ? await db
+              .select()
+              .from(simuladoOptions)
+              .where(inArray(simuladoOptions.questionId, questionIds))
+              .orderBy(simuladoOptions.position)
+        : [];
+    return {
+        slug: s.slug,
+        name: s.name,
+        description: s.description,
+        durationMinutes: s.durationMinutes,
+        questionCount: s.questionCount,
+        passPercent: s.passPercent,
+        published: s.published,
+        questions: questoes.map((q) => ({
+            id: q.id,
+            statement: q.statement,
+            topic: q.topic,
+            explanation: q.explanation,
+            options: opcoes
+                .filter((o) => o.questionId === q.id)
+                .map((o) => ({
+                    id: o.id,
+                    text: o.text,
+                    isCorrect: o.isCorrect,
+                    position: o.position,
+                })),
+        })),
+    };
+}
+
+export async function criarQuestaoSimulado(slug: string, dados: DadosQuestao) {
+    const s = await simuladoPorSlug(slug);
+    return db.transaction(async (tx) => {
+        const [q] = await tx
+            .insert(simuladoQuestions)
+            .values({
+                simuladoId: s.id,
+                statement: dados.statement,
+                topic: dados.topic,
+                explanation: dados.explanation,
+            })
+            .returning();
+        await tx.insert(simuladoOptions).values(
+            dados.options.map((o, i) => ({
+                questionId: q.id,
+                text: o.text,
+                isCorrect: o.isCorrect,
+                position: i + 1,
+            })),
+        );
+        return q;
+    });
+}
+
+export async function atualizarQuestaoSimulado(questionId: string, dados: DadosQuestao) {
+    const [q] = await db
+        .select({ id: simuladoQuestions.id })
+        .from(simuladoQuestions)
+        .where(eq(simuladoQuestions.id, questionId));
+    if (!q) throw new AppError(404, "Questão não encontrada");
+    await db.transaction(async (tx) => {
+        await tx
+            .update(simuladoQuestions)
+            .set({
+                statement: dados.statement,
+                topic: dados.topic,
+                explanation: dados.explanation,
+            })
+            .where(eq(simuladoQuestions.id, questionId));
+        // Substitui as opções. Como o id delas muda, apaga as respostas de tentativas
+        // que apontavam para as antigas (edição de banco reflete em revisões passadas).
+        await tx
+            .delete(simuladoAttemptAnswers)
+            .where(eq(simuladoAttemptAnswers.questionId, questionId));
+        await tx.delete(simuladoOptions).where(eq(simuladoOptions.questionId, questionId));
+        await tx.insert(simuladoOptions).values(
+            dados.options.map((o, i) => ({
+                questionId,
+                text: o.text,
+                isCorrect: o.isCorrect,
+                position: i + 1,
+            })),
+        );
+    });
+    return { ok: true };
+}
+
+export async function excluirQuestaoSimulado(questionId: string) {
+    const [q] = await db
+        .select({ id: simuladoQuestions.id })
+        .from(simuladoQuestions)
+        .where(eq(simuladoQuestions.id, questionId));
+    if (!q) throw new AppError(404, "Questão não encontrada");
+    await db.transaction(async (tx) => {
+        await tx
+            .delete(simuladoAttemptAnswers)
+            .where(eq(simuladoAttemptAnswers.questionId, questionId));
+        await tx
+            .delete(simuladoAttemptQuestions)
+            .where(eq(simuladoAttemptQuestions.questionId, questionId));
+        await tx.delete(simuladoOptions).where(eq(simuladoOptions.questionId, questionId));
+        await tx.delete(simuladoQuestions).where(eq(simuladoQuestions.id, questionId));
+    });
+    return { ok: true };
 }

--- a/backend/tests/simulado.test.ts
+++ b/backend/tests/simulado.test.ts
@@ -24,10 +24,13 @@ async function ajustarUsuario(email: string, campos: Record<string, unknown>) {
     await db.update(users).set(campos).where(eq(users.email, email));
 }
 
-async function criarUsuarioLogado() {
+async function criarUsuarioLogado(admin = false) {
     const dados = novoUsuario();
     await server.request("POST", "/register", { body: dados });
-    await ajustarUsuario(dados.email, { emailVerifiedAt: new Date() });
+    await ajustarUsuario(dados.email, {
+        emailVerifiedAt: new Date(),
+        ...(admin ? { role: "admin" } : {}),
+    });
     const login = await server.request("POST", "/login", {
         body: { email: dados.email, password: dados.password },
     });
@@ -55,6 +58,18 @@ async function put(path: string, token: string, body?: unknown) {
         headers: { ...auth(token), "Content-Type": "application/json" },
         body: body ? JSON.stringify(body) : undefined,
     });
+    return { status: res.status, body: await res.json().catch(() => null) };
+}
+async function patch(path: string, token: string, body?: unknown) {
+    const res = await fetch(`${server.base}${path}`, {
+        method: "PATCH",
+        headers: { ...auth(token), "Content-Type": "application/json" },
+        body: body ? JSON.stringify(body) : undefined,
+    });
+    return { status: res.status, body: await res.json().catch(() => null) };
+}
+async function del(path: string, token: string) {
+    const res = await fetch(`${server.base}${path}`, { method: "DELETE", headers: auth(token) });
     return { status: res.status, body: await res.json().catch(() => null) };
 }
 
@@ -250,5 +265,97 @@ describe("Simulado: responder, enviar e corrigir", () => {
         assert.equal(hist.body.length, 1);
         assert.equal(hist.body[0].passed, true);
         assert.equal(hist.body[0].score, 100);
+    });
+});
+
+describe("Simulado: CRUD admin", () => {
+    const novoSimulado = (over: Record<string, unknown> = {}) => ({
+        slug: `admin-${++seq}`,
+        name: "Simulado Admin",
+        durationMinutes: 30,
+        questionCount: 10,
+        passPercent: 70,
+        published: true,
+        ...over,
+    });
+    const novaQuestao = (over: Record<string, unknown> = {}) => ({
+        statement: "Enunciado da questão de teste",
+        topic: "Tema X",
+        explanation: "Porque sim.",
+        options: [
+            { text: "certa", isCorrect: true },
+            { text: "errada", isCorrect: false },
+        ],
+        ...over,
+    });
+
+    test("admin cria simulado; comum recebe 403", async () => {
+        const admin = await criarUsuarioLogado(true);
+        assert.equal((await post("/simulados", admin.token, novoSimulado())).status, 201);
+
+        const comum = await criarUsuarioLogado();
+        assert.equal((await post("/simulados", comum.token, novoSimulado())).status, 403);
+    });
+
+    test("slug duplicado retorna 409", async () => {
+        const admin = await criarUsuarioLogado(true);
+        const s = novoSimulado();
+        assert.equal((await post("/simulados", admin.token, s)).status, 201);
+        assert.equal((await post("/simulados", admin.token, s)).status, 409);
+    });
+
+    test("questão sem alternativa correta é rejeitada (400)", async () => {
+        const admin = await criarUsuarioLogado(true);
+        const s = novoSimulado();
+        await post("/simulados", admin.token, s);
+        const r = await post(`/simulados/${s.slug}/questions`, admin.token, {
+            statement: "Sem gabarito",
+            options: [
+                { text: "a", isCorrect: false },
+                { text: "b", isCorrect: false },
+            ],
+        });
+        assert.equal(r.status, 400);
+    });
+
+    test("fluxo: cria, adiciona questão, edita, exclui questão e simulado", async () => {
+        const admin = await criarUsuarioLogado(true);
+        const s = novoSimulado();
+        await post("/simulados", admin.token, s);
+
+        const criada = await post(`/simulados/${s.slug}/questions`, admin.token, novaQuestao());
+        assert.equal(criada.status, 201);
+
+        let det = await get(`/admin/simulados/${s.slug}`, admin.token);
+        assert.equal(det.body.questions.length, 1);
+        assert.ok(det.body.questions[0].options.some((o: any) => o.isCorrect === true));
+        const qId = det.body.questions[0].id;
+
+        const editou = await patch(
+            `/simulado-questions/${qId}`,
+            admin.token,
+            novaQuestao({
+                statement: "Enunciado editado",
+                options: [
+                    { text: "nova certa", isCorrect: true },
+                    { text: "nova errada", isCorrect: false },
+                    { text: "outra", isCorrect: false },
+                ],
+            }),
+        );
+        assert.equal(editou.status, 200);
+        det = await get(`/admin/simulados/${s.slug}`, admin.token);
+        assert.equal(det.body.questions[0].statement, "Enunciado editado");
+        assert.equal(det.body.questions[0].options.length, 3);
+
+        const lista = await get(`/admin/simulados`, admin.token);
+        assert.equal(Number(lista.body.find((x: any) => x.slug === s.slug).questoes), 1);
+
+        assert.equal((await del(`/simulado-questions/${qId}`, admin.token)).status, 200);
+        det = await get(`/admin/simulados/${s.slug}`, admin.token);
+        assert.equal(det.body.questions.length, 0);
+
+        assert.equal((await del(`/simulados/${s.slug}`, admin.token)).status, 200);
+        assert.equal((await get(`/admin/simulados/${s.slug}`, admin.token)).status, 404);
     });
 });


### PR DESCRIPTION
## O que é

CRUD admin de simulados no backend (primeira fatia; o frontend admin vem em seguida). Endpoints protegidos por `exigirAdmin`.

## Endpoints

- `GET /admin/simulados` — lista tudo (inclui não publicados) com contagem de questões
- `POST /simulados` — cria (slug único, nome, duração, nº, corte, publicado)
- `GET /admin/simulados/:slug` — simulado com as questões e o gabarito, para edição
- `PATCH /simulados/:slug` e `DELETE /simulados/:slug`
- `POST /simulados/:slug/questions` — adiciona questão (opções, tema, justificativa)
- `PATCH /simulado-questions/:id` e `DELETE /simulado-questions/:id`

## Detalhes

- Validação Zod: questão exige ao menos 2 alternativas e ao menos 1 correta (aceita múltipla resposta); slug em kebab-case.
- Exclusão trata as FKs em transação (remove tentativas, snapshots, respostas, opções e questões antes do simulado). Trocar as opções de uma questão na edição limpa as respostas de tentativas que apontavam pras antigas.
- Sem migration (as tabelas já existem).

## Testes

Integração: admin cria (201) e comum recebe 403; slug duplicado 409; questão sem correta 400; e o fluxo completo (cria, adiciona, edita, exclui questão e simulado). 40 testes de integração passando.
