### PR TITLE
Aba de conquistas, CRUD em abas e quiz com ordem aleatória

### DIFF
--- a/backend/src/services/lesson.service.ts
+++ b/backend/src/services/lesson.service.ts
@@ -104,25 +104,41 @@ export async function detalheDaAula(lessonId: string, userId: string) {
     const corretaPorQuestao = new Map<string, string>();
     for (const o of opts) if (o.isCorrect) corretaPorQuestao.set(o.questionId, o.id);
 
-    const questoes = qs.map((q) => {
-        const r = respostaPorQuestao.get(q.id);
-        return {
-            id: q.id,
-            statement: q.statement,
-            position: q.position,
-            options: opts
-                .filter((o) => o.questionId === q.id)
-                .map((o) => ({ id: o.id, text: o.text, position: o.position })),
-            // O gabarito só é revelado nas questões que o usuário já respondeu.
-            answer: r
-                ? {
-                      selectedOptionId: r.selectedOptionId,
-                      isCorrect: r.isCorrect,
-                      correctOptionId: corretaPorQuestao.get(q.id) ?? null,
-                  }
-                : null,
-        };
-    });
+    // Embaralha questões e alternativas para a correta não cair sempre em "A". A
+    // correção é por id da opção, então a ordem não muda o resultado; a position é
+    // renumerada para a nova ordem.
+    const embaralhar = <T>(arr: T[]): T[] => {
+        const a = [...arr];
+        for (let i = a.length - 1; i > 0; i--) {
+            const j = Math.floor(Math.random() * (i + 1));
+            [a[i], a[j]] = [a[j], a[i]];
+        }
+        return a;
+    };
+
+    const questoes = embaralhar(
+        qs.map((q) => {
+            const r = respostaPorQuestao.get(q.id);
+            return {
+                id: q.id,
+                statement: q.statement,
+                position: q.position,
+                options: embaralhar(opts.filter((o) => o.questionId === q.id)).map((o, i) => ({
+                    id: o.id,
+                    text: o.text,
+                    position: i + 1,
+                })),
+                // O gabarito só é revelado nas questões que o usuário já respondeu.
+                answer: r
+                    ? {
+                          selectedOptionId: r.selectedOptionId,
+                          isCorrect: r.isCorrect,
+                          correctOptionId: corretaPorQuestao.get(q.id) ?? null,
+                      }
+                    : null,
+            };
+        }),
+    ).map((q, i) => ({ ...q, position: i + 1 }));
 
     return {
         id: aula.id,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import { Configuracoes } from './pages/Configuracoes';
 import { Perfil } from './pages/Perfil';
 import { Ranking } from './pages/Ranking';
 import { Simulados } from './pages/Simulados';
+import { Conquistas } from './pages/Conquistas';
 import { SimuladoBriefing } from './pages/Simulados/Briefing';
 import { TentativaSimulado } from './pages/Simulados/Tentativa';
 import { SimuladosAdmin } from './pages/SimuladosAdmin';
@@ -148,6 +149,14 @@ function AppRoutes() {
         element={
           <PrivateRoute>
             <Simulados />
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/conquistas"
+        element={
+          <PrivateRoute>
+            <Conquistas />
           </PrivateRoute>
         }
       />

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,4 +2,5 @@
 @import './styles/tokens.css';
 @import './styles/app.css';
 @import './styles/simulado.css';
+@import './styles/conquistas.css';
 @import './styles/desafio.css';

--- a/frontend/src/pages/Configuracoes/index.tsx
+++ b/frontend/src/pages/Configuracoes/index.tsx
@@ -397,7 +397,14 @@ function ConquistasAdmin() {
   );
 }
 
+const ABAS_CFG = [
+  { key: 'tags', label: 'Tags' },
+  { key: 'linguagens', label: 'Linguagens' },
+  { key: 'conquistas', label: 'Conquistas' },
+] as const;
+
 export function Configuracoes() {
+  const [aba, setAba] = useState<(typeof ABAS_CFG)[number]['key']>('tags');
   return (
     <div className="home">
       <header className="topbar studio__bar">
@@ -416,33 +423,49 @@ export function Configuracoes() {
       </header>
 
       <div className="estudio-home">
-        <CrudList
-          titulo="Tags"
-          descricao="Categorias para filtrar as trilhas (ex.: Fundamentos, Linguagens, Algoritmos). Você atribui as tags ao criar ou editar uma trilha no Estúdio."
-          placeholder="Nome da nova tag"
-          confirmarExclusao={(t) =>
-            `Excluir a tag "${t.name}"? Ela será removida das trilhas que a usam.`
-          }
-          carregar={listarTags}
-          criar={criarTag}
-          atualizar={atualizarTag}
-          excluir={excluirTag}
-        />
+        <div className="cfg-tabs">
+          {ABAS_CFG.map((a) => (
+            <button
+              key={a.key}
+              className={`cfg-tab${aba === a.key ? ' cfg-tab--active' : ''}`}
+              onClick={() => setAba(a.key)}
+            >
+              {a.label}
+            </button>
+          ))}
+        </div>
 
-        <CrudList
-          titulo="Linguagens"
-          descricao="Conjunto fixo de linguagens que aparecem no perfil. Padronizar evita variações como JS, Javascript e javascript, mantendo os dados limpos para análises."
-          placeholder="Nome da nova linguagem"
-          confirmarExclusao={(l) =>
-            `Excluir a linguagem "${l.name}"? Ela será removida dos perfis que a usam.`
-          }
-          carregar={listarLinguagens}
-          criar={criarLinguagem}
-          atualizar={atualizarLinguagem}
-          excluir={excluirLinguagem}
-        />
+        {aba === 'tags' && (
+          <CrudList
+            titulo="Tags"
+            descricao="Categorias para filtrar as trilhas (ex.: Fundamentos, Linguagens, Algoritmos). Você atribui as tags ao criar ou editar uma trilha no Estúdio."
+            placeholder="Nome da nova tag"
+            confirmarExclusao={(t) =>
+              `Excluir a tag "${t.name}"? Ela será removida das trilhas que a usam.`
+            }
+            carregar={listarTags}
+            criar={criarTag}
+            atualizar={atualizarTag}
+            excluir={excluirTag}
+          />
+        )}
 
-        <ConquistasAdmin />
+        {aba === 'linguagens' && (
+          <CrudList
+            titulo="Linguagens"
+            descricao="Conjunto fixo de linguagens que aparecem no perfil. Padronizar evita variações como JS, Javascript e javascript, mantendo os dados limpos para análises."
+            placeholder="Nome da nova linguagem"
+            confirmarExclusao={(l) =>
+              `Excluir a linguagem "${l.name}"? Ela será removida dos perfis que a usam.`
+            }
+            carregar={listarLinguagens}
+            criar={criarLinguagem}
+            atualizar={atualizarLinguagem}
+            excluir={excluirLinguagem}
+          />
+        )}
+
+        {aba === 'conquistas' && <ConquistasAdmin />}
       </div>
     </div>
   );

--- a/frontend/src/pages/Conquistas/index.tsx
+++ b/frontend/src/pages/Conquistas/index.tsx
@@ -1,0 +1,246 @@
+import { useMemo, type CSSProperties } from 'react';
+import { useRequisicao } from '../../hooks/useRequisicao';
+import { SimTopbar } from '../Simulados/SimTopbar';
+import { BookOpen, Trophy, Lock, Check, IconeConquista } from '../../components/Icons';
+import { listarTrilhas, obterMinhasConquistas } from '../../services/trails';
+import { listarSimulados, historicoSimulados } from '../../services/simulados';
+import { provedorDe, nomeLimpo } from '../Simulados/provedores';
+
+// Um selo por faixa, ganho de forma cumulativa (85% acende bronze e prata).
+const TIERS = [
+  { key: 'bronze', label: 'Bronze', min: 70, cor: '#c0803f', faixa: '70-79%' },
+  { key: 'prata', label: 'Prata', min: 80, cor: '#8b95a7', faixa: '80-89%' },
+  { key: 'ouro', label: 'Ouro', min: 90, cor: '#d3a533', faixa: '90-99%' },
+  { key: 'diamante', label: 'Diamante', min: 100, cor: '#3bbdf5', faixa: '100%' },
+];
+
+function corVar(cor: string): CSSProperties {
+  return { ['--cor' as string]: cor } as CSSProperties;
+}
+
+export function Conquistas() {
+  const { dados, carregando } = useRequisicao(
+    () =>
+      Promise.all([
+        listarTrilhas(),
+        listarSimulados(),
+        historicoSimulados(),
+        obterMinhasConquistas(),
+      ]).then(([trilhas, simulados, historico, catalogo]) => ({
+        trilhas,
+        simulados,
+        historico,
+        catalogo,
+      })),
+    [],
+  );
+  const trilhas = dados?.trilhas ?? [];
+  const simulados = dados?.simulados ?? [];
+  const historico = dados?.historico ?? [];
+  const catalogo = dados?.catalogo ?? [];
+
+  const melhorPorSlug = useMemo(() => {
+    const m: Record<string, number> = {};
+    for (const t of historico) {
+      if (t.submittedAt == null || t.score == null) continue;
+      m[t.slug] = Math.max(m[t.slug] ?? 0, t.score);
+    }
+    return m;
+  }, [historico]);
+
+  const trilhasConcluidas = trilhas.filter((t) => t.lessons > 0 && t.done >= t.lessons).length;
+  const medalhas = simulados.reduce((acc, s) => {
+    const best = melhorPorSlug[s.slug] ?? 0;
+    return acc + TIERS.filter((tier) => best >= tier.min).length;
+  }, 0);
+  const especiaisGanhas = catalogo.filter((c) => c.earned).length;
+  const conquistadas = trilhasConcluidas + medalhas + especiaisGanhas;
+  const total = trilhas.length + simulados.length * TIERS.length + catalogo.length;
+
+  return (
+    <div className="home-shell">
+      <div className="home">
+        <SimTopbar active="/conquistas" />
+        <div className="conq">
+          <div className="conq__head">
+            <div>
+              <h1 className="conq__title">Conquistas</h1>
+              <p className="conq__sub">
+                Colecione selos concluindo trilhas e sendo aprovado nos simulados. Quanto maior a
+                nota, mais raro o selo.
+              </p>
+            </div>
+            <div className="conq__stats">
+              <div className="conq-stat">
+                <b>{conquistadas}</b>
+                <span>conquistadas</span>
+              </div>
+              <div className="conq-stat">
+                <b>{total}</b>
+                <span>no total</span>
+              </div>
+            </div>
+          </div>
+
+          {carregando ? (
+            <p className="sim-empty">Carregando conquistas...</p>
+          ) : (
+            <>
+              <div className="conq-sec">
+                <span className="conq-sec__icon">
+                  <BookOpen size={16} />
+                </span>
+                <span className="conq-sec__title">Conclusão de trilha</span>
+                <span className="conq-sec__hint">selo ao completar 100% de uma trilha</span>
+              </div>
+              {trilhas.length === 0 ? (
+                <p className="sim-empty">Nenhuma trilha disponível ainda.</p>
+              ) : (
+                <div className="conq-trilhas">
+                  {trilhas.map((t) => {
+                    const feito = t.lessons > 0 && t.done >= t.lessons;
+                    const status = feito
+                      ? 'Concluída'
+                      : t.done === 0
+                        ? 'não iniciada'
+                        : `${t.done}/${t.lessons} aulas`;
+                    return (
+                      <div key={t.id} className="conq-badge">
+                        <span
+                          className={`hex${feito ? '' : ' hex--locked'}`}
+                          style={feito ? corVar(t.hue) : undefined}
+                        >
+                          <span className="hex__in">
+                            {feito ? (
+                              <>
+                                <small>TRILHA</small>
+                                <b>{t.glyph}</b>
+                              </>
+                            ) : (
+                              <Lock size={20} />
+                            )}
+                          </span>
+                        </span>
+                        <div className="conq-badge__name">{t.name}</div>
+                        <div
+                          className={`conq-badge__status${feito ? ' conq-badge__status--done' : ''}`}
+                        >
+                          {status}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+
+              <div className="conq-sec">
+                <span className="conq-sec__icon">
+                  <Trophy size={15} />
+                </span>
+                <span className="conq-sec__title">Aprovação em simulado</span>
+                <span className="conq-sec__hint">selo pela sua melhor nota em cada exame</span>
+              </div>
+              <div className="conq-legend">
+                {TIERS.map((tier) => (
+                  <span key={tier.key} className="conq-legend__item">
+                    <span
+                      className="conq-legend__dot"
+                      style={{ borderColor: tier.cor, color: tier.cor }}
+                    >
+                      {tier.min}
+                    </span>
+                    <b>{tier.label}</b> {tier.faixa}
+                  </span>
+                ))}
+              </div>
+              {simulados.length === 0 ? (
+                <p className="sim-empty">Nenhum simulado disponível ainda.</p>
+              ) : (
+                <div className="conq-sims">
+                  {simulados.map((s) => {
+                    const best = melhorPorSlug[s.slug] ?? 0;
+                    const p = provedorDe(s.provider);
+                    return (
+                      <div key={s.slug} className="conq-sim">
+                        <div className="conq-sim__id">
+                          <span className="conq-sim__logo" style={{ background: p.cor }}>
+                            {p.sigla}
+                          </span>
+                          <div>
+                            <div className="conq-sim__code">{s.code ?? s.name}</div>
+                            <div className="conq-sim__name">{nomeLimpo(s.name, s.code)}</div>
+                          </div>
+                        </div>
+                        <div className="conq-sim__medals">
+                          {TIERS.map((tier) => {
+                            const ganho = best >= tier.min;
+                            return (
+                              <div key={tier.key} className="conq-medal">
+                                <span
+                                  className={`hex hex--sm${ganho ? '' : ' hex--locked'}`}
+                                  style={ganho ? corVar(tier.cor) : undefined}
+                                >
+                                  <span className="hex__in">
+                                    {ganho ? (
+                                      <>
+                                        <small>{p.label.toUpperCase()}</small>
+                                        <b>{tier.min}%</b>
+                                      </>
+                                    ) : (
+                                      <Lock size={15} />
+                                    )}
+                                  </span>
+                                </span>
+                                <span
+                                  className={`conq-medal__label${ganho ? '' : ' conq-medal__label--off'}`}
+                                >
+                                  {tier.label}
+                                </span>
+                              </div>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+
+              {catalogo.length > 0 && (
+                <>
+                  <div className="conq-sec">
+                    <span className="conq-sec__icon">
+                      <IconeConquista chave="trophy" size={16} />
+                    </span>
+                    <span className="conq-sec__title">Conquistas especiais</span>
+                    <span className="conq-sec__hint">
+                      desbloqueadas pelo seu progresso de estudo
+                    </span>
+                  </div>
+                  <div className="conq-catalog">
+                    {catalogo.map((c) => (
+                      <div key={c.id} className={`conq-cat${c.earned ? '' : ' conq-cat--off'}`}>
+                        <span className="conq-cat__icon">
+                          <IconeConquista chave={c.icon} size={22} />
+                        </span>
+                        <div className="conq-cat__body">
+                          <div className="conq-cat__name">{c.name}</div>
+                          <div className="conq-cat__desc">{c.description}</div>
+                        </div>
+                        {c.earned && (
+                          <span className="conq-cat__check">
+                            <Check size={13} />
+                          </span>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -56,6 +56,7 @@ const NAV = [
   { label: 'Trilhas', to: '/trilhas' },
   { label: 'Simulados', to: '/simulados' },
   { label: 'Desafios', to: '/desafios' },
+  { label: 'Conquistas', to: '/conquistas' },
   { label: 'Ranking', to: '/ranking' },
   { label: 'Comunidade', to: '/comunidade' },
 ];

--- a/frontend/src/pages/Simulados/SimTopbar.tsx
+++ b/frontend/src/pages/Simulados/SimTopbar.tsx
@@ -12,11 +12,12 @@ const NAV = [
   { label: 'Início', to: '/home' },
   { label: 'Trilhas', to: '/trilhas' },
   { label: 'Simulados', to: '/simulados' },
+  { label: 'Conquistas', to: '/conquistas' },
   { label: 'Ranking', to: '/ranking' },
   { label: 'Comunidade', to: '/comunidade' },
 ];
 
-export function SimTopbar() {
+export function SimTopbar({ active = '/simulados' }: { active?: string }) {
   const { user: authUser } = useAuth();
   const displayName = authUser?.name ?? homeUser.name;
 
@@ -29,7 +30,7 @@ export function SimTopbar() {
           <Link
             key={item.to}
             to={item.to}
-            className={`nav__item${item.to === '/simulados' ? ' nav__item--active' : ''}`}
+            className={`nav__item${item.to === active ? ' nav__item--active' : ''}`}
           >
             {item.label}
           </Link>

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -4379,3 +4379,30 @@
   font-size: 12.5px;
   color: var(--muted);
 }
+
+/* Abas do Configurações (Tags / Linguagens / Conquistas) */
+.cfg-tabs {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 28px;
+  border-bottom: 1px solid var(--border);
+}
+.cfg-tab {
+  padding: 10px 18px;
+  margin-bottom: -1px;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--muted);
+  cursor: pointer;
+}
+.cfg-tab:hover {
+  color: var(--text);
+}
+.cfg-tab--active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}

--- a/frontend/src/styles/conquistas.css
+++ b/frontend/src/styles/conquistas.css
@@ -1,0 +1,320 @@
+/* ensina.dev — estilos da aba de Conquistas. Depende de tokens.css. */
+
+.conq {
+  padding: 26px 28px 40px;
+}
+.conq__head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  flex-wrap: wrap;
+  margin-bottom: 22px;
+}
+.conq__title {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+.conq__sub {
+  margin: 4px 0 0;
+  max-width: 640px;
+  font-size: 14px;
+  color: var(--muted);
+}
+.conq__stats {
+  display: flex;
+  gap: 10px;
+  flex-shrink: 0;
+}
+.conq-stat {
+  min-width: 88px;
+  padding: 10px 18px;
+  text-align: center;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+}
+.conq-stat b {
+  display: block;
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+.conq-stat span {
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.conq-sec {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 26px 0 16px;
+}
+.conq-sec__icon {
+  display: inline-flex;
+  width: 30px;
+  height: 30px;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--r-md);
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+}
+.conq-sec__title {
+  font-size: 16px;
+  font-weight: 700;
+}
+.conq-sec__hint {
+  font-size: 12.5px;
+  color: var(--muted);
+}
+
+/* Grade de selos de trilha */
+.conq-trilhas {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 14px;
+}
+.conq-badge {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 9px;
+  padding: 20px 12px;
+  text-align: center;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-xl);
+}
+.conq-badge__name {
+  font-size: 13.5px;
+  font-weight: 600;
+}
+.conq-badge__status {
+  font-size: 12px;
+  color: var(--muted);
+}
+.conq-badge__status--done {
+  color: var(--success);
+  font-weight: 600;
+}
+
+/* Hexágono (selo) */
+.hex {
+  --cor: #9aa4b2;
+  width: 84px;
+  height: 92px;
+  display: grid;
+  place-items: center;
+  clip-path: polygon(50% 0, 100% 25%, 100% 75%, 50% 100%, 0 75%, 0 25%);
+  background: var(--cor);
+}
+.hex--sm {
+  width: 62px;
+  height: 68px;
+}
+.hex--locked {
+  background: var(--border-strong);
+}
+.hex__in {
+  width: 87%;
+  height: 87%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1px;
+  clip-path: polygon(50% 0, 100% 25%, 100% 75%, 50% 100%, 0 75%, 0 25%);
+  background: #10192b;
+  color: var(--cor);
+}
+.hex--locked .hex__in {
+  background: var(--surface-2);
+  color: var(--muted);
+}
+.hex__in small {
+  font-size: 8px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  opacity: 0.85;
+}
+.hex__in b {
+  font-size: 17px;
+  font-weight: 700;
+}
+.hex--sm .hex__in b {
+  font-size: 14px;
+}
+.hex--sm .hex__in small {
+  font-size: 7px;
+}
+
+/* Legenda das faixas */
+.conq-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-bottom: 14px;
+  font-size: 12.5px;
+  color: var(--muted);
+}
+.conq-legend__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.conq-legend__item b {
+  color: var(--text);
+}
+.conq-legend__dot {
+  display: inline-flex;
+  width: 21px;
+  height: 21px;
+  align-items: center;
+  justify-content: center;
+  border: 1.5px solid;
+  border-radius: 50%;
+  font-size: 9px;
+  font-weight: 700;
+}
+
+/* Linhas por simulado */
+.conq-sims {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.conq-sim {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  padding: 16px 22px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-xl);
+}
+.conq-sim__id {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.conq-sim__logo {
+  width: 40px;
+  height: 40px;
+  flex-shrink: 0;
+  border-radius: var(--r-md);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 13px;
+  font-weight: 700;
+}
+.conq-sim__code {
+  font-size: 15px;
+  font-weight: 700;
+}
+.conq-sim__name {
+  font-size: 12.5px;
+  color: var(--muted);
+}
+.conq-sim__medals {
+  display: flex;
+  gap: 18px;
+}
+.conq-medal {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+.conq-medal__label {
+  font-size: 11px;
+  font-weight: 600;
+}
+.conq-medal__label--off {
+  color: var(--muted);
+  font-weight: 400;
+}
+
+/* Catálogo (conquistas especiais) */
+.conq-catalog {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+}
+.conq-cat {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 16px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+}
+.conq-cat--off {
+  opacity: 0.55;
+}
+.conq-cat__icon {
+  display: inline-flex;
+  width: 42px;
+  height: 42px;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+}
+.conq-cat--off .conq-cat__icon {
+  color: var(--muted);
+  background: var(--surface-2);
+}
+.conq-cat__body {
+  flex: 1;
+  min-width: 0;
+}
+.conq-cat__name {
+  font-size: 14px;
+  font-weight: 600;
+}
+.conq-cat__desc {
+  font-size: 12.5px;
+  color: var(--muted);
+}
+.conq-cat__check {
+  display: inline-flex;
+  width: 22px;
+  height: 22px;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: var(--success);
+  color: #fff;
+}
+
+@media (max-width: 1000px) {
+  .conq-trilhas {
+    grid-template-columns: repeat(3, 1fr);
+  }
+  .conq-catalog {
+    grid-template-columns: 1fr;
+  }
+}
+@media (max-width: 640px) {
+  .conq {
+    padding: 20px 16px 32px;
+  }
+  .conq-trilhas {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .conq-sim__medals {
+    gap: 12px;
+  }
+}


### PR DESCRIPTION
## Aba de conquistas do usuário
Nova aba em /conquistas, montada a partir dos dados que já existem:
- Selo de conclusão para cada trilha (colorido ao chegar a 100%, cinza com o progresso caso contrário).
- Selos Bronze, Prata, Ouro e Diamante para cada simulado, pela melhor nota (cumulativos: 85% acende bronze e prata).
- Seção de conquistas especiais vinda do catálogo (xp, aulas e acertos).

## Configurações em abas
Tags, linguagens e conquistas, que ficavam empilhados numa página só, agora estão em abas separadas.

## Quiz das trilhas com ordem aleatória
Ao servir uma aula, a ordem das questões e das alternativas é embaralhada e a posição é renumerada, para a resposta certa não cair sempre na mesma posição. A correção usa o id da opção, então nada quebra. A edição no estúdio mantém a ordem original.

## Como testar
- /conquistas: os selos de trilha e as medalhas por simulado.
- Abra uma aula de trilha e recarregue o quiz: a ordem vem embaralhada.
- /configuracoes: as três abas.
