### PR TITLE
feat: adiciona recuperação de senha por email

### DIFF
--- a/backend/src/controllers/AuthController.ts
+++ b/backend/src/controllers/AuthController.ts
@@ -1,8 +1,13 @@
-import { loginSchema, registerSchema } from "../schemas/auth.schema.ts";
+import {
+    loginSchema,
+    registerSchema,
+    forgotPasswordSchema,
+    resetPasswordSchema,
+} from "../schemas/auth.schema.ts";
 import bcrypt from "bcrypt";
 import { db } from "../../db.ts";
 import { users, tokens } from "../../schema.ts";
-import { eq, and } from "drizzle-orm";
+import { eq, and, isNull } from "drizzle-orm";
 import type { Request, Response, NextFunction } from "express";
 import { env } from "../config/env.ts";
 import { authService } from "../services/auth.service.ts";
@@ -298,6 +303,77 @@ export const verifyEmail = async (req: Request, res: Response, next: NextFunctio
         });
 
         res.json({ mensagem: "Email verificado com sucesso. Você já pode fazer login." });
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const forgotPassword = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const { email } = forgotPasswordSchema.parse(req.body);
+
+        // Resposta sempre genérica, para não revelar se o email tem conta.
+        const resposta = {
+            mensagem: "Se houver uma conta com esse email, enviamos um link para redefinir a senha.",
+        };
+
+        const [user] = await db
+            .select({ id: users.id, passwordHash: users.passwordHash })
+            .from(users)
+            .where(eq(users.email, email));
+
+        // Só envia quando a conta existe e tem senha (login social não tem o que redefinir).
+        if (user && user.passwordHash) {
+            const token = await authService.gerarTokenResetSenha(user.id);
+            await emailService.enviarResetSenha(email, token);
+        }
+
+        res.json(resposta);
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const resetPassword = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const { token, password } = resetPasswordSchema.parse(req.body);
+
+        const hashCalculado = createHash("sha256").update(token).digest("hex");
+        const [registro] = await db
+            .select({
+                id: tokens.id,
+                userId: tokens.userId,
+                expiredAt: tokens.expiredAt,
+                usedAt: tokens.usedAt,
+            })
+            .from(tokens)
+            .where(and(eq(tokens.tokenHash, hashCalculado), eq(tokens.type, "password_reset")));
+
+        if (!registro || registro.expiredAt < new Date() || registro.usedAt !== null) {
+            return res.status(400).json({ erro: "Link inválido ou expirado. Peça um novo." });
+        }
+
+        const passwordHash = await bcrypt.hash(password, BCRYPT_COST);
+
+        await db.transaction(async (tx) => {
+            // Consome o token de reset.
+            await tx.update(tokens).set({ usedAt: new Date() }).where(eq(tokens.id, registro.id));
+            // Troca a senha.
+            await tx.update(users).set({ passwordHash }).where(eq(users.id, registro.userId));
+            // Revoga as sessões abertas (refresh tokens) por segurança.
+            await tx
+                .update(tokens)
+                .set({ usedAt: new Date() })
+                .where(
+                    and(
+                        eq(tokens.userId, registro.userId),
+                        eq(tokens.type, "refresh"),
+                        isNull(tokens.usedAt),
+                    ),
+                );
+        });
+
+        res.json({ mensagem: "Senha redefinida com sucesso. Você já pode fazer login." });
     } catch (err) {
         next(err);
     }

--- a/backend/src/middlewares/rateLimit.ts
+++ b/backend/src/middlewares/rateLimit.ts
@@ -34,3 +34,14 @@ export const verifyEmailLimiter = criarLimiter(
     20,
     "Muitas tentativas. Tente novamente em alguns minutos.",
 );
+
+// Pedir redefinição dispara email; mantém baixo para não virar vetor de spam.
+export const forgotPasswordLimiter = criarLimiter(
+    5,
+    "Muitos pedidos de redefinição. Tente novamente em alguns minutos.",
+);
+
+export const resetPasswordLimiter = criarLimiter(
+    20,
+    "Muitas tentativas. Tente novamente em alguns minutos.",
+);

--- a/backend/src/routes/auth.routes.ts
+++ b/backend/src/routes/auth.routes.ts
@@ -1,11 +1,21 @@
 import { Router } from "express";
-import { login, refresh, register, logout, verifyEmail } from "../controllers/AuthController.ts";
+import {
+    login,
+    refresh,
+    register,
+    logout,
+    verifyEmail,
+    forgotPassword,
+    resetPassword,
+} from "../controllers/AuthController.ts";
 import { iniciarOAuth, callbackOAuth } from "../controllers/OAuthController.ts";
 import {
     loginLimiter,
     registerLimiter,
     refreshLimiter,
     verifyEmailLimiter,
+    forgotPasswordLimiter,
+    resetPasswordLimiter,
 } from "../middlewares/rateLimit.ts";
 
 const router = Router();
@@ -15,6 +25,8 @@ router.post("/register", registerLimiter, register);
 router.post("/refresh", refreshLimiter, refresh);
 router.post("/logout", refreshLimiter, logout);
 router.post("/verify-email", verifyEmailLimiter, verifyEmail);
+router.post("/forgot-password", forgotPasswordLimiter, forgotPassword);
+router.post("/reset-password", resetPasswordLimiter, resetPassword);
 
 // Login social (OAuth): inicia o fluxo e trata o retorno do provedor.
 router.get("/auth/:provider", iniciarOAuth);

--- a/backend/src/schemas/auth.schema.ts
+++ b/backend/src/schemas/auth.schema.ts
@@ -1,5 +1,15 @@
 import { z } from "zod";
 
+// Regras de senha forte, compartilhadas entre cadastro e redefinição.
+const senhaForte = z
+    .string()
+    .min(12, "Senha deve ter ao menos 12 caracteres")
+    .max(72)
+    .refine((s) => /[a-z]/.test(s), "A senha deve conter uma letra minúscula")
+    .refine((s) => /[A-Z]/.test(s), "A senha deve conter uma letra maiúscula")
+    .refine((s) => /[0-9]/.test(s), "A senha deve conter pelo menos um número")
+    .refine((s) => /[^A-Za-z0-9]/.test(s), "A senha deve conter um caractere especial");
+
 export const registerSchema = z.object({
     name: z.string().min(2, "Nome deve ter ao menos 2 caracteres"),
     username: z
@@ -9,17 +19,19 @@ export const registerSchema = z.object({
         .max(20, "Usuário deve ter no máximo 20 caracteres")
         .regex(/^[a-zA-Z0-9_]+$/, "Use apenas letras, números e underscore"),
     email: z.email("Email inválido"),
-    password: z
-        .string()
-        .min(12, "Senha deve ter ao menos 12 caracteres")
-        .max(72)
-        .refine((s) => /[a-z]/.test(s), "A senha deve conter uma letra minúscula")
-        .refine((s) => /[A-Z]/.test(s), "A senha deve conter uma letra maiúscula")
-        .refine((s) => /[0-9]/.test(s), "A senha deve conter pelo menos um número")
-        .refine((s) => /[^A-Za-z0-9]/.test(s), "A senha deve conter um caractere especial"),
+    password: senhaForte,
     birthDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Data deve ser AAAA-MM-DD"),
     gender: z.string(),
     phone: z.string(),
+});
+
+export const forgotPasswordSchema = z.object({
+    email: z.email("Email inválido"),
+});
+
+export const resetPasswordSchema = z.object({
+    token: z.string().min(1, "Token é obrigatório."),
+    password: senhaForte,
 });
 
 export const loginSchema = z.object({

--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -30,4 +30,16 @@ export const authService = {
 
         return verificationToken;
     },
+    async gerarTokenResetSenha(userId: string, tx: Pick<typeof db, "insert"> = db) {
+        const resetToken = randomBytes(40).toString("hex");
+
+        await tx.insert(tokens).values({
+            userId,
+            tokenHash: createHash("sha256").update(resetToken).digest("hex"),
+            type: "password_reset",
+            expiredAt: new Date(Date.now() + 60 * 60 * 1000),
+        });
+
+        return resetToken;
+    },
 };

--- a/backend/src/services/email.service.ts
+++ b/backend/src/services/email.service.ts
@@ -22,7 +22,8 @@ interface Mensagem {
 // Uma falha é logada, não propagada: o cadastro não deve quebrar porque o email não saiu.
 async function enviar({ to, subject, html, text }: Mensagem) {
     if (!transporter) {
-        console.log(`[EMAIL] (SMTP não configurado) para=${to} assunto="${subject}"`);
+        // Em dev registra o corpo (com o link) para dar pra testar o fluxo sem SMTP.
+        console.log(`[EMAIL] (SMTP não configurado) para=${to} assunto="${subject}"\n${text}`);
         return;
     }
     try {
@@ -55,5 +56,17 @@ export const emailService = {
         );
         const text = `Confirme seu email para ativar sua conta no ensina.dev:\n${link}\n\nSe você não criou uma conta, ignore este email.`;
         await enviar({ to: email, subject: "Confirme seu email · ensina.dev", html, text });
+    },
+    async enviarResetSenha(email: string, token: string) {
+        const link = `${env.FRONTEND_URL}/redefinir-senha?token=${token}`;
+        const html = layout(
+            "Redefinir sua senha",
+            `<p style="font-size:15px;line-height:1.6;color:#555">Recebemos um pedido para redefinir sua senha. Clique no botão abaixo para criar uma nova. O link vale por 1 hora.</p>
+  <a href="${link}" style="display:inline-block;margin:20px 0;background:#2d6bf5;color:#fff;text-decoration:none;padding:12px 28px;border-radius:10px;font-weight:600">Redefinir senha</a>
+  <p style="font-size:13px;line-height:1.6;color:#888">Se o botão não funcionar, cole este link no navegador:<br><a href="${link}" style="color:#2d6bf5;word-break:break-all">${link}</a></p>
+  <p style="font-size:13px;color:#888;margin-top:24px">Se você não pediu isso, pode ignorar este email: sua senha continua a mesma.</p>`,
+        );
+        const text = `Redefina sua senha no ensina.dev (o link vale por 1 hora):\n${link}\n\nSe você não pediu isso, ignore este email.`;
+        await enviar({ to: email, subject: "Redefinir sua senha · ensina.dev", html, text });
     },
 };

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,8 @@ import { Desafio } from './pages/Desafios/Desafio';
 import { DesafiosAdmin } from './pages/DesafiosAdmin';
 import { DesafioEditor } from './pages/DesafiosAdmin/Editor';
 import { VerifyEmail } from './pages/VerifyEmail';
+import { RecuperarSenha } from './pages/RecuperarSenha';
+import { RedefinirSenha } from './pages/RedefinirSenha';
 import { OAuthCallback } from './pages/OAuthCallback';
 import { CompletarPerfil } from './pages/CompletarPerfil';
 import { Placeholder } from './pages/Placeholder';
@@ -48,6 +50,8 @@ function AppRoutes() {
       <Route path="/" element={isAuthenticated ? <Navigate to="/home" /> : <Login />} />
       <Route path="/cadastro" element={isAuthenticated ? <Navigate to="/home" /> : <Register />} />
       <Route path="/verificar-email" element={<VerifyEmail />} />
+      <Route path="/recuperar-senha" element={<RecuperarSenha />} />
+      <Route path="/redefinir-senha" element={<RedefinirSenha />} />
       <Route path="/auth/callback" element={<OAuthCallback />} />
       <Route
         path="/completar-perfil"

--- a/frontend/src/pages/RecuperarSenha/index.tsx
+++ b/frontend/src/pages/RecuperarSenha/index.tsx
@@ -1,0 +1,91 @@
+import { useState, type FormEvent } from 'react';
+import { Link } from 'react-router-dom';
+import api from '../../services/api';
+import { AuthShell } from '../../components/auth/AuthShell';
+import { AuthBrand } from '../../components/auth/AuthBrand';
+import { FormField } from '../../components/FormField';
+import { mensagemErro } from '../../utils/erro';
+
+const brand = (
+  <AuthBrand glow="login">
+    <div className="auth__brand-body">
+      <h1 className="auth__headline">
+        <span className="auth__kicker">
+          <span className="auth__kicker-soft">sem </span>estresse
+        </span>
+        <span className="auth__headline-main">Recupere seu acesso</span>
+      </h1>
+      <p className="auth__lede">
+        Informe seu email e enviamos um link para você criar uma nova senha em segundos.
+      </p>
+    </div>
+  </AuthBrand>
+);
+
+export function RecuperarSenha() {
+  const [email, setEmail] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [enviado, setEnviado] = useState(false);
+  const [mensagem, setMensagem] = useState('');
+  const [error, setError] = useState('');
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError('');
+    setSubmitting(true);
+    try {
+      const { data } = await api.post('/forgot-password', { email });
+      setMensagem(
+        data.mensagem ??
+          'Se houver uma conta com esse email, enviamos um link para redefinir a senha.',
+      );
+      setEnviado(true);
+    } catch (e: unknown) {
+      setError(mensagemErro(e, 'Não foi possível enviar o link. Tente novamente.'));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <AuthShell brand={brand}>
+      <h2 className="auth__title">Esqueceu a senha?</h2>
+      <p className="auth__subtitle">Enviamos um link de redefinição para o seu email.</p>
+
+      {enviado ? (
+        <>
+          <div className="auth__alert auth__alert--ok">{mensagem}</div>
+          <p className="auth__foot">
+            <Link className="link" to="/">
+              Voltar ao login
+            </Link>
+          </p>
+        </>
+      ) : (
+        <>
+          {error && <div className="auth__alert">{error}</div>}
+          <form className="form" onSubmit={handleSubmit} noValidate>
+            <FormField
+              label="E-mail"
+              type="email"
+              autoComplete="email"
+              placeholder="voce@email.com"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+            <button className="btn btn--accent btn--block" type="submit" disabled={submitting}>
+              {submitting ? 'Enviando...' : 'Enviar link'}
+            </button>
+          </form>
+          <p className="auth__foot">
+            Lembrou a senha?{' '}
+            <Link className="link" to="/">
+              Voltar ao login
+            </Link>
+          </p>
+        </>
+      )}
+    </AuthShell>
+  );
+}

--- a/frontend/src/pages/RedefinirSenha/index.tsx
+++ b/frontend/src/pages/RedefinirSenha/index.tsx
@@ -1,0 +1,115 @@
+import { useState, type FormEvent } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import api from '../../services/api';
+import { AuthShell } from '../../components/auth/AuthShell';
+import { AuthBrand } from '../../components/auth/AuthBrand';
+import { FormField } from '../../components/FormField';
+import { mensagemErro } from '../../utils/erro';
+
+const brand = (
+  <AuthBrand glow="register">
+    <div className="auth__brand-body">
+      <h1 className="auth__headline">
+        <span className="auth__kicker">
+          <span className="auth__kicker-soft">quase </span>lá
+        </span>
+        <span className="auth__headline-main">Crie uma nova senha</span>
+      </h1>
+      <p className="auth__lede">
+        Escolha uma senha forte e volte a estudar. O link é válido por 1 hora.
+      </p>
+    </div>
+  </AuthBrand>
+);
+
+export function RedefinirSenha() {
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get('token') ?? '';
+  const [password, setPassword] = useState('');
+  const [confirmacao, setConfirmacao] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [sucesso, setSucesso] = useState(false);
+  const [error, setError] = useState('');
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError('');
+    if (password !== confirmacao) {
+      setError('As senhas não coincidem.');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await api.post('/reset-password', { token, password });
+      setSucesso(true);
+    } catch (e: unknown) {
+      setError(mensagemErro(e, 'Não foi possível redefinir. O link pode ter expirado.'));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <AuthShell brand={brand}>
+      {!token ? (
+        <>
+          <h2 className="auth__title">Link inválido</h2>
+          <p className="auth__subtitle">O link de redefinição está incompleto ou expirou.</p>
+          <p className="auth__foot">
+            <Link className="link" to="/recuperar-senha">
+              Pedir um novo link
+            </Link>
+          </p>
+        </>
+      ) : sucesso ? (
+        <>
+          <h2 className="auth__title">Senha redefinida!</h2>
+          <p className="auth__subtitle">Já pode entrar com a sua nova senha.</p>
+          <Link className="btn btn--accent btn--block" to="/">
+            Ir para o login
+          </Link>
+        </>
+      ) : (
+        <>
+          <h2 className="auth__title">Criar nova senha</h2>
+          <p className="auth__subtitle">Escolha uma senha forte para a sua conta.</p>
+
+          {error && <div className="auth__alert">{error}</div>}
+
+          <form className="form" onSubmit={handleSubmit} noValidate>
+            <FormField
+              label="Nova senha"
+              type="password"
+              autoComplete="new-password"
+              placeholder="••••••••••"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            >
+              <span className="field__hint">
+                Mínimo 12 caracteres, com maiúscula, minúscula, número e símbolo.
+              </span>
+            </FormField>
+            <FormField
+              label="Confirmar senha"
+              type="password"
+              autoComplete="new-password"
+              placeholder="••••••••••"
+              value={confirmacao}
+              onChange={(e) => setConfirmacao(e.target.value)}
+              required
+            />
+            <button className="btn btn--accent btn--block" type="submit" disabled={submitting}>
+              {submitting ? 'Salvando...' : 'Redefinir senha'}
+            </button>
+          </form>
+          <p className="auth__foot">
+            <Link className="link" to="/">
+              Voltar ao login
+            </Link>
+          </p>
+        </>
+      )}
+    </AuthShell>
+  );
+}

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -4272,3 +4272,15 @@
   font-size: 12px;
   color: var(--muted);
 }
+
+/* Variante de sucesso do alerta de auth e dica abaixo de um campo. */
+.auth__alert--ok {
+  color: var(--success);
+  background: color-mix(in srgb, var(--success) 12%, transparent);
+  border-color: color-mix(in srgb, var(--success) 30%, transparent);
+}
+.field__hint {
+  margin-top: 6px;
+  font-size: 12.5px;
+  color: var(--muted);
+}


### PR DESCRIPTION
## Recuperação de senha

Fecha o fluxo de esqueci a senha, que já tinha o link no login mas não tinha as telas nem os endpoints.

- `/recuperar-senha`: informa o email e recebe um link de redefinição.
- `/redefinir-senha?token=...`: cria a nova senha a partir do link.

### Segurança

- O pedido responde sempre com a mesma mensagem genérica, sem revelar se o email tem conta; só envia quando a conta existe e usa senha (login social fica de fora).
- O token vale por 1 hora e é de uso único.
- Ao redefinir, as sessões abertas (refresh tokens) são revogadas.
- Endpoints com rate limit próprio.

### Notas

- Reaproveita a tabela `tokens` (tipo `password_reset`) e o email já existentes, então não há migration nem dependência nova.
- Em dev, o fallback de email passa a registrar o corpo com o link, para testar verificação e reset sem SMTP.

Validado de ponta a ponta (pedir, redefinir, login com a nova senha, a antiga falha, token de uso único, email inexistente não vaza) e 51/51 na integração.
