### PR TITLE
fix: corrige texto ilegível do simulado no modo escuro

### DIFF
--- a/frontend/src/styles/simulado.css
+++ b/frontend/src/styles/simulado.css
@@ -45,6 +45,7 @@
   padding: 18px;
   cursor: pointer;
   font-family: inherit;
+  color: var(--text);
 }
 .exam-card--active {
   border-color: var(--accent);
@@ -466,6 +467,7 @@
   border: 1.5px solid transparent;
   font-family: inherit;
   text-align: left;
+  color: var(--text);
 }
 .exam-opt__badge {
   width: 30px;


### PR DESCRIPTION
Corrige o texto do simulado que ficava ilegível no modo escuro.

Os cards da lista de simulados e as alternativas da prova são botões, e botão não herda a cor do texto: usavam o preto padrão do navegador e sumiam no fundo escuro. Agora seguem a cor de texto do tema.