### PR TITLE
Tooltips de glossário nas aulas e correção do estado das aulas concluídas

### DIFF
--- a/frontend/src/components/BlocosConteudo.tsx
+++ b/frontend/src/components/BlocosConteudo.tsx
@@ -1,7 +1,8 @@
-import type { ReactNode } from 'react';
+import { useMemo, type ReactNode } from 'react';
 import ReactMarkdown, { type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { parseGrid } from '../utils/tabela';
+import { glossariar } from './Glossario';
 
 // Bloco genérico de conteúdo (aulas e desafios usam o mesmo formato).
 export interface Bloco {
@@ -80,6 +81,16 @@ function citacaoInline(texto: string): ReactNode {
 
 // Renderiza o conteúdo a partir dos blocos do Estúdio (aulas e enunciados de desafio).
 export function BlocosConteudo({ blocks }: { blocks: Bloco[] }) {
+  // Aplica o glossário nos parágrafos e listas. Componentes memoizados para o markdown
+  // não remontar; a marcação é pura (não altera estado durante o render).
+  const componentes = useMemo<Components>(
+    () => ({
+      ...md,
+      p: ({ children }) => <p className="lesson__p">{glossariar(children)}</p>,
+      li: ({ children }) => <li>{glossariar(children)}</li>,
+    }),
+    [],
+  );
   return (
     <div className="lesson__md">
       {blocks.map((b, i) => {
@@ -117,7 +128,7 @@ export function BlocosConteudo({ blocks }: { blocks: Bloco[] }) {
           return <TabelaBloco key={i} value={b.value} />;
         }
         return (
-          <ReactMarkdown key={i} remarkPlugins={[remarkGfm]} components={md}>
+          <ReactMarkdown key={i} remarkPlugins={[remarkGfm]} components={componentes}>
             {b.value}
           </ReactMarkdown>
         );

--- a/frontend/src/components/Glossario.tsx
+++ b/frontend/src/components/Glossario.tsx
@@ -1,0 +1,65 @@
+import { Children, useState, type ReactNode } from 'react';
+import { GLOSSARIO } from '../data/glossario';
+
+const DEFS = new Map(GLOSSARIO.map((g) => [g.termo, g.definicao]));
+// Termos maiores primeiro para o casamento preferir o mais específico.
+const TERMOS = GLOSSARIO.map((g) => g.termo).sort((a, b) => b.length - a.length);
+const escapar = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const REGEX = new RegExp(`\\b(${TERMOS.map(escapar).join('|')})\\b`, 'g');
+
+// Termo com sublinhado pontilhado e a definição num tooltip. Abre no hover (desktop)
+// ou no toque/foco (mobile).
+function TermoDestacado({ termo, definicao }: { termo: string; definicao: string }) {
+  const [aberto, setAberto] = useState(false);
+  return (
+    <span
+      className={`glossario${aberto ? ' glossario--aberto' : ''}`}
+      tabIndex={0}
+      role="button"
+      aria-label={`${termo}: ${definicao}`}
+      onClick={(e) => {
+        e.stopPropagation();
+        setAberto((v) => !v);
+      }}
+      onBlur={() => setAberto(false)}
+    >
+      {termo}
+      <span className="glossario__pop" role="tooltip">
+        <b>{termo}</b>
+        {definicao}
+      </span>
+    </span>
+  );
+}
+
+// Marca a primeira ocorrência de cada termo no texto. Termos já usados na aula
+// (no set compartilhado) ficam como texto normal, para não poluir.
+function marcarTexto(texto: string, usados: Set<string>): ReactNode {
+  REGEX.lastIndex = 0;
+  const out: ReactNode[] = [];
+  let ultimo = 0;
+  let k = 0;
+  let m: RegExpExecArray | null;
+  while ((m = REGEX.exec(texto)) !== null) {
+    const termo = m[0];
+    const definicao = DEFS.get(termo);
+    if (!definicao || usados.has(termo)) continue;
+    if (m.index > ultimo) out.push(texto.slice(ultimo, m.index));
+    out.push(<TermoDestacado key={k++} termo={termo} definicao={definicao} />);
+    usados.add(termo);
+    ultimo = m.index + termo.length;
+  }
+  if (out.length === 0) return texto;
+  if (ultimo < texto.length) out.push(texto.slice(ultimo));
+  return out;
+}
+
+// Aplica o glossário aos filhos que são texto puro (não mexe em negrito, código, etc.).
+// O set de usados é local a cada chamada (parágrafo), então é uma função pura: não
+// depende de estado mutado durante o render, o que evita o bug com o StrictMode.
+export function glossariar(children: ReactNode): ReactNode {
+  const usados = new Set<string>();
+  return Children.map(children, (child) =>
+    typeof child === 'string' ? marcarTexto(child, usados) : child,
+  );
+}

--- a/frontend/src/data/glossario.ts
+++ b/frontend/src/data/glossario.ts
@@ -1,0 +1,100 @@
+// Glossário inicial de termos de nuvem, dados e IA que aparecem nas trilhas.
+// O renderizador da aula destaca a primeira ocorrência de cada termo com um tooltip.
+// (Na próxima etapa isto vira um CRUD no Configurações e passa a vir do backend.)
+export interface TermoGlossario {
+  termo: string;
+  definicao: string;
+}
+
+export const GLOSSARIO: TermoGlossario[] = [
+  {
+    termo: 'IaaS',
+    definicao:
+      'Infraestrutura como Serviço. Você aluga a infraestrutura básica (máquinas, rede, armazenamento) e ainda gerencia o sistema operacional e as aplicações. Ex.: uma máquina virtual no Azure ou EC2 na AWS.',
+  },
+  {
+    termo: 'PaaS',
+    definicao:
+      'Plataforma como Serviço. O provedor cuida da infraestrutura e da plataforma; você só implanta e gerencia a aplicação. Ex.: Azure App Service.',
+  },
+  {
+    termo: 'SaaS',
+    definicao:
+      'Software como Serviço. Software pronto, acessado pela internet, sem gerenciar nada da infraestrutura. Ex.: Microsoft 365, Gmail.',
+  },
+  {
+    termo: 'CapEx',
+    definicao:
+      'Despesa de capital. Investimento adiantado em ativos físicos, como comprar servidores e montar um data center. É o modelo típico do ambiente local (on-premises).',
+  },
+  {
+    termo: 'OpEx',
+    definicao:
+      'Despesa operacional. Gasto contínuo conforme o uso, sem investimento inicial. É o modelo da nuvem: você paga pelo que consome.',
+  },
+  {
+    termo: 'SLA',
+    definicao:
+      'Acordo de Nível de Serviço. O compromisso do provedor com disponibilidade e desempenho, por exemplo garantir 99,9% de uptime.',
+  },
+  {
+    termo: 'VM',
+    definicao:
+      'Máquina Virtual. Um computador por software que roda sobre um servidor físico, com seu próprio sistema operacional.',
+  },
+  {
+    termo: 'CDN',
+    definicao:
+      'Rede de Distribuição de Conteúdo. Servidores espalhados pelo mundo que entregam o conteúdo a partir do ponto mais próximo do usuário, reduzindo a latência.',
+  },
+  {
+    termo: 'API',
+    definicao:
+      'Interface de Programação de Aplicações. O conjunto de regras pelo qual um software conversa com outro.',
+  },
+  {
+    termo: 'SDK',
+    definicao:
+      'Kit de Desenvolvimento de Software. Conjunto de ferramentas e bibliotecas para construir aplicações para uma plataforma.',
+  },
+  {
+    termo: 'OLTP',
+    definicao:
+      'Processamento de Transações Online. Cargas de muitas transações curtas sobre dados atuais (inserções e atualizações), típicas de sistemas operacionais.',
+  },
+  {
+    termo: 'OLAP',
+    definicao:
+      'Processamento Analítico Online. Cargas de consultas complexas e agregações sobre grandes volumes de dados históricos, voltadas a análise.',
+  },
+  {
+    termo: 'ACID',
+    definicao:
+      'Atomicidade, Consistência, Isolamento e Durabilidade. As quatro garantias de uma transação confiável em um banco de dados.',
+  },
+  {
+    termo: 'ETL',
+    definicao:
+      'Extract, Transform, Load. Extrair os dados, transformá-los e só então carregá-los no destino.',
+  },
+  {
+    termo: 'ELT',
+    definicao:
+      'Extract, Load, Transform. Extrair, carregar os dados brutos no destino e transformá-los lá, aproveitando o poder de processamento do destino.',
+  },
+  {
+    termo: 'NoSQL',
+    definicao:
+      'Bancos não relacionais, de esquema flexível e que escalam horizontalmente. Incluem modelos de documento, chave-valor, coluna e grafo.',
+  },
+  {
+    termo: 'LLM',
+    definicao:
+      'Modelo de Linguagem Grande. Modelo de IA treinado em enormes volumes de texto para entender e gerar linguagem natural. É a base da IA generativa, como o GPT.',
+  },
+  {
+    termo: 'RAG',
+    definicao:
+      'Geração Aumentada por Recuperação. Buscar trechos relevantes de uma fonte confiável e injetá-los no prompt, para o modelo responder com base nesses dados.',
+  },
+];

--- a/frontend/src/pages/Aula/index.tsx
+++ b/frontend/src/pages/Aula/index.tsx
@@ -153,12 +153,12 @@ function SidebarTrilha({ trilha, aulaAtualId }: { trilha: TrailDetail; aulaAtual
           <div key={m.id} className="lesson__module">
             <div className="lesson__module-title">{m.title}</div>
             {m.lessons.map((l) => {
-              const estado = l.id === aulaAtualId ? 'current' : l.state;
+              const ativa = l.id === aulaAtualId;
               return (
                 <Link
                   key={l.id}
                   to={`/trilhas/${trilha.id}/aula/${l.id}`}
-                  className={`lesson__item lesson__item--${estado}${l.state === 'locked' ? ' lesson__item--disabled' : ''}`}
+                  className={`lesson__item lesson__item--${l.state}${ativa ? ' lesson__item--active' : ''}${l.state === 'locked' ? ' lesson__item--disabled' : ''}`}
                   onClick={() => setAberto(false)}
                 >
                   <span className="lesson__bullet">

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1689,7 +1689,8 @@
 .lesson__item--locked .lesson__item-name {
   color: var(--muted);
 }
-.lesson__item--current {
+/* Aula aberta: fundo destacado, separado do estado (done/current/locked). */
+.lesson__item--active {
   background: color-mix(in srgb, var(--accent) 12%, transparent);
 }
 .lesson__item--current .lesson__bullet {
@@ -4405,4 +4406,48 @@
 .cfg-tab--active {
   color: var(--accent);
   border-bottom-color: var(--accent);
+}
+
+/* Termo do glossário com tooltip na aula */
+.glossario {
+  position: relative;
+  border-bottom: 1px dotted var(--accent);
+  cursor: help;
+  color: inherit;
+  font-weight: inherit;
+}
+.glossario__pop {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 30;
+  width: max-content;
+  max-width: 260px;
+  padding: 10px 12px;
+  border-radius: var(--r-md);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.18);
+  font-size: 12.5px;
+  font-weight: 400;
+  line-height: 1.5;
+  color: var(--muted);
+  text-align: left;
+  white-space: normal;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.12s ease;
+  pointer-events: none;
+}
+.glossario__pop b {
+  display: block;
+  margin-bottom: 2px;
+  color: var(--text);
+}
+.glossario:hover .glossario__pop,
+.glossario:focus .glossario__pop,
+.glossario--aberto .glossario__pop {
+  opacity: 1;
+  visibility: visible;
 }


### PR DESCRIPTION
## Tooltips de glossário nas aulas
Termos de nuvem, dados e IA (IaaS, PaaS, SaaS, CapEx, OpEx, SLA, VM, CDN, API, SDK, OLTP, OLAP, ACID, ETL, ELT, NoSQL, LLM, RAG) ganham um tooltip com a definição direto na aula.
- Destaca a primeira ocorrência de cada termo por parágrafo, com um sublinhado pontilhado. Abre no hover (desktop) ou no toque (mobile).
- Só em parágrafos e listas; não toca em blocos de código, negrito nem tabelas.
- Dirigido pelo glossário, então todas as aulas que já existem ganham os tooltips sem reescrever nada.
- A marcação é pura (um set local por parágrafo), então não quebra com o StrictMode.

Nesta etapa o glossário fica em um módulo do frontend. Na próxima ele vira um CRUD no Configurações, com o backend guardando os termos.

## Correção do estado das aulas concluídas
Reabrir uma aula já concluída fazia ela perder o selo de concluída e a próxima aula aparecer destacada junto (as duas pareciam "clicadas"). A aula aberta era forçada ao estado "atual", sobrescrevendo o "concluída". Agora o estado (concluída, atual ou bloqueada) é separado do destaque da aula aberta.

## Como testar
- Abra uma aula das trilhas AWS/Azure e passe o mouse num termo sublinhado (ex.: CapEx, IaaS).
- Conclua uma aula, reabra ela: mantém o check verde e só ela fica destacada.
