### PR TITLE
feat: adiciona rate limit global nas rotas autenticadas do app

### DIFF
--- a/backend/app.ts
+++ b/backend/app.ts
@@ -7,6 +7,7 @@ import trailRoutes from "./src/routes/trail.routes.ts";
 import simuladoRoutes from "./src/routes/simulado.routes.ts";
 import desafioRoutes from "./src/routes/desafio.routes.ts";
 import { errorMiddleware } from "./src/middlewares/error.ts";
+import { apiLimiter } from "./src/middlewares/rateLimit.ts";
 import helmet from "helmet";
 import cors from "cors";
 import { UPLOADS_DIR } from "./src/config/paths.ts";
@@ -41,6 +42,7 @@ app.use(
 );
 
 app.use(authRoutes);
+app.use(apiLimiter);
 app.use(userRoutes);
 app.use(trailRoutes);
 app.use(simuladoRoutes);

--- a/backend/src/middlewares/rateLimit.ts
+++ b/backend/src/middlewares/rateLimit.ts
@@ -45,3 +45,14 @@ export const resetPasswordLimiter = criarLimiter(
     20,
     "Muitas tentativas. Tente novamente em alguns minutos.",
 );
+
+// Teto por IP folgado de propósito: escola e lab saem por um mesmo IP, então é
+// barreira anti-abuso em rajada, não limite por usuário. Auth tem os seus limiters.
+export const apiLimiter = rateLimit({
+    windowMs: 60 * 1000,
+    max: 1000,
+    message: { erro: "Muitas requisições em pouco tempo. Aguarde um instante." },
+    standardHeaders: true,
+    legacyHeaders: false,
+    skip: (req) => process.env.NODE_ENV === "test" || req.path === "/health",
+});


### PR DESCRIPTION
Fecha os alertas `js/missing-rate-limiting` (high) do CodeQL nas rotas autenticadas do app (perfil, trilhas, simulados, desafios), que faziam autorização sem rate limit.

- Um `apiLimiter` global cobre esses routers. Por IP, teto folgado (1000/min) porque escola e lab saem por um mesmo IP público, então é barreira anti-abuso em rajada, não limite por usuário.
- Os endpoints de auth (login, cadastro, refresh, verify, forgot, reset) já tinham limiters próprios e mais rígidos, e continuam só com eles, funcionando mesmo com o app sob carga.
- `/health` fica de fora.

Verificado no dev: `/achievements` responde com `RateLimit-Limit: 1000`, `/login` com o limite 10 do loginLimiter, e `/health` sem header de rate limit.

Sobre a outra flag do CodeQL (`js/cors-permissive-configuration` no app.ts): é falso positivo. O CORS permissivo só vale em dev; em produção trava no `FRONTEND_URL`. Deixei de fora deste PR.
