### PR TITLE
feat: envia o email de verificação de cadastro

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,11 @@
 PORT=SUA_PORTA_AQUI
 DATABASE_URL=tipo_banco://usuario:senha@host:PORTA/nome_banco
 JWT_SECRET=uma_chave_bem_longa_e_aleatoria_troque_isso_depois
+
+# Email (SMTP) — opcional em dev. Sem estas variáveis, o link de verificação
+# vai só para o log do backend, sem enviar de verdade.
+# SMTP_HOST=smtp-relay.brevo.com
+# SMTP_PORT=587
+# SMTP_USER=
+# SMTP_PASS=
+# EMAIL_FROM=ensina.dev <nao-responda@ensinadev.com.br>

--- a/backend/.env.prod.example
+++ b/backend/.env.prod.example
@@ -20,3 +20,16 @@ POSTGRES_DB=estudos
 # Conexão do backend ao banco — host "db" é o nome do serviço no compose.
 # Usuário/senha/base devem bater com os POSTGRES_* acima.
 DATABASE_URL=postgres://ensinadev:TROQUE_POR_UMA_SENHA_FORTE@db:5432/estudos
+
+# Envio de email por SMTP. Provedores gratuitos para baixo volume:
+#   Brevo    -> SMTP_HOST=smtp-relay.brevo.com  (300 emails/dia, sem cartão)
+#   Resend   -> SMTP_HOST=smtp.resend.com       (3000/mês, exige domínio verificado)
+#   SendGrid -> SMTP_HOST=smtp.sendgrid.net     (100/dia)
+# Sem SMTP_HOST/USER/PASS, o backend não envia (só registra o link no log).
+SMTP_HOST=smtp-relay.brevo.com
+SMTP_PORT=587
+SMTP_SECURE=false
+SMTP_USER=SEU_USUARIO_SMTP
+SMTP_PASS=SUA_CHAVE_SMTP
+# Remetente exibido no email (o domínio precisa estar verificado no provedor).
+EMAIL_FROM=ensina.dev <nao-responda@ensinadev.com.br>

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -19,6 +19,7 @@
                 "express-rate-limit": "^8.5.2",
                 "helmet": "^8.2.0",
                 "jsonwebtoken": "^9.0.3",
+                "nodemailer": "^9.0.3",
                 "pg": "^8.21.0",
                 "zod": "^4.4.3"
             },
@@ -28,6 +29,7 @@
                 "@types/express": "^5.0.6",
                 "@types/jsonwebtoken": "^9.0.10",
                 "@types/node": "^26.0.1",
+                "@types/nodemailer": "^8.0.1",
                 "@types/pg": "^8.20.0",
                 "drizzle-kit": "^0.31.10",
                 "eslint": "^10.6.0",
@@ -1239,6 +1241,16 @@
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~8.3.0"
+            }
+        },
+        "node_modules/@types/nodemailer": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-8.0.1.tgz",
+            "integrity": "sha512-PxpaInm8V1JQDd4j0ds5HfvWQk8JupS1C0Picb96QJsrrRDjBH+DlK7L4ZdNSqNULhiZRQHc40nLVShaGxXAMw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
             }
         },
         "node_modules/@types/pg": {
@@ -2977,6 +2989,15 @@
                 "node-gyp-build": "bin.js",
                 "node-gyp-build-optional": "optional.js",
                 "node-gyp-build-test": "build-test.js"
+            }
+        },
+        "node_modules/nodemailer": {
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.3.tgz",
+            "integrity": "sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==",
+            "license": "MIT-0",
+            "engines": {
+                "node": ">=6.0.0"
             }
         },
         "node_modules/object-assign": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,6 +26,7 @@
         "express-rate-limit": "^8.5.2",
         "helmet": "^8.2.0",
         "jsonwebtoken": "^9.0.3",
+        "nodemailer": "^9.0.3",
         "pg": "^8.21.0",
         "zod": "^4.4.3"
     },
@@ -35,6 +36,7 @@
         "@types/express": "^5.0.6",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^26.0.1",
+        "@types/nodemailer": "^8.0.1",
         "@types/pg": "^8.20.0",
         "drizzle-kit": "^0.31.10",
         "eslint": "^10.6.0",

--- a/backend/scripts/testar-email.ts
+++ b/backend/scripts/testar-email.ts
@@ -1,0 +1,35 @@
+// Envia um email de verificação de teste.
+// - Sem SMTP configurado: usa a conta de teste do nodemailer (Ethereal) e imprime
+//   uma URL de preview do email renderizado.
+// - Com SMTP configurado (ex.: em produção): envia de verdade para o endereço dado.
+//
+// Uso:  node scripts/testar-email.ts [email-de-destino]
+import nodemailer from "nodemailer";
+
+async function main() {
+    if (!process.env.SMTP_HOST) {
+        console.log("SMTP não configurado: usando a conta de teste do nodemailer (Ethereal).");
+        const acc = await nodemailer.createTestAccount();
+        process.env.SMTP_HOST = acc.smtp.host;
+        process.env.SMTP_PORT = String(acc.smtp.port);
+        process.env.SMTP_SECURE = String(acc.smtp.secure);
+        process.env.SMTP_USER = acc.user;
+        process.env.SMTP_PASS = acc.pass;
+    }
+    // env.ts valida estas duas; em produção já vêm do ambiente.
+    process.env.DATABASE_URL ??= "postgres://x:x@localhost:5432/x";
+    process.env.JWT_SECRET ??= "chave_de_teste_com_pelo_menos_32_caracteres_ok";
+
+    const destino = process.argv[2] || "aluno@example.com";
+    const { emailService } = await import("../src/services/email.service.ts");
+    console.log(`Enviando email de verificação de teste para ${destino}...`);
+    await emailService.enviarVerificacao(destino, "token-de-teste-abc123");
+    console.log("Concluído.");
+}
+
+main()
+    .then(() => process.exit(0))
+    .catch((e) => {
+        console.error(e);
+        process.exit(1);
+    });

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -20,6 +20,16 @@ const envSchema = z.object({
     OAUTH_CALLBACK_BASE: z.string().url().default("http://localhost:3001"),
     // Serviço interno que executa o código dos desafios em containers isolados.
     RUNNER_URL: z.string().url().default("http://runner:8080"),
+    // Envio de email por SMTP (opcional). Sem host/user/pass, o backend só loga o link.
+    SMTP_HOST: z.string().optional(),
+    SMTP_PORT: z.string().default("587"),
+    SMTP_USER: z.string().optional(),
+    SMTP_PASS: z.string().optional(),
+    SMTP_SECURE: z
+        .string()
+        .optional()
+        .transform((v) => v === "true"),
+    EMAIL_FROM: z.string().default("ensina.dev <nao-responda@ensinadev.com.br>"),
 });
 
 // Valida os dados e lança erro se tiver algo errado.

--- a/backend/src/services/email.service.ts
+++ b/backend/src/services/email.service.ts
@@ -1,9 +1,59 @@
+import nodemailer from "nodemailer";
 import { env } from "../config/env.ts";
+
+const smtpConfigurado = !!(env.SMTP_HOST && env.SMTP_USER && env.SMTP_PASS);
+
+const transporter = smtpConfigurado
+    ? nodemailer.createTransport({
+          host: env.SMTP_HOST,
+          port: Number(env.SMTP_PORT),
+          secure: env.SMTP_SECURE,
+          auth: { user: env.SMTP_USER, pass: env.SMTP_PASS },
+      })
+    : null;
+
+interface Mensagem {
+    to: string;
+    subject: string;
+    html: string;
+    text: string;
+}
+
+// Uma falha é logada, não propagada: o cadastro não deve quebrar porque o email não saiu.
+async function enviar({ to, subject, html, text }: Mensagem) {
+    if (!transporter) {
+        console.log(`[EMAIL] (SMTP não configurado) para=${to} assunto="${subject}"`);
+        return;
+    }
+    try {
+        const info = await transporter.sendMail({ from: env.EMAIL_FROM, to, subject, html, text });
+        const preview = nodemailer.getTestMessageUrl(info);
+        if (preview) console.log(`[EMAIL] preview: ${preview}`);
+    } catch (e) {
+        console.error(`Falha ao enviar email para ${to}:`, e);
+    }
+}
+
+// Estilos inline: clientes de email ignoram CSS externo.
+function layout(titulo: string, corpo: string) {
+    return `<div style="font-family:-apple-system,Segoe UI,Roboto,Arial,sans-serif;max-width:480px;margin:0 auto;padding:24px;color:#251f31">
+  <div style="font-size:20px;font-weight:700;color:#2d6bf5">ensina.dev</div>
+  <h1 style="font-size:22px;margin:22px 0 8px">${titulo}</h1>
+  ${corpo}
+</div>`;
+}
 
 export const emailService = {
     async enviarVerificacao(email: string, token: string) {
         const link = `${env.FRONTEND_URL}/verificar-email?token=${token}`;
-
-        console.log(`[VERIFY-LINK] ${email} ${link}`);
+        const html = layout(
+            "Confirme seu email",
+            `<p style="font-size:15px;line-height:1.6;color:#555">Falta pouco para começar. Clique no botão abaixo para ativar sua conta.</p>
+  <a href="${link}" style="display:inline-block;margin:20px 0;background:#2d6bf5;color:#fff;text-decoration:none;padding:12px 28px;border-radius:10px;font-weight:600">Confirmar email</a>
+  <p style="font-size:13px;line-height:1.6;color:#888">Se o botão não funcionar, cole este link no navegador:<br><a href="${link}" style="color:#2d6bf5;word-break:break-all">${link}</a></p>
+  <p style="font-size:13px;color:#888;margin-top:24px">Se você não criou uma conta, pode ignorar este email.</p>`,
+        );
+        const text = `Confirme seu email para ativar sua conta no ensina.dev:\n${link}\n\nSe você não criou uma conta, ignore este email.`;
+        await enviar({ to: email, subject: "Confirme seu email · ensina.dev", html, text });
     },
 };


### PR DESCRIPTION
## Envio do email de verificação

O cadastro passa a enviar de verdade o email de confirmação, que antes só ia para o log do servidor.

- Envio por SMTP, funciona com qualquer provedor (Brevo, Resend, SendGrid...), só ajustando as variáveis de ambiente.
- Template com a logo, botão de confirmar e o link como alternativa.
- Sem SMTP configurado (dev), o comportamento antigo é mantido: o link vai para o log, sem enviar.
- Uma falha no envio é registrada mas não derruba o cadastro, já que a conta já foi criada.
- Script `scripts/testar-email.ts` para conferir: sem SMTP gera um preview do email; com SMTP envia de verdade para o endereço informado.

### Configuração em produção

Preencher `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS` e `EMAIL_FROM` no `.env.prod` (exemplo atualizado em `.env.prod.example`). O deploy reconstrói o backend por causa da nova dependência.
