### PR TITLE
fix: melhora a visualização da aula no telefone

### DIFF
--- a/frontend/src/pages/Aula/index.tsx
+++ b/frontend/src/pages/Aula/index.tsx
@@ -5,7 +5,7 @@ import { Logo } from '../../components/Logo';
 import { MobileMenu } from '../../components/MobileMenu';
 import { UserMenu } from '../../components/UserMenu';
 import { ThemeToggle } from '../../components/ThemeToggle';
-import { Flame, Check, Help, Alert, X } from '../../components/Icons';
+import { Flame, Check, Help, Alert, X, ChevronDown } from '../../components/Icons';
 import { getInitials } from '../../utils/initials';
 import { user } from '../../data/home';
 import {
@@ -120,6 +120,7 @@ export function Aula() {
 }
 
 function SidebarTrilha({ trilha, aulaAtualId }: { trilha: TrailDetail; aulaAtualId: string }) {
+  const [aberto, setAberto] = useState(false);
   const todas = trilha.modules.flatMap((m) => m.lessons);
   const feitas = todas.filter((l) => l.state === 'done').length;
   const total = todas.length;
@@ -140,26 +141,42 @@ function SidebarTrilha({ trilha, aulaAtualId }: { trilha: TrailDetail; aulaAtual
         <span style={{ width: `${pct}%` }} />
       </div>
 
-      {trilha.modules.map((m) => (
-        <div key={m.id} className="lesson__module">
-          <div className="lesson__module-title">{m.title}</div>
-          {m.lessons.map((l) => {
-            const estado = l.id === aulaAtualId ? 'current' : l.state;
-            return (
-              <Link
-                key={l.id}
-                to={`/trilhas/${trilha.id}/aula/${l.id}`}
-                className={`lesson__item lesson__item--${estado}${l.state === 'locked' ? ' lesson__item--disabled' : ''}`}
-              >
-                <span className="lesson__bullet">
-                  {l.state === 'done' ? <Check size={11} /> : null}
-                </span>
-                <span className="lesson__item-name">{l.title}</span>
-              </Link>
-            );
-          })}
-        </div>
-      ))}
+      {/* No telefone a lista de aulas colapsa, para abrir a aula já mostrar o conteúdo. */}
+      <button
+        type="button"
+        className={`lesson__toggle${aberto ? ' lesson__toggle--aberto' : ''}`}
+        onClick={() => setAberto((v) => !v)}
+        aria-expanded={aberto}
+      >
+        Aulas da trilha
+        <span className="lesson__toggle-chevron">
+          <ChevronDown size={16} />
+        </span>
+      </button>
+
+      <div className={`lesson__modules${aberto ? ' lesson__modules--aberto' : ''}`}>
+        {trilha.modules.map((m) => (
+          <div key={m.id} className="lesson__module">
+            <div className="lesson__module-title">{m.title}</div>
+            {m.lessons.map((l) => {
+              const estado = l.id === aulaAtualId ? 'current' : l.state;
+              return (
+                <Link
+                  key={l.id}
+                  to={`/trilhas/${trilha.id}/aula/${l.id}`}
+                  className={`lesson__item lesson__item--${estado}${l.state === 'locked' ? ' lesson__item--disabled' : ''}`}
+                  onClick={() => setAberto(false)}
+                >
+                  <span className="lesson__bullet">
+                    {l.state === 'done' ? <Check size={11} /> : null}
+                  </span>
+                  <span className="lesson__item-name">{l.title}</span>
+                </Link>
+              );
+            })}
+          </div>
+        ))}
+      </div>
     </aside>
   );
 }

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1556,6 +1556,7 @@
 }
 .lesson__nav {
   align-self: stretch;
+  min-width: 0;
   background: var(--surface);
   border-right: 1px solid var(--border);
   padding: 22px 18px;
@@ -1669,7 +1670,34 @@
   font-weight: 700;
 }
 
+/* Botão de expandir a lista de aulas (só aparece no telefone). */
+.lesson__toggle {
+  display: none;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  margin-top: 4px;
+  padding: 8px 6px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.lesson__toggle-chevron {
+  display: inline-flex;
+  transition: transform 0.2s;
+}
+.lesson__toggle--aberto .lesson__toggle-chevron {
+  transform: rotate(180deg);
+}
+
 .lesson__content {
+  min-width: 0;
   padding: 34px 44px 40px;
   max-width: 820px;
   margin: 22px;
@@ -4068,8 +4096,31 @@
     align-self: auto;
     border-right: none;
     border-bottom: 1px solid var(--border);
-    max-height: 42vh;
+    padding: 14px 16px;
+  }
+  .lesson__toggle {
+    display: flex;
+  }
+  .lesson__modules {
+    display: none;
+    max-height: 60vh;
     overflow-y: auto;
+  }
+  .lesson__modules--aberto {
+    display: block;
+  }
+  .lesson__item {
+    height: auto;
+    min-height: 38px;
+    padding: 8px;
+  }
+  .lesson__item-name {
+    white-space: normal;
+    line-height: 1.35;
+  }
+  .lesson__content {
+    margin: 16px 12px 0;
+    padding: 22px 18px 28px;
   }
   .studio {
     grid-template-columns: 1fr;


### PR DESCRIPTION
## Visualização da aula no telefone

Ao abrir uma aula no celular, a trilha (lista das aulas) era despejada no topo e os títulos cortavam na borda. Este PR arruma isso.

- **Trilha colapsável**: no telefone a trilha vira um cabeçalho compacto (nome e progresso) com um botão "Aulas da trilha". Recolhida por padrão, então abrir a aula já mostra o conteúdo. Tocar numa aula navega e recolhe a lista. No desktop nada muda.
- **Fim do corte**: `min-width: 0` nas colunas do grid faz elas encolherem até a largura da tela, então título e conteúdo não vazam mais (código e tabelas seguem rolando na horizontal por dentro).
- **Títulos quebram** em vez de truncar, e o conteúdo ganha padding menor no telefone.

Só frontend, sem migration nem dependência nova.
