### PR TITLE
Badges das conquistas, navegação centralizada e correção dos testes

### DIFF
--- a/backend/tests/trail.test.ts
+++ b/backend/tests/trail.test.ts
@@ -102,7 +102,7 @@ async function responderQuiz(token: string, lessonId: string, acertos: number) {
     if (aula.status !== 200) return aula;
     const answers = aula.body.questions.map((q: any, idx: number) => ({
         questionId: q.id,
-        optionId: q.options.find((o: any) => o.position === (idx < acertos ? 2 : 1)).id,
+        optionId: q.options.find((o: any) => o.text === (idx < acertos ? "certa" : "errada")).id,
     }));
     return post(`/lessons/${lessonId}/quiz`, token, { answers });
 }

--- a/frontend/src/components/MobileMenu.tsx
+++ b/frontend/src/components/MobileMenu.tsx
@@ -3,14 +3,7 @@ import { Link, useLocation } from 'react-router-dom';
 import { Logo } from './Logo';
 import { X } from './Icons';
 
-const NAV = [
-  { label: 'Início', to: '/home' },
-  { label: 'Trilhas', to: '/trilhas' },
-  { label: 'Simulados', to: '/simulados' },
-  { label: 'Desafios', to: '/desafios' },
-  { label: 'Ranking', to: '/ranking' },
-  { label: 'Comunidade', to: '/comunidade' },
-];
+import { NAV_PRINCIPAL as NAV } from '../data/nav';
 
 // Hambúrguer + drawer lateral, visíveis só no telefone (controlados por CSS).
 export function MobileMenu() {

--- a/frontend/src/data/nav.ts
+++ b/frontend/src/data/nav.ts
@@ -1,0 +1,10 @@
+// Itens da navegação principal, compartilhados por todas as abas para não divergirem.
+export const NAV_PRINCIPAL = [
+  { label: 'Início', to: '/home' },
+  { label: 'Trilhas', to: '/trilhas' },
+  { label: 'Simulados', to: '/simulados' },
+  { label: 'Desafios', to: '/desafios' },
+  { label: 'Conquistas', to: '/conquistas' },
+  { label: 'Ranking', to: '/ranking' },
+  { label: 'Comunidade', to: '/comunidade' },
+];

--- a/frontend/src/pages/Aula/index.tsx
+++ b/frontend/src/pages/Aula/index.tsx
@@ -22,13 +22,7 @@ import remarkGfm from 'remark-gfm';
 import { statusErro } from '../../utils/erro';
 import { BlocosConteudo, md } from '../../components/BlocosConteudo';
 
-const NAV = [
-  { label: 'Início', to: '/home' },
-  { label: 'Trilhas', to: '/trilhas' },
-  { label: 'Desafios', to: '/desafios' },
-  { label: 'Ranking', to: '/ranking' },
-  { label: 'Comunidade', to: '/comunidade' },
-];
+import { NAV_PRINCIPAL as NAV } from '../../data/nav';
 
 export function Aula() {
   const { trailId, lessonId } = useParams();

--- a/frontend/src/pages/Conquistas/index.tsx
+++ b/frontend/src/pages/Conquistas/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type CSSProperties } from 'react';
+import { useMemo, type ReactNode } from 'react';
 import { useRequisicao } from '../../hooks/useRequisicao';
 import { SimTopbar } from '../Simulados/SimTopbar';
 import { BookOpen, Trophy, Lock, Check, IconeConquista } from '../../components/Icons';
@@ -8,14 +8,48 @@ import { provedorDe, nomeLimpo } from '../Simulados/provedores';
 
 // Um selo por faixa, ganho de forma cumulativa (85% acende bronze e prata).
 const TIERS = [
-  { key: 'bronze', label: 'Bronze', min: 70, cor: '#c0803f', faixa: '70-79%' },
-  { key: 'prata', label: 'Prata', min: 80, cor: '#8b95a7', faixa: '80-89%' },
-  { key: 'ouro', label: 'Ouro', min: 90, cor: '#d3a533', faixa: '90-99%' },
-  { key: 'diamante', label: 'Diamante', min: 100, cor: '#3bbdf5', faixa: '100%' },
+  { key: 'bronze', label: 'Bronze', min: 70, cor: '#c77b3b', faixa: '70-79%' },
+  { key: 'prata', label: 'Prata', min: 80, cor: '#a9aeb8', faixa: '80-89%' },
+  { key: 'ouro', label: 'Ouro', min: 90, cor: '#e0a82e', faixa: '90-99%' },
+  { key: 'diamante', label: 'Diamante', min: 100, cor: '#56c5e8', faixa: '100%' },
 ];
 
-function corVar(cor: string): CSSProperties {
-  return { ['--cor' as string]: cor } as CSSProperties;
+// Selo hexagonal: placa escura com borda colorida quando ganho, ou placa apagada
+// com cadeado quando bloqueado.
+function BadgeHex({
+  ganho,
+  cor,
+  sm,
+  children,
+}: {
+  ganho: boolean;
+  cor?: string;
+  sm?: boolean;
+  children?: ReactNode;
+}) {
+  return (
+    <div className={`badge__hex${sm ? ' badge__hex--sm' : ''}`}>
+      <svg className="badge__svg" viewBox="0 0 112 126">
+        <path
+          d="M56 5 L106 34 L106 92 L56 121 L6 92 L6 34 Z"
+          strokeWidth="5"
+          strokeLinejoin="round"
+          style={
+            ganho
+              ? { fill: '#232f3e', stroke: cor }
+              : { fill: 'var(--surface-2)', stroke: 'var(--border-strong)' }
+          }
+        />
+      </svg>
+      {ganho ? (
+        <div className="badge__content">{children}</div>
+      ) : (
+        <div className="badge__lock">
+          <Lock size={sm ? 17 : 21} />
+        </div>
+      )}
+    </div>
+  );
 }
 
 export function Conquistas() {
@@ -106,25 +140,14 @@ export function Conquistas() {
                         : `${t.done}/${t.lessons} aulas`;
                     return (
                       <div key={t.id} className="conq-badge">
-                        <span
-                          className={`hex${feito ? '' : ' hex--locked'}`}
-                          style={feito ? corVar(t.hue) : undefined}
-                        >
-                          <span className="hex__in">
-                            {feito ? (
-                              <>
-                                <small>TRILHA</small>
-                                <b>{t.glyph}</b>
-                              </>
-                            ) : (
-                              <Lock size={20} />
-                            )}
+                        <BadgeHex ganho={feito} cor={t.hue}>
+                          <span className="badge__vendor">TRILHA</span>
+                          <span className="badge__glyph" style={{ color: t.hue }}>
+                            {t.glyph}
                           </span>
-                        </span>
-                        <div className="conq-badge__name">{t.name}</div>
-                        <div
-                          className={`conq-badge__status${feito ? ' conq-badge__status--done' : ''}`}
-                        >
+                        </BadgeHex>
+                        <div className="badge__name">{t.name}</div>
+                        <div className={`badge__sub${feito ? ' badge__sub--done' : ''}`}>
                           {status}
                         </div>
                       </div>
@@ -176,26 +199,18 @@ export function Conquistas() {
                             const ganho = best >= tier.min;
                             return (
                               <div key={tier.key} className="conq-medal">
-                                <span
-                                  className={`hex hex--sm${ganho ? '' : ' hex--locked'}`}
-                                  style={ganho ? corVar(tier.cor) : undefined}
-                                >
-                                  <span className="hex__in">
-                                    {ganho ? (
-                                      <>
-                                        <small>{p.label.toUpperCase()}</small>
-                                        <b>{tier.min}%</b>
-                                      </>
-                                    ) : (
-                                      <Lock size={15} />
-                                    )}
+                                <BadgeHex ganho={ganho} cor={tier.cor} sm>
+                                  <span className="badge__vendor">{p.label.toUpperCase()}</span>
+                                  <span className="badge__score" style={{ color: tier.cor }}>
+                                    {tier.min}%
                                   </span>
-                                </span>
-                                <span
-                                  className={`conq-medal__label${ganho ? '' : ' conq-medal__label--off'}`}
+                                </BadgeHex>
+                                <div
+                                  className="badge__name"
+                                  style={ganho ? { color: tier.cor } : undefined}
                                 >
                                   {tier.label}
-                                </span>
+                                </div>
                               </div>
                             );
                           })}

--- a/frontend/src/pages/Desafios/DesTopbar.tsx
+++ b/frontend/src/pages/Desafios/DesTopbar.tsx
@@ -8,14 +8,7 @@ import { Flame } from '../../components/Icons';
 import { getInitials } from '../../utils/initials';
 import { user as homeUser } from '../../data/home';
 
-const NAV = [
-  { label: 'Início', to: '/home' },
-  { label: 'Trilhas', to: '/trilhas' },
-  { label: 'Simulados', to: '/simulados' },
-  { label: 'Desafios', to: '/desafios' },
-  { label: 'Ranking', to: '/ranking' },
-  { label: 'Comunidade', to: '/comunidade' },
-];
+import { NAV_PRINCIPAL as NAV } from '../../data/nav';
 
 export function DesTopbar() {
   const { user: authUser } = useAuth();

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -23,6 +23,7 @@ import {
 } from '../../services/trails';
 import { getDesafioDoDia, type DesafioDetalhe } from '../../services/desafios';
 import type { Trail } from '../../data/trails';
+import { NAV_PRINCIPAL as NAV } from '../../data/nav';
 
 const DIF_LABEL: Record<string, string> = { facil: 'Fácil', medio: 'Médio', dificil: 'Difícil' };
 
@@ -50,16 +51,6 @@ function dataPorExtenso(): string {
   });
   return s.charAt(0).toUpperCase() + s.slice(1);
 }
-
-const NAV = [
-  { label: 'Início', to: '/home' },
-  { label: 'Trilhas', to: '/trilhas' },
-  { label: 'Simulados', to: '/simulados' },
-  { label: 'Desafios', to: '/desafios' },
-  { label: 'Conquistas', to: '/conquistas' },
-  { label: 'Ranking', to: '/ranking' },
-  { label: 'Comunidade', to: '/comunidade' },
-];
 
 const CORES_FEED = ['#2D6BF5', '#E0655A', '#3DAE6B', '#E0A82E', '#8B5CF6'];
 

--- a/frontend/src/pages/Perfil/index.tsx
+++ b/frontend/src/pages/Perfil/index.tsx
@@ -45,13 +45,7 @@ import {
 } from '../../services/trails';
 import { urlImagem } from '../../utils/urlImagem';
 
-const NAV = [
-  { label: 'Início', to: '/home' },
-  { label: 'Trilhas', to: '/trilhas' },
-  { label: 'Desafios', to: '/desafios' },
-  { label: 'Ranking', to: '/ranking' },
-  { label: 'Comunidade', to: '/comunidade' },
-];
+import { NAV_PRINCIPAL as NAV } from '../../data/nav';
 
 // Só carrega o recortador quando o usuário vai trocar foto ou capa.
 const ImageCropper = lazy(() => import('../../components/ImageCropper'));

--- a/frontend/src/pages/Ranking/index.tsx
+++ b/frontend/src/pages/Ranking/index.tsx
@@ -12,14 +12,7 @@ import { getInitials } from '../../utils/initials';
 import { user as homeUser } from '../../data/home';
 import { obterRanking, type RankingResposta, type RankingPeriodo } from '../../services/trails';
 
-const NAV = [
-  { label: 'Início', to: '/home' },
-  { label: 'Trilhas', to: '/trilhas' },
-  { label: 'Simulados', to: '/simulados' },
-  { label: 'Desafios', to: '/desafios' },
-  { label: 'Ranking', to: '/ranking' },
-  { label: 'Comunidade', to: '/comunidade' },
-];
+import { NAV_PRINCIPAL as NAV } from '../../data/nav';
 const CORES = ['#5B8DEF', '#E0655A', '#2E9E6B', '#E0A82E', '#8B5CF6'];
 const MEDAL: Record<number, string> = { 1: 'var(--gold)', 2: 'var(--silver)', 3: 'var(--bronze)' };
 const PODIO: Record<number, { size: number; font: number; pedestal: number }> = {

--- a/frontend/src/pages/Simulados/SimTopbar.tsx
+++ b/frontend/src/pages/Simulados/SimTopbar.tsx
@@ -8,14 +8,7 @@ import { Flame } from '../../components/Icons';
 import { getInitials } from '../../utils/initials';
 import { user as homeUser } from '../../data/home';
 
-const NAV = [
-  { label: 'Início', to: '/home' },
-  { label: 'Trilhas', to: '/trilhas' },
-  { label: 'Simulados', to: '/simulados' },
-  { label: 'Conquistas', to: '/conquistas' },
-  { label: 'Ranking', to: '/ranking' },
-  { label: 'Comunidade', to: '/comunidade' },
-];
+import { NAV_PRINCIPAL as NAV } from '../../data/nav';
 
 export function SimTopbar({ active = '/simulados' }: { active?: string }) {
   const { user: authUser } = useAuth();

--- a/frontend/src/pages/Trilhas/index.tsx
+++ b/frontend/src/pages/Trilhas/index.tsx
@@ -21,14 +21,7 @@ import {
 
 type TrailComId = Trail & { id: string };
 
-const NAV = [
-  { label: 'Início', to: '/home' },
-  { label: 'Trilhas', to: '/trilhas' },
-  { label: 'Simulados', to: '/simulados' },
-  { label: 'Desafios', to: '/desafios' },
-  { label: 'Ranking', to: '/ranking' },
-  { label: 'Comunidade', to: '/comunidade' },
-];
+import { NAV_PRINCIPAL as NAV } from '../../data/nav';
 
 type Tint = { fg: string; bg: string };
 

--- a/frontend/src/styles/conquistas.css
+++ b/frontend/src/styles/conquistas.css
@@ -72,6 +72,76 @@
   color: var(--muted);
 }
 
+/* ===== Selo hexagonal (SVG) ===== */
+.badge__hex {
+  position: relative;
+  width: 104px;
+  height: 118px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.badge__hex--sm {
+  width: 84px;
+  height: 95px;
+}
+.badge__svg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+.badge__content {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  line-height: 1.05;
+}
+.badge__vendor {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: rgba(255, 255, 255, 0.82);
+}
+.badge__hex--sm .badge__vendor {
+  font-size: 8.5px;
+}
+.badge__glyph {
+  margin-top: 4px;
+  font-family: ui-monospace, 'JetBrains Mono', SFMono-Regular, Menlo, monospace;
+  font-size: 22px;
+  font-weight: 800;
+}
+.badge__score {
+  margin-top: 4px;
+  font-size: 19px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+.badge__hex--sm .badge__score {
+  font-size: 16px;
+}
+.badge__lock {
+  position: relative;
+  color: var(--muted);
+  display: flex;
+}
+.badge__name {
+  margin-top: 12px;
+  font-size: 12.5px;
+  font-weight: 700;
+  line-height: 1.3;
+}
+.badge__sub {
+  margin-top: 3px;
+  font-size: 11px;
+  color: var(--muted);
+}
+.badge__sub--done {
+  color: var(--success);
+}
+
 /* Grade de selos de trilha */
 .conq-trilhas {
   display: grid;
@@ -82,74 +152,12 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 9px;
+  gap: 0;
   padding: 20px 12px;
   text-align: center;
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--r-xl);
-}
-.conq-badge__name {
-  font-size: 13.5px;
-  font-weight: 600;
-}
-.conq-badge__status {
-  font-size: 12px;
-  color: var(--muted);
-}
-.conq-badge__status--done {
-  color: var(--success);
-  font-weight: 600;
-}
-
-/* Hexágono (selo) */
-.hex {
-  --cor: #9aa4b2;
-  width: 84px;
-  height: 92px;
-  display: grid;
-  place-items: center;
-  clip-path: polygon(50% 0, 100% 25%, 100% 75%, 50% 100%, 0 75%, 0 25%);
-  background: var(--cor);
-}
-.hex--sm {
-  width: 62px;
-  height: 68px;
-}
-.hex--locked {
-  background: var(--border-strong);
-}
-.hex__in {
-  width: 87%;
-  height: 87%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 1px;
-  clip-path: polygon(50% 0, 100% 25%, 100% 75%, 50% 100%, 0 75%, 0 25%);
-  background: #10192b;
-  color: var(--cor);
-}
-.hex--locked .hex__in {
-  background: var(--surface-2);
-  color: var(--muted);
-}
-.hex__in small {
-  font-size: 8px;
-  font-weight: 700;
-  letter-spacing: 0.06em;
-  opacity: 0.85;
-}
-.hex__in b {
-  font-size: 17px;
-  font-weight: 700;
-}
-.hex--sm .hex__in b {
-  font-size: 14px;
-}
-.hex--sm .hex__in small {
-  font-size: 7px;
 }
 
 /* Legenda das faixas */
@@ -225,21 +233,12 @@
 }
 .conq-sim__medals {
   display: flex;
-  gap: 18px;
+  gap: 16px;
 }
 .conq-medal {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 6px;
-}
-.conq-medal__label {
-  font-size: 11px;
-  font-weight: 600;
-}
-.conq-medal__label--off {
-  color: var(--muted);
-  font-weight: 400;
 }
 
 /* Catálogo (conquistas especiais) */
@@ -315,6 +314,6 @@
     grid-template-columns: repeat(2, 1fr);
   }
   .conq-sim__medals {
-    gap: 12px;
+    gap: 10px;
   }
 }


### PR DESCRIPTION
## Badges das conquistas
Os selos da aba /conquistas passam a usar o desenho hexagonal em SVG: placa escura com borda colorida quando ganho (vendor mais glyph na trilha, vendor mais nota no simulado) e placa apagada com cadeado quando bloqueado. Cores das medalhas Bronze, Prata, Ouro e Diamante como no material de referência, adaptadas aos temas claro e escuro.

## Navegação centralizada
Os itens do topo estavam duplicados em oito telas e divergiam (o Conquistas não aparecia em Trilhas, Ranking e outras). Agora vêm de um único módulo (data/nav.ts), então ficam iguais em todas as abas e não voltam a divergir.

## Correção dos testes de backend
Com o embaralhamento do quiz das trilhas, dois testes que respondiam pela posição da alternativa quebraram. O helper passou a responder pela alternativa certa de fato. Todos os testes verdes: 51 de integração e 84 unitários, rodados no Postgres efêmero.

## Como testar
- /conquistas: os novos selos (troque entre tema claro e escuro).
- Navegue entre as abas: o topo não muda mais.
