### PR TITLE
feat: painel admin de simulados com salvar atômico e alternativas embaralhadas

### DIFF
--- a/backend/src/controllers/SimuladoController.ts
+++ b/backend/src/controllers/SimuladoController.ts
@@ -4,6 +4,7 @@ import {
     createSimuladoSchema,
     updateSimuladoSchema,
     simuladoQuestionSchema,
+    sincronizarQuestoesSchema,
 } from "../schemas/simulado.schema.ts";
 import {
     listarSimulados,
@@ -20,6 +21,7 @@ import {
     criarQuestaoSimulado,
     atualizarQuestaoSimulado,
     excluirQuestaoSimulado,
+    sincronizarQuestoesSimulado,
 } from "../services/simulado.service.ts";
 
 export const listSimulados = async (_req: Request, res: Response, next: NextFunction) => {
@@ -150,6 +152,15 @@ export const updateSimuladoQuestion = async (req: Request, res: Response, next: 
 export const deleteSimuladoQuestion = async (req: Request, res: Response, next: NextFunction) => {
     try {
         res.json(await excluirQuestaoSimulado(String(req.params.id)));
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const syncSimuladoQuestions = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const { questions } = sincronizarQuestoesSchema.parse(req.body);
+        res.json(await sincronizarQuestoesSimulado(String(req.params.slug), questions));
     } catch (err) {
         next(err);
     }

--- a/backend/src/domain/simulado.test.ts
+++ b/backend/src/domain/simulado.test.ts
@@ -1,6 +1,11 @@
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
-import { corrigirSimulado, questaoCorreta, resumoPorTema } from "./simulado.ts";
+import {
+    corrigirSimulado,
+    questaoCorreta,
+    resumoPorTema,
+    embaralharComSemente,
+} from "./simulado.ts";
 
 describe("questaoCorreta", () => {
     test("resposta única certa", () => {
@@ -118,5 +123,34 @@ describe("resumoPorTema", () => {
         assert.deepEqual(resumoPorTema([{ topic: null, correta: false }]), [
             { topic: "Outros", erradas: 1, total: 1 },
         ]);
+    });
+});
+
+describe("embaralharComSemente", () => {
+    test("a mesma semente devolve sempre a mesma ordem", () => {
+        const itens = ["a", "b", "c", "d", "e", "f"];
+        assert.deepEqual(
+            embaralharComSemente(itens, "att-q"),
+            embaralharComSemente(itens, "att-q"),
+        );
+    });
+
+    test("é uma permutação dos mesmos itens", () => {
+        const itens = ["a", "b", "c", "d", "e", "f"];
+        assert.deepEqual([...embaralharComSemente(itens, "s")].sort(), [...itens].sort());
+    });
+
+    test("sementes diferentes geram ordens diferentes", () => {
+        const itens = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"];
+        assert.notDeepEqual(
+            embaralharComSemente(itens, "att1-q"),
+            embaralharComSemente(itens, "att2-q"),
+        );
+    });
+
+    test("não muta o array original", () => {
+        const itens = ["a", "b", "c"];
+        embaralharComSemente(itens, "s");
+        assert.deepEqual(itens, ["a", "b", "c"]);
     });
 });

--- a/backend/src/domain/simulado.ts
+++ b/backend/src/domain/simulado.ts
@@ -42,3 +42,32 @@ export function resumoPorTema(
         .map(([topic, v]) => ({ topic, erradas: v.erradas, total: v.total }))
         .sort((a, b) => b.erradas - a.erradas);
 }
+
+// Embaralhamento determinístico: a mesma semente devolve sempre a mesma ordem
+// (estável ao recarregar a tentativa); sementes diferentes embaralham diferente.
+function mulberry32(seed: number): () => number {
+    return () => {
+        seed = (seed + 0x6d2b79f5) | 0;
+        let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+}
+
+function hashString(s: string): number {
+    let h = 2166136261;
+    for (let i = 0; i < s.length; i++) {
+        h = Math.imul(h ^ s.charCodeAt(i), 16777619);
+    }
+    return h >>> 0;
+}
+
+export function embaralharComSemente<T>(itens: T[], semente: string): T[] {
+    const rand = mulberry32(hashString(semente));
+    const arr = [...itens];
+    for (let i = arr.length - 1; i > 0; i--) {
+        const j = Math.floor(rand() * (i + 1));
+        [arr[i], arr[j]] = [arr[j], arr[i]];
+    }
+    return arr;
+}

--- a/backend/src/routes/simulado.routes.ts
+++ b/backend/src/routes/simulado.routes.ts
@@ -15,6 +15,7 @@ import {
     createSimuladoQuestion,
     updateSimuladoQuestion,
     deleteSimuladoQuestion,
+    syncSimuladoQuestions,
 } from "../controllers/SimuladoController.ts";
 
 const router = Router();
@@ -33,6 +34,7 @@ router.get("/admin/simulados/:slug", autenticar, exigirAdmin, adminGetSimulado);
 router.patch("/simulados/:slug", autenticar, exigirAdmin, updateSimulado);
 router.delete("/simulados/:slug", autenticar, exigirAdmin, deleteSimulado);
 router.post("/simulados/:slug/questions", autenticar, exigirAdmin, createSimuladoQuestion);
+router.put("/admin/simulados/:slug/questions", autenticar, exigirAdmin, syncSimuladoQuestions);
 router.patch("/simulado-questions/:id", autenticar, exigirAdmin, updateSimuladoQuestion);
 router.delete("/simulado-questions/:id", autenticar, exigirAdmin, deleteSimuladoQuestion);
 

--- a/backend/src/schemas/simulado.schema.ts
+++ b/backend/src/schemas/simulado.schema.ts
@@ -45,3 +45,9 @@ export const simuladoQuestionSchema = z.object({
         .max(6, "No máximo 6 alternativas")
         .refine((opts) => opts.some((o) => o.isCorrect), "Marque ao menos uma alternativa correta"),
 });
+
+// Salvar tudo (atômico): cada questão pode ter id (edita) ou não (cria); as que
+// sumirem da lista são removidas. A validação da lista inteira é tudo-ou-nada.
+export const sincronizarQuestoesSchema = z.object({
+    questions: z.array(simuladoQuestionSchema.extend({ id: z.uuid().optional() })).max(200),
+});

--- a/backend/src/services/simulado.service.ts
+++ b/backend/src/services/simulado.service.ts
@@ -9,7 +9,12 @@ import {
 } from "../../schema.ts";
 import { eq, and, sql, inArray, desc, isNull, count } from "drizzle-orm";
 import { AppError } from "../errors/AppError.ts";
-import { corrigirSimulado, questaoCorreta, resumoPorTema } from "../domain/simulado.ts";
+import {
+    corrigirSimulado,
+    questaoCorreta,
+    resumoPorTema,
+    embaralharComSemente,
+} from "../domain/simulado.ts";
 
 function agrupar(pares: [string, string][]): Map<string, Set<string>> {
     const mapa = new Map<string, Set<string>>();
@@ -131,7 +136,10 @@ export async function estadoDaTentativa(userId: string, attemptId: string) {
 
     const paraResumo: { topic: string | null; correta: boolean }[] = [];
     const questions = questoes.map((q) => {
-        const opcoesDaQuestao = opcoes.filter((o) => o.questionId === q.id);
+        const opcoesDaQuestao = embaralharComSemente(
+            opcoes.filter((o) => o.questionId === q.id),
+            attemptId + q.id,
+        );
         if (enviado) {
             const corretasSet = new Set(
                 opcoesDaQuestao.filter((o) => o.isCorrect).map((o) => o.id),
@@ -515,6 +523,78 @@ export async function excluirQuestaoSimulado(questionId: string) {
             .where(eq(simuladoAttemptQuestions.questionId, questionId));
         await tx.delete(simuladoOptions).where(eq(simuladoOptions.questionId, questionId));
         await tx.delete(simuladoQuestions).where(eq(simuladoQuestions.id, questionId));
+    });
+    return { ok: true };
+}
+
+// Salvar tudo numa única transação (atômico): remove as questões que sumiram,
+// atualiza as que têm id e cria as novas. Se qualquer passo falhar, nada é gravado.
+export async function sincronizarQuestoesSimulado(
+    slug: string,
+    questoes: ({ id?: string } & DadosQuestao)[],
+) {
+    const s = await simuladoPorSlug(slug);
+    await db.transaction(async (tx) => {
+        const existentes = await tx
+            .select({ id: simuladoQuestions.id })
+            .from(simuladoQuestions)
+            .where(eq(simuladoQuestions.simuladoId, s.id));
+        const idsExistentes = new Set(existentes.map((q) => q.id));
+
+        const idsEnviados = new Set<string>();
+        for (const q of questoes) {
+            if (q.id) {
+                if (!idsExistentes.has(q.id))
+                    throw new AppError(400, "Questão não pertence a este simulado");
+                idsEnviados.add(q.id);
+            }
+        }
+
+        const aRemover = [...idsExistentes].filter((id) => !idsEnviados.has(id));
+        if (aRemover.length) {
+            await tx
+                .delete(simuladoAttemptAnswers)
+                .where(inArray(simuladoAttemptAnswers.questionId, aRemover));
+            await tx
+                .delete(simuladoAttemptQuestions)
+                .where(inArray(simuladoAttemptQuestions.questionId, aRemover));
+            await tx.delete(simuladoOptions).where(inArray(simuladoOptions.questionId, aRemover));
+            await tx.delete(simuladoQuestions).where(inArray(simuladoQuestions.id, aRemover));
+        }
+
+        for (const q of questoes) {
+            let questionId: string;
+            if (q.id) {
+                await tx
+                    .update(simuladoQuestions)
+                    .set({ statement: q.statement, topic: q.topic, explanation: q.explanation })
+                    .where(eq(simuladoQuestions.id, q.id));
+                await tx
+                    .delete(simuladoAttemptAnswers)
+                    .where(eq(simuladoAttemptAnswers.questionId, q.id));
+                await tx.delete(simuladoOptions).where(eq(simuladoOptions.questionId, q.id));
+                questionId = q.id;
+            } else {
+                const [nova] = await tx
+                    .insert(simuladoQuestions)
+                    .values({
+                        simuladoId: s.id,
+                        statement: q.statement,
+                        topic: q.topic,
+                        explanation: q.explanation,
+                    })
+                    .returning({ id: simuladoQuestions.id });
+                questionId = nova.id;
+            }
+            await tx.insert(simuladoOptions).values(
+                q.options.map((o, i) => ({
+                    questionId,
+                    text: o.text,
+                    isCorrect: o.isCorrect,
+                    position: i + 1,
+                })),
+            );
+        }
     });
     return { ok: true };
 }

--- a/backend/tests/simulado.test.ts
+++ b/backend/tests/simulado.test.ts
@@ -358,4 +358,47 @@ describe("Simulado: CRUD admin", () => {
         assert.equal((await del(`/simulados/${s.slug}`, admin.token)).status, 200);
         assert.equal((await get(`/admin/simulados/${s.slug}`, admin.token)).status, 404);
     });
+
+    test("sincroniza (salvar tudo) de forma atômica", async () => {
+        const admin = await criarUsuarioLogado(true);
+        const s = novoSimulado();
+        await post("/simulados", admin.token, s);
+        const q = (t: string) => ({
+            statement: `Enunciado ${t}`,
+            topic: "Tema",
+            options: [
+                { text: "certa", isCorrect: true },
+                { text: "errada", isCorrect: false },
+            ],
+        });
+
+        // cria duas de uma vez
+        let r = await put(`/admin/simulados/${s.slug}/questions`, admin.token, {
+            questions: [q("A"), q("B")],
+        });
+        assert.equal(r.status, 200);
+        let det = await get(`/admin/simulados/${s.slug}`, admin.token);
+        assert.equal(det.body.questions.length, 2);
+
+        // edita a 1a, remove a 2a, adiciona uma nova
+        const q1Id = det.body.questions[0].id;
+        r = await put(`/admin/simulados/${s.slug}/questions`, admin.token, {
+            questions: [{ ...q("A"), id: q1Id, statement: "Editada" }, q("C")],
+        });
+        assert.equal(r.status, 200);
+        det = await get(`/admin/simulados/${s.slug}`, admin.token);
+        const enunciados = det.body.questions.map((x: any) => x.statement).sort();
+        assert.deepEqual(enunciados, ["Editada", "Enunciado C"]);
+
+        // atômico: uma questão inválida rejeita tudo, sem alterar o estado
+        const ruim = await put(`/admin/simulados/${s.slug}/questions`, admin.token, {
+            questions: [
+                q("D"),
+                { statement: "sem correta", options: [{ text: "a", isCorrect: false }] },
+            ],
+        });
+        assert.equal(ruim.status, 400);
+        det = await get(`/admin/simulados/${s.slug}`, admin.token);
+        assert.equal(det.body.questions.length, 2);
+    });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
+import { ToastProvider } from './contexts/ToastContext';
 import { Login } from './pages/Login';
 import { Register } from './pages/Register';
 import { Home } from './pages/Home';
@@ -12,6 +13,8 @@ import { Perfil } from './pages/Perfil';
 import { Ranking } from './pages/Ranking';
 import { Simulados } from './pages/Simulados';
 import { TentativaSimulado } from './pages/Simulados/Tentativa';
+import { SimuladosAdmin } from './pages/SimuladosAdmin';
+import { SimuladoEditor } from './pages/SimuladosAdmin/Editor';
 import { VerifyEmail } from './pages/VerifyEmail';
 import { OAuthCallback } from './pages/OAuthCallback';
 import { CompletarPerfil } from './pages/CompletarPerfil';
@@ -92,6 +95,22 @@ function AppRoutes() {
         }
       />
       <Route
+        path="/estudio/simulados"
+        element={
+          <AdminRoute>
+            <SimuladosAdmin />
+          </AdminRoute>
+        }
+      />
+      <Route
+        path="/estudio/simulados/:slug"
+        element={
+          <AdminRoute>
+            <SimuladoEditor />
+          </AdminRoute>
+        }
+      />
+      <Route
         path="/estudio/:trailId"
         element={
           <AdminRoute>
@@ -161,7 +180,9 @@ function App() {
   return (
     <BrowserRouter>
       <AuthProvider>
-        <AppRoutes></AppRoutes>
+        <ToastProvider>
+          <AppRoutes />
+        </ToastProvider>
       </AuthProvider>
     </BrowserRouter>
   );

--- a/frontend/src/contexts/ToastContext.tsx
+++ b/frontend/src/contexts/ToastContext.tsx
@@ -1,0 +1,47 @@
+import { createContext, useCallback, useContext, useState, type ReactNode } from 'react';
+import { Check, X } from '../components/Icons';
+
+type Tipo = 'sucesso' | 'erro';
+interface Toast {
+  id: number;
+  msg: string;
+  tipo: Tipo;
+}
+
+interface ToastCtx {
+  mostrar: (msg: string, tipo?: Tipo) => void;
+}
+
+const Ctx = createContext<ToastCtx>({ mostrar: () => {} });
+
+export function useToast() {
+  return useContext(Ctx);
+}
+
+let idSeq = 0;
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const mostrar = useCallback((msg: string, tipo: Tipo = 'sucesso') => {
+    const id = idSeq++;
+    setToasts((prev) => [...prev, { id, msg, tipo }]);
+    setTimeout(() => setToasts((prev) => prev.filter((t) => t.id !== id)), 3200);
+  }, []);
+
+  return (
+    <Ctx.Provider value={{ mostrar }}>
+      {children}
+      <div className="toasts">
+        {toasts.map((t) => (
+          <div key={t.id} className={`toast toast--${t.tipo}`}>
+            <span className="toast__icon">
+              {t.tipo === 'sucesso' ? <Check size={13} /> : <X size={11} />}
+            </span>
+            <span>{t.msg}</span>
+          </div>
+        ))}
+      </div>
+    </Ctx.Provider>
+  );
+}

--- a/frontend/src/pages/EstudioHome/index.tsx
+++ b/frontend/src/pages/EstudioHome/index.tsx
@@ -126,6 +126,9 @@ export function EstudioHome() {
           <b>Painel do administrador</b>
         </div>
         <div className="topbar__spacer" />
+        <Link className="btn btn--ghost studio__btn" to="/estudio/simulados">
+          Simulados
+        </Link>
         <Link className="btn btn--ghost studio__btn" to="/home">
           Voltar ao app
         </Link>

--- a/frontend/src/pages/SimuladosAdmin/Editor.tsx
+++ b/frontend/src/pages/SimuladosAdmin/Editor.tsx
@@ -1,0 +1,276 @@
+import { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { Logo } from '../../components/Logo';
+import { Plus, Trash, Check, Minus } from '../../components/Icons';
+import { mensagemErro } from '../../utils/erro';
+import { useToast } from '../../contexts/ToastContext';
+import { obterSimuladoAdmin, sincronizarQuestoes } from '../../services/simulados';
+
+const LETRAS = ['A', 'B', 'C', 'D', 'E', 'F'];
+
+interface EdQuestao {
+  id?: string;
+  statement: string;
+  topic: string;
+  explanation: string;
+  options: { text: string; isCorrect: boolean }[];
+  msg?: string;
+  msgErro?: boolean;
+}
+
+const NOVA: EdQuestao = {
+  statement: '',
+  topic: '',
+  explanation: '',
+  options: [
+    { text: '', isCorrect: true },
+    { text: '', isCorrect: false },
+  ],
+};
+
+export function SimuladoEditor() {
+  const { slug = '' } = useParams();
+  const { mostrar } = useToast();
+  const [nome, setNome] = useState('');
+  const [questoes, setQuestoes] = useState<EdQuestao[]>([]);
+  const [carregando, setCarregando] = useState(true);
+  const [erro, setErro] = useState('');
+  const [salvandoTudo, setSalvandoTudo] = useState(false);
+  const [msgGeral, setMsgGeral] = useState('');
+
+  useEffect(() => {
+    obterSimuladoAdmin(slug)
+      .then((s) => {
+        setNome(s.name);
+        setQuestoes(
+          s.questions.map((q) => ({
+            id: q.id,
+            statement: q.statement,
+            topic: q.topic ?? '',
+            explanation: q.explanation ?? '',
+            options: q.options.map((o) => ({ text: o.text, isCorrect: o.isCorrect })),
+          })),
+        );
+      })
+      .catch(() => setErro('Não foi possível carregar o simulado.'))
+      .finally(() => setCarregando(false));
+  }, [slug]);
+
+  const patchQ = (qi: number, patch: Partial<EdQuestao>) =>
+    setQuestoes((prev) => prev.map((q, i) => (i === qi ? { ...q, ...patch } : q)));
+  const patchOpts = (qi: number, fn: (opts: EdQuestao['options']) => EdQuestao['options']) =>
+    setQuestoes((prev) => prev.map((q, i) => (i === qi ? { ...q, options: fn(q.options) } : q)));
+
+  function addQuestao() {
+    setQuestoes((prev) => [...prev, { ...NOVA, options: NOVA.options.map((o) => ({ ...o })) }]);
+  }
+
+  function excluirQuestao(qi: number) {
+    const q = questoes[qi];
+    if (q.id && !window.confirm('Remover esta questão? Ela será excluída ao salvar.')) return;
+    setQuestoes((prev) => prev.filter((_, i) => i !== qi));
+  }
+
+  async function salvarTudo() {
+    if (salvandoTudo) return;
+    setMsgGeral('');
+
+    // Valida no cliente e marca cada card; aborta antes de enviar se algo estiver errado.
+    let algumInvalido = false;
+    const validado = questoes.map((q) => {
+      const validas = q.options.filter((o) => o.text.trim());
+      let msg = '';
+      if (q.statement.trim().length < 3) msg = 'Enunciado muito curto.';
+      else if (validas.length < 2) msg = 'Precisa de ao menos 2 alternativas.';
+      else if (!validas.some((o) => o.isCorrect)) msg = 'Marque ao menos uma correta.';
+      if (msg) algumInvalido = true;
+      return { ...q, msg, msgErro: !!msg };
+    });
+    setQuestoes(validado);
+    if (algumInvalido) {
+      setMsgGeral('Corrija as questões em vermelho.');
+      return;
+    }
+
+    setSalvandoTudo(true);
+    const payload = validado.map((q) => ({
+      id: q.id,
+      statement: q.statement.trim(),
+      topic: q.topic.trim() || undefined,
+      explanation: q.explanation.trim() || undefined,
+      options: q.options
+        .filter((o) => o.text.trim())
+        .map((o) => ({ text: o.text.trim(), isCorrect: o.isCorrect })),
+    }));
+    try {
+      await sincronizarQuestoes(slug, payload);
+      // Recarrega com os ids do banco para o próximo "Salvar tudo" atualizar em vez de recriar.
+      const s = await obterSimuladoAdmin(slug);
+      setQuestoes(
+        s.questions.map((q) => ({
+          id: q.id,
+          statement: q.statement,
+          topic: q.topic ?? '',
+          explanation: q.explanation ?? '',
+          options: q.options.map((o) => ({ text: o.text, isCorrect: o.isCorrect })),
+        })),
+      );
+      setSalvandoTudo(false);
+      mostrar('Simulado salvo com sucesso.');
+    } catch (e: unknown) {
+      setSalvandoTudo(false);
+      mostrar(mensagemErro(e, 'Não foi possível salvar.'), 'erro');
+    }
+  }
+
+  return (
+    <div className="home">
+      <header className="topbar studio__bar">
+        <div className="studio__brand">
+          <Logo variant="solid" size={19} />
+          <span className="studio__badge">Estúdio</span>
+        </div>
+        <span className="studio__divider" />
+        <div className="studio__crumb">
+          <Link to="/estudio/simulados">Simulados</Link>
+          <span className="studio__crumb-sep">/</span>
+          <b>{nome || '...'}</b>
+        </div>
+        <div className="topbar__spacer" />
+        <button
+          className="btn btn--accent studio__btn"
+          disabled={salvandoTudo || carregando}
+          onClick={salvarTudo}
+        >
+          {salvandoTudo ? 'Salvando...' : 'Salvar tudo'}
+        </button>
+        <Link className="btn btn--ghost studio__btn" to="/estudio/simulados">
+          Voltar
+        </Link>
+      </header>
+
+      <div className="studio__editor">
+        <div className="studio__section">
+          <div className="studio__section-title">Questões</div>
+          <span className="studio__pill">{questoes.length}</span>
+        </div>
+        <p className="studio__section-sub">
+          Cada tentativa sorteia questões deste banco. Múltipla resposta é permitida: marque quantas
+          alternativas forem corretas.
+        </p>
+
+        {carregando && <p className="track__desc">Carregando...</p>}
+        {erro && <div className="auth__alert">{erro}</div>}
+
+        <div className="studio__questions">
+          {questoes.map((q, qi) => (
+            <div key={q.id ?? `nova-${qi}`} className="qcard">
+              <div className="qcard__head">
+                <span className="qcard__num">{qi + 1}</span>
+                <span className="qcard__label">Questão {qi + 1}</span>
+                <div className="topbar__spacer" />
+                <button
+                  className="qcard__del"
+                  onClick={() => excluirQuestao(qi)}
+                  aria-label="Excluir questão"
+                >
+                  <Trash size={16} />
+                </button>
+              </div>
+
+              <div className="qcard__field">
+                <input
+                  className="es-input"
+                  value={q.statement}
+                  placeholder="Enunciado da questão"
+                  onChange={(e) => patchQ(qi, { statement: e.target.value })}
+                />
+              </div>
+              <div className="qcard__field">
+                <input
+                  className="es-input"
+                  value={q.topic}
+                  placeholder="Tema (ex.: Segurança e identidade)"
+                  onChange={(e) => patchQ(qi, { topic: e.target.value })}
+                />
+              </div>
+
+              <div className="qcard__options">
+                {q.options.map((o, oi) => (
+                  <div key={oi} className={`qopt${o.isCorrect ? ' qopt--correct' : ''}`}>
+                    <button
+                      className="qopt__radio"
+                      onClick={() =>
+                        patchOpts(qi, (opts) =>
+                          opts.map((x, j) => (j === oi ? { ...x, isCorrect: !x.isCorrect } : x)),
+                        )
+                      }
+                      aria-label="Marcar como correta"
+                    >
+                      {o.isCorrect ? <Check size={12} /> : null}
+                    </button>
+                    <span className="qopt__letter">{LETRAS[oi] ?? oi + 1}</span>
+                    <input
+                      className="es-input"
+                      value={o.text}
+                      placeholder="Texto da alternativa"
+                      onChange={(e) =>
+                        patchOpts(qi, (opts) =>
+                          opts.map((x, j) => (j === oi ? { ...x, text: e.target.value } : x)),
+                        )
+                      }
+                    />
+                    {o.isCorrect && <span className="qopt__tag">correta</span>}
+                    <button
+                      className="qopt__remove"
+                      onClick={() => patchOpts(qi, (opts) => opts.filter((_, j) => j !== oi))}
+                      aria-label="Remover alternativa"
+                    >
+                      <Minus size={14} />
+                    </button>
+                  </div>
+                ))}
+              </div>
+              <button
+                className="studio__add studio__add--ghost"
+                onClick={() => patchOpts(qi, (opts) => [...opts, { text: '', isCorrect: false }])}
+              >
+                <Plus size={14} /> Adicionar alternativa
+              </button>
+
+              <textarea
+                className="sim-adm__ta"
+                value={q.explanation}
+                placeholder="Justificativa (aparece na revisão do aluno)"
+                onChange={(e) => patchQ(qi, { explanation: e.target.value })}
+              />
+
+              {q.msg && (
+                <div className="sim-adm__qfoot">
+                  <span className={`sim-adm__msg${q.msgErro ? ' sim-adm__msg--erro' : ''}`}>
+                    {q.msg}
+                  </span>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+
+        <button className="studio__add studio__add--dashed studio__add--lg" onClick={addQuestao}>
+          <Plus size={14} /> Adicionar questão
+        </button>
+
+        <div className="sim-adm__save">
+          <button
+            className="btn btn--accent"
+            disabled={salvandoTudo || carregando}
+            onClick={salvarTudo}
+          >
+            {salvandoTudo ? 'Salvando...' : 'Salvar tudo'}
+          </button>
+          {msgGeral && <span className="sim-adm__geral">{msgGeral}</span>}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/SimuladosAdmin/index.tsx
+++ b/frontend/src/pages/SimuladosAdmin/index.tsx
@@ -1,0 +1,282 @@
+import { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { Logo } from '../../components/Logo';
+import { Plus, Pencil, Trash, ChevronRight, GradCap } from '../../components/Icons';
+import { useRequisicao } from '../../hooks/useRequisicao';
+import { mensagemErro } from '../../utils/erro';
+import { useToast } from '../../contexts/ToastContext';
+import {
+  listarSimuladosAdmin,
+  obterSimuladoAdmin,
+  criarSimulado,
+  atualizarSimulado,
+  excluirSimulado,
+  type SimuladoAdminItem,
+} from '../../services/simulados';
+
+interface FormState {
+  slug: string;
+  name: string;
+  description: string;
+  durationMinutes: number;
+  questionCount: number;
+  passPercent: number;
+  published: boolean;
+  editando: boolean;
+}
+
+const NOVO: FormState = {
+  slug: '',
+  name: '',
+  description: '',
+  durationMinutes: 90,
+  questionCount: 65,
+  passPercent: 70,
+  published: false,
+  editando: false,
+};
+
+export function SimuladosAdmin() {
+  const navigate = useNavigate();
+  const { mostrar } = useToast();
+  const {
+    dados,
+    carregando,
+    erro: falhaCarga,
+    recarregar,
+  } = useRequisicao(listarSimuladosAdmin, []);
+  const simulados = dados ?? [];
+  const [form, setForm] = useState<FormState | null>(null);
+  const [erro, setErro] = useState('');
+  const [salvando, setSalvando] = useState(false);
+
+  async function editar(item: SimuladoAdminItem) {
+    setErro('');
+    try {
+      const s = await obterSimuladoAdmin(item.slug);
+      setForm({
+        slug: s.slug,
+        name: s.name,
+        description: s.description ?? '',
+        durationMinutes: s.durationMinutes,
+        questionCount: s.questionCount,
+        passPercent: s.passPercent,
+        published: s.published,
+        editando: true,
+      });
+    } catch {
+      setErro('Não foi possível carregar o simulado.');
+    }
+  }
+
+  async function salvar() {
+    if (!form || salvando) return;
+    setSalvando(true);
+    setErro('');
+    const payload = {
+      name: form.name,
+      description: form.description || undefined,
+      durationMinutes: form.durationMinutes,
+      questionCount: form.questionCount,
+      passPercent: form.passPercent,
+      published: form.published,
+    };
+    try {
+      if (form.editando) {
+        await atualizarSimulado(form.slug, payload);
+      } else {
+        await criarSimulado({ slug: form.slug, ...payload });
+      }
+      mostrar(form.editando ? 'Simulado atualizado.' : 'Simulado criado.');
+      setForm(null);
+      recarregar();
+    } catch (e: unknown) {
+      setErro(mensagemErro(e, 'Não foi possível salvar o simulado.'));
+    } finally {
+      setSalvando(false);
+    }
+  }
+
+  async function excluir(item: SimuladoAdminItem) {
+    if (!window.confirm(`Excluir o simulado "${item.name}" e todas as suas questões e tentativas?`))
+      return;
+    setErro('');
+    try {
+      await excluirSimulado(item.slug);
+      mostrar('Simulado excluído.');
+      recarregar();
+    } catch {
+      setErro('Não foi possível excluir o simulado.');
+    }
+  }
+
+  return (
+    <div className="home">
+      <header className="topbar studio__bar">
+        <div className="studio__brand">
+          <Logo variant="solid" size={19} />
+          <span className="studio__badge">Estúdio</span>
+        </div>
+        <span className="studio__divider" />
+        <div className="studio__crumb">
+          <b>Simulados</b>
+        </div>
+        <div className="topbar__spacer" />
+        <Link className="btn btn--ghost studio__btn" to="/estudio">
+          Trilhas
+        </Link>
+        <Link className="btn btn--ghost studio__btn" to="/home">
+          Voltar ao app
+        </Link>
+      </header>
+
+      <div className="estudio-home">
+        <div className="estudio-home__head">
+          <div>
+            <h1 className="estudio-home__title">Simulados</h1>
+            <p className="estudio-home__sub">Crie e edite provas e suas questões.</p>
+          </div>
+          {!form && (
+            <button className="btn btn--accent" onClick={() => setForm({ ...NOVO })}>
+              <Plus size={14} /> Novo simulado
+            </button>
+          )}
+        </div>
+
+        {form && (
+          <div className="estudio-form">
+            <div className="estudio-form__title">
+              {form.editando ? 'Editar simulado' : 'Novo simulado'}
+            </div>
+            <label className="studio__label">Slug (identificador na URL)</label>
+            <input
+              className="estudio-form__input"
+              value={form.slug}
+              disabled={form.editando}
+              placeholder="ex.: aws-cloud-practitioner"
+              onChange={(e) => setForm({ ...form, slug: e.target.value })}
+            />
+            <label className="studio__label">Nome</label>
+            <input
+              className="estudio-form__input"
+              value={form.name}
+              placeholder="Ex.: AWS Certified Cloud Practitioner"
+              onChange={(e) => setForm({ ...form, name: e.target.value })}
+            />
+            <label className="studio__label">Descrição</label>
+            <textarea
+              className="estudio-form__input estudio-form__textarea"
+              value={form.description}
+              placeholder="Descrição do simulado"
+              onChange={(e) => setForm({ ...form, description: e.target.value })}
+            />
+            <div className="sim-adm__row">
+              <div>
+                <label className="studio__label">Duração (min)</label>
+                <input
+                  className="estudio-form__input"
+                  type="number"
+                  value={form.durationMinutes}
+                  onChange={(e) => setForm({ ...form, durationMinutes: Number(e.target.value) })}
+                />
+              </div>
+              <div>
+                <label className="studio__label">Nº de questões</label>
+                <input
+                  className="estudio-form__input"
+                  type="number"
+                  value={form.questionCount}
+                  onChange={(e) => setForm({ ...form, questionCount: Number(e.target.value) })}
+                />
+              </div>
+              <div>
+                <label className="studio__label">Corte (%)</label>
+                <input
+                  className="estudio-form__input"
+                  type="number"
+                  value={form.passPercent}
+                  onChange={(e) => setForm({ ...form, passPercent: Number(e.target.value) })}
+                />
+              </div>
+            </div>
+            <label className="sim-adm__check">
+              <input
+                type="checkbox"
+                checked={form.published}
+                onChange={(e) => setForm({ ...form, published: e.target.checked })}
+              />
+              Publicado (visível para os alunos)
+            </label>
+            {erro && <div className="auth__alert">{erro}</div>}
+            <div className="estudio-form__actions">
+              <button
+                className="btn btn--ghost"
+                onClick={() => {
+                  setForm(null);
+                  setErro('');
+                }}
+              >
+                Cancelar
+              </button>
+              <button className="btn btn--accent" disabled={salvando} onClick={salvar}>
+                {salvando ? 'Salvando...' : form.editando ? 'Salvar' : 'Criar simulado'}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {carregando && <p className="track__desc">Carregando...</p>}
+        {!form && (erro || falhaCarga) && (
+          <div className="auth__alert">{erro || 'Não foi possível carregar os simulados.'}</div>
+        )}
+        {!carregando && simulados.length === 0 && !form && (
+          <p className="track__desc">Nenhum simulado cadastrado ainda.</p>
+        )}
+
+        <div className="estudio-home__list">
+          {simulados.map((s) => (
+            <div key={s.slug} className="estudio-home__card">
+              <button
+                className="estudio-home__open"
+                onClick={() => navigate(`/estudio/simulados/${s.slug}`)}
+              >
+                <span className="estudio-home__glyph">
+                  <GradCap size={18} />
+                </span>
+                <div className="estudio-home__meta">
+                  <div className="estudio-home__name">{s.name}</div>
+                  <div className="estudio-home__info">
+                    {s.questoes} questões · {s.published ? 'Publicado' : 'Rascunho'}
+                  </div>
+                </div>
+              </button>
+              <div className="estudio-home__actions">
+                <button
+                  className="estudio-home__act"
+                  onClick={() => editar(s)}
+                  aria-label="Editar simulado"
+                >
+                  <Pencil size={15} />
+                </button>
+                <button
+                  className="estudio-home__act estudio-home__act--danger"
+                  onClick={() => excluir(s)}
+                  aria-label="Excluir simulado"
+                >
+                  <Trash size={15} />
+                </button>
+                <button
+                  className="estudio-home__act"
+                  onClick={() => navigate(`/estudio/simulados/${s.slug}`)}
+                  aria-label="Editar questões"
+                >
+                  <ChevronRight size={16} />
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/services/simulados.ts
+++ b/frontend/src/services/simulados.ts
@@ -89,3 +89,102 @@ export async function historicoSimulados() {
   const { data } = await api.get<TentativaHistorico[]>('/me/simulado-attempts');
   return data;
 }
+
+// ===================== ADMIN =====================
+
+export interface SimuladoAdminItem {
+  slug: string;
+  name: string;
+  durationMinutes: number;
+  questionCount: number;
+  passPercent: number;
+  published: boolean;
+  questoes: number;
+}
+
+export interface QuestaoAdmin {
+  id: string;
+  statement: string;
+  topic: string | null;
+  explanation: string | null;
+  options: { id: string; text: string; isCorrect: boolean; position: number }[];
+}
+
+export interface SimuladoAdminDetalhe {
+  slug: string;
+  name: string;
+  description: string | null;
+  durationMinutes: number;
+  questionCount: number;
+  passPercent: number;
+  published: boolean;
+  questions: QuestaoAdmin[];
+}
+
+export interface PayloadSimulado {
+  slug: string;
+  name: string;
+  description?: string;
+  durationMinutes: number;
+  questionCount: number;
+  passPercent: number;
+  published: boolean;
+}
+export type PayloadSimuladoUpdate = Partial<Omit<PayloadSimulado, 'slug'>>;
+
+export interface PayloadQuestao {
+  statement: string;
+  topic?: string;
+  explanation?: string;
+  options: { text: string; isCorrect: boolean }[];
+}
+
+export async function listarSimuladosAdmin() {
+  const { data } = await api.get<SimuladoAdminItem[]>('/admin/simulados');
+  return data;
+}
+
+export async function obterSimuladoAdmin(slug: string) {
+  const { data } = await api.get<SimuladoAdminDetalhe>(`/admin/simulados/${slug}`);
+  return data;
+}
+
+export async function criarSimulado(payload: PayloadSimulado) {
+  const { data } = await api.post('/simulados', payload);
+  return data;
+}
+
+export async function atualizarSimulado(slug: string, payload: PayloadSimuladoUpdate) {
+  const { data } = await api.patch(`/simulados/${slug}`, payload);
+  return data;
+}
+
+export async function excluirSimulado(slug: string) {
+  await api.delete(`/simulados/${slug}`);
+}
+
+export async function criarQuestaoSimulado(slug: string, payload: PayloadQuestao) {
+  const { data } = await api.post<{ id: string }>(`/simulados/${slug}/questions`, payload);
+  return data;
+}
+
+export async function atualizarQuestaoSimulado(id: string, payload: PayloadQuestao) {
+  await api.patch(`/simulado-questions/${id}`, payload);
+}
+
+export async function excluirQuestaoSimulado(id: string) {
+  await api.delete(`/simulado-questions/${id}`);
+}
+
+export interface QuestaoSync {
+  id?: string;
+  statement: string;
+  topic?: string;
+  explanation?: string;
+  options: { text: string; isCorrect: boolean }[];
+}
+
+// Salva todas as questões de uma vez, de forma atômica (uma transação no backend).
+export async function sincronizarQuestoes(slug: string, questions: QuestaoSync[]) {
+  await api.put(`/admin/simulados/${slug}/questions`, { questions });
+}

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -3876,3 +3876,57 @@
   font-size: 13px;
   font-weight: 700;
 }
+
+/* ===================== TOAST ===================== */
+.toasts {
+  position: fixed;
+  top: 80px;
+  right: 24px;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  pointer-events: none;
+}
+.toast {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 220px;
+  max-width: 360px;
+  padding: 13px 16px;
+  border-radius: 12px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+  animation: toast-in 0.2s ease;
+}
+.toast__icon {
+  width: 24px;
+  height: 24px;
+  border-radius: 7px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+}
+.toast--sucesso .toast__icon {
+  background: var(--success);
+}
+.toast--erro .toast__icon {
+  background: var(--av-red);
+}
+@keyframes toast-in {
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/frontend/src/styles/simulado.css
+++ b/frontend/src/styles/simulado.css
@@ -983,3 +983,70 @@
   color: var(--muted);
   margin-top: 1px;
 }
+
+/* Admin de simulados */
+.sim-adm__row {
+  display: flex;
+  gap: 12px;
+}
+.sim-adm__row > div {
+  flex: 1;
+}
+.sim-adm__check {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin-top: 14px;
+  font-size: 14px;
+  font-weight: 500;
+}
+.sim-adm__ta {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  min-height: 64px;
+  resize: vertical;
+  margin-top: 12px;
+  padding: 11px 14px;
+  border: 1px solid var(--border-strong);
+  border-radius: 11px;
+  background: var(--input);
+  color: var(--text);
+  font-family: inherit;
+  font-size: 14px;
+  line-height: 1.5;
+  outline: none;
+}
+.sim-adm__ta:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 16%, transparent);
+}
+.sim-adm__qfoot {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 14px;
+}
+.sim-adm__qfoot .btn {
+  flex: none;
+  height: 40px;
+}
+.sim-adm__msg {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--success);
+}
+.sim-adm__msg--erro {
+  color: var(--av-red);
+}
+.sim-adm__save {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-top: 22px;
+}
+.sim-adm__geral {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--muted);
+}


### PR DESCRIPTION
## O que é

Frontend admin dos simulados (consome o CRUD do #54), mais duas melhorias de comportamento: salvar atômico e provas embaralhadas.

## Telas admin

- `/estudio/simulados`: lista os simulados (com contagem e status), cria/edita/exclui a prova (slug, nome, duração, nº, corte, publicado). Entrada pelo EstudioHome.
- `/estudio/simulados/:slug`: editor de questões estilo Estúdio (reusa `qcard`/`qopt`) — adicionar/editar/remover questão, com enunciado, tema, justificativa e alternativas (marca quantas forem corretas).

## Salvar atômico

O "Salvar tudo" edita tudo localmente e manda numa requisição só, num **endpoint de sincronização** (`PUT /admin/simulados/:slug/questions`) que remove as que sumiram, atualiza as com id e cria as novas **numa transação** (tudo-ou-nada; questão inválida rejeita o salvamento inteiro). Fica na página e um toast confirma; recarrega os ids pra o próximo salvar atualizar em vez de recriar.

## Alternativas embaralhadas por tentativa

`estadoDaTentativa` passa a embaralhar as alternativas de cada questão de forma **determinística** (semente = tentativa + questão): estável ao recarregar a mesma prova, diferente entre tentativas (a resposta certa cai em letras diferentes). Não afeta a correção (respostas gravadas por id). As questões já eram sorteadas por tentativa (`ORDER BY random()`); o embaralhamento fecha o "nunca cair a mesma prova". Subconjunto diferente de questões acontece quando o banco tem mais questões que o nº da prova.

## Extra

Toast global reutilizável (`ToastContext`), no canto superior direito, usado nos saves e exclusões do admin.

## Testes

- Unitários: `embaralharComSemente` (determinístico, permutação, não muta).
- Integração: CRUD admin, sincronização atômica (cria, edita+remove+adiciona, e inválida rejeita tudo sem alterar o estado). 41 de integração + 62 unitários, tudo verde. Sem migration.
