### PR TITLE
chore: adiciona o serviço runner ao compose de produção

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -38,6 +38,19 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
 
+  # Executor isolado dos desafios de código. É o único serviço com acesso ao
+  # Docker: sobe um container efêmero por submissão. O backend fala com ele pela
+  # rede interna (RUNNER_URL padrão http://runner:8080). As imagens de execução
+  # desafio-js/desafio-python precisam existir no host (rode runner/build-images.sh).
+  runner:
+    build:
+      context: ./runner
+    restart: unless-stopped
+    environment:
+      - MAX_CONCURRENT=2
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
 volumes:
   pgdata:
   caddy_data:


### PR DESCRIPTION
## Runner dos desafios em produção

Adiciona o serviço runner (execução do código dos desafios) ao compose de produção. Ele estava só no compose de desenvolvimento, então o deploy não subia ele e os desafios apareciam mas não podiam ser resolvidos.

O runner roda em um container próprio, é o único com acesso ao Docker (sobe um container efêmero por submissão) e o backend fala com ele pela rede interna do compose.

### Depois do merge e deploy

As imagens de execução precisam ser construídas no host uma vez, além de subir o serviço:

    bash runner/build-images.sh

Isso constrói desafio-js e desafio-python, que o runner usa para rodar o código do aluno. Eu cuido desse passo e do seed dos desafios assim que o deploy estiver no ar.
