### PR TITLE
Trilhas e simulados do DP-900 e do AI-900 e nova tela de simulados

### DIFF
--- a/backend/drizzle/0025_simulado_provider_code_level.sql
+++ b/backend/drizzle/0025_simulado_provider_code_level.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "simulados" ADD COLUMN "provider" varchar(40);--> statement-breakpoint
+ALTER TABLE "simulados" ADD COLUMN "code" varchar(40);--> statement-breakpoint
+ALTER TABLE "simulados" ADD COLUMN "level" varchar(40);

--- a/backend/drizzle/meta/0025_snapshot.json
+++ b/backend/drizzle/meta/0025_snapshot.json
@@ -1,0 +1,2024 @@
+{
+  "id": "ffaa8cd5-c561-4c68-a111-4b0bf6272bea",
+  "prevId": "e0212a3d-d846-4665-a531-1c4dd6061582",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.achievements": {
+      "name": "achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "criteria_type": {
+          "name": "criteria_type",
+          "type": "achievement_criteria",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "achievements_name_unique": {
+          "name": "achievements_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge_submissions": {
+      "name": "challenge_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "challenge_language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "challenge_submission_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "passed_count": {
+          "name": "passed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_count": {
+          "name": "total_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xp_earned": {
+          "name": "xp_earned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "challenge_submissions_user_id_users_id_fk": {
+          "name": "challenge_submissions_user_id_users_id_fk",
+          "tableFrom": "challenge_submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "challenge_submissions_challenge_id_challenges_id_fk": {
+          "name": "challenge_submissions_challenge_id_challenges_id_fk",
+          "tableFrom": "challenge_submissions",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge_tests": {
+      "name": "challenge_tests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_output": {
+          "name": "expected_output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "challenge_tests_challenge_id_challenges_id_fk": {
+          "name": "challenge_tests_challenge_id_challenges_id_fk",
+          "tableFrom": "challenge_tests",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenges": {
+      "name": "challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "challenge_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stdin'"
+        },
+        "entry_point": {
+          "name": "entry_point",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_blocks": {
+          "name": "statement_blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "question_difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'facil'"
+        },
+        "starter_code": {
+          "name": "starter_code",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_date": {
+          "name": "active_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "challenges_number_unique": {
+          "name": "challenges_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "number"
+          ]
+        },
+        "challenges_active_date_unique": {
+          "name": "challenges_active_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "active_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.languages": {
+      "name": "languages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "languages_name_unique": {
+          "name": "languages_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons_progress": {
+      "name": "lessons_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_progress_user_id_users_id_fk": {
+          "name": "lessons_progress_user_id_users_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_progress_lesson_id_lessons_id_fk": {
+          "name": "lessons_progress_lesson_id_lessons_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lessons_progress_user_id_lesson_id_unique": {
+          "name": "lessons_progress_user_id_lesson_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "lesson_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons": {
+      "name": "lessons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_blocks": {
+          "name": "content_blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_trail_id_trails_id_fk": {
+          "name": "lessons_trail_id_trails_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_module_id_modules_id_fk": {
+          "name": "lessons_module_id_modules_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "modules",
+          "columnsFrom": [
+            "module_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.modules": {
+      "name": "modules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "modules_trail_id_trails_id_fk": {
+          "name": "modules_trail_id_trails_id_fk",
+          "tableFrom": "modules",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_accounts": {
+      "name": "oauth_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_accounts_user_id_users_id_fk": {
+          "name": "oauth_accounts_user_id_users_id_fk",
+          "tableFrom": "oauth_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_accounts_provider_provider_id_unique": {
+          "name": "oauth_accounts_provider_provider_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "provider_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_answers": {
+      "name": "question_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_option_id": {
+          "name": "selected_option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_answers_user_id_users_id_fk": {
+          "name": "question_answers_user_id_users_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_question_id_questions_id_fk": {
+          "name": "question_answers_question_id_questions_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_selected_option_id_question_options_id_fk": {
+          "name": "question_answers_selected_option_id_question_options_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "question_options",
+          "columnsFrom": [
+            "selected_option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "question_answers_user_id_question_id_unique": {
+          "name": "question_answers_user_id_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_options": {
+      "name": "question_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_options_question_id_questions_id_fk": {
+          "name": "question_options_question_id_questions_id_fk",
+          "tableFrom": "question_options",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "question_difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'facil'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_lesson_id_lessons_id_fk": {
+          "name": "questions_lesson_id_lessons_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ranking_snapshots": {
+      "name": "ranking_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ranking_snapshots_user_id_users_id_fk": {
+          "name": "ranking_snapshots_user_id_users_id_fk",
+          "tableFrom": "ranking_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ranking_snapshots_user_id_snapshot_date_unique": {
+          "name": "ranking_snapshots_user_id_snapshot_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "snapshot_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_attempt_answers": {
+      "name": "simulado_attempt_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_attempt_answers_attempt_id_simulado_attempts_id_fk": {
+          "name": "simulado_attempt_answers_attempt_id_simulado_attempts_id_fk",
+          "tableFrom": "simulado_attempt_answers",
+          "tableTo": "simulado_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempt_answers_question_id_simulado_questions_id_fk": {
+          "name": "simulado_attempt_answers_question_id_simulado_questions_id_fk",
+          "tableFrom": "simulado_attempt_answers",
+          "tableTo": "simulado_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempt_answers_option_id_simulado_options_id_fk": {
+          "name": "simulado_attempt_answers_option_id_simulado_options_id_fk",
+          "tableFrom": "simulado_attempt_answers",
+          "tableTo": "simulado_options",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulado_attempt_answers_attempt_id_question_id_option_id_unique": {
+          "name": "simulado_attempt_answers_attempt_id_question_id_option_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "attempt_id",
+            "question_id",
+            "option_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_attempt_questions": {
+      "name": "simulado_attempt_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_attempt_questions_attempt_id_simulado_attempts_id_fk": {
+          "name": "simulado_attempt_questions_attempt_id_simulado_attempts_id_fk",
+          "tableFrom": "simulado_attempt_questions",
+          "tableTo": "simulado_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempt_questions_question_id_simulado_questions_id_fk": {
+          "name": "simulado_attempt_questions_question_id_simulado_questions_id_fk",
+          "tableFrom": "simulado_attempt_questions",
+          "tableTo": "simulado_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulado_attempt_questions_attempt_id_question_id_unique": {
+          "name": "simulado_attempt_questions_attempt_id_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "attempt_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_attempts": {
+      "name": "simulado_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "simulado_id": {
+          "name": "simulado_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passed": {
+          "name": "passed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_attempts_user_id_users_id_fk": {
+          "name": "simulado_attempts_user_id_users_id_fk",
+          "tableFrom": "simulado_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempts_simulado_id_simulados_id_fk": {
+          "name": "simulado_attempts_simulado_id_simulados_id_fk",
+          "tableFrom": "simulado_attempts",
+          "tableTo": "simulados",
+          "columnsFrom": [
+            "simulado_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_options": {
+      "name": "simulado_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_options_question_id_simulado_questions_id_fk": {
+          "name": "simulado_options_question_id_simulado_questions_id_fk",
+          "tableFrom": "simulado_options",
+          "tableTo": "simulado_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_questions": {
+      "name": "simulado_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "simulado_id": {
+          "name": "simulado_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_questions_simulado_id_simulados_id_fk": {
+          "name": "simulado_questions_simulado_id_simulados_id_fk",
+          "tableFrom": "simulado_questions",
+          "tableTo": "simulados",
+          "columnsFrom": [
+            "simulado_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulados": {
+      "name": "simulados",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_count": {
+          "name": "question_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pass_percent": {
+          "name": "pass_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulados_slug_unique": {
+          "name": "simulados_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tokens": {
+      "name": "tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'refresh'"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tokens_user_id_users_id_fk": {
+          "name": "tokens_user_id_users_id_fk",
+          "tableFrom": "tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tokens_token_hash_unique": {
+          "name": "tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_tags": {
+      "name": "trail_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "trail_tags_trail_id_trails_id_fk": {
+          "name": "trail_tags_trail_id_trails_id_fk",
+          "tableFrom": "trail_tags",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trail_tags_tag_id_tags_id_fk": {
+          "name": "trail_tags_tag_id_tags_id_fk",
+          "tableFrom": "trail_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trail_tags_trail_id_tag_id_unique": {
+          "name": "trail_tags_trail_id_tag_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trail_id",
+            "tag_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trails": {
+      "name": "trails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "trail_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_achievements": {
+      "name": "user_achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "achievement_id": {
+          "name": "achievement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_achievements_user_id_users_id_fk": {
+          "name": "user_achievements_user_id_users_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_achievements_achievement_id_achievements_id_fk": {
+          "name": "user_achievements_achievement_id_achievements_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "achievements",
+          "columnsFrom": [
+            "achievement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_achievements_user_id_achievement_id_unique": {
+          "name": "user_achievements_user_id_achievement_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "achievement_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username_changed_at": {
+          "name": "username_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occupation": {
+          "name": "occupation",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github": {
+          "name": "github",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin": {
+          "name": "linkedin",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "failed_login_attempts": {
+          "name": "failed_login_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.achievement_criteria": {
+      "name": "achievement_criteria",
+      "schema": "public",
+      "values": [
+        "xp_total",
+        "lessons_completed",
+        "questions_correct"
+      ]
+    },
+    "public.challenge_kind": {
+      "name": "challenge_kind",
+      "schema": "public",
+      "values": [
+        "stdin",
+        "function"
+      ]
+    },
+    "public.challenge_language": {
+      "name": "challenge_language",
+      "schema": "public",
+      "values": [
+        "javascript",
+        "python",
+        "csharp"
+      ]
+    },
+    "public.challenge_submission_status": {
+      "name": "challenge_submission_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "passed",
+        "failed",
+        "error",
+        "timeout"
+      ]
+    },
+    "public.question_difficulty": {
+      "name": "question_difficulty",
+      "schema": "public",
+      "values": [
+        "facil",
+        "medio",
+        "dificil"
+      ]
+    },
+    "public.trail_level": {
+      "name": "trail_level",
+      "schema": "public",
+      "values": [
+        "iniciante",
+        "intermediario",
+        "avancado"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin",
+        "moderator"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1783041864103,
       "tag": "0024_add_x_social",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1783092783956,
+      "tag": "0025_simulado_provider_code_level",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/schema.ts
+++ b/backend/schema.ts
@@ -256,6 +256,11 @@ export const simulados = pgTable("simulados", {
     slug: varchar("slug", { length: 80 }).notNull().unique(),
     name: varchar("name", { length: 160 }).notNull(),
     description: text("description"),
+    // Provedor da certificação (chave: aws, azure, gcp), código (ex.: DP-900) e nível
+    // (ex.: Fundamental, Associate). Usados na organização e nos filtros da lista.
+    provider: varchar("provider", { length: 40 }),
+    code: varchar("code", { length: 40 }),
+    level: varchar("level", { length: 40 }),
     durationMinutes: integer("duration_minutes").notNull(),
     questionCount: integer("question_count").notNull(),
     passPercent: integer("pass_percent").notNull(),

--- a/backend/scripts/seed-ai-900.ts
+++ b/backend/scripts/seed-ai-900.ts
@@ -1,0 +1,1522 @@
+// Seed do simulado Microsoft Azure AI Fundamentals (AI-900). Idempotente: se o
+// simulado já tiver questões, não faz nada.
+//
+// Rodar em dev:  node --env-file=.env scripts/seed-ai-900.ts
+// Rodar em prod: docker compose -f docker-compose.prod.yml exec -T backend \
+//                  node scripts/seed-ai-900.ts
+import { db } from "../db.ts";
+import { simulados, simuladoQuestions, simuladoOptions } from "../schema.ts";
+import { eq, count } from "drizzle-orm";
+
+const SLUG = "ai-900";
+
+type Questao = {
+    statement: string;
+    explanation: string;
+    topic: string;
+    options: [string, boolean][];
+};
+
+const QUESTOES: Questao[] = [
+    // Domínio 1 - Cargas de trabalho de IA e IA responsável
+    {
+        statement:
+            "Uma indústria quer inspecionar automaticamente peças em uma esteira de produção usando imagens de câmeras para identificar defeitos visuais como riscos e trincas. Qual carga de trabalho de IA atende a esse cenário?",
+        explanation:
+            "A visão computacional interpreta o conteúdo de imagens e vídeos, sendo ideal para detectar defeitos visuais em peças a partir de fotos da esteira. O processamento de linguagem natural lida com texto e fala, não com imagens. A mineração de conhecimento cria índices pesquisáveis sobre grandes volumes de conteúdo. A inteligência de documentos extrai campos de formulários e documentos, e não avalia defeitos físicos em produtos.",
+        topic: "Cargas de trabalho de IA",
+        options: [
+            ["Processamento de linguagem natural", false],
+            ["Visão computacional", true],
+            ["Mineração de conhecimento", false],
+            ["Inteligência de documentos", false],
+        ],
+    },
+    {
+        statement:
+            "Um e-commerce recebe milhares de avaliações escritas por clientes e quer classificar automaticamente cada texto como positivo, negativo ou neutro. Qual carga de trabalho de IA deve ser usada?",
+        explanation:
+            "A análise de sentimentos sobre textos escritos é uma tarefa de processamento de linguagem natural, que interpreta o significado e o tom da linguagem. A visão computacional trabalha com imagens. A IA generativa cria conteúdo novo em vez de classificar o tom de textos existentes. A inteligência de documentos foca em extrair dados estruturados de formulários e documentos.",
+        topic: "Cargas de trabalho de IA",
+        options: [
+            ["Visão computacional", false],
+            ["Processamento de linguagem natural", true],
+            ["IA generativa", false],
+            ["Inteligência de documentos", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa precisa extrair automaticamente número, data, valor total e itens de milhares de notas fiscais e recibos digitalizados, preservando os campos e suas posições. Qual carga de trabalho de IA é mais adequada?",
+        explanation:
+            "A inteligência de documentos (Document Intelligence) é especializada em extrair pares de chave e valor, tabelas e campos estruturados de formulários e documentos como notas fiscais e recibos. A mineração de conhecimento cria índices de busca sobre grandes acervos, mas não é focada na extração estruturada campo a campo. O processamento de linguagem natural entende texto livre, e o machine learning genérico exigiria construir e treinar o modelo do zero.",
+        topic: "Cargas de trabalho de IA",
+        options: [
+            ["Mineração de conhecimento", false],
+            ["Processamento de linguagem natural", false],
+            ["Inteligência de documentos", true],
+            ["Machine learning", false],
+        ],
+    },
+    {
+        statement:
+            "Um escritório de advocacia possui milhões de contratos em PDF e quer permitir que os advogados pesquisem e encontrem cláusulas e informações relevantes em todo esse acervo de forma rápida. Qual carga de trabalho de IA atende melhor a essa necessidade?",
+        explanation:
+            "A mineração de conhecimento, apoiada pelo Azure AI Search, extrai informações de grandes volumes de conteúdo não estruturado e cria um índice pesquisável, ideal para localizar cláusulas em milhões de contratos. A inteligência de documentos foca na extração de campos de documentos individuais. A visão computacional trata de imagens, e a IA generativa cria conteúdo novo em vez de indexar e pesquisar o acervo existente.",
+        topic: "Cargas de trabalho de IA",
+        options: [
+            ["Inteligência de documentos", false],
+            ["Mineração de conhecimento", true],
+            ["Visão computacional", false],
+            ["IA generativa", false],
+        ],
+    },
+    {
+        statement:
+            "Uma agência de marketing quer uma solução que produza textos originais de anúncios e imagens inéditas a partir de descrições fornecidas pela equipe. Qual carga de trabalho de IA descreve essa solução?",
+        explanation:
+            "A IA generativa cria conteúdo original, como textos, imagens e código, a partir de instruções em linguagem natural, exatamente o que o cenário pede. A mineração de conhecimento indexa e pesquisa conteúdo existente. O processamento de linguagem natural interpreta linguagem, mas não tem foco em gerar imagens inéditas. A visão computacional analisa imagens já existentes em vez de criá-las.",
+        topic: "Cargas de trabalho de IA",
+        options: [
+            ["Mineração de conhecimento", false],
+            ["Processamento de linguagem natural", false],
+            ["Visão computacional", false],
+            ["IA generativa", true],
+        ],
+    },
+    {
+        statement:
+            "Uma imobiliária quer estimar o preço de venda de imóveis com base em dados históricos como área, número de quartos e localização. Qual carga de trabalho de IA é a mais indicada?",
+        explanation:
+            "Prever um valor numérico a partir de dados históricos é uma tarefa clássica de machine learning, mais especificamente de regressão. A IA generativa cria conteúdo novo, não previsões numéricas baseadas em variáveis. A visão computacional lida com imagens e a inteligência de documentos com extração de campos de documentos, nenhuma adequada para estimar preços a partir de atributos tabulares.",
+        topic: "Cargas de trabalho de IA",
+        options: [
+            ["IA generativa", false],
+            ["Visão computacional", false],
+            ["Machine learning", true],
+            ["Inteligência de documentos", false],
+        ],
+    },
+    {
+        statement:
+            "Um gestor pergunta qual afirmação descreve melhor o conceito de inteligência artificial. Qual opção está correta?",
+        explanation:
+            "Inteligência artificial é software que imita capacidades humanas, como aprender a partir de dados, reconhecer imagens, entender linguagem e tomar decisões. Não é um banco de dados, nem um simples conjunto de regras fixas, nem um tipo de hardware. A capacidade de aprender com dados é justamente o que diferencia a IA de sistemas puramente determinísticos.",
+        topic: "Cargas de trabalho de IA",
+        options: [
+            [
+                "Software capaz de imitar comportamentos e capacidades humanas, como aprender com dados, reconhecer imagens e interpretar linguagem",
+                true,
+            ],
+            [
+                "Um banco de dados relacional usado apenas para armazenar grandes volumes de informação",
+                false,
+            ],
+            ["Um conjunto de regras fixas que nunca muda e não depende de dados", false],
+            [
+                "Um tipo de hardware que substitui completamente os processadores tradicionais",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma rede de lojas quer contar quantas pessoas entram em cada unidade analisando o vídeo das câmeras de segurança em tempo real. Qual carga de trabalho de IA deve ser aplicada?",
+        explanation:
+            "Detectar e contar pessoas em imagens e vídeos é uma tarefa de visão computacional, que inclui a detecção de objetos. A inteligência de documentos extrai dados de documentos, o processamento de linguagem natural lida com texto e fala, e a mineração de conhecimento cria índices pesquisáveis, nenhuma delas voltada para análise de vídeo em tempo real.",
+        topic: "Cargas de trabalho de IA",
+        options: [
+            ["Inteligência de documentos", false],
+            ["Visão computacional", true],
+            ["Processamento de linguagem natural", false],
+            ["Mineração de conhecimento", false],
+        ],
+    },
+    {
+        statement:
+            "Um aplicativo de atendimento precisa transcrever ligações telefônicas e traduzir o texto para outros idiomas automaticamente. Qual carga de trabalho de IA é a base dessa funcionalidade?",
+        explanation:
+            "Transcrever fala em texto e traduzir entre idiomas são tarefas de processamento de linguagem natural, que abrange reconhecimento de fala e tradução. A visão computacional trata de imagens. O machine learning genérico e a IA generativa não descrevem especificamente reconhecimento de fala e tradução, que são serviços de linguagem.",
+        topic: "Cargas de trabalho de IA",
+        options: [
+            ["Visão computacional", false],
+            ["IA generativa", false],
+            ["Processamento de linguagem natural", true],
+            ["Machine learning", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe está mapeando quais tarefas pertencem à carga de trabalho de visão computacional. Quais das opções a seguir são exemplos de visão computacional? (Selecione DUAS opções.)",
+        explanation:
+            "Detecção de objetos e classificação de imagens são tarefas de visão computacional, pois interpretam o conteúdo visual de imagens. Análise de sentimentos e tradução de textos pertencem ao processamento de linguagem natural, já que trabalham com linguagem escrita, e não com imagens.",
+        topic: "Cargas de trabalho de IA",
+        options: [
+            ["Detecção de objetos em fotos", true],
+            ["Análise de sentimentos em avaliações de texto", false],
+            ["Classificação de imagens", true],
+            ["Tradução de textos entre idiomas", false],
+        ],
+    },
+    {
+        statement:
+            "Ao planejar uma solução, um arquiteto precisa identificar tarefas de processamento de linguagem natural. Quais das opções a seguir são exemplos dessa carga de trabalho? (Selecione DUAS opções.)",
+        explanation:
+            "Detecção de idioma e reconhecimento de entidades nomeadas são tarefas de processamento de linguagem natural, focadas em interpretar texto. A detecção de faces é visão computacional, e a geração de imagens a partir de descrições é IA generativa, portanto não pertencem ao processamento de linguagem natural.",
+        topic: "Cargas de trabalho de IA",
+        options: [
+            ["Detecção do idioma de um texto", true],
+            ["Detecção de faces em imagens", false],
+            ["Reconhecimento de entidades nomeadas em documentos de texto", true],
+            ["Geração de imagens a partir de descrições", false],
+        ],
+    },
+    {
+        statement:
+            "Uma operadora quer prever quais clientes têm maior probabilidade de cancelar o serviço no próximo mês, atribuindo a cada cliente a categoria provável cancelar ou permanecer. Qual carga de trabalho de IA descreve essa solução?",
+        explanation:
+            "Atribuir clientes a categorias como cancelar ou permanecer a partir de dados históricos é uma tarefa de classificação, um tipo de machine learning. A mineração de conhecimento cria índices pesquisáveis, a visão computacional analisa imagens e a IA generativa cria conteúdo novo, nenhuma adequada para prever a probabilidade de cancelamento com base em dados do cliente.",
+        topic: "Cargas de trabalho de IA",
+        options: [
+            ["Mineração de conhecimento", false],
+            ["Visão computacional", false],
+            ["IA generativa", false],
+            ["Machine learning", true],
+        ],
+    },
+    {
+        statement:
+            "Uma instituição financeira descobre que seu modelo de aprovação de crédito nega empréstimos com mais frequência para pessoas de determinado gênero, mesmo com perfis financeiros equivalentes. Qual princípio de IA responsável está sendo violado?",
+        explanation:
+            "A imparcialidade determina que os sistemas de IA devem tratar todas as pessoas de forma justa, sem favorecer ou prejudicar grupos com base em características como gênero ou etnia. O cenário descreve um viés discriminatório, que fere justamente a imparcialidade. Transparência trata da compreensão do sistema, confiabilidade e segurança do funcionamento correto, e inclusão de tornar a solução acessível a todos, não do viés nas decisões.",
+        topic: "IA responsável",
+        options: [
+            ["Transparência", false],
+            ["Imparcialidade", true],
+            ["Confiabilidade e segurança", false],
+            ["Inclusão", false],
+        ],
+    },
+    {
+        statement:
+            "Uma fabricante de veículos autônomos realiza testes rigorosos para garantir que o carro reaja de forma segura a situações inesperadas na estrada, como obstáculos repentinos. Qual princípio de IA responsável orienta essa preocupação?",
+        explanation:
+            "A confiabilidade e segurança exige que os sistemas de IA funcionem de maneira confiável e segura, inclusive diante de condições inesperadas, minimizando riscos de danos. Privacidade e segurança trata da proteção de dados, responsabilidade da governança e da prestação de contas, e transparência da compreensão do sistema, nenhuma delas focada em reagir com segurança a imprevistos.",
+        topic: "IA responsável",
+        options: [
+            ["Privacidade e segurança", false],
+            ["Responsabilidade", false],
+            ["Confiabilidade e segurança", true],
+            ["Transparência", false],
+        ],
+    },
+    {
+        statement:
+            "Ao construir um modelo na área da saúde, uma empresa precisa garantir que os dados pessoais dos pacientes sejam protegidos contra acesso indevido e usados apenas com consentimento. Qual princípio de IA responsável está em foco?",
+        explanation:
+            "O princípio de privacidade e segurança determina que os sistemas de IA respeitem a privacidade e protejam os dados contra acessos não autorizados. Imparcialidade trata de decisões justas, inclusão de acessibilidade para todos, e confiabilidade e segurança do funcionamento correto do sistema, não especificamente da proteção de dados pessoais e do consentimento.",
+        topic: "IA responsável",
+        options: [
+            ["Imparcialidade", false],
+            ["Inclusão", false],
+            ["Confiabilidade e segurança", false],
+            ["Privacidade e segurança", true],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe desenvolve um aplicativo com comandos de voz, legendas e leitores de tela para que pessoas com diferentes deficiências também consigam utilizá-lo plenamente. Qual princípio de IA responsável está sendo aplicado?",
+        explanation:
+            "A inclusão determina que os sistemas de IA capacitem e considerem todas as pessoas, incluindo aquelas com deficiências, oferecendo recursos de acessibilidade. Imparcialidade trata de evitar vieses nas decisões, transparência da compreensão do sistema e responsabilidade da governança, enquanto o cenário foca em tornar a solução acessível a todos.",
+        topic: "IA responsável",
+        options: [
+            ["Imparcialidade", false],
+            ["Inclusão", true],
+            ["Transparência", false],
+            ["Responsabilidade", false],
+        ],
+    },
+    {
+        statement:
+            "Os usuários de um sistema de recomendação devem ser informados de que estão interagindo com uma IA, de como ela funciona em linhas gerais e de quais são suas limitações. Qual princípio de IA responsável trata dessa necessidade?",
+        explanation:
+            "A transparência estabelece que os sistemas de IA devem ser compreensíveis, informando os usuários sobre seu propósito, funcionamento e limitações. Responsabilidade trata de quem responde pelo sistema, privacidade e segurança da proteção de dados, e imparcialidade de decisões justas, ao passo que o cenário destaca dar clareza aos usuários sobre o sistema.",
+        topic: "IA responsável",
+        options: [
+            ["Responsabilidade", false],
+            ["Privacidade e segurança", false],
+            ["Transparência", true],
+            ["Imparcialidade", false],
+        ],
+    },
+    {
+        statement:
+            "Uma organização define uma estrutura de governança em que pessoas e equipes são responsáveis pelo funcionamento dos sistemas de IA e devem prestar contas de acordo com normas internas e legais. Qual princípio de IA responsável isso representa?",
+        explanation:
+            "A responsabilidade (accountability) determina que as pessoas que projetam e operam sistemas de IA devem prestar contas por seu funcionamento, dentro de uma estrutura de governança e conforme normas e leis. Transparência trata de tornar o sistema compreensível, confiabilidade e segurança do funcionamento seguro, e inclusão da acessibilidade, não da prestação de contas e da governança.",
+        topic: "IA responsável",
+        options: [
+            ["Transparência", false],
+            ["Responsabilidade", true],
+            ["Confiabilidade e segurança", false],
+            ["Inclusão", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa vai adotar uma ferramenta de triagem de currículos e quer garantir que candidatos igualmente qualificados tenham as mesmas chances, sem que o modelo favoreça um grupo específico. Qual princípio de IA responsável deve orientar essa avaliação?",
+        explanation:
+            "Garantir que candidatos igualmente qualificados sejam tratados de forma equivalente, sem favorecer grupos específicos, é o cerne da imparcialidade. Confiabilidade e segurança trata do funcionamento correto do sistema, privacidade e segurança da proteção de dados, e transparência da compreensão do sistema, nenhuma voltada especificamente para evitar vieses na seleção.",
+        topic: "IA responsável",
+        options: [
+            ["Confiabilidade e segurança", false],
+            ["Privacidade e segurança", false],
+            ["Imparcialidade", true],
+            ["Transparência", false],
+        ],
+    },
+    {
+        statement:
+            "Um médico precisa entender quais fatores levaram um modelo de IA a indicar determinado diagnóstico, para poder confiar na recomendação e explicá-la ao paciente. Qual princípio de IA responsável está diretamente relacionado a essa capacidade de interpretar o modelo?",
+        explanation:
+            "A transparência inclui a interpretabilidade, ou seja, permitir que as pessoas entendam como e por que o modelo chegou a um resultado. Inclusão trata de acessibilidade, responsabilidade da prestação de contas e imparcialidade de decisões justas, mas é a transparência que garante que o médico compreenda os fatores por trás da recomendação.",
+        topic: "IA responsável",
+        options: [
+            ["Inclusão", false],
+            ["Transparência", true],
+            ["Responsabilidade", false],
+            ["Imparcialidade", false],
+        ],
+    },
+    {
+        statement:
+            "Durante um treinamento, os participantes devem identificar quais itens são princípios oficiais de IA responsável da Microsoft. Quais das opções a seguir são princípios válidos? (Selecione DUAS opções.)",
+        explanation:
+            "Inclusão e confiabilidade e segurança fazem parte dos seis princípios de IA responsável da Microsoft, junto de imparcialidade, privacidade e segurança, transparência e responsabilidade. Escalabilidade e lucratividade são características de negócio ou de arquitetura, mas não constam entre os princípios de IA responsável.",
+        topic: "IA responsável",
+        options: [
+            ["Inclusão", true],
+            ["Escalabilidade", false],
+            ["Confiabilidade e segurança", true],
+            ["Lucratividade", false],
+        ],
+    },
+    {
+        statement:
+            "Um chatbot de suporte médico deve manter comportamento consistente, evitar respostas perigosas e encaminhar o usuário a um atendente humano quando não tiver confiança na resposta. Qual princípio de IA responsável está sendo priorizado?",
+        explanation:
+            "Manter comportamento consistente, evitar respostas perigosas e adotar um plano de contingência com atendimento humano reflete a confiabilidade e segurança, que busca operação segura mesmo diante de incertezas. Inclusão trata de acessibilidade, transparência da compreensão do sistema e privacidade e segurança da proteção de dados, nenhuma focada no funcionamento seguro e consistente do chatbot.",
+        topic: "IA responsável",
+        options: [
+            ["Inclusão", false],
+            ["Transparência", false],
+            ["Confiabilidade e segurança", true],
+            ["Privacidade e segurança", false],
+        ],
+    },
+
+    // Domínio 2 - Machine learning
+    {
+        statement:
+            "Uma imobiliária deseja estimar o preço de venda de imóveis, em reais, a partir de características como área construída, número de quartos e bairro. O objetivo é prever um valor numérico contínuo. Qual tipo de aprendizado de máquina é o mais adequado?",
+        explanation:
+            "A regressão é indicada quando o rótulo a ser previsto é um número contínuo, como um preço em reais. A classificação, seja binária ou multiclasse, prevê categorias, e não valores numéricos. O agrupamento é não supervisionado e apenas junta itens semelhantes, sem estimar um preço específico.",
+        topic: "Machine learning",
+        options: [
+            ["Regressão", true],
+            ["Classificação binária", false],
+            ["Agrupamento (clustering)", false],
+            ["Classificação multiclasse", false],
+        ],
+    },
+    {
+        statement:
+            "Um banco quer um modelo que avalie cada transação de cartão e a rotule como fraudulenta ou legítima, ou seja, apenas um entre dois resultados possíveis. Que tipo de tarefa de machine learning representa esse cenário?",
+        explanation:
+            "Rotular cada transação como fraudulenta ou legítima é um problema de classificação binária, pois existem exatamente duas classes possíveis. A regressão prevê valores numéricos contínuos. O agrupamento não usa rótulos conhecidos. A previsão de séries temporais estima valores futuros ao longo do tempo, o que não é o objetivo aqui.",
+        topic: "Machine learning",
+        options: [
+            ["Classificação binária", true],
+            ["Regressão", false],
+            ["Agrupamento (clustering)", false],
+            ["Previsão de séries temporais", false],
+        ],
+    },
+    {
+        statement:
+            "Uma central de atendimento quer classificar automaticamente cada chamado em uma de cinco categorias: entrega, cobrança, cancelamento, elogio ou reclamação. Cada chamado pertence a exatamente uma categoria. Qual abordagem resolve o problema?",
+        explanation:
+            "Atribuir cada chamado a uma entre cinco categorias conhecidas é um caso de classificação multiclasse. A classificação binária serve apenas para duas classes. A regressão prevê números contínuos. O agrupamento descobriria grupos por conta própria, sem respeitar as categorias já definidas pelo negócio.",
+        topic: "Machine learning",
+        options: [
+            ["Classificação multiclasse", true],
+            ["Classificação binária", false],
+            ["Regressão", false],
+            ["Agrupamento (clustering)", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe de marketing tem uma base de clientes sem nenhum rótulo e quer descobrir grupos de pessoas com comportamento de compra parecido para personalizar campanhas. Não há categorias definidas de antemão. Qual técnica é a mais indicada?",
+        explanation:
+            "O agrupamento é uma técnica de aprendizado não supervisionado que reúne observações semelhantes sem precisar de rótulos definidos previamente, perfeita para segmentar clientes. As opções de classificação e regressão são supervisionadas e exigiriam rótulos conhecidos, que não existem nesse cenário.",
+        topic: "Machine learning",
+        options: [
+            ["Agrupamento (clustering)", true],
+            ["Classificação multiclasse", false],
+            ["Regressão", false],
+            ["Classificação binária", false],
+        ],
+    },
+    {
+        statement:
+            "Um conjunto de dados é usado para prever a nota final de alunos a partir de horas de estudo, percentual de frequência e média das provas anteriores. Nesse conjunto, o que representa o rótulo (label)?",
+        explanation:
+            "O rótulo (label) é o valor que o modelo aprende a prever, aqui a nota final do aluno. Horas de estudo, frequência e média das provas anteriores são as features, isto é, as variáveis de entrada utilizadas para chegar à previsão.",
+        topic: "Machine learning",
+        options: [
+            ["A nota final do aluno", true],
+            ["As horas de estudo", false],
+            ["O percentual de frequência", false],
+            ["A média das provas anteriores", false],
+        ],
+    },
+    {
+        statement:
+            "Uma cientista de dados treina um modelo para prever se um cliente vai cancelar o serviço. A tabela tem as colunas tempo de contrato, valor mensal, número de chamados ao suporte e a coluna cancelou, com valores sim ou não. Quais colunas atuam como features?",
+        explanation:
+            "As features são as variáveis de entrada que descrevem cada cliente: tempo de contrato, valor mensal e número de chamados. A coluna cancelou é o rótulo (label), ou seja, aquilo que o modelo deve prever, e por isso nunca é tratada como feature.",
+        topic: "Machine learning",
+        options: [
+            ["Tempo de contrato, valor mensal e número de chamados ao suporte", true],
+            ["Somente a coluna cancelou", false],
+            ["Somente o valor mensal", false],
+            ["Tempo de contrato e a coluna cancelou", false],
+        ],
+    },
+    {
+        statement:
+            "No aprendizado supervisionado o modelo é treinado com dados que já possuem rótulos conhecidos. Quais das tarefas a seguir são exemplos de aprendizado supervisionado? (Selecione DUAS opções.)",
+        explanation:
+            "Regressão e classificação são tarefas supervisionadas, pois o modelo aprende a partir de exemplos já rotulados, seja um valor numérico ou uma categoria. O agrupamento é não supervisionado, já que trabalha sem rótulos. A redução de dimensionalidade transforma as features, mas não é uma tarefa de previsão supervisionada.",
+        topic: "Machine learning",
+        options: [
+            ["Regressão para prever o faturamento do próximo mês", true],
+            ["Classificação para identificar se um e-mail é spam", true],
+            ["Agrupamento de clientes por comportamento sem rótulos", false],
+            ["Redução de dimensionalidade das features de entrada", false],
+        ],
+    },
+    {
+        statement:
+            "Um serviço de streaming quer prever, para cada usuário, se ele vai dar a um filme uma avaliação de 1, 2, 3, 4 ou 5 estrelas, tratando cada quantidade de estrelas como uma categoria distinta. Qual tipo de tarefa melhor descreve esse objetivo?",
+        explanation:
+            "Como cada nota de estrelas é tratada como uma categoria distinta e existem cinco delas, o problema é de classificação multiclasse. A classificação binária só funcionaria com duas classes. O agrupamento não usaria as categorias já conhecidas. Se o objetivo fosse prever um número contínuo qualquer, a regressão seria a escolha, mas aqui as estrelas são categorias fixas.",
+        topic: "Machine learning",
+        options: [
+            ["Classificação multiclasse", true],
+            ["Regressão linear simples", false],
+            ["Agrupamento (clustering)", false],
+            ["Classificação binária", false],
+        ],
+    },
+    {
+        statement:
+            "Uma rede de varejo possui milhões de registros de compras sem qualquer classificação e quer que o próprio algoritmo descubra padrões e agrupe produtos frequentemente comprados juntos. Não existe um rótulo indicando a que grupo cada produto pertence. Que tipo de aprendizado se aplica?",
+        explanation:
+            "Sem rótulos predefinidos e com o objetivo de descobrir grupos naturais nos dados, o cenário pede aprendizado não supervisionado, tipicamente o agrupamento. Todas as opções supervisionadas dependeriam de rótulos conhecidos para treinar, o que não está disponível nesse caso.",
+        topic: "Machine learning",
+        options: [
+            ["Aprendizado não supervisionado com agrupamento", true],
+            ["Aprendizado supervisionado com regressão", false],
+            ["Aprendizado supervisionado com classificação binária", false],
+            ["Aprendizado supervisionado com classificação multiclasse", false],
+        ],
+    },
+    {
+        statement:
+            "Ao construir um modelo, uma analista separa parte dos dados e não os utiliza durante o treinamento, reservando-os apenas para medir o desempenho no final. Qual é o principal motivo para manter esse conjunto de teste separado?",
+        explanation:
+            "O conjunto de teste é mantido separado para estimar de forma honesta o desempenho do modelo em dados novos, que ele não viu durante o treino. Isso ajuda a detectar overfitting. Reservar dados para teste não aumenta o conjunto de treino, não acelera o treinamento e não substitui a escolha de métricas de avaliação.",
+        topic: "Machine learning",
+        options: [
+            ["Avaliar como o modelo se sai com dados que nunca viu durante o treino", true],
+            ["Aumentar a quantidade de dados de treinamento disponíveis", false],
+            ["Acelerar o processo de treinamento do modelo", false],
+            ["Eliminar a necessidade de escolher métricas de avaliação", false],
+        ],
+    },
+    {
+        statement:
+            "Durante a avaliação, um modelo apresenta acurácia muito alta nos dados de treino, mas desempenho bem pior nos dados de teste. Qual problema esse comportamento indica?",
+        explanation:
+            "Quando o modelo vai muito bem no treino e mal no teste, ele memorizou padrões específicos dos dados de treinamento e não generaliza, o que caracteriza overfitting. O underfitting apareceria como desempenho ruim tanto no treino quanto no teste. As demais opções descrevem outros problemas que não correspondem a esse padrão de treino alto e teste baixo.",
+        topic: "Machine learning",
+        options: [
+            ["Overfitting (sobreajuste) aos dados de treino", true],
+            ["Underfitting por modelo simples demais", false],
+            ["Vazamento de rótulos no conjunto de teste", false],
+            ["Desbalanceamento das classes de saída", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe percebe que seu modelo está sofrendo overfitting. Qual das ações a seguir tende a reduzir esse problema?",
+        explanation:
+            "Adicionar mais dados representativos ou reduzir a complexidade do modelo ajuda a melhorar a generalização e combater o overfitting. Treinar por mais épocas nos mesmos dados ou aumentar a complexidade tende a piorar o sobreajuste. Avaliar somente com os dados de treino esconde o problema em vez de resolvê-lo.",
+        topic: "Machine learning",
+        options: [
+            ["Fornecer mais dados de treinamento ou simplificar o modelo", true],
+            ["Treinar o modelo por muito mais épocas nos mesmos dados", false],
+            ["Aumentar a complexidade do modelo indefinidamente", false],
+            ["Avaliar o modelo apenas com os dados de treino", false],
+        ],
+    },
+    {
+        statement:
+            "Em um problema de classificação com classes equilibradas, uma analista quer uma métrica simples que represente a proporção de previsões corretas em relação ao total de previsões. Qual métrica atende diretamente a essa definição?",
+        explanation:
+            "A acurácia é a proporção de previsões corretas sobre o total de previsões, adequada quando as classes estão equilibradas. O R² e o RMSE são métricas de regressão, não de classificação. A silhueta avalia a qualidade de agrupamentos no aprendizado não supervisionado.",
+        topic: "Machine learning",
+        options: [
+            ["Acurácia", true],
+            ["Coeficiente de determinação (R²)", false],
+            ["Erro quadrático médio (RMSE)", false],
+            ["Silhueta do agrupamento", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe vai avaliar um modelo de classificação e precisa escolher métricas apropriadas para esse tipo de tarefa. Quais das opções a seguir são métricas de classificação? (Selecione DUAS opções.)",
+        explanation:
+            "Precisão e revocação são métricas típicas de classificação, calculadas a partir da matriz de confusão. O R² e o erro quadrático médio (RMSE) avaliam modelos de regressão, que preveem valores numéricos, e não categorias, por isso não se aplicam à classificação.",
+        topic: "Machine learning",
+        options: [
+            ["Precisão (precision)", true],
+            ["Revocação (recall)", true],
+            ["Coeficiente de determinação (R²)", false],
+            ["Erro quadrático médio (RMSE)", false],
+        ],
+    },
+    {
+        statement:
+            "Após treinar um modelo de regressão para prever o consumo de energia, uma analista obtém um valor de R² próximo de 0,95. O que esse resultado indica de forma geral?",
+        explanation:
+            "O R² (coeficiente de determinação) varia tipicamente de 0 a 1 e indica a proporção da variação dos valores reais que o modelo consegue explicar, então 0,95 sugere um bom ajuste em regressão. Ele não mede acurácia de classificação, nem revocação, nem número de clusters, pois essas são interpretações de outros tipos de tarefa.",
+        topic: "Machine learning",
+        options: [
+            ["O modelo explica boa parte da variação dos valores reais", true],
+            ["O modelo classificou 95% das amostras corretamente", false],
+            ["O modelo teve 95% de revocação nas classes positivas", false],
+            ["O modelo agrupou os dados em 95 clusters distintos", false],
+        ],
+    },
+    {
+        statement:
+            "Em um modelo de classificação binária que detecta doença, uma célula da matriz de confusão conta os casos em que o modelo previu doente, mas o paciente na verdade estava saudável. Como esses casos são chamados?",
+        explanation:
+            "Quando o modelo prevê a classe positiva (doente), mas o valor real é negativo (saudável), o caso é um falso positivo. Verdadeiro positivo seria prever doente para quem realmente está doente. Falso negativo seria prever saudável para quem está doente. Verdadeiro negativo seria prever saudável para quem está de fato saudável.",
+        topic: "Machine learning",
+        options: [
+            ["Falsos positivos", true],
+            ["Verdadeiros positivos", false],
+            ["Falsos negativos", false],
+            ["Verdadeiros negativos", false],
+        ],
+    },
+    {
+        statement:
+            "Uma organização vai começar a usar o Azure Machine Learning e precisa de um recurso central que reúna experimentos, modelos registrados, destinos de computação, endpoints e datastores em um único lugar. Qual recurso deve ser criado primeiro?",
+        explanation:
+            "O workspace do Azure Machine Learning é o recurso de nível superior que centraliza e organiza todos os artefatos, como experimentos, modelos, computação e endpoints. O Azure AI Search serve para busca, um serviço cognitivo isolado entrega modelos prontos e uma máquina virtual comum não oferece a estrutura de gestão de ativos de machine learning.",
+        topic: "Machine learning",
+        options: [
+            ["Um workspace do Azure Machine Learning", true],
+            ["Um recurso de Azure AI Search", false],
+            ["Uma conta de serviço cognitivo isolada", false],
+            ["Uma máquina virtual comum do Azure", false],
+        ],
+    },
+    {
+        statement:
+            "Uma pessoa sem experiência em programação quer treinar um modelo no Azure Machine Learning usando o Automated ML (AutoML). Quais afirmações sobre o AutoML estão corretas? (Selecione DUAS opções.)",
+        explanation:
+            "O AutoML experimenta automaticamente diferentes algoritmos e hiperparâmetros e compara os resultados para indicar o melhor modelo, com suporte a classificação, regressão e previsão de séries temporais. Ele foi criado justamente para reduzir a necessidade de codificar o treinamento manualmente e não se limita a agrupamento, então as duas últimas afirmações estão incorretas.",
+        topic: "Machine learning",
+        options: [
+            [
+                "Ele testa automaticamente vários algoritmos e configurações para encontrar um bom modelo",
+                true,
+            ],
+            [
+                "Ele oferece suporte a tarefas como classificação, regressão e previsão de séries temporais",
+                true,
+            ],
+            ["Ele exige que o usuário escreva manualmente todo o código de treinamento", false],
+            ["Ele funciona apenas para tarefas de agrupamento não supervisionado", false],
+        ],
+    },
+    {
+        statement:
+            "Uma analista quer montar um fluxo de treinamento e implantação arrastando e conectando componentes visuais, sem escrever código, dentro do Azure Machine Learning. Qual recurso é o mais indicado?",
+        explanation:
+            "O Designer oferece uma interface visual de arrastar e soltar para construir pipelines de treinamento e implantação sem escrever código, ideal para o cenário descrito. O SDK em Python e a CLI exigem código ou comandos. Os endpoints em lote servem para pontuar grandes volumes de dados, não para montar o fluxo visualmente.",
+        topic: "Machine learning",
+        options: [
+            ["O Designer do Azure Machine Learning", true],
+            ["O SDK do Azure Machine Learning em Python", false],
+            ["A CLI do Azure Machine Learning", false],
+            ["Os endpoints em lote (batch)", false],
+        ],
+    },
+    {
+        statement:
+            "Depois de treinar um modelo, uma equipe precisa disponibilizá-lo para receber requisições individuais e devolver previsões em tempo real, com baixa latência, para um aplicativo web. Qual recurso do Azure Machine Learning atende a essa necessidade?",
+        explanation:
+            "Um endpoint online, também chamado de tempo real, expõe o modelo como serviço para responder a requisições individuais com baixa latência, exatamente o que um aplicativo web precisa. O endpoint em lote é assíncrono e voltado a grandes volumes. A instância de computação serve para desenvolvimento e o datastore apenas armazena dados, sem servir previsões.",
+        topic: "Machine learning",
+        options: [
+            ["Um endpoint online (em tempo real)", true],
+            ["Um endpoint em lote (batch)", false],
+            ["Uma instância de computação para desenvolvimento", false],
+            ["Um datastore para armazenamento de dados", false],
+        ],
+    },
+
+    // Domínio 3 - Visão computacional
+    {
+        statement:
+            "Uma equipe precisa de um modelo que, para cada foto de uma prateleira de supermercado, informe não apenas quais produtos aparecem, mas também a posição de cada um por meio de coordenadas retangulares na imagem. Qual tarefa de visão computacional atende a esse requisito?",
+        explanation:
+            "A detecção de objetos identifica cada item e retorna sua localização por meio de uma caixa delimitadora (bounding box) com coordenadas. A classificação de imagem apenas atribui um rótulo à imagem inteira, sem indicar posição. A descrição de imagem gera uma legenda em linguagem natural e o OCR lê texto, nenhum deles fornece as coordenadas dos produtos.",
+        topic: "Visão computacional",
+        options: [
+            ["Detecção de objetos", true],
+            ["Classificação de imagem", false],
+            ["Descrição de imagem", false],
+            ["Extração de texto com OCR", false],
+        ],
+    },
+    {
+        statement:
+            "Um aplicativo de reciclagem recebe uma foto e precisa responder apenas se o objeto fotografado é vidro, papel, plástico ou metal, sem se preocupar com a posição do objeto na imagem. Qual tarefa de visão computacional melhor descreve esse cenário?",
+        explanation:
+            "Atribuir um único rótulo de categoria à imagem inteira é o papel da classificação de imagem. A detecção de objetos e a segmentação semântica seriam usadas se fosse necessário localizar o objeto, com caixa delimitadora ou por pixel. O reconhecimento facial trata de identificar pessoas, o que não se aplica aqui.",
+        topic: "Visão computacional",
+        options: [
+            ["Classificação de imagem", true],
+            ["Detecção de objetos", false],
+            ["Segmentação semântica", false],
+            ["Reconhecimento facial", false],
+        ],
+    },
+    {
+        statement:
+            "Em um projeto de análise de imagens de satélite, o objetivo é classificar cada pixel da imagem como floresta, água ou área urbana, de modo a colorir regiões inteiras conforme sua categoria. Qual técnica de visão computacional corresponde a essa abordagem em nível de pixel?",
+        explanation:
+            "A segmentação semântica classifica individualmente cada pixel de acordo com a categoria a que pertence, permitindo pintar regiões inteiras. A detecção de objetos apenas desenha caixas retangulares ao redor dos itens e a classificação de imagem gera um único rótulo para toda a imagem. O OCR não se aplica, pois trata de texto.",
+        topic: "Visão computacional",
+        options: [
+            ["Segmentação semântica", true],
+            ["Detecção de objetos", false],
+            ["Classificação de imagem", false],
+            ["Leitura de texto com OCR", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer digitalizar notas fiscais fotografadas e extrair o texto impresso e também anotações manuscritas contidas nelas. Qual recurso do Azure AI Vision deve ser utilizado?",
+        explanation:
+            "O recurso Read do Azure AI Vision é o OCR do serviço e extrai tanto texto impresso quanto manuscrito de imagens e documentos. A descrição gera uma legenda da cena, a detecção de objetos localiza itens com caixas delimitadoras e a geração de tags apenas lista elementos visuais, nenhum deles retorna o conteúdo textual.",
+        topic: "Visão computacional",
+        options: [
+            ["O recurso Read (OCR)", true],
+            ["A geração de descrição (caption)", false],
+            ["A detecção de objetos", false],
+            ["A geração de tags", false],
+        ],
+    },
+    {
+        statement:
+            "Sem treinar nenhum modelo, um desenvolvedor quer enviar fotos genéricas e receber automaticamente uma legenda descritiva e uma lista de marcações (tags) com os elementos presentes, como 'cachorro', 'grama' e 'ao ar livre'. Qual serviço oferece esses recursos prontos?",
+        explanation:
+            "O Azure AI Vision é um serviço pré-treinado que analisa imagens e retorna descrições e tags de objetos e cenas comuns, sem necessidade de treinamento. O Custom Vision exigiria treinar um modelo com imagens próprias. O Face trata especificamente de rostos e o Azure AI Language é voltado ao processamento de linguagem, não de imagens.",
+        topic: "Visão computacional",
+        options: [
+            ["Azure AI Vision", true],
+            ["Custom Vision", false],
+            ["Face", false],
+            ["Azure AI Language", false],
+        ],
+    },
+    {
+        statement:
+            "Uma indústria fabrica peças metálicas exclusivas e precisa de um modelo que classifique fotos dessas peças em categorias específicas que não existem em modelos genéricos. A equipe possui milhares de imagens rotuladas dessas peças. Qual serviço é o mais adequado?",
+        explanation:
+            "O Custom Vision permite treinar um classificador com as imagens rotuladas da própria empresa, ideal para categorias específicas que não constam em modelos prontos. O Azure AI Vision é pré-treinado para objetos comuns e não reconheceria essas peças exclusivas. O Face é para rostos e o recurso Read é para texto.",
+        topic: "Visão computacional",
+        options: [
+            ["Custom Vision", true],
+            ["Azure AI Vision", false],
+            ["Face", false],
+            ["O recurso Read", false],
+        ],
+    },
+    {
+        statement:
+            "Um sistema de controle de acesso corporativo precisa detectar rostos em fotos e verificar se o rosto capturado pela câmera pertence a um funcionário já cadastrado. Qual serviço do Azure é projetado para isso?",
+        explanation:
+            "O serviço Face é especializado em detecção de rostos e em recursos como verificação (comparar se dois rostos são da mesma pessoa) e identificação. O Azure AI Vision faz apenas detecção básica de rostos, sem identificação. O Custom Vision trata de classificação e detecção de objetos genéricos e o Azure AI Language não lida com imagens.",
+        topic: "Visão computacional",
+        options: [
+            ["Face", true],
+            ["Custom Vision", false],
+            ["Azure AI Vision", false],
+            ["Azure AI Language", false],
+        ],
+    },
+    {
+        statement:
+            "Um blog de viagens quer gerar automaticamente legendas em linguagem natural e tags para milhares de fotos de paisagens, cidades e comida comuns, sem investir tempo em treinamento de modelos. Qual é a melhor escolha?",
+        explanation:
+            "Como as imagens contêm objetos e cenas comuns e não há interesse em treinar modelos, o Azure AI Vision é ideal, pois já oferece descrição e tags prontas. O Custom Vision só faz sentido quando as categorias são específicas e exigem treinamento. O Face é para rostos e o Read é para texto, nenhum gera legendas de cena.",
+        topic: "Visão computacional",
+        options: [
+            ["Usar o Azure AI Vision, que já vem pré-treinado para cenas e objetos comuns", true],
+            ["Usar o Custom Vision, treinando um modelo com as fotos do blog", false],
+            ["Usar o serviço Face para gerar as legendas", false],
+            ["Usar o recurso Read para gerar as tags", false],
+        ],
+    },
+    {
+        statement:
+            "Sua equipe avalia o serviço Azure AI Vision e quer saber quais capacidades ele oferece de forma pré-treinada, sem necessidade de treinar modelos. Quais das opções a seguir são fornecidas pelo Azure AI Vision? (Selecione DUAS opções.)",
+        explanation:
+            "O Azure AI Vision oferece, prontos para uso, a geração de tags e descrições e o recurso Read para OCR. Treinar um classificador com imagens próprias é função do Custom Vision e identificar uma pessoa específica é função do serviço Face.",
+        topic: "Visão computacional",
+        options: [
+            ["Geração de tags e descrição para imagens", true],
+            ["Leitura de texto impresso e manuscrito com o recurso Read", true],
+            ["Treinamento de um classificador com imagens rotuladas próprias", false],
+            ["Identificação de qual funcionário específico aparece na foto", false],
+        ],
+    },
+    {
+        statement:
+            "Um aplicativo de fotografia precisa apenas localizar onde estão os rostos em cada imagem, desenhando um retângulo ao redor de cada face, sem identificar quem são as pessoas. Qual tarefa descreve esse requisito?",
+        explanation:
+            "A detecção facial localiza rostos e retorna suas coordenadas (caixa delimitadora), sem dizer de quem são. A identificação facial iria além, associando cada rosto a uma pessoa conhecida. A classificação de imagem daria um rótulo único à imagem e a segmentação semântica trabalharia em nível de pixel, o que não é necessário aqui.",
+        topic: "Visão computacional",
+        options: [
+            ["Detecção facial", true],
+            ["Identificação facial", false],
+            ["Classificação de imagem", false],
+            ["Segmentação semântica", false],
+        ],
+    },
+    {
+        statement:
+            "Uma rede de lojas quer um modelo que localize, com caixas delimitadoras, apenas os seus próprios produtos de marca própria dentro de fotos de prateleiras. Esses produtos não são reconhecidos por modelos genéricos. Qual abordagem é a correta?",
+        explanation:
+            "Como os produtos são específicos da marca e não constam em modelos prontos, é preciso treinar um modelo de detecção de objetos no Custom Vision, marcando as caixas nas imagens de exemplo. A detecção do Azure AI Vision só reconhece objetos comuns. O Face é para rostos e o Read é para texto.",
+        topic: "Visão computacional",
+        options: [
+            [
+                "Criar um projeto de detecção de objetos no Custom Vision com imagens rotuladas dos produtos",
+                true,
+            ],
+            ["Usar a detecção de objetos pré-treinada do Azure AI Vision", false],
+            ["Usar o serviço Face para localizar os produtos", false],
+            ["Usar o recurso Read para localizar os produtos", false],
+        ],
+    },
+    {
+        statement:
+            "Ao avaliar o recurso Read do Azure AI Vision, um analista pergunta que tipos de texto ele consegue extrair de imagens. Qual afirmação está correta?",
+        explanation:
+            "O recurso Read realiza OCR e reconhece texto impresso e manuscrito, retornando o conteúdo textual e sua localização. As demais opções limitam incorretamente as capacidades do recurso.",
+        topic: "Visão computacional",
+        options: [
+            ["Ele extrai tanto texto impresso quanto manuscrito", true],
+            ["Ele extrai apenas texto impresso, nunca manuscrito", false],
+            ["Ele extrai apenas texto manuscrito, nunca impresso", false],
+            ["Ele apenas conta quantas palavras existem, sem extrair o conteúdo", false],
+        ],
+    },
+    {
+        statement:
+            "Durante uma revisão de conceitos, um estudante pergunta qual a diferença fundamental entre classificação de imagem e segmentação semântica. Qual resposta está correta?",
+        explanation:
+            "A classificação de imagem gera um rótulo para a imagem como um todo, enquanto a segmentação semântica atribui uma categoria a cada pixel, permitindo delimitar regiões com precisão. As outras opções invertem os conceitos ou descrevem tarefas diferentes, como detecção de objetos, OCR ou detecção facial.",
+        topic: "Visão computacional",
+        options: [
+            [
+                "A classificação atribui um rótulo à imagem inteira, enquanto a segmentação semântica classifica cada pixel individualmente",
+                true,
+            ],
+            [
+                "A classificação trabalha pixel a pixel, enquanto a segmentação atribui um único rótulo à imagem",
+                false,
+            ],
+            ["Ambas retornam apenas caixas delimitadoras ao redor dos objetos", false],
+            ["A classificação lê texto e a segmentação detecta rostos", false],
+        ],
+    },
+    {
+        statement:
+            "Um leitor de tela para pessoas com deficiência visual precisa gerar automaticamente uma frase que descreva o conteúdo geral de uma foto, como 'uma pessoa andando de bicicleta em um parque'. Qual recurso do Azure AI Vision fornece essa frase?",
+        explanation:
+            "A descrição, ou caption, do Azure AI Vision gera uma frase em linguagem natural resumindo o conteúdo da imagem, útil para acessibilidade. A detecção de objetos apenas lista itens com coordenadas, o Read extrai texto e a miniatura inteligente recorta a imagem, nenhum produz a frase descritiva.",
+        topic: "Visão computacional",
+        options: [
+            ["A descrição (caption) da imagem", true],
+            ["A detecção de objetos", false],
+            ["O recurso Read", false],
+            ["A geração de miniatura inteligente", false],
+        ],
+    },
+    {
+        statement:
+            "Ao criar um novo projeto no Custom Vision, você deve escolher o tipo de projeto conforme o objetivo. Quais são os dois tipos de projeto oferecidos pelo Custom Vision? (Selecione DUAS opções.)",
+        explanation:
+            "O Custom Vision permite criar projetos de classificação de imagem (rótulo para a imagem inteira) e de detecção de objetos (localização com caixas delimitadoras). Segmentação semântica em nível de pixel não é um tipo de projeto do Custom Vision e a identificação facial pertence ao serviço Face.",
+        topic: "Visão computacional",
+        options: [
+            ["Classificação de imagem", true],
+            ["Detecção de objetos", true],
+            ["Segmentação semântica de pixels", false],
+            ["Identificação facial", false],
+        ],
+    },
+    {
+        statement:
+            "Um banco quer confirmar, no momento do login, se a selfie enviada pelo cliente corresponde à foto de referência que ele cadastrou. Trata-se de comparar dois rostos para dizer se são da mesma pessoa. Que capacidade do serviço Face atende a isso?",
+        explanation:
+            "A verificação facial compara dois rostos e indica se pertencem à mesma pessoa, exatamente o cenário descrito. A detecção de objetos, a geração de tags e a segmentação semântica não lidam com comparação de identidade facial.",
+        topic: "Visão computacional",
+        options: [
+            ["Verificação facial", true],
+            ["Detecção de objetos", false],
+            ["Geração de tags", false],
+            ["Segmentação semântica", false],
+        ],
+    },
+    {
+        statement:
+            "Uma vinícola quer um modelo que reconheça os rótulos exclusivos dos seus vinhos a partir de fotos, categorizando cada garrafa por safra e tipo. Esses rótulos não existem em nenhum modelo genérico. Qual serviço deve ser escolhido e por quê?",
+        explanation:
+            "Como as categorias (safra e tipo dos rótulos exclusivos) são específicas e não constam em modelos prontos, o Custom Vision é o correto, pois permite treinar com as imagens da vinícola. O Azure AI Vision não reconhece rótulos exclusivos automaticamente. O Face é para rostos e o Azure AI Language processa texto, não imagens de rótulos.",
+        topic: "Visão computacional",
+        options: [
+            [
+                "Custom Vision, porque as categorias são específicas e exigem treinamento com imagens próprias",
+                true,
+            ],
+            [
+                "Azure AI Vision, porque ele reconhece qualquer rótulo de vinho automaticamente",
+                false,
+            ],
+            ["Face, porque é preciso reconhecer padrões visuais", false],
+            ["Azure AI Language, porque envolve nomes de vinhos", false],
+        ],
+    },
+    {
+        statement:
+            "Um sistema de moderação precisa apenas marcar fotos que contenham objetos comuns, como 'carro', 'praia' ou 'comida', usando categorias genéricas amplamente conhecidas. A equipe não quer treinar modelos. Qual serviço atende melhor?",
+        explanation:
+            "Para objetos e cenas comuns sem treinamento, o Azure AI Vision já oferece tags pré-treinadas, sendo a opção mais rápida e simples. Treinar no Custom Vision seria trabalho desnecessário para categorias genéricas. O Face é para rostos e o Read é para texto, não para marcar objetos comuns.",
+        topic: "Visão computacional",
+        options: [
+            ["Azure AI Vision, com sua geração de tags pré-treinada", true],
+            ["Custom Vision, treinando um detector para cada objeto comum", false],
+            ["Face, para marcar os objetos comuns", false],
+            ["O recurso Read, para marcar os objetos comuns", false],
+        ],
+    },
+    {
+        statement:
+            "Um arquiteto de soluções quer saber quais tarefas de visão computacional fornecem informação sobre a localização de elementos dentro da imagem, e não apenas um rótulo geral. Quais das tarefas a seguir retornam localização? (Selecione DUAS opções.)",
+        explanation:
+            "A detecção de objetos indica a posição por meio de caixas delimitadoras e a segmentação semântica localiza elementos em nível de pixel, ambas fornecem localização. A classificação de imagem apenas rotula a imagem toda e a descrição gera uma frase da cena, sem indicar onde os elementos estão.",
+        topic: "Visão computacional",
+        options: [
+            ["Detecção de objetos, que retorna caixas delimitadoras", true],
+            ["Segmentação semântica, que classifica cada pixel", true],
+            ["Classificação de imagem, que atribui um rótulo à imagem inteira", false],
+            ["Geração de descrição, que resume a cena em uma frase", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe precisa apenas contar quantas pessoas aparecem em fotos, detectando a presença de rostos, sem identificar ninguém. Um colega afirma que tanto o Azure AI Vision quanto o serviço Face detectam rostos. Qual afirmação é correta sobre essa escolha?",
+        explanation:
+            "O Azure AI Vision detecta rostos e retorna suas posições, o que basta para contar pessoas. O serviço Face vai além, com verificação e identificação de pessoas. As demais opções são incorretas: o Custom Vision trata de objetos genéricos, o Azure AI Language processa texto e o serviço Face certamente detecta rostos, além de não ler texto.",
+        topic: "Visão computacional",
+        options: [
+            [
+                "O Azure AI Vision consegue detectar rostos e retornar suas posições, enquanto o serviço Face oferece recursos mais avançados, como identificação e verificação",
+                true,
+            ],
+            ["Somente o Custom Vision consegue detectar rostos", false],
+            ["Nenhum dos dois consegue detectar rostos, é preciso usar o Azure AI Language", false],
+            ["O serviço Face não consegue detectar rostos, apenas ler texto", false],
+        ],
+    },
+
+    // Domínio 4 - Processamento de linguagem natural
+    {
+        statement:
+            "Uma rede de hotéis quer analisar automaticamente milhares de avaliações de hóspedes para classificar cada comentário como positivo, negativo ou neutro, junto com uma pontuação de confiança. Qual recurso do Azure AI Language atende a essa necessidade?",
+        explanation:
+            "A análise de sentimento avalia o texto e retorna rótulos (positivo, negativo, neutro ou misto) com pontuações de confiança entre 0 e 1, exatamente o que a rede precisa para classificar as avaliações. A extração de frases-chave apenas lista os principais tópicos, sem julgar o tom. O reconhecimento de entidades nomeadas identifica pessoas, locais e organizações, e a detecção de idioma apenas informa o idioma do texto.",
+        topic: "Processamento de linguagem natural",
+        options: [
+            ["Análise de sentimento", true],
+            ["Extração de frases-chave", false],
+            ["Reconhecimento de entidades nomeadas", false],
+            ["Detecção de idioma", false],
+        ],
+    },
+    {
+        statement:
+            "Um portal de notícias deseja exibir, ao lado de cada artigo, uma lista curta com os principais assuntos abordados no texto, sem gerar frases novas nem resumos. Qual tarefa de PLN do Azure AI Language é a mais indicada?",
+        explanation:
+            "A extração de frases-chave identifica e retorna os termos e as expressões mais relevantes de um documento, ideal para destacar os principais assuntos de um artigo. A análise de sentimento mede o tom emocional, a tradução de texto converte o conteúdo para outro idioma e a conversão de fala em texto pertence ao Azure AI Speech e trabalha com áudio, não com texto escrito.",
+        topic: "Processamento de linguagem natural",
+        options: [
+            ["Análise de sentimento", false],
+            ["Extração de frases-chave", true],
+            ["Tradução de texto", false],
+            ["Conversão de fala em texto", false],
+        ],
+    },
+    {
+        statement:
+            "Um escritório de advocacia precisa varrer contratos e localizar automaticamente nomes de pessoas, empresas, datas e valores monetários mencionados no texto. Qual recurso do Azure AI Language deve ser usado?",
+        explanation:
+            "O reconhecimento de entidades nomeadas (NER) identifica e categoriza elementos do texto como pessoas, organizações, locais, datas e quantidades, atendendo à necessidade de localizar nomes, empresas, datas e valores. A análise de sentimento mede o tom, a sumarização condensa o documento e a detecção de idioma apenas identifica o idioma predominante.",
+        topic: "Processamento de linguagem natural",
+        options: [
+            ["Reconhecimento de entidades nomeadas (NER)", true],
+            ["Análise de sentimento", false],
+            ["Sumarização", false],
+            ["Detecção de idioma", false],
+        ],
+    },
+    {
+        statement:
+            "Um serviço de atendimento recebe mensagens de clientes de vários países e precisa identificar automaticamente em qual idioma cada mensagem foi escrita antes de encaminhá-la ao time correto. Qual recurso do Azure AI Language resolve isso?",
+        explanation:
+            "A detecção de idioma analisa um texto e retorna o idioma identificado, seu código ISO e uma pontuação de confiança, permitindo rotear a mensagem para o time certo. A extração de frases-chave e a análise de sentimento trabalham o conteúdo, não o idioma, e a tradução de fala pertence ao Azure AI Speech e lida com áudio.",
+        topic: "Processamento de linguagem natural",
+        options: [
+            ["Extração de frases-chave", false],
+            ["Análise de sentimento", false],
+            ["Detecção de idioma", true],
+            ["Tradução de fala", false],
+        ],
+    },
+    {
+        statement:
+            "Uma consultoria quer gerar automaticamente um resumo curto de relatórios longos, selecionando as frases mais importantes do próprio documento para dar aos executivos uma visão rápida. Qual recurso do Azure AI Language é o mais adequado?",
+        explanation:
+            "A sumarização produz uma versão condensada de um documento longo, na modalidade extrativa selecionando as frases mais relevantes do texto original. A extração de frases-chave retorna apenas termos soltos, e não frases que resumem o documento. O NER identifica entidades e a análise de sentimento mede o tom, e nenhum dos dois gera um resumo.",
+        topic: "Processamento de linguagem natural",
+        options: [
+            ["Sumarização", true],
+            ["Extração de frases-chave", false],
+            ["Reconhecimento de entidades nomeadas", false],
+            ["Análise de sentimento", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa grava reuniões e quer transcrever automaticamente o áudio falado em português para um documento de texto na mesma língua. Qual serviço e recurso do Azure devem ser usados?",
+        explanation:
+            "A conversão de fala em texto (speech-to-text) do Azure AI Speech transcreve áudio falado em texto no mesmo idioma, atendendo à necessidade de transcrever reuniões em português. A extração de frases-chave trabalha com texto já escrito, a tradução de texto do Translator mudaria o idioma e a conversão de texto em fala faz o caminho inverso, gerando áudio a partir de texto.",
+        topic: "Processamento de linguagem natural",
+        options: [
+            ["Azure AI Speech, conversão de fala em texto", true],
+            ["Azure AI Language, extração de frases-chave", false],
+            ["Azure AI Translator, tradução de texto", false],
+            ["Azure AI Speech, conversão de texto em fala", false],
+        ],
+    },
+    {
+        statement:
+            "Um aplicativo de acessibilidade precisa ler em voz alta, com uma voz natural, o conteúdo textual exibido na tela para usuários com deficiência visual. Qual recurso do Azure AI Speech deve ser utilizado?",
+        explanation:
+            "A conversão de texto em fala (text-to-speech) sintetiza áudio com voz natural a partir de um texto, permitindo ler o conteúdo da tela para o usuário. A conversão de fala em texto faz o inverso, transcrevendo áudio. A tradução de fala muda o idioma do áudio e a detecção de idioma é uma tarefa do Azure AI Language.",
+        topic: "Processamento de linguagem natural",
+        options: [
+            ["Conversão de texto em fala (text-to-speech)", true],
+            ["Conversão de fala em texto (speech-to-text)", false],
+            ["Tradução de fala", false],
+            ["Detecção de idioma", false],
+        ],
+    },
+    {
+        statement:
+            "Uma loja virtual precisa traduzir as descrições dos seus produtos, escritas em português, para inglês, espanhol e francês, mantendo o conteúdo como texto escrito. Qual serviço do Azure é o mais indicado?",
+        explanation:
+            "O Azure AI Translator faz tradução automática de texto entre mais de uma centena de idiomas, ideal para converter descrições de produtos para vários idiomas de destino. O Azure AI Speech lida com áudio, o Azure AI Language cobre tarefas como sentimento e entidades, mas não tradução, e o Azure AI Vision trata de imagens.",
+        topic: "Processamento de linguagem natural",
+        options: [
+            ["Azure AI Speech", false],
+            ["Azure AI Translator", true],
+            ["Azure AI Language", false],
+            ["Azure AI Vision", false],
+        ],
+    },
+    {
+        statement:
+            "Durante conferências internacionais, uma organização quer que a fala de um palestrante em inglês seja convertida, em tempo real, em áudio falado em português para a plateia. Qual recurso do Azure AI Speech atende a esse cenário?",
+        explanation:
+            "A tradução de fala do Azure AI Speech recebe áudio em um idioma e produz a fala traduzida em outro, permitindo levar o palestrante em inglês para a plateia em português. A conversão de fala em texto apenas transcreve no mesmo idioma, a conversão de texto em fala parte de texto escrito e o reconhecimento de locutor identifica quem está falando.",
+        topic: "Processamento de linguagem natural",
+        options: [
+            ["Tradução de fala", true],
+            ["Conversão de fala em texto", false],
+            ["Conversão de texto em fala", false],
+            ["Reconhecimento de locutor", false],
+        ],
+    },
+    {
+        statement:
+            "Um analista precisa entender a diferença entre transcrever e traduzir. Um áudio gravado em espanhol precisa virar texto também em espanhol, sem mudar de idioma. Qual operação descreve corretamente essa tarefa?",
+        explanation:
+            "Transcrever significa converter fala em texto mantendo o mesmo idioma, que é o caso de um áudio em espanhol virando texto em espanhol, tarefa da conversão de fala em texto. Traduzir implicaria mudar o idioma, o que não ocorre aqui. A conversão de texto em fala faria o caminho oposto, gerando áudio a partir de texto.",
+        topic: "Processamento de linguagem natural",
+        options: [
+            ["Transcrever, usando conversão de fala em texto", true],
+            ["Traduzir, usando o Azure AI Translator", false],
+            ["Traduzir, usando tradução de fala", false],
+            ["Transcrever, usando conversão de texto em fala", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe está criando um assistente virtual com o Conversational Language Understanding (CLU) do Azure AI Language. Quando um usuário digita 'Quero reservar uma mesa para dois', o assistente precisa identificar que a ação desejada é fazer uma reserva. Qual elemento do CLU representa essa ação desejada?",
+        explanation:
+            "No CLU, a intenção (intent) representa o objetivo ou a ação que o usuário deseja realizar, como fazer uma reserva. A entidade seria um dado extraído do enunciado, como o número de pessoas. O enunciado (utterance) é a própria frase digitada pelo usuário e frase-chave é uma tarefa distinta, não um elemento do CLU.",
+        topic: "Processamento de linguagem natural",
+        options: [
+            ["Intenção (intent)", true],
+            ["Entidade (entity)", false],
+            ["Enunciado (utterance)", false],
+            ["Frase-chave", false],
+        ],
+    },
+    {
+        statement:
+            "Ainda no assistente virtual com CLU, no enunciado 'Quero reservar uma mesa para dois', a equipe quer capturar o valor 'dois' como o número de pessoas. Qual elemento do CLU corresponde a esse dado extraído do enunciado?",
+        explanation:
+            "No CLU, a entidade (entity) é um dado específico extraído do enunciado, como o número de pessoas 'dois', que detalha a intenção. A intenção representa a ação desejada (fazer a reserva), o enunciado é a frase completa do usuário e modelo de linguagem não é um dos elementos que compõem uma definição de CLU.",
+        topic: "Processamento de linguagem natural",
+        options: [
+            ["Intenção (intent)", false],
+            ["Entidade (entity)", true],
+            ["Enunciado (utterance)", false],
+            ["Modelo de linguagem", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer detectar informações pessoais identificáveis (PII), como CPF e telefone, dentro de documentos de texto para mascará-las antes de armazenar. Qual serviço do Azure oferece esse recurso de PLN?",
+        explanation:
+            "O Azure AI Language inclui a detecção de informações pessoais (PII), capaz de localizar e mascarar dados como documentos e telefones em texto. O Azure AI Speech trata de áudio, o Azure AI Translator faz tradução e o Azure AI Bot Service é uma plataforma para construir bots, não um serviço de análise de texto.",
+        topic: "Processamento de linguagem natural",
+        options: [
+            ["Azure AI Language", true],
+            ["Azure AI Speech", false],
+            ["Azure AI Translator", false],
+            ["Azure AI Bot Service", false],
+        ],
+    },
+    {
+        statement:
+            "Ao enviar um trecho de texto para a detecção de idioma do Azure AI Language, o serviço retorna um único idioma como resultado, mesmo quando o texto mistura palavras de línguas diferentes. Qual afirmação descreve esse comportamento corretamente?",
+        explanation:
+            "A detecção de idioma avalia o texto como um todo e retorna o idioma predominante, acompanhado do nome, do código ISO e de uma pontuação de confiança. Ela não retorna um idioma por palavra nem traduz o texto. Quando não consegue identificar, retorna '(Unknown)', mas isso não acontece apenas por haver mistura de idiomas.",
+        topic: "Processamento de linguagem natural",
+        options: [
+            [
+                "O serviço retorna o idioma predominante, com o nome, o código ISO e uma pontuação de confiança",
+                true,
+            ],
+            ["O serviço retorna todos os idiomas encontrados, um para cada palavra", false],
+            ["O serviço traduz automaticamente o texto para o inglês", false],
+            ["O serviço retorna apenas 'desconhecido' sempre que há mais de um idioma", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe de dados vai usar o Azure AI Language para enriquecer avaliações de clientes. Quais das tarefas a seguir são recursos de processamento de linguagem natural oferecidos por esse serviço? (Selecione DUAS opções.)",
+        explanation:
+            "A análise de sentimento e o reconhecimento de entidades nomeadas são tarefas de PLN do Azure AI Language, usadas para medir o tom e extrair pessoas, locais e organizações do texto. A conversão de texto em fala pertence ao Azure AI Speech e a tradução automática entre idiomas é função do Azure AI Translator.",
+        topic: "Processamento de linguagem natural",
+        options: [
+            ["Análise de sentimento", true],
+            ["Reconhecimento de entidades nomeadas", true],
+            ["Conversão de texto em fala", false],
+            ["Tradução automática de texto entre idiomas", false],
+        ],
+    },
+    {
+        statement:
+            "Um arquiteto de soluções está avaliando o Azure AI Speech para um projeto de call center. Quais recursos a seguir fazem parte desse serviço? (Selecione DUAS opções.)",
+        explanation:
+            "A conversão de fala em texto e a conversão de texto em fala são recursos centrais do Azure AI Speech, que transcreve áudio e sintetiza voz. A extração de frases-chave e a detecção de idioma de um texto são tarefas do Azure AI Language, que trabalha com texto escrito e não com áudio.",
+        topic: "Processamento de linguagem natural",
+        options: [
+            ["Conversão de fala em texto", true],
+            ["Conversão de texto em fala", true],
+            ["Extração de frases-chave", false],
+            ["Detecção de idioma de um texto", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa global vai adotar o Azure AI Translator nos seus fluxos de conteúdo. Quais afirmações sobre esse serviço estão corretas? (Selecione DUAS opções.)",
+        explanation:
+            "O Azure AI Translator traduz texto entre mais de uma centena de idiomas e oferece tradução de documentos preservando o layout e a formatação do original. Transcrever áudio é tarefa do Azure AI Speech e medir sentimento é uma capacidade do Azure AI Language, não do Translator.",
+        topic: "Processamento de linguagem natural",
+        options: [
+            ["Ele traduz texto entre mais de uma centena de idiomas", true],
+            ["Ele oferece tradução de documentos preservando a formatação", true],
+            ["Ele transcreve o áudio de reuniões em texto", false],
+            ["Ele mede o sentimento positivo ou negativo do texto", false],
+        ],
+    },
+    {
+        statement:
+            "Depois de enviar uma avaliação para a análise de sentimento do Azure AI Language, a aplicação recebe um rótulo geral e três pontuações associadas ao texto. O que essas três pontuações representam?",
+        explanation:
+            "A análise de sentimento retorna um rótulo geral e pontuações de confiança para positivo, neutro e negativo, cada uma variando de 0 a 1 e com soma próxima de 1. Elas não contam palavras, não representam traduções nem frases-chave, que são resultados de outras tarefas de PLN.",
+        topic: "Processamento de linguagem natural",
+        options: [
+            [
+                "A confiança de que o texto é positivo, neutro e negativo, cada uma entre 0 e 1",
+                true,
+            ],
+            ["O número de palavras positivas, neutras e negativas encontradas", false],
+            ["As três traduções mais prováveis do texto", false],
+            ["As três frases-chave mais relevantes do texto", false],
+        ],
+    },
+    {
+        statement:
+            "Ao treinar um modelo de Conversational Language Understanding (CLU), uma equipe fornece vários exemplos de frases que os usuários poderiam dizer e, para cada uma, indica a intenção correspondente e rotula os dados relevantes. Como se chamam essas frases de exemplo usadas no treinamento?",
+        explanation:
+            "No CLU, os enunciados (utterances) são os exemplos de frases que os usuários podem dizer e que alimentam o treinamento do modelo. Cada enunciado é associado a uma intenção (a ação desejada) e pode ter entidades rotuladas (dados extraídos), mas o termo que designa as próprias frases de exemplo é enunciado.",
+        topic: "Processamento de linguagem natural",
+        options: [
+            ["Enunciados (utterances)", true],
+            ["Intenções (intents)", false],
+            ["Entidades (entities)", false],
+            ["Pontuações de confiança", false],
+        ],
+    },
+    {
+        statement:
+            "Um aplicativo de mensagens de texto precisa permitir que usuários que escrevem em japonês conversem por escrito com usuários que escrevem em português, traduzindo as mensagens digitadas em tempo real. Nenhum áudio está envolvido. Qual serviço do Azure é o mais indicado?",
+        explanation:
+            "Como o cenário envolve apenas texto escrito sendo convertido de um idioma para outro, o Azure AI Translator é o serviço adequado para traduzir as mensagens em tempo real. O Azure AI Speech só seria necessário se houvesse áudio, o Azure AI Language cobre análise de texto mas não tradução e o Azure Machine Learning é uma plataforma genérica de ML, não um serviço pronto de tradução.",
+        topic: "Processamento de linguagem natural",
+        options: [
+            ["Azure AI Translator", true],
+            ["Azure AI Speech", false],
+            ["Azure AI Language", false],
+            ["Azure Machine Learning", false],
+        ],
+    },
+
+    // Domínio 5 - IA generativa
+    {
+        statement:
+            "Uma equipe está avaliando diferentes abordagens de IA. Qual característica distingue a IA generativa das abordagens tradicionais de aprendizado de máquina?",
+        explanation:
+            "A IA generativa cria conteúdo original e inédito, como texto, imagens, áudio e código, a partir dos padrões aprendidos. As abordagens tradicionais costumam classificar dados, prever valores ou detectar anomalias, sem produzir conteúdo novo.",
+        topic: "IA generativa",
+        options: [
+            ["Ela gera conteúdo novo e original, como texto, imagens e código", true],
+            ["Ela apenas classifica dados existentes em categorias predefinidas", false],
+            ["Ela se limita a prever valores numéricos com base em dados históricos", false],
+            ["Ela detecta anomalias em conjuntos de dados sem produzir saídas", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer uma solução que redija rascunhos de e-mails, resuma documentos e sugira código para os desenvolvedores. Qual carga de trabalho de IA melhor descreve essa necessidade?",
+        explanation:
+            "Redigir textos, resumir documentos e sugerir código são tarefas de geração de conteúdo novo, características da IA generativa. Visão computacional analisa imagens, a detecção de anomalias identifica desvios e a mineração de conhecimento extrai informações de documentos, mas nenhuma gera conteúdo original.",
+        topic: "IA generativa",
+        options: [
+            ["IA generativa", true],
+            ["Visão computacional", false],
+            ["Detecção de anomalias", false],
+            ["Mineração de conhecimento", false],
+        ],
+    },
+    {
+        statement:
+            "Um analista lista exemplos de saídas que modelos de IA generativa podem produzir. Quais das opções a seguir são exemplos válidos de conteúdo gerado por IA generativa? (Selecione DUAS opções.)",
+        explanation:
+            "Modelos de IA generativa produzem conteúdo original, como imagens criadas a partir de uma descrição textual e trechos de código-fonte. Ajustar o brilho de uma foto existente e ordenar uma planilha são operações determinísticas de edição e organização, não geração de conteúdo novo.",
+        topic: "IA generativa",
+        options: [
+            ["Uma imagem inédita criada a partir de uma descrição em linguagem natural", true],
+            ["Um trecho de código-fonte gerado a partir de uma instrução do desenvolvedor", true],
+            ["O ajuste automático de brilho e contraste de uma foto já existente", false],
+            ["A ordenação alfabética das linhas de uma planilha", false],
+        ],
+    },
+    {
+        statement:
+            "Ao explicar a base dos serviços de IA generativa de texto, um instrutor menciona os LLMs. O que é um modelo de linguagem grande (LLM)?",
+        explanation:
+            "Um LLM é um modelo treinado com enormes volumes de texto que aprende padrões da linguagem para entender e gerar texto em linguagem natural. Ele não é um banco de dados relacional, nem uma regra fixa de tradução, nem uma planilha de estatísticas de palavras.",
+        topic: "IA generativa",
+        options: [
+            [
+                "Um modelo treinado com grandes volumes de texto para entender e gerar linguagem natural",
+                true,
+            ],
+            ["Um banco de dados relacional otimizado para consultas de texto", false],
+            ["Um conjunto fixo de regras de tradução entre dois idiomas", false],
+            ["Uma planilha que armazena estatísticas de frequência de palavras", false],
+        ],
+    },
+    {
+        statement:
+            "Um material de estudo afirma que os LLMs modernos, como os da família GPT, são construídos sobre uma arquitetura específica de rede neural. Qual arquitetura é a base desses modelos?",
+        explanation:
+            "Os LLMs modernos se baseiam na arquitetura transformer, que usa mecanismos de atenção para pesar a importância das palavras no contexto. Redes convolucionais são típicas de imagens, e árvores de decisão e regressão linear são modelos clássicos que não sustentam LLMs.",
+        topic: "IA generativa",
+        options: [
+            ["A arquitetura transformer, baseada em mecanismos de atenção", true],
+            ["A rede neural convolucional (CNN)", false],
+            ["A árvore de decisão", false],
+            ["A regressão linear", false],
+        ],
+    },
+    {
+        statement:
+            "Ao configurar chamadas ao Azure OpenAI Service, uma desenvolvedora percebe que o custo e os limites são medidos em tokens. No contexto de LLMs, o que é um token?",
+        explanation:
+            "Um token é uma unidade de texto, como uma palavra ou parte de uma palavra, na qual o texto é dividido para ser processado pelo modelo. Não é a chave de autenticação da API, nem um parâmetro de aleatoriedade, nem um registro de log.",
+        topic: "IA generativa",
+        options: [
+            [
+                "Uma unidade de texto, como uma palavra ou parte de uma palavra, processada pelo modelo",
+                true,
+            ],
+            ["A chave secreta usada para autenticar as chamadas à API", false],
+            ["Um parâmetro que controla a aleatoriedade das respostas", false],
+            ["Um registro de auditoria de cada requisição feita ao modelo", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe precisa comparar a semelhança de significado entre milhares de trechos de texto para uma busca semântica. Qual recurso de IA generativa representa o texto como vetores numéricos que capturam significado?",
+        explanation:
+            "Embeddings são representações vetoriais numéricas que capturam o significado semântico do texto, de modo que textos com sentido parecido ficam próximos no espaço vetorial. Tokens são unidades de texto, prompts são as instruções de entrada e completions são as respostas geradas.",
+        topic: "IA generativa",
+        options: [
+            ["Embeddings", true],
+            ["Tokens", false],
+            ["Prompts", false],
+            ["Completions", false],
+        ],
+    },
+    {
+        statement:
+            "Em uma interação com um modelo GPT, o usuário digita uma instrução e o modelo devolve um texto gerado. Como se chamam, respectivamente, a instrução de entrada e a resposta produzida pelo modelo?",
+        explanation:
+            "O prompt é a instrução ou entrada fornecida ao modelo, e a completion é a resposta gerada por ele. Token e embedding são conceitos de processamento interno, não os nomes da entrada e da saída da interação.",
+        topic: "IA generativa",
+        options: [
+            ["Prompt e completion", true],
+            ["Completion e prompt", false],
+            ["Token e embedding", false],
+            ["Embedding e token", false],
+        ],
+    },
+    {
+        statement:
+            "A Microsoft descreve várias de suas soluções como copilots. No contexto de IA generativa, o que caracteriza um copilot?",
+        explanation:
+            "Um copilot é um assistente baseado em IA generativa integrado a um aplicativo para ajudar o usuário a criar conteúdo, obter respostas e realizar tarefas com apoio de linguagem natural. Não é um antivírus, nem um substituto autônomo do usuário sem qualquer supervisão, nem um corretor ortográfico de regras fixas.",
+        topic: "IA generativa",
+        options: [
+            [
+                "Um assistente baseado em IA generativa integrado a aplicativos para apoiar o usuário",
+                true,
+            ],
+            ["Um antivírus que monitora ameaças de segurança em tempo real", false],
+            ["Um sistema que substitui completamente o usuário sem qualquer supervisão", false],
+            ["Um corretor ortográfico baseado apenas em regras fixas", false],
+        ],
+    },
+    {
+        statement:
+            "Uma pessoa desenvolvedora quer sugestões de código e funções completas geradas diretamente no editor a partir de comentários e do contexto do arquivo. Qual copilot é voltado especificamente para esse cenário?",
+        explanation:
+            "O GitHub Copilot é o assistente de IA generativa voltado a desenvolvedores, sugerindo código e funções no editor a partir do contexto e de comentários. O Microsoft Copilot é um assistente de produtividade geral, e as demais opções nem sequer são copilots de codificação.",
+        topic: "IA generativa",
+        options: [
+            ["GitHub Copilot", true],
+            ["Azure Monitor", false],
+            ["Power BI", false],
+            ["Azure Backup", false],
+        ],
+    },
+    {
+        statement:
+            "Uma organização quer usar modelos da OpenAI, como o GPT, com a segurança, a conformidade e o suporte empresarial do Azure. Qual serviço atende diretamente a essa necessidade?",
+        explanation:
+            "O Azure OpenAI Service disponibiliza modelos da OpenAI, como GPT, embeddings e DALL-E, com a governança, a segurança e a escala do Azure. O Azure AI Search faz busca, o Azure Machine Learning treina modelos personalizados e o Azure AI Vision analisa imagens.",
+        topic: "IA generativa",
+        options: [
+            ["Azure OpenAI Service", true],
+            ["Azure AI Search", false],
+            ["Azure Machine Learning", false],
+            ["Azure AI Vision", false],
+        ],
+    },
+    {
+        statement:
+            "Ao escolher um modelo no Azure OpenAI Service para alimentar um chatbot de atendimento que conversa em linguagem natural, qual família de modelos é a mais adequada?",
+        explanation:
+            "Os modelos da família GPT são otimizados para entender e gerar linguagem natural, sendo a base de experiências de chat e geração de texto. Os modelos de embeddings geram vetores, o DALL-E gera imagens e o Whisper transcreve áudio.",
+        topic: "IA generativa",
+        options: [
+            ["Modelos GPT", true],
+            ["Modelos de embeddings", false],
+            ["Modelo DALL-E", false],
+            ["Modelo Whisper", false],
+        ],
+    },
+    {
+        statement:
+            "Uma agência de marketing quer gerar imagens originais a partir de descrições textuais, como 'um gato astronauta em aquarela'. Qual modelo do Azure OpenAI Service atende a esse objetivo?",
+        explanation:
+            "O DALL-E é o modelo do Azure OpenAI Service voltado à geração de imagens a partir de descrições em linguagem natural. Os modelos GPT geram texto, os de embeddings geram vetores numéricos e o Whisper faz transcrição de fala.",
+        topic: "IA generativa",
+        options: [
+            ["DALL-E", true],
+            ["GPT", false],
+            ["Embeddings", false],
+            ["Whisper", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe precisa converter documentos em vetores numéricos para viabilizar uma busca por similaridade semântica. Qual família de modelos do Azure OpenAI Service é indicada para gerar esses vetores?",
+        explanation:
+            "Os modelos de embeddings convertem texto em vetores numéricos que capturam significado, viabilizando busca semântica e comparação de similaridade. GPT gera texto, DALL-E gera imagens e o Whisper transcreve fala, nenhum deles com essa finalidade principal.",
+        topic: "IA generativa",
+        options: [
+            ["Modelos de embeddings", true],
+            ["Modelos GPT", false],
+            ["Modelo DALL-E", false],
+            ["Modelo Whisper para transcrição de fala", false],
+        ],
+    },
+    {
+        statement:
+            "Uma arquiteta lista as capacidades disponíveis no Azure OpenAI Service. Quais das opções a seguir correspondem a famílias de modelos oferecidas pelo serviço? (Selecione DUAS opções.)",
+        explanation:
+            "O Azure OpenAI Service oferece, entre outros, os modelos GPT para geração de texto e chat e o DALL-E para geração de imagens. Máquinas virtuais e redes de entrega de conteúdo são serviços de infraestrutura do Azure, não famílias de modelos de IA generativa.",
+        topic: "IA generativa",
+        options: [
+            ["Modelos GPT para geração de texto e chat", true],
+            ["Modelo DALL-E para geração de imagens", true],
+            ["Máquinas virtuais para hospedar aplicações web", false],
+            ["Rede de entrega de conteúdo (CDN) para distribuir arquivos", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe quer uma plataforma unificada para explorar um catálogo de modelos, testar prompts em um playground e avaliar, implantar e gerenciar aplicações de IA generativa e copilots. Qual solução do Azure atende a esse propósito?",
+        explanation:
+            "O Azure AI Foundry é a plataforma para construir, personalizar, avaliar, implantar e gerenciar aplicações de IA generativa e copilots, incluindo catálogo de modelos e playground. O Azure OpenAI Service fornece os modelos, mas o Foundry é o ambiente de desenvolvimento e gestão dessas soluções.",
+        topic: "IA generativa",
+        options: [
+            ["Azure AI Foundry", true],
+            ["Azure DevOps", false],
+            ["Azure Logic Apps", false],
+            ["Azure Blob Storage", false],
+        ],
+    },
+    {
+        statement:
+            "As respostas de um modelo GPT estão vagas e fora do formato desejado. Uma desenvolvedora decide melhorar as instruções, adicionando contexto, exemplos e o formato esperado da saída. Como se chama essa prática?",
+        explanation:
+            "Engenharia de prompt é a prática de elaborar e refinar as instruções enviadas ao modelo, com contexto, exemplos e formato desejado, para obter respostas melhores. O fine-tuning altera os pesos do modelo com dados adicionais, o grounding fornece dados de contexto e a tokenização apenas divide o texto em tokens.",
+        topic: "IA generativa",
+        options: [
+            ["Engenharia de prompt", true],
+            ["Fine-tuning (ajuste fino)", false],
+            ["Tokenização", false],
+            ["Normalização de dados", false],
+        ],
+    },
+    {
+        statement:
+            "Para orientar o comportamento de um modelo de chat, uma desenvolvedora inclui na conversa alguns exemplos de perguntas e respostas no formato desejado antes da pergunta real do usuário. Qual técnica de engenharia de prompt ela está aplicando?",
+        explanation:
+            "Fornecer alguns exemplos no próprio prompt para orientar o modelo é a técnica de few-shot (poucos exemplos). Zero-shot não fornece exemplos, o grounding adiciona dados de contexto factual e o fine-tuning reteina o modelo com um conjunto de dados.",
+        topic: "IA generativa",
+        options: [
+            ["Few-shot (fornecer poucos exemplos no prompt)", true],
+            ["Zero-shot (não fornecer nenhum exemplo)", false],
+            ["Fine-tuning (reteinar o modelo com um conjunto de dados)", false],
+            ["Redução de dimensionalidade", false],
+        ],
+    },
+    {
+        statement:
+            "Para reduzir respostas inventadas, uma equipe passa a incluir no prompt informações confiáveis e específicas do domínio para que o modelo baseie a resposta nesses dados. Como se chama essa técnica?",
+        explanation:
+            "Grounding é fornecer ao modelo dados de contexto confiáveis para que a resposta se baseie neles, reduzindo alucinações. Não se trata de aumentar a temperatura, de tokenizar o texto nem de comprimir o modelo.",
+        topic: "IA generativa",
+        options: [
+            ["Grounding (fundamentar a resposta com dados de contexto)", true],
+            ["Aumentar a temperatura do modelo", false],
+            ["Tokenização do prompt", false],
+            ["Quantização do modelo", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer que o chatbot responda usando os documentos internos atualizados da própria organização, recuperando trechos relevantes de uma base de conhecimento e adicionando-os ao prompt antes da geração. Qual abordagem descreve esse padrão?",
+        explanation:
+            "A Geração Aumentada por Recuperação (RAG) recupera trechos relevantes de uma fonte de dados, muitas vezes via busca vetorial, e os adiciona ao prompt para fundamentar a resposta em dados atuais e próprios. O fine-tuning reescreve os pesos do modelo, e as demais opções não descrevem esse fluxo.",
+        topic: "IA generativa",
+        options: [
+            ["RAG (Geração Aumentada por Recuperação)", true],
+            ["Fine-tuning completo do modelo base", false],
+            ["Aumento de dados (data augmentation) de imagens", false],
+            ["Balanceamento de carga entre modelos", false],
+        ],
+    },
+    {
+        statement:
+            "Um modelo de linguagem responde com uma citação de aparência convincente, mas que na verdade não existe e está factualmente incorreta. Como esse comportamento é chamado no contexto da IA generativa?",
+        explanation:
+            "Alucinação é quando o modelo gera conteúdo plausível, porém falso ou sem base factual. Viés se refere a padrões injustos aprendidos dos dados, overfitting é um problema de treinamento e latência é o tempo de resposta, nenhum descreve uma resposta inventada.",
+        topic: "IA generativa",
+        options: [
+            ["Alucinação", true],
+            ["Viés (bias)", false],
+            ["Overfitting (sobreajuste)", false],
+            ["Latência", false],
+        ],
+    },
+    {
+        statement:
+            "Um modelo de IA generativa passa a produzir respostas que favorecem sistematicamente um grupo e desfavorecem outro, refletindo desigualdades presentes nos dados de treinamento. Qual risco de IA generativa esse cenário ilustra?",
+        explanation:
+            "Viés ocorre quando o modelo reproduz e amplifica desigualdades presentes nos dados de treinamento, gerando saídas injustas. Alucinação é a invenção de fatos, e as outras opções não descrevem esse tipo de problema ético.",
+        topic: "IA generativa",
+        options: [
+            ["Viés (bias) nos resultados do modelo", true],
+            ["Alucinação de fatos inexistentes", false],
+            ["Perda de pacotes na rede", false],
+            ["Expiração da chave de API", false],
+        ],
+    },
+    {
+        statement:
+            "Uma organização precisa detectar e bloquear conteúdo de ódio, sexual, violento e de automutilação tanto nas entradas quanto nas respostas de um modelo. Qual recurso do Azure OpenAI Service atende a esse requisito?",
+        explanation:
+            "Os filtros de conteúdo do Azure OpenAI Service analisam prompts e respostas em categorias como ódio, sexual, violência e automutilação, com níveis de severidade configuráveis, bloqueando conteúdo nocivo. Nenhum dos outros recursos citados executa essa moderação.",
+        topic: "IA generativa",
+        options: [
+            ["Filtros de conteúdo (content filters)", true],
+            ["Regras de firewall de rede", false],
+            ["Cache de respostas do modelo", false],
+            ["Compactação de tokens", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe quer implantar uma solução de IA generativa seguindo boas práticas de IA responsável. Quais das medidas a seguir estão alinhadas a esse objetivo? (Selecione DUAS opções.)",
+        explanation:
+            "Aplicar filtros de conteúdo para reduzir saídas nocivas e manter supervisão humana sobre decisões sensíveis são práticas centrais de IA generativa responsável. Publicar as chaves de API no código público e desativar toda a moderação para acelerar respostas contrariam diretamente esses princípios.",
+        topic: "IA generativa",
+        options: [
+            ["Aplicar filtros de conteúdo para reduzir saídas nocivas", true],
+            ["Manter supervisão humana sobre decisões sensíveis", true],
+            ["Publicar as chaves de API no código-fonte público", false],
+            ["Desativar toda a moderação para acelerar as respostas", false],
+        ],
+    },
+];
+
+async function seed() {
+    let [simulado] = await db.select().from(simulados).where(eq(simulados.slug, SLUG));
+    if (!simulado) {
+        [simulado] = await db
+            .insert(simulados)
+            .values({
+                slug: SLUG,
+                name: "Microsoft Azure AI Fundamentals (AI-900)",
+                provider: "azure",
+                code: "AI-900",
+                level: "Fundamental",
+                description:
+                    "Simulado no formato da prova AI-900: 60 minutos, corte de 70%. Mistura resposta única e múltipla.",
+                durationMinutes: 60,
+                questionCount: 50,
+                passPercent: 70,
+                published: true,
+            })
+            .returning();
+        console.log(`Simulado criado: ${simulado.slug}`);
+    }
+    // Mantém provedor, código e nível em dia mesmo se o simulado já existia.
+    await db
+        .update(simulados)
+        .set({ provider: "azure", code: "AI-900", level: "Fundamental" })
+        .where(eq(simulados.id, simulado.id));
+
+    const [{ n }] = await db
+        .select({ n: count() })
+        .from(simuladoQuestions)
+        .where(eq(simuladoQuestions.simuladoId, simulado.id));
+    if (Number(n) > 0) {
+        console.log(`Simulado já tem ${n} questões, nada a fazer.`);
+        return;
+    }
+
+    for (let i = 0; i < QUESTOES.length; i++) {
+        const q = QUESTOES[i];
+        const [questao] = await db
+            .insert(simuladoQuestions)
+            .values({
+                simuladoId: simulado.id,
+                statement: q.statement,
+                explanation: q.explanation,
+                topic: q.topic,
+            })
+            .returning();
+        await db.insert(simuladoOptions).values(
+            q.options.map(([text, isCorrect], idx) => ({
+                questionId: questao.id,
+                text,
+                isCorrect,
+                position: idx + 1,
+            })),
+        );
+    }
+    console.log(`Seed concluído: ${QUESTOES.length} questões inseridas.`);
+}
+
+seed()
+    .then(() => process.exit(0))
+    .catch((e) => {
+        console.error("Falha no seed:", e);
+        process.exit(1);
+    });

--- a/backend/scripts/seed-aws-ccp.ts
+++ b/backend/scripts/seed-aws-ccp.ts
@@ -3167,6 +3167,9 @@ async function seed() {
             .values({
                 slug: SLUG,
                 name: "AWS Certified Cloud Practitioner",
+                provider: "aws",
+                code: "CLF-C02",
+                level: "Fundamental",
                 description:
                     "Simulado no formato da prova CLF-C02: 90 minutos, corte de 70%. Mistura resposta única e múltipla.",
                 durationMinutes: 90,
@@ -3177,6 +3180,11 @@ async function seed() {
             .returning();
         console.log(`Simulado criado: ${simulado.slug}`);
     }
+    // Mantém provedor, código e nível em dia mesmo se o simulado já existia.
+    await db
+        .update(simulados)
+        .set({ provider: "aws", code: "CLF-C02", level: "Fundamental" })
+        .where(eq(simulados.id, simulado.id));
 
     const [{ n }] = await db
         .select({ n: count() })

--- a/backend/scripts/seed-az-900.ts
+++ b/backend/scripts/seed-az-900.ts
@@ -3035,6 +3035,9 @@ async function seed() {
             .values({
                 slug: SLUG,
                 name: "Microsoft Azure Fundamentals (AZ-900)",
+                provider: "azure",
+                code: "AZ-900",
+                level: "Fundamental",
                 description:
                     "Simulado no formato da prova AZ-900: 45 minutos, corte de 70%. Mistura resposta única e múltipla.",
                 durationMinutes: 45,
@@ -3045,6 +3048,11 @@ async function seed() {
             .returning();
         console.log(`Simulado criado: ${simulado.slug}`);
     }
+    // Mantém provedor, código e nível em dia mesmo se o simulado já existia.
+    await db
+        .update(simulados)
+        .set({ provider: "azure", code: "AZ-900", level: "Fundamental" })
+        .where(eq(simulados.id, simulado.id));
 
     const [{ n }] = await db
         .select({ n: count() })

--- a/backend/scripts/seed-dp-900.ts
+++ b/backend/scripts/seed-dp-900.ts
@@ -1,0 +1,1477 @@
+// Seed do simulado Microsoft Azure Data Fundamentals (DP-900). Idempotente: se o
+// simulado já tiver questões, não faz nada.
+//
+// Rodar em dev:  node --env-file=.env scripts/seed-dp-900.ts
+// Rodar em prod: docker compose -f docker-compose.prod.yml exec -T backend \
+//                  node scripts/seed-dp-900.ts
+import { db } from "../db.ts";
+import { simulados, simuladoQuestions, simuladoOptions } from "../schema.ts";
+import { eq, count } from "drizzle-orm";
+
+const SLUG = "dp-900";
+
+type Questao = {
+    statement: string;
+    explanation: string;
+    topic: string;
+    options: [string, boolean][];
+};
+
+const QUESTOES: Questao[] = [
+    // Domínio 1 - Conceitos centrais de dados
+    {
+        statement:
+            "Um sistema financeiro armazena registros de clientes com colunas fixas como CPF, nome e saldo, todos seguindo um esquema bem definido. Que tipo de dado é esse?",
+        explanation:
+            "Dados estruturados seguem um esquema rígido de linhas e colunas e são típicos de bancos de dados relacionais. Dados semiestruturados e não estruturados não exigem esse formato tabular fixo.",
+        topic: "Conceitos de dados",
+        options: [
+            ["Dados estruturados", true],
+            ["Dados semiestruturados", false],
+            ["Dados não estruturados", false],
+            ["Dados binários sem esquema", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa de mídia precisa armazenar vídeos, imagens e arquivos de áudio que não se encaixam em linhas e colunas. Como esses dados são classificados?",
+        explanation:
+            "Vídeos, imagens e áudio são dados não estruturados, pois não possuem um modelo de dados predefinido. Costumam ser guardados em armazenamento de blobs ou em data lakes.",
+        topic: "Conceitos de dados",
+        options: [
+            ["Dados não estruturados", true],
+            ["Dados estruturados", false],
+            ["Dados relacionais", false],
+            ["Dados normalizados", false],
+        ],
+    },
+    {
+        statement:
+            "Um desenvolvedor recebe documentos JSON em que cada registro pode ter campos diferentes, com pares de chave e valor e aninhamento. Que categoria descreve melhor esses documentos?",
+        explanation:
+            "O JSON tem organização por chaves e hierarquia, mas não exige um esquema tabular fixo, o que caracteriza dados semiestruturados. Não são estruturados (sem tabela rígida) nem totalmente não estruturados (existe alguma estrutura).",
+        topic: "Conceitos de dados",
+        options: [
+            ["Dados semiestruturados", true],
+            ["Dados estruturados", false],
+            ["Dados não estruturados", false],
+            ["Dados colunares", false],
+        ],
+    },
+    {
+        statement: "Quais características descrevem dados estruturados? (Selecione DUAS opções.)",
+        explanation:
+            "Dados estruturados possuem esquema fixo e se organizam em linhas e colunas, sendo típicos de bancos relacionais. Imagens e vídeos são dados não estruturados, e a ausência total de esquema não descreve dados estruturados.",
+        topic: "Conceitos de dados",
+        options: [
+            ["Seguem um esquema predefinido e fixo", true],
+            ["Organizam-se em linhas e colunas", true],
+            ["São representados por imagens e vídeos", false],
+            ["Não possuem nenhum tipo de esquema", false],
+        ],
+    },
+    {
+        statement:
+            "Uma solução precisa guardar grandes volumes de arquivos não estruturados, como fotos e documentos digitalizados, com baixo custo. Qual opção de armazenamento é mais adequada?",
+        explanation:
+            "O armazenamento de blobs (object storage) foi feito para dados não estruturados em larga escala e baixo custo. Um banco relacional é otimizado para dados tabulares estruturados, não para arquivos binários.",
+        topic: "Conceitos de dados",
+        options: [
+            ["Armazenamento de blobs (object storage)", true],
+            ["Banco de dados relacional normalizado", false],
+            ["Tabela de um data warehouse", false],
+            ["Índice de chave primária", false],
+        ],
+    },
+    {
+        statement:
+            "Um analista exporta uma tabela para um arquivo de texto em que cada linha é um registro e os campos são separados por vírgula. Qual formato de arquivo é esse?",
+        explanation:
+            "O CSV é um formato de texto delimitado e orientado a linhas, em que os valores são separados por vírgula. É simples e legível, mas não guarda tipos nem compactação como os formatos colunares.",
+        topic: "Conceitos de dados",
+        options: [
+            ["CSV", true],
+            ["Parquet", false],
+            ["Avro", false],
+            ["ORC", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe de análise consulta poucas colunas de tabelas com bilhões de linhas e quer leitura rápida e boa compressão. Qual formato de arquivo é o mais indicado?",
+        explanation:
+            "O Parquet armazena os dados por coluna, o que reduz a leitura e melhora a compressão em cargas analíticas que acessam poucas colunas. Formatos de texto como CSV e JSON leem a linha inteira e comprimem pior.",
+        topic: "Conceitos de dados",
+        options: [
+            ["Parquet", true],
+            ["CSV", false],
+            ["JSON", false],
+            ["XML", false],
+        ],
+    },
+    {
+        statement:
+            "Um pipeline de streaming grava eventos continuamente e precisa recuperar registros completos com o esquema embutido no próprio arquivo. Qual formato é mais apropriado?",
+        explanation:
+            "O Avro é orientado a linhas e guarda o esquema junto dos dados, o que favorece escrita intensa e streaming, além da recuperação de registros inteiros. Parquet e ORC são colunares, melhores para leitura analítica do que para escrita contínua.",
+        topic: "Conceitos de dados",
+        options: [
+            ["Avro", true],
+            ["Parquet", false],
+            ["ORC", false],
+            ["CSV", false],
+        ],
+    },
+    {
+        statement:
+            "Quais formatos de arquivo são colunares e otimizados para cargas analíticas com boa compressão? (Selecione DUAS opções.)",
+        explanation:
+            "Parquet e ORC armazenam dados por coluna, o que melhora a compressão e a leitura analítica. CSV e JSON são formatos de texto orientados a linha, sem esse ganho.",
+        topic: "Conceitos de dados",
+        options: [
+            ["Parquet", true],
+            ["ORC", true],
+            ["CSV", false],
+            ["JSON", false],
+        ],
+    },
+    {
+        statement:
+            "Qual formato de arquivo representa dados de forma hierárquica usando pares de chave e valor e é amplamente usado em APIs web?",
+        explanation:
+            "O JSON organiza dados em uma estrutura hierárquica de chaves e valores, muito usada em APIs. Parquet e ORC são formatos colunares binários, não voltados a esse tipo de troca de mensagens.",
+        topic: "Conceitos de dados",
+        options: [
+            ["JSON", true],
+            ["Parquet", false],
+            ["ORC", false],
+            ["Avro", false],
+        ],
+    },
+    {
+        statement:
+            "Um data warehouse baseado em Hive precisa de um formato colunar com alta compressão e leitura otimizada para consultas analíticas. Qual formato atende bem a esse cenário?",
+        explanation:
+            "O ORC (Optimized Row Columnar) é um formato colunar com forte compressão, otimizado para leituras analíticas e muito usado no ecossistema Hive. O CSV é um formato de texto por linha, sem essas otimizações.",
+        topic: "Conceitos de dados",
+        options: [
+            ["ORC", true],
+            ["CSV", false],
+            ["JSON", false],
+            ["XML", false],
+        ],
+    },
+    {
+        statement:
+            "Um sistema legado troca mensagens em um formato de texto hierárquico que usa marcações (tags) de abertura e fechamento para delimitar os elementos. Qual formato é esse?",
+        explanation:
+            "O XML usa tags de abertura e fechamento para estruturar dados de forma hierárquica, sendo comum em sistemas legados e integrações. É semiestruturado, assim como o JSON, mas mais verboso.",
+        topic: "Conceitos de dados",
+        options: [
+            ["XML", true],
+            ["CSV", false],
+            ["Parquet", false],
+            ["ORC", false],
+        ],
+    },
+    {
+        statement:
+            "Quais formatos representam dados semiestruturados de forma hierárquica baseada em texto? (Selecione DUAS opções.)",
+        explanation:
+            "JSON e XML são formatos de texto hierárquicos e representam dados semiestruturados. Parquet e ORC são formatos colunares binários voltados a análise, e não a essa representação hierárquica em texto.",
+        topic: "Conceitos de dados",
+        options: [
+            ["JSON", true],
+            ["XML", true],
+            ["Parquet", false],
+            ["ORC", false],
+        ],
+    },
+    {
+        statement:
+            "Uma aplicação precisa armazenar catálogos de produtos em que cada item tem atributos muito variáveis, sem esquema fixo, e exige escala horizontal. Qual tipo de banco atende melhor?",
+        explanation:
+            "Bancos não relacionais (NoSQL), como os de documentos, lidam bem com esquemas flexíveis e escala horizontal. Um banco relacional exigiria um esquema fixo, menos adequado para atributos muito variáveis.",
+        topic: "Conceitos de dados",
+        options: [
+            ["Banco de dados não relacional (NoSQL)", true],
+            ["Banco de dados relacional com esquema fixo", false],
+            ["Data warehouse relacional", false],
+            ["Sistema de arquivos CSV", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa precisa de integridade referencial, junções entre tabelas e controle de concorrência para dados transacionais. Deve escolher arquivos simples ou um banco de dados?",
+        explanation:
+            "Bancos de dados oferecem esquema, integridade referencial, junções e controle de concorrência, recursos que arquivos simples não fornecem. Arquivos avulsos servem melhor para armazenamento bruto e troca de dados.",
+        topic: "Conceitos de dados",
+        options: [
+            ["Um banco de dados", true],
+            ["Arquivos CSV em uma pasta", false],
+            ["Arquivos de texto não estruturados", false],
+            ["Um único arquivo JSON", false],
+        ],
+    },
+    {
+        statement:
+            "Um sistema de caixa de supermercado registra muitas transações pequenas de inserção e atualização, com dados sempre atuais e alta concorrência. Que tipo de carga de trabalho é essa?",
+        explanation:
+            "O OLTP (processamento de transações online) lida com muitas transações curtas sobre dados operacionais atuais, priorizando concorrência e integridade. O OLAP é voltado a análises e agregações sobre dados históricos.",
+        topic: "Cargas de trabalho e funções",
+        options: [
+            ["OLTP (processamento de transações online)", true],
+            ["OLAP (processamento analítico online)", false],
+            ["Processamento em lote noturno", false],
+            ["Data warehouse desnormalizado", false],
+        ],
+    },
+    {
+        statement: "Por que os bancos de dados OLTP costumam usar um modelo normalizado?",
+        explanation:
+            "A normalização reduz a redundância e mantém a integridade dos dados nas muitas operações de escrita típicas do OLTP. Já o OLAP costuma desnormalizar para acelerar consultas de leitura.",
+        topic: "Cargas de trabalho e funções",
+        options: [
+            ["Para reduzir a redundância e manter a integridade em muitas escritas", true],
+            ["Para acelerar agregações sobre dados históricos", false],
+            ["Para permitir consultas em esquema estrela", false],
+            ["Para eliminar a necessidade de chaves primárias", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe de BI executa consultas complexas com agregações sobre anos de dados históricos para gerar relatórios. Que tipo de carga de trabalho descreve isso?",
+        explanation:
+            "O OLAP (processamento analítico online) foca em consultas complexas e agregações sobre grandes volumes de dados históricos. O OLTP é otimizado para transações operacionais curtas e atuais.",
+        topic: "Cargas de trabalho e funções",
+        options: [
+            ["OLAP (processamento analítico online)", true],
+            ["OLTP (processamento de transações online)", false],
+            ["Processamento de fluxo em tempo real", false],
+            ["Transação ACID de escrita única", false],
+        ],
+    },
+    {
+        statement:
+            "Quais características são típicas de uma carga de trabalho analítica (OLAP)? (Selecione DUAS opções.)",
+        explanation:
+            "Cargas OLAP trabalham com dados históricos e usam modelos desnormalizados, como o esquema estrela, para acelerar agregações. Muitas transações curtas de escrita e a normalização em 3FN são típicas do OLTP.",
+        topic: "Cargas de trabalho e funções",
+        options: [
+            ["Consultas de agregação sobre dados históricos", true],
+            ["Modelo de dados desnormalizado", true],
+            ["Muitas transações curtas de escrita", false],
+            ["Modelo altamente normalizado para reduzir redundância", false],
+        ],
+    },
+    {
+        statement:
+            "Em um data warehouse, uma tabela de fatos central se conecta a várias tabelas de dimensão, formando um modelo desnormalizado voltado a análises. Como esse modelo é chamado?",
+        explanation:
+            "O esquema estrela (star schema) tem uma tabela de fatos ligada a tabelas de dimensão e é típico de cargas OLAP, favorecendo agregações rápidas. Modelos totalmente normalizados são mais comuns em OLTP.",
+        topic: "Cargas de trabalho e funções",
+        options: [
+            ["Esquema estrela (star schema)", true],
+            ["Modelo totalmente normalizado em 3FN", false],
+            ["Modelo de documentos aninhados", false],
+            ["Armazenamento de blobs", false],
+        ],
+    },
+    {
+        statement:
+            "Em uma transferência bancária, o débito em uma conta e o crédito em outra devem acontecer por completo ou não acontecer de forma alguma. Qual propriedade ACID garante isso?",
+        explanation:
+            "A atomicidade garante que a transação seja tratada como uma unidade indivisível: ou tudo é confirmado, ou nada é aplicado. A durabilidade trata da persistência após a confirmação, não do tudo ou nada.",
+        topic: "Cargas de trabalho e funções",
+        options: [
+            ["Atomicidade", true],
+            ["Durabilidade", false],
+            ["Isolamento", false],
+            ["Consistência", false],
+        ],
+    },
+    {
+        statement:
+            "Após uma transação ser confirmada (commit), seus efeitos devem sobreviver mesmo a uma queda de energia do servidor. Qual propriedade ACID descreve essa garantia?",
+        explanation:
+            "A durabilidade assegura que os dados de uma transação confirmada persistem mesmo diante de falhas do sistema. O isolamento trata da interferência entre transações concorrentes, não da persistência.",
+        topic: "Cargas de trabalho e funções",
+        options: [
+            ["Durabilidade", true],
+            ["Isolamento", false],
+            ["Atomicidade", false],
+            ["Consistência", false],
+        ],
+    },
+    {
+        statement:
+            "Duas transações simultâneas atualizam os mesmos dados, e cada uma deve executar como se estivesse sozinha, sem enxergar alterações parciais da outra. Qual propriedade ACID garante isso?",
+        explanation:
+            "O isolamento garante que transações concorrentes não interfiram umas nas outras, evitando que uma veja o estado intermediário da outra. A consistência cuida de manter válidas as regras e restrições do banco.",
+        topic: "Cargas de trabalho e funções",
+        options: [
+            ["Isolamento", true],
+            ["Atomicidade", false],
+            ["Durabilidade", false],
+            ["Consistência", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa processa toda a folha de pagamento uma vez por mês, reunindo grandes volumes de dados e executando o trabalho em horário agendado. Que tipo de processamento é esse?",
+        explanation:
+            "O processamento em lote (batch) reúne grandes volumes de dados e os processa em intervalos agendados, com foco em vazão, não em baixa latência. O processamento em fluxo (streaming) trata os dados continuamente à medida que chegam.",
+        topic: "Cargas de trabalho e funções",
+        options: [
+            ["Processamento em lote (batch)", true],
+            ["Processamento em fluxo (streaming)", false],
+            ["Processamento transacional OLTP", false],
+            ["Processamento interativo em tempo real", false],
+        ],
+    },
+    {
+        statement:
+            "Sensores de IoT enviam leituras continuamente e a empresa precisa reagir a cada evento em tempo quase real. Que abordagem de processamento é a mais adequada?",
+        explanation:
+            "O processamento em fluxo (streaming) trata os dados de forma contínua, com baixa latência, à medida que os eventos chegam. O processamento em lote acumularia os dados para tratá-los mais tarde, o que não atende ao tempo quase real.",
+        topic: "Cargas de trabalho e funções",
+        options: [
+            ["Processamento em fluxo (streaming)", true],
+            ["Processamento em lote (batch) diário", false],
+            ["Relatório mensal agendado", false],
+            ["Carga OLAP em data warehouse", false],
+        ],
+    },
+    {
+        statement:
+            "Um profissional é responsável por backups, segurança, controle de acesso e ajuste de desempenho de um banco de dados. Qual função ele exerce?",
+        explanation:
+            "O administrador de banco de dados (DBA) cuida de backup, segurança, controle de acesso e desempenho do banco. O engenheiro de dados foca em pipelines de ingestão e transformação, e o analista, em relatórios e insights.",
+        topic: "Cargas de trabalho e funções",
+        options: [
+            ["Administrador de banco de dados (DBA)", true],
+            ["Engenheiro de dados", false],
+            ["Analista de dados", false],
+            ["Cientista de dados", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa precisa construir pipelines para ingerir, limpar e transformar dados de várias fontes antes de disponibilizá-los para análise. Qual função é responsável por isso?",
+        explanation:
+            "O engenheiro de dados projeta e mantém pipelines de ingestão e transformação (ETL/ELT) que preparam os dados para consumo. O analista de dados usa esses dados prontos para criar relatórios, e o DBA administra o banco em si.",
+        topic: "Cargas de trabalho e funções",
+        options: [
+            ["Engenheiro de dados", true],
+            ["Analista de dados", false],
+            ["Administrador de banco de dados (DBA)", false],
+            ["Gerente de projetos", false],
+        ],
+    },
+    {
+        statement:
+            "Um profissional cria painéis e relatórios visuais no Power BI para ajudar a área de negócio a tomar decisões. Qual função ele exerce?",
+        explanation:
+            "O analista de dados explora os dados e cria visualizações e relatórios, sendo o Power BI uma ferramenta típica dessa função. O engenheiro de dados prepara os dados, mas normalmente não é quem produz os relatórios de negócio.",
+        topic: "Cargas de trabalho e funções",
+        options: [
+            ["Analista de dados", true],
+            ["Engenheiro de dados", false],
+            ["Administrador de banco de dados (DBA)", false],
+            ["Arquiteto de rede", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço do Azure é usado principalmente para orquestrar e automatizar pipelines de integração e transformação de dados (ETL/ELT)?",
+        explanation:
+            "O Azure Data Factory é o serviço de integração de dados usado para criar e orquestrar pipelines de ETL/ELT. O Power BI é voltado à visualização e aos relatórios, não à orquestração de pipelines.",
+        topic: "Cargas de trabalho e funções",
+        options: [
+            ["Azure Data Factory", true],
+            ["Power BI", false],
+            ["Azure Blob Storage", false],
+            ["Microsoft Excel", false],
+        ],
+    },
+
+    // Domínio 2 - Dados relacionais
+    {
+        statement:
+            "Em um banco de dados relacional você modela a entidade Produto. Onde ficam armazenados os dados de um produto individual, como um teclado específico?",
+        explanation:
+            "Cada linha (registro) de uma tabela representa uma instância única da entidade, enquanto as colunas guardam os atributos e a tabela como um todo representa a entidade.",
+        topic: "Dados relacionais",
+        options: [
+            ["Em uma linha da tabela Produto", true],
+            ["Em uma coluna da tabela Produto", false],
+            ["No nome da tabela", false],
+            ["Em um índice da tabela", false],
+        ],
+    },
+    {
+        statement:
+            "Qual característica descreve corretamente uma chave primária em uma tabela relacional?",
+        explanation:
+            "A chave primária identifica cada linha de forma única e não pode conter valores nulos nem duplicados.",
+        topic: "Dados relacionais",
+        options: [
+            ["Identifica cada linha de forma única e não aceita valores nulos", true],
+            ["Pode conter valores duplicados desde que não sejam nulos", false],
+            ["Serve apenas para ligar a tabela a outra e pode ser nula", false],
+            ["Deve obrigatoriamente ser uma coluna de texto", false],
+        ],
+    },
+    {
+        statement:
+            "A tabela Pedidos possui uma coluna ClienteId que aponta para a chave primária da tabela Clientes. Que tipo de chave é ClienteId dentro de Pedidos?",
+        explanation:
+            "A chave estrangeira referencia a chave primária de outra tabela, estabelecendo o relacionamento e permitindo impor a integridade referencial.",
+        topic: "Dados relacionais",
+        options: [
+            ["Chave estrangeira", true],
+            ["Chave primária", false],
+            ["Chave candidata", false],
+            ["Índice agrupado", false],
+        ],
+    },
+    {
+        statement:
+            "Na terminologia relacional, como é chamado o elemento que define um atributo, como Email ou DataNascimento, com um tipo de dado associado?",
+        explanation:
+            "A coluna representa um atributo da entidade e possui um tipo de dado que restringe os valores aceitos naquela posição.",
+        topic: "Dados relacionais",
+        options: [
+            ["Coluna", true],
+            ["Linha", false],
+            ["Registro", false],
+            ["Chave estrangeira", false],
+        ],
+    },
+    {
+        statement:
+            "Um cliente pode ter vários pedidos, mas cada pedido pertence a um único cliente. Que tipo de relacionamento descreve essa situação?",
+        explanation:
+            "Um para muitos é o relacionamento em que uma linha de uma tabela se associa a várias linhas de outra, sem que o inverso ocorra.",
+        topic: "Dados relacionais",
+        options: [
+            ["Um para muitos", true],
+            ["Um para um", false],
+            ["Muitos para muitos", false],
+            ["Sem relacionamento entre as tabelas", false],
+        ],
+    },
+    {
+        statement:
+            "Em uma escola, um aluno pode se matricular em vários cursos e cada curso tem vários alunos. Como esse relacionamento muitos para muitos costuma ser implementado no modelo relacional?",
+        explanation:
+            "Um relacionamento muitos para muitos é resolvido com uma tabela de ligação (junção) que armazena as chaves estrangeiras das duas tabelas.",
+        topic: "Dados relacionais",
+        options: [
+            ["Com uma tabela de ligação que guarda as chaves estrangeiras das duas tabelas", true],
+            ["Colocando uma única chave estrangeira direta em uma das tabelas", false],
+            ["Duplicando as linhas em ambas as tabelas", false],
+            ["Removendo a chave primária de uma das tabelas", false],
+        ],
+    },
+    {
+        statement: "O que a integridade referencial garante em um banco de dados relacional?",
+        explanation:
+            "A integridade referencial impede que uma chave estrangeira aponte para um valor que não existe na tabela referenciada, mantendo os relacionamentos consistentes.",
+        topic: "Dados relacionais",
+        options: [
+            [
+                "Que uma chave estrangeira só aponte para valores existentes na tabela referenciada",
+                true,
+            ],
+            ["Que todas as colunas tenham apenas valores atômicos", false],
+            ["Que a tabela esteja obrigatoriamente na terceira forma normal", false],
+            ["Que os índices sejam recriados a cada consulta", false],
+        ],
+    },
+    {
+        statement:
+            "Uma tabela possui uma coluna Telefones que guarda vários números separados por vírgula na mesma célula. Qual forma normal está sendo violada?",
+        explanation:
+            "A primeira forma normal (1FN) exige que cada coluna contenha apenas valores atômicos, ou seja, um único valor indivisível por célula.",
+        topic: "Dados relacionais",
+        options: [
+            ["Primeira forma normal (1FN)", true],
+            ["Segunda forma normal (2FN)", false],
+            ["Terceira forma normal (3FN)", false],
+            ["Forma normal de Boyce-Codd", false],
+        ],
+    },
+    {
+        statement:
+            "Uma tabela usa a chave primária composta (PedidoId, ProdutoId). A coluna NomeProduto depende apenas de ProdutoId, e não da chave composta inteira. Qual forma normal essa situação viola?",
+        explanation:
+            "A segunda forma normal (2FN) exige que todo atributo não chave dependa da chave primária inteira; depender de apenas parte de uma chave composta é uma dependência parcial que viola a 2FN.",
+        topic: "Dados relacionais",
+        options: [
+            ["Segunda forma normal (2FN), por dependência parcial", true],
+            ["Primeira forma normal (1FN), por falta de atomicidade", false],
+            ["Terceira forma normal (3FN), por dependência transitiva", false],
+            ["Nenhuma forma normal é violada", false],
+        ],
+    },
+    {
+        statement:
+            "Em uma tabela de Funcionários, a coluna NomeDepartamento depende de DepartamentoId, que por sua vez depende da chave primária FuncionarioId. Que problema de normalização isso indica?",
+        explanation:
+            "Uma dependência transitiva, em que um atributo não chave depende de outro atributo não chave, viola a terceira forma normal (3FN).",
+        topic: "Dados relacionais",
+        options: [
+            ["Dependência transitiva, que viola a 3FN", true],
+            ["Dependência parcial, que viola a 2FN", false],
+            ["Falta de atomicidade, que viola a 1FN", false],
+            ["Ausência de chave primária na tabela", false],
+        ],
+    },
+    {
+        statement:
+            "Quais problemas a normalização de um banco de dados relacional ajuda a reduzir? (Selecione DUAS opções.)",
+        explanation:
+            "A normalização diminui a redundância de dados repetidos e as anomalias de inserção, atualização e exclusão que surgem quando a mesma informação é duplicada em vários lugares.",
+        topic: "Dados relacionais",
+        options: [
+            ["Redundância de dados repetidos em várias linhas ou tabelas", true],
+            ["Anomalias de atualização causadas por dados duplicados", true],
+            ["A necessidade de usar o comando SELECT nas consultas", false],
+            ["A existência de chaves primárias nas tabelas", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe percebe que um relatório muito acessado exige muitos joins e está lento. De forma deliberada, decide duplicar algumas colunas em uma tabela para reduzir esses joins. Como se chama essa técnica?",
+        explanation:
+            "A desnormalização introduz redundância controlada para melhorar o desempenho de leitura, reduzindo a quantidade de joins necessários, ao custo de mais duplicação.",
+        topic: "Dados relacionais",
+        options: [
+            ["Desnormalização", true],
+            ["Normalização", false],
+            ["Integridade referencial", false],
+            ["Particionamento horizontal", false],
+        ],
+    },
+    {
+        statement:
+            "Um administrador precisa criar uma nova tabela e depois alterar a estrutura de outra tabela existente. A qual categoria de comandos SQL pertencem CREATE e ALTER?",
+        explanation:
+            "CREATE, ALTER, DROP e TRUNCATE são comandos DDL (Linguagem de Definição de Dados), usados para definir e modificar a estrutura dos objetos do banco.",
+        topic: "SQL e objetos de banco",
+        options: [
+            ["DDL (Linguagem de Definição de Dados)", true],
+            ["DML (Linguagem de Manipulação de Dados)", false],
+            ["DQL (Linguagem de Consulta de Dados)", false],
+            ["DCL (Linguagem de Controle de Dados)", false],
+        ],
+    },
+    {
+        statement:
+            "Qual comando SQL é usado para modificar os valores de linhas já existentes em uma tabela?",
+        explanation:
+            "UPDATE é um comando DML que altera os dados de linhas já existentes; INSERT adiciona novas linhas e DELETE remove linhas.",
+        topic: "SQL e objetos de banco",
+        options: [
+            ["UPDATE", true],
+            ["CREATE", false],
+            ["GRANT", false],
+            ["SELECT", false],
+        ],
+    },
+    {
+        statement:
+            "Um analista quer apenas recuperar dados de uma tabela, sem alterá-los. Qual comando SQL ele deve usar?",
+        explanation:
+            "SELECT é o comando de consulta (DQL) usado para recuperar dados de uma ou mais tabelas sem modificá-los.",
+        topic: "SQL e objetos de banco",
+        options: [
+            ["SELECT", true],
+            ["INSERT", false],
+            ["ALTER", false],
+            ["REVOKE", false],
+        ],
+    },
+    {
+        statement:
+            "Quais comandos SQL pertencem à categoria DCL (Linguagem de Controle de Dados), usada para gerenciar permissões de acesso? (Selecione DUAS opções.)",
+        explanation:
+            "GRANT concede permissões e REVOKE remove permissões; ambos fazem parte da DCL, que controla o acesso aos objetos do banco.",
+        topic: "SQL e objetos de banco",
+        options: [
+            ["GRANT", true],
+            ["REVOKE", true],
+            ["INSERT", false],
+            ["DROP", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe quer disponibilizar uma consulta salva que combina colunas de várias tabelas e pode ser consultada como se fosse uma tabela. Qual objeto de banco atende a essa necessidade?",
+        explanation:
+            "Uma view é uma consulta salva e virtual que apresenta dados de uma ou mais tabelas e pode ser consultada como se fosse uma tabela.",
+        topic: "SQL e objetos de banco",
+        options: [
+            ["View", true],
+            ["Índice", false],
+            ["Chave primária", false],
+            ["Sequência de backup", false],
+        ],
+    },
+    {
+        statement:
+            "Você precisa encapsular um bloco de comandos SQL reutilizável que aceita parâmetros e pode ser executado sob demanda pela aplicação. Qual objeto de banco você deve usar?",
+        explanation:
+            "Uma stored procedure (procedimento armazenado) é um bloco de código SQL reutilizável, que pode receber parâmetros e ser executado quando chamado.",
+        topic: "SQL e objetos de banco",
+        options: [
+            ["Stored procedure", true],
+            ["View", false],
+            ["Índice", false],
+            ["Chave estrangeira", false],
+        ],
+    },
+    {
+        statement:
+            "As consultas em uma tabela grande estão lentas ao filtrar pela coluna Sobrenome. Qual objeto de banco pode acelerar essas buscas?",
+        explanation:
+            "Um índice melhora o desempenho das buscas ao permitir que o mecanismo localize rapidamente as linhas sem varrer a tabela inteira.",
+        topic: "SQL e objetos de banco",
+        options: [
+            ["Índice", true],
+            ["View", false],
+            ["Chave estrangeira", false],
+            ["Stored procedure", false],
+        ],
+    },
+    {
+        statement:
+            "Qual objeto de banco de dados é projetado para receber entradas, executar um cálculo e retornar um valor que pode ser usado dentro de uma consulta?",
+        explanation:
+            "Uma function (função) recebe parâmetros, executa uma lógica e retorna um valor, podendo ser usada diretamente em expressões e consultas SELECT.",
+        topic: "SQL e objetos de banco",
+        options: [
+            ["Function", true],
+            ["Índice", false],
+            ["Chave primária", false],
+            ["Restrição de verificação", false],
+        ],
+    },
+    {
+        statement:
+            "Uma startup vai desenvolver uma aplicação nova na nuvem e quer um banco relacional totalmente gerenciado, sem administrar o sistema operacional nem aplicar patches. Qual serviço do Azure é o mais indicado?",
+        explanation:
+            "O Azure SQL Database é uma oferta PaaS totalmente gerenciada, ideal para aplicações novas na nuvem, cuidando de patches, backups e infraestrutura.",
+        topic: "Serviços relacionais no Azure",
+        options: [
+            ["Azure SQL Database", true],
+            ["SQL Server em uma máquina virtual do Azure", false],
+            ["Azure Blob Storage", false],
+            ["Azure Cosmos DB", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer migrar um banco SQL Server local para a nuvem com o mínimo de alterações, mantendo recursos como SQL Server Agent e quase 100% de compatibilidade. Qual opção do Azure é a mais adequada?",
+        explanation:
+            "O Azure SQL Managed Instance oferece compatibilidade quase total com o SQL Server local, sendo ideal para cenários de lift-and-shift com pouca ou nenhuma alteração.",
+        topic: "Serviços relacionais no Azure",
+        options: [
+            ["Azure SQL Managed Instance", true],
+            ["Azure SQL Database (banco único)", false],
+            ["Azure Database for PostgreSQL", false],
+            ["Azure Table Storage", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe precisa de controle total sobre o sistema operacional e a instância do SQL Server, incluindo a instalação de componentes personalizados no servidor. Qual opção de hospedagem no Azure oferece esse nível de controle?",
+        explanation:
+            "SQL Server em uma máquina virtual do Azure é uma solução IaaS, na qual você gerencia o sistema operacional e a instância do SQL Server, tendo controle total.",
+        topic: "Serviços relacionais no Azure",
+        options: [
+            ["SQL Server em uma máquina virtual do Azure", true],
+            ["Azure SQL Database serverless", false],
+            ["Azure SQL Managed Instance", false],
+            ["Azure Database for MySQL", false],
+        ],
+    },
+    {
+        statement:
+            "Ao escolher o Azure SQL Database (PaaS) em vez de rodar SQL Server em uma VM (IaaS), qual responsabilidade deixa de ser da equipe de TI do cliente?",
+        explanation:
+            "No modelo PaaS do Azure SQL Database, a Microsoft cuida da aplicação de patches no sistema operacional e no mecanismo de banco, o que continua sendo do cliente no IaaS.",
+        topic: "Serviços relacionais no Azure",
+        options: [
+            ["A aplicação de patches no sistema operacional e no mecanismo de banco", true],
+            ["A definição do esquema das tabelas da aplicação", false],
+            ["A escrita das consultas SQL usadas pela aplicação", false],
+            ["A modelagem dos relacionamentos entre as tabelas", false],
+        ],
+    },
+    {
+        statement:
+            "Qual opção de implantação do Azure SQL Database escala automaticamente os recursos de computação e pode pausar durante períodos de inatividade, cobrando pelo uso?",
+        explanation:
+            "A opção serverless do Azure SQL Database escala a computação automaticamente e pode pausar quando o banco fica inativo, sendo cobrada conforme o consumo.",
+        topic: "Serviços relacionais no Azure",
+        options: [
+            ["Serverless", true],
+            ["Elastic pool", false],
+            ["Managed Instance", false],
+            ["SQL Server em uma VM do Azure", false],
+        ],
+    },
+    {
+        statement:
+            "Um provedor SaaS hospeda dezenas de bancos de dados com picos de uso em horários diferentes e quer compartilhar um conjunto de recursos entre eles para otimizar custos. Qual opção do Azure SQL Database atende a isso?",
+        explanation:
+            "O elastic pool permite que vários bancos de dados compartilhem um mesmo conjunto de recursos, sendo econômico quando o uso dos bancos é variável e não simultâneo.",
+        topic: "Serviços relacionais no Azure",
+        options: [
+            ["Elastic pool", true],
+            ["Banco único (single database) isolado", false],
+            ["SQL Server em uma VM do Azure", false],
+            ["Azure SQL Managed Instance", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe usa uma aplicação open source que exige um banco PostgreSQL e quer um serviço totalmente gerenciado no Azure. Qual serviço é o adequado?",
+        explanation:
+            "O Azure Database for PostgreSQL é o serviço gerenciado do Azure para bancos PostgreSQL, cuidando de backups, alta disponibilidade e patches.",
+        topic: "Serviços relacionais no Azure",
+        options: [
+            ["Azure Database for PostgreSQL", true],
+            ["Azure SQL Database", false],
+            ["Azure SQL Managed Instance", false],
+            ["Azure Cosmos DB for NoSQL", false],
+        ],
+    },
+    {
+        statement:
+            "Ao planejar um novo projeto com banco relacional open source gerenciado no Azure em 2026, quais serviços a Microsoft mantém como foco atual? (Selecione DUAS opções.)",
+        explanation:
+            "O Azure Database for MariaDB foi descontinuado pela Microsoft, de modo que o foco atual para bancos open source gerenciados são o PostgreSQL e o MySQL.",
+        topic: "Serviços relacionais no Azure",
+        options: [
+            ["Azure Database for PostgreSQL", true],
+            ["Azure Database for MySQL", true],
+            ["Azure Database for MariaDB", false],
+            ["Azure Database for Oracle", false],
+        ],
+    },
+
+    // Domínio 3 - Dados não relacionais
+    {
+        statement:
+            "Um arquiteto de soluções precisa de um recurso do Azure que agrupe, sob um mesmo namespace e conjunto de credenciais, serviços para blobs, compartilhamentos de arquivo, tabelas NoSQL e filas de mensagens. Qual recurso ele deve provisionar?",
+        explanation:
+            "A conta de armazenamento (storage account) é o container de nível superior que engloba os quatro serviços de dados: Blob, Files, Table e Queue.",
+        topic: "Armazenamento não relacional",
+        options: [
+            ["Uma conta de armazenamento do Azure (Azure Storage account)", true],
+            ["Uma instância do Azure Cosmos DB", false],
+            ["Um Azure SQL Database", false],
+            ["Um workspace do Azure Synapse Analytics", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe de ciência de dados precisa guardar, em grande escala, arquivos Parquet e CSV brutos para alimentar um data lake. Qual serviço da conta de armazenamento é o mais adequado para esses dados não estruturados?",
+        explanation:
+            "O Blob Storage é otimizado para grandes volumes de dados não estruturados e é a base do Azure Data Lake Storage Gen2.",
+        topic: "Armazenamento não relacional",
+        options: [
+            ["Azure Table Storage", false],
+            ["Azure Blob Storage", true],
+            ["Azure Files", false],
+            ["Azure Queue Storage", false],
+        ],
+    },
+    {
+        statement:
+            "No Azure Blob Storage, como os blobs são organizados dentro de uma conta de armazenamento?",
+        explanation:
+            "Dentro de uma conta de armazenamento, os blobs ficam organizados em containers, que funcionam como pastas de nível superior.",
+        topic: "Armazenamento não relacional",
+        options: [
+            ["Em containers", true],
+            ["Em tabelas", false],
+            ["Em filas", false],
+            ["Em compartilhamentos SMB", false],
+        ],
+    },
+    {
+        statement:
+            "Uma aplicação lê com muita frequência um conjunto de arquivos recém-enviados. Qual camada de acesso do Blob Storage oferece o menor custo de acesso para dados usados com frequência?",
+        explanation:
+            "A camada Hot tem o maior custo de armazenamento, porém o menor custo de acesso, sendo ideal para dados lidos com frequência.",
+        topic: "Armazenamento não relacional",
+        options: [
+            ["Cool (Fria)", false],
+            ["Cold (Fria)", false],
+            ["Hot (Quente)", true],
+            ["Archive (Arquivo)", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa precisa reter documentos fiscais por sete anos apenas para conformidade legal, praticamente sem nunca acessá-los. Qual camada de acesso do Blob Storage oferece o menor custo de armazenamento?",
+        explanation:
+            "A camada Archive tem o menor custo de armazenamento, adequada para dados raramente acessados que toleram latência na recuperação.",
+        topic: "Armazenamento não relacional",
+        options: [
+            ["Hot (Quente)", false],
+            ["Cool (Fria)", false],
+            ["Cold (Fria)", false],
+            ["Archive (Arquivo)", true],
+        ],
+    },
+    {
+        statement:
+            "Um blob está guardado na camada Archive e a aplicação agora precisa ler o seu conteúdo. O que é necessário para acessar esses dados?",
+        explanation:
+            "Dados na camada Archive ficam offline; para lê-los é preciso reidratar (rehydrate) o blob para a camada Hot ou Cool, processo que pode levar horas.",
+        topic: "Armazenamento não relacional",
+        options: [
+            ["Reidratar o blob para a camada Hot ou Cool, o que pode levar horas", true],
+            ["Nada, a leitura na camada Archive é imediata como nas demais", false],
+            ["Converter a conta de armazenamento em Azure Cosmos DB", false],
+            ["Montar o blob via protocolo SMB", false],
+        ],
+    },
+    {
+        statement:
+            "Ao escolher entre as camadas Hot e Cool do Blob Storage, qual é o principal trade-off a ser considerado?",
+        explanation:
+            "Quanto mais fria a camada, menor o custo de guardar os dados e maior o custo de acessá-los. A Hot é o oposto da Cool nesse aspecto.",
+        topic: "Armazenamento não relacional",
+        options: [
+            [
+                "A Hot tem armazenamento mais caro e acesso mais barato; a Cool tem armazenamento mais barato e acesso mais caro",
+                true,
+            ],
+            ["A Hot e a Cool têm exatamente o mesmo custo, mudando apenas a região", false],
+            ["A Cool tem armazenamento mais caro e acesso mais barato que a Hot", false],
+            ["A Hot só aceita dados estruturados e a Cool só dados não estruturados", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer substituir um servidor de arquivos local por um compartilhamento na nuvem que possa ser montado por máquinas Windows via SMB e por servidores Linux via NFS. Qual serviço atende a esse requisito?",
+        explanation:
+            "O Azure Files oferece compartilhamentos de arquivos gerenciados acessíveis por SMB e NFS, montáveis tanto na nuvem quanto no ambiente local.",
+        topic: "Armazenamento não relacional",
+        options: [
+            ["Azure Blob Storage", false],
+            ["Azure Files", true],
+            ["Azure Table Storage", false],
+            ["Azure Queue Storage", false],
+        ],
+    },
+    {
+        statement:
+            "Quais protocolos são suportados pelo Azure Files para montar compartilhamentos de arquivos em clientes na nuvem e no local? (Selecione DUAS opções.)",
+        explanation:
+            "O Azure Files disponibiliza compartilhamentos de arquivos acessíveis pelos protocolos SMB e NFS. AMQP é de mensageria e ODBC é de conexão a bancos relacionais.",
+        topic: "Armazenamento não relacional",
+        options: [
+            ["SMB", true],
+            ["NFS", true],
+            ["AMQP", false],
+            ["ODBC", false],
+        ],
+    },
+    {
+        statement:
+            "Uma aplicação precisa armazenar bilhões de entidades de perfil de usuário, cada uma com atributos que podem variar, com baixo custo e sem necessidade de junções ou relacionamentos. Qual serviço é o mais indicado?",
+        explanation:
+            "O Azure Table Storage é um armazenamento NoSQL de chave-valor, sem schema fixo e econômico para grandes volumes de dados semiestruturados.",
+        topic: "Armazenamento não relacional",
+        options: [
+            ["Azure SQL Database", false],
+            ["Azure Blob Storage", false],
+            ["Azure Table Storage", true],
+            ["Azure Queue Storage", false],
+        ],
+    },
+    {
+        statement:
+            "No Azure Table Storage, duas entidades na mesma tabela podem ter conjuntos de propriedades diferentes entre si. Qual característica desse serviço isso demonstra?",
+        explanation:
+            "O Table Storage não impõe schema fixo (schemaless), então cada entidade pode ter propriedades diferentes das demais na mesma tabela.",
+        topic: "Armazenamento não relacional",
+        options: [
+            ["Ausência de schema fixo (schemaless)", true],
+            ["Integridade referencial entre tabelas", false],
+            ["Normalização automática dos dados", false],
+            ["Conformidade ACID com transações distribuídas", false],
+        ],
+    },
+    {
+        statement:
+            "No Azure Table Storage, qual combinação de valores identifica exclusivamente uma entidade e determina como os dados são particionados?",
+        explanation:
+            "Cada entidade do Table Storage é identificada de forma única pela combinação de PartitionKey e RowKey; a PartitionKey define o particionamento dos dados.",
+        topic: "Armazenamento não relacional",
+        options: [
+            ["Chave primária e chave estrangeira", false],
+            ["ID e timestamp", false],
+            ["Chave de partição (PartitionKey) e chave de linha (RowKey)", true],
+            ["Container e nome do blob", false],
+        ],
+    },
+    {
+        statement:
+            "Um sistema de e-commerce precisa desacoplar o recebimento de pedidos do processamento de pagamentos, permitindo comunicação assíncrona entre os componentes. Qual serviço da conta de armazenamento é indicado para enfileirar essas mensagens?",
+        explanation:
+            "O Azure Queue Storage guarda grandes quantidades de mensagens que podem ser processadas de forma assíncrona, desacoplando os componentes de uma aplicação.",
+        topic: "Armazenamento não relacional",
+        options: [
+            ["Azure Queue Storage", true],
+            ["Azure Files", false],
+            ["Azure Blob Storage", false],
+            ["Azure Table Storage", false],
+        ],
+    },
+    {
+        statement:
+            "Uma startup global precisa de um banco de dados NoSQL totalmente gerenciado que replique dados automaticamente em várias regiões, garanta latência de milissegundos e escale horizontalmente conforme a demanda. Qual serviço do Azure atende a esses requisitos?",
+        explanation:
+            "O Azure Cosmos DB é um serviço de banco de dados NoSQL PaaS com distribuição global, latência de milissegundos, escala horizontal automática e alta disponibilidade.",
+        topic: "Azure Cosmos DB",
+        options: [
+            ["Azure SQL Database", false],
+            ["Azure Table Storage", false],
+            ["Azure Cosmos DB", true],
+            ["Azure Database for PostgreSQL", false],
+        ],
+    },
+    {
+        statement:
+            "Uma nova aplicação será desenvolvida do zero e armazenará documentos JSON no Azure Cosmos DB. Qual API é recomendada por ser a nativa e costumar receber os recursos mais recentes primeiro?",
+        explanation:
+            "A API para NoSQL (Core) é a API nativa do Cosmos DB, armazena documentos JSON e normalmente recebe os novos recursos antes das demais.",
+        topic: "Azure Cosmos DB",
+        options: [
+            ["API para NoSQL", true],
+            ["API para MongoDB", false],
+            ["API para Apache Cassandra", false],
+            ["API para Apache Gremlin", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa possui uma aplicação que já usa MongoDB e quer migrá-la para o Azure Cosmos DB com o mínimo de alterações de código, reaproveitando drivers e ferramentas atuais. Qual API do Cosmos DB deve escolher?",
+        explanation:
+            "A API para MongoDB é compatível com o protocolo do MongoDB, permitindo migrar aplicações existentes reaproveitando bibliotecas e ferramentas.",
+        topic: "Azure Cosmos DB",
+        options: [
+            ["API para NoSQL", false],
+            ["API para MongoDB", true],
+            ["API para Table", false],
+            ["API para Apache Gremlin", false],
+        ],
+    },
+    {
+        statement:
+            "Uma rede social precisa modelar usuários e os relacionamentos entre eles, como amizades e seguidores, na forma de vértices e arestas, executando consultas de grafo. Qual API do Azure Cosmos DB é a mais adequada?",
+        explanation:
+            "A API para Apache Gremlin do Cosmos DB é voltada para bancos de dados de grafo, representando dados como vértices (entidades) e arestas (relacionamentos).",
+        topic: "Azure Cosmos DB",
+        options: [
+            ["API para Apache Cassandra", false],
+            ["API para Table", false],
+            ["API para Apache Gremlin", true],
+            ["API para MongoDB", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe já opera cargas de trabalho no Apache Cassandra e quer um serviço gerenciado no Azure compatível com a linguagem CQL e o modelo de dados em famílias de colunas. Qual API do Cosmos DB deve usar?",
+        explanation:
+            "A API para Apache Cassandra oferece compatibilidade com CQL e o modelo colunar, permitindo migrar cargas de trabalho Cassandra existentes.",
+        topic: "Azure Cosmos DB",
+        options: [
+            ["API para Apache Gremlin", false],
+            ["API para Apache Cassandra", true],
+            ["API para NoSQL", false],
+            ["API para MongoDB", false],
+        ],
+    },
+    {
+        statement:
+            "Uma aplicação já usa o Azure Table Storage, mas agora precisa de distribuição global, latência garantida e maior throughput. Qual API do Azure Cosmos DB permite migrar mantendo um modelo de dados semelhante de chave-valor?",
+        explanation:
+            "A API para Table do Cosmos DB oferece um modelo chave-valor compatível com o Azure Table Storage, porém com os benefícios premium do Cosmos DB, como distribuição global e latência garantida.",
+        topic: "Azure Cosmos DB",
+        options: [
+            ["API para Table", true],
+            ["API para NoSQL", false],
+            ["API para Apache Gremlin", false],
+            ["API para Apache Cassandra", false],
+        ],
+    },
+    {
+        statement:
+            "Quais cenários são casos de uso típicos do Azure Cosmos DB, por se beneficiarem de distribuição global e baixa latência? (Selecione DUAS opções.)",
+        explanation:
+            "O Cosmos DB se destaca em cenários de tempo real e escala global, como telemetria de IoT e e-commerce. Data warehouse analítico em batch e backups frios são melhor atendidos por outros serviços.",
+        topic: "Azure Cosmos DB",
+        options: [
+            ["Telemetria de dispositivos IoT em tempo real", true],
+            ["Catálogo e carrinho de e-commerce com usuários no mundo todo", true],
+            ["Data warehouse para relatórios analíticos históricos em batch", false],
+            ["Armazenamento de backups frios raramente acessados", false],
+        ],
+    },
+    {
+        statement:
+            "Um jogo online com milhões de jogadores simultâneos no mundo todo precisa de um banco de dados que suporte picos massivos de tráfego, baixa latência de leitura e escrita e escala elástica. Qual serviço é o mais indicado?",
+        explanation:
+            "O Cosmos DB é amplamente usado em jogos por oferecer escala elástica, baixa latência e distribuição global para suportar picos de milhões de jogadores.",
+        topic: "Azure Cosmos DB",
+        options: [
+            ["Azure Table Storage", false],
+            ["Azure Cosmos DB", true],
+            ["Azure SQL Database", false],
+            ["Azure Files", false],
+        ],
+    },
+
+    // Domínio 4 - Cargas de trabalho de análise
+    {
+        statement:
+            "Uma empresa precisa limpar, padronizar e agregar os dados em uma área intermediária antes de gravá-los no data warehouse, de modo que apenas informações já tratadas cheguem ao destino. Qual abordagem descreve esse fluxo?",
+        explanation:
+            "No ETL os dados são transformados antes de serem carregados no destino, garantindo que apenas dados já tratados cheguem ao data warehouse.",
+        topic: "Análise e data warehouse",
+        options: [
+            ["ELT (Extract, Load, Transform)", false],
+            ["ETL (Extract, Transform, Load)", true],
+            ["Processamento de fluxo em tempo real", false],
+            ["Schema-on-read", false],
+        ],
+    },
+    {
+        statement:
+            "Em um data lake moderno, a equipe carrega primeiro os dados brutos no destino e só depois executa as transformações, aproveitando o poder de processamento do próprio armazenamento analítico. Que abordagem é essa?",
+        explanation:
+            "No ELT os dados brutos são carregados primeiro e transformados no destino, aproveitando a escala de processamento do armazenamento analítico.",
+        topic: "Análise e data warehouse",
+        options: [
+            ["ELT (Extract, Load, Transform)", true],
+            ["ETL (Extract, Transform, Load)", false],
+            ["Processamento OLTP", false],
+            ["Normalização em terceira forma normal", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe quer orquestrar, de forma gerenciada e sem provisionar servidores, pipelines que copiam e movem dados agendados entre dezenas de fontes locais e na nuvem. Qual serviço do Azure atende a esse cenário?",
+        explanation:
+            "O Azure Data Factory é o serviço gerenciado de integração de dados que orquestra pipelines de ingestão, cópia e movimentação entre fontes.",
+        topic: "Análise e data warehouse",
+        options: [
+            ["Azure Databricks", false],
+            ["Power BI Desktop", false],
+            ["Azure Data Factory", true],
+            ["Azure Event Hubs", false],
+        ],
+    },
+    {
+        statement:
+            "Um repositório analítico relacional, curado e altamente estruturado aplica o esquema no momento da gravação (schema-on-write) e é otimizado para consultas de relatórios e BI. Qual repositório é esse?",
+        explanation:
+            "O data warehouse é um armazenamento relacional curado, com schema-on-write, projetado para consultas analíticas e relatórios.",
+        topic: "Análise e data warehouse",
+        options: [
+            ["Data lake", false],
+            ["Data warehouse", true],
+            ["Fila de mensagens", false],
+            ["Banco NoSQL de documentos", false],
+        ],
+    },
+    {
+        statement:
+            "Uma organização precisa guardar grandes volumes de dados brutos em formatos variados (estruturados, semiestruturados e não estruturados) ao menor custo possível, definindo a estrutura apenas na hora de ler. Qual solução é a mais adequada?",
+        explanation:
+            "O data lake armazena dados brutos de qualquer formato a baixo custo e usa schema-on-read, aplicando a estrutura somente na leitura.",
+        topic: "Análise e data warehouse",
+        options: [
+            ["Data warehouse relacional", false],
+            ["Banco de dados OLTP", false],
+            ["Índice de busca", false],
+            ["Data lake", true],
+        ],
+    },
+    {
+        statement:
+            "Qual arquitetura de dados combina o armazenamento flexível e barato de dados brutos de um data lake com os recursos de estrutura, esquema e consulta de um data warehouse?",
+        explanation:
+            "O lakehouse une as vantagens do data lake (dados brutos e baixo custo) com as do data warehouse (estrutura e consultas) em uma única arquitetura.",
+        topic: "Análise e data warehouse",
+        options: [
+            ["Lakehouse", true],
+            ["Data mart isolado", false],
+            ["Cubo OLAP tradicional", false],
+            ["Banco de dados em grafo", false],
+        ],
+    },
+    {
+        statement:
+            "Qual plataforma da Microsoft é uma solução SaaS unificada que reúne, em um único produto, integração de dados, engenharia de dados, data warehouse, ciência de dados, análise em tempo real e Power BI?",
+        explanation:
+            "O Microsoft Fabric é a plataforma SaaS unificada de análise que integra todas as cargas de trabalho de dados em uma só experiência.",
+        topic: "Análise e data warehouse",
+        options: [
+            ["Azure Databricks", false],
+            ["SQL Server Management Studio", false],
+            ["Microsoft Fabric", true],
+            ["Azure Data Factory", false],
+        ],
+    },
+    {
+        statement:
+            "No Microsoft Fabric, qual componente funciona como o data lake único e centralizado da organização, armazenando cada dado uma só vez para ser reutilizado por todas as cargas de trabalho?",
+        explanation:
+            "O OneLake é o data lake unificado do Fabric, que guarda o dado uma única vez e o disponibiliza para todos os workloads, evitando duplicação.",
+        topic: "Análise e data warehouse",
+        options: [
+            ["Azure Blob Storage clássico", false],
+            ["OneLake", true],
+            ["Azure Table Storage", false],
+            ["Um data mart por departamento", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe de engenharia de dados quer processar grandes volumes de dados com Apache Spark e notebooks dentro do Microsoft Fabric. Qual carga de trabalho do Fabric ela deve usar?",
+        explanation:
+            "A carga Synapse Data Engineering do Fabric fornece o ambiente Apache Spark para processar dados em escala usando notebooks.",
+        topic: "Análise e data warehouse",
+        options: [
+            ["Power BI", false],
+            ["Data Warehouse", false],
+            ["Real-Time Intelligence", false],
+            ["Synapse Data Engineering", true],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço de análise do Azure é baseado no Apache Spark e oferece notebooks colaborativos para engenharia de dados, ciência de dados e machine learning?",
+        explanation:
+            "O Azure Databricks é a plataforma de análise baseada em Apache Spark, com notebooks colaborativos para engenharia, ciência de dados e ML.",
+        topic: "Análise e data warehouse",
+        options: [
+            ["Azure Databricks", true],
+            ["Azure Data Factory", false],
+            ["Azure Stream Analytics", false],
+            ["Azure Cosmos DB", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço fornece a camada de armazenamento para análise de big data no Azure, construído sobre o Blob Storage e com namespace hierárquico que organiza os dados em diretórios?",
+        explanation:
+            "O Azure Data Lake Storage Gen2 acrescenta o namespace hierárquico ao Blob Storage, servindo como camada de armazenamento para big data.",
+        topic: "Análise e data warehouse",
+        options: [
+            ["Azure Files", false],
+            ["Azure Queue Storage", false],
+            ["Azure Data Lake Storage Gen2", true],
+            ["Azure SQL Database", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço do Azure oferece um data warehouse corporativo com análise em larga escala e tem tido seus recursos convergidos para o Microsoft Fabric?",
+        explanation:
+            "O Azure Synapse Analytics é o serviço de data warehouse corporativo e análise do Azure, cujos recursos vêm convergindo para o Microsoft Fabric.",
+        topic: "Análise e data warehouse",
+        options: [
+            ["Azure Cosmos DB", false],
+            ["Azure Synapse Analytics", true],
+            ["Azure Event Hubs", false],
+            ["Azure Blob Storage", false],
+        ],
+    },
+    {
+        statement: "Quais afirmações descrevem corretamente um data lake? (Selecione DUAS opções.)",
+        explanation:
+            "O data lake guarda dados brutos de qualquer formato a baixo custo e usa schema-on-read; exigir dados relacionais curados descreve o data warehouse, e OLTP é um cenário transacional, não analítico.",
+        topic: "Análise e data warehouse",
+        options: [
+            ["Armazena dados brutos em diversos formatos a baixo custo", true],
+            ["Aplica o esquema no momento da leitura (schema-on-read)", true],
+            ["Exige que os dados sejam relacionais e curados antes da gravação", false],
+            ["É otimizado principalmente para transações OLTP de baixa latência", false],
+        ],
+    },
+    {
+        statement:
+            "Um sistema coleta os dados de vendas ao longo de todo o dia e os processa juntos durante a madrugada para fechar os relatórios diários. Que tipo de processamento é esse?",
+        explanation:
+            "O processamento em lote (batch) agrupa os dados e os processa em intervalos agendados, tolerando maior latência, como em fechamentos diários.",
+        topic: "Tempo real e streaming",
+        options: [
+            ["Processamento de fluxo (streaming)", false],
+            ["Processamento por janela deslizante", false],
+            ["Processamento de eventos complexos em tempo real", false],
+            ["Processamento em lote (batch)", true],
+        ],
+    },
+    {
+        statement:
+            "Um sistema antifraude precisa avaliar cada transação de cartão no instante em que ela ocorre, com latência de milissegundos, para bloquear operações suspeitas. Que tipo de processamento é indicado?",
+        explanation:
+            "O processamento de fluxo (streaming) analisa os dados continuamente, à medida que chegam, com baixa latência, ideal para detecção de fraude e IoT.",
+        topic: "Tempo real e streaming",
+        options: [
+            ["Processamento de fluxo (streaming)", true],
+            ["Processamento em lote (batch)", false],
+            ["Carga incremental noturna", false],
+            ["Exportação agendada para CSV", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço do Azure processa fluxos de dados em tempo real usando uma linguagem de consulta semelhante ao SQL para filtrar e agregar eventos?",
+        explanation:
+            "O Azure Stream Analytics processa dados em tempo real usando uma linguagem de consulta parecida com SQL sobre os fluxos de eventos.",
+        topic: "Tempo real e streaming",
+        options: [
+            ["Azure Data Factory", false],
+            ["Power BI Service", false],
+            ["Azure Stream Analytics", true],
+            ["Azure Synapse Analytics", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço do Azure é projetado para ingerir milhões de eventos por segundo vindos de dispositivos e aplicações, servindo como porta de entrada de dados de telemetria para posterior processamento?",
+        explanation:
+            "O Azure Event Hubs é um serviço de ingestão de big data capaz de receber milhões de eventos por segundo para processamento em tempo real ou posterior.",
+        topic: "Tempo real e streaming",
+        options: [
+            ["Azure SQL Database", false],
+            ["Azure Event Hubs", true],
+            ["Azure Blob Storage", false],
+            ["Azure Data Lake Storage Gen2", false],
+        ],
+    },
+    {
+        statement:
+            "Ao processar um fluxo, uma equipe quer agrupar os eventos em segmentos de tempo fixos, contíguos e sem sobreposição, agregando as leituras a cada 5 minutos. Que tipo de janela de tempo é essa?",
+        explanation:
+            "A janela em cascata (tumbling window) divide o fluxo em intervalos de tempo fixos, contíguos e sem sobreposição.",
+        topic: "Tempo real e streaming",
+        options: [
+            ["Janela deslizante (sliding)", false],
+            ["Janela de sessão (session)", false],
+            ["Janela de salto (hopping)", false],
+            ["Janela em cascata (tumbling)", true],
+        ],
+    },
+    {
+        statement:
+            "No Microsoft Fabric, qual carga de trabalho é voltada a capturar, analisar e agir sobre dados em movimento, incluindo o recurso Eventstream para ingerir e rotear fluxos de eventos sem código?",
+        explanation:
+            "A carga Real-Time Intelligence do Fabric lida com dados em tempo real e usa o Eventstream para ingerir e encaminhar fluxos de eventos.",
+        topic: "Tempo real e streaming",
+        options: [
+            ["Real-Time Intelligence", true],
+            ["Data Warehouse", false],
+            ["Data Science", false],
+            ["Synapse Data Engineering", false],
+        ],
+    },
+    {
+        statement:
+            "Qual mecanismo, disponível em plataformas como o Azure Databricks, permite processar fluxos de dados em tempo real usando basicamente a mesma API estruturada do processamento em lote do Apache Spark?",
+        explanation:
+            "O Spark Structured Streaming processa fluxos em tempo real com a mesma API estruturada usada no processamento em lote do Apache Spark.",
+        topic: "Tempo real e streaming",
+        options: [
+            ["Azure Data Factory Mapping Data Flows", false],
+            ["Power Query", false],
+            ["Spark Structured Streaming", true],
+            ["Transact-SQL", false],
+        ],
+    },
+    {
+        statement:
+            "Quais características são típicas do processamento de dados em fluxo (streaming)? (Selecione DUAS opções.)",
+        explanation:
+            "O streaming se caracteriza pelo processamento contínuo e de baixa latência dos eventos, ideal para IoT e fraude; lotes agendados e tolerância a horas de atraso descrevem o processamento em lote.",
+        topic: "Tempo real e streaming",
+        options: [
+            ["Processa os eventos continuamente e com baixa latência, à medida que chegam", true],
+            ["É adequado a cenários como IoT e detecção de fraude", true],
+            ["Processa os dados somente em grandes lotes agendados", false],
+            ["Tolera naturalmente horas de atraso entre a coleta e o processamento", false],
+        ],
+    },
+    {
+        statement:
+            "Qual componente do Power BI é o aplicativo de desktop gratuito usado por analistas para se conectar a fontes de dados, modelar os dados e criar relatórios?",
+        explanation:
+            "O Power BI Desktop é o aplicativo de autoria, gratuito, usado para conectar-se a dados, modelar e criar relatórios.",
+        topic: "Power BI e visualização",
+        options: [
+            ["Serviço do Power BI (Power BI Service)", false],
+            ["Power BI Desktop", true],
+            ["Power BI Mobile", false],
+            ["Power BI Report Builder para relatórios paginados", false],
+        ],
+    },
+    {
+        statement:
+            "Depois de finalizar um relatório no Power BI Desktop, um analista precisa publicá-lo na nuvem para compartilhá-lo com colegas por meio de workspaces e dashboards. Qual componente ele utiliza?",
+        explanation:
+            "O Serviço do Power BI é a plataforma SaaS na nuvem usada para publicar, compartilhar e distribuir relatórios e dashboards.",
+        topic: "Power BI e visualização",
+        options: [
+            ["Serviço do Power BI (Power BI Service)", true],
+            ["Power BI Desktop", false],
+            ["Editor do Power Query", false],
+            ["Um arquivo .pbix salvo localmente", false],
+        ],
+    },
+    {
+        statement:
+            "No Power BI, um analista precisa criar uma medida com um cálculo agregado personalizado, como o total de vendas do ano anterior. Qual linguagem de fórmula ele utiliza?",
+        explanation:
+            "As medidas e cálculos do modelo no Power BI são criados com a linguagem DAX; a linguagem M do Power Query é usada para transformar e carregar os dados, não para as medidas.",
+        topic: "Power BI e visualização",
+        options: [
+            ["Transact-SQL", false],
+            ["KQL (Kusto Query Language)", false],
+            ["DAX (Data Analysis Expressions)", true],
+            ["Linguagem M do Power Query", false],
+        ],
+    },
+    {
+        statement:
+            "Um analista quer mostrar a evolução da receita mensal ao longo dos últimos dois anos, destacando a tendência ao longo do tempo. Qual visualização é a mais indicada?",
+        explanation:
+            "O gráfico de linhas é o mais indicado para mostrar tendências e a evolução de um valor ao longo do tempo.",
+        topic: "Power BI e visualização",
+        options: [
+            ["Gráfico de pizza", false],
+            ["Cartão (KPI)", false],
+            ["Gráfico de dispersão", false],
+            ["Gráfico de linhas", true],
+        ],
+    },
+    {
+        statement:
+            "Para comparar o total de vendas entre diferentes categorias de produtos em um relatório do Power BI, qual visualização é a mais apropriada?",
+        explanation:
+            "Gráficos de barras ou colunas são ideais para comparar valores entre categorias distintas.",
+        topic: "Power BI e visualização",
+        options: [
+            ["Gráfico de barras ou colunas", true],
+            ["Gráfico de linhas", false],
+            ["Gráfico de dispersão", false],
+            ["Cartão (KPI)", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer visualizar o volume de vendas distribuído pelos estados do Brasil, destacando as diferenças regionais em um relatório do Power BI. Qual visualização representa melhor esses dados?",
+        explanation:
+            "O visual de mapa é o mais indicado para representar dados com dimensão geográfica, como o volume de vendas por estado.",
+        topic: "Power BI e visualização",
+        options: [
+            ["Gráfico de rosca (donut)", false],
+            ["Mapa", true],
+            ["Gráfico de linhas", false],
+            ["Matriz", false],
+        ],
+    },
+    {
+        statement:
+            "Quais afirmações sobre os componentes do Power BI estão corretas? (Selecione DUAS opções.)",
+        explanation:
+            "O Power BI Desktop cria e modela relatórios, e o Serviço do Power BI os publica e compartilha na nuvem; o Power BI Mobile serve para consumir relatórios em dispositivos móveis, não para criá-los.",
+        topic: "Power BI e visualização",
+        options: [
+            ["O Power BI Desktop é usado para criar e modelar relatórios", true],
+            [
+                "O Serviço do Power BI, na nuvem, é usado para publicar e compartilhar relatórios",
+                true,
+            ],
+            ["O Power BI Mobile é a ferramenta principal para criar e modelar relatórios", false],
+            ["O Power BI Desktop só funciona na nuvem e não pode ser instalado localmente", false],
+        ],
+    },
+];
+
+async function seed() {
+    let [simulado] = await db.select().from(simulados).where(eq(simulados.slug, SLUG));
+    if (!simulado) {
+        [simulado] = await db
+            .insert(simulados)
+            .values({
+                slug: SLUG,
+                name: "Microsoft Azure Data Fundamentals (DP-900)",
+                provider: "azure",
+                code: "DP-900",
+                level: "Fundamental",
+                description:
+                    "Simulado no formato da prova DP-900: 60 minutos, corte de 70%. Mistura resposta única e múltipla.",
+                durationMinutes: 60,
+                questionCount: 50,
+                passPercent: 70,
+                published: true,
+            })
+            .returning();
+        console.log(`Simulado criado: ${simulado.slug}`);
+    }
+    // Mantém provedor, código e nível em dia mesmo se o simulado já existia.
+    await db
+        .update(simulados)
+        .set({ provider: "azure", code: "DP-900", level: "Fundamental" })
+        .where(eq(simulados.id, simulado.id));
+
+    const [{ n }] = await db
+        .select({ n: count() })
+        .from(simuladoQuestions)
+        .where(eq(simuladoQuestions.simuladoId, simulado.id));
+    if (Number(n) > 0) {
+        console.log(`Simulado já tem ${n} questões, nada a fazer.`);
+        return;
+    }
+
+    for (let i = 0; i < QUESTOES.length; i++) {
+        const q = QUESTOES[i];
+        const [questao] = await db
+            .insert(simuladoQuestions)
+            .values({
+                simuladoId: simulado.id,
+                statement: q.statement,
+                explanation: q.explanation,
+                topic: q.topic,
+            })
+            .returning();
+        await db.insert(simuladoOptions).values(
+            q.options.map(([text, isCorrect], idx) => ({
+                questionId: questao.id,
+                text,
+                isCorrect,
+                position: idx + 1,
+            })),
+        );
+    }
+    console.log(`Seed concluído: ${QUESTOES.length} questões inseridas.`);
+}
+
+seed()
+    .then(() => process.exit(0))
+    .catch((e) => {
+        console.error("Falha no seed:", e);
+        process.exit(1);
+    });

--- a/backend/scripts/seed-trilha-ai900.ts
+++ b/backend/scripts/seed-trilha-ai900.ts
@@ -1,0 +1,1322 @@
+// Seed da trilha AI-900 (Microsoft Azure AI Fundamentals). Cria a trilha se não
+// existir, com módulos e aulas em blocos + 5 questões por aula. Idempotente e não
+// destrutivo: se a trilha já tiver aulas, não faz nada.
+//
+// Rodar em prod: docker compose -f docker-compose.prod.yml exec -T backend node scripts/seed-trilha-ai900.ts
+import { db } from "../db.ts";
+import { trails, modules, lessons, questions, questionOptions } from "../schema.ts";
+import { eq } from "drizzle-orm";
+
+const NOME = "AZURE AI-900";
+const DESCRICAO =
+    "Trilha de fundamentos de inteligência artificial no Microsoft Azure para a certificação AI-900: cargas de trabalho de IA e IA responsável, machine learning, visão computacional, processamento de linguagem natural e IA generativa com o Azure OpenAI.";
+
+type Bloco = { type: "text" | "code" | "quote" | "table"; value: string };
+type Questao = {
+    statement: string;
+    difficulty: "facil" | "medio" | "dificil";
+    options: { text: string; isCorrect: boolean }[];
+};
+type Aula = { titulo: string; blocks: Bloco[]; questions: Questao[] };
+type Modulo = { titulo: string; aulas: Aula[] };
+
+const MODULO3: Aula[] = [
+    {
+        titulo: "Cargas de trabalho de visão computacional",
+        blocks: [
+            {
+                type: "text",
+                value: "## O que é visão computacional\n Visão computacional é a área da IA que extrai informação de imagens e vídeos. As cargas de trabalho mais cobradas no AI-900 são classificação de imagem, detecção de objetos, segmentação semântica, OCR e análise facial. O que a prova mais pede é saber associar um cenário à tarefa certa, então preste atenção nas palavras-chave de cada uma.",
+            },
+            {
+                type: "table",
+                value: '[["Tarefa","O que faz","Saída típica"],["Classificação de imagem","Rotula a imagem inteira","Uma classe para a foto"],["Detecção de objetos","Localiza vários itens","Classe mais caixa delimitadora"],["Segmentação semântica","Classifica cada pixel","Máscara por região"],["OCR","Lê texto presente na imagem","Texto extraído"],["Análise facial","Detecta e analisa rostos","Rostos e atributos"]]',
+            },
+            {
+                type: "text",
+                value: "## Classificação x detecção de objetos\n A dúvida clássica da prova é entre essas duas. A classificação responde 'o que é esta imagem?' e devolve um único rótulo para a foto toda. A detecção de objetos responde 'o que existe e onde?', devolvendo cada item com uma caixa delimitadora (bounding box). Se o cenário fala em localizar, contar ou marcar a posição de algo, é detecção de objetos. A segmentação semântica vai além e classifica pixel a pixel, útil quando você precisa do contorno exato de cada região.",
+            },
+            {
+                type: "quote",
+                value: "Classificação rotula a imagem inteira; detecção de objetos localiza cada item com uma caixa delimitadora; segmentação semântica classifica pixel a pixel.",
+            },
+            {
+                type: "table",
+                value: '[["Cenário","Tarefa correta"],["Marcar a foto como praia ou cidade","Classificação de imagem"],["Contar e localizar carros numa rua","Detecção de objetos"],["Separar estrada, céu e pedestres pixel a pixel","Segmentação semântica"],["Ler a placa de um veículo na foto","OCR"],["Encontrar rostos numa foto de grupo","Análise facial"]]',
+            },
+        ],
+        questions: [
+            {
+                statement:
+                    "Um aplicativo precisa marcar cada foto enviada como 'cachorro' ou 'gato', sem indicar onde o animal está na imagem. Qual carga de trabalho resolve isso?",
+                difficulty: "facil",
+                options: [
+                    { text: "Classificação de imagem", isCorrect: true },
+                    { text: "Detecção de objetos", isCorrect: false },
+                    { text: "Segmentação semântica", isCorrect: false },
+                    { text: "OCR", isCorrect: false },
+                ],
+            },
+            {
+                statement:
+                    "Uma loja quer localizar e contar cada produto na prateleira, desenhando um retângulo em volta de cada um. Qual tarefa de visão é essa?",
+                difficulty: "facil",
+                options: [
+                    { text: "Detecção de objetos", isCorrect: true },
+                    { text: "Classificação de imagem", isCorrect: false },
+                    { text: "OCR", isCorrect: false },
+                    { text: "Análise facial", isCorrect: false },
+                ],
+            },
+            {
+                statement:
+                    "Um sistema precisa extrair o texto impresso de fotos de notas fiscais para lançar os valores. Qual carga de trabalho de visão é indicada?",
+                difficulty: "facil",
+                options: [
+                    { text: "OCR", isCorrect: true },
+                    { text: "Classificação de imagem", isCorrect: false },
+                    { text: "Detecção de objetos", isCorrect: false },
+                    { text: "Segmentação semântica", isCorrect: false },
+                ],
+            },
+            {
+                statement:
+                    "Um carro autônomo precisa classificar cada pixel da câmera como via, calçada, pedestre ou veículo, com o contorno exato de cada região. Qual tarefa atende a isso?",
+                difficulty: "medio",
+                options: [
+                    { text: "Segmentação semântica", isCorrect: true },
+                    { text: "Detecção de objetos", isCorrect: false },
+                    { text: "Classificação de imagem", isCorrect: false },
+                    { text: "OCR", isCorrect: false },
+                ],
+            },
+            {
+                statement:
+                    "Qual é a principal diferença entre classificação de imagem e detecção de objetos?",
+                difficulty: "medio",
+                options: [
+                    {
+                        text: "A detecção de objetos localiza itens com caixas delimitadoras, enquanto a classificação atribui um único rótulo à imagem inteira",
+                        isCorrect: true,
+                    },
+                    {
+                        text: "A classificação lê texto na imagem e a detecção de objetos não",
+                        isCorrect: false,
+                    },
+                    {
+                        text: "A classificação trabalha pixel a pixel e a detecção de objetos não",
+                        isCorrect: false,
+                    },
+                    {
+                        text: "Não há diferença, são nomes diferentes para a mesma tarefa",
+                        isCorrect: false,
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        titulo: "O serviço Azure AI Vision",
+        blocks: [
+            {
+                type: "text",
+                value: "## O serviço Azure AI Vision\n O Azure AI Vision reúne modelos pré-treinados que já entendem imagens sem que você precise treinar nada. Você envia a imagem e consome o resultado direto pela API. Ele cobre análise de imagem (tags, descrição, detecção de objetos e detecção de conteúdo) e leitura de texto com o recurso Read.",
+            },
+            {
+                type: "table",
+                value: '[["Recurso","O que entrega"],["Marcações (tags)","Palavras-chave sobre o conteúdo da imagem"],["Descrição e legenda","Frase que descreve a cena"],["Detecção de objetos","Itens comuns com caixas delimitadoras"],["Detecção de conteúdo","Sinaliza conteúdo adulto ou impróprio"],["Read","Extrai texto impresso e manuscrito (OCR)"]]',
+            },
+            {
+                type: "text",
+                value: "## Leitura de texto com o Read\n O recurso Read é o OCR do Azure AI Vision. Ele extrai texto impresso e manuscrito de fotos, documentos digitalizados e capturas de tela, devolvendo o texto e a posição de cada linha. É a escolha para transformar imagem de documento em texto pesquisável.",
+            },
+            {
+                type: "quote",
+                value: "O recurso Read do Azure AI Vision é o OCR: extrai texto impresso e manuscrito de imagens e documentos.",
+            },
+            {
+                type: "text",
+                value: "## Pronto para usar\n Como os modelos já vêm treinados, o Azure AI Vision é ideal quando você precisa de resultados rápidos para categorias gerais e não tem imagens rotuladas nem equipe de ciência de dados. Se o seu caso exige reconhecer classes específicas do seu domínio, aí entra o Custom Vision, tema da próxima aula.",
+            },
+        ],
+        questions: [
+            {
+                statement:
+                    "Você quer, sem treinar nenhum modelo, obter tags e uma legenda que descreva o conteúdo das fotos de um catálogo. Qual serviço usar?",
+                difficulty: "facil",
+                options: [
+                    { text: "Azure AI Vision (análise de imagem)", isCorrect: true },
+                    { text: "Azure Machine Learning", isCorrect: false },
+                    { text: "Custom Vision", isCorrect: false },
+                    { text: "Azure AI Language", isCorrect: false },
+                ],
+            },
+            {
+                statement:
+                    "Uma equipe precisa extrair texto manuscrito de formulários digitalizados. Qual recurso do Azure AI Vision atende a isso?",
+                difficulty: "facil",
+                options: [
+                    { text: "Read", isCorrect: true },
+                    { text: "Marcações (tags)", isCorrect: false },
+                    { text: "Detecção de objetos", isCorrect: false },
+                    { text: "Descrição", isCorrect: false },
+                ],
+            },
+            {
+                statement:
+                    "Um fórum quer sinalizar automaticamente imagens com conteúdo adulto ou impróprio enviadas pelos usuários. Qual recurso do Azure AI Vision ajuda?",
+                difficulty: "medio",
+                options: [
+                    { text: "Detecção de conteúdo", isCorrect: true },
+                    { text: "Read", isCorrect: false },
+                    { text: "Marcações (tags)", isCorrect: false },
+                    { text: "Descrição e legenda", isCorrect: false },
+                ],
+            },
+            {
+                statement:
+                    "Uma empresa sem cientistas de dados e sem imagens rotuladas precisa reconhecer objetos comuns em fotos o mais rápido possível. Qual é a melhor opção?",
+                difficulty: "medio",
+                options: [
+                    { text: "Usar os modelos pré-treinados do Azure AI Vision", isCorrect: true },
+                    { text: "Treinar um modelo do zero no Custom Vision", isCorrect: false },
+                    { text: "Treinar um modelo no Azure Machine Learning", isCorrect: false },
+                    { text: "Não é possível sem treinar antes", isCorrect: false },
+                ],
+            },
+            {
+                statement: "O que o recurso Read do Azure AI Vision faz?",
+                difficulty: "medio",
+                options: [
+                    {
+                        text: "Lê texto impresso e manuscrito em imagens e documentos",
+                        isCorrect: true,
+                    },
+                    { text: "Gera uma legenda descrevendo a imagem", isCorrect: false },
+                    { text: "Detecta rostos e seus atributos", isCorrect: false },
+                    {
+                        text: "Classifica a imagem inteira com rótulos personalizados",
+                        isCorrect: false,
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        titulo: "Custom Vision e reconhecimento facial",
+        blocks: [
+            {
+                type: "text",
+                value: "## Quando o pré-treinado não basta\n O Custom Vision deixa você treinar um modelo de visão com as suas próprias imagens rotuladas. É a saída quando o modelo genérico do Azure AI Vision não reconhece as classes específicas do seu negócio, como os produtos da sua loja ou os defeitos da sua linha de produção. Você envia as imagens, marca as classes e o serviço treina o modelo.",
+            },
+            {
+                type: "table",
+                value: '[["Tipo de projeto","O que resolve"],["Classificação","Aplica seus próprios rótulos à imagem inteira"],["Detecção de objetos","Localiza suas classes com caixas delimitadoras"]]',
+            },
+            {
+                type: "text",
+                value: "## O serviço Face\n O Face é especializado em rostos. Ele faz detecção (encontra os rostos e devolve a caixa delimitadora), análise de atributos (como posição da cabeça, uso de óculos, desfoque e oclusão) e reconhecimento facial. O reconhecimento tem duas operações principais: verificação, que compara dois rostos (1 para 1), e identificação, que procura a pessoa dentro de um grupo já cadastrado (1 para muitos).",
+            },
+            {
+                type: "table",
+                value: '[["Situação","Serviço indicado"],["Categorias gerais já reconhecidas","Azure AI Vision (pré-treinado)"],["Classes específicas do seu negócio","Custom Vision (treinado por você)"],["Detectar e reconhecer rostos","Face"]]',
+            },
+            {
+                type: "quote",
+                value: "Use o Azure AI Vision pré-treinado para categorias gerais; use o Custom Vision quando precisar reconhecer classes específicas com suas próprias imagens.",
+            },
+            {
+                type: "text",
+                value: "## Escolhendo o serviço\n Regra prática para a prova: rostos vão para o Face; classes específicas suas vão para o Custom Vision (projeto de classificação ou de detecção de objetos); categorias gerais e leitura de texto vão para o Azure AI Vision pré-treinado. Vale lembrar que os recursos de reconhecimento facial exigem aprovação de acesso limitado por questões de IA responsável.",
+            },
+        ],
+        questions: [
+            {
+                statement:
+                    "Uma fábrica quer reconhecer seus próprios modelos de peça, que não aparecem em nenhum modelo genérico. Qual serviço permite treinar isso com as imagens dela?",
+                difficulty: "facil",
+                options: [
+                    { text: "Custom Vision", isCorrect: true },
+                    { text: "Azure AI Vision pré-treinado", isCorrect: false },
+                    { text: "Read", isCorrect: false },
+                    { text: "Azure AI Language", isCorrect: false },
+                ],
+            },
+            {
+                statement:
+                    "Você tem fotos rotuladas e quer um modelo que localize defeitos na peça com caixas delimitadoras. Qual tipo de projeto do Custom Vision usar?",
+                difficulty: "medio",
+                options: [
+                    { text: "Detecção de objetos", isCorrect: true },
+                    { text: "Classificação", isCorrect: false },
+                    { text: "Read (OCR)", isCorrect: false },
+                    { text: "Segmentação semântica", isCorrect: false },
+                ],
+            },
+            {
+                statement:
+                    "Um aplicativo de banco quer confirmar se a selfie do cliente e a foto do documento são da mesma pessoa. Qual serviço é o indicado?",
+                difficulty: "facil",
+                options: [
+                    { text: "Face", isCorrect: true },
+                    { text: "Custom Vision", isCorrect: false },
+                    { text: "Read", isCorrect: false },
+                    { text: "Azure AI Vision tags", isCorrect: false },
+                ],
+            },
+            {
+                statement:
+                    "Sua empresa precisa reconhecer categorias gerais em fotos (carro, praia, comida) sem treinar nada e sem imagens próprias. Qual é a melhor escolha?",
+                difficulty: "medio",
+                options: [
+                    { text: "Azure AI Vision pré-treinado", isCorrect: true },
+                    { text: "Custom Vision de classificação", isCorrect: false },
+                    { text: "Custom Vision de detecção de objetos", isCorrect: false },
+                    { text: "Treinar um modelo do zero", isCorrect: false },
+                ],
+            },
+            {
+                statement:
+                    "Uma catraca captura o rosto de quem chega e compara com um conjunto de funcionários cadastrados para descobrir quem é a pessoa. Que operação do Face é essa?",
+                difficulty: "dificil",
+                options: [
+                    { text: "Identificação (1 para muitos)", isCorrect: true },
+                    { text: "Verificação (1 para 1)", isCorrect: false },
+                    { text: "Apenas detecção de rosto", isCorrect: false },
+                    { text: "Classificação de imagem", isCorrect: false },
+                ],
+            },
+        ],
+    },
+];
+
+const MODULO4: Aula[] = [
+    {
+        titulo: "Cargas de trabalho de PLN",
+        blocks: [
+            {
+                type: "text",
+                value: "## O que é processamento de linguagem natural\nProcessamento de linguagem natural (PLN) é a área da IA que faz o computador entender, interpretar e gerar texto e fala em linguagem humana. Na prova, o mais cobrado é ler um cenário e apontar qual tarefa de linguagem resolve o problema. Vamos passar por cada uma.\n\n## Análise de sentimento\nClassifica a opinião expressa em um texto como positiva, negativa, neutra ou mista, junto de uma pontuação de confiança entre 0 e 1. Serve para medir a reação do público em avaliações de produto, comentários de redes sociais e respostas de pesquisa. Se o cenário quer saber se a opinião do cliente é boa ou ruim, é análise de sentimento.\n\n## Extração de frases-chave\nIdentifica os principais pontos e termos de um texto e devolve uma lista de frases-chave, sem julgar a opinião. Serve para descobrir rapidamente do que trata um documento grande sem lê-lo inteiro. Se o cenário pede os assuntos ou tópicos centrais, é extração de frases-chave.\n\n## Reconhecimento de entidades nomeadas\nTambém chamado de NER (Named Entity Recognition), localiza e classifica itens do mundo real citados no texto, como pessoas, locais, organizações, datas, quantidades e valores. Serve para extrair dados de um texto livre, por exemplo puxar nomes e datas de um contrato. Se o cenário quer identificar pessoas, lugares ou datas dentro do texto, é NER.\n\n## Detecção de idioma\nIdentifica em qual idioma um texto foi escrito e devolve o nome do idioma, o código e uma pontuação de confiança. Quando não consegue decidir, retorna (Unknown). Serve para encaminhar cada mensagem ao time certo ou ao tradutor certo. Se o cenário pergunta em que língua está o texto, é detecção de idioma.\n\n## Sumarização\nGera um resumo curto de um texto longo. A sumarização extrativa seleciona as frases mais importantes do original, e a abstrativa escreve frases novas que condensam a ideia. Serve para dar um resumo executivo de documentos, e-mails e transcrições. Se o cenário pede encurtar um texto preservando o essencial, é sumarização.",
+            },
+            {
+                type: "table",
+                value: '[["Tarefa","O que faz","Cenário típico"],["Análise de sentimento","Diz se a opinião é positiva, negativa, neutra ou mista","Medir se as avaliações de um produto são boas ou ruins"],["Extração de frases-chave","Lista os principais termos e tópicos do texto","Descobrir os assuntos centrais de documentos longos"],["Reconhecimento de entidades (NER)","Identifica pessoas, locais, datas, organizações e valores","Extrair nomes e datas de um contrato"],["Detecção de idioma","Diz em qual idioma o texto está, com código e confiança","Rotear mensagens de clientes para o time certo"],["Sumarização","Resume um texto longo em poucas frases","Gerar um resumo executivo de um relatório"]]',
+            },
+            {
+                type: "text",
+                value: "## Não confunda frases-chave com entidades\nAs duas tarefas puxam pedaços do texto, mas com objetivos diferentes. A extração de frases-chave devolve os tópicos e assuntos gerais, sem dizer o que cada um representa. O NER classifica cada item em um tipo conhecido, como pessoa, local ou data. Se o cenário só quer os temas, é frases-chave. Se quer identificar e rotular pessoas, lugares ou datas, é NER.",
+            },
+            {
+                type: "quote",
+                value: "Ligue o verbo do cenário à tarefa: opinião boa ou ruim é análise de sentimento; tópicos principais é extração de frases-chave; pessoas, locais e datas é reconhecimento de entidades; qual idioma é detecção de idioma; encurtar mantendo o essencial é sumarização.",
+            },
+        ],
+        questions: [
+            {
+                statement:
+                    "A equipe de marketing quer saber se os comentários sobre um novo produto nas redes sociais expressam opinião positiva ou negativa. Qual tarefa de PLN atende?",
+                difficulty: "facil",
+                options: [
+                    { text: "Análise de sentimento", isCorrect: true },
+                    { text: "Extração de frases-chave", isCorrect: false },
+                    { text: "Detecção de idioma", isCorrect: false },
+                    { text: "Sumarização", isCorrect: false },
+                ],
+            },
+            {
+                statement:
+                    "Um sistema recebe mensagens de clientes de vários países e precisa descobrir em qual idioma cada mensagem foi escrita antes de encaminhá-la. Qual tarefa usar?",
+                difficulty: "facil",
+                options: [
+                    { text: "Detecção de idioma", isCorrect: true },
+                    { text: "Análise de sentimento", isCorrect: false },
+                    { text: "Reconhecimento de entidades nomeadas", isCorrect: false },
+                    { text: "Sumarização", isCorrect: false },
+                ],
+            },
+            {
+                statement:
+                    "Um escritório de advocacia precisa extrair automaticamente nomes de pessoas, datas e locais citados em contratos digitalizados. Qual tarefa de PLN faz isso?",
+                difficulty: "medio",
+                options: [
+                    { text: "Reconhecimento de entidades nomeadas (NER)", isCorrect: true },
+                    { text: "Extração de frases-chave", isCorrect: false },
+                    { text: "Análise de sentimento", isCorrect: false },
+                    { text: "Detecção de idioma", isCorrect: false },
+                ],
+            },
+            {
+                statement:
+                    "Uma empresa quer transformar relatórios de dez páginas em um parágrafo curto que preserve o essencial. Qual tarefa de PLN é indicada?",
+                difficulty: "medio",
+                options: [
+                    { text: "Sumarização", isCorrect: true },
+                    { text: "Extração de frases-chave", isCorrect: false },
+                    { text: "Reconhecimento de entidades nomeadas", isCorrect: false },
+                    { text: "Análise de sentimento", isCorrect: false },
+                ],
+            },
+            {
+                statement:
+                    "Um analista quer apenas uma lista dos temas gerais discutidos em milhares de avaliações, sem identificar ou rotular pessoas, locais ou datas específicas. Qual tarefa de PLN é a mais adequada?",
+                difficulty: "dificil",
+                options: [
+                    { text: "Extração de frases-chave", isCorrect: true },
+                    { text: "Reconhecimento de entidades nomeadas (NER)", isCorrect: false },
+                    { text: "Análise de sentimento", isCorrect: false },
+                    { text: "Detecção de idioma", isCorrect: false },
+                ],
+            },
+        ],
+    },
+    {
+        titulo: "Fala e tradução",
+        blocks: [
+            {
+                type: "text",
+                value: "## Fala e tradução na IA\nDuas famílias de tarefas andam juntas aqui: converter entre fala e texto, e converter conteúdo de um idioma para outro. A prova cobra saber qual tarefa é qual e a diferença entre transcrever e traduzir.\n\n## Conversão de fala em texto\nA fala em texto (speech-to-text) recebe áudio de voz e devolve o texto correspondente, no mesmo idioma. É o que faz a legenda automática, o ditado por voz e a transcrição de reuniões e chamadas. Pode rodar em tempo real, enquanto a pessoa fala, ou em lote, sobre arquivos gravados.\n\n## Conversão de texto em fala\nO texto em fala (text-to-speech) faz o caminho inverso: recebe texto e gera áudio de voz sintetizada. É o que dá voz a assistentes virtuais, leitores de tela e centrais de atendimento. As vozes neurais soam naturais e permitem ajustar entonação e ritmo.\n\n## Tradução de texto e de fala\nTraduzir é converter conteúdo de um idioma de origem para um idioma de destino. A tradução de texto recebe texto em uma língua e devolve texto em outra. A tradução de fala recebe áudio falado em uma língua e devolve o conteúdo em outra, como texto ou como áudio, o que permite conversas entre pessoas de idiomas diferentes.",
+            },
+            {
+                type: "text",
+                value: "## Transcrever não é traduzir\nEsse é o ponto que mais confunde na prova. Transcrever é passar fala para texto mantendo o mesmo idioma: um áudio em português vira texto em português. Traduzir é trocar de idioma: um conteúdo em português vira conteúdo em inglês, seja em texto ou em fala. A conversão de fala em texto transcreve, o tradutor traduz. Quando o cenário mistura os dois, como um áudio em espanhol que precisa virar texto em português, existe tradução envolvida, porque o idioma muda.",
+            },
+            {
+                type: "table",
+                value: '[["Tarefa","Entrada","Saída","Muda de idioma?"],["Fala em texto (speech-to-text)","Áudio de voz","Texto no mesmo idioma","Não"],["Texto em fala (text-to-speech)","Texto","Áudio de voz","Não"],["Tradução de texto","Texto em um idioma","Texto em outro idioma","Sim"],["Tradução de fala","Áudio em um idioma","Texto ou áudio em outro idioma","Sim"]]',
+            },
+            {
+                type: "quote",
+                value: "Transcrição mantém o idioma e só troca a forma, de fala para texto. Tradução troca o idioma. Se o cenário muda a língua, é tradução, não transcrição.",
+            },
+        ],
+        questions: [
+            {
+                statement:
+                    "Um aplicativo de reuniões precisa gerar legendas em tempo real do que os participantes falam, mantendo o mesmo idioma. Qual recurso usar?",
+                difficulty: "facil",
+                options: [
+                    { text: "Conversão de fala em texto", isCorrect: true },
+                    { text: "Conversão de texto em fala", isCorrect: false },
+                    { text: "Tradução de texto", isCorrect: false },
+                    { text: "Tradução de fala", isCorrect: false },
+                ],
+            },
+            {
+                statement:
+                    "Um assistente virtual precisa ler em voz alta, com voz natural, respostas que estão escritas em texto. Qual recurso é esse?",
+                difficulty: "facil",
+                options: [
+                    { text: "Conversão de texto em fala", isCorrect: true },
+                    { text: "Conversão de fala em texto", isCorrect: false },
+                    { text: "Tradução de fala", isCorrect: false },
+                    { text: "Detecção de idioma", isCorrect: false },
+                ],
+            },
+            {
+                statement:
+                    "Uma loja online quer exibir as descrições de produtos escritas em inglês também em português e espanhol. Qual recurso é indicado?",
+                difficulty: "medio",
+                options: [
+                    { text: "Tradução de texto", isCorrect: true },
+                    { text: "Conversão de texto em fala", isCorrect: false },
+                    { text: "Conversão de fala em texto", isCorrect: false },
+                    { text: "Análise de sentimento", isCorrect: false },
+                ],
+            },
+            {
+                statement:
+                    "Um áudio de uma entrevista em português precisa virar um documento de texto também em português. Esse caso é de...?",
+                difficulty: "medio",
+                options: [
+                    { text: "Transcrição, feita pela conversão de fala em texto", isCorrect: true },
+                    { text: "Tradução de fala", isCorrect: false },
+                    { text: "Tradução de texto", isCorrect: false },
+                    { text: "Conversão de texto em fala", isCorrect: false },
+                ],
+            },
+            {
+                statement:
+                    "Durante uma videochamada, uma pessoa fala em japonês e a outra precisa receber o conteúdo em português falado, em tempo real. Qual recurso atende?",
+                difficulty: "dificil",
+                options: [
+                    { text: "Tradução de fala", isCorrect: true },
+                    { text: "Conversão de fala em texto", isCorrect: false },
+                    { text: "Tradução de texto", isCorrect: false },
+                    { text: "Conversão de texto em fala", isCorrect: false },
+                ],
+            },
+        ],
+    },
+    {
+        titulo: "Serviços de linguagem no Azure",
+        blocks: [
+            {
+                type: "text",
+                value: "## Os serviços de linguagem do Azure\nAs tarefas de PLN e de fala que vimos são entregues no Azure por três serviços dentro do Azure AI Services. Saber qual serviço faz o quê é o foco desta aula.\n\n## Azure AI Language\nÉ o serviço para tarefas sobre texto. Reúne análise de sentimento, reconhecimento de entidades nomeadas, extração de frases-chave, detecção de idioma, sumarização, detecção de informações pessoais (PII) e resposta a perguntas. Também traz a compreensão de linguagem conversacional (CLU), usada para dar inteligência a bots e assistentes.\n\n## Compreensão de linguagem conversacional (CLU)\nA CLU interpreta o que o usuário diz e descobre o que ele quer. Trabalha com dois conceitos que caem muito na prova. A intenção (intent) é o objetivo por trás da frase, como ligar uma luz ou consultar o saldo. A entidade (entity) é o dado específico citado na frase, como o cômodo cozinha ou a cidade Recife. O texto enviado pelo usuário é o enunciado (utterance). Em 'ligue a luz da cozinha', a intenção é ligar a luz e a entidade é a cozinha.\n\n## Azure AI Speech\nÉ o serviço para tarefas de fala: conversão de fala em texto, conversão de texto em fala, tradução de fala e reconhecimento de locutor. É ele que gera legendas, dá voz a assistentes e transcreve áudio.\n\n## Azure AI Translator\nÉ o serviço dedicado à tradução de texto entre mais de cem idiomas, com tradução automática neural. Serve para traduzir documentos, sites e mensagens de um idioma para outro.",
+            },
+            {
+                type: "table",
+                value: '[["Serviço","Para que serve","Exemplos de tarefa"],["Azure AI Language","Entender e analisar texto","Sentimento, entidades, frases-chave, idioma, sumarização, CLU"],["Azure AI Speech","Trabalhar com áudio de voz","Fala em texto, texto em fala, tradução de fala"],["Azure AI Translator","Traduzir texto entre idiomas","Traduzir documentos, sites e mensagens"]]',
+            },
+            {
+                type: "table",
+                value: '[["Conceito da CLU","O que é","Exemplo em \'ligue a luz da cozinha\'"],["Enunciado (utterance)","O que o usuário diz ou escreve","ligue a luz da cozinha"],["Intenção (intent)","O objetivo por trás da frase","ligar a luz"],["Entidade (entity)","O dado específico citado na frase","cozinha"]]',
+            },
+            {
+                type: "text",
+                value: "## Como escolher o serviço no cenário\nA pergunta chave é sobre o que a solução atua. Se o insumo é texto e o objetivo é extrair sentido dele, como opinião, entidades, tópicos, idioma ou resumo, ou ainda entender comandos de um bot, o serviço é o Azure AI Language. Se entra ou sai áudio de voz, é o Azure AI Speech. Se a meta é apenas passar texto de um idioma para outro, é o Azure AI Translator. Um assistente de voz completo costuma juntar os três: o Speech transcreve a fala, o Language entende a intenção e o Speech responde por voz.",
+            },
+            {
+                type: "quote",
+                value: "Texto se analisa no Azure AI Language, áudio de voz se resolve no Azure AI Speech e traduzir texto entre idiomas é o Azure AI Translator. Na CLU, a intenção é o que o usuário quer e a entidade é o detalhe da frase.",
+            },
+        ],
+        questions: [
+            {
+                statement:
+                    "Uma empresa quer analisar o sentimento e extrair as entidades de milhares de avaliações em texto. Qual serviço do Azure usar?",
+                difficulty: "facil",
+                options: [
+                    { text: "Azure AI Language", isCorrect: true },
+                    { text: "Azure AI Speech", isCorrect: false },
+                    { text: "Azure AI Translator", isCorrect: false },
+                    { text: "Azure AI Vision", isCorrect: false },
+                ],
+            },
+            {
+                statement:
+                    "Um portal de notícias precisa traduzir seus artigos de texto do português para o inglês e o espanhol. Qual serviço é o indicado?",
+                difficulty: "facil",
+                options: [
+                    { text: "Azure AI Translator", isCorrect: true },
+                    { text: "Azure AI Language", isCorrect: false },
+                    { text: "Azure AI Speech", isCorrect: false },
+                    { text: "Azure AI Document Intelligence", isCorrect: false },
+                ],
+            },
+            {
+                statement:
+                    "Um sistema de atendimento precisa transcrever para texto milhares de ligações telefônicas gravadas. Qual serviço do Azure atende?",
+                difficulty: "medio",
+                options: [
+                    { text: "Azure AI Speech", isCorrect: true },
+                    { text: "Azure AI Language", isCorrect: false },
+                    { text: "Azure AI Translator", isCorrect: false },
+                    { text: "Azure AI Vision", isCorrect: false },
+                ],
+            },
+            {
+                statement:
+                    "Uma equipe vai construir um chatbot que entende comandos como 'quero cancelar meu pedido' e identifica o que o usuário deseja. Qual serviço do Azure oferece a compreensão de linguagem conversacional para isso?",
+                difficulty: "medio",
+                options: [
+                    { text: "Azure AI Language", isCorrect: true },
+                    { text: "Azure AI Speech", isCorrect: false },
+                    { text: "Azure AI Translator", isCorrect: false },
+                    { text: "Azure AI Bot Service", isCorrect: false },
+                ],
+            },
+            {
+                statement:
+                    "Um assistente doméstico recebe o comando 'aumente a temperatura da sala para 22 graus'. O modelo de linguagem conversacional precisa reconhecer 'aumentar a temperatura', 'sala' e '22 graus'. Respectivamente, esses elementos são classificados como...?",
+                difficulty: "dificil",
+                options: [
+                    { text: "Intenção, entidade e entidade", isCorrect: true },
+                    { text: "Intenção, intenção e entidade", isCorrect: false },
+                    { text: "Entidade, intenção e enunciado", isCorrect: false },
+                    { text: "Enunciado, entidade e intenção", isCorrect: false },
+                ],
+            },
+        ],
+    },
+];
+
+const MODULO5: Aula[] = [
+    {
+        titulo: "O que é IA generativa",
+        blocks: [
+            {
+                type: "text",
+                value: "## O que caracteriza a IA generativa\n\nA IA generativa é a categoria de inteligência artificial capaz de criar conteúdo novo e original: texto, imagens, código, áudio e vídeo. Em vez de apenas classificar ou prever sobre dados que já existem, ela produz artefatos inéditos a partir de padrões aprendidos em enormes volumes de dados de treinamento.\n\nEssa é a diferença central para as outras cargas de trabalho de IA. A visão computacional analisa imagens, o processamento de linguagem natural clássico extrai sentimento ou entidades de um texto, e a detecção de anomalias sinaliza valores fora do padrão. Todas interpretam algo que já está lá. A carga generativa é a única que gera um resultado novo em resposta a uma instrução em linguagem natural.",
+            },
+            {
+                type: "table",
+                value: '[["Carga de trabalho","O que faz","Exemplo"],["Visão computacional","Analisa e interpreta imagens","Detectar objetos numa foto"],["PLN clássico","Extrai informação de um texto","Analisar o sentimento de uma avaliação"],["Detecção de anomalias","Identifica valores fora do padrão","Sinalizar uma transação suspeita"],["IA generativa","Cria conteúdo novo e original","Escrever um email a partir de um pedido"]]',
+            },
+            {
+                type: "text",
+                value: "## Modelos de linguagem grandes e transformers\n\nO motor da IA generativa de texto é o modelo de linguagem grande (LLM, de large language model), treinado em quantidades gigantescas de texto para prever qual é o próximo pedaço de conteúdo mais provável. A família GPT (Generative Pre-trained Transformer) é o exemplo mais conhecido.\n\nEsses modelos usam a arquitetura transformer, cuja inovação é o mecanismo de atenção: ao processar cada parte do texto, o modelo pesa a importância das outras partes para entender o contexto e as relações entre as palavras. É isso que permite gerar respostas coerentes e no tema.\n\nAntes de processar, o texto é quebrado em tokens, que são palavras inteiras ou pedaços de palavras. O modelo sempre trabalha com tokens, não com letras soltas.",
+            },
+            {
+                type: "table",
+                value: '[["Conceito","O que é"],["Token","Pedaço de texto (palavra ou parte dela) que o modelo processa"],["Embedding","Representação numérica em vetor que captura o significado de um texto"],["Prompt","A instrução ou entrada que você fornece ao modelo"],["Completion","A resposta gerada pelo modelo a partir do prompt"],["Copilot","Assistente de IA integrado a um aplicativo para ajudar o usuário"]]',
+            },
+            {
+                type: "text",
+                value: "## Embeddings, prompts e copilots\n\nOs embeddings traduzem texto em vetores de números que capturam o significado. Palavras ou frases com sentido parecido ficam próximas nesse espaço vetorial, o que torna os embeddings a base de buscas semânticas e de comparações por similaridade.\n\nA conversa com o modelo acontece por prompt e completion: você envia um prompt (a instrução) e recebe uma completion (o texto gerado). Escrever bons prompts é o que mais influencia a qualidade da resposta.\n\nQuando esses modelos são embutidos em um aplicativo para atuar como assistente, temos um copilot. O Microsoft Copilot e o GitHub Copilot são exemplos: eles não substituem a pessoa, e sim ajudam a redigir, resumir e programar mais rápido.",
+            },
+            {
+                type: "quote",
+                value: "A IA generativa é a única carga de trabalho que cria conteúdo novo e original em resposta a um prompt em linguagem natural, em vez de apenas analisar dados que já existem.",
+            },
+        ],
+        questions: [
+            {
+                statement:
+                    "Uma equipe de marketing quer um sistema que escreva descrições de produtos originais a partir de algumas palavras-chave. Qual carga de trabalho de IA atende a esse pedido?",
+                difficulty: "facil",
+                options: [
+                    { text: "IA generativa", isCorrect: true },
+                    { text: "Detecção de anomalias", isCorrect: false },
+                    { text: "Visão computacional", isCorrect: false },
+                    { text: "Análise de sentimento", isCorrect: false },
+                ],
+            },
+            {
+                statement: "No contexto de um modelo de linguagem, o que é um token?",
+                difficulty: "facil",
+                options: [
+                    {
+                        text: "Um pedaço de texto, como uma palavra ou parte dela, que o modelo processa",
+                        isCorrect: true,
+                    },
+                    {
+                        text: "Uma chave de segurança usada para autenticar chamadas à API",
+                        isCorrect: false,
+                    },
+                    { text: "O vetor numérico final gerado pelo modelo", isCorrect: false },
+                    { text: "Um pixel de uma imagem gerada", isCorrect: false },
+                ],
+            },
+            {
+                statement:
+                    "Um desenvolvedor precisa medir o quanto dois textos são parecidos em significado para montar uma busca semântica. Qual recurso da IA generativa é a base dessa comparação?",
+                difficulty: "medio",
+                options: [
+                    { text: "Embeddings", isCorrect: true },
+                    { text: "Tokens", isCorrect: false },
+                    { text: "Filtros de conteúdo", isCorrect: false },
+                    { text: "Mensagens de sistema", isCorrect: false },
+                ],
+            },
+            {
+                statement:
+                    "Você digita uma instrução em um modelo de linguagem e recebe um texto de volta. Como se chamam, respectivamente, a instrução enviada e o texto recebido?",
+                difficulty: "medio",
+                options: [
+                    { text: "Prompt e completion", isCorrect: true },
+                    { text: "Token e embedding", isCorrect: false },
+                    { text: "Completion e prompt", isCorrect: false },
+                    { text: "Encoder e decoder", isCorrect: false },
+                ],
+            },
+            {
+                statement:
+                    "Uma empresa integra um assistente de IA ao seu editor de textos para sugerir redações e resumir documentos enquanto o funcionário trabalha. Como esse tipo de assistente embutido no aplicativo é chamado?",
+                difficulty: "medio",
+                options: [
+                    { text: "Copilot", isCorrect: true },
+                    { text: "Embedding", isCorrect: false },
+                    { text: "Anomalia", isCorrect: false },
+                    { text: "Encoder", isCorrect: false },
+                ],
+            },
+        ],
+    },
+    {
+        titulo: "IA generativa no Azure",
+        blocks: [
+            {
+                type: "text",
+                value: "## Onde a IA generativa vive no Azure\n\nPara usar IA generativa no Azure de forma corporativa, o serviço central é o Azure OpenAI Service. Ele dá acesso, por API, aos modelos da OpenAI (as famílias GPT, de embeddings e o DALL-E) rodando dentro da nuvem da Microsoft, com a segurança, a governança e a conformidade regional que uma empresa precisa.\n\nA capacidade é a mesma dos modelos da OpenAI, mas com o controle de acesso do Azure, disponibilidade por região e filtros de conteúdo integrados.",
+            },
+            {
+                type: "table",
+                value: '[["Família de modelo","Para que serve","Exemplo de uso"],["GPT","Gera e entende texto e conversa","Chat, resumo e geração de código"],["Embeddings","Transforma texto em vetores de significado","Busca semântica e comparação por similaridade"],["DALL-E","Gera imagens a partir de texto","Criar uma ilustração a partir de uma descrição"]]',
+            },
+            {
+                type: "text",
+                value: "## Azure AI Foundry, a plataforma de construção\n\nO Azure AI Foundry é a plataforma unificada para construir, testar e implantar soluções de IA generativa e copilots. Ele reúne em um só lugar o catálogo de modelos (com modelos da OpenAI e também de parceiros como Meta e Hugging Face), um playground para experimentar prompts, ferramentas de avaliação e o fluxo de implantação.\n\nUma forma simples de separar os dois: o Azure OpenAI Service fornece os modelos, enquanto o Azure AI Foundry é o ambiente onde você escolhe, ajusta, avalia e publica a solução que usa esses modelos. O Foundry era conhecido antes como Azure AI Studio.",
+            },
+            {
+                type: "table",
+                value: '[["Caso de uso","Como a IA generativa ajuda"],["Assistente ou copilot","Responde perguntas e apoia tarefas dentro de um aplicativo"],["Resumo","Condensa documentos ou reuniões longas em pontos principais"],["Geração de conteúdo","Cria rascunhos de texto, imagens ou código"],["Busca semântica","Encontra informação por significado usando embeddings"]]',
+            },
+            {
+                type: "quote",
+                value: "O Azure OpenAI Service fornece os modelos generativos (GPT, embeddings e DALL-E); o Azure AI Foundry é a plataforma para construir, avaliar e implantar a solução.",
+            },
+        ],
+        questions: [
+            {
+                statement:
+                    "Uma empresa quer usar os modelos GPT da OpenAI, mas precisa de controle de acesso corporativo, conformidade e disponibilidade por região do Azure. Qual serviço ela deve usar?",
+                difficulty: "facil",
+                options: [
+                    { text: "Azure OpenAI Service", isCorrect: true },
+                    { text: "Azure Machine Learning designer", isCorrect: false },
+                    { text: "Azure AI Search", isCorrect: false },
+                    { text: "Azure Bot Service", isCorrect: false },
+                ],
+            },
+            {
+                statement:
+                    "Qual família de modelos do Azure OpenAI é usada para gerar imagens a partir de uma descrição em texto?",
+                difficulty: "facil",
+                options: [
+                    { text: "DALL-E", isCorrect: true },
+                    { text: "GPT", isCorrect: false },
+                    { text: "Embeddings", isCorrect: false },
+                    { text: "Detecção de anomalias", isCorrect: false },
+                ],
+            },
+            {
+                statement:
+                    "Um time precisa transformar milhares de documentos em vetores numéricos para montar uma busca por significado. Qual família de modelos do Azure OpenAI atende a isso?",
+                difficulty: "medio",
+                options: [
+                    { text: "Modelos de embeddings", isCorrect: true },
+                    { text: "Modelos GPT", isCorrect: false },
+                    { text: "Modelos DALL-E", isCorrect: false },
+                    { text: "Modelos de detecção de anomalias", isCorrect: false },
+                ],
+            },
+            {
+                statement:
+                    "Uma equipe quer um ambiente único para navegar por um catálogo de modelos, testar prompts em um playground e implantar um copilot. Qual plataforma do Azure oferece isso?",
+                difficulty: "medio",
+                options: [
+                    { text: "Azure AI Foundry", isCorrect: true },
+                    { text: "Azure OpenAI Service usado sozinho", isCorrect: false },
+                    { text: "Azure Blob Storage", isCorrect: false },
+                    { text: "Power BI", isCorrect: false },
+                ],
+            },
+            {
+                statement:
+                    "Um gerente pede um recurso que resuma automaticamente relatórios longos em poucos pontos principais. Esse é um caso de uso típico de qual tecnologia?",
+                difficulty: "medio",
+                options: [
+                    { text: "IA generativa com modelos GPT", isCorrect: true },
+                    { text: "Detecção de anomalias", isCorrect: false },
+                    { text: "Reconhecimento óptico de caracteres (OCR)", isCorrect: false },
+                    {
+                        text: "Modelos de embeddings para escrever o texto do resumo",
+                        isCorrect: false,
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        titulo: "IA generativa responsável",
+        blocks: [
+            {
+                type: "text",
+                value: "## Os riscos próprios da IA generativa\n\nPor criar conteúdo novo, a IA generativa traz riscos que as outras cargas não têm na mesma intensidade. O mais citado é a alucinação: o modelo produz uma resposta que parece correta e confiante, mas é falsa ou inventada. Como o texto soa convincente, o erro pode passar despercebido.\n\nOutros dois riscos importantes são o viés, quando o modelo reproduz preconceitos presentes nos dados de treinamento, e a geração de conteúdo nocivo, como material ofensivo, violento ou de ódio. Tratar esses riscos é o objetivo da IA generativa responsável.",
+            },
+            {
+                type: "text",
+                value: "## Prompt, grounding e RAG\n\nTrês técnicas ajudam a obter respostas melhores e mais confiáveis. A engenharia de prompt é a prática de escrever instruções claras, dar exemplos e usar uma mensagem de sistema para orientar o comportamento do modelo.\n\nO grounding consiste em fornecer ao modelo um contexto factual e relevante junto com o prompt, para que a resposta se baseie nesses dados e não apenas no que ele memorizou no treinamento. Isso reduz muito as alucinações.\n\nA forma mais comum de fazer grounding é o RAG (Retrieval Augmented Generation, ou geração aumentada por recuperação): antes de responder, o sistema busca documentos relevantes em uma fonte confiável, como um índice do Azure AI Search, e injeta esse conteúdo no prompt. Assim o modelo responde com base nos seus dados.",
+            },
+            {
+                type: "table",
+                value: '[["Risco","Mitigação principal"],["Alucinação (informação incorreta)","Grounding e RAG com dados confiáveis"],["Conteúdo nocivo","Filtros de conteúdo do Azure OpenAI"],["Viés nos resultados","Curadoria de dados e avaliação pela imparcialidade"],["Uso indevido","Supervisão humana e governança"]]',
+            },
+            {
+                type: "text",
+                value: "## Filtros de conteúdo e os seis princípios\n\nO Azure OpenAI inclui filtros de conteúdo integrados que detectam e bloqueiam material nocivo em categorias como ódio, sexual, violência e automutilação, com níveis de severidade configuráveis. Eles agem tanto no prompt de entrada quanto na resposta gerada.\n\nOs seis princípios de IA responsável da Microsoft continuam valendo para a IA generativa, cada um com um foco específico nesse cenário.",
+            },
+            {
+                type: "table",
+                value: '[["Princípio","Aplicação na IA generativa"],["Imparcialidade","Reduzir viés para não favorecer nem prejudicar grupos"],["Confiabilidade e segurança","Usar filtros de conteúdo e testar contra alucinações"],["Privacidade e segurança","Proteger os dados enviados no prompt e no grounding"],["Inclusão","Garantir que a solução atenda pessoas com necessidades diversas"],["Transparência","Deixar claro que o usuário fala com uma IA e citar as fontes"],["Responsabilidade","Manter supervisão humana e governança sobre o sistema"]]',
+            },
+            {
+                type: "quote",
+                value: "Grounding e RAG combatem a alucinação ao dar ao modelo dados confiáveis como contexto, enquanto os filtros de conteúdo do Azure OpenAI bloqueiam conteúdo nocivo na entrada e na saída.",
+            },
+        ],
+        questions: [
+            {
+                statement:
+                    "Um chatbot generativo respondeu a um cliente com um dado de produto que parecia correto, mas era totalmente inventado. Como esse tipo de erro é chamado?",
+                difficulty: "facil",
+                options: [
+                    { text: "Alucinação", isCorrect: true },
+                    { text: "Anomalia", isCorrect: false },
+                    { text: "Sobreajuste de imagem", isCorrect: false },
+                    { text: "Filtro de conteúdo", isCorrect: false },
+                ],
+            },
+            {
+                statement:
+                    "Uma empresa quer que o assistente responda perguntas com base nos manuais internos dela, e não apenas no conhecimento geral do modelo. Qual abordagem atende melhor a isso?",
+                difficulty: "medio",
+                options: [
+                    {
+                        text: "RAG, buscando os manuais e injetando o conteúdo no prompt",
+                        isCorrect: true,
+                    },
+                    { text: "Aumentar o número de tokens da resposta", isCorrect: false },
+                    { text: "Desativar os filtros de conteúdo", isCorrect: false },
+                    {
+                        text: "Trocar o modelo GPT por um modelo apenas de embeddings",
+                        isCorrect: false,
+                    },
+                ],
+            },
+            {
+                statement:
+                    "Que recurso do Azure OpenAI detecta e bloqueia material de ódio, sexual, violento ou de automutilação tanto no prompt quanto na resposta?",
+                difficulty: "medio",
+                options: [
+                    { text: "Os filtros de conteúdo", isCorrect: true },
+                    { text: "Os embeddings", isCorrect: false },
+                    { text: "O playground do Azure AI Foundry", isCorrect: false },
+                    { text: "A tokenização", isCorrect: false },
+                ],
+            },
+            {
+                statement:
+                    "Ao avaliar um modelo, uma empresa percebe que ele reproduz preconceitos dos dados de treinamento e trata grupos de forma desigual. Qual princípio de IA responsável orienta a correção desse problema?",
+                difficulty: "medio",
+                options: [
+                    { text: "Imparcialidade", isCorrect: true },
+                    { text: "Transparência", isCorrect: false },
+                    { text: "Inclusão", isCorrect: false },
+                    { text: "Responsabilidade", isCorrect: false },
+                ],
+            },
+            {
+                statement:
+                    "Um desenvolvedor melhora as respostas do modelo escrevendo instruções mais claras, dando exemplos e definindo uma mensagem de sistema. Como se chama essa prática?",
+                difficulty: "medio",
+                options: [
+                    { text: "Engenharia de prompt", isCorrect: true },
+                    { text: "Detecção de anomalias", isCorrect: false },
+                    { text: "Filtragem de conteúdo", isCorrect: false },
+                    { text: "Tokenização", isCorrect: false },
+                ],
+            },
+        ],
+    },
+];
+
+const MODULOS: Modulo[] = [
+    {
+        titulo: "Módulo 1 - Introdução à IA e IA responsável",
+        aulas: [
+            {
+                titulo: "O que é IA e as cargas de trabalho de IA",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "## O que é inteligência artificial\nInteligência artificial é software que imita capacidades associadas à inteligência humana, como aprender com dados, reconhecer padrões, entender linguagem, interpretar imagens e tomar decisões. Em vez de seguir apenas regras escritas à mão, um sistema de IA aprende a partir de exemplos e melhora conforme recebe mais dados.\n\nNo AI-900, a IA é organizada em cargas de trabalho (workloads): grupos de capacidades que resolvem um tipo de problema. Identificar qual carga resolve um cenário é uma das coisas que mais caem na prova.\n\n## Machine learning é a base de tudo\nMachine learning (aprendizado de máquina) treina um modelo a partir de dados históricos para fazer previsões sobre dados novos. Quase toda carga de IA moderna usa machine learning por baixo. Exemplo: prever o preço de um imóvel a partir de área, bairro e número de quartos, ou estimar a demanda de vendas do próximo mês. No Azure, o serviço é o Azure Machine Learning.",
+                    },
+                    {
+                        type: "text",
+                        value: "## As demais cargas de trabalho\n**Visão computacional** interpreta imagens e vídeos: classifica fotos, detecta e localiza objetos, lê texto impresso com OCR e reconhece rostos. Serviço: Azure AI Vision. Exemplo: uma câmera que lê placas de veículos na entrada de um estacionamento.\n\n**Processamento de linguagem natural (PLN)** entende e gera linguagem escrita e falada: análise de sentimento, extração de frases-chave, tradução, transcrição de fala e chatbots. Serviços: Azure AI Language e Azure AI Speech. Exemplo: classificar avaliações de clientes como positivas ou negativas.\n\n**Document intelligence** extrai dados de formulários e documentos, devolvendo campos estruturados como valores, datas e totais a partir de faturas, recibos e identidades. Serviço: Azure AI Document Intelligence. Exemplo: ler automaticamente o valor e o vencimento de milhares de notas fiscais.\n\n**Knowledge mining (mineração de conhecimento)** varre grandes volumes de conteúdo e cria um índice pesquisável, conectando informação espalhada em documentos, PDFs e imagens. Serviço: Azure AI Search. Exemplo: um buscador interno que localiza cláusulas em milhares de contratos.\n\n**IA generativa** cria conteúdo novo, como texto, imagem, código ou resumo, a partir de um prompt, usando modelos de linguagem de grande porte. Serviço: Azure OpenAI Service. Exemplo: um assistente que redige e-mails ou gera imagens a partir de uma descrição.",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Carga de trabalho","O que faz","Exemplo de uso","Serviço Azure"],["Machine learning","Treina modelos que preveem valores ou categorias","Prever o preço de um imóvel","Azure Machine Learning"],["Visão computacional","Interpreta imagens e vídeos","Ler placas com OCR","Azure AI Vision"],["Processamento de linguagem natural","Entende e gera fala e texto","Análise de sentimento de avaliações","Azure AI Language e Azure AI Speech"],["Document intelligence","Extrai campos de formulários e documentos","Ler dados de notas fiscais","Azure AI Document Intelligence"],["Knowledge mining","Cria índice pesquisável de muitos documentos","Busca interna em contratos","Azure AI Search"],["IA generativa","Cria conteúdo novo a partir de um prompt","Redigir texto ou gerar imagem","Azure OpenAI Service"]]',
+                    },
+                    {
+                        type: "code",
+                        value: '{\n  "fornecedor": "Café Bom Ltda",\n  "numeroNota": "1042",\n  "valorTotal": 289.90,\n  "vencimento": "2026-08-15"\n}',
+                    },
+                    {
+                        type: "quote",
+                        value: "Prever números ou categorias é machine learning; interpretar imagens é visão computacional; entender fala e texto é PLN; extrair campos de documentos é document intelligence; indexar muitos documentos para busca é knowledge mining; e criar conteúdo novo é IA generativa.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement:
+                            "Uma loja quer prever o total de vendas do próximo mês com base no histórico de vendas dos últimos anos. Qual carga de trabalho de IA é a mais adequada?",
+                        difficulty: "facil",
+                        options: [
+                            { text: "Machine learning", isCorrect: true },
+                            { text: "Visão computacional", isCorrect: false },
+                            { text: "Knowledge mining", isCorrect: false },
+                            { text: "Document intelligence", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Uma rede de estacionamentos quer usar câmeras para ler automaticamente as placas dos veículos na entrada. Qual carga de trabalho resolve isso?",
+                        difficulty: "facil",
+                        options: [
+                            { text: "Visão computacional", isCorrect: true },
+                            { text: "Processamento de linguagem natural", isCorrect: false },
+                            { text: "Machine learning de previsão de vendas", isCorrect: false },
+                            { text: "IA generativa", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Um SAC precisa classificar automaticamente os comentários dos clientes como positivos, negativos ou neutros. Qual carga de trabalho e serviço atendem esse caso?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Processamento de linguagem natural com Azure AI Language",
+                                isCorrect: true,
+                            },
+                            { text: "Visão computacional com Azure AI Vision", isCorrect: false },
+                            {
+                                text: "Document intelligence com Azure AI Document Intelligence",
+                                isCorrect: false,
+                            },
+                            { text: "Knowledge mining com Azure AI Search", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "O setor financeiro recebe milhares de faturas em PDF e quer extrair de cada uma o fornecedor, o valor e o vencimento, sem digitação manual. Qual serviço do Azure é indicado?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "Azure AI Document Intelligence", isCorrect: true },
+                            { text: "Azure AI Search", isCorrect: false },
+                            { text: "Azure Machine Learning", isCorrect: false },
+                            { text: "Azure AI Vision", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Um banco planeja duas soluções: a solução A é um assistente que redige respostas novas para clientes a partir de instruções em texto, e a solução B é um buscador que indexa todo o acervo de manuais internos para consulta. Qual carga de trabalho corresponde à solução A?",
+                        difficulty: "dificil",
+                        options: [
+                            { text: "IA generativa", isCorrect: true },
+                            { text: "Knowledge mining", isCorrect: false },
+                            { text: "Document intelligence", isCorrect: false },
+                            { text: "Visão computacional", isCorrect: false },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Os princípios de IA responsável da Microsoft",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "## O que é IA responsável\nA Microsoft definiu seis princípios para guiar o desenvolvimento e o uso de IA de forma ética e confiável. Na prova, o formato mais comum é receber um cenário e apontar qual princípio ele representa, então vale decorar os seis e o foco de cada um.\n\n## Imparcialidade (fairness)\nSistemas de IA devem tratar todas as pessoas de forma justa, sem favorecer nem prejudicar grupos por gênero, etnia, idade ou outra característica. O risco a evitar é o viés (bias) nos dados ou no modelo. Exemplo: um modelo que aprova crédito não pode negar mais pedidos de um grupo apenas por causa do gênero.\n\n## Confiabilidade e segurança (reliability e safety)\nSistemas de IA devem funcionar de forma confiável, consistente e segura, inclusive diante de situações inesperadas. Isso exige testes rigorosos e monitoramento contínuo. Exemplo: o piloto automático de um carro precisa reagir com segurança a uma condição de estrada que nunca viu no treino.\n\n## Privacidade e segurança (privacy e security)\nSistemas de IA devem proteger os dados das pessoas e respeitar a privacidade, garantindo que as informações sejam usadas de forma segura e apenas para o fim previsto. Exemplo: anonimizar dados de pacientes usados para treinar um modelo e controlar quem pode acessá-los.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Inclusão (inclusiveness)\nSistemas de IA devem empoderar todas as pessoas e alcançar quem tem alguma deficiência ou faz parte de grupos frequentemente deixados de fora. Exemplo: oferecer legendas automáticas, leitor de tela e controle por voz para que pessoas com deficiência consigam usar o produto.\n\n## Transparência (transparency)\nSistemas de IA devem ser compreensíveis: as pessoas precisam entender como o sistema funciona, para que ele serve e quais são suas limitações. Exemplo: informar ao usuário quais dados o modelo usa para decidir e avisar em que situações ele pode errar.\n\n## Responsabilidade (accountability)\nPessoas e organizações devem se responsabilizar pelos sistemas de IA que criam e operam, com governança e supervisão humana. A IA não assume a culpa sozinha: quem responde são as pessoas. Exemplo: a empresa designa uma equipe responsável por auditar o modelo e responder oficialmente por seus resultados.",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Princípio","Foco central","Exemplo prático"],["Imparcialidade (fairness)","Tratar todos de forma justa, sem viés","Crédito não pode discriminar por gênero"],["Confiabilidade e segurança (reliability e safety)","Funcionar de forma segura e consistente","Carro autônomo reage bem a uma situação nova"],["Privacidade e segurança (privacy e security)","Proteger dados e a privacidade","Anonimizar dados de pacientes no treino"],["Inclusão (inclusiveness)","Alcançar e empoderar todas as pessoas","Legendas e leitor de tela para acessibilidade"],["Transparência (transparency)","Ser compreensível e explicar limitações","Informar como o modelo toma decisões"],["Responsabilidade (accountability)","Pessoas respondem pelo sistema","Equipe de governança audita o modelo"]]',
+                    },
+                    {
+                        type: "text",
+                        value: "## Como não confundir na prova\nAlguns princípios se parecem. Transparência é sobre entender como o sistema funciona; responsabilidade é sobre quem responde por ele. Imparcialidade é não discriminar grupos por causa de viés; inclusão é garantir que todos, inclusive pessoas com deficiência, consigam usar o sistema. Se o cenário fala em comportamento seguro mesmo em situações raras, é confiabilidade e segurança; se fala em proteger dados pessoais, é privacidade e segurança.",
+                    },
+                    {
+                        type: "quote",
+                        value: "Transparência é entender como a IA funciona; responsabilidade é ter pessoas que respondem por ela. Imparcialidade combate o viés contra grupos; inclusão garante que todos, inclusive pessoas com deficiência, consigam usar o sistema.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement:
+                            "Um modelo de aprovação de empréstimos passou a recusar mais pedidos de mulheres por causa de um viés presente nos dados de treino. Qual princípio de IA responsável foi violado?",
+                        difficulty: "facil",
+                        options: [
+                            { text: "Imparcialidade", isCorrect: true },
+                            { text: "Transparência", isCorrect: false },
+                            { text: "Confiabilidade e segurança", isCorrect: false },
+                            { text: "Inclusão", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Uma equipe adiciona legendas automáticas e navegação por voz para que pessoas com deficiência consigam usar o aplicativo. Qual princípio isso representa?",
+                        difficulty: "facil",
+                        options: [
+                            { text: "Inclusão", isCorrect: true },
+                            { text: "Privacidade e segurança", isCorrect: false },
+                            { text: "Responsabilidade", isCorrect: false },
+                            { text: "Imparcialidade", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Antes de treinar um modelo, um hospital anonimiza os dados dos pacientes e restringe quem pode acessá-los. Qual princípio está sendo aplicado?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "Privacidade e segurança", isCorrect: true },
+                            { text: "Transparência", isCorrect: false },
+                            { text: "Inclusão", isCorrect: false },
+                            { text: "Confiabilidade e segurança", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "O fabricante de um carro autônomo executa milhares de testes para garantir que o veículo reaja com segurança a situações de trânsito imprevistas. Qual princípio orienta essa preocupação?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "Confiabilidade e segurança", isCorrect: true },
+                            { text: "Privacidade e segurança", isCorrect: false },
+                            { text: "Imparcialidade", isCorrect: false },
+                            { text: "Transparência", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Uma empresa publica um documento explicando quais dados o modelo usa, como ele chega às decisões e em que situações pode errar, para que os usuários entendam seu funcionamento. Qual princípio isso representa?",
+                        difficulty: "dificil",
+                        options: [
+                            { text: "Transparência", isCorrect: true },
+                            { text: "Responsabilidade", isCorrect: false },
+                            { text: "Inclusão", isCorrect: false },
+                            { text: "Confiabilidade e segurança", isCorrect: false },
+                        ],
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        titulo: "Módulo 2 - Fundamentos de machine learning",
+        aulas: [
+            {
+                titulo: "Tipos de machine learning",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "## Aprender a partir de dados\nMachine learning treina um modelo para achar padrões em dados históricos e usar esses padrões para prever resultados sobre dados novos. Em vez de você escrever a regra na mão, os dados ensinam a regra ao modelo.\n\nCada exemplo dos dados tem características, as features, que são as colunas de entrada, e muitas vezes um rótulo, o label, que é a resposta que você quer prever. Para estimar o preço de um imóvel, as features podem ser área, número de quartos e bairro; o label é o preço. O modelo aprende como as features se relacionam com o label e passa a prever o label de imóveis que ainda não viu.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Supervisionado e não supervisionado\nA grande divisão do machine learning é se os dados de treino têm ou não o label conhecido.\n\nNo aprendizado supervisionado os exemplos já vêm rotulados. O modelo estuda pares de features e label e aprende a prever o label. Ele se divide em dois casos: regressão, quando o label é um número, e classificação, quando o label é uma categoria.\n\nNo aprendizado não supervisionado não existe label. O modelo recebe só as features e precisa achar estrutura sozinho. O caso mais comum é o clustering, ou agrupamento, que junta exemplos parecidos em grupos sem que ninguém diga de antemão quais são esses grupos.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Binária ou multiclasse\nA classificação prevê a qual categoria um exemplo pertence. Quando existem só duas categorias possíveis, é classificação binária: spam ou não spam, aprovado ou reprovado, fraude ou não fraude. Quando existem três ou mais categorias, é classificação multiclasse: prever a espécie de uma flor entre várias, ou o gênero de um filme. A lógica é a mesma; muda só a quantidade de classes na saída.",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Tipo","Aprendizado","Prevê","Exemplo"],["Regressão","Supervisionado","Um valor numérico contínuo","Preço de um imóvel"],["Classificação binária","Supervisionado","Uma entre duas categorias","E-mail é spam ou não"],["Classificação multiclasse","Supervisionado","Uma entre três ou mais categorias","Espécie de uma flor"],["Clustering (agrupamento)","Não supervisionado","Grupos de itens parecidos, sem rótulo","Segmentar clientes por comportamento"]]',
+                    },
+                    {
+                        type: "text",
+                        value: "## Como escolher o tipo\nDeixe a pergunta guiar. Você quer prever um número, como valor, temperatura ou quantidade? É regressão. Quer prever uma categoria e tem exemplos já rotulados para treinar? É classificação, binária para duas classes e multiclasse para três ou mais. Não tem rótulo nenhum e quer descobrir agrupamentos naturais nos dados? É clustering. A primeira pergunta a fazer é sobre o label: com label é supervisionado, sem label é não supervisionado.",
+                    },
+                    {
+                        type: "quote",
+                        value: "Regressão prevê um valor numérico; classificação prevê uma categoria (binária para duas classes, multiclasse para três ou mais); clustering agrupa dados que não têm rótulo.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement:
+                            "Uma imobiliária quer estimar o valor de venda de apartamentos a partir da área, do número de quartos e do bairro. Qual tipo de machine learning resolve esse problema?",
+                        difficulty: "facil",
+                        options: [
+                            { text: "Regressão", isCorrect: true },
+                            { text: "Classificação binária", isCorrect: false },
+                            { text: "Classificação multiclasse", isCorrect: false },
+                            { text: "Clustering", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Um serviço de e-mail precisa marcar cada mensagem que chega como spam ou não spam, usando exemplos já rotulados. Que tipo de problema é esse?",
+                        difficulty: "facil",
+                        options: [
+                            { text: "Classificação binária", isCorrect: true },
+                            { text: "Classificação multiclasse", isCorrect: false },
+                            { text: "Regressão", isCorrect: false },
+                            { text: "Clustering", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Uma equipe de marketing tem dados de compra de milhares de clientes, mas nenhum rótulo, e quer descobrir grupos de clientes com comportamento parecido. Qual abordagem usar?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "Clustering", isCorrect: true },
+                            { text: "Classificação binária", isCorrect: false },
+                            { text: "Classificação multiclasse", isCorrect: false },
+                            { text: "Regressão", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Numa tabela usada para prever a nota final de alunos, cada linha tem horas de estudo, frequência e a nota final já registrada. Nesse conjunto de treino, a coluna nota final é o que?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "O label, o rótulo que se quer prever", isCorrect: true },
+                            { text: "Uma feature de entrada", isCorrect: false },
+                            { text: "Um cluster", isCorrect: false },
+                            { text: "Um hiperparâmetro do modelo", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Um aplicativo de identificação de plantas recebe uma foto e precisa dizer a qual das doze espécies do catálogo ela pertence. Que tipo de tarefa de machine learning é essa?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "Classificação multiclasse", isCorrect: true },
+                            { text: "Classificação binária", isCorrect: false },
+                            { text: "Regressão", isCorrect: false },
+                            { text: "Clustering", isCorrect: false },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Treinar e avaliar um modelo",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "## Dividir os dados em treino e teste\nTreinar um modelo e avaliá-lo nos mesmos dados engana: ele já viu as respostas e parece perfeito. Por isso os dados são separados em pelo menos dois conjuntos. O conjunto de treino é usado para o modelo aprender. O conjunto de validação ou teste fica reservado e serve para medir o desempenho em exemplos que o modelo nunca viu.\n\nUma divisão comum guarda a maior parte para treino, por volta de 70% a 80%, e o restante para teste. O que importa é o desempenho no teste, porque ele estima como o modelo vai se sair no mundo real, diante de dados novos.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Overfitting e underfitting\nDois problemas atrapalham essa generalização.\n\nO overfitting, ou sobreajuste, é quando o modelo decora o treino em vez de aprender o padrão geral. O sinal clássico é ir muito bem no treino e mal no teste. Ele memorizou até o ruído dos dados e não sabe lidar com exemplos novos.\n\nO underfitting, ou subajuste, é o oposto: o modelo é simples demais para o problema e vai mal até no treino. Não captou o padrão nem nos dados que estudou.\n\nO alvo fica no meio: um modelo que vai bem no treino e continua bem no teste.",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Métrica","Usada em","O que mede"],["Acurácia","Classificação","A fração total de previsões corretas"],["Precisão","Classificação","Dos exemplos previstos como positivos, quantos eram mesmo positivos"],["Recall (revocação)","Classificação","Dos positivos reais, quantos o modelo conseguiu encontrar"],["R² (coeficiente de determinação)","Regressão","Quanto da variação dos dados o modelo consegue explicar"],["Erro (MAE, RMSE)","Regressão","O tamanho médio da diferença entre o previsto e o real"]]',
+                    },
+                    {
+                        type: "text",
+                        value: "## A matriz de confusão\nNuma classificação, a matriz de confusão organiza os acertos e os erros comparando o valor real com o valor previsto. Ela tem quatro caselas. Verdadeiro positivo (VP) e verdadeiro negativo (VN) são os acertos. Falso positivo (FP) é quando o modelo previu positivo mas era negativo, o alarme falso. Falso negativo (FN) é quando previu negativo mas era positivo, o caso que passou batido.\n\nDessas quatro caselas saem as métricas. A acurácia é a soma dos acertos sobre o total. A precisão olha os falsos positivos: VP dividido por VP mais FP. O recall olha os falsos negativos: VP dividido por VP mais FN. Por isso precisão e recall contam uma história que a acurácia sozinha esconde, principalmente quando uma classe é bem mais rara que a outra.",
+                    },
+                    {
+                        type: "table",
+                        value: '[["","Previsto positivo","Previsto negativo"],["Real positivo","Verdadeiro positivo (VP)","Falso negativo (FN)"],["Real negativo","Falso positivo (FP)","Verdadeiro negativo (VN)"]]',
+                    },
+                    {
+                        type: "quote",
+                        value: "Overfitting vai bem no treino e mal em dados novos; underfitting vai mal até no treino. Precisão penaliza os falsos positivos; recall penaliza os falsos negativos.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement:
+                            "Um modelo acerta 98% no conjunto de treino, mas só 62% no conjunto de teste. Como se chama esse problema?",
+                        difficulty: "facil",
+                        options: [
+                            { text: "Overfitting (sobreajuste)", isCorrect: true },
+                            { text: "Underfitting (subajuste)", isCorrect: false },
+                            { text: "Generalização equilibrada", isCorrect: false },
+                            { text: "Divisão de treino e teste", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Por que reservar um conjunto de teste em vez de avaliar o modelo nos próprios dados de treino?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "Para medir o desempenho em dados que o modelo não viu no treino",
+                                isCorrect: true,
+                            },
+                            { text: "Para o treino terminar mais rápido", isCorrect: false },
+                            { text: "Para aumentar o número de features", isCorrect: false },
+                            { text: "Para rotular os dados automaticamente", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Você treinou um modelo para prever o consumo mensal de energia de uma casa, que é um valor numérico. Qual métrica é adequada para avaliar esse modelo?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "R²", isCorrect: true },
+                            { text: "Recall", isCorrect: false },
+                            { text: "Precisão", isCorrect: false },
+                            { text: "Acurácia", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Um modelo de triagem médica não pode deixar passar quem realmente está doente, ou seja, precisa minimizar os falsos negativos. Qual métrica deve ser priorizada?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "Recall (revocação)", isCorrect: true },
+                            { text: "Precisão", isCorrect: false },
+                            { text: "R²", isCorrect: false },
+                            { text: "Erro médio absoluto", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Num detector de fraude, uma transação legítima foi classificada como fraude. Na matriz de confusão, esse resultado é um:",
+                        difficulty: "medio",
+                        options: [
+                            { text: "Falso positivo", isCorrect: true },
+                            { text: "Falso negativo", isCorrect: false },
+                            { text: "Verdadeiro positivo", isCorrect: false },
+                            { text: "Verdadeiro negativo", isCorrect: false },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Machine learning no Azure",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "## O Azure Machine Learning e o workspace\nO Azure Machine Learning é o serviço da Azure para o ciclo completo de machine learning: preparar dados, treinar, avaliar, registrar e implantar modelos. Ele atende tanto quem programa quanto quem prefere ferramentas visuais.\n\nTudo vive dentro de um workspace, o recurso central que reúne os experimentos, os conjuntos de dados, os modelos treinados, a computação e os endpoints. Você acessa esse conteúdo pelo Azure Machine Learning studio, o portal web do serviço. Sem um workspace não há onde os outros recursos existirem, então ele é sempre o ponto de partida.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Automated machine learning e Designer\nDentro do workspace existem dois caminhos para treinar sem escrever muito código.\n\nO Automated machine learning, o AutoML, testa vários algoritmos e combinações de configuração de forma automática, compara os resultados por uma métrica que você escolhe e aponta o melhor modelo para os seus dados. É a escolha de quem quer um bom modelo sem dominar os detalhes de cada algoritmo.\n\nO Designer é um editor visual de arrastar e soltar. Você monta o fluxo de treino conectando blocos numa tela, do carregamento dos dados até o modelo, sem programar. Serve para desenhar e enxergar o pipeline passo a passo.",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Recurso","Para que serve","Quando usar"],["Workspace","Recurso central que reúne dados, modelos e computação","Sempre, é o ponto de partida do serviço"],["Automated ML (AutoML)","Testa algoritmos e aponta o melhor modelo sozinho","Quer o melhor modelo sem escolher o algoritmo na mão"],["Designer","Monta o fluxo de treino de forma visual, sem código","Desenhar o pipeline arrastando e conectando blocos"],["Compute","Máquinas gerenciadas que rodam treino e inferência","Precisa de poder de processamento para treinar ou servir"],["Endpoint","Publica o modelo como serviço web para receber previsões","Colocar um modelo treinado em produção"]]',
+                    },
+                    {
+                        type: "text",
+                        value: "## Computação e implantação como endpoint\nTreinar e servir modelos exige poder de processamento, e no Azure Machine Learning isso vem da computação, o compute: máquinas gerenciadas que a plataforma liga para trabalhar e desliga quando não precisa. Você define o tamanho conforme a carga.\n\nDepois de treinado e registrado, o modelo é implantado como um endpoint, um serviço web que recebe dados de entrada e devolve a previsão. Uma aplicação chama esse endpoint, envia um exemplo novo e recebe o resultado. Esse ato de usar o modelo pronto para prever dados novos é a inferência. Treino é aprender com os dados; inferência é aplicar o que foi aprendido.",
+                    },
+                    {
+                        type: "quote",
+                        value: "O AutoML acha o melhor modelo sozinho; o Designer monta o fluxo sem código; a computação (compute) fornece o poder de processamento; e o modelo é publicado como um endpoint para a inferência.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement:
+                            "Uma analista quer o modelo de maior desempenho para os seus dados, mas não domina os algoritmos de machine learning nem quer escrevê-los. Qual recurso do Azure Machine Learning atende melhor?",
+                        difficulty: "facil",
+                        options: [
+                            { text: "Automated machine learning (AutoML)", isCorrect: true },
+                            { text: "Designer", isCorrect: false },
+                            { text: "Endpoint", isCorrect: false },
+                            { text: "Compute", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Qual é o recurso central do Azure Machine Learning, que reúne experimentos, dados, modelos e computação em um só lugar?",
+                        difficulty: "facil",
+                        options: [
+                            { text: "O workspace", isCorrect: true },
+                            { text: "O endpoint", isCorrect: false },
+                            { text: "O Designer", isCorrect: false },
+                            { text: "O grupo de recursos", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Um time quer construir o fluxo de treinamento arrastando e conectando blocos numa tela, sem escrever código. Qual recurso usar?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "O Designer", isCorrect: true },
+                            { text: "O Automated machine learning", isCorrect: false },
+                            { text: "O compute", isCorrect: false },
+                            { text: "O endpoint", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Um modelo já foi treinado e validado. Agora um aplicativo precisa enviar novos dados e receber a previsão em tempo real. O que fazer com o modelo?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "Implantá-lo como um endpoint", isCorrect: true },
+                            { text: "Rodar um novo experimento de AutoML", isCorrect: false },
+                            { text: "Criar outro workspace", isCorrect: false },
+                            { text: "Aumentar o tamanho do compute de treino", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement: "No Azure Machine Learning, o que é inferência?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Usar um modelo já treinado para gerar previsões sobre dados novos",
+                                isCorrect: true,
+                            },
+                            { text: "Dividir os dados em treino e teste", isCorrect: false },
+                            { text: "Rotular os dados antes do treino", isCorrect: false },
+                            { text: "Escolher quais features entram no modelo", isCorrect: false },
+                        ],
+                    },
+                ],
+            },
+        ],
+    },
+    { titulo: "Módulo 3 - Visão computacional", aulas: MODULO3 },
+    { titulo: "Módulo 4 - Processamento de linguagem natural (PLN)", aulas: MODULO4 },
+    { titulo: "Módulo 5 - IA generativa", aulas: MODULO5 },
+];
+
+async function seed() {
+    let [trilha] = await db.select().from(trails).where(eq(trails.name, NOME));
+    if (!trilha) {
+        [trilha] = await db
+            .insert(trails)
+            .values({ name: NOME, trailLevel: "iniciante", description: DESCRICAO })
+            .returning();
+        console.log(`Trilha criada: ${trilha.name}`);
+    }
+
+    const existentes = await db.select().from(lessons).where(eq(lessons.trailId, trilha.id));
+    if (existentes.length > 0) {
+        console.log(`Trilha ${NOME} já tem ${existentes.length} aulas. Nada a fazer.`);
+        return;
+    }
+
+    let totalAulas = 0;
+    let totalQuestoes = 0;
+    for (let mi = 0; mi < MODULOS.length; mi++) {
+        const m = MODULOS[mi];
+        const [mod] = await db
+            .insert(modules)
+            .values({ trailId: trilha.id, title: m.titulo, position: mi + 1 })
+            .returning();
+        for (let li = 0; li < m.aulas.length; li++) {
+            const a = m.aulas[li];
+            const [lesson] = await db
+                .insert(lessons)
+                .values({
+                    trailId: trilha.id,
+                    moduleId: mod.id,
+                    title: a.titulo,
+                    content: null,
+                    contentBlocks: a.blocks,
+                    position: li + 1,
+                    published: true,
+                })
+                .returning();
+            for (let qi = 0; qi < a.questions.length; qi++) {
+                const q = a.questions[qi];
+                const [questao] = await db
+                    .insert(questions)
+                    .values({
+                        lessonId: lesson.id,
+                        statement: q.statement,
+                        difficulty: q.difficulty,
+                        position: qi + 1,
+                    })
+                    .returning();
+                await db.insert(questionOptions).values(
+                    q.options.map((o, k) => ({
+                        questionId: questao.id,
+                        text: o.text,
+                        isCorrect: o.isCorrect,
+                        position: k + 1,
+                    })),
+                );
+            }
+            totalAulas++;
+            totalQuestoes += a.questions.length;
+        }
+    }
+    console.log(
+        `Seed concluído: ${MODULOS.length} módulos, ${totalAulas} aulas, ${totalQuestoes} questões.`,
+    );
+}
+
+seed()
+    .then(() => process.exit(0))
+    .catch((e) => {
+        console.error("Falha no seed:", e);
+        process.exit(1);
+    });

--- a/backend/scripts/seed-trilha-dp900.ts
+++ b/backend/scripts/seed-trilha-dp900.ts
@@ -1,0 +1,1349 @@
+// Seed da trilha DP-900 (Microsoft Azure Data Fundamentals). Cria a trilha se não
+// existir, com módulos e aulas em blocos + 5 questões por aula. Idempotente e não
+// destrutivo: se a trilha já tiver aulas, não faz nada.
+//
+// Rodar em prod: docker compose -f docker-compose.prod.yml exec -T backend node scripts/seed-trilha-dp900.ts
+import { db } from "../db.ts";
+import { trails, modules, lessons, questions, questionOptions } from "../schema.ts";
+import { eq } from "drizzle-orm";
+
+const NOME = "AZURE DP-900";
+const DESCRICAO =
+    "Trilha de fundamentos de dados no Microsoft Azure para a certificação DP-900: conceitos de dados, cargas transacionais e analíticas, dados relacionais e não relacionais no Azure, e cargas de análise com Microsoft Fabric, Azure Databricks e Power BI.";
+
+type Bloco = { type: "text" | "code" | "quote" | "table"; value: string };
+type Questao = {
+    statement: string;
+    difficulty: "facil" | "medio" | "dificil";
+    options: { text: string; isCorrect: boolean }[];
+};
+type Aula = { titulo: string; blocks: Bloco[]; questions: Questao[] };
+type Modulo = { titulo: string; aulas: Aula[] };
+
+const MODULOS: Modulo[] = [
+    {
+        titulo: "Módulo 1 - Conceitos centrais de dados",
+        aulas: [
+            {
+                titulo: "Dados estruturados, semiestruturados e não estruturados",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "## Os três tipos de dados\nTodo dado que uma empresa guarda cai em um de três tipos, definidos pelo quanto ele segue um formato fixo. Classificar o dado é o primeiro passo para decidir onde guardar e como consultar.\n\n## Dados estruturados\nSão dados que cabem em tabelas com schema fixo, organizados em linhas e colunas. Cada coluna tem um tipo definido (texto, número, data) e todo registro segue o mesmo formato. O schema é definido antes de gravar, então a estrutura vem primeiro e o dado depois. É o formato típico dos bancos relacionais. Exemplos: cadastro de clientes, lançamentos financeiros e catálogo de produtos.\n\n## Dados semiestruturados\nTêm alguma organização, mas o schema é flexível e self-describing: o próprio dado carrega as marcações que descrevem seus campos. Dois registros podem ter campos diferentes. Entram aqui JSON, XML, pares chave-valor, documentos e grafos. Exemplos: um documento JSON de um pedido, um arquivo XML de configuração e dados de redes sociais. Costumam ficar em bancos NoSQL, como o Azure Cosmos DB.\n\n## Dados não estruturados\nNão seguem nenhum modelo de dados definido. O conteúdo existe, mas não há linhas, colunas nem campos que o organizem por dentro. Exemplos: imagens, áudio, vídeo, PDFs e e-mails. Ficam bem em armazenamento de objetos como o Azure Blob Storage ou em um data lake.",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Tipo","Característica","Exemplo","Onde armazenar"],["Estruturado","Schema fixo em linhas e colunas","Cadastro de clientes","Banco relacional como Azure SQL"],["Semiestruturado","Schema flexível e self-describing","Documento JSON ou XML","Banco NoSQL como Azure Cosmos DB"],["Não estruturado","Sem modelo de dados definido","Imagem, vídeo ou PDF","Blob Storage ou data lake"]]',
+                    },
+                    {
+                        type: "code",
+                        value: '{\n  "pedido": 1042,\n  "cliente": "Ana",\n  "itens": ["café", "filtro"],\n  "entrega": { "cidade": "Recife" }\n}',
+                    },
+                    {
+                        type: "quote",
+                        value: "O que separa os três é o schema. Estruturado tem schema fixo definido antes de gravar. Semiestruturado carrega o schema dentro do próprio dado. Não estruturado não tem schema nenhum.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement:
+                            "Uma empresa guarda o cadastro de clientes em tabelas com colunas fixas de nome, CPF e data de nascimento, iguais em todo registro. Como esses dados são classificados?",
+                        difficulty: "facil",
+                        options: [
+                            { text: "Estruturados", isCorrect: true },
+                            { text: "Semiestruturados", isCorrect: false },
+                            { text: "Não estruturados", isCorrect: false },
+                            { text: "Sem qualquer organização", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Um aplicativo recebe pedidos como documentos JSON em que cada pedido pode ter campos diferentes. Que tipo de dado é esse?",
+                        difficulty: "facil",
+                        options: [
+                            { text: "Semiestruturado", isCorrect: true },
+                            { text: "Estruturado", isCorrect: false },
+                            { text: "Não estruturado", isCorrect: false },
+                            { text: "Relacional normalizado", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Um time precisa armazenar milhares de imagens de exames e gravações de áudio de atendimento. Qual serviço combina com esse dado não estruturado?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "Azure Blob Storage", isCorrect: true },
+                            { text: "Azure SQL Database", isCorrect: false },
+                            { text: "Uma tabela relacional normalizada", isCorrect: false },
+                            { text: "Um índice de colunas em banco relacional", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement: "Qual afirmação descreve corretamente dados semiestruturados?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Carregam a própria descrição dos campos e admitem schema flexível",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Exigem schema fixo definido antes da gravação",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Não possuem qualquer forma de organização interna",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Só podem ser guardados em bancos relacionais",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Uma equipe quer guardar perfis cuja estrutura muda de um registro para outro, usando pares chave-valor e documentos. Qual banco atende melhor?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "Azure Cosmos DB", isCorrect: true },
+                            { text: "Azure SQL Database", isCorrect: false },
+                            { text: "Azure Blob Storage", isCorrect: false },
+                            { text: "SQL Server com schema fixo", isCorrect: false },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Formatos de arquivo e opções de armazenamento",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "## Por que o formato importa\nO mesmo dado pode ser gravado em formatos diferentes, e a escolha muda o tamanho do arquivo e a velocidade de leitura. Uns são feitos para o humano ler e trocar dados entre sistemas. Outros são feitos para a máquina processar grandes volumes em análise.\n\n## Formatos comuns\nCSV e outros delimitados guardam dados em texto, uma linha por registro, com campos separados por um caractere como a vírgula. São leves, portáteis e fáceis de ler, mas não guardam tipos nem hierarquia. JSON organiza os dados em hierarquia com pares chave-valor e é self-describing. XML também é hierárquico, usando tags para marcar cada campo.\n\n## Formatos otimizados para análise\nParquet e ORC guardam os dados por coluna (colunar). Como os valores de uma mesma coluna ficam juntos e são parecidos, a compressão fica muito boa e a leitura analítica busca só as colunas necessárias, sem varrer o resto. Avro guarda os dados por linha, favorece a escrita e o transporte de mensagens e mantém o schema junto do arquivo. Regra geral: colunar para leitura analítica, por linha para escrita intensa.",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Formato","Organização","Quando usar"],["CSV","Texto delimitado, por linha","Troca simples e portátil de dados"],["JSON","Hierárquico e self-describing","Dados semiestruturados e APIs"],["XML","Hierárquico com tags","Integração e configuração"],["Parquet","Colunar","Leitura analítica com boa compressão"],["ORC","Colunar","Leitura analítica em grandes volumes"],["Avro","Por linha","Escrita intensa e streaming"]]',
+                    },
+                    {
+                        type: "text",
+                        value: "## Onde guardar: arquivos ou bancos\nUm data store pode ser um conjunto de arquivos ou um banco de dados. Arquivos em um data lake servem bem para guardar volume bruto barato, em qualquer formato. Bancos de dados dão estrutura, consultas e regras de integridade.\n\nEntre os bancos, os relacionais guardam dados em tabelas com schema fixo e relações entre elas, com forte consistência. Os não relacionais (NoSQL) trazem schema flexível e escalam bem para documentos, chave-valor, colunas largas e grafos. Não existe o melhor em abstrato: escolhe-se o armazenamento pelo caso de uso, olhando formato do dado, volume, padrão de consulta e necessidade de consistência.",
+                    },
+                    {
+                        type: "quote",
+                        value: "Colunar (Parquet e ORC) vence na leitura analítica e na compressão porque busca só as colunas pedidas. Por linha (Avro) vence na escrita e no transporte de dados.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement:
+                            "Uma empresa exporta uma tabela para um arquivo de texto simples, uma linha por registro, com campos separados por vírgula, para enviar a um parceiro. Que formato é esse?",
+                        difficulty: "facil",
+                        options: [
+                            { text: "CSV", isCorrect: true },
+                            { text: "Parquet", isCorrect: false },
+                            { text: "Avro", isCorrect: false },
+                            { text: "ORC", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Um data warehouse precisa ler poucas colunas de bilhões de linhas gerando o menor arquivo possível. Qual formato é o mais indicado?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "Parquet", isCorrect: true },
+                            { text: "CSV", isCorrect: false },
+                            { text: "XML", isCorrect: false },
+                            { text: "JSON", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Uma pipeline de streaming grava muitos eventos e precisa manter o schema junto dos dados, favorecendo a escrita. Qual formato combina?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "Avro", isCorrect: true },
+                            { text: "Parquet", isCorrect: false },
+                            { text: "ORC", isCorrect: false },
+                            { text: "CSV", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Qual formato é hierárquico, self-describing e muito usado em APIs web?",
+                        difficulty: "facil",
+                        options: [
+                            { text: "JSON", isCorrect: true },
+                            { text: "CSV", isCorrect: false },
+                            { text: "Parquet", isCorrect: false },
+                            { text: "ORC", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Um time precisa guardar um volume enorme de arquivos brutos, de vários formatos, com o menor custo, antes de processar. Qual opção de armazenamento faz mais sentido?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "Arquivos em um data lake", isCorrect: true },
+                            { text: "Um banco relacional normalizado", isCorrect: false },
+                            { text: "Uma única tabela em memória", isCorrect: false },
+                            { text: "Um índice colunar em banco relacional", isCorrect: false },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Cargas de trabalho: transacional (OLTP) e analítica (OLAP)",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "## Duas cargas de trabalho, dois objetivos\nSistemas de dados servem a dois tipos de trabalho bem diferentes. Um roda a operação do dia a dia, registrando o que acontece agora. O outro analisa o histórico acumulado para gerar relatório e apoiar decisão. Cada um pede um desenho de banco diferente.\n\n## OLTP: processamento transacional\nOLTP (Online Transaction Processing) lida com muitas transações pequenas de leitura e escrita sobre dados atuais. É o que roda por trás de um sistema de pedidos, um caixa de loja ou um app de banco. O banco costuma ser normalizado, para evitar dado repetido e manter a integridade, e precisa garantir ACID em cada transação.\n\n## OLAP: processamento analítico\nOLAP (Online Analytical Processing) faz leitura pesada com agregações sobre grandes volumes de dados históricos, para relatório e BI. As consultas somam, contam e agrupam milhões de linhas. Para ler rápido, o dado costuma ficar desnormalizado, muitas vezes em esquema estrela, com uma tabela de fatos no centro e tabelas de dimensão em volta.",
+                    },
+                    {
+                        type: "text",
+                        value: "## ACID em uma transação\nACID é o conjunto de garantias que um banco transacional dá a cada transação:\n- Atomicidade: tudo acontece ou nada acontece, sem meio-termo.\n- Consistência: a transação leva o banco de um estado válido a outro estado válido.\n- Isolamento: transações simultâneas não interferem umas nas outras.\n- Durabilidade: uma vez confirmada, a alteração persiste mesmo se faltar energia.\n\n## O fluxo geral de análise\nLevar o dado do sistema operacional até um painel segue etapas: ingerir os dados das fontes, processar e transformar (limpar e padronizar), armazenar em um repositório analítico, modelar e servir os dados prontos para consulta e, por fim, visualizar em relatórios e dashboards.",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Aspecto","OLTP","OLAP"],["Objetivo","Rodar a operação do dia a dia","Analisar histórico para decisão"],["Operações","Muitas transações pequenas de leitura e escrita","Consultas de leitura com agregações"],["Dados","Atuais","Históricos acumulados"],["Modelagem","Normalizado","Desnormalizado, esquema estrela"],["Garantia principal","ACID em cada transação","Leitura rápida de grandes volumes"],["Exemplo","Sistema de pedidos","Relatório de vendas no BI"]]',
+                    },
+                    {
+                        type: "quote",
+                        value: "OLTP escreve muito e mantém o dado atual normalizado com ACID. OLAP lê muito e mantém o histórico desnormalizado em esquema estrela. Se a pergunta é operação, é OLTP; se é relatório, é OLAP.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement:
+                            "Um sistema de pedidos registra o tempo todo novas compras, atualiza estoque e confirma pagamentos, com muitas transações pequenas. Que tipo de carga é essa?",
+                        difficulty: "facil",
+                        options: [
+                            { text: "OLTP", isCorrect: true },
+                            { text: "OLAP", isCorrect: false },
+                            { text: "Data lake", isCorrect: false },
+                            { text: "ETL", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Uma área de BI precisa somar as vendas dos últimos cinco anos por região e produto. Que tipo de carga atende melhor?",
+                        difficulty: "facil",
+                        options: [
+                            { text: "OLAP", isCorrect: true },
+                            { text: "OLTP", isCorrect: false },
+                            { text: "Transacional", isCorrect: false },
+                            { text: "Chave-valor", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Em um banco transacional, uma transferência debita uma conta e credita outra. Se o débito ocorre mas o crédito falha, nada deve valer. Qual propriedade ACID garante isso?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "Atomicidade", isCorrect: true },
+                            { text: "Isolamento", isCorrect: false },
+                            { text: "Durabilidade", isCorrect: false },
+                            { text: "Consistência", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Um data warehouse organiza os dados com uma tabela de fatos no centro e tabelas de dimensão ao redor, de forma desnormalizada. Como se chama esse desenho?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "Esquema estrela", isCorrect: true },
+                            { text: "Normalização completa", isCorrect: false },
+                            { text: "Índice colunar", isCorrect: false },
+                            { text: "Modelo relacional normalizado", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Ao montar uma solução analítica, um time quer a ordem geral do fluxo de dados. Qual sequência descreve esse fluxo?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Ingerir, processar e transformar, armazenar, modelar e servir, visualizar",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Visualizar, ingerir, armazenar, transformar, modelar",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Modelar, visualizar, ingerir, armazenar, transformar",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Armazenar, visualizar, ingerir, transformar, modelar",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Funções e responsabilidades: administrador de banco, engenheiro e analista de dados",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "## Quem cuida do quê\nTrabalhar com dados na nuvem envolve papéis diferentes, cada um com foco próprio. No DP-900 aparecem três funções principais: administrador de banco de dados, engenheiro de dados e analista de dados. Elas se complementam ao longo do caminho do dado.\n\n## Administrador de banco de dados (DBA)\nO DBA projeta, instala, mantém e protege o banco. Cuida da disponibilidade, do desempenho e da segurança, define permissões de acesso e, acima de tudo, garante backup e restauração para não perder dado. Quando o banco fica lento ou cai, é quem responde.\n\n## Engenheiro de dados\nO engenheiro de dados constrói e opera os pipelines que ingerem e transformam dados. Integra fontes diferentes, cuida de data lakes e data warehouses e entrega o dado limpo e pronto para quem vai analisar. É quem faz o processo de ingestão e transformação rodar.\n\n## Analista de dados\nO analista de dados explora, modela e visualiza os dados para gerar insight e apoiar a decisão do negócio. Cria relatórios e dashboards, muitas vezes no Power BI, e traduz números em respostas para as áreas.",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Função","Foco","Tarefas típicas","Ferramentas"],["DBA","Manter o banco no ar e seguro","Backup, restauração, desempenho e segurança","SQL Server Management Studio e Azure portal"],["Engenheiro de dados","Mover e preparar o dado","Pipelines de ingestão e transformação, data lakes e warehouses","Azure Data Factory e Azure Synapse Analytics"],["Analista de dados","Gerar insight para decisão","Modelar, visualizar e criar relatórios","Power BI"]]',
+                    },
+                    {
+                        type: "text",
+                        value: "## Como os papéis se conectam\nNo caminho do dado, os três se encaixam em sequência. O engenheiro de dados traz os dados das fontes e os prepara em um repositório central. O DBA garante que os bancos envolvidos fiquem disponíveis, rápidos e seguros. O analista de dados pega esse dado pronto e o transforma em relatórios que respondem perguntas do negócio. Restaurar um backup é tarefa do DBA, montar uma pipeline de ingestão é do engenheiro e criar um dashboard de vendas é do analista.",
+                    },
+                    {
+                        type: "quote",
+                        value: "DBA mantém o banco no ar e protegido. Engenheiro de dados constrói os pipelines e entrega o dado pronto. Analista de dados transforma o dado em insight, quase sempre no Power BI.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement:
+                            "O banco de produção começou a apresentar lentidão e é preciso revisar índices, ajustar o desempenho e conferir a rotina de backup. Qual profissional é o responsável?",
+                        difficulty: "facil",
+                        options: [
+                            { text: "Administrador de banco de dados", isCorrect: true },
+                            { text: "Analista de dados", isCorrect: false },
+                            { text: "Engenheiro de dados", isCorrect: false },
+                            { text: "Cientista de dados", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Uma empresa quer transformar dados já preparados em um painel de vendas interativo no Power BI. Quem faz esse trabalho?",
+                        difficulty: "facil",
+                        options: [
+                            { text: "Analista de dados", isCorrect: true },
+                            { text: "Administrador de banco de dados", isCorrect: false },
+                            { text: "Engenheiro de dados", isCorrect: false },
+                            { text: "Administrador de rede", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "É preciso montar uma pipeline que ingere dados de vários sistemas, limpa e grava tudo em um data lake para consumo posterior. Qual função assume isso?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "Engenheiro de dados", isCorrect: true },
+                            { text: "Analista de dados", isCorrect: false },
+                            { text: "Administrador de banco de dados", isCorrect: false },
+                            { text: "Gerente de projeto", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Uma empresa perdeu dados após uma falha e precisa restaurar o banco a partir do último backup íntegro. Quem conduz a restauração?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "Administrador de banco de dados", isCorrect: true },
+                            { text: "Engenheiro de dados", isCorrect: false },
+                            { text: "Analista de dados", isCorrect: false },
+                            { text: "Desenvolvedor de front-end", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Qual ferramenta é a mais associada ao trabalho do analista de dados no ecossistema Microsoft?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "Power BI", isCorrect: true },
+                            { text: "Azure Data Factory", isCorrect: false },
+                            { text: "SQL Server Management Studio", isCorrect: false },
+                            { text: "Azure Blob Storage", isCorrect: false },
+                        ],
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        titulo: "Módulo 2 - Conceitos de dados relacionais",
+        aulas: [
+            {
+                titulo: "Conceitos relacionais: tabelas, chaves e relacionamentos",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "## O modelo relacional\nNo modelo relacional os dados ficam guardados em tabelas. Cada tabela representa um tipo de entidade do mundo real, como Cliente, Produto ou Pedido. É a forma mais comum de organizar dados estruturados, aqueles que seguem um formato fixo e bem definido.\n\n## Linhas e colunas\nCada linha da tabela, também chamada de registro ou instância, é uma ocorrência daquela entidade, por exemplo um cliente específico. Cada coluna, ou atributo, guarda uma informação da entidade e tem um tipo de dado definido, como texto, número inteiro ou data. Todos os valores de uma mesma coluna seguem o mesmo tipo.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Chave primária e chave estrangeira\nA chave primária (primary key) identifica cada linha de forma única dentro da tabela. Seu valor não pode se repetir e não pode ser nulo, por isso ela localiza um registro sem ambiguidade.\n\nA chave estrangeira (foreign key) é uma coluna que aponta para a chave primária de outra tabela. É ela que cria o relacionamento entre duas tabelas. Por exemplo, a tabela Pedido guarda o identificador do cliente que fez o pedido, referenciando a chave primária da tabela Cliente.",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Elemento","O que é"],["Tabela","Conjunto de dados de um tipo de entidade"],["Linha","Um registro, uma ocorrência da entidade"],["Coluna","Um atributo com um tipo de dado"],["Chave primária","Identifica cada linha de forma única, sem repetir nem ser nula"],["Chave estrangeira","Coluna que aponta para a chave primária de outra tabela"]]',
+                    },
+                    {
+                        type: "text",
+                        value: "## Tipos de relacionamento\nAs ligações entre tabelas podem ser de três tipos.\n\nUm para um: cada linha de A se liga a no máximo uma linha de B. Exemplo: um funcionário e o seu crachá.\n\nUm para muitos: uma linha de A se liga a várias linhas de B, mas cada linha de B se liga a apenas uma de A. É o tipo mais comum. Exemplo: um cliente tem vários pedidos.\n\nMuitos para muitos: várias linhas de A se ligam a várias de B. Normalmente isso se resolve com uma terceira tabela de ligação. Exemplo: alunos e disciplinas.\n\n## Integridade referencial\nA integridade referencial garante que toda chave estrangeira aponte para uma linha que realmente existe na outra tabela. Ela impede cadastrar um pedido para um cliente inexistente ou apagar um cliente que ainda tem pedidos ligados a ele.",
+                    },
+                    {
+                        type: "quote",
+                        value: "A chave primária identifica a linha dentro da própria tabela; a chave estrangeira usa essa chave para ligar uma tabela à outra.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement:
+                            "Uma tabela Cliente precisa de uma coluna que identifique cada cliente sem repetir valores e sem aceitar nulo. Que tipo de coluna é essa?",
+                        difficulty: "facil",
+                        options: [
+                            { text: "Chave primária", isCorrect: true },
+                            { text: "Chave estrangeira", isCorrect: false },
+                            { text: "Índice comum", isCorrect: false },
+                            { text: "Atributo descritivo qualquer", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Na tabela Pedido existe a coluna id_cliente, que guarda o identificador do dono do pedido e aponta para a tabela Cliente. Como essa coluna é chamada?",
+                        difficulty: "facil",
+                        options: [
+                            { text: "Chave estrangeira", isCorrect: true },
+                            { text: "Chave primária", isCorrect: false },
+                            { text: "Chave candidata", isCorrect: false },
+                            { text: "Coluna atômica", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Um cliente pode ter vários pedidos, mas cada pedido pertence a um único cliente. Que tipo de relacionamento existe entre Cliente e Pedido?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "Um para muitos", isCorrect: true },
+                            { text: "Um para um", isCorrect: false },
+                            { text: "Muitos para muitos", isCorrect: false },
+                            { text: "Nenhum relacionamento", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Um sistema precisa relacionar Aluno e Disciplina, sabendo que um aluno cursa várias disciplinas e uma disciplina tem vários alunos. Qual é a forma usual de representar isso no modelo relacional?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Criar uma terceira tabela de ligação entre Aluno e Disciplina",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Guardar todos os alunos em uma única coluna da tabela Disciplina",
+                                isCorrect: false,
+                            },
+                            { text: "Remover a chave primária das duas tabelas", isCorrect: false },
+                            {
+                                text: "Usar apenas uma chave estrangeira na tabela Aluno",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Ao tentar excluir um cliente que ainda possui pedidos registrados, o banco bloqueia a operação. Que conceito está atuando nesse caso?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "Integridade referencial", isCorrect: true },
+                            { text: "Normalização até a 3FN", isCorrect: false },
+                            { text: "Indexação da chave primária", isCorrect: false },
+                            { text: "Desnormalização controlada", isCorrect: false },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Normalização",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "## O que é normalização\nNormalizar é organizar as colunas e as tabelas de um banco relacional para reduzir dados duplicados e dependências mal resolvidas. Em vez de repetir a mesma informação em vários lugares, ela fica guardada uma única vez, no lugar certo.\n\n## Por que normalizar\nDados repetidos levam a anomalias, ou seja, problemas na hora de mexer no banco.\n\nAnomalia de inserção: não dá para cadastrar uma informação sem ter outra junto.\n\nAnomalia de atualização: a mesma informação está em vários lugares e alguém atualiza só uma parte, deixando o banco inconsistente.\n\nAnomalia de exclusão: ao apagar uma linha, você perde sem querer outra informação que estava junto.\n\nNormalizar também economiza espaço e ajuda a manter a consistência dos dados.",
+                    },
+                    {
+                        type: "text",
+                        value: "## As três primeiras formas normais\nPrimeira forma normal (1FN): cada coluna guarda um valor atômico, isto é, um único valor indivisível. Nada de listas dentro de uma célula nem grupos de colunas repetidas como Telefone1, Telefone2 e Telefone3.\n\nSegunda forma normal (2FN): a tabela já está na 1FN e nenhuma coluna depende apenas de parte da chave. Isso importa quando a chave primária é composta por mais de uma coluna, pois cada atributo precisa depender da chave inteira.\n\nTerceira forma normal (3FN): a tabela já está na 2FN e não tem dependência transitiva. Ou seja, nenhuma coluna comum depende de outra coluna comum; toda coluna depende apenas da chave primária.",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Forma normal","Regra em uma linha"],["1FN","Valores atômicos, sem grupos repetidos"],["2FN","Está na 1FN e sem dependência parcial da chave"],["3FN","Está na 2FN e sem dependência transitiva"]]',
+                    },
+                    {
+                        type: "text",
+                        value: "## O preço da normalização\nQuanto mais você normaliza, mais tabelas aparecem, cada uma com um pedaço da informação. Para montar um relatório completo, a consulta precisa juntar essas tabelas com joins, o que pode deixar a leitura mais lenta. Por isso, em cenários de análise e relatórios é comum aceitar alguma repetição de propósito, o que se chama desnormalização, para ganhar velocidade na consulta.",
+                    },
+                    {
+                        type: "quote",
+                        value: "Normalizar reduz repetição e anomalias, mas cobra o preço de mais tabelas e mais joins na hora de consultar.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement:
+                            "Uma tabela guarda na mesma célula da coluna Telefones o valor 9999-0000, 8888-1111. Qual regra está sendo violada?",
+                        difficulty: "facil",
+                        options: [
+                            { text: "Primeira forma normal (1FN)", isCorrect: true },
+                            { text: "Segunda forma normal (2FN)", isCorrect: false },
+                            { text: "Terceira forma normal (3FN)", isCorrect: false },
+                            { text: "Integridade referencial", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Qual é o principal objetivo da normalização em um banco relacional?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "Reduzir dados duplicados e evitar anomalias",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Aumentar a repetição para acelerar consultas",
+                                isCorrect: false,
+                            },
+                            { text: "Eliminar todas as chaves estrangeiras", isCorrect: false },
+                            { text: "Converter o banco relacional em NoSQL", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "O endereço de um cliente está repetido em todas as linhas de pedido dele. Ao mudar de endereço, alguém atualiza apenas alguns pedidos e o banco fica com dados conflitantes. Que anomalia é essa?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "Anomalia de atualização", isCorrect: true },
+                            { text: "Anomalia de inserção", isCorrect: false },
+                            { text: "Anomalia de exclusão", isCorrect: false },
+                            { text: "Anomalia de índice", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Uma tabela já está na 2FN, mas a coluna cidade é determinada pela coluna cep, e não diretamente pela chave primária. Qual forma normal resolve essa dependência transitiva?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "Terceira forma normal (3FN)", isCorrect: true },
+                            { text: "Primeira forma normal (1FN)", isCorrect: false },
+                            { text: "Segunda forma normal (2FN)", isCorrect: false },
+                            { text: "Nenhuma forma normal trata isso", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "A equipe de relatórios reclama que as consultas ficaram lentas porque precisam juntar muitas tabelas. Qual é o trade-off esperado de um banco muito normalizado?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Menos repetição de dados, porém mais joins nas consultas",
+                                isCorrect: true,
+                            },
+                            { text: "Mais repetição de dados e menos tabelas", isCorrect: false },
+                            {
+                                text: "Perda automática da integridade referencial",
+                                isCorrect: false,
+                            },
+                            { text: "Impossibilidade de definir chave primária", isCorrect: false },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "SQL: DDL, DML, DQL e objetos de banco",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "## O que é SQL\nSQL (Structured Query Language) é a linguagem padrão para trabalhar com bancos relacionais. Com ela você cria a estrutura, insere e altera dados e faz consultas. Os comandos são agrupados em categorias conforme a função que exercem.\n\n## As categorias de comandos\nDDL (Data Definition Language) define e altera a estrutura do banco, como tabelas e colunas.\n\nDML (Data Manipulation Language) mexe nos dados que estão dentro das tabelas.\n\nDQL (Data Query Language) é a categoria da consulta, feita com o SELECT. Em muitos materiais o SELECT aparece dentro da própria DML, mas o DP-900 costuma tratar a consulta à parte.\n\nDCL (Data Control Language) controla quem pode fazer o quê, por meio de permissões.",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Categoria","Comandos","Para que serve"],["DDL","CREATE, ALTER, DROP, TRUNCATE","Define e altera a estrutura dos objetos"],["DML","INSERT, UPDATE, DELETE","Insere, altera e remove dados das tabelas"],["DQL","SELECT","Consulta e retorna dados"],["DCL","GRANT, REVOKE","Concede e revoga permissões de acesso"]]',
+                    },
+                    {
+                        type: "text",
+                        value: "## Objetos de banco\nAlém das tabelas, o banco tem outros objetos que ajudam no dia a dia.\n\nView: uma consulta salva que funciona como uma tabela virtual. Você consulta a view como se fosse uma tabela, mas por trás existe um SELECT guardado. Serve para simplificar consultas e esconder colunas.\n\nStored procedure: um bloco de comandos SQL salvo no banco, que pode receber parâmetros e ser executado quando precisar. Boa para reaproveitar lógica.\n\nFunction (função): parecida com a stored procedure, porém feita para calcular e retornar um valor, podendo ser usada dentro de uma consulta.\n\nIndex (índice): uma estrutura que acelera a busca por certas colunas, como o índice remissivo de um livro. Ajuda a ler mais rápido, mas ocupa espaço e pode deixar a escrita um pouco mais lenta.",
+                    },
+                    {
+                        type: "code",
+                        value: "SELECT nome, email\nFROM Cliente\nWHERE cidade = 'São Paulo'\nORDER BY nome;",
+                    },
+                    {
+                        type: "text",
+                        value: "## Dialetos do SQL\nO SQL tem uma base padronizada, mas cada banco traz a sua variação.\n\nT-SQL (Transact-SQL): o dialeto do SQL Server e do Azure SQL.\n\nPL/pgSQL: o dialeto usado no PostgreSQL para escrever funções e procedures.\n\nConhecer o dialeto ajuda a usar recursos específicos de cada banco, mas um SELECT básico é praticamente igual em todos eles.",
+                    },
+                    {
+                        type: "quote",
+                        value: "DDL mexe na estrutura, DML mexe nos dados e o SELECT (DQL) apenas lê; a DCL cuida das permissões.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement:
+                            "Um desenvolvedor vai criar uma nova tabela com o comando CREATE TABLE. A qual categoria de comando SQL ele pertence?",
+                        difficulty: "facil",
+                        options: [
+                            { text: "DDL", isCorrect: true },
+                            { text: "DML", isCorrect: false },
+                            { text: "DQL", isCorrect: false },
+                            { text: "DCL", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Qual comando SQL é usado para consultar e retornar dados de uma tabela?",
+                        difficulty: "facil",
+                        options: [
+                            { text: "SELECT", isCorrect: true },
+                            { text: "INSERT", isCorrect: false },
+                            { text: "ALTER", isCorrect: false },
+                            { text: "GRANT", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Uma analista quer salvar uma consulta complexa para que outras pessoas a usem como se fosse uma tabela, sem reescrever o SELECT toda vez. Qual objeto de banco atende melhor?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "View", isCorrect: true },
+                            { text: "Stored procedure", isCorrect: false },
+                            { text: "Index", isCorrect: false },
+                            { text: "Chave estrangeira", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "As buscas por email na tabela Cliente estão lentas porque o banco varre a tabela inteira. Qual objeto pode acelerar a busca por essa coluna?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "Index", isCorrect: true },
+                            { text: "View", isCorrect: false },
+                            { text: "Chave estrangeira", isCorrect: false },
+                            { text: "Comando GRANT", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Uma equipe precisa esvaziar todas as linhas de uma tabela, mantendo a tabela existente. O comando escolhido é classificado como DDL e costuma não poder ser desfeito, diferente do DELETE. Qual é ele?",
+                        difficulty: "dificil",
+                        options: [
+                            { text: "TRUNCATE", isCorrect: true },
+                            { text: "DROP", isCorrect: false },
+                            { text: "DELETE", isCorrect: false },
+                            { text: "ALTER", isCorrect: false },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Serviços de dados relacionais no Azure",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "## IaaS ou PaaS para banco de dados\nNo Azure você pode rodar um banco relacional de duas formas principais. Na IaaS você tem uma máquina virtual e instala o banco nela, cuidando de quase tudo. Na PaaS a plataforma cuida da infraestrutura, do sistema operacional e de tarefas como backup e aplicação de patches, e você foca no banco e nos dados. Quanto mais gerenciado é o serviço, menos manutenção sobra para você.",
+                    },
+                    {
+                        type: "text",
+                        value: "## SQL Server em Máquina Virtual do Azure (IaaS)\nAqui você cria uma máquina virtual no Azure e roda o SQL Server dentro dela. Você tem controle total: escolhe a versão exata, configura o sistema operacional e ajusta o que quiser. Em troca, é você quem cuida dos patches do sistema operacional, dos backups e da alta disponibilidade. É uma boa opção quando você precisa de uma versão específica ou de acesso ao sistema operacional.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Azure SQL Managed Instance (PaaS)\nO Managed Instance é um serviço gerenciado quase 100% compatível com o SQL Server local. Ele é a escolha típica para migrar sistemas existentes para a nuvem com pouca mudança, o chamado lift-and-shift, porque suporta recursos que o Azure SQL Database sozinho não oferece.\n\n## Azure SQL Database (PaaS puro)\nÉ um banco totalmente gerenciado, pensado para aplicações novas nascidas na nuvem. Ele oferece opções de implantação.\n\nSingle database: um banco isolado, com recursos próprios.\n\nElastic pool: vários bancos que compartilham um conjunto de recursos, bom quando o uso de cada um varia em horários diferentes.\n\nServerless: o banco escala sozinho e pode pausar quando não há uso, cobrando conforme o consumo.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Motores open source gerenciados\nAlém das opções baseadas em SQL Server, o Azure oferece bancos open source como serviço totalmente gerenciado, ou seja, você não cuida da infraestrutura nem do sistema operacional. Os principais são o Azure Database for PostgreSQL e o Azure Database for MySQL. O Azure Database for MariaDB fazia parte dessa mesma família e ainda aparece em materiais mais antigos do DP-900, mas foi descontinuado pela Microsoft, então o foco atual fica em PostgreSQL e MySQL.",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Serviço","Modelo","Quando usar"],["SQL Server em VM do Azure","IaaS","Controle total e versão específica, aceitando cuidar do SO e do banco"],["Azure SQL Managed Instance","PaaS","Migrar sistemas do SQL Server local com pouca mudança (lift-and-shift)"],["Azure SQL Database","PaaS","Aplicações novas na nuvem, com single database, elastic pool ou serverless"],["Azure Database for PostgreSQL e MySQL","PaaS","Usar motores open source gerenciados sem cuidar da infraestrutura"]]',
+                    },
+                    {
+                        type: "quote",
+                        value: "O Managed Instance é a ponte para migrar o SQL Server local; o Azure SQL Database é feito para apps novos na nuvem; a máquina virtual entrega controle total ao custo de mais manutenção.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement:
+                            "Uma empresa quer o banco na nuvem sem se preocupar com patches do sistema operacional nem com backups, deixando isso com a plataforma. Que modelo atende melhor?",
+                        difficulty: "facil",
+                        options: [
+                            { text: "PaaS", isCorrect: true },
+                            { text: "IaaS", isCorrect: false },
+                            { text: "On-premises", isCorrect: false },
+                            { text: "Colocation", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Qual serviço do Azure dá controle total, permitindo instalar uma versão específica do SQL Server e acessar o sistema operacional?",
+                        difficulty: "facil",
+                        options: [
+                            { text: "SQL Server em Máquina Virtual do Azure", isCorrect: true },
+                            { text: "Azure SQL Database serverless", isCorrect: false },
+                            { text: "Azure SQL Managed Instance", isCorrect: false },
+                            { text: "Azure Database for PostgreSQL", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Uma equipe vai migrar para a nuvem um sistema que roda em SQL Server local, usa muitos recursos e deve mudar o mínimo possível. Qual serviço PaaS é o mais indicado?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "Azure SQL Managed Instance", isCorrect: true },
+                            { text: "SQL Server em Máquina Virtual do Azure", isCorrect: false },
+                            { text: "Azure Database for MySQL", isCorrect: false },
+                            { text: "Azure SQL Database single database", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Uma startup vai criar um app novo na nuvem sobre um banco PostgreSQL gerenciado, sem administrar servidores nem infraestrutura. Qual serviço escolher?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "Azure Database for PostgreSQL", isCorrect: true },
+                            { text: "SQL Server em Máquina Virtual do Azure", isCorrect: false },
+                            { text: "Azure SQL Managed Instance", isCorrect: false },
+                            { text: "Azure SQL Database single database", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Uma aplicação tem uso intermitente e fica horas sem nenhuma consulta. A empresa quer que o banco pause sozinho nos períodos ociosos e pague conforme o consumo. Qual opção do Azure SQL Database atende?",
+                        difficulty: "dificil",
+                        options: [
+                            { text: "Serverless", isCorrect: true },
+                            { text: "Elastic pool", isCorrect: false },
+                            { text: "Single database provisionado", isCorrect: false },
+                            { text: "SQL Server em Máquina Virtual do Azure", isCorrect: false },
+                        ],
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        titulo: "Módulo 3 - Dados não relacionais no Azure",
+        aulas: [
+            {
+                titulo: "Azure Storage: Blob, Files e Table",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "## A conta de armazenamento\nA conta de armazenamento (storage account) é o guarda-chuva que reúne vários serviços de dados no Azure. Dentro de uma mesma conta você encontra o Blob (objetos), o Files (compartilhamentos de arquivo), o Table (NoSQL chave-valor) e o Queue (filas de mensagens). Você cria a conta uma vez e escolhe qual serviço usar conforme o tipo de dado.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Azure Blob Storage\nO Blob guarda dados não estruturados, como imagens, vídeos, backups e logs. Os blobs ficam organizados em containers, que funcionam como pastas dentro da conta. Cada blob fica em uma camada de acesso que troca custo de guardar por custo de ler: quanto mais barato for armazenar, mais caro e lento fica recuperar o dado. A camada Archive é a mais barata para guardar, mas mantém o dado offline, então antes de ler é preciso reidratar o blob, o que pode levar horas.",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Camada","Melhor para","Custo de guardar","Custo de ler"],["Hot","Dados acessados com frequência","O mais alto","O mais baixo"],["Cool","Acesso raro, retido por pelo menos 30 dias","Menor que Hot","Maior que Hot"],["Cold","Acesso raro, retido por pelo menos 90 dias","Menor que Cool","Maior que Cool"],["Archive","Quase nunca lido, retido por pelo menos 180 dias","O mais baixo","O mais alto e lento"]]',
+                    },
+                    {
+                        type: "text",
+                        value: "## Files, Table e Queue\nO Azure Files entrega compartilhamentos de arquivo gerenciados, acessados pelos protocolos SMB e NFS. O mesmo compartilhamento pode ser montado ao mesmo tempo em VMs na nuvem e em máquinas locais, funcionando como um drive de rede compartilhado.\n\nO Azure Table Storage é um banco NoSQL de chave-valor, sem schema fixo, barato para guardar grandes volumes de dados semiestruturados. Cada linha é identificada por uma chave de partição e uma chave de linha.\n\nO Azure Queue Storage guarda mensagens em fila e serve para comunicação assíncrona entre componentes de uma aplicação, desacoplando quem produz de quem consome.",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Serviço","Tipo de dado","Quando usar"],["Blob","Objetos não estruturados","Imagens, vídeos, backups e logs"],["Files","Compartilhamento de arquivos","Drive de rede montável por SMB ou NFS"],["Table","NoSQL chave-valor","Dados semiestruturados em grande volume e baixo custo"],["Queue","Mensagens em fila","Comunicação assíncrona entre componentes"]]',
+                    },
+                    {
+                        type: "quote",
+                        value: "Guarde o mapa dos quatro serviços da conta: Blob para dados não estruturados, Files para compartilhamento montável por SMB e NFS, Table para NoSQL chave-valor e Queue para mensagens assíncronas.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement:
+                            "Uma empresa precisa armazenar milhões de imagens e vídeos enviados pelos usuários. Qual serviço da conta de armazenamento é o indicado?",
+                        difficulty: "facil",
+                        options: [
+                            { text: "Azure Blob Storage", isCorrect: true },
+                            { text: "Azure Files", isCorrect: false },
+                            { text: "Azure Table Storage", isCorrect: false },
+                            { text: "Azure Queue Storage", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Um time guarda backups que quase nunca serão lidos e quer o menor custo de armazenamento possível, aceitando esperar horas para recuperar. Qual camada de acesso do Blob usar?",
+                        difficulty: "facil",
+                        options: [
+                            { text: "Cool", isCorrect: false },
+                            { text: "Archive", isCorrect: true },
+                            { text: "Hot", isCorrect: false },
+                            { text: "Cold", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Você precisa de um compartilhamento de arquivos que possa ser montado ao mesmo tempo por VMs na nuvem e por máquinas locais, usando SMB ou NFS. Qual serviço atende?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "Azure Files", isCorrect: true },
+                            { text: "Azure Blob Storage", isCorrect: false },
+                            { text: "Azure Table Storage", isCorrect: false },
+                            { text: "Azure Queue Storage", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Uma aplicação precisa gravar um grande volume de registros semiestruturados de forma barata, sem schema fixo e sem relacionamentos entre tabelas. Qual serviço da conta de armazenamento se encaixa?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "Azure Blob Storage", isCorrect: false },
+                            { text: "Azure Files", isCorrect: false },
+                            { text: "Azure Table Storage", isCorrect: true },
+                            { text: "Azure Queue Storage", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Dois componentes de um sistema precisam trocar mensagens de forma assíncrona, sem depender de estarem disponíveis no mesmo instante. Qual serviço da conta de armazenamento resolve isso?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "Azure Table Storage", isCorrect: false },
+                            { text: "Azure Queue Storage", isCorrect: true },
+                            { text: "Azure Blob Storage", isCorrect: false },
+                            { text: "Azure Files", isCorrect: false },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Azure Cosmos DB e suas APIs",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "## O que é o Azure Cosmos DB\nO Azure Cosmos DB é um banco de dados NoSQL totalmente gerenciado, oferecido como PaaS. Você não cuida de servidor, patch nem backup de infraestrutura: o Azure administra tudo isso. Ele foi feito para aplicações modernas que lidam com dados semiestruturados, alto volume e usuários espalhados pelo mundo.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Características que definem o serviço\nQuatro pontos resumem o Cosmos DB. Distribuição global: com poucos cliques você replica os dados em várias regiões do mundo, deixando o dado perto do usuário. Latência baixa: respostas na casa de poucos milissegundos. Escala horizontal automática: a capacidade acompanha o tráfego, subindo e descendo conforme a demanda. Alta disponibilidade: um SLA forte, sustentado justamente por essa replicação em várias regiões.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Várias APIs, use a que você já conhece\nO Cosmos DB fala diferentes APIs, então você trabalha com o modelo de dados e as ferramentas que já domina. A API nativa é a API for NoSQL, que guarda documentos JSON. As outras existem principalmente para reaproveitar código, drivers e conhecimento de bancos que a equipe já usa, ou para migrar cargas existentes sem reescrever tudo.",
+                    },
+                    {
+                        type: "table",
+                        value: '[["API","Modelo de dados","Quando usar"],["API for NoSQL","Documentos JSON","Aplicação nova; é a API nativa e mais completa"],["API for MongoDB","Documentos","Reaproveitar ou migrar apps e ferramentas MongoDB"],["API for Apache Cassandra","Colunar (wide-column)","Migrar cargas Cassandra ou dados colunares em escala"],["API for Table","Chave-valor","Evoluir do Azure Table Storage com distribuição global"],["API for Apache Gremlin","Grafo (vértices e arestas)","Dados com muitos relacionamentos, como redes e recomendações"]]',
+                    },
+                    {
+                        type: "text",
+                        value: "## Casos de uso\nO Cosmos DB brilha em cenários de tempo real com dados semiestruturados, alto volume e baixa latência global. Exemplos comuns: telemetria de dispositivos IoT, catálogo e carrinho de e-commerce, perfis e placares de jogos, e personalização de conteúdo. Em geral, qualquer aplicação com usuários espalhados pelo mundo que precise de resposta rápida se beneficia da distribuição global.",
+                    },
+                    {
+                        type: "quote",
+                        value: "O Cosmos DB é NoSQL como PaaS, com distribuição global e latência de poucos milissegundos. A API nativa é a API for NoSQL (documentos JSON); as demais existem para reaproveitar MongoDB, Cassandra, Table e Gremlin.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement:
+                            "Uma aplicação tem usuários na Europa, na Ásia e nas Américas e precisa de resposta rápida em todas as regiões. Qual recurso do Azure Cosmos DB atende diretamente a essa necessidade?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "Distribuição global, replicando os dados em várias regiões",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Uma única réplica em uma região central para todos os usuários",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Armazenamento local sem qualquer replicação",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Processamento em lote executado uma vez por dia",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Qual é a API nativa do Azure Cosmos DB, recomendada para uma aplicação nova que armazena documentos JSON?",
+                        difficulty: "facil",
+                        options: [
+                            { text: "API for MongoDB", isCorrect: false },
+                            { text: "API for NoSQL", isCorrect: true },
+                            { text: "API for Apache Cassandra", isCorrect: false },
+                            { text: "API for Apache Gremlin", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Um sistema de rede social precisa modelar pessoas e as conexões entre elas, com muitas relações e consultas de caminhos entre nós. Qual API do Cosmos DB é a mais indicada?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "API for NoSQL", isCorrect: false },
+                            { text: "API for Table", isCorrect: false },
+                            { text: "API for Apache Gremlin", isCorrect: true },
+                            { text: "API for MongoDB", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Uma equipe já tem uma aplicação escrita para o MongoDB e quer migrar para um serviço gerenciado no Azure reaproveitando os drivers e o código existentes. Qual API do Cosmos DB facilita isso?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "API for MongoDB", isCorrect: true },
+                            { text: "API for NoSQL", isCorrect: false },
+                            { text: "API for Apache Cassandra", isCorrect: false },
+                            { text: "API for Table", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Uma aplicação usa hoje o Azure Table Storage, mas passou a precisar de distribuição global e latência garantida por SLA, mantendo o modelo chave-valor. Qual é a evolução natural?",
+                        difficulty: "dificil",
+                        options: [
+                            { text: "Azure Blob Storage", isCorrect: false },
+                            { text: "Azure Files", isCorrect: false },
+                            { text: "API for NoSQL do Azure Cosmos DB", isCorrect: false },
+                            { text: "API for Table do Azure Cosmos DB", isCorrect: true },
+                        ],
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        titulo: "Módulo 4 - Cargas de trabalho de análise no Azure",
+        aulas: [
+            {
+                titulo: "Ingestão, processamento e armazenamentos analíticos",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "## O fluxo de análise em larga escala\nTransformar dados em decisões segue quase sempre o mesmo caminho. Primeiro você ingere os dados das fontes (bancos, arquivos, APIs, eventos). Depois processa e transforma esses dados, limpando e dando formato. Em seguida armazena tudo num repositório analítico. Por fim, modela e serve os dados para consulta e visualiza os resultados em relatórios e dashboards.\n\nCada etapa costuma usar um serviço diferente do Azure, mas a ideia geral é sempre essa: da fonte bruta até o insight que aparece na tela.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Ingestão e processamento: ETL e ELT\nHá duas ordens clássicas para preparar os dados. No ETL (extrair, transformar, carregar) você transforma os dados antes de gravar no destino. Só entra no repositório aquilo que já está limpo e no formato certo. É a abordagem tradicional de data warehouse.\n\nNo ELT (extrair, carregar, transformar) você grava primeiro os dados brutos no destino e transforma depois, dentro dele, aproveitando o poder de processamento e a escala do próprio destino. Combina muito com data lakes e com plataformas modernas de computação elástica.\n\nPara orquestrar esse vaivém existe o Azure Data Factory, o serviço de integração de dados do Azure. Ele coordena pipelines: sequências de atividades que copiam e transformam dados de dezenas de fontes de forma agendada e monitorada.",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Aspecto","ETL","ELT"],["Ordem","Transforma antes de carregar","Carrega bruto e transforma depois"],["Onde transforma","Fora do destino, num motor próprio","Dentro do destino, usando a escala dele"],["Combina com","Data warehouse tradicional","Data lake e nuvem elástica"],["Chega ao destino","Só dado já curado","Dado bruto, pronto para explorar"]]',
+                    },
+                    {
+                        type: "text",
+                        value: "## Onde os dados analíticos ficam\nDepois de ingeridos, os dados precisam morar em algum lugar pensado para análise. Há três modelos principais.\n\nO data warehouse é relacional. Usa schema-on-write: o esquema é definido na hora de gravar, então tudo entra já modelado, curado e organizado em tabelas. Isso deixa as consultas rápidas e previsíveis, ideal para relatórios de negócio.\n\nO data lake guarda arquivos brutos de qualquer formato (CSV, JSON, Parquet, imagens, logs) numa storage barata e muito escalável. Usa schema-on-read: você só aplica a estrutura na hora de ler. É flexível e aceita qualquer dado, mas exige mais trabalho para consultar.\n\nO lakehouse une os dois mundos: guarda arquivos abertos num data lake, mas por cima oferece recursos de data warehouse, como tabelas, esquema e consultas SQL. É o modelo que o Microsoft Fabric e o Azure Databricks adotam.",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Característica","Data warehouse","Data lake","Lakehouse"],["Tipo de dado","Estruturado e curado","Bruto, qualquer formato","Bruto com camada estruturada"],["Esquema","Schema-on-write","Schema-on-read","Schema-on-read com tabelas"],["Custo de armazenamento","Mais alto","Baixo","Baixo"],["Consulta","SQL rápido e modelado","Precisa de preparo","SQL sobre arquivos abertos"]]',
+                    },
+                    {
+                        type: "quote",
+                        value: "ETL transforma antes de gravar (só dado curado entra); ELT grava o bruto e transforma depois, no destino. Schema-on-write é do data warehouse; schema-on-read é do data lake.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement:
+                            "Uma empresa quer despejar rapidamente arquivos brutos de várias fontes num repositório barato e só depois, usando a escala do próprio destino, aplicar as transformações. Qual abordagem descreve isso?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "ELT: os dados são carregados brutos e transformados depois, no destino",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "ETL: os dados são transformados antes de serem carregados",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Schema-on-write, típico do data warehouse relacional",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Modelagem em estrela feita antes da ingestão",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Um time de dados precisa armazenar arquivos brutos de qualquer formato (CSV, JSON, logs, imagens) num repositório barato e muito escalável, aplicando estrutura só na hora de ler. Que armazenamento analítico atende melhor?",
+                        difficulty: "facil",
+                        options: [
+                            { text: "Data lake", isCorrect: true },
+                            { text: "Data warehouse relacional", isCorrect: false },
+                            { text: "Cache em memória", isCorrect: false },
+                            { text: "Banco transacional OLTP", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Relatórios de negócio precisam rodar consultas rápidas e previsíveis sobre dados já curados, modelados e organizados em tabelas, com o esquema definido na gravação. Que armazenamento é o mais indicado?",
+                        difficulty: "facil",
+                        options: [
+                            { text: "Data warehouse", isCorrect: true },
+                            { text: "Data lake com schema-on-read", isCorrect: false },
+                            { text: "Fila de mensagens", isCorrect: false },
+                            { text: "Compartilhamento de arquivos genérico", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Uma equipe quer orquestrar pipelines que copiam e transformam dados de dezenas de fontes de forma agendada e monitorada, sem escrever a infraestrutura na mão. Qual serviço do Azure faz essa orquestração?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "Azure Data Factory", isCorrect: true },
+                            { text: "Power BI Desktop", isCorrect: false },
+                            { text: "Azure Blob Storage", isCorrect: false },
+                            { text: "Azure Stream Analytics", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "A arquitetura escolhida guarda os arquivos abertos num data lake, mas oferece por cima tabelas, esquema e consultas SQL, como no Fabric e no Databricks. Como se chama esse modelo que une os dois mundos?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "Lakehouse", isCorrect: true },
+                            { text: "Data mart isolado", isCorrect: false },
+                            { text: "Banco NoSQL de documentos", isCorrect: false },
+                            { text: "OLTP normalizado", isCorrect: false },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Plataformas de análise: Microsoft Fabric e Azure Databricks",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "## Microsoft Fabric: a plataforma unificada\nO Microsoft Fabric é a plataforma SaaS de análise da Microsoft. A ideia central é reunir num único produto tudo que vai do dado ao insight: ingestão, engenharia, armazenamento, ciência de dados, tempo real e visualização. Como é SaaS, você não gerencia servidores nem clusters; foca no dado e na análise.\n\nNo coração do Fabric está o OneLake, um único data lake para toda a organização. A regra de ouro é: o dado fica guardado uma vez e todos os workloads o usam ali mesmo, sem cópias espalhadas. Pense no OneLake como o OneDrive dos dados da empresa. Ele é construído sobre o Azure Data Lake Storage Gen2 e usa o formato aberto Delta Parquet.",
+                    },
+                    {
+                        type: "text",
+                        value: "## As cargas de trabalho do Fabric\nDentro do Fabric, cada tipo de tarefa tem sua experiência, todas integradas e apontando para o mesmo OneLake:\n\n- Data Factory: ingestão de dados e pipelines.\n- Engenharia de Dados (Synapse Data Engineering): transformação em larga escala com Apache Spark.\n- Data Warehouse: armazém relacional consultado com SQL.\n- Data Science: criação de modelos de machine learning.\n- Real-Time Intelligence: análise de dados em tempo real.\n- Power BI: relatórios e dashboards.\n\nComo tudo compartilha o mesmo lake, um dado ingerido pelo Data Factory pode ser transformado no Spark, servido pelo Data Warehouse e visualizado no Power BI sem ficar copiando arquivo de um lado para o outro.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Azure Databricks\nO Azure Databricks é uma plataforma de análise baseada no Apache Spark, oferecida no Azure em parceria com a Databricks. É muito forte em engenharia de dados, ciência de dados e machine learning em larga escala. Seu ambiente gira em torno de notebooks colaborativos, onde os times escrevem código em Python, SQL, Scala ou R e trabalham juntos no mesmo projeto.\n\nEnquanto o Fabric é SaaS e tenta cobrir toda a jornada de análise de ponta a ponta, o Databricks brilha quando o time quer controle sobre clusters Spark e processamento pesado de dados e de modelos.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Synapse Analytics e o armazenamento\nAntes do Fabric, o serviço de data warehouse e análise corporativa do Azure era o Azure Synapse Analytics, que juntava pools SQL, Spark e pipelines num só lugar. Seus recursos hoje convergem para o Microsoft Fabric, que é o serviço guarda-chuva atual de análise da Microsoft.\n\nEm todas essas plataformas, a camada de armazenamento costuma ser o Azure Data Lake Storage Gen2 (ADLS Gen2). Ele é otimizado para análise porque adiciona um namespace hierárquico (pastas de verdade) sobre o armazenamento de blobs, o que acelera as operações de big data.",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Aspecto","Microsoft Fabric","Azure Databricks"],["O que é","Plataforma SaaS unificada, do dado ao insight","Plataforma de análise baseada em Apache Spark"],["Base","OneLake e workloads integrados","Apache Spark e notebooks colaborativos"],["Perfil","Cobre toda a jornada com pouca gestão","Engenharia, ciência de dados e ML pesados"],["Quando usar","Solução completa e integrada de análise","Controle sobre Spark e cargas de ML em escala"]]',
+                    },
+                    {
+                        type: "quote",
+                        value: "O Microsoft Fabric é o serviço guarda-chuva atual de análise: SaaS, com o OneLake guardando o dado uma única vez para todos os workloads. Os recursos do Azure Synapse Analytics convergem para o Fabric.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement:
+                            "Uma organização quer uma plataforma de análise SaaS que reúna num só produto ingestão, engenharia, data warehouse, ciência de dados, tempo real e visualização, sem gerenciar servidores. Qual serviço atende?",
+                        difficulty: "facil",
+                        options: [
+                            { text: "Microsoft Fabric", isCorrect: true },
+                            { text: "Azure Blob Storage", isCorrect: false },
+                            { text: "Azure SQL Database", isCorrect: false },
+                            { text: "Azure Data Factory sozinho", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "No Microsoft Fabric, uma empresa quer que o dado seja guardado uma única vez e usado por todos os workloads, sem cópias espalhadas. Que componente cumpre esse papel de data lake único da organização?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "OneLake", isCorrect: true },
+                            { text: "Power BI Mobile", isCorrect: false },
+                            { text: "Um pool SQL dedicado", isCorrect: false },
+                            { text: "Uma conta de armazenamento por equipe", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Um time de ciência de dados quer processar grandes volumes com Apache Spark em notebooks colaborativos, com forte controle sobre os clusters, para engenharia de dados e machine learning em escala. Qual plataforma é a mais alinhada?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "Azure Databricks", isCorrect: true },
+                            { text: "Power BI Service", isCorrect: false },
+                            { text: "Azure Data Lake Storage Gen2", isCorrect: false },
+                            { text: "Azure Stream Analytics", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Uma equipe usava o Azure Synapse Analytics como serviço de data warehouse e análise corporativa. Para onde os recursos desse tipo de análise estão convergindo como serviço guarda-chuva atual da Microsoft?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "Microsoft Fabric", isCorrect: true },
+                            { text: "Azure Cosmos DB", isCorrect: false },
+                            { text: "Power BI Desktop", isCorrect: false },
+                            { text: "Azure Event Hubs", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Nas plataformas analíticas do Azure, qual serviço costuma ser a camada de armazenamento, com namespace hierárquico otimizado para big data sobre o armazenamento de blobs?",
+                        difficulty: "facil",
+                        options: [
+                            { text: "Azure Data Lake Storage Gen2", isCorrect: true },
+                            { text: "Azure SQL Database", isCorrect: false },
+                            { text: "Power BI Service", isCorrect: false },
+                            { text: "Azure Table Storage", isCorrect: false },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Análise em tempo real: lote (batch) e fluxo (streaming)",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "## Dois jeitos de processar dados\nNem todo dado precisa ser analisado na mesma velocidade. Existem dois grandes modos de processamento.\n\nNo processamento em lote (batch) você junta um grande volume de dados e processa de tempos em tempos, em blocos. A latência é maior, porque você espera acumular para rodar. É perfeito para relatórios e fechamentos, como processar todas as vendas do dia durante a madrugada.\n\nNo processamento em fluxo (streaming) cada evento é processado de forma contínua, um a um, assim que chega. A latência é baixíssima, quase em tempo real. É o modo certo para dados que chegam sem parar: sensores de IoT, cliques em um site, transações de cartão e detecção de fraude.",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Aspecto","Lote (batch)","Fluxo (streaming)"],["Latência","Maior, roda de tempos em tempos","Baixa, quase em tempo real"],["Volume por vez","Grande bloco acumulado","Evento a evento, contínuo"],["Exemplo","Fechamento das vendas do dia à noite","Sensores de IoT e detecção de fraude"],["Quando usar","Relatórios e cargas periódicas","Reação imediata a eventos"]]',
+                    },
+                    {
+                        type: "text",
+                        value: "## Janelas de tempo no streaming\nNum fluxo os eventos nunca param de chegar, então não dá para simplesmente somar tudo. Para calcular agregações (como quantos cliques por minuto) o streaming usa janelas de tempo: recortes que agrupam os eventos de um intervalo definido.\n\nUm exemplo comum é a janela em cascata (tumbling), fatias fixas e sem sobreposição, por exemplo a cada 30 segundos. A cada janela que fecha, o sistema calcula o resultado daquele intervalo e segue para a próxima. É assim que se obtêm médias, contagens e totais contínuos sobre um fluxo que não tem fim.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Serviços da Microsoft para tempo real\nO Azure oferece várias peças para trabalhar com dados em movimento:\n\n- Azure Event Hubs: porta de entrada que ingere milhões de eventos por segundo vindos das fontes.\n- Azure Stream Analytics: motor que processa o fluxo com uma linguagem parecida com SQL e joga o resultado num destino.\n- Real-Time Intelligence do Microsoft Fabric: a experiência de tempo real do Fabric, com o Eventstream para capturar e rotear eventos sem código.\n- Spark Structured Streaming: processamento de fluxo em escala sobre o Apache Spark.\n\nUm desenho típico é os eventos entrarem pelo Event Hubs e serem processados pelo Stream Analytics ou pelo Eventstream do Fabric.",
+                    },
+                    {
+                        type: "quote",
+                        value: "Batch acumula um grande volume e processa de tempos em tempos (latência maior, bom para fechamentos); streaming processa evento a evento em tempo quase real (baixa latência, bom para IoT e fraude). O Event Hubs ingere os eventos.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement:
+                            "Uma varejista processa todas as vendas do dia durante a madrugada, em um único bloco, para gerar o relatório da manhã seguinte. Que tipo de processamento é esse?",
+                        difficulty: "facil",
+                        options: [
+                            { text: "Processamento em lote (batch)", isCorrect: true },
+                            { text: "Processamento em fluxo (streaming)", isCorrect: false },
+                            {
+                                text: "Processamento evento a evento em tempo real",
+                                isCorrect: false,
+                            },
+                            { text: "Consulta transacional OLTP", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Uma fintech precisa analisar cada transação de cartão assim que ela acontece para detectar fraude na hora, com latência mínima. Que tipo de processamento atende?",
+                        difficulty: "facil",
+                        options: [
+                            { text: "Processamento em fluxo (streaming)", isCorrect: true },
+                            { text: "Processamento em lote (batch) noturno", isCorrect: false },
+                            { text: "Carga periódica semanal", isCorrect: false },
+                            { text: "Exportação diária para planilha", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Uma solução de IoT recebe milhões de eventos por segundo de sensores e precisa de um serviço do Azure para ingerir esse fluxo de entrada. Qual serviço é o indicado como porta de entrada dos eventos?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "Azure Event Hubs", isCorrect: true },
+                            { text: "Power BI Desktop", isCorrect: false },
+                            { text: "Azure SQL Database", isCorrect: false },
+                            { text: "Azure Blob Storage", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Ao analisar um fluxo contínuo, um time quer contar quantos cliques ocorrem a cada 30 segundos, em fatias fixas e sem sobreposição. Que conceito de streaming ele está usando?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "Janela de tempo (por exemplo, tumbling)", isCorrect: true },
+                            { text: "Schema-on-write", isCorrect: false },
+                            { text: "Processamento em lote", isCorrect: false },
+                            { text: "Índice columnstore", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Uma equipe quer processar um fluxo de eventos usando uma linguagem parecida com SQL e enviar o resultado a um destino, sem montar clusters. Qual serviço do Azure é feito para esse processamento de streaming?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "Azure Stream Analytics", isCorrect: true },
+                            { text: "Azure Data Factory", isCorrect: false },
+                            { text: "Pool SQL dedicado do Synapse", isCorrect: false },
+                            { text: "Power BI Mobile", isCorrect: false },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Visualização de dados com o Power BI",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "## O que é o Power BI\nO Power BI é a ferramenta de análise de negócio e visualização de dados da Microsoft. Com ele você conecta os dados, modela e transforma esses dados em relatórios e dashboards interativos que ajudam a decidir.\n\nO Power BI tem três componentes principais que trabalham juntos:\n\n- Power BI Desktop: aplicativo para Windows, gratuito, onde você conecta às fontes, modela os dados e cria os relatórios. É o lugar de construção.\n- Serviço do Power BI: a parte na nuvem (SaaS), onde você publica os relatórios, monta dashboards, compartilha e colabora com o time.\n- Power BI Mobile: aplicativos para celular e tablet, para consumir relatórios e dashboards de qualquer lugar.",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Componente","Onde roda","Para que serve"],["Power BI Desktop","Aplicativo Windows","Conectar, modelar e criar relatórios"],["Serviço do Power BI","Nuvem (SaaS)","Publicar, compartilhar e montar dashboards"],["Power BI Mobile","Celular e tablet","Consumir relatórios em qualquer lugar"]]',
+                    },
+                    {
+                        type: "text",
+                        value: "## O fluxo de trabalho e o modelo de dados\nO caminho típico no Power BI tem quatro passos: conectar às fontes, modelar os dados, construir os relatórios e, por fim, publicar e compartilhar no Serviço.\n\nModelar é a parte que dá poder de verdade. Você relaciona as tabelas entre si (por exemplo, ligar a tabela de vendas à de produtos) e cria medidas, que são cálculos sob demanda escritos em DAX, a linguagem de fórmulas do Power BI. Uma medida como Total de Vendas ou Margem % é recalculada conforme o usuário filtra e navega no relatório. Um bom modelo, com tabelas bem relacionadas e medidas claras, é o que faz o relatório responder rápido e certo.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Escolher a visualização certa\nCada pergunta pede um tipo de gráfico. Errar o visual atrapalha a leitura, então vale conhecer o uso clássico de cada um:\n\n- Barras ou colunas: comparar valores entre categorias.\n- Linha: mostrar tendência ao longo do tempo.\n- Pizza ou rosca: parte de um todo, sempre com moderação e poucas fatias.\n- Dispersão: correlação entre duas medidas numéricas.\n- Mapa: dados geográficos, por região ou país.\n- Cartão ou KPI: destacar um único número importante.\n- Tabela ou matriz: mostrar o detalhe, linha a linha.",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Visualização","Quando usar"],["Barras ou colunas","Comparar categorias"],["Linha","Tendência ao longo do tempo"],["Pizza ou rosca","Parte de um todo, com poucas fatias"],["Dispersão","Correlação entre duas medidas"],["Mapa","Dados geográficos"],["Cartão ou KPI","Um único número em destaque"],["Tabela ou matriz","Detalhe linha a linha"]]',
+                    },
+                    {
+                        type: "quote",
+                        value: "Constrói no Power BI Desktop (Windows), publica e compartilha no Serviço do Power BI (nuvem), consome no Mobile. Linha para tendência no tempo, barras para comparar categorias, mapa para dado geográfico.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement:
+                            "Um analista precisa conectar às fontes, modelar os dados e construir os relatórios em um aplicativo de Windows, antes de publicar. Qual componente do Power BI ele usa para essa construção?",
+                        difficulty: "facil",
+                        options: [
+                            { text: "Power BI Desktop", isCorrect: true },
+                            { text: "Serviço do Power BI", isCorrect: false },
+                            { text: "Power BI Mobile", isCorrect: false },
+                            { text: "Excel Online", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Um relatório precisa mostrar como a receita mensal evoluiu ao longo dos últimos dois anos, destacando a tendência. Qual visualização é a mais adequada?",
+                        difficulty: "facil",
+                        options: [
+                            { text: "Gráfico de linha", isCorrect: true },
+                            { text: "Gráfico de pizza", isCorrect: false },
+                            { text: "Cartão (KPI) único", isCorrect: false },
+                            { text: "Mapa geográfico", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "O gestor quer comparar o total de vendas entre as diferentes categorias de produto, lado a lado. Qual visualização comunica melhor essa comparação?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "Gráfico de barras ou colunas", isCorrect: true },
+                            { text: "Gráfico de linha", isCorrect: false },
+                            { text: "Gráfico de dispersão", isCorrect: false },
+                            { text: "Cartão (KPI)", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "No modelo de dados do Power BI, um analista precisa criar um cálculo de Margem % que seja recalculado conforme o usuário filtra o relatório. Que recurso, escrito em DAX, ele deve usar?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "Uma medida", isCorrect: true },
+                            { text: "Uma relação entre tabelas", isCorrect: false },
+                            { text: "Um dashboard no Serviço", isCorrect: false },
+                            { text: "Uma visualização de mapa", isCorrect: false },
+                        ],
+                    },
+                    {
+                        statement:
+                            "A diretoria quer publicar os relatórios na nuvem, montar dashboards e compartilhar com o time para colaborar. Qual componente do Power BI é o indicado?",
+                        difficulty: "medio",
+                        options: [
+                            { text: "Serviço do Power BI", isCorrect: true },
+                            { text: "Power BI Desktop", isCorrect: false },
+                            { text: "Power BI Mobile", isCorrect: false },
+                            { text: "Editor do Power Query", isCorrect: false },
+                        ],
+                    },
+                ],
+            },
+        ],
+    },
+];
+
+async function seed() {
+    let [trilha] = await db.select().from(trails).where(eq(trails.name, NOME));
+    if (!trilha) {
+        [trilha] = await db
+            .insert(trails)
+            .values({ name: NOME, trailLevel: "iniciante", description: DESCRICAO })
+            .returning();
+        console.log(`Trilha criada: ${trilha.name}`);
+    }
+
+    const existentes = await db.select().from(lessons).where(eq(lessons.trailId, trilha.id));
+    if (existentes.length > 0) {
+        console.log(`Trilha ${NOME} já tem ${existentes.length} aulas. Nada a fazer.`);
+        return;
+    }
+
+    let totalAulas = 0;
+    let totalQuestoes = 0;
+    for (let mi = 0; mi < MODULOS.length; mi++) {
+        const m = MODULOS[mi];
+        const [mod] = await db
+            .insert(modules)
+            .values({ trailId: trilha.id, title: m.titulo, position: mi + 1 })
+            .returning();
+        for (let li = 0; li < m.aulas.length; li++) {
+            const a = m.aulas[li];
+            const [lesson] = await db
+                .insert(lessons)
+                .values({
+                    trailId: trilha.id,
+                    moduleId: mod.id,
+                    title: a.titulo,
+                    content: null,
+                    contentBlocks: a.blocks,
+                    position: li + 1,
+                    published: true,
+                })
+                .returning();
+            for (let qi = 0; qi < a.questions.length; qi++) {
+                const q = a.questions[qi];
+                const [questao] = await db
+                    .insert(questions)
+                    .values({
+                        lessonId: lesson.id,
+                        statement: q.statement,
+                        difficulty: q.difficulty,
+                        position: qi + 1,
+                    })
+                    .returning();
+                await db.insert(questionOptions).values(
+                    q.options.map((o, k) => ({
+                        questionId: questao.id,
+                        text: o.text,
+                        isCorrect: o.isCorrect,
+                        position: k + 1,
+                    })),
+                );
+            }
+            totalAulas++;
+            totalQuestoes += a.questions.length;
+        }
+    }
+    console.log(
+        `Seed concluído: ${MODULOS.length} módulos, ${totalAulas} aulas, ${totalQuestoes} questões.`,
+    );
+}
+
+seed()
+    .then(() => process.exit(0))
+    .catch((e) => {
+        console.error("Falha no seed:", e);
+        process.exit(1);
+    });

--- a/backend/src/services/simulado.service.ts
+++ b/backend/src/services/simulado.service.ts
@@ -7,7 +7,7 @@ import {
     simuladoAttemptQuestions,
     simuladoAttemptAnswers,
 } from "../../schema.ts";
-import { eq, and, sql, inArray, desc, isNull, count } from "drizzle-orm";
+import { eq, and, sql, inArray, desc, isNull, count, ne } from "drizzle-orm";
 import { AppError } from "../errors/AppError.ts";
 import {
     corrigirSimulado,
@@ -35,6 +35,9 @@ export async function listarSimulados() {
             slug: simulados.slug,
             name: simulados.name,
             description: simulados.description,
+            provider: simulados.provider,
+            code: simulados.code,
+            level: simulados.level,
             durationMinutes: simulados.durationMinutes,
             questionCount: simulados.questionCount,
             passPercent: simulados.passPercent,
@@ -42,6 +45,18 @@ export async function listarSimulados() {
         .from(simulados)
         .where(eq(simulados.published, true))
         .orderBy(simulados.name);
+}
+
+// Cancela as tentativas em aberto do usuário: marca submittedAt sem gravar score/passed.
+// Como toda tentativa realmente enviada tem score, o histórico exibe estas como "Cancelada"
+// e o cronômetro delas para. Opcionalmente preserva uma tentativa (a que será retomada).
+async function cancelarTentativasEmAberto(userId: string, exceto: string | null) {
+    const condicoes = [eq(simuladoAttempts.userId, userId), isNull(simuladoAttempts.submittedAt)];
+    if (exceto) condicoes.push(ne(simuladoAttempts.id, exceto));
+    await db
+        .update(simuladoAttempts)
+        .set({ submittedAt: new Date() })
+        .where(and(...condicoes));
 }
 
 export async function iniciarTentativa(userId: string, slug: string) {
@@ -67,8 +82,13 @@ export async function iniciarTentativa(userId: string, slug: string) {
         .orderBy(desc(simuladoAttempts.startedAt))
         .limit(1);
     if (emAberto && emAberto.expiresAt > agora) {
+        // Retoma esta tentativa e cancela qualquer outra em aberto (de outros simulados).
+        await cancelarTentativasEmAberto(userId, emAberto.id);
         return estadoDaTentativa(userId, emAberto.id);
     }
+
+    // Vai criar uma nova: cancela todas as tentativas em aberto, parando o cronômetro delas.
+    await cancelarTentativasEmAberto(userId, null);
 
     const sorteadas = await db
         .select({ id: simuladoQuestions.id })
@@ -165,9 +185,20 @@ export async function estadoDaTentativa(userId: string, attemptId: string) {
         };
     });
 
+    const [sim] = await db
+        .select({
+            slug: simulados.slug,
+            name: simulados.name,
+            passPercent: simulados.passPercent,
+        })
+        .from(simulados)
+        .where(eq(simulados.id, attempt.simuladoId));
     const restanteMs = attempt.expiresAt.getTime() - Date.now();
     return {
         attemptId: attempt.id,
+        slug: sim?.slug ?? null,
+        simulado: sim?.name ?? null,
+        passPercent: sim?.passPercent ?? null,
         submitted: enviado,
         expiresAt: attempt.expiresAt,
         remainingSeconds: enviado ? 0 : Math.max(0, Math.floor(restanteMs / 1000)),
@@ -175,6 +206,10 @@ export async function estadoDaTentativa(userId: string, attemptId: string) {
             ? {
                   score: attempt.score,
                   passed: attempt.passed,
+                  elapsedSeconds: Math.max(
+                      0,
+                      Math.round((attempt.submittedAt!.getTime() - attempt.startedAt.getTime()) / 1000),
+                  ),
                   temasARevisar: resumoPorTema(paraResumo),
               }
             : {}),

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import { Configuracoes } from './pages/Configuracoes';
 import { Perfil } from './pages/Perfil';
 import { Ranking } from './pages/Ranking';
 import { Simulados } from './pages/Simulados';
+import { SimuladoBriefing } from './pages/Simulados/Briefing';
 import { TentativaSimulado } from './pages/Simulados/Tentativa';
 import { SimuladosAdmin } from './pages/SimuladosAdmin';
 import { SimuladoEditor } from './pages/SimuladosAdmin/Editor';
@@ -155,6 +156,14 @@ function AppRoutes() {
         element={
           <PrivateRoute>
             <TentativaSimulado />
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/simulados/:slug"
+        element={
+          <PrivateRoute>
+            <SimuladoBriefing />
           </PrivateRoute>
         }
       />

--- a/frontend/src/pages/Simulados/Briefing.tsx
+++ b/frontend/src/pages/Simulados/Briefing.tsx
@@ -1,0 +1,216 @@
+import { useState, type ReactNode } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useRequisicao } from '../../hooks/useRequisicao';
+import { SimTopbar } from './SimTopbar';
+import { ClockExam, Check, Target, BookOpen, Alert, Play } from '../../components/Icons';
+import {
+  listarSimulados,
+  historicoSimulados,
+  iniciarTentativa,
+  type TentativaHistorico,
+} from '../../services/simulados';
+import { provedorDe, nomeLimpo, nivelClasse } from './provedores';
+import { ConfirmModal } from './ConfirmModal';
+
+function formatData(iso: string) {
+  return new Date(iso).toLocaleDateString('pt-BR', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+export function SimuladoBriefing() {
+  const { slug } = useParams<{ slug: string }>();
+  const navigate = useNavigate();
+  const { dados, carregando } = useRequisicao(
+    () =>
+      Promise.all([listarSimulados(), historicoSimulados()]).then(([exams, historico]) => ({
+        exams,
+        historico,
+      })),
+    [],
+  );
+  const exam = dados?.exams.find((e) => e.slug === slug) ?? null;
+  const tentativas = (dados?.historico ?? []).filter((t) => t.slug === slug);
+  const [iniciando, setIniciando] = useState(false);
+  const [confirmando, setConfirmando] = useState(false);
+  const [voltarPara, setVoltarPara] = useState<string | null>(null);
+
+  async function iniciar() {
+    if (!exam || iniciando) return;
+    setIniciando(true);
+    try {
+      const t = await iniciarTentativa(exam.slug);
+      navigate(`/simulados/tentativa/${t.attemptId}`);
+    } catch (e) {
+      console.error('Falha ao iniciar simulado', e);
+      setIniciando(false);
+    }
+  }
+
+  const p = exam ? provedorDe(exam.provider) : null;
+
+  return (
+    <div className="home-shell">
+      <div className="home">
+        <SimTopbar />
+        <div className="sim sim--brief">
+          <button className="sim-back" onClick={() => navigate('/simulados')}>
+            ← Voltar aos simulados
+          </button>
+
+          {carregando ? (
+            <p className="sim-empty">Carregando...</p>
+          ) : !exam || !p ? (
+            <p className="sim-empty">Simulado não encontrado.</p>
+          ) : (
+            <>
+              <header className="sim-brief__head">
+                <span className="simc__logo simc__logo--lg" style={{ background: p.cor }}>
+                  {p.sigla}
+                </span>
+                <div className="sim-brief__id">
+                  <div className="simc__vendor">{p.nome}</div>
+                  <h1 className="sim-brief__code">{exam.code ?? exam.name}</h1>
+                  <div className="sim-brief__name">{nomeLimpo(exam.name, exam.code)}</div>
+                </div>
+                {exam.level && (
+                  <span className={`simc__level simc__level--${nivelClasse(exam.level)}`}>
+                    {exam.level}
+                  </span>
+                )}
+              </header>
+
+              <div className="sim-brief__grid">
+                <div className="card sim-rules">
+                  <div className="sim-rules__title">Como funciona o simulado</div>
+                  <div className="sim-rules__sub">
+                    Leia antes de começar. O cronômetro inicia assim que você iniciar.
+                  </div>
+                  <div className="sim-rules__grid">
+                    <Regra
+                      icon={<ClockExam size={18} />}
+                      t={`${exam.durationMinutes} minutos`}
+                      d="O cronômetro começa ao iniciar e não pausa até enviar."
+                    />
+                    <Regra
+                      icon={<Check size={17} />}
+                      t={`${exam.questionCount} questões`}
+                      d="Múltipla escolha; algumas pedem mais de uma resposta."
+                    />
+                    <Regra
+                      icon={<Target size={17} />}
+                      t={`${exam.passPercent}% para passar`}
+                      d="Cada questão vale igual; múltiplas contam tudo-ou-nada."
+                    />
+                    <Regra
+                      icon={<BookOpen size={17} />}
+                      t="Revisão ao final"
+                      d="Veja o que errou, o assunto de cada questão e o que revisar."
+                    />
+                  </div>
+                  <div className="sim-warn">
+                    <span className="sim-warn__icon">
+                      <Alert size={18} />
+                    </span>
+                    <div>
+                      <b>Uma vez iniciado, o cronômetro não para.</b> Se o tempo acabar, o simulado
+                      é enviado automaticamente com as respostas marcadas até ali.
+                    </div>
+                  </div>
+                  <button className="sim-start" onClick={() => setConfirmando(true)}>
+                    <Play size={15} />{' '}
+                    {tentativas.length > 0 ? 'Refazer simulado' : 'Iniciar simulado'}
+                  </button>
+                </div>
+
+                <div className="card">
+                  <div className="sim-attempts__title">Suas últimas tentativas</div>
+                  {tentativas.length === 0 ? (
+                    <p className="sim-empty">Você ainda não fez este simulado.</p>
+                  ) : (
+                    <div className="sim-attempts">
+                      {tentativas.slice(0, 6).map((a) => (
+                        <ItemTentativa
+                          key={a.attemptId}
+                          a={a}
+                          onClick={() => {
+                            if (a.submittedAt == null) setVoltarPara(a.attemptId);
+                            else if (a.score != null)
+                              navigate(`/simulados/tentativa/${a.attemptId}`);
+                          }}
+                        />
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </>
+          )}
+
+          {confirmando && exam && (
+            <ConfirmModal
+              title="Iniciar o simulado?"
+              confirmLabel="Sim, iniciar"
+              onConfirm={iniciar}
+              onCancel={() => setConfirmando(false)}
+              loading={iniciando}
+            >
+              Assim que você iniciar, o cronômetro de <b>{exam.durationMinutes} minutos</b> começa a
+              contar e não para. Tem certeza que quer começar agora?
+            </ConfirmModal>
+          )}
+
+          {voltarPara && (
+            <ConfirmModal
+              title="Tentativa em andamento"
+              confirmLabel="Voltar para a prova"
+              onConfirm={() => navigate(`/simulados/tentativa/${voltarPara}`)}
+              onCancel={() => setVoltarPara(null)}
+            >
+              Você tem uma tentativa em andamento com o cronômetro rodando. Deseja voltar para ela?
+            </ConfirmModal>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Regra({ icon, t, d }: { icon: ReactNode; t: string; d: string }) {
+  return (
+    <div className="sim-rule">
+      <span className="sim-rule__icon">{icon}</span>
+      <div>
+        <div className="sim-rule__t">{t}</div>
+        <div className="sim-rule__d">{d}</div>
+      </div>
+    </div>
+  );
+}
+
+function ItemTentativa({ a, onClick }: { a: TentativaHistorico; onClick: () => void }) {
+  const enviado = a.submittedAt != null;
+  const cancelada = enviado && a.score == null;
+  const ok = a.passed === true;
+  const estado = cancelada ? 'cancel' : !enviado ? 'wip' : ok ? 'ok' : 'no';
+  const rotulo = cancelada
+    ? 'Cancelada'
+    : !enviado
+      ? 'Em andamento'
+      : ok
+        ? 'Aprovado'
+        : 'Reprovado';
+  return (
+    <button className={`sim-attempt${cancelada ? ' sim-attempt--off' : ''}`} onClick={onClick}>
+      <span className={`sim-attempt__score sim-attempt__score--${estado}`}>
+        {enviado && !cancelada ? `${a.score}%` : '—'}
+      </span>
+      <div className="sim-attempt__id">
+        <div className="sim-attempt__exam">{formatData(a.startedAt)}</div>
+      </div>
+      <span className={`sim-attempt__verdict sim-attempt__verdict--${estado}`}>{rotulo}</span>
+    </button>
+  );
+}

--- a/frontend/src/pages/Simulados/ConfirmModal.tsx
+++ b/frontend/src/pages/Simulados/ConfirmModal.tsx
@@ -1,0 +1,51 @@
+import type { ReactNode } from 'react';
+import { Alert } from '../../components/Icons';
+
+export function ConfirmModal({
+  title,
+  children,
+  confirmLabel,
+  onConfirm,
+  onCancel,
+  loading = false,
+}: {
+  title: string;
+  children: ReactNode;
+  confirmLabel: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  loading?: boolean;
+}) {
+  return (
+    <div
+      className="sim-modal"
+      role="dialog"
+      aria-modal="true"
+      onClick={() => !loading && onCancel()}
+    >
+      <div className="sim-modal__card" onClick={(ev) => ev.stopPropagation()}>
+        <span className="sim-modal__icon">
+          <Alert size={22} />
+        </span>
+        <h2 className="sim-modal__title">{title}</h2>
+        <p className="sim-modal__text">{children}</p>
+        <div className="sim-modal__actions">
+          <button
+            className="sim-modal__btn sim-modal__btn--ghost"
+            onClick={onCancel}
+            disabled={loading}
+          >
+            Cancelar
+          </button>
+          <button
+            className="sim-modal__btn sim-modal__btn--primary"
+            onClick={onConfirm}
+            disabled={loading}
+          >
+            {loading ? 'Aguarde...' : confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Simulados/Resultado.tsx
+++ b/frontend/src/pages/Simulados/Resultado.tsx
@@ -1,8 +1,10 @@
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Check, X, Info, BookOpen, Trophy, Target, Redo } from '../../components/Icons';
 import type { TentativaEstado, QuestaoSimulado } from '../../services/simulados';
 
 const RING = 352;
+const VISIVEIS = 4;
 
 function mesmoConjunto(a: string[], b: string[]) {
   if (a.length !== b.length) return false;
@@ -28,17 +30,27 @@ function faixa(pct: number) {
   if (pct >= 55) return { fg: 'var(--amber)', label: 'Reforçar' };
   return { fg: 'var(--av-red)', label: 'Frágil' };
 }
+function formatarTempo(seg: number) {
+  const min = Math.round(seg / 60);
+  if (min < 60) return `${min}min`;
+  const h = Math.floor(min / 60);
+  const m = min % 60;
+  return m ? `${h}h ${m}min` : `${h}h`;
+}
 
 export function Resultado({ dados }: { dados: TentativaEstado }) {
   const navigate = useNavigate();
+  const [todas, setTodas] = useState(false);
   const isPass = dados.passed === true;
   const score = dados.score ?? 0;
+  const passPercent = dados.passPercent ?? 70;
+  const gap = Math.max(0, passPercent - score);
   const questions = dados.questions;
   const total = questions.length;
   const acertos = questions.filter(acertou).length;
   const erros = total - acertos;
   const erradas = questions.filter((q) => !acertou(q));
-  const temas = dados.temasARevisar ?? [];
+  const tempo = dados.elapsedSeconds != null ? formatarTempo(dados.elapsedSeconds) : null;
 
   const porTema = new Map<string, { acertos: number; total: number }>();
   for (const q of questions) {
@@ -51,15 +63,21 @@ export function Resultado({ dados }: { dados: TentativaEstado }) {
   const dominios = [...porTema.entries()]
     .map(([name, v]) => ({ name, pct: v.total ? Math.round((v.acertos / v.total) * 100) : 0 }))
     .sort((a, b) => a.pct - b.pct);
+  const maisFragil = dominios[0];
 
+  const mostradas = todas ? erradas : erradas.slice(0, VISIVEIS);
   const ringOffset = Math.round(RING * (1 - score / 100));
   const heroBg = isPass
     ? 'linear-gradient(150deg, var(--success), color-mix(in srgb, var(--success) 52%, #06371f))'
     : 'linear-gradient(150deg, #d9536b, #8a2f42)';
-  const titulo = isPass ? 'Aprovado! Mandou bem.' : 'Quase lá.';
+  const titulo = isPass ? 'Você foi aprovado!' : 'Você não foi aprovado desta vez';
   const sub = isPass
-    ? 'Você atingiu a nota de corte. Revise os pontos abaixo pra chegar ainda mais confiante.'
-    : 'Faltou pouco pra nota de corte. Reforce os temas abaixo e tente de novo.';
+    ? 'Você passou da nota de corte. Revise os pontos abaixo pra ficar ainda mais confiante.'
+    : `Você ficou a ${gap}% da aprovação. Revise os tópicos abaixo e refaça o simulado. Você está quase lá.`;
+
+  function refazer() {
+    navigate(dados.slug ? `/simulados/${dados.slug}` : '/simulados');
+  }
 
   return (
     <div className="sim">
@@ -117,18 +135,18 @@ export function Resultado({ dados }: { dados: TentativaEstado }) {
               <div className="res-stat__l">erros</div>
             </div>
             <div className="res-stat">
-              <div className="res-stat__v">{total}</div>
-              <div className="res-stat__l">questões</div>
+              <div className="res-stat__v">{tempo ?? total}</div>
+              <div className="res-stat__l">{tempo ? 'tempo' : 'questões'}</div>
             </div>
           </div>
         </div>
       </div>
 
-      <div className="sim__grid">
+      <div className="res-grid">
         <div className="sim__col">
           <div className="card">
-            <div className="res-sec__title">Desempenho por tema</div>
-            <div className="res-sec__sub">Veja onde você foi bem e onde precisa reforçar.</div>
+            <div className="res-sec__title">Desempenho por domínio</div>
+            <div className="res-sec__sub">Veja onde você mandou bem e onde precisa reforçar.</div>
             <div className="res-domains">
               {dominios.map((d) => {
                 const c = faixa(d.pct);
@@ -161,18 +179,18 @@ export function Resultado({ dados }: { dados: TentativaEstado }) {
           {erradas.length > 0 && (
             <div className="card">
               <div className="res-review__head">
-                <div className="res-sec__title">Revise o que você errou</div>
+                <div className="res-sec__title">Onde você errou</div>
                 <div className="topbar__spacer" />
-                <span className="res-review__count">{erros} erradas</span>
+                <span className="res-review__count">{erros} questões erradas</span>
               </div>
               <div className="res-sec__sub">
-                Confira a resposta certa, o porquê e o assunto de cada questão.
+                Estude estes tópicos com atenção: foram os que mais pesaram na sua nota.
               </div>
               <div className="res-wrongs">
-                {erradas.map((q) => (
+                {mostradas.map((q) => (
                   <div key={q.id} className="res-wrong">
                     <div className="res-wrong__meta">
-                      <span className="res-wrong__q">Questão {q.position}</span>
+                      <span className="res-wrong__q">Q{q.position}</span>
                       {q.topic && <span className="res-wrong__domain">{q.topic}</span>}
                     </div>
                     <div className="res-wrong__text">{q.statement}</div>
@@ -202,7 +220,7 @@ export function Resultado({ dados }: { dados: TentativaEstado }) {
                           <Info size={17} />
                         </span>
                         <div>
-                          <b>Por quê:</b> {q.explanation}
+                          <b>Por que você errou:</b> {q.explanation}
                         </div>
                       </div>
                     )}
@@ -217,39 +235,62 @@ export function Resultado({ dados }: { dados: TentativaEstado }) {
                   </div>
                 ))}
               </div>
+              {erradas.length > VISIVEIS && (
+                <button className="res-more" onClick={() => setTodas((v) => !v)}>
+                  {todas ? 'Mostrar menos' : `Ver todas as ${erros} questões erradas`}
+                </button>
+              )}
             </div>
           )}
         </div>
 
         <div className="sim__col">
           <div className="card">
-            <div className="res-plan__title">Temas para revisar</div>
+            <div className="res-plan__title">Seu plano de estudo</div>
             <div className="res-plan__sub">
-              {temas.length > 0
-                ? 'Priorize os assuntos onde você mais errou.'
-                : 'Você não errou nenhum tema. Excelente!'}
+              {isPass
+                ? 'Mandou bem. Revise os poucos erros e siga treinando pra manter o nível.'
+                : 'Faltou pouco. Foque nestes tópicos e tente de novo em alguns dias.'}
             </div>
-            {temas.length > 0 && (
-              <div className="res-plan">
-                {temas.map((t) => (
-                  <div key={t.topic} className="res-plan-item">
-                    <span className="res-plan-item__icon">
-                      <BookOpen size={16} />
-                    </span>
-                    <div>
-                      <div className="res-plan-item__t">{t.topic}</div>
-                      <div className="res-plan-item__s">
-                        {t.erradas} de {t.total} erradas
-                      </div>
+            <div className="res-plan">
+              {maisFragil && (
+                <div className="res-plan-item">
+                  <span className="res-plan-item__icon">
+                    <BookOpen size={16} />
+                  </span>
+                  <div>
+                    <div className="res-plan-item__t">Estude pelas trilhas</div>
+                    <div className="res-plan-item__s">
+                      Comece pelo tema mais frágil: {maisFragil.name} ({maisFragil.pct}%)
                     </div>
                   </div>
-                ))}
+                </div>
+              )}
+              <div className="res-plan-item">
+                <span className="res-plan-item__icon">
+                  <Info size={16} />
+                </span>
+                <div>
+                  <div className="res-plan-item__t">Revise cada questão errada</div>
+                  <div className="res-plan-item__s">
+                    Leia a explicação e o assunto indicado de cada uma.
+                  </div>
+                </div>
               </div>
-            )}
-            <button
-              className="btn btn--accent res-plan__redo"
-              onClick={() => navigate('/simulados')}
-            >
+              <div className="res-plan-item">
+                <span className="res-plan-item__icon">
+                  <Redo size={16} />
+                </span>
+                <div>
+                  <div className="res-plan-item__t">Refaça o simulado</div>
+                  <div className="res-plan-item__s">Meça sua evolução daqui a alguns dias.</div>
+                </div>
+              </div>
+            </div>
+            <button className="btn btn--accent res-plan__redo" onClick={() => navigate('/trilhas')}>
+              <BookOpen size={16} /> Começar plano de estudo
+            </button>
+            <button className="res-plan__ghost" onClick={refazer}>
               <Redo size={16} /> Refazer simulado
             </button>
           </div>
@@ -259,13 +300,11 @@ export function Resultado({ dados }: { dados: TentativaEstado }) {
               {isPass ? <Trophy size={26} /> : <Target size={26} />}
             </span>
             <div>
-              <div className="res-seal__t">
-                {isPass ? 'Pronto pra prova' : 'Continue treinando'}
-              </div>
+              <div className="res-seal__t">{isPass ? 'Aprovado!' : 'Continue tentando'}</div>
               <div className="res-seal__s">
                 {isPass
                   ? 'Seu desempenho está no nível de aprovação.'
-                  : 'Cada tentativa te deixa mais perto.'}
+                  : `Faltam ${gap}% para a aprovação.`}
               </div>
             </div>
           </div>

--- a/frontend/src/pages/Simulados/index.tsx
+++ b/frontend/src/pages/Simulados/index.tsx
@@ -1,22 +1,12 @@
-import { useState, type ReactNode } from 'react';
+import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useRequisicao } from '../../hooks/useRequisicao';
 import { SimTopbar } from './SimTopbar';
-import { GradCap, Check, Play, Alert, ClockExam, Target, BookOpen } from '../../components/Icons';
-import {
-  listarSimulados,
-  historicoSimulados,
-  iniciarTentativa,
-  type TentativaHistorico,
-} from '../../services/simulados';
+import { Search, Play, Info } from '../../components/Icons';
+import { listarSimulados, historicoSimulados, type SimuladoResumo } from '../../services/simulados';
+import { provedorDe, nomeLimpo, nivelClasse, ORDEM_PROV } from './provedores';
 
-function formatData(iso: string) {
-  return new Date(iso).toLocaleDateString('pt-BR', {
-    day: '2-digit',
-    month: 'short',
-    year: 'numeric',
-  });
-}
+type Melhor = { score: number; passed: boolean };
 
 export function Simulados() {
   const navigate = useNavigate();
@@ -31,21 +21,56 @@ export function Simulados() {
   const exams = dados?.exams ?? [];
   const historico = dados?.historico ?? [];
 
-  const [slug, setSlug] = useState<string | null>(null);
-  const [iniciando, setIniciando] = useState(false);
-  const selecionado = exams.find((e) => e.slug === slug) ?? exams[0] ?? null;
+  const [busca, setBusca] = useState('');
+  const [filtro, setFiltro] = useState<string | null>(null);
 
-  async function iniciar() {
-    if (!selecionado || iniciando) return;
-    setIniciando(true);
-    try {
-      const t = await iniciarTentativa(selecionado.slug);
-      navigate(`/simulados/tentativa/${t.attemptId}`);
-    } catch (e) {
-      console.error('Falha ao iniciar simulado', e);
-      setIniciando(false);
+  // Melhor tentativa enviada por simulado (maior percentual).
+  const melhorPorSlug = useMemo(() => {
+    const m: Record<string, Melhor> = {};
+    for (const t of historico) {
+      if (t.submittedAt == null || t.score == null) continue;
+      const atual = m[t.slug];
+      if (!atual || t.score > atual.score)
+        m[t.slug] = { score: t.score, passed: t.passed === true };
     }
-  }
+    return m;
+  }, [historico]);
+
+  const contagem = useMemo(() => {
+    const c: Record<string, number> = {};
+    for (const e of exams) {
+      const p = e.provider ?? 'outros';
+      c[p] = (c[p] ?? 0) + 1;
+    }
+    return c;
+  }, [exams]);
+
+  const provedores = useMemo(
+    () =>
+      Object.keys(contagem).sort(
+        (a, b) => (ORDEM_PROV.indexOf(a) + 1 || 99) - (ORDEM_PROV.indexOf(b) + 1 || 99),
+      ),
+    [contagem],
+  );
+
+  const filtrados = useMemo(() => {
+    const q = busca.trim().toLowerCase();
+    return exams.filter((e) => {
+      if (filtro && (e.provider ?? 'outros') !== filtro) return false;
+      if (!q) return true;
+      const prov = provedorDe(e.provider).nome.toLowerCase();
+      return (
+        e.name.toLowerCase().includes(q) ||
+        (e.code ?? '').toLowerCase().includes(q) ||
+        prov.includes(q)
+      );
+    });
+  }, [exams, busca, filtro]);
+
+  const aprovados = useMemo(
+    () => Object.values(melhorPorSlug).filter((m) => m.passed).length,
+    [melhorPorSlug],
+  );
 
   return (
     <div className="home-shell">
@@ -53,11 +78,27 @@ export function Simulados() {
         <SimTopbar />
         <div className="sim">
           <div className="sim__head">
-            <h1 className="sim__title">Simulados de certificação</h1>
-            <p className="sim__sub">
-              Pratique com provas cronometradas no formato oficial e chegue confiante no dia do
-              exame.
-            </p>
+            <div>
+              <h1 className="sim__title">Simulados de certificação</h1>
+              <p className="sim__sub">
+                Pratique com provas cronometradas no formato oficial e chegue confiante no dia do
+                exame.
+              </p>
+            </div>
+            <div className="sim__stats">
+              <div className="sim-stat">
+                <b>{exams.length}</b>
+                <span>simulados</span>
+              </div>
+              <div className="sim-stat">
+                <b>{provedores.length}</b>
+                <span>provedores</span>
+              </div>
+              <div className="sim-stat">
+                <b>{aprovados}</b>
+                <span>aprovados</span>
+              </div>
+            </div>
           </div>
 
           {carregando ? (
@@ -65,141 +106,65 @@ export function Simulados() {
           ) : exams.length === 0 ? (
             <p className="sim-empty">Nenhum simulado disponível ainda.</p>
           ) : (
-            <div className="sim__grid">
-              <div className="sim__col">
-                <div className="sim__exams">
-                  {exams.map((e) => (
+            <>
+              <div className="sim__toolbar">
+                <label className="sim__search">
+                  <Search size={16} />
+                  <input
+                    value={busca}
+                    onChange={(e) => setBusca(e.target.value)}
+                    placeholder="Buscar por código, nome ou provedor..."
+                  />
+                </label>
+                <div className="sim__filters">
+                  <button
+                    className={`sim-pill${filtro === null ? ' sim-pill--active' : ''}`}
+                    onClick={() => setFiltro(null)}
+                  >
+                    Todos <span className="sim-pill__n">{exams.length}</span>
+                  </button>
+                  {provedores.map((p) => (
                     <button
-                      key={e.slug}
-                      className={`exam-card${e.slug === selecionado?.slug ? ' exam-card--active' : ''}`}
-                      onClick={() => setSlug(e.slug)}
+                      key={p}
+                      className={`sim-pill${filtro === p ? ' sim-pill--active' : ''}`}
+                      onClick={() => setFiltro(p)}
                     >
-                      {e.slug === selecionado?.slug && (
-                        <span className="exam-card__check">
-                          <Check size={13} />
-                        </span>
-                      )}
-                      <div className="exam-card__top">
-                        <span className="exam-card__logo">
-                          <GradCap size={24} />
-                        </span>
-                        <div>
-                          <div className="exam-card__vendor">Certificação</div>
-                          <div className="exam-card__code">{e.name}</div>
-                        </div>
-                      </div>
-                      {e.description && <div className="exam-card__name">{e.description}</div>}
-                      <div className="exam-card__meta">
-                        <span>
-                          <b>{e.questionCount}</b> questões
-                        </span>
-                        <span>
-                          <b>{e.durationMinutes}</b> min
-                        </span>
-                        <span>
-                          <b>{e.passPercent}%</b> p/ passar
-                        </span>
-                      </div>
+                      {provedorDe(p).label} <span className="sim-pill__n">{contagem[p]}</span>
                     </button>
                   ))}
                 </div>
-
-                {selecionado && (
-                  <div className="card sim-rules">
-                    <div className="sim-rules__title">Como funciona o simulado</div>
-                    <div className="sim-rules__sub">
-                      Leia antes de começar. O cronômetro inicia assim que você iniciar.
-                    </div>
-                    <div className="sim-rules__grid">
-                      <Regra
-                        icon={<ClockExam size={18} />}
-                        t={`${selecionado.durationMinutes} minutos`}
-                        d="O cronômetro começa ao iniciar e não pausa até enviar."
-                      />
-                      <Regra
-                        icon={<Check size={17} />}
-                        t={`${selecionado.questionCount} questões`}
-                        d="Múltipla escolha; algumas pedem mais de uma resposta."
-                      />
-                      <Regra
-                        icon={<Target size={17} />}
-                        t={`${selecionado.passPercent}% para passar`}
-                        d="Cada questão vale igual; múltiplas contam tudo-ou-nada."
-                      />
-                      <Regra
-                        icon={<BookOpen size={17} />}
-                        t="Revisão ao final"
-                        d="Veja o que errou, o assunto de cada questão e o que revisar."
-                      />
-                    </div>
-                    <div className="sim-warn">
-                      <span className="sim-warn__icon">
-                        <Alert size={18} />
-                      </span>
-                      <div>
-                        <b>Uma vez iniciado, o cronômetro não para.</b> Se o tempo acabar, o
-                        simulado é enviado automaticamente com as respostas marcadas até ali.
-                      </div>
-                    </div>
-                  </div>
-                )}
               </div>
 
-              <div className="sim__col">
-                {selecionado && (
-                  <div className="card">
-                    <div className="sim-pick__label">Simulado selecionado</div>
-                    <div className="sim-pick__head">
-                      <span className="exam-card__logo">
-                        <GradCap size={22} />
-                      </span>
-                      <div>
-                        <div className="exam-card__vendor">Certificação</div>
-                        <div className="sim-pick__code">{selecionado.name}</div>
-                      </div>
-                    </div>
-                    <div className="sim-pick__rows">
-                      <Linha
-                        icon={<ClockExam size={18} />}
-                        label="Duração"
-                        value={`${selecionado.durationMinutes} min`}
-                      />
-                      <Linha
-                        icon={<Check size={18} />}
-                        label="Questões"
-                        value={`${selecionado.questionCount}`}
-                      />
-                      <Linha
-                        icon={<Target size={18} />}
-                        label="Aprovação"
-                        value={`${selecionado.passPercent}%`}
-                      />
-                    </div>
-                    <button className="sim-start" onClick={iniciar} disabled={iniciando}>
-                      <Play size={15} /> {iniciando ? 'Preparando...' : 'Iniciar simulado'}
-                    </button>
-                    <div className="sim-pick__note">O cronômetro só começa quando você inicia.</div>
-                  </div>
-                )}
+              <div className="sim__count">
+                {filtrados.length} {filtrados.length === 1 ? 'simulado' : 'simulados'}
+              </div>
 
-                <div className="card">
-                  <div className="sim-attempts__title">Suas últimas tentativas</div>
-                  {historico.length === 0 ? (
-                    <p className="sim-empty">Você ainda não fez nenhum simulado.</p>
-                  ) : (
-                    <div className="sim-attempts">
-                      {historico.slice(0, 5).map((a) => (
-                        <ItemTentativa
-                          key={a.attemptId}
-                          a={a}
-                          onClick={() => navigate(`/simulados/tentativa/${a.attemptId}`)}
-                        />
-                      ))}
-                    </div>
-                  )}
+              {filtrados.length === 0 ? (
+                <p className="sim-empty">Nenhum simulado encontrado.</p>
+              ) : (
+                <div className="sim__grid">
+                  {filtrados.map((e) => (
+                    <CardSimulado
+                      key={e.slug}
+                      e={e}
+                      melhor={melhorPorSlug[e.slug]}
+                      onAbrir={() => navigate(`/simulados/${e.slug}`)}
+                    />
+                  ))}
+                </div>
+              )}
+
+              <div className="sim__footer">
+                <span className="sim__footer-icon">
+                  <Info size={18} />
+                </span>
+                <div>
+                  <b>Provas no formato oficial, cronometradas.</b> O relógio inicia ao começar e não
+                  para. Ao enviar, você recebe o percentual, a aprovação e a explicação de cada
+                  questão.
                 </div>
               </div>
-            </div>
+            </>
           )}
         </div>
       </div>
@@ -207,43 +172,68 @@ export function Simulados() {
   );
 }
 
-function Regra({ icon, t, d }: { icon: ReactNode; t: string; d: string }) {
+function CardSimulado({
+  e,
+  melhor,
+  onAbrir,
+}: {
+  e: SimuladoResumo;
+  melhor?: Melhor;
+  onAbrir: () => void;
+}) {
+  const p = provedorDe(e.provider);
+  const feito = !!melhor;
+  const aprovado = melhor?.passed === true;
   return (
-    <div className="sim-rule">
-      <span className="sim-rule__icon">{icon}</span>
-      <div>
-        <div className="sim-rule__t">{t}</div>
-        <div className="sim-rule__d">{d}</div>
+    <div className="simc">
+      <div className="simc__top">
+        <span className="simc__logo" style={{ background: p.cor }}>
+          {p.sigla}
+        </span>
+        <div className="simc__id">
+          <div className="simc__vendor">{p.nome}</div>
+          <div className="simc__code">{e.code ?? e.name}</div>
+        </div>
+        {e.level && (
+          <span className={`simc__level simc__level--${nivelClasse(e.level)}`}>{e.level}</span>
+        )}
       </div>
-    </div>
-  );
-}
-
-function Linha({ icon, label, value }: { icon: ReactNode; label: string; value: string }) {
-  return (
-    <div className="sim-pick__row">
-      <span className="sim-pick__row-icon">{icon}</span>
-      <span className="sim-pick__row-label">{label}</span>
-      <span className="sim-pick__row-val">{value}</span>
-    </div>
-  );
-}
-
-function ItemTentativa({ a, onClick }: { a: TentativaHistorico; onClick: () => void }) {
-  const enviado = a.submittedAt != null;
-  const ok = a.passed === true;
-  return (
-    <button className="sim-attempt" onClick={onClick}>
-      <span className={`sim-attempt__score sim-attempt__score--${ok ? 'ok' : 'no'}`}>
-        {enviado ? `${a.score}%` : '—'}
-      </span>
-      <div className="sim-attempt__id">
-        <div className="sim-attempt__exam">{a.simulado}</div>
-        <div className="sim-attempt__date">{formatData(a.startedAt)}</div>
+      <div className="simc__name">{nomeLimpo(e.name, e.code)}</div>
+      <div className="simc__meta">
+        <span>
+          <b>{e.questionCount}</b> questões
+        </span>
+        <span>
+          <b>{e.durationMinutes}</b> min
+        </span>
+        <span>
+          <b>{e.passPercent}%</b> p/ passar
+        </span>
       </div>
-      <span className={`sim-attempt__verdict sim-attempt__verdict--${ok ? 'ok' : 'no'}`}>
-        {enviado ? (ok ? 'Aprovado' : 'Reprovado') : 'Em andamento'}
-      </span>
-    </button>
+      <div className="simc__divider" />
+      <div className="simc__status">
+        {feito ? (
+          <>
+            <div className="simc__status-row">
+              <span className={`simc__verdict simc__verdict--${aprovado ? 'ok' : 'no'}`}>
+                {aprovado ? 'Aprovado' : 'Reprovado'}
+              </span>
+              <span className="simc__best">melhor {melhor!.score}%</span>
+            </div>
+            <div className="simc__bar">
+              <span
+                className={aprovado ? 'simc__bar--ok' : 'simc__bar--no'}
+                style={{ width: `${melhor!.score}%` }}
+              />
+            </div>
+          </>
+        ) : (
+          <div className="simc__notstarted">Não iniciado</div>
+        )}
+      </div>
+      <button className={`simc__btn${feito ? ' simc__btn--redo' : ''}`} onClick={onAbrir}>
+        <Play size={13} /> {feito ? 'Refazer' : 'Iniciar'}
+      </button>
+    </div>
   );
 }

--- a/frontend/src/pages/Simulados/provedores.ts
+++ b/frontend/src/pages/Simulados/provedores.ts
@@ -1,0 +1,33 @@
+// Config de cada provedor de certificação: nome exibido, rótulo curto do filtro,
+// cor e sigla do selo. Compartilhado entre a lista e o briefing.
+export const PROVEDORES: Record<
+  string,
+  { nome: string; label: string; cor: string; sigla: string }
+> = {
+  aws: { nome: 'Amazon Web Services', label: 'AWS', cor: '#ff9900', sigla: 'aws' },
+  azure: { nome: 'Microsoft Azure', label: 'Azure', cor: '#0078d4', sigla: 'Az' },
+  gcp: { nome: 'Google Cloud', label: 'Google Cloud', cor: '#1a73e8', sigla: 'GC' },
+};
+
+const PROV_PADRAO = { nome: 'Certificação', label: 'Outros', cor: '#6b7280', sigla: '•' };
+
+export const ORDEM_PROV = ['aws', 'azure', 'gcp'];
+
+export function provedorDe(p: string | null) {
+  return (p && PROVEDORES[p]) || PROV_PADRAO;
+}
+
+// Remove o código entre parênteses e o prefixo "Microsoft " do nome, já que o
+// código e o provedor aparecem à parte.
+export function nomeLimpo(name: string, code: string | null) {
+  let n = name;
+  if (code) n = n.replace(` (${code})`, '');
+  return n.replace(/^Microsoft\s+/, '');
+}
+
+export function nivelClasse(level: string) {
+  const l = level.toLowerCase();
+  if (l.includes('assoc')) return 'assoc';
+  if (l.includes('prof') || l.includes('expert')) return 'prof';
+  return 'fund';
+}

--- a/frontend/src/pages/Trilhas/index.tsx
+++ b/frontend/src/pages/Trilhas/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { useTheme } from '../../contexts/ThemeContext';
@@ -266,7 +266,7 @@ export function Trilhas() {
                       </div>
                     </div>
                   </div>
-                  <p className="track__desc">{t.desc}</p>
+                  <TrilhaDesc>{t.desc}</TrilhaDesc>
                   <div className="progress">
                     <div className="progress__track">
                       <span
@@ -313,5 +313,44 @@ export function Trilhas() {
         </div>
       </div>
     </div>
+  );
+}
+
+// Descrição do card com "ler mais": mostra o botão só quando o texto passa de 3 linhas,
+// e expande apenas este card (estado próprio), sem mexer nos vizinhos.
+function TrilhaDesc({ children }: { children: string }) {
+  const ref = useRef<HTMLParagraphElement>(null);
+  const [truncado, setTruncado] = useState(false);
+  const [aberto, setAberto] = useState(false);
+
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el || aberto) return;
+    const medir = () => setTruncado(el.scrollHeight > el.clientHeight + 1);
+    medir();
+    window.addEventListener('resize', medir);
+    return () => window.removeEventListener('resize', medir);
+  }, [children, aberto]);
+
+  return (
+    <>
+      <p ref={ref} className={`track__desc${aberto ? ' track__desc--full' : ''}`}>
+        {children}
+      </p>
+      <div className="track__more-row">
+        {(truncado || aberto) && (
+          <button
+            type="button"
+            className="track__more"
+            onClick={(e) => {
+              e.stopPropagation();
+              setAberto((v) => !v);
+            }}
+          >
+            {aberto ? 'Ler menos' : 'Ler mais'}
+          </button>
+        )}
+      </div>
+    </>
   );
 }

--- a/frontend/src/services/simulados.ts
+++ b/frontend/src/services/simulados.ts
@@ -4,6 +4,9 @@ export interface SimuladoResumo {
   slug: string;
   name: string;
   description: string | null;
+  provider: string | null;
+  code: string | null;
+  level: string | null;
   durationMinutes: number;
   questionCount: number;
   passPercent: number;
@@ -35,11 +38,15 @@ export interface TemaRevisar {
 
 export interface TentativaEstado {
   attemptId: string;
+  slug?: string | null;
+  simulado?: string | null;
+  passPercent?: number | null;
   submitted: boolean;
   expiresAt: string;
   remainingSeconds: number;
   score?: number;
   passed?: boolean;
+  elapsedSeconds?: number;
   temasARevisar?: TemaRevisar[];
   questions: QuestaoSimulado[];
 }

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1447,6 +1447,8 @@
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 16px;
+  /* start: expandir um card com "ler mais" não estica os vizinhos da linha. */
+  align-items: start;
 }
 .track {
   display: flex;
@@ -1506,7 +1508,35 @@
   font-size: 13px;
   line-height: 1.5;
   color: var(--muted);
-  min-height: 39px;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+  overflow: hidden;
+  min-height: 59px;
+}
+.track__desc--full {
+  -webkit-line-clamp: unset;
+  line-clamp: unset;
+  overflow: visible;
+}
+/* Linha reservada do "ler mais": mantém a altura uniforme mesmo quando não há botão. */
+.track__more-row {
+  min-height: 20px;
+  margin-top: 3px;
+}
+.track__more {
+  padding: 0;
+  border: none;
+  background: none;
+  font-family: inherit;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--accent);
+  cursor: pointer;
+}
+.track__more:hover {
+  text-decoration: underline;
 }
 .track__foot {
   display: flex;

--- a/frontend/src/styles/simulado.css
+++ b/frontend/src/styles/simulado.css
@@ -2,9 +2,14 @@
 
 /* ===================== SIMULADOS ===================== */
 .sim {
-  padding: 26px;
+  padding: 26px 28px 40px;
 }
 .sim__head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  flex-wrap: wrap;
   margin-bottom: 20px;
 }
 .sim__title {
@@ -20,9 +25,9 @@
 }
 .sim__grid {
   display: grid;
-  grid-template-columns: 1fr 336px;
-  gap: 24px;
-  align-items: start;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  align-items: stretch;
 }
 .sim__col {
   display: flex;
@@ -120,7 +125,7 @@
 }
 .sim-rules__grid {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
   gap: 14px;
   margin-top: 20px;
 }
@@ -1072,5 +1077,482 @@
   }
   .exam-nav__grid {
     grid-template-columns: repeat(5, 1fr);
+  }
+}
+
+/* ============ NOVA TELA DE SIMULADOS (grade + filtros) ============ */
+.sim__stats {
+  display: flex;
+  gap: 10px;
+  flex-shrink: 0;
+}
+.sim-stat {
+  min-width: 74px;
+  padding: 9px 16px;
+  text-align: center;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+}
+.sim-stat b {
+  display: block;
+  font-size: 20px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+.sim-stat span {
+  font-size: 11px;
+  color: var(--muted);
+}
+.sim__toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+.sim__search {
+  flex: 1;
+  min-width: 220px;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  height: 42px;
+  padding: 0 14px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  color: var(--muted);
+}
+.sim__search input {
+  flex: 1;
+  border: none;
+  background: none;
+  outline: none;
+  font-family: inherit;
+  font-size: 14px;
+  color: var(--text);
+}
+.sim__filters {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.sim-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  height: 42px;
+  padding: 0 16px;
+  border-radius: var(--r-lg);
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.sim-pill--active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+.sim-pill__n {
+  font-size: 11px;
+  opacity: 0.7;
+}
+.sim-pill--active .sim-pill__n {
+  opacity: 0.85;
+}
+.sim__count {
+  font-size: 12.5px;
+  color: var(--muted);
+  margin-bottom: 14px;
+}
+.simc {
+  display: flex;
+  flex-direction: column;
+  padding: 16px 18px 18px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-xl);
+}
+.simc__top {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+}
+.simc__logo {
+  width: 38px;
+  height: 38px;
+  flex-shrink: 0;
+  border-radius: var(--r-md);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 13px;
+  font-weight: 700;
+}
+.simc__id {
+  min-width: 0;
+  flex: 1;
+}
+.simc__vendor {
+  font-size: 11px;
+  color: var(--muted);
+}
+.simc__code {
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+.simc__level {
+  flex-shrink: 0;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 3px 9px;
+  border-radius: 99px;
+}
+.simc__level--fund {
+  color: var(--success);
+  background: color-mix(in srgb, var(--success) 14%, transparent);
+}
+.simc__level--assoc {
+  color: #b7791f;
+  background: color-mix(in srgb, #d69e2e 20%, transparent);
+}
+.simc__level--prof {
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+}
+.simc__name {
+  margin-top: 12px;
+  font-size: 14px;
+  font-weight: 600;
+}
+.simc__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 12px;
+  margin-top: 8px;
+  font-size: 12.5px;
+  color: var(--muted);
+}
+.simc__meta b {
+  color: var(--text);
+  font-weight: 700;
+}
+.simc__divider {
+  height: 1px;
+  background: var(--border);
+  margin: 14px 0;
+}
+.simc__status {
+  min-height: 34px;
+  margin-bottom: 12px;
+}
+.simc__status-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: 12.5px;
+  margin-bottom: 7px;
+}
+.simc__verdict {
+  font-weight: 700;
+}
+.simc__verdict--ok {
+  color: var(--success);
+}
+.simc__verdict--no {
+  color: var(--av-red);
+}
+.simc__best {
+  color: var(--muted);
+}
+.simc__bar {
+  height: 6px;
+  border-radius: 99px;
+  background: var(--surface-2);
+  overflow: hidden;
+}
+.simc__bar span {
+  display: block;
+  height: 100%;
+  border-radius: 99px;
+}
+.simc__bar--ok {
+  background: var(--success);
+}
+.simc__bar--no {
+  background: var(--av-red);
+}
+.simc__notstarted {
+  font-size: 12.5px;
+  color: var(--muted);
+}
+.simc__btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  height: 40px;
+  border-radius: var(--r-lg);
+  border: none;
+  background: var(--accent);
+  color: #fff;
+  font-family: inherit;
+  font-size: 13.5px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.simc__btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+.simc__btn--redo {
+  background: none;
+  border: 1px solid var(--border-strong);
+  color: var(--text);
+}
+.sim__footer {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  margin-top: 20px;
+  padding: 14px 18px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  font-size: 13px;
+  color: var(--muted);
+}
+.sim__footer b {
+  color: var(--text);
+}
+.sim__footer-icon {
+  flex-shrink: 0;
+  color: var(--accent);
+  margin-top: 1px;
+}
+@media (max-width: 1040px) {
+  .sim__grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+@media (max-width: 680px) {
+  .sim {
+    padding: 20px 16px 32px;
+  }
+  .sim__grid {
+    grid-template-columns: 1fr;
+  }
+  .sim__stats {
+    width: 100%;
+  }
+  .sim-stat {
+    flex: 1;
+  }
+}
+
+/* ============ BRIEFING DE UM SIMULADO ============ */
+.sim--brief {
+  /* usa a largura toda, como a lista */
+}
+.sim-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 16px;
+  padding: 6px 2px;
+  background: none;
+  border: none;
+  font-family: inherit;
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--muted);
+  cursor: pointer;
+}
+.sim-back:hover {
+  color: var(--text);
+}
+.sim-brief__head {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+.sim-brief__id {
+  flex: 1;
+  min-width: 0;
+}
+.sim-brief__code {
+  margin: 2px 0 0;
+  font-size: 24px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+.sim-brief__name {
+  font-size: 14px;
+  color: var(--muted);
+  margin-top: 2px;
+}
+.simc__logo--lg {
+  width: 52px;
+  height: 52px;
+  font-size: 16px;
+}
+.sim-brief__grid {
+  display: grid;
+  grid-template-columns: 1fr 360px;
+  gap: 18px;
+  align-items: start;
+}
+@media (max-width: 760px) {
+  .sim-brief__grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ============ MODAL DE CONFIRMAÇÃO ============ */
+.sim-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  background: rgba(0, 0, 0, 0.5);
+}
+.sim-modal__card {
+  width: 100%;
+  max-width: 420px;
+  padding: 26px;
+  border-radius: var(--r-xl);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  text-align: center;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.3);
+}
+.sim-modal__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  color: #b7791f;
+  background: color-mix(in srgb, var(--amber) 16%, transparent);
+}
+.sim-modal__title {
+  margin: 14px 0 0;
+  font-size: 18px;
+  font-weight: 700;
+}
+.sim-modal__text {
+  margin: 8px 0 0;
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--muted);
+}
+.sim-modal__text b {
+  color: var(--text);
+}
+.sim-modal__actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 22px;
+}
+.sim-modal__btn {
+  flex: 1;
+  height: 44px;
+  border-radius: var(--r-lg);
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.sim-modal__btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+.sim-modal__btn--ghost {
+  background: none;
+  border: 1px solid var(--border-strong);
+  color: var(--text);
+}
+.sim-modal__btn--primary {
+  border: none;
+  background: var(--accent);
+  color: #fff;
+}
+
+/* estados extras das tentativas: em andamento (wip) e cancelada */
+.sim-attempt__score--wip {
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+}
+.sim-attempt__score--cancel {
+  color: var(--muted);
+  background: var(--surface-2);
+}
+.sim-attempt__verdict--wip {
+  color: var(--accent);
+}
+.sim-attempt__verdict--cancel {
+  color: var(--muted);
+}
+.sim-attempt--off {
+  cursor: default;
+}
+
+/* ============ RESULTADO: grid próprio e botões novos ============ */
+.res-grid {
+  display: grid;
+  grid-template-columns: 1fr 340px;
+  gap: 18px;
+  align-items: start;
+  margin-top: 18px;
+}
+.res-more {
+  width: 100%;
+  margin-top: 14px;
+  padding: 12px;
+  border-radius: var(--r-lg);
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+  color: var(--text);
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.res-more:hover {
+  border-color: var(--border-strong);
+}
+.res-plan__ghost {
+  width: 100%;
+  height: 44px;
+  margin-top: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border-radius: var(--r-lg);
+  border: 1px solid var(--border-strong);
+  background: none;
+  color: var(--text);
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+@media (max-width: 900px) {
+  .res-grid {
+    grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Nova tela de simulados
- Lista em grade de cards agrupados por provedor (AWS, Azure, Google Cloud), com busca e filtros.
- Novos campos no simulado: provedor, código e nível (migration 0025). Os seeds existentes foram atualizados para preenchê-los.
- Tela de briefing por simulado com as regras, as últimas tentativas e um modal de confirmação antes de iniciar. O cronômetro só começa ali.
- Iniciar um simulado cancela qualquer tentativa em aberto, e clicar em uma tentativa em andamento pergunta antes de voltar.
- Tela de resultado reorganizada: desempenho por domínio, questões erradas com explicação, tempo gasto e plano de estudo.

## Conteúdo novo
- Trilha e simulado do DP-900 (Azure Data Fundamentals): 14 aulas e 106 questões.
- Trilha e simulado do AI-900 (Azure AI Fundamentals): 14 aulas e 106 questões, com a IA generativa como domínio de maior peso.

## Trilhas
- Descrição dos cards limitada a três linhas, com um ler mais que expande apenas o card clicado.

## Como testar
- Simulados: filtrar por provedor, abrir um simulado, ver o briefing e o modal, fazer e revisar.
- Trilhas: abrir AZURE DP-900 e AZURE AI-900.

## Deploy em produção
Depois de subir, aplicar a migration 0025 e rodar os seeds (idempotentes): seed-trilha-dp900, seed-dp-900, seed-trilha-ai900 e seed-ai-900. Reexecutar seed-aws-ccp e seed-az-900 para preencher provedor, código e nível dos simulados que já existem.
