### PR TITLE
feat: adiciona as trilhas de HTML e CSS para iniciantes

### DIFF
--- a/backend/scripts/seed-trilha-css.ts
+++ b/backend/scripts/seed-trilha-css.ts
@@ -1,0 +1,5479 @@
+// Trilha de CSS para iniciantes, blocos com quiz de 5 questões por aula.
+// questões por aula. Idempotente pelo marcador "Módulo 1 - Introdução ao CSS", que só
+// existe nesta estrutura nova. É destrutivo: apaga módulos/aulas/questões antigos
+// da trilha antes de recriar (o progresso da trilha AWS é reiniciado).
+//
+// Rodar em prod: docker compose -f docker-compose.prod.yml exec -T backend node scripts/seed-trilha-css.ts
+import { db } from "../db.ts";
+import {
+    trails,
+    modules,
+    lessons,
+    questions,
+    questionOptions,
+    questionAnswers,
+    lessonProgress,
+} from "../schema.ts";
+import { eq, and, inArray } from "drizzle-orm";
+
+const NOME = "CSS";
+const MARCADOR = "Módulo 1 - Introdução ao CSS";
+
+type Bloco = { type: "text" | "code" | "quote" | "table"; value: string };
+type Questao = {
+    statement: string;
+    difficulty: "facil" | "medio" | "dificil";
+    options: { text: string; isCorrect: boolean }[];
+};
+type Aula = { titulo: string; blocks: Bloco[]; questions: Questao[] };
+type Modulo = { titulo: string; aulas: Aula[] };
+
+const DADOS: Modulo[] = [
+    {
+        titulo: "Módulo 1 - Introdução ao CSS",
+        aulas: [
+            {
+                titulo: "O que é CSS e como funciona",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "# O que é CSS e como funciona\n\nSeja bem-vindo ao seu primeiro contato com o **CSS**! Se você já deu os primeiros passos no HTML, chegou a hora de deixar suas páginas bonitas. E se ainda acha que isso tudo é um bicho de sete cabeças, pode relaxar: aqui a gente começa do zero, com calma e com muito exemplo.\n\nAté agora, com HTML, você aprendeu a **estruturar** o conteúdo: dizer o que é título, o que é parágrafo, o que é imagem. Só que uma página feita apenas de HTML tem uma cara meio sem graça, tudo preto no branco, empilhado de cima para baixo. É aí que entra o CSS: ele é a ferramenta que transforma aquela estrutura crua em algo colorido, organizado e agradável de olhar.",
+                    },
+                    {
+                        type: "quote",
+                        value: "**CSS** quer dizer _Cascading Style Sheets_, ou Folhas de Estilo em Cascata. A palavra que importa aqui é **estilo**: o CSS não cria conteúdo nem estrutura, ele apenas descreve **como** o conteúdo que já existe no HTML deve **aparecer** — a cor, o tamanho, o espaçamento, a posição. Enquanto o HTML diz _o que é_ cada coisa, o CSS diz _como cada coisa se parece_.",
+                    },
+                    {
+                        type: "text",
+                        value: "## HTML é a estrutura, CSS é a decoração\n\nA melhor forma de entender a dupla HTML + CSS é pensar numa **casa**.\n\nQuando se constrói uma casa, primeiro se levanta a **estrutura**: as paredes, o teto, as portas, as janelas, os cômodos. Isso é o **HTML**. É o que sustenta tudo e define o que existe: aqui é uma parede, ali é uma janela, este cômodo é a cozinha.\n\nSó que uma casa recém-construída, no osso, é cinza e sem graça. Aí entra o **decorador**: ele pinta as paredes, escolhe o piso, pendura os quadros, posiciona os móveis, ajusta a iluminação. Ele não derruba nem levanta nenhuma parede, apenas cuida da **aparência**. Esse é o papel do **CSS**.\n\nRepare no ponto mais importante dessa analogia: o decorador trabalha **sobre** uma estrutura que já existe. Sem parede, não há o que pintar. Por isso o HTML vem primeiro, e o CSS entra depois para embelezar o que já está lá.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Uma página sem CSS e com CSS\n\nVamos ver isso na prática. Imagine um pedacinho de HTML bem simples, com um título e um parágrafo:",
+                    },
+                    {
+                        type: "code",
+                        value: "<h1>Bolo de cenoura</h1>\n<p>A melhor receita da vovó, pronta em 40 minutos.</p>",
+                    },
+                    {
+                        type: "text",
+                        value: "Aberto no navegador **sem nenhum CSS**, esse código aparece do jeito padrão: letras pretas, fundo branco, a fonte que o navegador escolher, tudo encostado no canto esquerdo. Funciona, mas é sem graça.\n\nAgora veja o que acontece quando adicionamos um pouco de **CSS** para colorir e organizar:",
+                    },
+                    {
+                        type: "code",
+                        value: "<style>\n  h1 {\n    color: darkorange;\n    text-align: center;\n  }\n  p {\n    color: gray;\n    font-family: sans-serif;\n  }\n</style>\n\n<h1>Bolo de cenoura</h1>\n<p>A melhor receita da vovó, pronta em 40 minutos.</p>",
+                    },
+                    {
+                        type: "text",
+                        value: "O **HTML continua exatamente o mesmo** — o título ainda é um `<h1>` e o texto ainda é um `<p>`. O que mudou foi o CSS que colocamos ali dentro: agora o título fica **laranja** e **centralizado**, e o parágrafo fica **cinza** com uma fonte sem serifa. Não mexemos no conteúdo, só na aparência. Essa é a mágica do CSS. Não se preocupe com os detalhes desse código ainda, a gente vai destrinchar tudo já já.",
+                    },
+                    {
+                        type: "text",
+                        value: '## A anatomia de uma regra CSS\n\nTodo o CSS do mundo é feito de **regras**. Uma regra é um pedacinho que diz: "para tal elemento, aplique tal aparência". E toda regra segue **sempre** o mesmo formato:',
+                    },
+                    {
+                        type: "code",
+                        value: "seletor {\n  propriedade: valor;\n}",
+                    },
+                    {
+                        type: "text",
+                        value: "À primeira vista parece estranho, mas são só três ideias. Vamos usar um exemplo de verdade para dissecar:",
+                    },
+                    {
+                        type: "code",
+                        value: "h1 {\n  color: blue;\n}",
+                    },
+                    {
+                        type: "text",
+                        value: 'Esse pedacinho lê-se assim: "todo `<h1>` deve ter a cor azul". Ele tem estas partes:\n\n- **Seletor** (`h1`): escolhe **quem** vai receber o estilo. Aqui, todos os elementos `<h1>` da página.\n- **Chaves** (`{ }`): abrem e fecham o **bloco de declarações**. Tudo o que estiver entre elas se aplica ao seletor.\n- **Propriedade** (`color`): diz **o que** você quer mudar. Neste caso, a cor do texto.\n- **Valor** (`blue`): diz **como** você quer aquilo. Neste caso, azul.\n- **Dois-pontos** (`:`): separa a propriedade do valor.\n- **Ponto e vírgula** (`;`): marca o **fim** da declaração.\n\nO par `propriedade: valor;` (por exemplo, `color: blue;`) tem um nome: é uma **declaração**. Uma regra pode ter uma ou várias declarações, uma embaixo da outra.',
+                    },
+                    {
+                        type: "text",
+                        value: "## Várias declarações na mesma regra\n\nNa maioria das vezes você quer mudar mais de uma coisa no mesmo elemento. É só colocar **uma declaração por linha**, cada uma terminando com ponto e vírgula:",
+                    },
+                    {
+                        type: "code",
+                        value: "p {\n  color: gray;\n  font-size: 18px;\n  text-align: center;\n}",
+                    },
+                    {
+                        type: "text",
+                        value: "Aqui, todo parágrafo `<p>` da página fica **cinza**, com letra de tamanho **18 pixels** e **centralizado**. Três declarações, três mudanças, todas dentro do mesmo bloco de chaves.\n\nUm conselho que vale ouro para quem começa: **não esqueça o ponto e vírgula** no fim de cada declaração. É ele que separa uma da outra. Esquecer o `;` é um dos errinhos mais comuns e faz a regra parar de funcionar dali em diante.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Comentários no CSS\n\nAssim como no HTML você deixa recados com `<!-- -->`, no CSS também dá para escrever **comentários**: trechos que o navegador **ignora** por completo e que não mudam em nada a aparência da página.\n\nNo CSS, o comentário fica entre `/*` e `*/`. Tudo o que estiver entre esses dois sinais é um recado só para quem lê o código:",
+                    },
+                    {
+                        type: "code",
+                        value: "/* Cor principal da marca */\nh1 {\n  color: darkorange;\n}\n\n/* A regra abaixo está desativada por enquanto:\np {\n  color: red;\n}\n*/",
+                    },
+                    {
+                        type: "text",
+                        value: "No exemplo, o primeiro comentário **explica** para que serve a regra seguinte. Já o segundo **desativa** uma regra inteira: como o bloco do `p` está dentro de `/* */`, o navegador o ignora, e o parágrafo não fica vermelho. Comentários são ótimos para anotar, organizar o arquivo em seções e testar coisas sem apagar o código.\n\nAtenção a um detalhe: no CSS **não existe** o comentário de uma linha com `//` (isso é de outras linguagens). No CSS é sempre `/* */`, mesmo para um recado curtinho.",
+                    },
+                    {
+                        type: "text",
+                        value: "## O que dá pra mudar com CSS\n\nVocê deve estar se perguntando: afinal, o que exatamente eu consigo controlar com CSS? Praticamente **toda a aparência** da página. Dá para agrupar as possibilidades em quatro grandes famílias:\n\n- **Cor**: a cor do texto (`color`), a cor de fundo (`background-color`), a cor das bordas.\n- **Tamanho**: o tamanho da letra (`font-size`), a largura (`width`) e a altura (`height`) dos elementos.\n- **Espaço**: o espaço por dentro (`padding`) e por fora (`margin`) de cada elemento, afastando ou aproximando as coisas.\n- **Posição**: onde cada elemento fica e como o conteúdo se alinha (`text-align`), à esquerda, ao centro ou à direita.\n\nNão precisa decorar nenhuma dessas propriedades agora. Elas vão aparecer aos poucos ao longo da trilha. A ideia aqui é só você ter uma noção do **tamanho do universo** que o CSS abre para você.",
+                    },
+                    {
+                        type: "table",
+                        value: '[["O que você quer mudar","Uma propriedade de exemplo","O que ela faz"],["A cor do texto","`color`","Pinta as letras de uma cor"],["A cor de fundo","`background-color`","Pinta o fundo do elemento"],["O tamanho da letra","`font-size`","Deixa o texto maior ou menor"],["O espaço interno","`padding`","Afasta o conteúdo da borda do elemento"],["O alinhamento do texto","`text-align`","Alinha à esquerda, ao centro ou à direita"]]',
+                    },
+                    {
+                        type: "text",
+                        value: "## Juntando tudo num exemplo\n\nPara fechar, veja uma folha de estilo curtinha que usa várias dessas ideias de uma vez. Ela dá cor, tamanho e espaço a um título e a um parágrafo:",
+                    },
+                    {
+                        type: "code",
+                        value: "<style>\n  /* Título grande, azul e centralizado */\n  h1 {\n    color: navy;\n    font-size: 32px;\n    text-align: center;\n  }\n\n  /* Parágrafo cinza com um respiro por dentro */\n  p {\n    color: dimgray;\n    padding: 10px;\n  }\n</style>\n\n<h1>Minha primeira página com estilo</h1>\n<p>Agora o CSS deixou tudo com a nossa cara.</p>",
+                    },
+                    {
+                        type: "quote",
+                        value: "**Recapitulando:** o **CSS** (_Cascading Style Sheets_) cuida da **aparência** da página, enquanto o HTML cuida da estrutura — a estrutura da casa é o HTML, a decoração é o CSS. Todo CSS é feito de **regras** no formato `seletor { propriedade: valor; }`: o **seletor** escolhe o elemento, a **propriedade** diz o que mudar e o **valor** diz como. Cada declaração termina em `;`, e **comentários** vão entre `/* */`. Com CSS você controla **cor, tamanho, espaço e posição** de tudo na tela.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement: "De que parte de uma página web o CSS cuida?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "Da aparência: cores, tamanhos, espaçamentos e posição dos elementos.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Da estrutura e do conteúdo, definindo o que é título e o que é parágrafo.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Do comportamento, fazendo a página reagir a cliques.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "De guardar os arquivos do site em um servidor.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "Qual é o formato correto de uma regra de CSS?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`seletor { propriedade: valor; }`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`propriedade { seletor: valor; }`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`<seletor>propriedade: valor</seletor>`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`valor: propriedade (seletor);`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "Como se escreve um comentário em CSS?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "`/* assim */`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`<!-- assim -->`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`// assim`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`# assim`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "Na regra `p { color: gray; }`, o que é o `color`?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "A propriedade, ou seja, o que está sendo alterado (a cor do texto).",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "O seletor, que escolhe quais elementos recebem o estilo.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O valor, que define qual cor será usada.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Um comentário, que o navegador ignora.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Na analogia da casa, o HTML é a estrutura (paredes, portas) e o CSS é a decoração (pintura, móveis). O que essa comparação explica sobre a relação entre os dois?",
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "O CSS atua sobre uma estrutura que já precisa existir; sem o HTML definindo os elementos, não há o que estilizar. Por isso o HTML vem primeiro.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Que o CSS substitui o HTML: depois de decorar, as paredes deixam de ser necessárias.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Que HTML e CSS fazem exatamente a mesma coisa, então tanto faz qual usar.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Que o CSS levanta as paredes e o HTML apenas as pinta.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Como aplicar CSS",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "# Como aplicar CSS\n\nNa aula anterior você entendeu o que é o CSS e como uma regra funciona. Mas ficou uma pergunta no ar: **onde** a gente escreve esse CSS para que ele grude no HTML?\n\nExistem **três formas** de aplicar CSS a uma página, e nesta aula vamos conhecer as três, uma de cada vez. Já adianto: elas não são igualmente boas. Uma delas é o jeito profissional, e as outras duas têm o seu lugar, mas com ressalvas. No fim você vai saber qual usar e por quê.",
+                    },
+                    {
+                        type: "quote",
+                        value: "Há **três formas** de aplicar CSS: **inline** (no atributo `style` de um elemento), **interno** (dentro de uma tag `<style>` no `<head>`) e **externo** (num arquivo `.css` separado, ligado à página com `<link>`). As três funcionam, mas o **externo** é o recomendado, porque separa o conteúdo (HTML) do estilo (CSS).",
+                    },
+                    {
+                        type: "text",
+                        value: '## Forma 1: CSS inline (o atributo style)\n\nA primeira forma é escrever o estilo **diretamente no elemento**, usando um atributo chamado `style`. É o chamado CSS **inline** ("na mesma linha").\n\nAqui você não escreve o seletor nem as chaves, só as declarações, porque o estilo já está colado no elemento que vai recebê-lo:',
+                    },
+                    {
+                        type: "code",
+                        value: '<h1 style="color: blue; text-align: center;">Bem-vindo</h1>\n\n<p style="color: gray;">Este parágrafo está cinza.</p>',
+                    },
+                    {
+                        type: "text",
+                        value: 'Repare que, dentro das aspas do `style`, vão apenas as declarações (`color: blue; text-align: center;`), separadas por ponto e vírgula. O estilo se aplica **só àquele elemento**, e a nenhum outro.\n\nParece prático, e para um teste rápido até é. Mas o inline tem problemas sérios:\n\n- **Não dá para reaproveitar**: se você quiser dez parágrafos cinza, terá que repetir `style="color: gray;"` dez vezes.\n- **Vira uma bagunça**: o HTML fica poluído, com estrutura e estilo misturados na mesma linha.\n- **É difícil de manter**: para trocar a cor de tudo, você teria que caçar e alterar cada elemento na mão.\n\nPor isso o inline é usado com muita parcimônia, guardado para exceções bem pontuais.',
+                    },
+                    {
+                        type: "text",
+                        value: '## Forma 2: CSS interno (a tag <style>)\n\nA segunda forma é reunir todo o CSS num único lugar da página: dentro de uma tag `<style>`, colocada no `<head>` do documento. É o CSS **interno** (ou "embutido").\n\nAgora sim voltamos a escrever regras completas, com seletor e chaves, como você aprendeu na aula passada:',
+                    },
+                    {
+                        type: "code",
+                        value: '<!DOCTYPE html>\n<html lang="pt-br">\n  <head>\n    <meta charset="UTF-8">\n    <title>Minha página</title>\n    <style>\n      h1 {\n        color: blue;\n        text-align: center;\n      }\n      p {\n        color: gray;\n      }\n    </style>\n  </head>\n  <body>\n    <h1>Bem-vindo</h1>\n    <p>Este parágrafo está cinza.</p>\n    <p>E este também, sem repetir estilo nenhum!</p>\n  </body>\n</html>',
+                    },
+                    {
+                        type: "text",
+                        value: "Bem melhor, não? Aqui uma única regra `p { color: gray; }` pinta **todos** os parágrafos de cinza de uma vez — os dois do exemplo e quantos mais você adicionar. O estilo ficou concentrado num só lugar, o `<head>`, separado do conteúdo que está no `<body>`.\n\nO CSS interno resolve o reúso **dentro de uma página**. O porém aparece quando o site tem **várias páginas**: como cada `<style>` vive dentro de um arquivo HTML, você teria que copiar o mesmo bloco de estilos para cada página. E se um dia quisesse mudar a cor do site inteiro, teria que editar página por página. É aí que entra a terceira forma.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Forma 3: CSS externo (o arquivo .css)\n\nA terceira forma é a que os profissionais usam no dia a dia: colocar todo o CSS num **arquivo separado**, com a extensão `.css`, e depois **ligar** esse arquivo à página.\n\nSão dois passos. Primeiro, você cria um arquivo só de estilo, por exemplo `estilos.css`, contendo apenas as regras (sem nenhuma tag HTML, sem `<style>`):",
+                    },
+                    {
+                        type: "code",
+                        value: "/* estilos.css */\nh1 {\n  color: blue;\n  text-align: center;\n}\n\np {\n  color: gray;\n}",
+                    },
+                    {
+                        type: "text",
+                        value: "Repare que dentro do arquivo `.css` **não existe HTML nenhum**: nada de `<style>`, nada de `<body>`, só as regras puras. O arquivo é 100% CSS.\n\nO segundo passo é **avisar** a página de que ela deve usar esse arquivo. Isso é feito com a tag `<link>`, colocada no `<head>`:",
+                    },
+                    {
+                        type: "code",
+                        value: '<!DOCTYPE html>\n<html lang="pt-br">\n  <head>\n    <meta charset="UTF-8">\n    <title>Minha página</title>\n    <link rel="stylesheet" href="estilos.css">\n  </head>\n  <body>\n    <h1>Bem-vindo</h1>\n    <p>Este parágrafo está cinza.</p>\n  </body>\n</html>',
+                    },
+                    {
+                        type: "text",
+                        value: 'A tag `<link>` é um elemento vazio (não tem fechamento) e traz dois atributos importantes:\n\n- `rel="stylesheet"`: diz **que tipo** de ligação é essa. `stylesheet` significa "folha de estilos", ou seja, estou ligando um arquivo de CSS.\n- `href="estilos.css"`: diz **onde** está o arquivo, o caminho até ele. Aqui, um `estilos.css` que fica na mesma pasta do HTML.\n\nCom essa única linha, a página passa a usar **todas** as regras do arquivo externo, exatamente como se estivessem ali dentro.',
+                    },
+                    {
+                        type: "text",
+                        value: "## Por que o externo é o jeito certo\n\nO grande trunfo do CSS externo é que **um mesmo arquivo `.css` pode ser ligado a quantas páginas você quiser**. Imagine um site com 50 páginas: todas apontando para o mesmo `estilos.css`. Isso traz vantagens enormes:\n\n- **Reúso**: você escreve o estilo uma vez e usa em todas as páginas.\n- **Manutenção fácil**: para mudar a cara do site inteiro, edita **um só arquivo**, e a mudança aparece em todas as páginas de uma vez.\n- **HTML limpo**: o conteúdo (HTML) fica de um lado e o estilo (CSS) do outro; cada arquivo cuida de uma coisa.\n- **Página mais rápida**: o navegador baixa o `.css` uma vez e reaproveita nas páginas seguintes.",
+                    },
+                    {
+                        type: "text",
+                        value: "Uma analogia ajuda: o arquivo externo é como o **guarda-roupa** de uma casa. Em vez de cada pessoa esconder uma cópia da mesma roupa no próprio quarto (inline), ou cada quarto ter um armário repetido (interno), existe **um guarda-roupa central** que todos usam. Trocou a roupa lá, todo mundo aparece diferente.",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Forma","Onde o CSS fica","Serve melhor para...","Recomendado?"],["Inline","No atributo `style` do elemento","Um ajuste pontual e único","Não, evite"],["Interno","Numa tag `<style>` no `<head>`","Uma página só ou testes rápidos","Com ressalvas"],["Externo","Num arquivo `.css` ligado por `<link>`","O site inteiro, projetos de verdade","Sim, é o ideal"]]',
+                    },
+                    {
+                        type: "text",
+                        value: "## Separar conteúdo de estilo\n\nPor trás da preferência pelo CSS externo existe um princípio importante da web: **separar o conteúdo da apresentação**.\n\nA ideia é que o **HTML** cuide só do conteúdo e da estrutura (o que é título, o que é parágrafo) e o **CSS** cuide só da aparência (que cor, que tamanho). Cada um no seu arquivo, cada um com a sua responsabilidade.\n\nIsso deixa tudo mais organizado: dá para mexer nas cores no arquivo `.css` sem tocar no conteúdo, e reescrever um texto no HTML sem medo de bagunçar o visual. Quando conteúdo e estilo ficam embolados na mesma linha (como no inline), perde-se justamente essa clareza. É por isso que, deste ponto em diante, quase todo o CSS que você escrever vai morar num arquivo externo.",
+                    },
+                    {
+                        type: "quote",
+                        value: '**Cheat sheet:** há três formas de aplicar CSS. **Inline** usa o atributo `style` no elemento e serve só para exceções. **Interno** usa `<style>` no `<head>` e vale para uma página. **Externo** guarda tudo num arquivo `.css` ligado pela tag `<link rel="stylesheet" href="...">` no `<head>`, e é o **jeito recomendado**: um mesmo arquivo estiliza o site inteiro, facilita a manutenção e **separa o conteúdo (HTML) do estilo (CSS)**.',
+                    },
+                ],
+                questions: [
+                    {
+                        statement: "Quais são as três formas de aplicar CSS a uma página?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "Inline (no atributo `style`), interno (na tag `<style>`) e externo (num arquivo `.css`).",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Somente inline e interno; não existe CSS em arquivo separado.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Por tag, por classe e por id.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Nome, hexadecimal e `rgb()`.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Qual atributo aplica CSS diretamente em um único elemento (o CSS inline)?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`style`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`class`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`css`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`link`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Qual linha liga corretamente um arquivo CSS externo a uma página HTML?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: '`<link rel="stylesheet" href="estilos.css">`',
+                                isCorrect: true,
+                            },
+                            {
+                                text: '`<style src="estilos.css">`',
+                                isCorrect: false,
+                            },
+                            {
+                                text: '`<css href="estilos.css">`',
+                                isCorrect: false,
+                            },
+                            {
+                                text: '`<script src="estilos.css">`',
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Por que o CSS externo facilita a manutenção de um site com muitas páginas?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Porque um único arquivo `.css` estiliza todas as páginas; ao editar esse arquivo, a mudança aparece em todas de uma vez.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Porque cada página passa a ter o seu próprio estilo, sem depender das outras.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Porque o CSS externo é o único que o navegador consegue exibir.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Porque ele coloca as declarações dentro de cada elemento, uma a uma.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Você mantém um site de 50 páginas e precisa trocar a cor de todos os títulos. Qual abordagem faz isso com o menor esforço?",
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "Ter o CSS em um arquivo externo ligado por `<link>` em todas as páginas e mudar a cor nesse único arquivo.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Usar CSS inline e alterar o atributo `style` de cada título, um por um, nas 50 páginas.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Usar CSS interno e editar a tag `<style>` de cada uma das 50 páginas.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Não é possível; é preciso reescrever as 50 páginas do zero.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Seletores básicos",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "# Seletores básicos\n\nVocê já sabe que uma regra CSS tem o formato `seletor { propriedade: valor; }`. Até agora a gente focou na parte da direita, as propriedades e os valores. Nesta aula o holofote vai para a parte da esquerda: o **seletor**.\n\nO seletor é a peça que decide **quem** vai receber o estilo. Escolher bem o seletor é metade do trabalho no CSS. A boa notícia é que os seletores básicos são pouquinhos e fáceis de pegar. Vamos conhecer os principais, um por um.",
+                    },
+                    {
+                        type: "quote",
+                        value: "O **seletor** é a parte da regra que escolhe **quais elementos** receberão o estilo. Os três seletores básicos são: por **tipo** (o nome da tag, como `p`), por **classe** (um nome escolhido por você, precedido de `.`, como `.destaque`) e por **id** (um identificador único, precedido de `#`, como `#topo`). Há ainda o **universal** (`*`), que atinge todos.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Seletor de tipo (por tag)\n\nO seletor mais simples é o de **tipo**, também chamado de seletor de elemento ou de tag. Você já o viu na aula 1. Basta escrever o **nome da tag**, e a regra atinge **todos** os elementos daquele tipo na página.\n\nNo exemplo abaixo, toda `<p>` fica azul, não importa quantas existam:",
+                    },
+                    {
+                        type: "code",
+                        value: "<style>\n  p {\n    color: blue;\n  }\n</style>\n\n<p>Este parágrafo fica azul.</p>\n<p>Este também fica azul.</p>\n<p>E este aqui, azul igualmente.</p>",
+                    },
+                    {
+                        type: "text",
+                        value: "Simples assim: uma regrinha e todos os parágrafos mudam de cor. (Nos exemplos a seguir vamos juntar o CSS num `<style>` só para você poder testar tudo num arquivo único; num projeto de verdade, esse CSS moraria num `.css` externo, como você viu na aula passada.)\n\nO seletor de tipo é ótimo quando você quer um estilo **geral** para todos os elementos de uma espécie. Mas ele tem um limite: e se você quiser deixar azul **apenas um** parágrafo específico, e não todos? Para isso ele não serve. Precisamos de algo mais preciso, e é aí que entram as **classes**.",
+                    },
+                    {
+                        type: "text",
+                        value: '## Seletor de classe (com ponto)\n\nA **classe** é o seletor mais usado no dia a dia, porque é o mais flexível. A ideia tem duas partes que trabalham juntas:\n\n1. No **HTML**, você marca os elementos que quer estilizar com o atributo `class`, dando a eles um nome à sua escolha.\n2. No **CSS**, você escreve esse mesmo nome precedido de um **ponto** (`.`) e define o estilo.\n\nO ponto é o sinal que diz ao CSS: "isto aqui é o nome de uma classe". Veja:',
+                    },
+                    {
+                        type: "code",
+                        value: '<style>\n  .destaque {\n    color: red;\n    font-weight: bold;\n  }\n</style>\n\n<p class="destaque">Este parágrafo é importante!</p>\n<p>Este é um parágrafo comum.</p>\n<p class="destaque">Este também merece destaque.</p>',
+                    },
+                    {
+                        type: "text",
+                        value: 'No CSS, `.destaque` significa "todos os elementos que tiverem `class="destaque"`". Repare no resultado: o primeiro e o terceiro parágrafos, que levam a classe, ficam vermelhos e em negrito; o do meio, sem classe, continua normal.\n\nAs classes são poderosas por três motivos:\n\n- **Você escolhe quais elementos** recebem o estilo, marcando só eles com a classe.\n- **A mesma classe serve para vários elementos**, mesmo que sejam tags diferentes (um `<p>` e um `<h2>` podem compartilhar a classe `.destaque`).\n- **Um elemento pode ter várias classes** ao mesmo tempo, separadas por espaço no atributo, assim: `class="destaque caixa"`.\n\nUm bom nome de classe descreve o **papel** do elemento (`.destaque`, `.aviso`, `.botao`), e não o efeito exato. Isso ajuda a manter o CSS organizado.',
+                    },
+                    {
+                        type: "code",
+                        value: '<style>\n  .aviso {\n    color: darkred;\n  }\n  .caixa {\n    padding: 12px;\n  }\n</style>\n\n<!-- A mesma classe .aviso em tags diferentes -->\n<h2 class="aviso">Atenção</h2>\n<p class="aviso">Leia com cuidado.</p>\n\n<!-- Um elemento com duas classes ao mesmo tempo -->\n<p class="aviso caixa">Aviso dentro de uma caixa.</p>',
+                    },
+                    {
+                        type: "text",
+                        value: '## Seletor de id (com cerquilha)\n\nO **id** é parecido com a classe, mas com uma diferença fundamental: ele identifica **um único** elemento na página. "Id" vem de _identifier_ (identificador), e a regra é que **cada id deve ser único** — nenhum outro elemento na mesma página pode repetir aquele id.\n\nO funcionamento é análogo ao da classe, trocando duas coisas: no HTML usamos o atributo `id` (em vez de `class`), e no CSS usamos uma **cerquilha** `#` (em vez do ponto):',
+                    },
+                    {
+                        type: "code",
+                        value: '<style>\n  #cabecalho {\n    background-color: navy;\n    color: white;\n  }\n</style>\n\n<header id="cabecalho">\n  <h1>Meu site</h1>\n</header>',
+                    },
+                    {
+                        type: "text",
+                        value: 'Aqui, a regra `#cabecalho` se aplica ao único elemento que tem `id="cabecalho"`. Como o id é único, ele costuma marcar partes **singulares** da página, aquelas que só existem uma vez: o cabeçalho principal, o rodapé, um menu específico.\n\nSe você repetir o mesmo id em dois elementos, o navegador até aplica o estilo, mas isso é considerado **errado** e pode causar dor de cabeça mais adiante (principalmente quando você começar a usar JavaScript, que conta com ids únicos para achar elementos). Regra de bolso: **id não se repete**.',
+                    },
+                    {
+                        type: "text",
+                        value: "## Classe ou id: qual usar?\n\nEssa é uma dúvida clássica de quem começa. Os dois estilizam, então qual escolher? A diferença está na **quantidade**:\n\n- Use **classe** quando o estilo pode se repetir, valer para **vários** elementos. É o caso mais comum, de longe.\n- Use **id** quando se refere a **um** elemento único e específico da página.\n\nNa prática, a recomendação da maioria dos desenvolvedores é: **na dúvida, use classe**. Classes são mais flexíveis e reaproveitáveis, e você raramente se arrepende de ter usado uma. O id fica reservado para quando a unicidade realmente importa.",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Aspecto","Classe","Id"],["Símbolo no CSS","Ponto: `.destaque`","Cerquilha: `#topo`"],["Atributo no HTML","`class=\\"...\\"`","`id=\\"...\\"`"],["Quantos podem existir?","Vários; a classe se repete","Um só; o id é único na página"],["Quando usar","Estilo que se repete (o caso comum)","Um elemento único e específico"]]',
+                    },
+                    {
+                        type: "text",
+                        value: '## Seletor universal\n\nExiste um seletor curinga que atinge **absolutamente todos** os elementos da página de uma vez: o **universal**, representado por um asterisco `*`.\n\nEle é usado com moderação, geralmente para um ajuste bem geral. Um uso clássico é "zerar" espaçamentos que o navegador aplica por padrão, para começar o estilo de um ponto neutro:',
+                    },
+                    {
+                        type: "code",
+                        value: "<style>\n  /* Aplica a TODOS os elementos da página */\n  * {\n    margin: 0;\n    padding: 0;\n  }\n</style>",
+                    },
+                    {
+                        type: "text",
+                        value: "## Agrupar seletores com vírgula\n\nÀs vezes você quer aplicar **o mesmo estilo** a vários seletores diferentes. Em vez de repetir o bloco de declarações para cada um, você pode **agrupá-los** separando os seletores por **vírgula**.\n\nImagine que você quer todos os títulos (`<h1>`, `<h2>` e `<h3>`) na cor azul-marinho. Em vez de escrever três regras iguais, escreve uma só:",
+                    },
+                    {
+                        type: "code",
+                        value: "<style>\n  /* A vírgula liga vários seletores à mesma regra */\n  h1, h2, h3 {\n    color: navy;\n    font-family: sans-serif;\n  }\n</style>\n\n<h1>Título grande</h1>\n<h2>Subtítulo</h2>\n<h3>Título menor</h3>",
+                    },
+                    {
+                        type: "text",
+                        value: 'A vírgula, ali, quer dizer **"e"**: "aplique este estilo ao `h1`, **e** ao `h2`, **e** ao `h3`". As três tags ficam azul-marinho com uma única regra.\n\nCuidado para não confundir: `h1, h2` (com vírgula) é diferente de `h1 h2` (com espaço). A vírgula agrupa seletores independentes; o espaço tem outro significado (seleciona um elemento dentro do outro), que você vai estudar mais para a frente. Por ora, guarde a vírgula como o jeito de **evitar repetição**, aplicando um estilo a vários seletores de uma vez.',
+                    },
+                    {
+                        type: "quote",
+                        value: '**Cheat sheet dos seletores:** o **seletor** escolhe quem recebe o estilo. Por **tipo** (`p`) atinge todas as tags daquele nome. Por **classe** (`.destaque`, casando com `class="destaque"`) você escolhe vários elementos e reutiliza o estilo — é o mais usado. Por **id** (`#topo`, casando com `id="topo"`) você mira **um** elemento único. O **universal** (`*`) pega todos. E a **vírgula** (`h1, h2, h3`) aplica o mesmo estilo a vários seletores de uma vez. Na dúvida entre classe e id, **use classe**.',
+                    },
+                ],
+                questions: [
+                    {
+                        statement: "Qual símbolo identifica um seletor de classe no CSS?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "O ponto, como em `.destaque`.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "A cerquilha, como em `#destaque`.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O asterisco, como em `*destaque`.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "A vírgula, como em `,destaque`.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Qual seletor atinge TODOS os elementos da página de uma só vez?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "O universal, escrito `*`.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "O seletor de tipo `p`.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "A classe `.tudo`.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O id `#todos`.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "Qual é a diferença principal entre uma classe e um id?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "A classe pode se repetir em vários elementos; o id deve ser único, um por página.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "O id pode se repetir à vontade; a classe só pode aparecer uma vez.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Classe e id são a mesma coisa, só muda o símbolo.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "A classe só funciona em títulos e o id só em parágrafos.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "O que significa a vírgula na regra `h1, h2, h3 { color: navy; }`?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Que o mesmo estilo se aplica aos três seletores: ao `h1`, ao `h2` e ao `h3`.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Que ela seleciona um `h3` que esteja dentro de um `h2`, dentro de um `h1`.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Que o estilo vale só para o primeiro seletor, o `h1`.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Que serão criadas três cores diferentes, uma para cada título.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Você tem vários avisos espalhados pela página, em tags diferentes (um é `<p>`, outro é `<div>`), e quer que todos tenham o mesmo visual. Qual é o melhor seletor?",
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "Uma **classe** (por exemplo `.aviso`) aplicada a todos eles, já que a classe se repete e funciona em tags diferentes.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Um **id** repetido em cada aviso, pois o id foi feito para se repetir.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O seletor de **tipo** `p`, que já pega todos os avisos da página.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O seletor **universal** `*`, para atingir exatamente esses avisos.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Cores no CSS",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "# Cores no CSS\n\nPoucas coisas transformam tanto uma página quanto a **cor**. Trocar o cinza sem graça por uma boa paleta muda por completo a sensação de um site. Por isso vale a pena entender bem como o CSS lida com cores, e você vai ver que existe mais de um jeito de escrever a mesma cor.\n\nNesta aula você vai conhecer as quatro formas mais comuns de dizer uma cor no CSS, dos nomes prontos aos códigos mais precisos, e vai aprender a diferença entre pintar o **texto** e pintar o **fundo**.",
+                    },
+                    {
+                        type: "quote",
+                        value: "No CSS, a **mesma cor** pode ser escrita de várias formas: por **nome** (`red`), em **hexadecimal** (`#ff0000`), com **`rgb()`** (mistura de vermelho, verde e azul) ou com **`hsl()`** (matiz, saturação e luminosidade). A versão **`rgba()`** ainda permite controlar o quão **transparente** a cor fica. E lembre: `color` pinta o **texto**, enquanto `background-color` pinta o **fundo**.",
+                    },
+                    {
+                        type: "text",
+                        value: "## color e background-color: o texto e o fundo\n\nAntes de falar dos formatos de cor, precisamos separar **duas propriedades** que todo mundo confunde no começo:\n\n- `color` define a cor do **texto** (as letras).\n- `background-color` define a cor do **fundo** do elemento (a área atrás do conteúdo).\n\nSão coisas diferentes e independentes. Veja as duas trabalhando juntas:",
+                    },
+                    {
+                        type: "code",
+                        value: '<style>\n  .cartao {\n    color: white;\n    background-color: navy;\n  }\n</style>\n\n<p class="cartao">Texto branco sobre fundo azul-marinho.</p>',
+                    },
+                    {
+                        type: "text",
+                        value: "No exemplo, o parágrafo com a classe `.cartao` fica com as **letras brancas** (`color: white`) sobre um **fundo azul-marinho** (`background-color: navy`). Se você trocasse só o `color`, mudaria a cor das letras; se trocasse só o `background-color`, mudaria o fundo atrás delas.\n\nGuardada essa diferença, agora podemos explorar as várias formas de **escrever** uma cor. Todas elas valem tanto para `color` quanto para `background-color` (e para qualquer outra propriedade de cor).",
+                    },
+                    {
+                        type: "text",
+                        value: "## Forma 1: nomes de cor\n\nA forma mais simples de todas é usar o **nome da cor em inglês**. O CSS entende cerca de 140 nomes prontos, de `black` e `white` aos mais específicos, como `tomato`, `steelblue` ou `gold`:",
+                    },
+                    {
+                        type: "code",
+                        value: '<style>\n  h1 { color: crimson; }\n  p  { color: teal; }\n  .destaque { background-color: gold; }\n</style>\n\n<h1>Título vermelho-carmesim</h1>\n<p>Parágrafo em verde-azulado.</p>\n<p class="destaque">Fundo dourado.</p>',
+                    },
+                    {
+                        type: "text",
+                        value: "Os nomes são práticos e fáceis de lembrar, ótimos para aprender e para testes rápidos. O problema é que são **limitados**: são só cerca de 140, e dificilmente você vai achar exatamente aquele tom específico de que precisa. Para ter **liberdade total** de cor, usamos os formatos numéricos, que vêm a seguir.",
+                    },
+                    {
+                        type: "text",
+                        value: '## Forma 2: hexadecimal (#RRGGBB)\n\nO formato **hexadecimal** (ou "hex") é o mais comum no dia a dia de quem faz sites. Ele parece assustador no início, mas a lógica é simples. Uma cor hex é uma cerquilha `#` seguida de **seis caracteres**, organizados em três pares — `#RRGGBB`:\n\n- Os dois primeiros (`RR`) dizem quanto tem de **vermelho** (_red_).\n- Os dois do meio (`GG`), quanto tem de **verde** (_green_).\n- Os dois últimos (`BB`), quanto tem de **azul** (_blue_).\n\nCada par vai de `00` (nada daquela cor) até `ff` (o máximo daquela cor). Sim, aparecem letras: no sistema hexadecimal, depois do 9 vêm as letras de `a` a `f`. Você não precisa fazer contas, só entender que **quanto maior o par, mais forte aquela componente**.',
+                    },
+                    {
+                        type: "code",
+                        value: '<style>\n  .titulo { color: #1e90ff; }            /* um azul vivo */\n  .fundo  { background-color: #f5f5f5; } /* cinza bem claro */\n</style>\n\n<h1 class="titulo">Título azul</h1>\n<p class="fundo">Parágrafo com fundo cinza claro.</p>',
+                    },
+                    {
+                        type: "text",
+                        value: "Alguns valores hex que vale a pena reconhecer de cara:\n\n- `#000000` é **preto** (zero das três cores).\n- `#ffffff` é **branco** (o máximo das três).\n- `#ff0000` é **vermelho puro** (vermelho no talo, verde e azul zerados).\n\nQuando os três pares são repetidos (como `#ffffff` ou `#1188cc`), existe um **atalho** de três dígitos: `#fff` é o mesmo que `#ffffff`, e `#000` é o mesmo que `#000000`. Na prática, você quase nunca vai inventar esses códigos de cabeça: pega eles de um **seletor de cores** (o color picker do seu editor ou de um site de paletas) e cola no CSS.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Forma 3: rgb() e rgba()\n\nO formato **`rgb()`** diz a mesma coisa que o hexadecimal (quanto de vermelho, verde e azul), mas usando **números** de 0 a 255, que muita gente acha mais fáceis de ler. A ordem é sempre vermelho, verde, azul:",
+                    },
+                    {
+                        type: "code",
+                        value: "<style>\n  h1 { color: rgb(30, 144, 255); }  /* o mesmo azul do #1e90ff */\n  p  { color: rgb(0, 0, 0); }       /* preto */\n</style>\n\n<h1>Título azul com rgb()</h1>\n<p>Texto preto.</p>",
+                    },
+                    {
+                        type: "text",
+                        value: "Cada número vai de `0` (nada) a `255` (o máximo) daquela componente. Assim, `rgb(255, 0, 0)` é vermelho puro, `rgb(0, 0, 0)` é preto e `rgb(255, 255, 255)` é branco. É a mesma lógica do hex, só que em números que a gente lê mais fácil.\n\nO `rgb()` tem uma versão irmã que adiciona um quarto valor: a **transparência**. É a **`rgba()`**, em que o `a` vem de _alpha_ (o canal de transparência):",
+                    },
+                    {
+                        type: "code",
+                        value: '<style>\n  .caixa {\n    /* preto com 50% de transparência */\n    background-color: rgba(0, 0, 0, 0.5);\n  }\n</style>\n\n<div class="caixa">\n  <p>O fundo preto aqui está meio transparente.</p>\n</div>',
+                    },
+                    {
+                        type: "text",
+                        value: "Esse quarto valor, o **alpha**, vai de `0` a `1` e controla a **opacidade** da cor:\n\n- `0` é **totalmente transparente** (a cor some, dá para ver tudo atrás).\n- `1` é **totalmente opaco** (a cor cheia, igual ao `rgb()` normal).\n- `0.5` é **meio a meio**, um véu translúcido.\n\nA transparência é ótima para efeitos como uma tarja escura por cima de uma foto, deixando o texto legível sem esconder a imagem. Uma curiosidade: o hexadecimal moderno também aceita transparência com dois dígitos a mais, mas o `rgba()` costuma ser mais fácil de entender no começo.",
+                    },
+                    {
+                        type: "text",
+                        value: '## Forma 4: hsl()\n\nA última forma é a **`hsl()`**, que muita gente considera a mais **intuitiva** para escolher cores na mão, porque descreve a cor do jeito que a gente pensa. São três valores:\n\n- **H** (_hue_, matiz): a cor em si, num círculo de `0` a `360` graus. `0` é vermelho, `120` é verde, `240` é azul, e aí volta ao vermelho em `360`.\n- **S** (_saturation_, saturação): o quão viva é a cor, de `0%` (cinza sem graça) a `100%` (cor vibrante).\n- **L** (_lightness_, luminosidade): o quão clara, de `0%` (preto) a `100%` (branco), com `50%` sendo a cor "cheia".',
+                    },
+                    {
+                        type: "code",
+                        value: '<style>\n  .a { color: hsl(0, 100%, 50%); }    /* vermelho puro */\n  .b { color: hsl(120, 100%, 50%); }  /* verde puro */\n  .c { color: hsl(240, 100%, 50%); }  /* azul puro */\n</style>\n\n<p class="a">Vermelho.</p>\n<p class="b">Verde.</p>\n<p class="c">Azul.</p>',
+                    },
+                    {
+                        type: "text",
+                        value: "A grande vantagem do `hsl()` aparece quando você quer **variações** de uma cor. Fixando o matiz (o primeiro número) e mexendo só na luminosidade, você cria tons mais claros ou mais escuros da **mesma** cor com facilidade, algo bem mais trabalhoso no hexadecimal:",
+                    },
+                    {
+                        type: "code",
+                        value: '<style>\n  /* Mesmo azul (matiz 210), do mais escuro ao mais claro */\n  .escuro { background-color: hsl(210, 100%, 30%); }\n  .medio  { background-color: hsl(210, 100%, 50%); }\n  .claro  { background-color: hsl(210, 100%, 80%); }\n</style>\n\n<p class="escuro">Azul escuro</p>\n<p class="medio">Azul médio</p>\n<p class="claro">Azul claro</p>',
+                    },
+                    {
+                        type: "text",
+                        value: "## As quatro formas lado a lado\n\nPara amarrar tudo, a tabela abaixo mostra a **mesma cor** (um tom de tomate) escrita das quatro maneiras. Todas produzem exatamente o mesmo resultado na tela; só muda a notação:",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Forma","O mesmo tomate escrito assim","Quando costuma ser útil"],["Nome","`tomato`","Testes rápidos e cores bem conhecidas"],["Hexadecimal","`#ff6347`","O padrão no dia a dia, vindo de um color picker"],["`rgb()`","`rgb(255, 99, 71)`","Números de 0 a 255, fáceis de ler"],["`hsl()`","`hsl(9, 100%, 64%)`","Escolher e criar variações de tom na mão"]]',
+                    },
+                    {
+                        type: "text",
+                        value: "## Afinal, qual devo usar?\n\nBoa notícia: **todas funcionam**, e você pode até misturar formatos no mesmo projeto. Mas, na prática:\n\n- Para **começar e testar**, os **nomes** são os mais fáceis.\n- No **dia a dia**, o **hexadecimal** é o mais comum, porque é o que os color pickers e as ferramentas de design costumam entregar.\n- Quando precisar de **transparência**, use `rgba()`.\n- Quando quiser **ajustar tons na mão**, o `hsl()` é o mais confortável.\n\nNão precisa decorar códigos de cor. O caminho normal é escolher a cor num seletor visual e colar o valor no CSS. O importante é **reconhecer** cada formato quando cruzar com ele.",
+                    },
+                    {
+                        type: "quote",
+                        value: "**Cheat sheet das cores:** `color` pinta o **texto** e `background-color` pinta o **fundo**. Uma cor pode ser escrita por **nome** (`tomato`), em **hexadecimal** `#RRGGBB` (cada par de `00` a `ff`, com atalho de 3 dígitos como `#fff`), com **`rgb()`** (três números de 0 a 255) ou com **`hsl()`** (matiz 0–360, saturação e luminosidade em %). Para **transparência**, use **`rgba()`** com um alpha de `0` (invisível) a `1` (opaco). Todas as formas valem para qualquer propriedade de cor.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement: "Qual propriedade define a cor do fundo de um elemento?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`background-color`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`color`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`background-image`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`text-color`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Uma cor hexadecimal como `#ff0000` tem quantos caracteres depois do `#`, e o que eles representam?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "Seis, em três pares: vermelho, verde e azul.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Três, um para cada cor primária.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Oito, um para cada cor do arco-íris.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Dois, apenas para o brilho da cor.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "No valor `rgba(0, 0, 0, 0.5)`, o que faz o último número, o `0.5`?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Controla a transparência: `0` é totalmente transparente, `1` é opaco, e `0.5` fica meio a meio.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Define o tom de cinza do preto.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Indica quantos pixels a cor ocupa na tela.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Escolhe entre as cores vermelho, verde e azul.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "Qual destes valores representa o **vermelho puro**?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "`rgb(255, 0, 0)`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`rgb(0, 255, 0)`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`rgb(0, 0, 255)`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`#00ff00`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Um colega afirma que `#ffffff`, `rgb(255, 255, 255)` e o nome `white` são três cores diferentes. Qual resposta o corrige?",
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "São a **mesma** cor (o branco) escrita de três formas diferentes; o resultado na tela é idêntico.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Estão certas em serem diferentes: uma é branca, outra é cinza e outra é creme.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Só o nome `white` é branco; os outros dois são tons de azul.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "São diferentes porque `rgb()` e hexadecimal nunca podem representar a mesma cor.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        titulo: "Módulo 2 - Seletores, cascata e especificidade",
+        aulas: [
+            {
+                titulo: "Combinadores e seletores de atributo",
+                blocks: [
+                    {
+                        type: "text",
+                        value: '# Combinadores e seletores de atributo\n\nNo módulo passado você aprendeu a mirar elementos com seletores simples: pelo nome da tag (`p`), pela classe (`.destaque`) ou pelo id (`#topo`). Isso já resolve muita coisa, mas cedo ou tarde bate uma vontade mais fina: "quero estilizar só os parágrafos que estão **dentro** de um artigo" ou "só o item que vem **logo depois** de um título".\n\nÉ aí que entram os **combinadores**. Eles não são seletores novos: são **símbolos que você coloca entre dois seletores** para descrever a **relação** entre os elementos. Nesta aula você vai conhecer os quatro combinadores e, de quebra, um jeito de selecionar elementos pelos seus atributos.',
+                    },
+                    {
+                        type: "quote",
+                        value: "Um **combinador** é o símbolo (ou o espaço) que fica **entre dois seletores** e descreve a **relação de parentesco ou vizinhança** entre eles. Trocar esse símbolo muda por completo quais elementos são atingidos: `article p` (espaço) mira descendentes em qualquer nível; `article > p` (maior que) mira só os filhos diretos; `h2 + p` (mais) mira o irmão logo em seguida; e `h2 ~ p` (til) mira todos os irmãos seguintes.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Uma árvore de parentesco\n\nAntes dos símbolos, precisamos de uma imagem na cabeça. Todo HTML é uma **árvore de família**: uns elementos ficam dentro dos outros, então dá para falar em **pais**, **filhos**, **irmãos** e até **netos**.\n\nVeja este HTML e repare no encaixe:",
+                    },
+                    {
+                        type: "code",
+                        value: "<article>\n  <h2>Título do post</h2>\n  <p>Primeiro parágrafo.</p>\n  <section>\n    <p>Parágrafo dentro de uma section.</p>\n  </section>\n</article>",
+                    },
+                    {
+                        type: "text",
+                        value: "Nessa árvore:\n\n- O `article` é o **pai** do `h2`, do primeiro `p` e da `section`.\n- Esses três são **irmãos** entre si, porque têm o mesmo pai.\n- O `p` que está dentro da `section` é **neto** do `article` (ele é filho da `section`, que é filha do `article`).\n\nOs combinadores usam exatamente esse vocabulário. Vamos a eles, um de cada vez.",
+                    },
+                    {
+                        type: "text",
+                        value: '## O combinador descendente: o espaço\n\nO mais usado de todos é também o mais discreto: um simples **espaço** entre dois seletores. `nav a` quer dizer "todo `a` que esteja **dentro** de um `nav`, não importa quão fundo". Filho, neto, bisneto: se estiver lá dentro em qualquer nível, é selecionado.',
+                    },
+                    {
+                        type: "code",
+                        value: "/* Todo link dentro de um nav perde o sublinhado — em qualquer nível */\nnav a {\n  text-decoration: none;\n}",
+                    },
+                    {
+                        type: "code",
+                        value: '<nav>\n  <a href="#">Início</a>          <!-- pega: filho direto do nav -->\n  <ul>\n    <li><a href="#">Blog</a></li> <!-- pega também: é neto do nav -->\n  </ul>\n</nav>\n\n<a href="#">Contato</a>           <!-- NÃO pega: está fora do nav -->',
+                    },
+                    {
+                        type: "text",
+                        value: '## Filho direto: o `>`\n\nÀs vezes "qualquer descendente" é demais. O combinador **filho direto**, escrito com o sinal de maior `>`, seleciona **só os filhos diretos**, ignorando netos e bisnetos. Pense assim: `article > p` mira os filhos, mas não os netos.',
+                    },
+                    {
+                        type: "code",
+                        value: "/* Só os parágrafos que são filhos DIRETOS do article ficam em negrito */\narticle > p {\n  font-weight: bold;\n}",
+                    },
+                    {
+                        type: "code",
+                        value: "<article>\n  <p>Fico em negrito: sou filho direto do article.</p>\n  <section>\n    <p>NÃO fico: sou neto (filho da section).</p>\n  </section>\n</article>",
+                    },
+                    {
+                        type: "text",
+                        value: "## Irmão adjacente: o `+`\n\nOs dois próximos combinadores olham para o lado, para os **irmãos** (elementos com o mesmo pai). O irmão **adjacente**, escrito com `+`, seleciona o elemento que vem **imediatamente depois** de outro. `h2 + p` mira o **primeiro** parágrafo logo em seguida de um `h2` — só ele, mais nenhum.",
+                    },
+                    {
+                        type: "code",
+                        value: "/* O parágrafo IMEDIATAMENTE após um h2 ganha um respiro em cima */\nh2 + p {\n  margin-top: 16px;\n}",
+                    },
+                    {
+                        type: "code",
+                        value: "<h2>Seção</h2>\n<p>Fico com o recuo: venho logo depois do h2.</p>\n<p>NÃO fico: já não sou o primeiro depois do h2.</p>",
+                    },
+                    {
+                        type: "text",
+                        value: "## Irmão geral: o `~`\n\nO irmão **geral**, escrito com o til `~`, é o primo mais generoso do `+`: em vez de pegar só o próximo, ele pega **todos os irmãos que vierem depois**. `h2 ~ p` seleciona todos os parágrafos irmãos que aparecem após um `h2`.",
+                    },
+                    {
+                        type: "code",
+                        value: "/* TODOS os parágrafos irmãos que vierem depois de um h2 ficam cinzas */\nh2 ~ p {\n  color: gray;\n}",
+                    },
+                    {
+                        type: "code",
+                        value: "<h2>Seção</h2>\n<p>Fico cinza.</p>\n<span>Não sou p, então passo batido.</span>\n<p>Também fico cinza: sou um irmão posterior do h2.</p>",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Combinador","Símbolo","Seleciona","Exemplo"],["Descendente","(espaço)","Qualquer descendente, em qualquer nível","`nav a`"],["Filho direto","`>`","Só os filhos diretos","`article > p`"],["Irmão adjacente","`+`","O irmão logo em seguida","`h2 + p`"],["Irmão geral","`~`","Todos os irmãos seguintes","`h2 ~ p`"]]',
+                    },
+                    {
+                        type: "text",
+                        value: '## Selecionando por atributo: os colchetes `[ ]`\n\nAlém de tag, classe e id, você pode mirar elementos pelos seus **atributos**, aqueles pares `nome="valor"` que você viu no módulo de HTML. Basta colocar o atributo entre **colchetes** `[ ]`. É especialmente útil em **formulários**, onde vários `input` diferem só pelo atributo `type`.\n\n- `[href]` seleciona todo elemento que **tenha** o atributo `href`, não importa o valor.\n- `[type="text"]` seleciona os que têm `type` **igual a** `text`.\n- Você pode grudar o colchete num seletor de tag: `input[type="password"]` mira só os campos de senha.',
+                    },
+                    {
+                        type: "code",
+                        value: '/* Todo campo de texto ganha uma borda cinza */\ninput[type="text"] {\n  border: 1px solid #ccc;\n}\n\n/* Campos de senha ganham um fundo levemente amarelado */\ninput[type="password"] {\n  background: #fffbea;\n}\n\n/* Links que abrem em nova aba (target="_blank") ficam com outra cor */\na[target="_blank"] {\n  color: teal;\n}',
+                    },
+                    {
+                        type: "text",
+                        value: 'Dá para ir além do "igual a": existem variações para casar o **começo**, o **fim** ou um **pedaço** do valor. Por exemplo, `[href^="https"]` pega os links cujo `href` **começa** com `https`, e `[src$=".png"]` pega as imagens cujo `src` **termina** em `.png`. Você não precisa decorar isso agora, só saber que existe: quando precisar, é só consultar. Por ora, `[atributo]` e `[atributo="valor"]` já cobrem a maioria dos casos.',
+                    },
+                    {
+                        type: "quote",
+                        value: '**Cheat sheet:** os **combinadores** ficam entre dois seletores e descrevem a relação: **espaço** = qualquer descendente (`nav a`); **`>`** = filho direto (`article > p`); **`+`** = o irmão logo em seguida (`h2 + p`); **`~`** = todos os irmãos seguintes (`h2 ~ p`). Já os **seletores de atributo** miram pelos atributos entre colchetes: `[href]` (tem o atributo) ou `[type="text"]` (valor exato), ótimos em formulários e muitas vezes grudados na tag, como `input[type="password"]`.',
+                    },
+                ],
+                questions: [
+                    {
+                        statement:
+                            "O que o espaço entre dois seletores, como em `article p`, seleciona?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "Qualquer `p` que esteja dentro de um `article`, em qualquer nível de profundidade (filho, neto, bisneto).",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Apenas o `p` que é filho direto do `article`.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O `p` que vem imediatamente depois do `article`.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Todo `article` que esteja dentro de um `p`.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Qual combinador seleciona apenas os filhos diretos de um elemento, ignorando os netos?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`>` (maior que)",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "O espaço",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`+` (mais)",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`~` (til)",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "O seletor `h2 + p` estiliza qual elemento?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "O primeiro parágrafo que vem imediatamente depois de um `h2`, sendo irmão dele.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Todos os parágrafos que aparecem depois do `h2`.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Todos os parágrafos que estão dentro do `h2`.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O parágrafo que vem logo antes do `h2`.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: 'O que o seletor `input[type="text"]` seleciona?',
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Os elementos `input` cujo atributo `type` é igual a `text`.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Todos os elementos `input` da página, independentemente do tipo.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Os `input` que têm a classe `text`.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O texto que o usuário digitou dentro do campo.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Você quer deixar em cinza TODOS os parágrafos que aparecem depois de um `h2` e são irmãos dele, não só o primeiro. Qual seletor faz isso?",
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "`h2 ~ p`, porque o til seleciona todos os irmãos que vêm depois.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`h2 + p`, porque o mais seleciona todos os irmãos seguintes.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`h2 > p`, porque os parágrafos são filhos diretos do `h2`.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`h2 p`, porque os parágrafos ficam dentro do `h2`.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Pseudo-classes e pseudo-elementos",
+                blocks: [
+                    {
+                        type: "text",
+                        value: '# Pseudo-classes e pseudo-elementos\n\nAté agora, todos os nossos seletores miravam elementos que existem "crus" no HTML. Mas e se você quiser estilizar um botão **só enquanto o mouse está em cima** dele? Ou pintar **só o primeiro item** de uma lista? Ou ainda colocar um símbolo **antes** de um texto sem escrever esse símbolo no HTML?\n\nPara esses casos existem as **pseudo-classes** e os **pseudo-elementos**. O prefixo _pseudo_ vem do grego e quer dizer "falso", "aparente". A ideia é selecionar algo que não é um elemento comum: um **estado** ("enquanto está sob o mouse"), uma **posição** ("o primeiro filho") ou uma **parte** do elemento que nem existe no HTML.',
+                    },
+                    {
+                        type: "quote",
+                        value: "Uma **pseudo-classe** começa com **um** dois-pontos (`:hover`, `:first-child`) e mira o elemento em um certo **estado** ou **posição**. Um **pseudo-elemento** começa com **dois** dois-pontos (`::before`, `::placeholder`) e mira uma **parte** do elemento, ou cria um pedacinho novo que não existe no HTML. A regra de bolso: `:` para estado, `::` para parte.",
+                    },
+                    {
+                        type: "text",
+                        value: '## Pseudo-classes de estado: `:hover`, `:focus`, `:active`\n\nAs três pseudo-classes mais usadas descrevem como o usuário está **interagindo** com o elemento naquele instante:\n\n- `:hover` vale enquanto o **ponteiro do mouse está em cima** do elemento. É o clássico "muda de cor quando passo o mouse".\n- `:focus` vale quando o elemento está **em foco**, ou seja, selecionado para receber a digitação (um campo de formulário clicado, ou um botão alcançado com a tecla Tab).\n- `:active` vale no **instante do clique**, enquanto o botão do mouse está pressionado.',
+                    },
+                    {
+                        type: "code",
+                        value: "/* Cor normal do botão */\nbutton {\n  background: royalblue;\n  color: white;\n}\n\n/* Enquanto o mouse está em cima */\nbutton:hover {\n  background: mediumblue;\n}\n\n/* No instante em que está sendo clicado */\nbutton:active {\n  background: navy;\n}\n\n/* Quando um campo de texto está em foco */\ninput:focus {\n  border: 2px solid royalblue;\n}",
+                    },
+                    {
+                        type: "text",
+                        value: 'Vale um destaque para o `:focus`. Muita gente se incomoda com a "bordinha" que aparece nos campos e botões e some com ela no CSS. **Não faça isso sem oferecer um substituto.** Quem navega pelo teclado (por preferência ou por necessidade) usa justamente esse realce de foco para saber onde está na página. Se você tira o destaque padrão, ponha outro no lugar, como uma borda ou uma sombra bem visível. Acessibilidade também é responsabilidade do CSS.',
+                    },
+                    {
+                        type: "text",
+                        value: "## Pseudo-classes de posição: `:first-child`, `:last-child`, `:nth-child()`\n\nOutro grupo de pseudo-classes seleciona o elemento pela sua **posição entre os irmãos**:\n\n- `:first-child` mira o elemento que é o **primeiro filho** do seu pai.\n- `:last-child` mira o **último filho**.\n- `:nth-child(n)` é o mais poderoso: mira o filho de **número n**. Você pode passar um número (`:nth-child(3)` = o terceiro), a palavra `odd` (ímpares), a palavra `even` (pares) ou até uma fórmula.",
+                    },
+                    {
+                        type: "code",
+                        value: '/* Deixa o primeiro item da lista em negrito */\nli:first-child {\n  font-weight: bold;\n}\n\n/* Tira a borda de baixo do último item, para não sobrar uma linha solta */\nli:last-child {\n  border-bottom: none;\n}\n\n/* Pinta o fundo das linhas pares — o famoso "zebrado" de tabelas */\ntr:nth-child(even) {\n  background: #f2f2f2;\n}',
+                    },
+                    {
+                        type: "text",
+                        value: "O `:nth-child()` merece um segundo olhar porque o `even`/`odd` resolve um problema muito comum: o **zebrado**. Alternar a cor de fundo das linhas de uma tabela (ou dos itens de uma lista longa) deixa tudo mais fácil de ler, e você consegue isso com uma única regra, sem marcar linha por linha no HTML. Se um dia precisar de um ritmo diferente, dá para usar fórmulas como `:nth-child(3n)` (de três em três), mas para começar `even` e `odd` já cobrem quase tudo.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Excluindo com `:not()`\n\nÀs vezes é mais fácil dizer o que você **não** quer. A pseudo-classe `:not()` seleciona tudo **menos** o que estiver dentro dos parênteses. Por exemplo, `li:not(.ativo)` mira todos os `li` que **não** têm a classe `ativo`.",
+                    },
+                    {
+                        type: "code",
+                        value: '/* Todos os botões, exceto os que têm a classe "desativado" */\nbutton:not(.desativado) {\n  cursor: pointer;\n}\n\n/* Todos os itens da lista, menos o último, ganham uma linha separadora */\nli:not(:last-child) {\n  border-bottom: 1px solid #ddd;\n}',
+                    },
+                    {
+                        type: "table",
+                        value: '[["Pseudo-classe","Seleciona"],["`:hover`","O elemento sob o ponteiro do mouse"],["`:focus`","O elemento em foco, pronto para receber digitação"],["`:active`","O elemento no instante do clique"],["`:first-child`","O primeiro filho do seu pai"],["`:last-child`","O último filho do seu pai"],["`:nth-child(n)`","O filho de número n (aceita `even`, `odd` e fórmulas)"],["`:not(x)`","Todos, menos os que casam com `x`"]]',
+                    },
+                    {
+                        type: "text",
+                        value: "## Pseudo-elementos: `::before` e `::after`\n\nAgora entramos nos **pseudo-elementos**, marcados por **dois** dois-pontos. Os dois mais famosos são o `::before` e o `::after`: eles **criam um pedacinho de conteúdo** logo **antes** e logo **depois** do conteúdo do elemento, sem que você precise escrever nada disso no HTML.\n\nPara esse pedacinho aparecer, ele **precisa** da propriedade `content`, que diz qual texto (ou símbolo) colocar ali. Sem `content`, o pseudo-elemento simplesmente não aparece.",
+                    },
+                    {
+                        type: "code",
+                        value: '/* Marca os campos obrigatórios com um asterisco vermelho depois do rótulo */\nlabel.obrigatorio::after {\n  content: " *";\n  color: red;\n}\n\n/* Coloca a palavra "Dica:" antes de todo parágrafo de dica */\np.dica::before {\n  content: "Dica: ";\n  font-weight: bold;\n}',
+                    },
+                    {
+                        type: "text",
+                        value: 'Um uso muito comum é adicionar **rótulos e enfeites** sem poluir o HTML. Como esse conteúdo é puramente visual, o lugar dele é no CSS, não no HTML. Você também vai encontrar `content: ""` (vazio) combinado com tamanho e cor de fundo para desenhar pequenas formas decorativas, mas isso é papo para mais adiante. Por ora, guarde a dupla: `::before`/`::after` sempre acompanhados de `content`.',
+                    },
+                    {
+                        type: "text",
+                        value: "## Estilizando o texto de dica: `::placeholder`\n\nQuando você cria um campo com o atributo `placeholder`, o navegador mostra um textinho de dica dentro do campo, que some quando o usuário começa a digitar. Esse texto é uma **parte** do campo, então também é um pseudo-elemento: o `::placeholder`. Com ele você ajusta a cor e o estilo dessa dica.",
+                    },
+                    {
+                        type: "code",
+                        value: '<input type="email" placeholder="seu@email.com">',
+                    },
+                    {
+                        type: "code",
+                        value: "/* Deixa o texto de dica cinza-claro e em itálico */\ninput::placeholder {\n  color: #999;\n  font-style: italic;\n}",
+                    },
+                    {
+                        type: "quote",
+                        value: "**Cheat sheet:** um dois-pontos (`:`) marca **pseudo-classe** (estado ou posição): `:hover` (sob o mouse), `:focus` (em foco — não suma com ele sem substituir), `:active` (no clique), `:first-child`/`:last-child`/`:nth-child()` (posição, com `even`/`odd` para o zebrado) e `:not()` (exclusão). Dois dois-pontos (`::`) marcam **pseudo-elemento** (uma parte): `::before` e `::after` sempre com `content`, e `::placeholder` para o texto de dica dos campos.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement: "O que a pseudo-classe `:hover` seleciona?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "O elemento enquanto o ponteiro do mouse está em cima dele.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "O primeiro filho de um elemento.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O elemento no instante exato do clique.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Uma parte do elemento criada só pelo CSS.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Quantos dois-pontos marcam um pseudo-elemento como o `::before`?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "Dois (`::`).",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Um (`:`).",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Nenhum; usa-se um ponto (`.`).",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Três (`:::`).",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "O que a regra `tr:nth-child(even)` faz?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Aplica o estilo às linhas de posição par, criando o efeito zebrado.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Aplica o estilo apenas à primeira linha da tabela.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Aplica o estilo a todas as linhas, sem exceção.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Aplica o estilo somente à linha que está sob o mouse.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Qual propriedade é indispensável para que um `::before` ou `::after` apareça na tela?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "`content`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`color`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`display`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`placeholder`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "O que o seletor `li:not(:last-child)` seleciona?",
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "Todos os itens da lista, exceto o último.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Apenas o último item da lista.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Todos os itens da lista, sem exceção.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Apenas o primeiro item da lista.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Herança e cascata",
+                blocks: [
+                    {
+                        type: "text",
+                        value: '# Herança e cascata\n\nVocê já sabe escrever regras e mirar os elementos certos. Agora vem uma pergunta natural: quando um elemento poderia ser afetado por **várias** regras, ou por **nenhuma** diretamente, quem decide a aparência final?\n\nA resposta envolve dois mecanismos que trabalham nos bastidores de todo CSS: a **herança**, que faz certos estilos "descerem" dos pais para os filhos automaticamente, e a **cascata**, o conjunto de regras que o navegador usa para escolher um vencedor quando mais de uma regra tenta valer. Entender essa dupla é o que separa quem "chuta CSS até funcionar" de quem realmente sabe o que está fazendo.',
+                    },
+                    {
+                        type: "quote",
+                        value: "Dois mecanismos definem o valor final de cada propriedade. A **herança** faz algumas propriedades (como cor e fonte) passarem do elemento pai para os filhos sem você repetir nada. A **cascata** é o processo de desempate: quando várias regras miram o mesmo elemento, o navegador as ordena por **origem**, depois por **especificidade** e, por fim, por **ordem de aparição** — e a que sobra vence.",
+                    },
+                    {
+                        type: "text",
+                        value: '## Herança: estilos que descem dos pais\n\n**Herança** é a ideia de que alguns estilos aplicados a um elemento são **repassados aos seus descendentes** automaticamente. É como um traço de família: se você define a cor do texto no `body`, os parágrafos, títulos e listas lá dentro tendem a "herdar" essa mesma cor, sem você repetir a regra em cada um.\n\nAs propriedades que se herdam são, quase todas, ligadas a **texto**: `color`, `font-family`, `font-size`, `font-weight`, `line-height`, `text-align`. Faz sentido: você quer que a fonte escolhida valha para a página inteira, então nada mais prático do que defini-la uma vez no topo e deixar descer.',
+                    },
+                    {
+                        type: "code",
+                        value: "/* Definido uma única vez no body... */\nbody {\n  color: #333;\n  font-family: Arial, sans-serif;\n}",
+                    },
+                    {
+                        type: "code",
+                        value: "<body>\n  <h1>Este título herda a cor #333 e a fonte Arial</h1>\n  <p>Este parágrafo também, sem precisar de nenhuma regra própria.</p>\n</body>",
+                    },
+                    {
+                        type: "text",
+                        value: "## O que NÃO se herda\n\nAgora imagine se **tudo** fosse herdado. Você põe uma borda no `body` e, de repente, cada parágrafo, cada link e cada imagem também ganha aquela borda. Um caos. Por isso, propriedades ligadas a **layout e caixa** **não** são herdadas: `border`, `margin`, `padding`, `width`, `height`, `background`.\n\nA regra prática para lembrar: o que é sobre **texto** costuma ser herdado; o que é sobre **a caixa do elemento** (tamanho, espaçamento, fundo, borda) não é. Cada elemento cuida da sua própria caixa.",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Propriedade","É herdada?","Sobre o quê"],["`color`","Sim","Texto"],["`font-family`","Sim","Texto"],["`font-size`","Sim","Texto"],["`line-height`","Sim","Texto"],["`background`","Não","Caixa"],["`border`","Não","Caixa"],["`margin` / `padding`","Não","Caixa"],["`width` / `height`","Não","Caixa"]]',
+                    },
+                    {
+                        type: "text",
+                        value: '## A cascata: escolhendo um vencedor\n\nO "C" de CSS vem de _Cascading_, ou seja, **em cascata**. O nome descreve o que acontece quando **várias regras** miram o mesmo elemento e discordam: elas passam por um funil de desempate até sobrar uma vencedora. O navegador decide em três etapas, nesta ordem:\n\n1. **Origem** da regra: existe o CSS que **você** escreve (o do autor da página), o que o **usuário** pode configurar no navegador e o **estilo padrão do próprio navegador**. O seu, de autor, tem prioridade sobre o padrão do navegador.\n2. **Especificidade**: entre as suas próprias regras, a mais "específica" vence. Esse cálculo é tão importante que ganhou uma aula só para ele — a próxima.\n3. **Ordem de aparição**: se duas regras empatam em tudo, vence a que aparece **por último** no CSS.',
+                    },
+                    {
+                        type: "text",
+                        value: 'Vamos ver a terceira etapa, a mais fácil de observar. Quando duas regras têm exatamente o mesmo alvo e o mesmo peso, a **última a ser escrita** ganha, porque ela "passa por cima" da anterior:',
+                    },
+                    {
+                        type: "code",
+                        value: "p {\n  color: blue;\n}\n\n/* Vem depois e mira o mesmo p com o mesmo peso: é esta que vale */\np {\n  color: green;\n}\n\n/* Resultado na tela: o parágrafo fica verde */",
+                    },
+                    {
+                        type: "text",
+                        value: '## Controlando na mão: `inherit` e `initial`\n\nÀs vezes você quer **forçar** a herança, ou **desfazê-la**. Para isso existem dois valores especiais que servem para qualquer propriedade:\n\n- `inherit` diz "use o mesmo valor do meu elemento pai", mesmo em propriedades que normalmente não se herdam.\n- `initial` diz "volte ao valor **inicial** que o CSS define para esta propriedade", desfazendo qualquer herança. Para `color`, por exemplo, esse valor inicial é o preto.\n\nUm caso clássico do `inherit`: botões e campos de formulário, por padrão, **não** herdam a fonte da página, eles vêm com uma fonte própria do navegador. Se você quer que um botão use a mesma fonte do resto, força com `inherit`:',
+                    },
+                    {
+                        type: "code",
+                        value: "/* Faz o botão usar a mesma fonte herdada do resto da página */\nbutton {\n  font-family: inherit;\n}\n\n/* Volta a cor deste elemento ao valor inicial padrão do CSS (preto) */\n.reset {\n  color: initial;\n}",
+                    },
+                    {
+                        type: "text",
+                        value: '## `!important`: o martelo que quebra a cascata\n\nExiste uma forma de dizer ao navegador "esta declaração vence, e ponto final": basta acrescentar `!important` no fim do valor. Ela pula na frente de praticamente todas as outras regras, ignorando especificidade e ordem.\n\nParece a solução mágica para quando um estilo "não quer pegar", mas é justamente aí que mora o perigo.',
+                    },
+                    {
+                        type: "code",
+                        value: "p {\n  color: red !important; /* vence mesmo contra uma regra mais específica */\n}\n\n/* Esta, embora mais específica, PERDE por causa do !important acima */\n#conteudo p {\n  color: blue;\n}",
+                    },
+                    {
+                        type: "text",
+                        value: '### Por que evitar o `!important`\n\nO problema do `!important` é que ele **quebra o fluxo natural** da cascata. Quando você usa um para "resolver" um problema, mais cedo ou mais tarde vai precisar de **outro** `!important` para sobrepor o primeiro, e logo o seu CSS vira uma guerra de martelos onde ninguém mais sabe qual regra manda. De quebra, o código fica muito mais difícil de manter e de depurar.\n\nA recomendação é clara: **evite** o `!important`. Se um estilo não está pegando, quase sempre o certo é entender a **especificidade** (nosso próximo assunto) e ajustar o seletor, em vez de apelar para o martelo.',
+                    },
+                    {
+                        type: "quote",
+                        value: "**Cheat sheet:** a **herança** repassa aos filhos, sozinha, propriedades de **texto** (`color`, `font-family`, `font-size`...); propriedades de **caixa** (`border`, `margin`, `padding`, `background`) **não** se herdam. A **cascata** desempata regras concorrentes por **origem → especificidade → ordem** (no empate, a última vence). `inherit` força a herança; `initial` volta ao valor inicial. E o `!important` até vence tudo, mas quebra a cascata e vira dor de cabeça: **evite**.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement:
+                            "Qual destas propriedades é herdada dos elementos pais para os filhos por padrão?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`color`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`border`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`margin`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`width`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: 'A que se refere a palavra "cascata" (o C de CSS)?',
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "Ao processo pelo qual o navegador decide qual regra vence quando várias miram o mesmo elemento.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Ao efeito visual de água caindo que se aplica ao fundo das páginas.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "À ordem em que as imagens são baixadas pelo navegador.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Ao fato de o HTML ficar aninhado em forma de árvore.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Duas regras miram o mesmo elemento com o mesmo peso (mesma especificidade). Qual delas vence?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "A que aparecer por último no arquivo CSS.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "A que aparecer primeiro no arquivo CSS.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "A que tiver o seletor com o nome maior.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Nenhuma; o navegador ignora as duas.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "O que o valor `inherit` faz quando aplicado a uma propriedade?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Faz a propriedade usar o mesmo valor do elemento pai, mesmo que ela normalmente não seja herdada.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Volta a propriedade ao valor padrão do navegador.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Impede que os filhos daquele elemento herdem qualquer coisa.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Faz a regra vencer todas as outras, como o `!important`.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "Por que a recomendação geral é evitar o `!important`?",
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "Porque ele quebra o fluxo natural da cascata e leva a uma escalada de novos `!important` para sobrepor os anteriores, deixando o CSS difícil de manter.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Porque ele não funciona na maioria dos navegadores modernos.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Porque ele deixa a página mais lenta para carregar.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Porque ele só pode ser usado uma vez por arquivo CSS.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Especificidade",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "# Especificidade\n\nNa aula anterior vimos que, quando duas regras empatam, vence a última escrita. Mas e quando elas **não** empatam? Você já deve ter passado por isto: escreveu uma regra que parecia certinha e, mesmo assim, o estilo **não pegou** — outra regra, escrita bem antes, teimava em vencer. Isso não é bug: é a **especificidade** em ação.\n\nA especificidade é a etapa da cascata que decide o vencedor **pelo peso** do seletor, não pela ordem. Uma regra mais específica vence uma menos específica **mesmo que venha antes** no arquivo. Entender esse peso é o que finalmente te dá controle sobre o CSS.",
+                    },
+                    {
+                        type: "quote",
+                        value: "A **especificidade** é uma pontuação que o navegador dá a cada seletor para decidir quem vence quando duas regras miram o mesmo elemento. Quanto mais específico o seletor, maior o peso. A hierarquia é: **id** vale mais que **classe** (e atributo, e pseudo-classe), que por sua vez vale mais que **tag** (nome de elemento). E o mais importante: **peso vence ordem** — a regra mais específica ganha mesmo que apareça antes.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Nem toda regra pesa o mesmo\n\nImagine duas regras brigando pela cor de um mesmo parágrafo. Uma mira pela tag, a outra pela classe. Repare que, de propósito, a regra da classe vem **antes** no arquivo:",
+                    },
+                    {
+                        type: "code",
+                        value: "/* A classe é mais específica, então ela vence... */\n.destaque {\n  color: red;\n}\n\n/* ...mesmo que esta regra de tag venha DEPOIS no arquivo */\np {\n  color: black;\n}",
+                    },
+                    {
+                        type: "code",
+                        value: '<p class="destaque">Este parágrafo fica VERMELHO, não preto.</p>',
+                    },
+                    {
+                        type: "text",
+                        value: "Esse exemplo é a alma da aula. Só pela ordem, `p { color: black }` venceria, porque vem depois. Mas o `.destaque` é **mais específico** (classe pesa mais que tag), e por isso o vermelho ganha. Grave isto: **peso vence ordem**. A ordem só é usada como desempate quando o peso é igual.",
+                    },
+                    {
+                        type: "text",
+                        value: '## O placar: (ids, classes, tags)\n\nPara comparar seletores, pense na especificidade como um **placar de três colunas**. Da esquerda (mais forte) para a direita (mais fraca):\n\n- **Coluna 1 — ids:** quantos seletores de **id** (`#algo`) o seu seletor tem.\n- **Coluna 2 — classes:** quantas **classes** (`.algo`), **seletores de atributo** (`[type="text"]`) e **pseudo-classes** (`:hover`) ele tem.\n- **Coluna 3 — tags:** quantos nomes de **tag** (`p`, `div`) e **pseudo-elementos** (`::before`) ele tem.\n\nPara saber quem vence, compare **coluna por coluna, da esquerda para a direita**. Um único id (placar `1-0-0`) vence qualquer quantidade de classes (`0-5-0`), que por sua vez vence qualquer quantidade de tags (`0-0-9`). É como comparar centenas, dezenas e unidades: a casa da esquerda manda primeiro.',
+                    },
+                    {
+                        type: "table",
+                        value: '[["Seletor","Ids","Classes","Tags","Placar"],["`p`","0","0","1","0-0-1"],["`.destaque`","0","1","0","0-1-0"],["`p.destaque`","0","1","1","0-1-1"],["`#topo`","1","0","0","1-0-0"],["`nav ul li a`","0","0","4","0-0-4"],["`#topo .menu a`","1","1","1","1-1-1"]]',
+                    },
+                    {
+                        type: "text",
+                        value: "## Calculando na prática\n\nVamos pontuar alguns seletores contando quantos ids, classes e tags cada um tem. É só somar por coluna:",
+                    },
+                    {
+                        type: "code",
+                        value: "/* 1 tag                   ->  placar 0-0-1 */\nli { }\n\n/* 2 tags                  ->  placar 0-0-2 */\nul li { }\n\n/* 1 classe + 1 tag        ->  placar 0-1-1 */\nli.ativo { }\n\n/* 1 id                    ->  placar 1-0-0  (sozinho, vence os três de cima) */\n#menu { }\n\n/* 1 id + 1 classe + 1 tag ->  placar 1-1-1 */\n#menu li.ativo { }",
+                    },
+                    {
+                        type: "text",
+                        value: 'Repare no `#menu` sozinho: com um único id ele faz `1-0-0` e **atropela** o `ul li.ativo` (que faz `0-1-2`), porque a comparação começa pela coluna dos ids, e ali o placar já é 1 contra 0. Não adianta o outro ter mais classes e tags: a coluna da esquerda decide primeiro. É justamente por isso que ids são tão "pesados" e, como veremos, tão perigosos de usar sem critério.',
+                    },
+                    {
+                        type: "text",
+                        value: "## Empate no placar? Aí a ordem decide\n\nE quando dois seletores têm **exatamente o mesmo placar**? Aí, e só aí, entra a regra da aula passada: vence a que aparece **por último** no CSS. A ordem é o último critério de desempate, acionado apenas quando a especificidade não resolveu.",
+                    },
+                    {
+                        type: "code",
+                        value: "/* Placar 0-1-0 */\n.aviso {\n  color: orange;\n}\n\n/* Também 0-1-0: empate! Como vem depois, é esta que vale */\n.destaque {\n  color: red;\n}",
+                    },
+                    {
+                        type: "code",
+                        value: '<p class="aviso destaque">Fico VERMELHO: houve empate no placar, e o vermelho vem por último.</p>',
+                    },
+                    {
+                        type: "text",
+                        value: '## Boas práticas para não virar bagunça\n\nEspecificidade mal cuidada é uma das maiores fontes de frustração no CSS: você escreve uma regra e ela "não pega" porque outra, mais específica, está vencendo em silêncio. Alguns hábitos evitam quase toda essa dor:\n\n- **Prefira classes.** Elas têm um peso equilibrado: fáceis de sobrepor quando preciso, mas específicas o bastante para mirar o que você quer. É a ferramenta do dia a dia.\n- **Evite estilizar por id.** Um id pesa muito no placar e é difícil de sobrepor depois. Reserve os ids para outras finalidades (âncoras, JavaScript) e estilize por classe.\n- **Fuja do `!important`.** Como vimos na aula passada, ele quebra a cascata e só empurra o problema para frente.\n- **Mantenha os seletores curtos.** Um `.card .titulo` é mais fácil de gerenciar do que um `body div.container article .card h2.titulo`. Seletores longos são específicos demais e viram uma dor para sobrepor.',
+                    },
+                    {
+                        type: "table",
+                        value: '[["Em vez de...","Prefira..."],["`#menu-principal { }` (id)","`.menu-principal { }` (classe)"],["`color: red !important;`","Ajustar o seletor para vencer no placar"],["`body .container ul li a.link`","`.link` (curto e direto)"]]',
+                    },
+                    {
+                        type: "quote",
+                        value: "**Cheat sheet:** a **especificidade** decide o vencedor pelo **peso**, não pela ordem — a regra mais específica ganha mesmo vindo antes. Pense num placar de três colunas: **ids | classes (e atributos e pseudo-classes) | tags (e pseudo-elementos)**, comparado da esquerda para a direita. Um id (`1-0-0`) vence qualquer punhado de classes; classes vencem qualquer punhado de tags. **Empatou** no placar? Aí, sim, vence a última escrita. Na prática: **estilize por classe**, evite id e `!important`, e mantenha os seletores curtos.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement:
+                            "Entre um seletor de tag, um de classe e um de id, qual tem a MAIOR especificidade (o maior peso)?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "O seletor de id.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "O seletor de classe.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O seletor de tag.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Todos têm exatamente o mesmo peso.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Quando duas regras têm exatamente a mesma especificidade, qual critério decide o vencedor?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "A ordem: vence a que aparece por último no CSS.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "O tamanho do arquivo: vence a que estiver no arquivo maior.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O comprimento do nome: vence o seletor com mais letras.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Nenhuma vence; as duas são descartadas.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            'No arquivo, a regra `.destaque { color: red }` vem ANTES de `p { color: black }`. Que cor fica um `<p class="destaque">`?',
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Vermelho, porque a classe é mais específica que a tag, e peso vence ordem.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Preto, porque a regra da tag vem depois no arquivo.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Preto, porque a tag sempre vence a classe.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Cinza, porque as duas regras se anulam.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Qual é o placar de especificidade do seletor `#menu li.ativo`, na notação (ids, classes, tags)?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "1-1-1 (um id, uma classe, uma tag).",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "0-1-1 (nenhum id, uma classe, uma tag).",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "3-0-0 (conta tudo como se fosse id).",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "1-0-2 (um id e duas tags).",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Você escreveu `.botao { background: green }`, mas o botão continua azul porque existe `#app .botao { background: blue }`. Qual é a melhor atitude, seguindo as boas práticas?",
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "Reconhecer que `#app .botao` (1-1-0) é mais específico que `.botao` (0-1-0) e ajustar o seletor ou a estrutura para competir no mesmo nível, em vez de recorrer ao `!important`.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Adicionar `!important` na sua regra, pois é a forma recomendada de resolver esses conflitos.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Concluir que o CSS está quebrado, pois a última regra escrita deveria sempre vencer.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Trocar o nome da propriedade de `background` para `background-color` para forçar a mudança.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        titulo: "Módulo 3 - Box model e unidades",
+        aulas: [
+            {
+                titulo: "O box model",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "# O box model\n\nBem-vindo ao Módulo 3! Até aqui você aprendeu a **pintar** os elementos: mudar cores, fontes e textos. Agora vamos aprender a **dar espaço e tamanho** a eles, e tudo começa por uma ideia simples e poderosa: no CSS, **cada elemento da página é uma caixa retangular**.\n\nUm título é uma caixa. Um parágrafo é uma caixa. Uma imagem, um botão, um link: todos são caixas. Quando você entende como essas caixas são construídas por dentro, o espaçamento e o alinhamento deixam de ser um mistério. Esse é o famoso **box model** (modelo de caixas), a base de todo o layout na web.",
+                    },
+                    {
+                        type: "quote",
+                        value: "No CSS, **todo elemento é uma caixa** formada por quatro camadas, de dentro para fora: o **conteúdo** (`content`), o **preenchimento** (`padding`), a **borda** (`border`) e a **margem** (`margin`). Entender essas quatro camadas é entender como o espaço funciona em uma página.",
+                    },
+                    {
+                        type: "text",
+                        value: "## A analogia do quadro na parede\n\nImagine um **quadro emoldurado** pendurado numa parede. Olhando de dentro para fora, você encontra, na mesma ordem, as quatro camadas do box model:\n\n- A **foto** dentro do quadro é o **conteúdo** (`content`): o texto ou a imagem de verdade.\n- O **paspatur**, aquela borda de papel entre a foto e a moldura, é o **preenchimento** (`padding`): um respiro **por dentro**, entre o conteúdo e a moldura.\n- A **moldura** de madeira é a **borda** (`border`): a linha que contorna a caixa.\n- O **espaço na parede** entre este quadro e o vizinho é a **margem** (`margin`): a distância **por fora**, que afasta uma caixa das outras.\n\nGuarde essa imagem. Toda vez que ficar em dúvida sobre padding e margin, volte para o quadro na parede.",
+                    },
+                    {
+                        type: "code",
+                        value: ".cartao {\n  /* o conteúdo tem 200px de largura */\n  width: 200px;\n\n  /* respiro interno, entre o texto e a borda */\n  padding: 20px;\n\n  /* a moldura da caixa */\n  border: 4px solid #333;\n\n  /* espaço externo, afastando o cartão dos vizinhos */\n  margin: 30px;\n}",
+                    },
+                    {
+                        type: "text",
+                        value: "## Camada 1: o conteúdo (`content`)\n\nO **conteúdo** é o miolo da caixa: o texto do parágrafo, a imagem, o rótulo do botão. É a única camada que existe **de verdade** desde o começo; as outras três são espaços que você adiciona ao redor dela.\n\nO tamanho dessa área é controlado principalmente pelas propriedades `width` (largura) e `height` (altura), que estudamos a fundo na próxima aula. Por enquanto, guarde só que o conteúdo é o **centro** de tudo, a foto dentro do quadro.",
+                    },
+                    {
+                        type: "text",
+                        value: '## Camada 2: o preenchimento (`padding`)\n\nO `padding` é o espaço **por dentro** da caixa, entre o conteúdo e a borda. Ele funciona como um **empurrão para dentro**: afasta o texto das paredes da caixa para o conteúdo não ficar grudado na borda.\n\nUm detalhe importante: o `padding` faz parte da caixa. Se a caixa tem cor de fundo, essa cor **também aparece na área do padding**. Por isso ele é ótimo para dar "ar" dentro de botões e cartões.',
+                    },
+                    {
+                        type: "code",
+                        value: ".botao {\n  background: #2563eb;\n  color: white;\n  /* 12px em cima e embaixo, 24px nas laterais */\n  padding: 12px 24px;\n}",
+                    },
+                    {
+                        type: "text",
+                        value: "## Camada 3: a borda (`border`)\n\nA `border` é a **moldura** da caixa: uma linha desenhada em volta do conteúdo e do padding. Para definir uma borda, você quase sempre informa três coisas de uma vez: a **espessura**, o **estilo** e a **cor**.",
+                    },
+                    {
+                        type: "code",
+                        value: ".caixa {\n  /* espessura | estilo | cor */\n  border: 2px solid #333;\n}\n\n/* também dá para escrever separado: */\n.outra-caixa {\n  border-width: 2px;\n  border-style: dashed;   /* solid, dashed, dotted... */\n  border-color: crimson;\n}",
+                    },
+                    {
+                        type: "text",
+                        value: "## Camada 4: a margem (`margin`)\n\nA `margin` é o espaço **por fora** da caixa: a distância entre a borda dela e os elementos vizinhos. Se o padding empurra o conteúdo para dentro, a margem **empurra os vizinhos para longe**.\n\nDiferente do padding, a margem é **sempre transparente**: ela não tem cor, é só espaço vazio. Serve para separar uma caixa da outra, como o espaço entre dois quadros na parede.",
+                    },
+                    {
+                        type: "code",
+                        value: ".paragrafo {\n  /* afasta este parágrafo 16px dos elementos de cima e de baixo */\n  margin: 16px 0;\n}",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Camada","Onde fica","O que faz","No quadro na parede"],["`content`","No centro","O texto ou a imagem de verdade","A foto"],["`padding`","Entre o conteúdo e a borda","Respiro por dentro da caixa","O paspatur"],["`border`","Contornando a caixa","Desenha a moldura","A moldura de madeira"],["`margin`","Por fora da borda","Afasta a caixa dos vizinhos","O espaço na parede"]]',
+                    },
+                    {
+                        type: "text",
+                        value: "## Atalho: os quatro lados de uma vez\n\nTanto o `padding` quanto a `margin` podem receber valores diferentes para cada lado. Existe um **atalho** muito usado que define os quatro lados numa linha só. A ordem segue o sentido do relógio, começando pelo topo: **cima, direita, baixo, esquerda**.",
+                    },
+                    {
+                        type: "code",
+                        value: "/* 1 valor: os quatro lados iguais */\npadding: 20px;\n\n/* 2 valores: cima/baixo | esquerda/direita */\npadding: 10px 30px;\n\n/* 4 valores: cima | direita | baixo | esquerda (sentido horário) */\npadding: 10px 20px 30px 40px;",
+                    },
+                    {
+                        type: "text",
+                        value: '## A diferença entre `margin` e `padding`\n\nEssa é a dúvida número um de quem começa, então vale fixar. As duas propriedades criam espaço, mas em **lados opostos** da borda:\n\n- O `padding` cria espaço **por dentro** da borda (entre o conteúdo e a borda). Ele **aumenta a área colorida** da caixa e faz o conteúdo "respirar".\n- A `margin` cria espaço **por fora** da borda (entre a caixa e os vizinhos). Ela é **transparente** e serve para **separar** as caixas umas das outras.\n\nUma regra prática: quando quiser dar ar **dentro** de um botão ou cartão, use `padding`. Quando quiser **afastar** dois elementos um do outro, use `margin`.',
+                    },
+                    {
+                        type: "code",
+                        value: "/* Padding: o fundo azul cresce e o texto ganha respiro POR DENTRO */\n.cartao {\n  background: #dbeafe;\n  padding: 24px;\n}\n\n/* Margin: espaço transparente POR FORA, separando um cartão do outro */\n.cartao {\n  margin-bottom: 16px;\n}",
+                    },
+                    {
+                        type: "quote",
+                        value: "**Recapitulando:** todo elemento é uma **caixa** com quatro camadas, de dentro para fora: `content` (a foto), `padding` (o paspatur, espaço interno), `border` (a moldura) e `margin` (o espaço na parede, externo). O `padding` empurra o conteúdo **para dentro** e recebe a cor de fundo; a `margin` empurra os vizinhos **para fora** e é sempre transparente. No atalho de quatro valores, a ordem é **cima, direita, baixo, esquerda**.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement:
+                            "Quais são as quatro camadas do box model, na ordem de dentro para fora?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`content`, `padding`, `border`, `margin`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`margin`, `border`, `padding`, `content`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`padding`, `content`, `margin`, `border`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`border`, `content`, `margin`, `padding`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Na analogia do quadro na parede, o que representa a margem (`margin`)?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "O espaço na parede entre um quadro e o quadro vizinho.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "A foto dentro do quadro.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "A moldura de madeira.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O paspatur, entre a foto e a moldura.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "Qual é a diferença entre `padding` e `margin`?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "O `padding` é o espaço interno (entre o conteúdo e a borda); a `margin` é o espaço externo (entre a caixa e os vizinhos).",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "O `padding` é o espaço externo e a `margin` é o espaço interno.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Os dois são exatamente a mesma coisa, só muda o nome.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O `padding` só funciona no topo e a `margin` só nas laterais.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Uma caixa tem cor de fundo. Onde essa cor aparece em relação às camadas?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "No conteúdo e no `padding`, que fazem parte da caixa; a `margin` continua transparente.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Na `margin`, que é a camada mais externa e visível.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Só na borda, nunca no interior da caixa.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Em nenhuma camada; cor de fundo não tem a ver com o box model.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "No código `padding: 10px 20px 30px 40px;`, qual valor se aplica ao lado esquerdo?",
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "40px, porque a ordem do atalho é cima, direita, baixo e esquerda.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "10px, porque o primeiro valor é sempre a esquerda.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "20px, porque o segundo valor é a esquerda.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "30px, porque a ordem começa pela esquerda e vai até o topo.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "box-sizing e dimensões",
+                blocks: [
+                    {
+                        type: "text",
+                        value: '# box-sizing e dimensões\n\nNa aula passada você conheceu as quatro camadas da caixa. Agora vamos falar de **tamanho**: como definir a largura e a altura de um elemento com `width` e `height`, e por que, quando você faz isso, o resultado às vezes sai **maior do que você pediu**.\n\nEsse "susto" tem explicação, e a solução cabe em uma linha de CSS que praticamente todo projeto do mundo usa. Vamos entender de onde vem o problema para a solução fazer todo o sentido.',
+                    },
+                    {
+                        type: "quote",
+                        value: "Por padrão, o CSS usa `box-sizing: content-box`: o `width` mede **só o conteúdo**, e o `padding` e a `border` são **somados por fora**, deixando a caixa maior que o número que você escreveu. Trocar para `box-sizing: border-box` faz o `width` **incluir** o padding e a borda, então a caixa tem exatamente a largura pedida. É por isso que quase todo projeto começa com essa troca.",
+                    },
+                    {
+                        type: "text",
+                        value: "## `width` e `height`\n\nAs propriedades `width` (largura) e `height` (altura) definem o tamanho da **área de conteúdo** da caixa. O valor pode ser em pixels, em porcentagem e em várias outras unidades que veremos na última aula.",
+                    },
+                    {
+                        type: "code",
+                        value: ".caixa {\n  width: 300px;\n  height: 150px;\n  background: #dbeafe;\n}",
+                    },
+                    {
+                        type: "text",
+                        value: "## O problema do box model padrão\n\nAqui vem a pegadinha clássica. Por padrão, o navegador usa um modo chamado `content-box`, no qual o `width` mede **apenas o conteúdo**. O `padding` e a `border` são adicionados **por fora** desse valor.\n\nOu seja: se você pede uma caixa de `300px` e ainda coloca padding e borda, a caixa **de verdade** na tela fica maior que 300px. Veja o exemplo:",
+                    },
+                    {
+                        type: "code",
+                        value: ".caixa {\n  width: 300px;       /* só o conteúdo */\n  padding: 20px;      /* +20 de cada lado */\n  border: 5px solid;  /* +5 de cada lado */\n}",
+                    },
+                    {
+                        type: "text",
+                        value: '## Fazendo a conta\n\nNo exemplo acima, a largura que aparece na tela **não é** 300px. O navegador soma tudo o que está na horizontal:\n\n- `300px` do conteúdo\n- `+ 20px` de padding à esquerda `+ 20px` de padding à direita\n- `+ 5px` de borda à esquerda `+ 5px` de borda à direita\n\nTotal: **350px**. Você pediu 300, recebeu 350. Numa página com várias caixas lado a lado, esses 50px "invisíveis" bagunçam todo o layout, e o pior: é difícil perceber de onde vem o problema.',
+                    },
+                    {
+                        type: "table",
+                        value: '[["O que você escreveu","Valor","Entra na largura final?"],["`width`","300px","Sim (é o conteúdo)"],["`padding` (2 lados)","20px + 20px","Sim, somado por fora"],["`border` (2 lados)","5px + 5px","Sim, somado por fora"],["**Largura real na tela**","**350px**","O total de tudo"]]',
+                    },
+                    {
+                        type: "text",
+                        value: '## A solução: `box-sizing: border-box`\n\nA propriedade `box-sizing` controla **o que o `width` inclui**. Ela tem dois valores:\n\n- `content-box`: o padrão; o `width` mede só o conteúdo (o problema de cima).\n- `border-box`: o `width` passa a incluir o padding e a borda.\n\nCom `border-box`, quando você pede `width: 300px`, a caixa tem **exatamente 300px** na tela, sem susto. O padding e a borda são "descontados" **por dentro**, comendo espaço do conteúdo em vez de esticar a caixa.',
+                    },
+                    {
+                        type: "code",
+                        value: ".caixa {\n  box-sizing: border-box;\n  width: 300px;       /* a caixa inteira mede 300px */\n  padding: 20px;\n  border: 5px solid;\n  /* o conteúdo encolhe para 250px, mas o total continua 300px */\n}",
+                    },
+                    {
+                        type: "text",
+                        value: '## Por que praticamente todo mundo usa\n\nPensar "a caixa mede o que eu pedi" é muito mais intuitivo do que ficar somando padding e borda de cabeça. Por isso virou **costume universal** aplicar `border-box` em **todos** os elementos da página logo no início do CSS.\n\nIsso é feito com o seletor `*` (asterisco), que significa "todo elemento". Este pequeno trecho abre praticamente qualquer folha de estilo profissional:',
+                    },
+                    {
+                        type: "code",
+                        value: "* {\n  box-sizing: border-box;\n}",
+                    },
+                    {
+                        type: "text",
+                        value: "## Limites: `min-width`, `max-width` e companhia\n\nNem sempre você quer um tamanho fixo. Muitas vezes quer um tamanho que **se adapta**, mas dentro de **limites**. Para isso existem quatro propriedades:\n\n- `min-width`: a caixa nunca fica **mais estreita** que isso.\n- `max-width`: a caixa nunca fica **mais larga** que isso.\n- `min-height` e `max-height`: a mesma ideia, para a altura.\n\nO caso mais comum de todos é o `max-width`. Ele é o segredo por trás de textos que não ficam largos demais em telas grandes, mas ainda encolhem bem no celular.",
+                    },
+                    {
+                        type: "code",
+                        value: "/* O container ocupa toda a largura disponível... */\n/* ...mas nunca passa de 800px em telas grandes */\n.container {\n  width: 100%;\n  max-width: 800px;\n}\n\n/* Imagem que encolhe junto com a tela, sem estourar o layout */\nimg {\n  max-width: 100%;\n}",
+                    },
+                    {
+                        type: "quote",
+                        value: "**Recapitulando:** `width` e `height` definem o tamanho do conteúdo. No modo padrão (`content-box`), padding e borda são **somados por fora**, e a caixa fica maior que o `width` pedido. Trocar para `box-sizing: border-box` faz o `width` **já incluir** padding e borda, e por isso quase todo projeto começa com `* { box-sizing: border-box; }`. Para tamanhos flexíveis com limites, use `min-width`/`max-width` (e as versões de altura); `max-width` é o mais usado, ótimo para conteúdo responsivo.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement: "Qual propriedade define a largura de um elemento?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`width`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`length`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`size`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`margin`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Qual valor de `box-sizing` faz o `width` incluir o padding e a borda?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`border-box`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`content-box`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`padding-box`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`full-box`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "No modo padrão (`content-box`), uma caixa com `width: 200px`, `padding: 10px` e `border: 5px solid` ocupa qual largura na tela?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "230px (200 + 10 + 10 de padding + 5 + 5 de borda).",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "200px, porque o `width` já é o tamanho final.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "215px (200 + 10 + 5).",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "220px (200 + 10 + 10).",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Por que é tão comum começar o CSS com `* { box-sizing: border-box; }`?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Para que toda caixa tenha exatamente a largura pedida, sem o padding e a borda esticando o tamanho.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Para deixar todos os textos da página em negrito.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Para remover as margens de todos os elementos.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Para fazer a página carregar mais rápido no celular.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Você quer um container que ocupe a largura disponível, mas nunca fique mais largo que 960px. Qual propriedade resolve isso?",
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "`max-width: 960px` (junto com `width: 100%`), limitando o crescimento sem fixar o tamanho.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`min-width: 960px`, que garante no mínimo 960px de largura.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`width: 960px` fixo, que impede o container de encolher no celular.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`height: 960px`, que controla a altura da caixa.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "A propriedade display",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "# A propriedade display\n\nVocê já reparou que alguns elementos ocupam a **linha inteira** (um parágrafo empurra o próximo para baixo), enquanto outros ficam **lado a lado** (várias palavras em negrito na mesma linha)? Isso não é coincidência: cada elemento tem um **comportamento de exibição** padrão, controlado pela propriedade `display`.\n\nEntender o `display` é entender **como os elementos se organizam** na página: quem quebra linha, quem fica ao lado de quem, quem some da tela. É uma das propriedades mais importantes de todo o CSS.",
+                    },
+                    {
+                        type: "quote",
+                        value: "A propriedade `display` define como um elemento se comporta no layout. Os três valores clássicos são `block` (ocupa a linha inteira e empilha), `inline` (fica na mesma linha, do tamanho do conteúdo) e `inline-block` (fica na linha como o inline, mas aceita largura, altura e padding como o block). Já `display: none` **remove** o elemento da página por completo.",
+                    },
+                    {
+                        type: "text",
+                        value: "## O fluxo normal do documento\n\nAntes de você mexer em qualquer coisa, o navegador já organiza os elementos numa ordem natural: de cima para baixo e, dentro de cada linha, da esquerda para a direita, na mesma sequência em que aparecem no HTML. Esse comportamento padrão tem um nome: **fluxo normal** do documento.\n\nÉ como um texto sendo digitado numa folha: as palavras vão preenchendo a linha e, quando o espaço acaba (ou quando começa um novo bloco), pulam para a linha de baixo. A propriedade `display` é justamente o que decide **como cada elemento participa desse fluxo**.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Elementos `block`\n\nUm elemento **block** (de bloco) se comporta como um **tijolo**: ocupa **toda a largura disponível** da linha e empurra o próximo elemento para **baixo**. Ou seja, dois blocos nunca ficam lado a lado naturalmente; eles se **empilham**.\n\nElementos como `<div>`, `<p>`, `<h1>` e `<ul>` são block por padrão. Como ocupam a linha toda, você **pode** definir `width`, `height`, `margin` e `padding` neles à vontade.",
+                    },
+                    {
+                        type: "code",
+                        value: "<p>Primeiro parágrafo.</p>\n<p>Segundo parágrafo.</p>\n\n<!-- Cada <p> é block: ocupa a linha inteira, -->\n<!-- então o segundo aparece ABAIXO do primeiro. -->",
+                    },
+                    {
+                        type: "text",
+                        value: '## Elementos `inline`\n\nUm elemento **inline** (em linha) se comporta como uma **palavra** no meio de um texto: fica **na mesma linha** que o conteúdo ao redor e ocupa **apenas o espaço do seu conteúdo**, nem um pixel a mais. Vários elementos inline se acomodam lado a lado até a linha encher.\n\nElementos como `<a>` (link), `<strong>` (negrito) e `<span>` são inline por padrão. E aqui vem um detalhe importante: em elementos inline, o `width` e o `height` **são ignorados**. Faz sentido: não dá para definir a "largura" de uma palavra no meio de uma frase sem quebrar o texto.',
+                    },
+                    {
+                        type: "code",
+                        value: '<p>Este texto tem uma <strong>palavra em destaque</strong>\ne um <a href="#">link</a> na mesma linha.</p>',
+                    },
+                    {
+                        type: "table",
+                        value: '[["Aspecto","`block`","`inline`"],["Ocupa","A linha inteira","Só o tamanho do conteúdo"],["O elemento seguinte","Vai para baixo (empilha)","Fica ao lado (mesma linha)"],["Aceita `width` e `height`?","Sim","Não (são ignorados)"],["Exemplos","`<div>`, `<p>`, `<h1>`","`<a>`, `<strong>`, `<span>`"]]',
+                    },
+                    {
+                        type: "text",
+                        value: "## `inline-block`: o melhor dos dois mundos\n\nE se você quisesse elementos **lado a lado** (como o inline), mas que **aceitassem largura e altura** (como o block)? É exatamente isso que o `display: inline-block` faz.\n\nUm elemento inline-block fica na linha, ao lado dos vizinhos, mas se comporta como uma caixinha completa: respeita `width`, `height`, `padding` e `margin` nos quatro lados. É muito usado para criar coisas como botões, itens de menu e etiquetas que ficam em fileira.",
+                    },
+                    {
+                        type: "code",
+                        value: ".tag {\n  display: inline-block;\n  width: 80px;          /* agora o width É respeitado */\n  padding: 6px 12px;\n  margin: 4px;\n  background: #dbeafe;\n  text-align: center;\n}",
+                    },
+                    {
+                        type: "code",
+                        value: '<span class="tag">HTML</span>\n<span class="tag">CSS</span>\n<span class="tag">JS</span>\n\n<!-- As três etiquetas ficam lado a lado, -->\n<!-- cada uma com 80px de largura. -->',
+                    },
+                    {
+                        type: "text",
+                        value: '## Sumindo com elementos: `display: none` vs `visibility: hidden`\n\nExistem duas formas de "esconder" um elemento, e elas são **bem diferentes**. Confundir as duas é um erro clássico.\n\n- `display: none` **remove** o elemento por completo: ele some da tela **e não ocupa mais espaço nenhum**. É como se tivesse sido apagado do HTML, e os vizinhos se movem para ocupar o lugar dele.\n- `visibility: hidden` deixa o elemento **invisível, mas o espaço dele continua reservado**. É como um convidado invisível que ainda ocupa a cadeira: você não o vê, mas o lugar segue lá, vazio.',
+                    },
+                    {
+                        type: "code",
+                        value: "/* Some e libera o espaço: os vizinhos encostam */\n.oculto {\n  display: none;\n}\n\n/* Fica invisível, mas o buraco vazio permanece */\n.invisivel {\n  visibility: hidden;\n}",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Comportamento","`display: none`","`visibility: hidden`"],["Aparece na tela?","Não","Não"],["Ocupa espaço?","Não (some por completo)","Sim (o lugar fica reservado)"],["Analogia","Apagado do HTML","Convidado invisível na cadeira"]]',
+                    },
+                    {
+                        type: "quote",
+                        value: "**Recapitulando:** o `display` define como o elemento participa do **fluxo normal**. `block` ocupa a linha inteira e empilha os vizinhos para baixo (aceita `width`/`height`); `inline` fica na mesma linha e ignora `width`/`height`; `inline-block` combina os dois: fica na linha e aceita dimensões. Para esconder: `display: none` remove o elemento **e o espaço dele**, enquanto `visibility: hidden` só o deixa invisível, **mantendo o espaço** reservado.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement: "Como se comporta um elemento com `display: block`?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "Ocupa a linha inteira e empurra o elemento seguinte para baixo (empilha).",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Fica sempre na mesma linha que os vizinhos.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Some da página e não ocupa espaço.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Fica invisível, mas mantém o espaço reservado.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "Qual destes elementos é `inline` por padrão?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`<strong>`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`<div>`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`<p>`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`<h1>`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "Qual é a principal vantagem do `display: inline-block`?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Fica na mesma linha que os vizinhos (como o inline) e, ao mesmo tempo, respeita `width` e `height` (como o block).",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Faz o elemento sumir da página sem ocupar espaço.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Ocupa sempre a linha inteira, empilhando os vizinhos.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Impede que o elemento receba qualquer padding ou margin.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Qual é a diferença entre `display: none` e `visibility: hidden`?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "`display: none` remove o elemento e o espaço dele; `visibility: hidden` o deixa invisível, mas mantém o espaço reservado.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "São idênticos: os dois removem o elemento e o espaço.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`display: none` mantém o espaço; `visibility: hidden` remove tudo.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`display: none` funciona só no celular; `visibility: hidden`, só no computador.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Você definiu `width: 100px` em um `<span>`, mas a largura não muda. Por quê?",
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "Porque `<span>` é inline por padrão, e elementos inline ignoram `width` e `height`; use `inline-block` (ou `block`) para o `width` valer.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Porque faltou um ponto e vírgula no final da regra.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Porque a tag `<span>` não aceita nenhum estilo CSS.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Porque `width` só funciona em imagens.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Unidades no CSS",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "# Unidades no CSS\n\nToda vez que você escreveu `padding: 20px` ou `width: 300px` nas aulas anteriores, usou uma **unidade de medida**: o `px`. Mas o `px` é só uma entre várias, e escolher a unidade certa faz uma diferença enorme, principalmente quando a página precisa funcionar bem tanto no computador quanto no celular.\n\nNesta aula você vai conhecer as unidades mais usadas do CSS e, mais importante, vai entender **quando usar cada uma**. Vamos dividi-las em dois grandes grupos: as **absolutas** e as **relativas**.",
+                    },
+                    {
+                        type: "quote",
+                        value: "As unidades **absolutas**, como o `px`, têm um tamanho **fixo**. As **relativas**, como `%`, `em`, `rem`, `vw` e `vh`, têm um tamanho que **depende de outra coisa** (do elemento pai, da fonte raiz ou do tamanho da tela). Unidades relativas são a chave para páginas que se **adaptam** a qualquer tela.",
+                    },
+                    {
+                        type: "text",
+                        value: '## Unidades absolutas: o `px`\n\nUma unidade **absoluta** vale sempre a mesma coisa, não importa o contexto. A mais usada de longe é o **pixel** (`px`). Pense no `px` como um "pontinho" na tela: `16px` de altura é sempre `16px`, aqui e em qualquer outro lugar.\n\nO `px` é **previsível** e ótimo para coisas que devem ter um tamanho exato: a espessura de uma borda, um pequeno espaçamento, o raio de um cantinho arredondado. A desvantagem é que ele **não se adapta**: se o usuário aumenta a fonte do navegador, um texto em `px` teima em não acompanhar.',
+                    },
+                    {
+                        type: "code",
+                        value: ".caixa {\n  border: 2px solid #333;   /* borda fina e exata */\n  border-radius: 8px;        /* cantos arredondados */\n  padding: 16px;\n}",
+                    },
+                    {
+                        type: "text",
+                        value: '## Unidades relativas\n\nUma unidade **relativa** não tem um tamanho próprio: ela é calculada **em relação a alguma referência**. Muda a referência, muda o tamanho. É isso que as torna tão poderosas para layouts flexíveis. Vamos às quatro mais importantes.\n\n## `%` (porcentagem)\n\nA porcentagem é relativa ao **elemento pai**. Um `width: 50%` significa "metade da largura do elemento que me contém". Se o pai for mais largo, o filho acompanha; se for mais estreito, o filho encolhe junto.',
+                    },
+                    {
+                        type: "code",
+                        value: "/* Esta coluna sempre ocupa metade do espaço do pai */\n.coluna {\n  width: 50%;\n}",
+                    },
+                    {
+                        type: "text",
+                        value: '## `em`: relativa à fonte do elemento\n\nA unidade `em` é relativa ao **tamanho da fonte** do próprio elemento. Se a fonte de um elemento é `16px`, então `1em` vale `16px`, `2em` vale `32px`, `1.5em` vale `24px`, e assim por diante. É ótima para espaçamentos que devem **acompanhar o tamanho do texto**: um botão com `padding: 1em` mantém a proporção, quer a fonte seja grande, quer seja pequena.\n\nO `em` tem uma pegadinha: ele **se acumula** quando os elementos estão aninhados. Se um elemento pai já aumentou a fonte, o `em` do filho parte desse valor maior, o que pode fazer os tamanhos "crescerem em cascata" sem querer.',
+                    },
+                    {
+                        type: "code",
+                        value: ".botao {\n  font-size: 20px;\n  /* 1.5em = 1.5 x 20px = 30px de padding */\n  padding: 1.5em;\n}",
+                    },
+                    {
+                        type: "text",
+                        value: '## `rem`: relativa à fonte raiz\n\nO `rem` (de _root em_, "em da raiz") resolve a pegadinha do acúmulo. Em vez de olhar para a fonte do próprio elemento, ele sempre olha para a fonte do elemento **raiz**, o `<html>`. Como essa referência é **única e fixa** para a página inteira, `1rem` vale o mesmo em qualquer lugar, esteja o elemento aninhado onde estiver.\n\nPor padrão, a fonte raiz dos navegadores é `16px`, então `1rem = 16px`, `1.5rem = 24px` e `2rem = 32px`. Essa previsibilidade fez do `rem` a unidade preferida para **tamanhos de fonte e espaçamentos** em projetos modernos.',
+                    },
+                    {
+                        type: "code",
+                        value: "html {\n  font-size: 16px;   /* a referência de 1rem */\n}\n\nh1    { font-size: 2rem; }     /* 32px, sempre */\np     { font-size: 1rem; }     /* 16px, sempre */\nsmall { font-size: 0.875rem; } /* 14px, sempre */",
+                    },
+                    {
+                        type: "text",
+                        value: "## A diferença entre `em` e `rem`\n\nOs dois olham para o tamanho de uma fonte, mas para **fontes diferentes**:\n\n- `em` é relativo à fonte do **próprio elemento**. Por isso ele **acumula** em elementos aninhados.\n- `rem` é relativo à fonte do elemento **raiz** (`<html>`), que é sempre a mesma. Por isso ele **não acumula**: é estável e previsível.\n\nNa dúvida, comece com `rem`: ele evita surpresas. Deixe o `em` para quando você **quer** que o tamanho acompanhe a fonte local, como o padding interno de um botão.",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Unidade","Relativa a...","Acumula no aninhamento?","Boa para..."],["`em`","A fonte do próprio elemento","Sim","Espaços que seguem a fonte local"],["`rem`","A fonte da raiz (`<html>`)","Não","Fontes e espaçamentos previsíveis"]]',
+                    },
+                    {
+                        type: "text",
+                        value: "## `vw` e `vh`: relativas ao tamanho da tela\n\nAs unidades `vw` e `vh` são relativas ao tamanho da **janela do navegador** (a _viewport_, a área visível da tela):\n\n- `vw` (_viewport width_): `1vw` = 1% da **largura** da janela; `100vw` é a largura inteira.\n- `vh` (_viewport height_): `1vh` = 1% da **altura** da janela; `100vh` é a altura inteira.\n\nSão perfeitas para elementos que devem ocupar uma fração da tela independentemente do conteúdo, como uma seção de destaque que preenche a tela toda (`height: 100vh`).",
+                    },
+                    {
+                        type: "code",
+                        value: "/* Seção que ocupa exatamente a altura inteira da tela */\n.destaque {\n  height: 100vh;\n}\n\n/* Título cujo tamanho acompanha a largura da janela */\n.titulo-gigante {\n  font-size: 5vw;\n}",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Unidade","Tipo","Relativa a...","Quando usar"],["`px`","Absoluta","Nada (tamanho fixo)","Bordas, raios, detalhes exatos"],["`%`","Relativa","O elemento pai","Larguras de colunas e containers"],["`em`","Relativa","A fonte do elemento","Espaços que seguem a fonte local"],["`rem`","Relativa","A fonte da raiz","Fontes e espaçamentos previsíveis"],["`vw` / `vh`","Relativa","A largura/altura da tela","Seções em tela cheia"]]',
+                    },
+                    {
+                        type: "quote",
+                        value: "**Recapitulando:** unidades **absolutas** (`px`) têm tamanho fixo, ótimas para bordas e detalhes exatos. As **relativas** se adaptam: `%` é relativa ao **pai**; `em`, à fonte do **próprio elemento** (e por isso **acumula** no aninhamento); `rem`, à fonte da **raiz** (`<html>`), estável e sem acúmulo; `vw`/`vh`, ao tamanho da **tela**. A regra prática: `rem` para fontes e espaços, `%` e `vw`/`vh` para larguras e seções, `px` para os detalhes que precisam ser exatos.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement: "Qual destas é uma unidade absoluta, de tamanho fixo?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`px`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`%`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`rem`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`vw`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "A que se refere `1vh`?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "1% da altura da janela do navegador (viewport).",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "1% da largura da janela do navegador.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Ao tamanho da fonte do elemento raiz.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "À largura do elemento pai.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "No código `width: 50%`, a porcentagem é calculada em relação a quê?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "À largura do elemento pai (o que contém esse elemento).",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Ao tamanho total da tela, sempre.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "À fonte do elemento raiz `<html>`.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "A um valor fixo de 500px.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "Qual é a diferença entre `em` e `rem`?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "`em` é relativo à fonte do próprio elemento (e acumula no aninhamento); `rem` é relativo à fonte da raiz `<html>` (e não acumula).",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "São exatamente iguais; só muda a forma de escrever.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`rem` é uma unidade absoluta e `em` é relativa.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`em` só funciona em fontes e `rem` só em margens.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "Com a fonte raiz no padrão de 16px, quanto vale `1.5rem`?",
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "24px (1,5 x 16px).",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "16px, porque `rem` ignora o número.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "1,5px, tomando o valor ao pé da letra.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "32px (2 x 16px).",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        titulo: "Módulo 4 - Tipografia, backgrounds e bordas",
+        aulas: [
+            {
+                titulo: "Tipografia",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "# Tipografia\n\nBem-vindo ao Módulo 4! A partir de agora a gente começa a deixar as páginas **bonitas** de verdade. E não existe ponto de partida melhor do que a **tipografia**, ou seja, o cuidado com a aparência das **letras**.\n\nPode parecer um detalhe pequeno, mas é uma das coisas que mais mudam a cara de um site. A fonte certa passa profissionalismo; a fonte errada afasta o visitante antes mesmo de ele ler a primeira frase. Nesta aula você vai aprender a escolher a fonte, ajustar o tamanho, a espessura e o estilo do texto, tudo com CSS.",
+                    },
+                    {
+                        type: "quote",
+                        value: "**Tipografia** é a aparência do texto. Com CSS você controla **qual** fonte usar (`font-family`), o **tamanho** das letras (`font-size`), a **espessura** ou peso (`font-weight`) e se o texto é inclinado (`font-style`). Como nem todo computador tem todas as fontes, você lista uma **pilha de fontes** com alternativas de reserva, e ainda pode carregar fontes da web com o Google Fonts.",
+                    },
+                    {
+                        type: "text",
+                        value: "## O que é uma fonte\n\nUma **fonte** (ou família tipográfica) é o **conjunto de desenhos das letras**, números e símbolos. Arial, Times New Roman e Courier são exemplos que você provavelmente já ouviu falar. Cada uma tem uma personalidade própria.\n\nAs fontes costumam ser separadas em três grandes grupos:\n\n- **Serifadas** (_serif_): têm uns pezinhos nas pontas das letras, como a Times New Roman. Passam um ar clássico, de jornal e livro.\n- **Sem serifa** (_sans-serif_): não têm esses pezinhos, como a Arial. Têm um visual limpo e moderno, muito usado na web.\n- **Monoespaçadas** (_monospace_): todas as letras ocupam a **mesma largura**, como a Courier. São a cara de código de programação.\n\nNão precisa decorar isso agora. Só guarde que existem estilos diferentes e que a escolha da fonte dá o tom de voz da sua página.",
+                    },
+                    {
+                        type: "text",
+                        value: "## `font-family`: escolhendo a fonte\n\nA propriedade `font-family` diz **qual fonte** o texto deve usar. Você poderia imaginar que basta escrever o nome de uma fonte e pronto, mas tem um detalhe importante: a fonte precisa **estar instalada no computador do visitante** para o navegador conseguir mostrá-la. E você não tem como garantir isso.\n\nA solução é listar **várias fontes**, separadas por vírgula, formando uma **pilha de fontes** (_font stack_). O navegador tenta a primeira; se não tiver, passa para a segunda; e assim por diante, até achar uma que exista.",
+                    },
+                    {
+                        type: "code",
+                        value: "/* O navegador tenta Arial; se não houver, tenta Helvetica; */\n/* por fim, usa qualquer fonte sem serifa disponível.         */\nbody {\n  font-family: Arial, Helvetica, sans-serif;\n}",
+                    },
+                    {
+                        type: "text",
+                        value: '## Sempre termine com uma família genérica\n\nRepare que o **último** item da pilha do exemplo é `sans-serif`. Esse não é o nome de uma fonte específica, e sim de uma **família genérica**: um pedido do tipo "se não achou nenhuma das anteriores, use **qualquer** fonte sem serifa que você tiver". É a sua rede de segurança, então **sempre** feche a pilha com uma genérica (`serif`, `sans-serif` ou `monospace`).\n\nMais um detalhe de sintaxe: nomes de fonte com **espaços** precisam vir entre **aspas**. Escreva `"Times New Roman"`, e não `Times New Roman` solto.',
+                    },
+                    {
+                        type: "code",
+                        value: '/* Nomes com espaco vao entre aspas. */\nh1 {\n  font-family: "Times New Roman", Georgia, serif;\n}\n\ncode {\n  font-family: "Courier New", monospace;\n}',
+                    },
+                    {
+                        type: "table",
+                        value: '[["Família genérica","Como é","Exemplo de fonte","Boa para"],["`serif`","Tem pezinhos nas letras","Times New Roman, Georgia","Textos longos, ar clássico"],["`sans-serif`","Traços limpos, sem pezinhos","Arial, Helvetica","Telas e interfaces modernas"],["`monospace`","Todas as letras com a mesma largura","Courier New, Consolas","Mostrar código"]]',
+                    },
+                    {
+                        type: "text",
+                        value: "## `font-size`: o tamanho da letra\n\nA propriedade `font-size` define o **tamanho** do texto. A unidade mais comum para começar é o **pixel**, escrito `px`. Quanto maior o número, maior a letra.\n\nNa maioria dos navegadores, o texto normal já vem com `16px` por padrão. A partir daí, você aumenta os títulos e ajusta o resto ao seu gosto.",
+                    },
+                    {
+                        type: "code",
+                        value: "h1 {\n  font-size: 32px;\n}\n\np {\n  font-size: 16px;\n}\n\nsmall {\n  font-size: 12px;\n}",
+                    },
+                    {
+                        type: "text",
+                        value: "## `font-weight`: a espessura do traço\n\nA propriedade `font-weight` controla a **espessura** (o peso) das letras, o famoso **negrito**. Você pode usar palavras ou números:\n\n- `normal`: o peso comum (equivale ao número `400`).\n- `bold`: negrito (equivale a `700`).\n- Números de `100` a `900`, de 100 em 100: quanto maior, mais grossa a letra. Nem toda fonte oferece todos esses pesos.\n\nOu seja, `font-weight: bold` e `font-weight: 700` fazem a mesma coisa.",
+                    },
+                    {
+                        type: "code",
+                        value: "h1 {\n  font-weight: bold;   /* o mesmo que 700 */\n}\n\n.destaque {\n  font-weight: 600;    /* um pouco mais grosso que o normal */\n}\n\np {\n  font-weight: normal; /* o mesmo que 400 */\n}",
+                    },
+                    {
+                        type: "text",
+                        value: "## `font-style`: o texto inclinado\n\nA propriedade `font-style` serve principalmente para deixar o texto em **itálico** (aquele estilo inclinado, usado em citações e títulos de obras). Os valores que você vai usar no dia a dia são dois:\n\n- `normal`: texto em pé, o padrão.\n- `italic`: texto inclinado.",
+                    },
+                    {
+                        type: "code",
+                        value: "em {\n  font-style: italic;\n}\n\nblockquote {\n  font-style: italic;\n}",
+                    },
+                    {
+                        type: "text",
+                        value: "## Fontes da web com o Google Fonts\n\nE se você quiser usar uma fonte bonita que quase ninguém tem instalada? A resposta são as **fontes da web**: fontes que o navegador **baixa** junto com a página. O serviço mais popular para isso é o **Google Fonts**, que é gratuito.\n\nO passo a passo é simples:\n\n1. Acesse `fonts.google.com` e escolha uma fonte (por exemplo, a **Roboto**).\n2. O site te dá um trecho de `<link>` para colar dentro do `<head>` do seu HTML.\n3. Depois é só usar o nome da fonte normalmente no `font-family`.",
+                    },
+                    {
+                        type: "code",
+                        value: '<!-- No <head> do seu HTML: carrega a fonte Roboto do Google Fonts -->\n<link rel="preconnect" href="https://fonts.googleapis.com">\n<link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">',
+                    },
+                    {
+                        type: "code",
+                        value: '/* Agora a fonte Roboto esta disponivel para usar no CSS. */\n/* Mantemos Arial e sans-serif como reserva, por seguranca. */\nbody {\n  font-family: "Roboto", Arial, sans-serif;\n}',
+                    },
+                    {
+                        type: "text",
+                        value: "Repare que, mesmo usando uma fonte da web, eu mantive `Arial, sans-serif` no fim da pilha. É a mesma ideia de reserva de antes: se por algum motivo a Roboto não carregar (internet lenta, por exemplo), o texto ainda aparece numa fonte parecida em vez de quebrar.",
+                    },
+                    {
+                        type: "text",
+                        value: "## O atalho `font`\n\nEscrever `font-family`, `font-size`, `font-weight` e `font-style` em linhas separadas funciona, mas dá para juntar tudo em uma linha só com o atalho `font`. Ele reúne várias propriedades da fonte de uma vez.\n\nDuas regras para não errar:\n\n- A ordem geral é: `font-style`, `font-weight`, `font-size` e, por último, a `font-family`.\n- O `font-size` e a `font-family` são **obrigatórios**; o resto é opcional.",
+                    },
+                    {
+                        type: "code",
+                        value: '/* Longo: uma propriedade por linha */\np {\n  font-style: italic;\n  font-weight: bold;\n  font-size: 16px;\n  font-family: "Roboto", sans-serif;\n}\n\n/* Curto: tudo no atalho font (mesmo resultado) */\np {\n  font: italic bold 16px "Roboto", sans-serif;\n}',
+                    },
+                    {
+                        type: "quote",
+                        value: "**Resumo:** `font-family` recebe uma **pilha de fontes** separadas por vírgula (o navegador usa a primeira que existir) e deve terminar numa **família genérica** como `sans-serif`. `font-size` define o tamanho (em `px`), `font-weight` a espessura (`normal`/`bold` ou `100` a `900`) e `font-style` o itálico. Para fontes que o visitante talvez não tenha, use o **Google Fonts** com um `<link>` no `<head>`. E o atalho `font` junta tudo, sendo `font-size` e `font-family` obrigatórios.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement:
+                            "Na pilha `font-family: Arial, Helvetica, sans-serif;`, para que serve o último item, `sans-serif`?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "É uma família genérica de reserva: se nenhuma das fontes anteriores existir, o navegador usa qualquer fonte sem serifa disponível.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "É o nome da fonte principal que sempre será usada.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Define o tamanho da fonte.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Faz o texto ficar em negrito.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "Qual propriedade controla a espessura (o negrito) das letras?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`font-weight`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`font-size`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`font-style`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`text-align`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "Por que costumamos listar mais de uma fonte no `font-family`?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Porque a fonte precisa existir no computador do visitante; a lista funciona como um plano B, e o navegador usa a primeira que estiver disponível.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Para o texto aparecer em várias fontes ao mesmo tempo.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Para deixar a página mais pesada e bonita.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Porque o CSS exige no mínimo três fontes em toda regra.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Para usar uma fonte do Google Fonts na sua página, o que você precisa fazer?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Adicionar o `<link>` da fonte no `<head>` do HTML e depois usar o nome dela no `font-family`.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Instalar a fonte no computador de cada visitante manualmente.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Nada; toda fonte do Google já vem disponível em qualquer site.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Escrever o nome da fonte apenas no `<title>` da página.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            'No atalho `font: italic bold 16px "Roboto", sans-serif;`, quais valores são obrigatórios?',
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "O tamanho (`font-size`) e a família (`font-family`); o estilo e o peso são opcionais.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Todos os quatro valores são obrigatórios, sempre.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Apenas o estilo (`italic`).",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Nenhum; o atalho `font` funciona vazio.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Propriedades de texto",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "# Propriedades de texto\n\nNa aula anterior você deu um rosto às letras escolhendo a fonte. Agora vamos **organizar** esse texto na página: o espaço entre as linhas, o alinhamento, os sublinhados, as maiúsculas e por aí vai.\n\nEssas propriedades parecem pequenas, mas juntas fazem toda a diferença na **legibilidade**, ou seja, no quanto o texto é confortável de ler. Um texto bem espaçado convida à leitura; um texto apertado cansa e afasta.",
+                    },
+                    {
+                        type: "quote",
+                        value: "Estas propriedades cuidam de **como o texto se distribui**: `line-height` controla o espaço entre as linhas (a entrelinha), `letter-spacing` e `word-spacing` o espaço entre letras e palavras, `text-align` o alinhamento, `text-decoration` os sublinhados e riscos, `text-transform` as maiúsculas e minúsculas, e `text-indent` o recuo da primeira linha. O grande objetivo de todas elas é a **legibilidade**.",
+                    },
+                    {
+                        type: "text",
+                        value: '## `line-height`: o espaço entre as linhas\n\nA propriedade `line-height` define a **altura de cada linha** de texto, ou seja, o espaço da **entrelinha**. Pense num caderno: se as linhas ficam muito coladas umas nas outras, a leitura fica sufocante; se ficam arejadas demais, o texto se perde. O ponto de equilíbrio deixa a leitura leve.\n\nA forma recomendada de definir esse valor é com um **número puro** (sem unidade), que funciona como um **multiplicador** do tamanho da fonte. Um `line-height: 1.5` significa "uma vez e meia a altura da fonte", um valor confortável para textos de leitura.',
+                    },
+                    {
+                        type: "code",
+                        value: "body {\n  font-size: 16px;\n  line-height: 1.5;  /* 1,5 x o tamanho da fonte = 24px por linha */\n}",
+                    },
+                    {
+                        type: "text",
+                        value: "Você também pode usar um valor fixo, como `line-height: 24px`, mas o número puro costuma ser melhor: ele **se ajusta sozinho** se você mudar o `font-size` depois. Para blocos de texto corrido, algo entre `1.4` e `1.6` é uma escolha segura.",
+                    },
+                    {
+                        type: "text",
+                        value: "## `letter-spacing` e `word-spacing`\n\nEssas duas propriedades ajustam o espaço **horizontal** do texto:\n\n- `letter-spacing`: o espaço **entre as letras**.\n- `word-spacing`: o espaço **entre as palavras**.\n\nUse com moderação. Um leve `letter-spacing` pode dar um ar elegante a um título em maiúsculas, mas exageros deixam o texto difícil de ler. Os valores costumam vir em `px` e aceitam números negativos, que **aproximam** as letras.",
+                    },
+                    {
+                        type: "code",
+                        value: "h1 {\n  text-transform: uppercase;\n  letter-spacing: 2px;   /* afasta um pouco as letras do titulo */\n}\n\n.esticado {\n  word-spacing: 8px;     /* mais espaco entre as palavras */\n}",
+                    },
+                    {
+                        type: "text",
+                        value: "## `text-align`: o alinhamento horizontal\n\nA propriedade `text-align` decide como o texto se alinha na **horizontal**, dentro do seu espaço. Os quatro valores mais usados são:\n\n- `left`: alinhado à **esquerda** (o padrão em português).\n- `right`: alinhado à **direita**.\n- `center`: **centralizado**.\n- `justify`: **justificado**, quando o texto estica para encostar nas duas margens, como em jornais.",
+                    },
+                    {
+                        type: "code",
+                        value: "h1 {\n  text-align: center;\n}\n\n.data {\n  text-align: right;\n}\n\np {\n  text-align: justify;\n}",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Valor","O que faz","Quando usar"],["`left`","Alinha à esquerda","Textos em geral (padrão)"],["`right`","Alinha à direita","Datas, números, detalhes"],["`center`","Centraliza","Títulos, chamadas curtas"],["`justify`","Estica até as duas margens","Blocos longos, estilo jornal"]]',
+                    },
+                    {
+                        type: "text",
+                        value: "## `text-decoration`: linhas no texto\n\nA propriedade `text-decoration` adiciona (ou remove) **linhas** no texto. Os valores mais comuns:\n\n- `underline`: **sublinhado**.\n- `line-through`: texto **riscado** (aquele risco no meio, útil para mostrar um preço antigo).\n- `overline`: uma linha **acima** do texto.\n- `none`: **nenhuma** linha.\n\nO uso mais frequente no dia a dia é justamente o `none`: os links (`<a>`) já vêm sublinhados por padrão, e muita gente prefere **tirar** esse sublinhado.",
+                    },
+                    {
+                        type: "code",
+                        value: "/* Remove o sublinhado padrao dos links */\na {\n  text-decoration: none;\n}\n\n/* Preco antigo, riscado */\n.preco-antigo {\n  text-decoration: line-through;\n}",
+                    },
+                    {
+                        type: "text",
+                        value: "## `text-transform`: a caixa das letras\n\nA propriedade `text-transform` muda a **caixa** (maiúsculas ou minúsculas) do texto **na exibição**, sem que você precise reescrever nada no HTML. Os valores:\n\n- `uppercase`: TUDO EM MAIÚSCULAS.\n- `lowercase`: tudo em minúsculas.\n- `capitalize`: A Primeira Letra De Cada Palavra Em Maiúscula.\n- `none`: mantém como está escrito.\n\nUm detalhe importante: isso é só **visual**. O texto de verdade, lá no HTML, continua igual; o que muda é apenas como ele aparece na tela. Isso é ótimo, porque você escreve o conteúdo normalmente e decide a aparência no CSS.",
+                    },
+                    {
+                        type: "code",
+                        value: "h1 {\n  text-transform: uppercase;   /* MOSTRA EM MAIUSCULAS */\n}\n\n.nome {\n  text-transform: capitalize;  /* Primeira Letra Maiuscula */\n}",
+                    },
+                    {
+                        type: "text",
+                        value: "## `text-indent`: o recuo da primeira linha\n\nA propriedade `text-indent` cria um **recuo na primeira linha** de um parágrafo, aquele espacinho que empurra o começo do texto para a direita, como se vê em muitos livros impressos. É um toque clássico para textos longos.",
+                    },
+                    {
+                        type: "code",
+                        value: "p {\n  text-indent: 40px;  /* empurra o inicio da 1a linha em 40px */\n}",
+                    },
+                    {
+                        type: "quote",
+                        value: "**Resumo:** para um texto legível, comece com um `line-height` folgado (por volta de `1.5`). Ajuste o espaçamento com `letter-spacing` (entre letras) e `word-spacing` (entre palavras), sempre com moderação. Alinhe com `text-align` (`left`, `right`, `center`, `justify`). Use `text-decoration: none` para tirar o sublinhado dos links, `text-transform` para controlar maiúsculas/minúsculas **só na exibição**, e `text-indent` para recuar a primeira linha do parágrafo.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement: "O que a propriedade `line-height` controla?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "O espaço entre as linhas do texto (a entrelinha).",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "A cor do texto.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O espaço entre as letras.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O tamanho da fonte.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "Qual regra remove o sublinhado padrão de um link?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`a { text-decoration: none; }`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`a { text-transform: none; }`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`a { font-style: normal; }`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`a { text-align: none; }`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Ao aplicar `text-transform: uppercase` a um título, o que acontece com o texto escrito no HTML?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Nada muda no HTML; a mudança para maiúsculas é apenas visual, na hora de exibir.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "O texto no HTML é reescrito em maiúsculas permanentemente.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O texto some do HTML e vira uma imagem.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O navegador apaga as letras minúsculas do arquivo.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "O que significa `text-align: justify`?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "O texto é esticado para encostar nas duas margens, como nas colunas de jornal.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "O texto fica centralizado na página.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O texto é alinhado apenas à direita.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Cada palavra fica em uma linha separada.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Um bloco de texto está com as linhas muito coladas e cansativo de ler. Qual ajuste melhora mais diretamente a legibilidade?",
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "Aumentar o `line-height` para um valor mais folgado, como `1.5`, dando mais respiro entre as linhas.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Diminuir o `line-height` para `1`, colando ainda mais as linhas.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Aplicar `text-decoration: underline` em todo o parágrafo.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Trocar o `text-align` para `right`.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Backgrounds",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "# Backgrounds\n\nAté aqui a gente cuidou do texto. Agora vamos olhar para **trás** dele, para o **fundo** dos elementos. Em inglês, fundo é _background_, e é assim que a propriedade se chama.\n\nO fundo é como o **papel de parede** de um cômodo: fica atrás de tudo e define boa parte do clima do ambiente. Um fundo pode ser uma cor sólida, uma imagem ou até uma transição suave de cores (um gradiente). Nesta aula você vai aprender a controlar todos eles.",
+                    },
+                    {
+                        type: "quote",
+                        value: "O fundo de um elemento pode ser uma **cor** (`background-color`), uma **imagem** (`background-image` com `url()`) ou um **gradiente** (`linear-gradient()`). Sobre a imagem de fundo você controla o **tamanho** (`background-size`), a **posição** (`background-position`) e se ela **se repete** (`background-repeat`). E o atalho `background` junta tudo isso em uma linha só.",
+                    },
+                    {
+                        type: "text",
+                        value: "## `background-color`: a cor de fundo\n\nA forma mais simples de fundo é uma **cor sólida**, definida com `background-color`. Você provavelmente já viu as maneiras de escrever uma cor em CSS; todas valem aqui:\n\n- por **nome**: `red`, `white`, `black`, `steelblue`...\n- em **hexadecimal**: `#ff0000`, `#ffffff`, `#333`...\n- em **RGB**: `rgb(255, 0, 0)`.\n\nEscolha a que preferir; o resultado é o mesmo.",
+                    },
+                    {
+                        type: "code",
+                        value: ".cartao {\n  background-color: #f5f5f5;   /* um cinza bem claro */\n}\n\n.aviso {\n  background-color: gold;\n}\n\nbody {\n  background-color: rgb(240, 248, 255);\n}",
+                    },
+                    {
+                        type: "text",
+                        value: "## `background-image`: uma imagem de fundo\n\nPara colocar uma **imagem** no fundo, use `background-image` com a notação `url()`, informando o **caminho** do arquivo entre parênteses (e, de preferência, entre aspas). A imagem fica **atrás** do conteúdo do elemento.\n\nUm aviso desde já: por padrão, se a imagem for menor que o elemento, ela se **repete** para preencher todo o espaço, feito ladrilhos num piso. Já já vamos controlar isso.",
+                    },
+                    {
+                        type: "code",
+                        value: '.hero {\n  background-image: url("foto-praia.jpg");\n}\n\n/* O caminho pode ser um endereco da web tambem */\nbody {\n  background-image: url("https://exemplo.com/textura.png");\n}',
+                    },
+                    {
+                        type: "text",
+                        value: "## `background-repeat`: repetir ou não\n\nComo acabamos de ver, uma imagem de fundo se **repete** por padrão. A propriedade `background-repeat` controla isso:\n\n- `repeat`: repete em todas as direções (o padrão).\n- `no-repeat`: **não** repete, mostra a imagem uma única vez.\n- `repeat-x`: repete só na **horizontal**.\n- `repeat-y`: repete só na **vertical**.\n\nPara uma foto grande de destaque, você quase sempre vai querer `no-repeat`. Já uma pequena textura pode ficar boa repetida, como um azulejo.",
+                    },
+                    {
+                        type: "code",
+                        value: '.hero {\n  background-image: url("foto-praia.jpg");\n  background-repeat: no-repeat;\n}',
+                    },
+                    {
+                        type: "text",
+                        value: "## `background-size`: o tamanho da imagem\n\nA propriedade `background-size` diz **que tamanho** a imagem de fundo deve ter. Dois valores são especialmente úteis, e vale a pena entender bem a diferença:\n\n- `cover`: a imagem **cobre todo** o elemento, sem deixar espaços em branco. Para isso, ela pode ser **cortada** nas bordas. É o valor perfeito para fotos de fundo que ocupam a tela inteira.\n- `contain`: a imagem aparece **inteira**, sem cortar nada. Em troca, podem **sobrar espaços** ao redor se as proporções não baterem.\n\nVocê também pode dar valores exatos, como `background-size: 200px 100px` (largura e altura).",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Valor","O que faz","Efeito colateral"],["`cover`","Cobre todo o elemento","Pode **cortar** partes da imagem"],["`contain`","Mostra a imagem inteira","Podem **sobrar espaços** ao redor"],["`200px 150px`","Tamanho exato (largura e altura)","Pode distorcer se a proporção não bater"],["`auto`","Tamanho original da imagem","Pode ser maior ou menor que o elemento"]]',
+                    },
+                    {
+                        type: "code",
+                        value: '.hero {\n  background-image: url("foto-praia.jpg");\n  background-repeat: no-repeat;\n  background-size: cover;   /* preenche o bloco todo, cortando o que sobra */\n}',
+                    },
+                    {
+                        type: "text",
+                        value: "## `background-position`: onde a imagem fica\n\nQuando a imagem não preenche o elemento inteiro (ou quando é cortada pelo `cover`), a propriedade `background-position` decide **qual parte** dela fica visível, ou seja, o ponto de ancoragem. Você pode usar palavras como `top`, `bottom`, `left`, `right` e `center`, combinando-as, ou valores em `px` e `%`.\n\nO valor `center` (ou `center center`) é um dos mais usados: mantém o miolo da imagem sempre visível.",
+                    },
+                    {
+                        type: "code",
+                        value: '.hero {\n  background-image: url("foto-praia.jpg");\n  background-repeat: no-repeat;\n  background-size: cover;\n  background-position: center;    /* centraliza a imagem no bloco */\n}\n\n.canto {\n  background-position: top right; /* ancora no canto superior direito */\n}',
+                    },
+                    {
+                        type: "text",
+                        value: "## Gradientes com `linear-gradient()`\n\nUm **gradiente** é uma **transição suave entre cores**, como o céu ao entardecer, que vai do laranja ao azul sem uma linha divisória. Em CSS, o gradiente mais comum é o **linear** (em linha reta), criado com a função `linear-gradient()`.\n\nUm detalhe que confunde no começo: o gradiente é tratado como uma **imagem**, não como uma cor. Por isso ele vai em `background-image` (ou no atalho `background`), e **não** em `background-color`.\n\nDentro dos parênteses você informa, de forma opcional, a **direção** e, depois, as **cores**:\n\n- a direção pode ser uma palavra como `to right` (para a direita) ou `to bottom` (para baixo), ou um ângulo como `45deg`;\n- em seguida vêm as cores, separadas por vírgula.",
+                    },
+                    {
+                        type: "code",
+                        value: "/* Da esquerda (azul) para a direita (verde) */\n.faixa {\n  background-image: linear-gradient(to right, blue, green);\n}\n\n/* De cima para baixo, com tres cores */\n.ceu {\n  background-image: linear-gradient(to bottom, #1e3c72, #2a5298, #7db9e8);\n}\n\n/* Num angulo de 45 graus */\n.diagonal {\n  background-image: linear-gradient(45deg, #ff8a00, #e52e71);\n}",
+                    },
+                    {
+                        type: "text",
+                        value: "## O atalho `background`\n\nAssim como o `font`, existe um atalho `background` que reúne várias propriedades de fundo em uma linha só: cor, imagem, repetição, posição e tamanho. Ele deixa o CSS mais enxuto.\n\nUm detalhe de sintaxe: quando você informa a posição e o tamanho juntos, eles vêm separados por uma **barra** `/`, na ordem `posição / tamanho`.",
+                    },
+                    {
+                        type: "code",
+                        value: '/* Longo: uma propriedade por linha */\n.hero {\n  background-color: #222;\n  background-image: url("foto-praia.jpg");\n  background-repeat: no-repeat;\n  background-position: center;\n  background-size: cover;\n}\n\n/* Curto: tudo no atalho background (posicao / tamanho) */\n.hero {\n  background: #222 url("foto-praia.jpg") no-repeat center / cover;\n}',
+                    },
+                    {
+                        type: "quote",
+                        value: '**Resumo:** `background-color` pinta o fundo com uma cor sólida. `background-image: url("...")` coloca uma imagem, que por padrão **se repete**; controle isso com `background-repeat` (use `no-repeat` para fotos). O `background-size` ajusta o tamanho: `cover` preenche cortando, `contain` mostra inteira podendo sobrar espaço. `background-position` escolhe a parte visível (`center` é o mais comum). Gradientes vêm de `linear-gradient()` e contam como **imagem**. O atalho `background` junta tudo, com `posição / tamanho` separados por barra.',
+                    },
+                ],
+                questions: [
+                    {
+                        statement:
+                            "Qual propriedade define uma cor sólida de fundo para um elemento?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`background-color`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`color`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`background-repeat`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`border-color`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Como você indica o arquivo de uma imagem de fundo em `background-image`?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: 'Com a notação `url()`, colocando o caminho do arquivo dentro dos parênteses, por exemplo `url("foto.jpg")`.',
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Escrevendo apenas o nome do arquivo solto, sem nada em volta.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Usando a função `image()` com o nome entre colchetes.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Com a notação `src()`, como nas imagens do HTML.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Qual a diferença entre `background-size: cover` e `background-size: contain`?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "`cover` preenche todo o elemento, podendo cortar partes da imagem; `contain` mostra a imagem inteira, mas pode sobrar espaço ao redor.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`cover` mostra a imagem inteira e `contain` corta as bordas.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Os dois fazem exatamente a mesma coisa.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`cover` repete a imagem e `contain` impede a repetição.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Por padrão, uma imagem menor que o elemento se repete preenchendo o fundo. Qual valor faz ela aparecer uma única vez?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "`background-repeat: no-repeat`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`background-repeat: repeat`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`background-size: cover`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`background-position: center`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Você quer um fundo com uma transição suave do azul para o verde usando `linear-gradient()`. Em qual propriedade ele deve ser aplicado, e por quê?",
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "Em `background-image` (ou no atalho `background`), porque um gradiente é tratado como uma imagem, não como uma cor.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Em `background-color`, porque gradiente é um tipo de cor.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Em `color`, que define todas as cores do elemento.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Em `background-repeat`, que é quem desenha os gradientes.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Bordas, cantos e sombras",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "# Bordas, cantos e sombras\n\nChegamos à última aula do módulo, e ela é sobre os **acabamentos**: aqueles detalhes que transformam uma caixa sem graça num elemento com cara de profissional. Vamos aprender a desenhar uma **moldura** ao redor dos elementos, **arredondar** os cantos (até fazer círculos perfeitos) e criar **sombras** que dão sensação de profundidade.\n\nSão propriedades muito usadas em **cartões**, botões e fotos de perfil. Depois desta aula, suas páginas vão ganhar um caprichado e tanto.",
+                    },
+                    {
+                        type: "quote",
+                        value: "`border` desenha uma **moldura** ao redor do elemento, com espessura, estilo e cor. `border-radius` **arredonda os cantos** (e, no ponto certo, vira um círculo). `box-shadow` cria uma **sombra**, dando profundidade. E `outline` é um traço por **fora** da borda que **não ocupa espaço** no layout, muito importante para indicar o foco e ajudar na acessibilidade.",
+                    },
+                    {
+                        type: "text",
+                        value: "## `border`: a moldura do elemento\n\nA propriedade `border` desenha uma **linha ao redor** do elemento, como a moldura de um quadro. Uma borda tem **três características**:\n\n- a **espessura** (largura da linha), como `2px`;\n- o **estilo** (o tipo de traço), como `solid` (linha contínua);\n- a **cor**, como `black`.\n\nVocê pode escrever as três de uma vez no atalho `border`, na ordem **espessura, estilo, cor**. É a forma mais comum.",
+                    },
+                    {
+                        type: "code",
+                        value: "/* Atalho: espessura, estilo e cor de uma vez */\n.cartao {\n  border: 2px solid black;\n}\n\n/* O mesmo resultado, separado em tres propriedades */\n.cartao {\n  border-width: 2px;\n  border-style: solid;\n  border-color: black;\n}",
+                    },
+                    {
+                        type: "text",
+                        value: "## Estilos de borda e lados separados\n\nO **estilo** é obrigatório para a borda aparecer (sem ele, o navegador não sabe que traço desenhar). Os estilos mais usados são `solid` (contínua), `dashed` (tracejada), `dotted` (pontilhada) e `double` (linha dupla).\n\nVocê também pode aplicar borda em **apenas um lado**, com `border-top`, `border-right`, `border-bottom` e `border-left`. Um truque comum é usar só o `border-bottom` para criar um sublinhado decorativo embaixo de um título.",
+                    },
+                    {
+                        type: "code",
+                        value: '/* Estilos diferentes */\n.tracejada  { border: 2px dashed steelblue; }\n.pontilhada { border: 2px dotted gray; }\n\n/* Borda so embaixo: um "sublinhado" para o titulo */\nh2 {\n  border-bottom: 3px solid #e52e71;\n}',
+                    },
+                    {
+                        type: "table",
+                        value: '[["Estilo","Como aparece"],["`solid`","Linha contínua"],["`dashed`","Linha tracejada (tracinhos)"],["`dotted`","Linha pontilhada (bolinhas)"],["`double`","Duas linhas paralelas"],["`none`","Sem borda (o padrão)"]]',
+                    },
+                    {
+                        type: "text",
+                        value: "## `border-radius`: cantos arredondados\n\nPor padrão, os cantos de um elemento são em quina, num ângulo reto. A propriedade `border-radius` **arredonda** esses cantos. Quanto maior o valor, mais suave a curva. Os valores podem ser em `px` ou em `%`.\n\nÉ o que dá aquele visual amigável de **botões** e **cartões** modernos.",
+                    },
+                    {
+                        type: "code",
+                        value: ".botao {\n  border-radius: 8px;    /* cantos levemente arredondados */\n}\n\n.cartao {\n  border-radius: 16px;   /* cantos bem redondos */\n}",
+                    },
+                    {
+                        type: "text",
+                        value: "## Fazendo um círculo com `border-radius: 50%`\n\nAqui vai um truque muito útil: se você aplicar `border-radius: 50%` a um elemento **quadrado** (mesma largura e altura), os cantos se arredondam tanto que ele vira um **círculo perfeito**. É exatamente assim que se fazem aquelas **fotos de perfil redondas** que você vê em todo lugar.",
+                    },
+                    {
+                        type: "code",
+                        value: '<img class="avatar" src="perfil.jpg" alt="Foto de perfil">\n\n<style>\n  .avatar {\n    width: 120px;\n    height: 120px;         /* largura = altura: um quadrado */\n    border-radius: 50%;    /* 50% transforma o quadrado em circulo */\n    object-fit: cover;     /* evita distorcer a foto */\n  }\n</style>',
+                    },
+                    {
+                        type: "text",
+                        value: "## `box-shadow`: sombra e profundidade\n\nA propriedade `box-shadow` projeta uma **sombra** atrás do elemento, dando a sensação de que ele está **levemente elevado** sobre a página, como um cartão flutuando um pouco acima da mesa. É um dos recursos que mais dão um ar moderno e profissional.\n\nOs valores, nesta ordem, são:\n\n1. deslocamento **horizontal** (para a direita, se positivo);\n2. deslocamento **vertical** (para baixo, se positivo);\n3. o **desfoque** (_blur_): quanto maior, mais suave e espalhada a sombra;\n4. a **cor** da sombra.",
+                    },
+                    {
+                        type: "code",
+                        value: "/* horizontal, vertical, desfoque, cor */\n.cartao {\n  box-shadow: 0 4px 8px gray;\n}\n\n/* Sombra bem suave, um classico de cartoes */\n.cartao-suave {\n  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.15);\n}",
+                    },
+                    {
+                        type: "text",
+                        value: "No segundo exemplo apareceu `rgba(0, 0, 0, 0.15)`. É a cor preta (`0, 0, 0`) com uma **transparência** de apenas `0.15` (o quarto número, chamado _alpha_, vai de `0` totalmente transparente a `1` totalmente opaco). Sombras semitransparentes ficam bem mais naturais do que um cinza chapado, porque deixam o fundo aparecer um pouquinho.",
+                    },
+                    {
+                        type: "text",
+                        value: "## `outline` vs `border`\n\nÀ primeira vista, `outline` parece só mais uma borda: é um traço em volta do elemento. Mas há diferenças importantes:\n\n- o `outline` é desenhado **por fora** da borda e **não ocupa espaço** no layout; ele não empurra os elementos vizinhos nem muda o tamanho da caixa. Já a `border` **ocupa espaço** e faz parte do tamanho do elemento.\n- por isso, quando o navegador desenha ou remove um `outline`, o layout **não treme**; com a `border`, adicionar ou tirar pode deslocar as coisas ao redor.\n\nO `outline` tem um papel de destaque na **acessibilidade**: é ele que o navegador mostra em volta de um botão ou campo quando você navega pelo **teclado** (a tecla Tab), indicando onde está o **foco**.",
+                    },
+                    {
+                        type: "code",
+                        value: "/* border ocupa espaco; outline nao */\n.campo {\n  border: 1px solid #ccc;\n}\n\n/* Realce de foco (aparece ao navegar pelo teclado) */\n.campo:focus {\n  outline: 2px solid steelblue;\n}",
+                    },
+                    {
+                        type: "text",
+                        value: 'Um alerta de acessibilidade: é tentador escrever `outline: none` para "limpar" aquele contorno que aparece ao clicar. **Evite** fazer isso sem colocar outro destaque de foco no lugar. Sem nenhum indicador de foco, quem navega pelo teclado se perde na página, sem saber onde está. Se for remover o contorno padrão, ofereça um substituto visível.',
+                    },
+                    {
+                        type: "table",
+                        value: '[["Aspecto","`border`","`outline`"],["Ocupa espaço no layout?","Sim","Não"],["Afeta o tamanho da caixa?","Sim","Não"],["Fica onde?","Na moldura do elemento","Por fora da borda"],["Uso mais comum","Molduras e divisões","Realce de **foco** (acessibilidade)"]]',
+                    },
+                    {
+                        type: "quote",
+                        value: "**Resumo:** `border` é a moldura, no formato **espessura estilo cor** (ex.: `2px solid black`); dá para aplicar por lado (`border-bottom`). `border-radius` arredonda os cantos, e `50%` num quadrado vira um **círculo** (foto de perfil). `box-shadow` cria sombra na ordem **horizontal, vertical, desfoque, cor**, ótima com cores semitransparentes (`rgba`). Já o `outline` é um traço por fora que **não ocupa espaço**, essencial para marcar o **foco**, então não o remova sem oferecer um substituto.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement:
+                            "No atalho `border: 2px solid black;`, o que cada parte define, na ordem?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "A espessura (`2px`), o estilo do traço (`solid`) e a cor (`black`).",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "A cor, o tamanho da fonte e o espaçamento.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "A posição, o desfoque e a sombra.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "A largura, a altura e a cor do elemento.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "O que acontece ao aplicar `border-radius: 50%` a um elemento quadrado (mesma largura e altura)?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "Ele vira um círculo perfeito.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Ele fica com metade do tamanho original.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Ele ganha uma borda pontilhada.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Nada muda, pois `50%` não é um valor válido.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Na propriedade `box-shadow: 0 4px 8px gray;`, o que representam os dois primeiros valores (`0` e `4px`)?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "O deslocamento horizontal e o vertical da sombra.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "A cor e a transparência da sombra.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "A espessura da borda e o arredondamento.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "A largura e a altura do elemento.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "Qual é uma diferença importante entre `outline` e `border`?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "O `outline` não ocupa espaço no layout (não empurra os vizinhos), enquanto a `border` faz parte do tamanho do elemento.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "O `outline` só funciona em imagens, e a `border` só em textos.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "A `border` é invisível e o `outline` é sempre vermelho.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Não há diferença: são duas formas de escrever a mesma coisa.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Por que é desaconselhado simplesmente aplicar `outline: none` nos elementos ao receber foco?",
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "Porque o `outline` de foco indica, para quem navega pelo teclado, onde a pessoa está na página; removê-lo sem um substituto prejudica a acessibilidade.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Porque `outline: none` deixa a página mais lenta para carregar.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Porque isso apaga todas as bordas de todos os elementos do site.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Porque o `outline` é obrigatório para a página ser válida em HTML.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        titulo: "Módulo 5 - Flexbox",
+        aulas: [
+            {
+                titulo: "Introdução ao Flexbox",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "# Introdução ao Flexbox\n\nAté aqui você aprendeu a dar cor, tamanho e espaçamento aos elementos. Agora vamos dar um passo enorme: aprender a **posicionar** as coisas na tela do jeito que você quiser. Colocar itens lado a lado, centralizar um botão no meio da página, distribuir cards com o mesmo espaço entre eles... tudo isso é trabalho de **layout**, e a ferramenta mais usada para isso hoje se chama **Flexbox**.\n\nCalma que a gente vai do zero, sem pressa. No fim desta aula você vai entender o que é o Flexbox, como ligá-lo e qual é o modelo mental que faz todo o resto se encaixar.",
+                    },
+                    {
+                        type: "quote",
+                        value: "O **Flexbox** (de _flexible box_, caixa flexível) é um **jeito de organizar elementos** em uma direção: uma linha ou uma coluna. Você escolhe um elemento para ser o **container** e escreve `display: flex` nele. A partir daí, os **filhos diretos** desse container viram **itens flexíveis** e passam a se alinhar e se distribuir com facilidade, sem gambiarra.",
+                    },
+                    {
+                        type: "text",
+                        value: "## O problema que o Flexbox resolve\n\nPor padrão, muitos elementos de HTML (como a `<div>`) são **blocos**: cada um ocupa a largura toda e **empilha** um embaixo do outro, feito tijolos numa parede. Isso é ótimo para um texto corrido, mas atrapalha quando você quer, por exemplo, um menu com os itens **lado a lado**.\n\nE tem um clássico que assombra todo iniciante: **centralizar** de verdade, principalmente na vertical. Deixar uma caixa exatamente no meio da tela, na horizontal **e** na vertical, já foi motivo de dor de cabeça e de vários truques estranhos.\n\nO Flexbox nasceu justamente para resolver isso. Ele foi feito para **alinhar** e **distribuir** elementos com poucas linhas, de um jeito previsível.",
+                    },
+                    {
+                        type: "code",
+                        value: '<style>\n  .caixa {\n    background: #6366f1;\n    color: white;\n    padding: 20px;\n    margin: 5px;\n  }\n</style>\n\n<!-- Sem Flexbox: cada div é um bloco e empilha uma embaixo da outra -->\n<div class="caixa">Um</div>\n<div class="caixa">Dois</div>\n<div class="caixa">Três</div>',
+                    },
+                    {
+                        type: "text",
+                        value: "## Ligando o Flexbox com `display: flex`\n\nPara usar o Flexbox, a gente precisa de um **elemento pai** que envolva os itens. Nele, aplicamos a propriedade `display` com o valor `flex`. Só isso já muda tudo: aquilo que estava empilhado passa a ficar **lado a lado**.\n\nVeja o mesmo exemplo de antes, agora com as três caixas dentro de um pai com `display: flex`:",
+                    },
+                    {
+                        type: "code",
+                        value: '<style>\n  .painel {\n    display: flex;   /* liga o Flexbox neste pai */\n  }\n  .caixa {\n    background: #6366f1;\n    color: white;\n    padding: 20px;\n    margin: 5px;\n  }\n</style>\n\n<!-- Com display: flex no pai, os filhos ficam lado a lado -->\n<div class="painel">\n  <div class="caixa">Um</div>\n  <div class="caixa">Dois</div>\n  <div class="caixa">Três</div>\n</div>',
+                    },
+                    {
+                        type: "text",
+                        value: '## Container e itens: quem é quem\n\nO Flexbox trabalha sempre com **dois papéis**, e entender essa divisão é meio caminho andado:\n\n- O **flex container** é o elemento pai, aquele que recebeu o `display: flex`. É ele quem **manda** na organização.\n- Os **flex itens** são os **filhos diretos** do container. São eles que obedecem e se posicionam.\n\nUma analogia: pense numa **bandeja** com **copos** em cima. A bandeja é o container; os copos são os itens. Quando você mexe na bandeja, os copos se ajustam. No Flexbox é a mesma ideia: você configura o container, e os itens respondem.\n\nUm detalhe importante: só os **filhos diretos** viram itens flexíveis. Um "neto" (um elemento dentro de um filho) não é afetado diretamente pelo `display: flex` do avô.',
+                    },
+                    {
+                        type: "code",
+                        value: '<style>\n  .bandeja {\n    display: flex;       /* este é o container */\n    background: #e0e7ff;\n    padding: 10px;\n  }\n  .copo {\n    background: #4f46e5;  /* estes são os itens (filhos diretos) */\n    color: white;\n    padding: 20px;\n    margin: 5px;\n  }\n</style>\n\n<div class="bandeja">\n  <div class="copo">A</div>\n  <div class="copo">B</div>\n  <div class="copo">C</div>\n</div>',
+                    },
+                    {
+                        type: "text",
+                        value: '## Os dois eixos: principal e cruzado\n\nAqui está o conceito mais importante do Flexbox, o que faz todo o resto fazer sentido. Todo container flex tem **dois eixos**, duas linhas invisíveis que se cruzam:\n\n- O **eixo principal** (_main axis_) é a direção em que os itens são colocados. Por padrão, ele é **horizontal**, da esquerda para a direita. É por isso que, nos exemplos acima, as caixas ficaram em linha.\n- O **eixo cruzado** (_cross axis_) é **perpendicular** ao principal. Se o principal é horizontal, o cruzado é **vertical** (de cima para baixo).\n\nGuarde essa imagem: o eixo principal é a "fila" onde os itens entram; o eixo cruzado é a direção que atravessa essa fila. Nas próximas aulas você vai alinhar itens **em cada um desses eixos** separadamente, então vale a pena fixar bem essa ideia agora.',
+                    },
+                    {
+                        type: "table",
+                        value: '[["","Eixo principal (main axis)","Eixo cruzado (cross axis)"],["Direção padrão","Horizontal (esquerda → direita)","Vertical (cima → baixo)"],["É a direção em que...","os itens entram na fila","a fila é atravessada"],["Propriedade que alinha (aula 2)","`justify-content`","`align-items`"],["Analogia","a fila do caixa","a altura de cada pessoa na fila"]]',
+                    },
+                    {
+                        type: "code",
+                        value: '<style>\n  .fila {\n    display: flex;\n    background: #f1f5f9;\n    padding: 10px;\n  }\n  .item {\n    background: #0ea5e9;\n    color: white;\n    padding: 16px 24px;\n    margin: 4px;\n  }\n</style>\n\n<!-- Os itens entram na direção do eixo principal (horizontal por padrão) -->\n<div class="fila">\n  <div class="item">1</div>\n  <div class="item">2</div>\n  <div class="item">3</div>\n  <div class="item">4</div>\n</div>',
+                    },
+                    {
+                        type: "text",
+                        value: "## E se eu quiser em coluna?\n\nO eixo principal **não é fixo** na horizontal. Dá para virá-lo para a **vertical**, fazendo os itens empilharem como uma coluna, com a propriedade `flex-direction` (que veremos com calma na aula 3). O ponto para guardar agora é: **quando você muda a direção principal, o eixo cruzado muda junto**, sempre perpendicular. Os dois andam de mãos dadas.\n\nPor enquanto, fique com o padrão (linha horizontal). Na próxima aula vamos usar esses dois eixos para finalmente **centralizar** qualquer coisa, na horizontal e na vertical.",
+                    },
+                    {
+                        type: "quote",
+                        value: "**Cheat sheet:** o **Flexbox** organiza os filhos de um elemento em linha ou coluna. Você o liga com `display: flex` no **container** (o pai); os **filhos diretos** viram **itens**. Todo container tem um **eixo principal** (horizontal por padrão, onde os itens se enfileiram) e um **eixo cruzado** (perpendicular, vertical por padrão). Entender esses dois eixos é a chave para alinhar qualquer coisa nas próximas aulas.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement:
+                            "Qual propriedade e valor transformam um elemento em um container flex?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`display: flex`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`flex: display`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`position: flex`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`align: flex`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "No Flexbox, quem são os itens flexíveis?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "Os filhos diretos do container (o elemento que recebeu `display: flex`).",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "O próprio elemento container.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Todos os elementos da página, sem exceção.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Apenas os elementos que contêm texto.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Por padrão, em qual direção fica o eixo principal de um container flex?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Horizontal, da esquerda para a direita.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Vertical, de cima para baixo.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Na diagonal, do canto superior ao inferior.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Depende do tamanho da tela do usuário.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Três `<div>` (que são blocos) estão empilhadas. O que acontece quando o elemento pai delas recebe `display: flex`?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Elas passam a ficar lado a lado, na direção do eixo principal.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Continuam empilhadas uma sobre a outra, sem mudança.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Somem da página até você adicionar mais CSS.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Viram automaticamente uma imagem única.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "Sobre os eixos do Flexbox, qual afirmação está correta?",
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "O eixo cruzado é sempre perpendicular ao principal; se o principal é horizontal, o cruzado é vertical.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Os dois eixos apontam sempre para a horizontal.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O eixo principal é sempre vertical e não há como mudá-lo.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O `display: flex` afeta diretamente também os netos (filhos dos filhos).",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Alinhamento no Flexbox",
+                blocks: [
+                    {
+                        type: "text",
+                        value: '# Alinhamento no Flexbox\n\nNa aula passada você ligou o Flexbox e conheceu os dois eixos. Agora vem a parte que faz a maioria das pessoas se apaixonar por ele: **alinhar e distribuir** os itens com uma ou duas linhas de CSS. É aqui que aquele sonho de "centralizar no meio da tela" finalmente vira algo trivial.\n\nA regra é simples e vale memorizar: **cada eixo tem a sua própria propriedade de alinhamento**. Vamos ver uma de cada vez.',
+                    },
+                    {
+                        type: "quote",
+                        value: "No Flexbox o alinhamento é dividido por eixo: `justify-content` alinha os itens no **eixo principal** (a direção da fila) e `align-items` alinha os itens no **eixo cruzado** (a direção que atravessa a fila). Para **centralizar de verdade**, na horizontal e na vertical, basta usar as duas juntas com o valor `center`.",
+                    },
+                    {
+                        type: "text",
+                        value: "## `justify-content`: distribuindo no eixo principal\n\nA propriedade `justify-content` controla como os itens ficam ao longo do **eixo principal** (por padrão, na horizontal). Ela brilha quando **sobra espaço** no container: é ela quem decide o que fazer com essa sobra.\n\nOs valores mais usados são:\n\n- `flex-start`: agrupa os itens no **início** (é o padrão). Numa linha, isso é a **esquerda**.\n- `flex-end`: agrupa os itens no **fim** (a direita).\n- `center`: agrupa os itens no **centro**.\n- `space-between`: cola o primeiro no início, o último no fim e joga **todo o espaço entre** os itens.\n- `space-around`: dá um espaço **em volta** de cada item (as pontas ficam com metade do espaço).\n- `space-evenly`: distribui o espaço de forma **igual** entre os itens e nas bordas.",
+                    },
+                    {
+                        type: "code",
+                        value: '<style>\n  .barra {\n    display: flex;\n    justify-content: center;  /* agrupa os itens no centro do eixo principal */\n    background: #f1f5f9;\n    padding: 10px;\n  }\n  .item {\n    background: #6366f1;\n    color: white;\n    padding: 16px 24px;\n    margin: 4px;\n  }\n</style>\n\n<div class="barra">\n  <div class="item">A</div>\n  <div class="item">B</div>\n  <div class="item">C</div>\n</div>',
+                    },
+                    {
+                        type: "code",
+                        value: "/* Troque só o valor de justify-content para sentir a diferença: */\n\n.barra {\n  display: flex;\n  justify-content: space-between; /* extremos nas pontas, espaço no meio */\n}\n\n/* space-around -> espaço em volta de cada item          */\n/* space-evenly -> todos os espaços exatamente iguais     */\n/* flex-end     -> tudo empurrado para a direita          */",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Valor de `justify-content`","O que faz no eixo principal"],["`flex-start`","Agrupa tudo no início (padrão)"],["`center`","Agrupa tudo no centro"],["`flex-end`","Agrupa tudo no fim"],["`space-between`","Extremos colados nas pontas, espaço entre os itens"],["`space-around`","Espaço ao redor de cada item"],["`space-evenly`","Espaços iguais entre os itens e nas bordas"]]',
+                    },
+                    {
+                        type: "text",
+                        value: "## `align-items`: alinhando no eixo cruzado\n\nSe `justify-content` cuida do eixo principal, `align-items` cuida do **eixo cruzado** (por padrão, a **vertical**). Ela decide como os itens se posicionam **de cima a baixo** dentro do container.\n\nPara enxergar o efeito, o container precisa ter uma **altura** maior que a dos itens, senão não sobra espaço na vertical para mexer. Os valores principais:\n\n- `stretch`: **estica** os itens para preencher a altura toda (é o padrão).\n- `flex-start`: alinha os itens no **topo**.\n- `flex-end`: alinha os itens **embaixo**.\n- `center`: alinha os itens no **meio** (verticalmente).\n- `baseline`: alinha pela **linha de base** do texto dos itens.",
+                    },
+                    {
+                        type: "code",
+                        value: '<style>\n  .painel {\n    display: flex;\n    align-items: center;  /* centraliza os itens na vertical */\n    height: 200px;        /* precisa de altura para haver o que alinhar */\n    background: #f1f5f9;\n  }\n  .item {\n    background: #10b981;\n    color: white;\n    padding: 16px 24px;\n    margin: 4px;\n  }\n</style>\n\n<div class="painel">\n  <div class="item">A</div>\n  <div class="item">B</div>\n  <div class="item">C</div>\n</div>',
+                    },
+                    {
+                        type: "text",
+                        value: "## Centralizar de verdade: as duas propriedades juntas\n\nChegou o momento mais aguardado. Para colocar algo **exatamente no centro** de uma área, na horizontal **e** na vertical, você combina as duas propriedades com o valor `center`:\n\n- `justify-content: center` centraliza no eixo principal (horizontal).\n- `align-items: center` centraliza no eixo cruzado (vertical).\n\nJuntas, elas resolvem aquele problema histórico de centralização em **três linhas**. Guarde este trio: você vai usar a vida inteira.",
+                    },
+                    {
+                        type: "code",
+                        value: '<style>\n  .tela {\n    display: flex;\n    justify-content: center;  /* centro na horizontal */\n    align-items: center;      /* centro na vertical   */\n    height: 300px;\n    background: #1e293b;\n  }\n  .cartao {\n    background: white;\n    color: #1e293b;\n    padding: 30px 50px;\n    border-radius: 8px;\n  }\n</style>\n\n<div class="tela">\n  <div class="cartao">Estou no centro!</div>\n</div>',
+                    },
+                    {
+                        type: "text",
+                        value: "## `align-content`: quando há várias linhas\n\nExiste ainda uma terceira propriedade de alinhamento, a `align-content`. Ela só entra em cena quando os itens ocupam **mais de uma linha** dentro do container (isso acontece quando ativamos a quebra com `flex-wrap`, assunto da próxima aula).\n\nA diferença é sutil, mas importante:\n\n- `align-items` alinha os itens **dentro da sua própria linha**.\n- `align-content` alinha o **conjunto de linhas** como um todo, distribuindo o espaço **entre as linhas** no eixo cruzado.\n\nOs valores lembram os do `justify-content` (`flex-start`, `center`, `space-between`, `space-around`, `space-evenly`, `stretch`). Se você só tem **uma linha** de itens, a `align-content` não faz efeito nenhum, e é por isso que ela costuma confundir no começo.",
+                    },
+                    {
+                        type: "code",
+                        value: '<style>\n  .grade {\n    display: flex;\n    flex-wrap: wrap;         /* permite quebrar em várias linhas */\n    align-content: center;   /* centraliza o CONJUNTO de linhas na vertical */\n    height: 300px;\n    background: #f1f5f9;\n  }\n  .item {\n    background: #f59e0b;\n    color: white;\n    width: 120px;\n    padding: 20px;\n    margin: 5px;\n  }\n</style>\n\n<div class="grade">\n  <div class="item">1</div>\n  <div class="item">2</div>\n  <div class="item">3</div>\n  <div class="item">4</div>\n  <div class="item">5</div>\n</div>',
+                    },
+                    {
+                        type: "table",
+                        value: '[["Propriedade","Atua em...","Serve para..."],["`justify-content`","Eixo principal","Distribuir os itens ao longo da fila"],["`align-items`","Eixo cruzado","Alinhar os itens dentro da linha"],["`align-content`","Eixo cruzado","Distribuir várias linhas (só com quebra)"]]',
+                    },
+                    {
+                        type: "quote",
+                        value: "**Cheat sheet:** `justify-content` alinha no **eixo principal** (horizontal por padrão) e decide o que fazer com o espaço que sobra: `center`, `space-between`, `space-around`, `space-evenly`... `align-items` alinha no **eixo cruzado** (vertical por padrão): `center`, `flex-start`, `flex-end`, `stretch`. Para **centralizar de vez**, use as duas com `center`. Já a `align-content` só age quando há **várias linhas** (com `flex-wrap`), organizando o conjunto de linhas.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement:
+                            "Qual propriedade alinha os itens ao longo do eixo principal (horizontal por padrão)?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`justify-content`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`align-items`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`align-content`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`text-align`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Para alinhar os itens no centro na vertical (eixo cruzado), qual declaração você usa?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`align-items: center`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`justify-content: center`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`vertical-align: middle`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`margin: center`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Qual combinação centraliza um elemento exatamente no meio, na horizontal e na vertical?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "`justify-content: center` e `align-items: center` juntos.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`text-align: center` sozinho.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`justify-content: center` sozinho.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`margin: 0 auto` com `padding: center`.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "O que o valor `space-between` do `justify-content` faz?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Cola o primeiro item no início e o último no fim, jogando o espaço que sobra entre os itens.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Centraliza todos os itens no meio do container.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Dá o mesmo espaço em volta de cada item, inclusive nas bordas.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Empilha os itens em uma coluna.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Por que a propriedade `align-content` às vezes parece não fazer nada?",
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "Porque ela só tem efeito quando há mais de uma linha de itens (com `flex-wrap`); em uma linha só, não há linhas para distribuir.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Porque ela foi removida das versões modernas do CSS.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Porque ela funciona apenas com `display: grid`.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Porque ela exige que os itens tenham `position: absolute`.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Direção, quebra e espaçamento",
+                blocks: [
+                    {
+                        type: "text",
+                        value: '# Direção, quebra e espaçamento\n\nAté agora nossos itens ficaram sempre em uma linha horizontal, sem sair do lugar. Nesta aula você ganha o controle sobre a **direção** dessa fila, sobre o que acontece quando ela **não cabe** na tela e sobre o **espaço** entre os itens. São quatro propriedades que deixam o layout muito mais flexível (o nome "Flexbox" não é à toa).',
+                    },
+                    {
+                        type: "quote",
+                        value: "Quatro propriedades comandam o arranjo dos itens: `flex-direction` escolhe se a fila é uma **linha** ou uma **coluna** (e isso **gira os eixos**); `flex-wrap` permite que os itens **quebrem** para a linha de baixo quando não cabem; `gap` cria um **espaço uniforme** entre eles; e `order` muda a **ordem visual** sem mexer no HTML.",
+                    },
+                    {
+                        type: "text",
+                        value: "## `flex-direction`: linha ou coluna\n\nLembra do **eixo principal** da aula 1? A propriedade `flex-direction` é quem define para onde ele aponta. Ela aceita quatro valores:\n\n- `row` (o padrão): itens em **linha**, da esquerda para a direita. Eixo principal **horizontal**.\n- `column`: itens em **coluna**, de cima para baixo. Eixo principal **vertical**.\n- `row-reverse`: linha, mas da **direita para a esquerda**.\n- `column-reverse`: coluna, mas de **baixo para cima**.\n\nO detalhe que mais confunde: ao trocar para `column`, os **eixos giram**. Agora o eixo principal é o **vertical**, então `justify-content` passa a alinhar na **vertical**, e `align-items`, na **horizontal**. As propriedades não mudam de nome, mas o eixo em que elas agem, sim.",
+                    },
+                    {
+                        type: "code",
+                        value: '<style>\n  .menu {\n    display: flex;\n    flex-direction: column;  /* empilha os itens numa coluna */\n    background: #f1f5f9;\n    padding: 10px;\n  }\n  .item {\n    background: #6366f1;\n    color: white;\n    padding: 12px;\n    margin: 4px;\n  }\n</style>\n\n<div class="menu">\n  <div class="item">Início</div>\n  <div class="item">Perfil</div>\n  <div class="item">Sair</div>\n</div>',
+                    },
+                    {
+                        type: "text",
+                        value: 'Repare no efeito colateral: com `flex-direction: column`, se você quiser centralizar os itens **na horizontal** agora vai usar `align-items: center` (o eixo cruzado virou horizontal), enquanto `justify-content` cuida da distribuição **na vertical**. Sempre que um alinhamento parecer estranho, volte e pergunte: "qual é o meu eixo principal agora?".',
+                    },
+                    {
+                        type: "text",
+                        value: "## `flex-wrap`: deixando os itens quebrarem\n\nPor padrão, o Flexbox tenta manter **todos os itens na mesma linha**, custe o que custar. Se não couberem, ele **espreme** os itens para caber (esse padrão se chama `nowrap`). Em telas pequenas, isso deixa tudo apertado.\n\nCom `flex-wrap: wrap`, você libera os itens para **pular para a linha de baixo** quando o espaço acabar, igual às palavras de um texto que quebram para a próxima linha. Essa é a base de layouts que se adaptam a diferentes tamanhos de tela.\n\n- `nowrap` (padrão): tudo numa linha só, mesmo que aperte.\n- `wrap`: quebra para novas linhas quando necessário.\n- `wrap-reverse`: quebra, mas empilhando as linhas na direção contrária.",
+                    },
+                    {
+                        type: "code",
+                        value: '<style>\n  .galeria {\n    display: flex;\n    flex-wrap: wrap;   /* os itens pulam de linha quando não cabem */\n    background: #f1f5f9;\n    padding: 10px;\n  }\n  .foto {\n    background: #0ea5e9;\n    color: white;\n    width: 150px;\n    height: 80px;\n    margin: 5px;\n  }\n</style>\n\n<div class="galeria">\n  <div class="foto">1</div>\n  <div class="foto">2</div>\n  <div class="foto">3</div>\n  <div class="foto">4</div>\n  <div class="foto">5</div>\n  <div class="foto">6</div>\n</div>',
+                    },
+                    {
+                        type: "text",
+                        value: "## `gap`: o espaço entre os itens\n\nAté aqui, para afastar um item do outro, a gente vinha usando `margin` em cada um. Funciona, mas tem um efeito chato: sobra margem nas **pontas**, e a conta fica confusa. O jeito moderno e bem mais simples é a propriedade `gap`, aplicada **no container**.\n\nO `gap` define uma **distância uniforme** só **entre** os itens, sem sobrar espaço nas bordas. Uma única linha resolve o espaçamento de todos:\n\n- `gap: 16px` deixa 16px entre os itens, tanto na horizontal quanto na vertical (quando há quebra).\n- Dá para usar dois valores: `gap: 20px 10px` (20px entre as linhas, 10px entre as colunas).",
+                    },
+                    {
+                        type: "code",
+                        value: '<style>\n  .cartoes {\n    display: flex;\n    gap: 16px;   /* 16px só entre os itens, sem sobrar nas bordas */\n    background: #f1f5f9;\n    padding: 16px;\n  }\n  .cartao {\n    background: #8b5cf6;\n    color: white;\n    padding: 20px 30px;\n  }\n</style>\n\n<div class="cartoes">\n  <div class="cartao">Um</div>\n  <div class="cartao">Dois</div>\n  <div class="cartao">Três</div>\n</div>',
+                    },
+                    {
+                        type: "text",
+                        value: "## `order`: mudando a ordem visual\n\nNormalmente os itens aparecem na **mesma ordem** em que estão escritos no HTML. A propriedade `order` permite mudar essa ordem **visual** sem tocar no HTML. Ela recebe um número, e os itens são exibidos do **menor para o maior**.\n\nPor padrão, todo item tem `order: 0`. Se você der `order: 1` a um item, ele vai para o **fim** (porque 1 é maior que 0). Se der `order: -1`, ele vai para o **começo** (porque -1 é menor que 0).\n\nÉ útil para reorganizar blocos em telas diferentes, mas use com cuidado: ele muda só a ordem **visual**, não a ordem em que o conteúdo é **lido** por leitores de tela. Ou seja, não abuse dele, para não atrapalhar quem depende da acessibilidade.",
+                    },
+                    {
+                        type: "code",
+                        value: '<style>\n  .fila {\n    display: flex;\n    gap: 8px;\n  }\n  .item {\n    background: #64748b;\n    color: white;\n    padding: 16px 24px;\n  }\n  .destaque {\n    order: -1;          /* vai para o começo, mesmo escrito por último */\n    background: #ef4444;\n  }\n</style>\n\n<div class="fila">\n  <div class="item">1º no HTML</div>\n  <div class="item">2º no HTML</div>\n  <div class="item destaque">3º no HTML</div>\n</div>',
+                    },
+                    {
+                        type: "table",
+                        value: '[["Propriedade","Onde se aplica","Para que serve"],["`flex-direction`","No container","Linha (`row`) ou coluna (`column`); gira os eixos"],["`flex-wrap`","No container","Permite os itens quebrarem para outra linha"],["`gap`","No container","Espaço uniforme entre os itens"],["`order`","No item","Muda a ordem visual (menor aparece primeiro)"]]',
+                    },
+                    {
+                        type: "quote",
+                        value: "**Cheat sheet:** `flex-direction` escolhe a direção da fila, `row` (padrão) ou `column`, e ao virar coluna os **eixos giram** (o principal passa a ser vertical). `flex-wrap: wrap` deixa os itens **quebrarem** para a próxima linha quando não cabem. `gap` cria um espaço **uniforme só entre** os itens, o jeito moderno de substituir as margens. E `order` reordena os itens **visualmente** (menor primeiro) sem mudar o HTML, use com parcimônia por causa da acessibilidade.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement:
+                            "Qual valor de `flex-direction` empilha os itens em uma coluna, de cima para baixo?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`column`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`row`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`vertical`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`stack`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Qual propriedade cria um espaço uniforme apenas entre os itens de um container flex?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`gap`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`padding`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`order`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`margin: auto`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "O que a declaração `flex-wrap: wrap` permite?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Que os itens pulem para a próxima linha quando não cabem na atual.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Que todos os itens sejam espremidos em uma única linha.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Que os itens fiquem centralizados na vertical.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Que a ordem dos itens seja invertida.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Ao mudar `flex-direction` para `column`, o que acontece com o `justify-content`?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "O eixo principal vira vertical, então `justify-content` passa a alinhar os itens na vertical.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Nada muda: `justify-content` continua alinhando na horizontal.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O `justify-content` deixa de funcionar completamente.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Os itens desaparecem da tela.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Um item foi escrito por último no HTML, mas você quer que ele apareça primeiro na tela. Qual solução e qual cuidado?",
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "Dar a ele um `order` menor que o dos outros (como `-1`); o cuidado é que isso muda só a ordem visual, não a lida por leitores de tela.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Usar `order: 100`, que sempre leva o item para o começo.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Não é possível reordenar sem reescrever o HTML.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Usar `flex-wrap: wrap-reverse`, que reordena os itens sem nenhum efeito colateral.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Dimensionando os itens",
+                blocks: [
+                    {
+                        type: "text",
+                        value: '# Dimensionando os itens\n\nVocê já sabe organizar, alinhar e espaçar os itens. Falta a última peça do Flexbox: controlar o **tamanho** de cada item, quanto ele pode **crescer**, quanto pode **encolher** e qual é o seu tamanho **de partida**. É isso que dá aquele efeito "elástico" em que uns itens esticam para ocupar o espaço e outros ficam fixos.\n\nNo fim da aula, a gente junta tudo o que viu no módulo para montar uma **barra de navegação** de verdade. Bora fechar o Flexbox com chave de ouro.',
+                    },
+                    {
+                        type: "quote",
+                        value: "Cada item flexível tem três controles de tamanho no eixo principal: `flex-grow` (quanto ele pode **crescer** para ocupar a sobra de espaço), `flex-shrink` (quanto ele pode **encolher** quando falta espaço) e `flex-basis` (o tamanho **inicial**, antes de crescer ou encolher). O atalho `flex` junta os três em uma linha. E `align-self` deixa **um** item quebrar o alinhamento definido pelo container.",
+                    },
+                    {
+                        type: "text",
+                        value: '## `flex-grow`: crescer para ocupar a sobra\n\nQuando sobra espaço no eixo principal, o `flex-grow` decide se um item **estica** para ocupar essa folga. Ele recebe um número que funciona como um **peso**:\n\n- `flex-grow: 0` (padrão): o item **não cresce**, mantém o tamanho.\n- `flex-grow: 1`: o item **cresce** para ocupar o espaço livre.\n- Se vários itens têm `flex-grow`, o espaço é dividido na **proporção** dos números. Um item com `flex-grow: 2` fica com o **dobro** da sobra em relação a um com `flex-grow: 1`.\n\nPense no número como "quantas fatias do espaço que sobra este item quer".',
+                    },
+                    {
+                        type: "code",
+                        value: '<style>\n  .barra {\n    display: flex;\n    gap: 8px;\n  }\n  .item {\n    background: #6366f1;\n    color: white;\n    padding: 16px;\n  }\n  .cresce {\n    flex-grow: 1;   /* este item estica e ocupa toda a sobra */\n  }\n</style>\n\n<div class="barra">\n  <div class="item">Fixo</div>\n  <div class="item cresce">Eu estico</div>\n  <div class="item">Fixo</div>\n</div>',
+                    },
+                    {
+                        type: "text",
+                        value: '## `flex-shrink`: encolher quando falta espaço\n\nO `flex-shrink` é o oposto do `flex-grow`: ele entra em ação quando **falta** espaço e os itens precisam **encolher** para caber. Também é um número que funciona como peso:\n\n- `flex-shrink: 1` (padrão): o item **pode encolher** se necessário.\n- `flex-shrink: 0`: o item **não encolhe** de jeito nenhum, mantém o tamanho mesmo que estoure.\n- Quanto **maior** o número, **mais** o item cede espaço em relação aos outros.\n\nUm uso comum de `flex-shrink: 0` é impedir que um logotipo ou um ícone seja "amassado" quando a tela fica estreita.',
+                    },
+                    {
+                        type: "code",
+                        value: '<style>\n  .barra {\n    display: flex;\n    width: 300px;   /* pouco espaço, de propósito */\n    gap: 8px;\n  }\n  .item {\n    background: #10b981;\n    color: white;\n    padding: 16px;\n    width: 150px;\n  }\n  .nao-encolhe {\n    flex-shrink: 0;  /* mantém os 150px mesmo faltando espaço */\n    background: #ef4444;\n  }\n</style>\n\n<div class="barra">\n  <div class="item">Encolho</div>\n  <div class="item">Encolho</div>\n  <div class="item nao-encolhe">Firme</div>\n</div>',
+                    },
+                    {
+                        type: "text",
+                        value: '## `flex-basis`: o tamanho de partida\n\nO `flex-basis` define o tamanho **inicial** do item no eixo principal, **antes** de o grow e o shrink entrarem em ação. É como o "ponto de partida" da negociação de espaço.\n\n- O padrão é `auto`, que usa o tamanho natural do conteúdo (ou a `width`/`height`, se houver uma).\n- Você pode fixar um valor: `flex-basis: 200px` diz "comece com 200px e, a partir daí, cresça ou encolha".\n\nNa prática, dentro do Flexbox costuma-se preferir o `flex-basis` no lugar de `width` para definir o tamanho base, porque ele se integra melhor à lógica de crescer e encolher.',
+                    },
+                    {
+                        type: "text",
+                        value: "## O atalho `flex`: três em um\n\nEscrever `flex-grow`, `flex-shrink` e `flex-basis` separados dá trabalho. Por isso existe o atalho `flex`, que junta os três em uma linha, **nesta ordem**: `flex: <grow> <shrink> <basis>`.\n\nAlguns atalhos que você vai ver o tempo todo:\n\n- `flex: 1` é o mesmo que `flex: 1 1 0`: o item cresce, encolhe e parte do zero. É o jeito clássico de fazer itens dividirem o espaço **igualmente**.\n- `flex: 0 0 auto` trava o item no tamanho do conteúdo (não cresce nem encolhe).\n- `flex: 0 0 200px` fixa o item em 200px, firme.",
+                    },
+                    {
+                        type: "code",
+                        value: '<style>\n  .colunas {\n    display: flex;\n    gap: 8px;\n  }\n  .coluna {\n    flex: 1;   /* atalho de 1 1 0: todas dividem o espaço por igual */\n    background: #8b5cf6;\n    color: white;\n    padding: 20px;\n    text-align: center;\n  }\n</style>\n\n<div class="colunas">\n  <div class="coluna">1/3</div>\n  <div class="coluna">1/3</div>\n  <div class="coluna">1/3</div>\n</div>',
+                    },
+                    {
+                        type: "text",
+                        value: "## `align-self`: a exceção de um item só\n\nLá na aula 2, o `align-items` alinhava **todos** os itens no eixo cruzado de uma vez. Mas e se você quiser que **um único** item se comporte diferente dos demais? Para isso existe o `align-self`, aplicado **no item** (e não no container).\n\nEle aceita os mesmos valores do `align-items` (`flex-start`, `center`, `flex-end`, `stretch`, `baseline`) e **sobrescreve**, só para aquele item, o alinhamento definido pelo container. É a maneira de abrir uma exceção sem bagunçar o resto.",
+                    },
+                    {
+                        type: "code",
+                        value: '<style>\n  .painel {\n    display: flex;\n    align-items: flex-start;  /* todos no topo... */\n    height: 200px;\n    gap: 8px;\n    background: #f1f5f9;\n  }\n  .item {\n    background: #0ea5e9;\n    color: white;\n    padding: 16px;\n  }\n  .especial {\n    align-self: center;  /* ...menos este, que vai para o meio */\n    background: #f59e0b;\n  }\n</style>\n\n<div class="painel">\n  <div class="item">Topo</div>\n  <div class="item especial">Meio</div>\n  <div class="item">Topo</div>\n</div>',
+                    },
+                    {
+                        type: "text",
+                        value: "## Juntando tudo: uma barra de navegação\n\nAgora o grand finale: uma **barra de navegação** de verdade, usando quase tudo o que você aprendeu no módulo. O padrão é clássico: **logo à esquerda**, **links à direita**, tudo **alinhado na vertical** e com **espaço** entre os links.\n\nOs ingredientes:\n\n- `display: flex` no `<nav>` para colocar tudo em linha.\n- `justify-content: space-between` para empurrar o logo para uma ponta e os links para a outra.\n- `align-items: center` para centralizar tudo na vertical.\n- `gap` para espaçar os links entre si.",
+                    },
+                    {
+                        type: "code",
+                        value: '<style>\n  .navbar {\n    display: flex;\n    justify-content: space-between; /* logo numa ponta, links na outra */\n    align-items: center;            /* tudo centralizado na vertical  */\n    background: #1e293b;\n    padding: 16px 24px;\n  }\n  .logo {\n    color: white;\n    font-size: 20px;\n    font-weight: bold;\n  }\n  .links {\n    display: flex;\n    gap: 24px;   /* espaço entre os links */\n  }\n  .links a {\n    color: #cbd5e1;\n    text-decoration: none;\n  }\n</style>\n\n<nav class="navbar">\n  <div class="logo">ensina.dev</div>\n  <div class="links">\n    <a href="#">Início</a>\n    <a href="#">Trilhas</a>\n    <a href="#">Entrar</a>\n  </div>\n</nav>',
+                    },
+                    {
+                        type: "table",
+                        value: '[["Propriedade","Valor padrão","O que controla"],["`flex-grow`","`0`","Quanto o item cresce na sobra de espaço"],["`flex-shrink`","`1`","Quanto o item encolhe na falta de espaço"],["`flex-basis`","`auto`","Tamanho inicial antes de crescer ou encolher"],["`flex: 1`","(atalho)","Igual a `1 1 0`: divide o espaço por igual"],["`align-self`","`auto`","Alinhamento no eixo cruzado de um item só"]]',
+                    },
+                    {
+                        type: "quote",
+                        value: "**Cheat sheet final do módulo:** no eixo principal, `flex-grow` faz o item **crescer** na sobra, `flex-shrink` o faz **encolher** na falta, e `flex-basis` define o **tamanho inicial**. O atalho `flex: 1 1 0` (ou só `flex: 1`) faz itens **dividirem o espaço igualmente**. O `align-self` abre uma **exceção** de alinhamento para um item. Juntando `display: flex`, `justify-content`, `align-items` e `gap`, você monta layouts como uma **barra de navegação** em poucas linhas. Parabéns, você concluiu o módulo de Flexbox!",
+                    },
+                ],
+                questions: [
+                    {
+                        statement: "O que `flex-grow: 1` faz com um item?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "Permite que ele cresça para ocupar o espaço que sobra no eixo principal.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Faz o item encolher até desaparecer.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Centraliza o item na vertical.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Muda a cor de fundo do item.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "O atalho `flex` reúne quais três propriedades, nesta ordem?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`flex-grow`, `flex-shrink` e `flex-basis`.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`flex-basis`, `flex-grow` e `flex-shrink`.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`justify-content`, `align-items` e `gap`.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`width`, `height` e `margin`.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Você quer que três colunas dividam o espaço disponível igualmente. Qual declaração, aplicada a cada coluna, resolve isso de forma mais direta?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "`flex: 1`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`width: 33px`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`flex-shrink: 0`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`order: 1`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "Para que serve o `align-self` aplicado a um item?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Sobrescrever, só para aquele item, o alinhamento no eixo cruzado definido pelo container.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Alinhar de uma vez todos os itens do container.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Definir o espaço entre os itens.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Mudar a direção do container para coluna.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Numa barra de navegação com o logo à esquerda e os links à direita, qual conjunto de propriedades no container produz esse layout?",
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "`display: flex` com `justify-content: space-between` e `align-items: center`.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`display: flex` com `flex-direction: column` e `flex-wrap: wrap`.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`display: block` com `text-align: right`.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`justify-content: center` com `flex-grow: 0` em todos os itens.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        titulo: "Módulo 6 - Grid",
+        aulas: [
+            {
+                titulo: "Introdução ao Grid",
+                blocks: [
+                    {
+                        type: "text",
+                        value: '# Introdução ao Grid\n\nSe você acompanhou o módulo anterior, acabou de conhecer o **Flexbox** e viu como ele é ótimo para alinhar coisas em **uma linha** ou **uma coluna**. Guarde essa ideia de "uma direção de cada vez", porque agora a gente dá um passo adiante.\n\nChegou a vez do **Grid**, a ferramenta mais poderosa que o CSS tem para montar **layouts** de página. Com ele você organiza o conteúdo em **linhas e colunas ao mesmo tempo**, como se desenhasse uma grade e fosse encaixando as coisas nos espaços. Parece coisa de gente avançada, mas você vai ver que é surpreendentemente intuitivo. Bora do zero, com calma.',
+                    },
+                    {
+                        type: "quote",
+                        value: "O **Grid** é o sistema de layout do CSS feito para **duas dimensões**: **linhas e colunas** ao mesmo tempo. Você liga o grid no elemento **pai** (o container) com `display: grid`, define o formato da grade com propriedades como `grid-template-columns`, e os elementos **filhos** se encaixam sozinhos nas células dessa grade.",
+                    },
+                    {
+                        type: "text",
+                        value: "## De uma dimensão para duas\n\nAntes de mais nada, vale entender a diferença entre o Flexbox e o Grid. Os dois servem para posicionar elementos, mas pensam de formas diferentes.\n\n- O **Flexbox** trabalha em **uma dimensão** por vez: ou uma **linha** (itens lado a lado) ou uma **coluna** (itens empilhados). É como arrumar livros numa **única prateleira**.\n- O **Grid** trabalha em **duas dimensões** de uma vez só: **linhas e colunas juntas**. É como uma **estante inteira**, cheia de prateleiras e divisórias, em que cada objeto tem o seu quadradinho.\n\nUma imagem que ajuda demais: pense numa folha de **papel quadriculado** ou num **tabuleiro de xadrez**. Você decide quantas colunas e quantas linhas quer, e isso cria um monte de **células** (os quadradinhos). O conteúdo vai ocupando essas células. Essa é a alma do Grid.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Ligando o grid: `display: grid`\n\nTodo grid começa por um **container**, o elemento **pai** que vai segurar os itens. Para transformar um elemento comum em um container de grid, você aplica `display: grid` nele, do mesmo jeito que fazia `display: flex` no Flexbox.\n\nA partir daí acontece uma mágica silenciosa: os **filhos diretos** desse container viram automaticamente **itens do grid**. Você não precisa configurar nada neles ainda; eles já entram na dança. Veja um HTML bem simples, um container `grade` com três caixas dentro:",
+                    },
+                    {
+                        type: "code",
+                        value: '<div class="grade">\n  <div class="caixa">1</div>\n  <div class="caixa">2</div>\n  <div class="caixa">3</div>\n</div>',
+                    },
+                    {
+                        type: "code",
+                        value: ".grade {\n  display: grid;\n}",
+                    },
+                    {
+                        type: "text",
+                        value: "## Só `display: grid` ainda não basta\n\nSe você aplicar apenas o `display: grid` como acima, o resultado pode decepcionar: as três caixas continuam **empilhadas uma embaixo da outra**, como se nada tivesse mudado. Calma, faz todo sentido.\n\nÉ que o grid ainda não sabe **quantas colunas** você quer. Sem essa informação, ele assume o padrão: **uma única coluna**, e vai empilhando as linhas. Ou seja, o `display: grid` só **prepara o terreno**. Quem de fato desenha a grade é a próxima propriedade.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Definindo as colunas: `grid-template-columns`\n\nA propriedade `grid-template-columns` é o coração do Grid. Ela vai no **container** e serve para dizer **quantas colunas** a grade tem e **qual a largura de cada uma**.\n\nA regra é direta: você escreve um valor de largura **para cada coluna** que quiser, separados por espaço. Três valores, três colunas. Quatro valores, quatro colunas. Veja como criar três colunas fixas de 200 pixels cada:",
+                    },
+                    {
+                        type: "code",
+                        value: ".grade {\n  display: grid;\n  grid-template-columns: 200px 200px 200px;\n}",
+                    },
+                    {
+                        type: "text",
+                        value: "Agora sim: as três caixas ficam **lado a lado**, cada uma numa coluna de 200px. Se houvesse uma quarta caixa, ela **pularia para a linha de baixo**, na primeira coluna, porque a grade só tem três colunas. O grid cria as novas linhas sozinho conforme o conteúdo chega.\n\nRepare no padrão: **a quantidade de valores define a quantidade de colunas**. Isso vai te acompanhar pelo Grid inteiro.\n\nSó tem um porém: larguras fixas em `px` são meio teimosas. Se a tela do visitante for menor que 600px (200 + 200 + 200), o conteúdo vaza para fora. Precisamos de algo mais flexível.",
+                    },
+                    {
+                        type: "text",
+                        value: '## A unidade `fr`: repartindo o espaço\n\nAí entra a estrela do Grid: a unidade `fr`, de **fração** (_fraction_, em inglês). Em vez de dizer "esta coluna tem 200 pixels", você diz "esta coluna fica com **uma fatia** do espaço disponível". O grid soma todas as frações e reparte o espaço proporcionalmente entre as colunas.\n\nA analogia perfeita é uma **pizza**: não importa o tamanho exato da pizza, o que importa é **em quantas fatias** você a divide. Se você pede três colunas de `1fr` cada, o container é dividido em três fatias iguais. Se a tela cresce, as três crescem juntas; se encolhe, encolhem juntas, sempre ocupando a largura toda sem vazar.',
+                    },
+                    {
+                        type: "code",
+                        value: "/* Três colunas de tamanho igual, cada uma com 1 fatia do espaço */\n.grade {\n  display: grid;\n  grid-template-columns: 1fr 1fr 1fr;\n}",
+                    },
+                    {
+                        type: "text",
+                        value: "E se você quiser colunas de tamanhos **diferentes**? É só dar mais fatias para umas do que para outras. Pense em `2fr 1fr`: são três fatias no total, a primeira coluna leva **duas** e a segunda leva **uma**. Ou seja, a primeira fica com o **dobro** da largura da segunda.",
+                    },
+                    {
+                        type: "code",
+                        value: "/* A primeira coluna fica com o dobro da largura da segunda */\n.grade {\n  display: grid;\n  grid-template-columns: 2fr 1fr;\n}",
+                    },
+                    {
+                        type: "text",
+                        value: 'O melhor é que dá para **misturar** `fr` com larguras fixas. Um caso clássico de site: uma **barra lateral** (menu) com largura fixa e uma **área de conteúdo** que ocupa todo o resto. Escrevemos `200px 1fr`: a primeira coluna tem 200px cravados, e o `1fr` da segunda significa "pega tudo o que sobrar".',
+                    },
+                    {
+                        type: "code",
+                        value: "/* Barra lateral fixa + conteúdo que ocupa o resto */\n.grade {\n  display: grid;\n  grid-template-columns: 200px 1fr;\n}",
+                    },
+                    {
+                        type: "text",
+                        value: '## Menos repetição: `repeat()`\n\nEscrever `1fr 1fr 1fr 1fr` já é meio chato. Imagine `1fr` doze vezes para uma grade grande. Para evitar essa repetição cansativa, o Grid oferece a função `repeat()`.\n\nEla recebe duas coisas: **quantas vezes** repetir e **o que** repetir. Assim, `repeat(3, 1fr)` quer dizer "repita `1fr` três vezes", que é exatamente o mesmo que escrever `1fr 1fr 1fr`, só que muito mais curto e fácil de manter.',
+                    },
+                    {
+                        type: "code",
+                        value: "/* Estas duas regras produzem exatamente a mesma grade */\n.grade {\n  grid-template-columns: repeat(3, 1fr);\n}\n\n/* ...é o mesmo que escrever: */\n.grade {\n  grid-template-columns: 1fr 1fr 1fr;\n}",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Você escreve","O que acontece","Quando usar"],["`200px 200px`","Duas colunas fixas de 200px","Quando a largura precisa ser exata"],["`1fr 1fr 1fr`","Três colunas iguais que dividem o espaço","O caso mais comum: colunas flexíveis"],["`2fr 1fr`","Primeira coluna com o dobro da segunda","Colunas com proporções diferentes"],["`200px 1fr`","Uma fixa e outra que ocupa o resto","Barra lateral + conteúdo"],["`repeat(4, 1fr)`","Quatro colunas iguais, sem repetição","Muitas colunas do mesmo tamanho"]]',
+                    },
+                    {
+                        type: "quote",
+                        value: "**Recapitulando:** o **Grid** faz layout em **2 dimensões**. Ligue-o no container com `display: grid` e defina as colunas com `grid-template-columns`, em que **cada valor é uma coluna**. Use `px` para larguras fixas e a unidade `fr` (fração) para dividir o espaço proporcionalmente, tipo fatias de pizza (`1fr 1fr 1fr` são três colunas iguais). Misture os dois quando precisar (`200px 1fr`) e use `repeat()` para não repetir valores (`repeat(3, 1fr)`).",
+                    },
+                ],
+                questions: [
+                    {
+                        statement: "Em qual elemento você aplica a propriedade `display: grid`?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "No elemento pai (o container), para que os filhos diretos virem itens do grid.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Em cada elemento filho, um por um.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Sempre na tag `<body>`, e em nenhum outro lugar.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Dentro do seletor `:root`, obrigatoriamente.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "A regra `grid-template-columns: 1fr 1fr 1fr;` cria quantas colunas?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "Três colunas de tamanho igual.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Uma única coluna com o triplo da largura.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Três linhas empilhadas, não colunas.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Nenhuma; a unidade `fr` não funciona em colunas.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "O que significa a unidade `fr` em `grid-template-columns`?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Uma fração do espaço disponível; o grid reparte o espaço proporcionalmente entre as frações.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Uma medida fixa sempre igual a 16 pixels.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "A moldura (frame) que envolve o grid por fora.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "A quantidade de linhas que o grid terá.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "O valor `repeat(4, 1fr)` é equivalente a qual outro valor?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "`1fr 1fr 1fr 1fr`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`4fr`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`1fr 4fr`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`repeat(1fr, 4)`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Você quer uma barra lateral fixa de 250px e uma área de conteúdo que ocupe todo o espaço restante. Qual valor faz isso?",
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "`grid-template-columns: 250px 1fr;`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`grid-template-columns: 250px 250px;`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`grid-template-columns: 1fr 1fr;`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`grid-template-columns: repeat(2, 250px);`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Espaçamento e posicionamento",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "# Espaçamento e posicionamento\n\nNa aula anterior você aprendeu a criar colunas com `grid-template-columns`, a unidade `fr` e a função `repeat()`. Já dá para montar grades bem úteis! Agora vamos deixar tudo mais bonito e mais poderoso.\n\nNesta aula você vai aprender três coisas: como colocar um **respiro** entre as células com `gap`, como controlar as **linhas** (as fileiras horizontais) com `grid-template-rows`, e como **posicionar um item específico** para ele ocupar mais de uma célula. No caminho, você vai conhecer as **linhas numeradas** do grid, que são a régua invisível que segura tudo no lugar.",
+                    },
+                    {
+                        type: "quote",
+                        value: "O `gap` cria um **espaçamento** entre as células do grid. O `grid-template-rows` define a **altura das linhas**, assim como `grid-template-columns` define as colunas. E, para **posicionar um item** manualmente, você usa `grid-column` e `grid-row` apontando para as **linhas numeradas** do grid, aquelas que separam uma célula da outra.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Espaço entre as células: `gap`\n\nPor padrão, as células de um grid ficam **coladas** umas nas outras, sem nenhum respiro. Na maioria dos layouts a gente quer um espacinho entre elas, e é aí que entra o `gap`.\n\nO `gap` vai no **container** e define o tamanho do vão entre as células, tanto na horizontal quanto na vertical. A analogia é o **rejunte entre azulejos**: o azulejo é a célula, e o rejunte é aquele espaço regular que separa um do outro. Um único valor já cuida de todos os vãos:",
+                    },
+                    {
+                        type: "code",
+                        value: ".grade {\n  display: grid;\n  grid-template-columns: repeat(3, 1fr);\n  gap: 16px;\n}",
+                    },
+                    {
+                        type: "text",
+                        value: "Com `gap: 16px`, todas as células ganham 16 pixels de distância entre si. Um detalhe importante e muito conveniente: o `gap` cria espaço **só entre** as células, **nunca nas bordas externas** do grid. Ou seja, você não fica com um vão sobrando grudado na parede do container.\n\nSe quiser vãos diferentes na horizontal e na vertical, dá para usar dois valores: o primeiro é o espaço **entre as linhas** e o segundo, **entre as colunas**. Também existem as versões `row-gap` e `column-gap` para controlar cada um por conta própria.",
+                    },
+                    {
+                        type: "code",
+                        value: "/* Um valor: mesmo espaço em todas as direções */\n.grade {\n  gap: 16px;\n}\n\n/* Dois valores: 24px entre as linhas, 8px entre as colunas */\n.grade {\n  gap: 24px 8px;\n}",
+                    },
+                    {
+                        type: "text",
+                        value: "## Definindo as linhas: `grid-template-rows`\n\nAté agora só falamos de colunas. Mas o Grid é 2D, lembra? Então existe uma propriedade gêmea para as **linhas** (as fileiras horizontais): a `grid-template-rows`. Ela funciona **exatamente igual** à de colunas, só que controla a **altura** de cada linha em vez da largura.\n\nEscreva um valor para cada linha que quiser definir. Aqui criamos uma grade com duas colunas e duas linhas, a primeira linha com 100px de altura e a segunda com 200px:",
+                    },
+                    {
+                        type: "code",
+                        value: ".grade {\n  display: grid;\n  grid-template-columns: 1fr 1fr;\n  grid-template-rows: 100px 200px;\n  gap: 10px;\n}",
+                    },
+                    {
+                        type: "text",
+                        value: 'Uma dúvida comum: "e se eu tiver mais itens do que as linhas que defini?". Sem problema. Você define as linhas que quiser controlar, e o grid **cria as linhas restantes sozinho**, com a altura necessária para o conteúdo caber.\n\nPor isso, na prática, é muito comum definir só as colunas e **deixar as linhas por conta do grid**. Mas quando você precisa de uma altura específica, como um cabeçalho de 80px ou um rodapé baixinho, o `grid-template-rows` é a ferramenta certa.',
+                    },
+                    {
+                        type: "text",
+                        value: '## A régua invisível: as linhas do grid\n\nAqui vem uma ideia que destrava o posicionamento no Grid. Toda grade é cercada por **linhas numeradas**, chamadas em inglês de _grid lines_. Não confunda com as "fileiras": aqui, "linha" quer dizer o **traço** que separa uma célula da outra, como as linhas de um caderno ou as marcas de uma régua.\n\nO detalhe que pega todo mundo: a numeração começa em **1**, e ela conta os **traços**, não as células. Então, se você tem **3 colunas**, existem **4 linhas verticais**: uma antes da primeira coluna (número 1), uma entre a primeira e a segunda (número 2), outra entre a segunda e a terceira (número 3) e uma depois da última (número 4). É sempre **uma linha a mais** do que a quantidade de colunas.',
+                    },
+                    {
+                        type: "code",
+                        value: "/*\n  Grade com 3 colunas e as suas 4 linhas verticais:\n\n  1           2           3           4\n  |  coluna 1 |  coluna 2 |  coluna 3 |\n  |___________|___________|___________|\n*/",
+                    },
+                    {
+                        type: "text",
+                        value: '## Posicionando um item: `grid-column` e `grid-row`\n\nAgora a parte divertida. Sabendo os números das linhas, você pode pegar um item **específico** e dizer exatamente **onde ele começa e onde termina**. Para isso existem duas propriedades, que dessa vez vão no **item filho** (e não no container):\n\n- `grid-column`: em quais linhas **verticais** o item começa e termina (controla a largura em colunas).\n- `grid-row`: em quais linhas **horizontais** o item começa e termina (controla a altura em linhas).\n\nA sintaxe usa uma barra: `início / fim`. Por exemplo, `grid-column: 1 / 3` significa "comece na linha 1 e vá até a linha 3". Como isso atravessa a coluna 1 e a coluna 2, o item ocupa **duas colunas**.',
+                    },
+                    {
+                        type: "code",
+                        value: ".grade {\n  display: grid;\n  grid-template-columns: repeat(3, 1fr);\n  gap: 10px;\n}\n\n/* Este item começa na linha 1 e vai até a linha 3: ocupa 2 colunas */\n.destaque {\n  grid-column: 1 / 3;\n}",
+                    },
+                    {
+                        type: "text",
+                        value: 'Preste atenção na conta: da **linha 1 até a linha 3** são **duas** células no meio (a coluna 1 e a coluna 2). É por isso que `1 / 3` ocupa duas colunas, e não três. No começo isso confunde, mas depois de fazer umas duas vezes vira automático.\n\nExiste um atalho para quem só quer saber "quantas células ocupar" sem contar linha por linha: a palavra `span` (que significa "estender por"). Escrever `grid-column: span 2` quer dizer "ocupe 2 colunas a partir de onde eu estiver", sem precisar decorar o número da linha final.',
+                    },
+                    {
+                        type: "code",
+                        value: "/* Ocupa 2 colunas, sem precisar contar as linhas */\n.destaque {\n  grid-column: span 2;\n}\n\n/* Dá para combinar: ocupa 2 colunas E 2 linhas (um item grande) */\n.banner {\n  grid-column: span 2;\n  grid-row: span 2;\n}",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Propriedade","Vai no...","Para que serve"],["`gap`","Container","Espaço entre as células"],["`grid-template-rows`","Container","Altura de cada linha (fileira)"],["`grid-column`","Item filho","Em quais colunas o item começa e termina"],["`grid-row`","Item filho","Em quais linhas o item começa e termina"],["`span 2`","Item filho","Atalho para ocupar 2 células a partir da posição atual"]]',
+                    },
+                    {
+                        type: "quote",
+                        value: "**Recapitulando:** o `gap` (no container) cria o respiro **entre** as células, como o rejunte de azulejos, sem sobrar nas bordas. O `grid-template-rows` define a **altura das linhas**, e o grid cria sozinho as linhas que faltarem. Para posicionar um item, use `grid-column` e `grid-row` (no **filho**) apontando as **linhas numeradas** no formato `início / fim`, lembrando que `1 / 3` ocupa **2 células**. O atalho `span 2` ocupa 2 células sem contar linhas.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement: "Para que serve a propriedade `gap` em um grid?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "Cria o espaçamento entre as células do grid.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Aumenta o número de colunas automaticamente.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Deixa o texto das células em negrito.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Remove o container do grid.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "Em qual elemento você aplica `grid-column` e `grid-row`?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "No item filho que você quer posicionar.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Sempre no container pai do grid.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Na tag `<html>`.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "No seletor de cada parágrafo da página.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "O que a propriedade `grid-template-rows` controla?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "A altura de cada linha (fileira horizontal) do grid.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "A largura de cada coluna do grid.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O espaço entre as células.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "A cor de fundo das linhas.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Numa grade com 3 colunas, quantas linhas verticais numeradas existem?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "4, sempre uma a mais do que o número de colunas.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "3, uma para cada coluna.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "2, apenas as das bordas.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "6, duas para cada coluna.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "Um item tem `grid-column: 1 / 3;`. Quantas colunas ele ocupa?",
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "2 colunas, porque vai da linha 1 até a linha 3, atravessando as colunas 1 e 2.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "3 colunas, uma para cada número que aparece na regra.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "1 coluna, apenas a de número 1.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "4 colunas, contando também as bordas.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Áreas nomeadas",
+                blocks: [
+                    {
+                        type: "text",
+                        value: '# Áreas nomeadas\n\nNa aula passada você posicionou itens contando as **linhas numeradas** do grid. Funciona muito bem, mas convenhamos: ficar contando "linha 1, linha 3, linha 4..." pode dar um nó na cabeça em layouts maiores.\n\nBoa notícia: o Grid tem um jeito **muito mais visual** de organizar a página, quase como desenhar. Chama-se **áreas nomeadas**. A ideia é dar **nomes** aos pedaços do layout (tipo "cabeçalho", "menu", "conteúdo") e depois **desenhar** onde cada um fica, usando esses nomes. É a forma mais intuitiva de montar o layout de uma página inteira. Vem ver.',
+                    },
+                    {
+                        type: "quote",
+                        value: "Com áreas nomeadas, você primeiro **batiza** cada item com `grid-area: umNome` e depois **desenha o layout** no container com `grid-template-areas`, escrevendo os nomes como se fosse um mapa em texto. Cada linha de texto vira uma fileira da grade, e repetir um nome faz aquela área se **esticar** para ocupar mais células.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Passo 1: dar nomes aos itens com `grid-area`\n\nO processo tem duas etapas. A primeira é **batizar** cada item filho com um nome à sua escolha, usando a propriedade `grid-area`. O nome é livre: escolha algo que descreva o papel daquele pedaço, como `cabecalho`, `menu`, `conteudo` e `rodape`.\n\nImagine que temos quatro blocos numa página. Damos um nome para cada um:",
+                    },
+                    {
+                        type: "code",
+                        value: ".cabecalho { grid-area: cabecalho; }\n.menu      { grid-area: menu; }\n.conteudo  { grid-area: conteudo; }\n.rodape    { grid-area: rodape; }",
+                    },
+                    {
+                        type: "text",
+                        value: "## Passo 2: desenhar o layout com `grid-template-areas`\n\nAgora vem a parte que parece mágica. No **container**, a propriedade `grid-template-areas` deixa você **desenhar** o layout usando os nomes que acabou de criar. Você escreve os nomes dentro de aspas, e o resultado parece um **mapinha** ou uma **planta baixa** da página.\n\nCada par de aspas representa uma **fileira** (uma linha) da grade. Dentro das aspas, cada nome representa uma **coluna**. Olha como fica intuitivo:",
+                    },
+                    {
+                        type: "code",
+                        value: '.pagina {\n  display: grid;\n  grid-template-areas:\n    "cabecalho cabecalho"\n    "menu      conteudo"\n    "rodape    rodape";\n}',
+                    },
+                    {
+                        type: "text",
+                        value: 'Consegue **enxergar** o layout só de olhar o texto? É essa a beleza. Vamos ler o mapa juntos:\n\n- A primeira fileira, `"cabecalho cabecalho"`, tem o nome `cabecalho` repetido nas duas colunas. Isso faz o cabeçalho **se esticar** por toda a largura, ocupando as duas colunas.\n- A segunda fileira, `"menu conteudo"`, coloca o menu na coluna da esquerda e o conteúdo na direita.\n- A terceira, `"rodape rodape"`, estica o rodapé pela largura toda, igual ao cabeçalho.\n\nA regra de ouro é essa: **repetir o nome em células vizinhas faz a área ocupar todas elas**. E cada item vai parar exatamente no lugar onde o seu nome aparece no desenho. Você não conta uma linha sequer.',
+                    },
+                    {
+                        type: "text",
+                        value: "## Deixando uma célula vazia com `.`\n\nE se você quiser um **buraco** no layout, uma célula que fica de propósito vazia? Para isso existe o **ponto** (`.`). Onde você colocar um ponto no lugar de um nome, aquela célula fica em branco.\n\nNo exemplo abaixo, a grade tem três colunas, e o canto inferior direito fica vazio de propósito:",
+                    },
+                    {
+                        type: "code",
+                        value: '.pagina {\n  display: grid;\n  grid-template-areas:\n    "cabecalho cabecalho cabecalho"\n    "menu      conteudo  conteudo"\n    "menu      rodape    .";\n}',
+                    },
+                    {
+                        type: "text",
+                        value: "## Montando o layout clássico de uma página\n\nAgora vamos juntar tudo num exemplo de verdade: o layout mais comum da web, com **cabeçalho** no topo, **barra lateral** (menu) à esquerda, **conteúdo** principal à direita e **rodapé** embaixo. Esse arranjo aparece em incontáveis sites por aí.\n\nPrimeiro, o HTML: são só quatro blocos dentro de um container. Repare que cada bloco recebe uma classe que combina com o nome que vamos usar no CSS.",
+                    },
+                    {
+                        type: "code",
+                        value: '<div class="pagina">\n  <header class="cabecalho">Cabeçalho</header>\n  <nav class="menu">Menu</nav>\n  <main class="conteudo">Conteúdo principal</main>\n  <footer class="rodape">Rodapé</footer>\n</div>',
+                    },
+                    {
+                        type: "text",
+                        value: "Agora o CSS. Além de nomear as áreas e desenhar o mapa, a gente combina com o que já sabe: `grid-template-columns` para dizer que o menu tem 200px e o conteúdo pega o resto, `grid-template-rows` para as alturas, `gap` para o respiro e uma altura mínima na página inteira.",
+                    },
+                    {
+                        type: "code",
+                        value: '.pagina {\n  display: grid;\n  grid-template-columns: 200px 1fr;\n  grid-template-rows: 80px 1fr 60px;\n  grid-template-areas:\n    "cabecalho cabecalho"\n    "menu      conteudo"\n    "rodape    rodape";\n  gap: 10px;\n  min-height: 100vh;\n}\n\n.cabecalho { grid-area: cabecalho; }\n.menu      { grid-area: menu; }\n.conteudo  { grid-area: conteudo; }\n.rodape    { grid-area: rodape; }',
+                    },
+                    {
+                        type: "text",
+                        value: 'Pare um instante para apreciar o que esse código faz. Com pouquíssimas linhas, você montou um layout completo e, o melhor de tudo, **fácil de ler**. Qualquer pessoa bate o olho no `grid-template-areas` e entende na hora onde cada coisa fica.\n\nE tem um superpoder escondido: para **reorganizar** a página, você mexe **só no desenho**. Quer o menu à direita? Inverta os nomes na fileira do meio (`"conteudo menu"`). Quer trocar a ordem das seções? Reordene as fileiras. O HTML nem precisa ser tocado. O layout virou um mapa que você edita à vontade.',
+                    },
+                    {
+                        type: "table",
+                        value: '[["Recurso","Vai no...","O que faz"],["`grid-area: nome`","Item filho","Dá um nome ao item"],["`grid-template-areas`","Container","Desenha o layout posicionando os nomes"],["Nome repetido","Dentro do desenho","A área se estica pelas células vizinhas"],["`.` (ponto)","Dentro do desenho","Deixa aquela célula vazia de propósito"]]',
+                    },
+                    {
+                        type: "quote",
+                        value: "**Recapitulando:** as **áreas nomeadas** são a forma mais visual de montar layouts. Primeiro dê um nome a cada item com `grid-area: nome` (no filho); depois desenhe o mapa no container com `grid-template-areas`, em que **cada aspas é uma fileira** e **cada nome é uma coluna**. Repetir o nome **estica** a área pelas células vizinhas, e um `.` deixa a célula **vazia**. Combinado com `grid-template-columns`, `grid-template-rows` e `gap`, isso monta o layout de uma página inteira que você reorganiza só editando o desenho.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement:
+                            "Para que serve a propriedade `grid-area` aplicada a um item filho?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "Para dar um nome ao item, que depois será usado no desenho do layout.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Para definir a cor de fundo do item.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Para criar novas colunas no grid.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Para remover o espaçamento entre as células.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "Onde você aplica a propriedade `grid-template-areas`?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "No container (o elemento pai do grid).",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Em cada item filho separadamente.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Na tag `<title>`.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "No seletor de cada parágrafo.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            'No desenho do `grid-template-areas`, o que significa repetir o mesmo nome em células vizinhas, como em `"cabecalho cabecalho"`?',
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Aquela área se estica para ocupar todas as células onde o nome aparece.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "O navegador mostra um erro de nome duplicado.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "São criados dois cabeçalhos idênticos, um em cada célula.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O segundo nome é simplesmente ignorado.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "O que representa um ponto (`.`) dentro do `grid-template-areas`?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Uma célula deixada vazia de propósito.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "O fim do desenho do layout.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Uma célula que repete o nome anterior.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Um comentário dentro do CSS.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            'As fileiras de um `grid-template-areas` são `"cabecalho cabecalho"`, `"menu conteudo"` e `"rodape rodape"`. O que esse desenho descreve?',
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "Um cabeçalho e um rodapé que ocupam a largura toda, com o menu e o conteúdo lado a lado no meio.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Quatro áreas empilhadas verticalmente, uma embaixo da outra.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Duas colunas iguais, sem cabeçalho nem rodapé.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Um layout com o menu ocupando toda a largura no topo.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Grid responsivo e Grid vs Flexbox",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "# Grid responsivo e Grid vs Flexbox\n\nVocê já sabe criar grades, espaçar, posicionar e desenhar layouts inteiros. Falta um último passo para virar gente grande no Grid: fazer a grade **se adaptar sozinha** a qualquer tamanho de tela, sem ter que reescrever nada para o celular. E, para fechar o módulo com chave de ouro, vamos responder à pergunta que todo mundo faz: **afinal, uso Grid ou Flexbox?**\n\nEsta aula amarra tudo. No fim dela, você vai olhar para uma galeria de fotos que se reorganiza sozinha quando a janela muda de tamanho e vai entender exatamente como aquilo funciona.",
+                    },
+                    {
+                        type: "quote",
+                        value: "A função `minmax()` define um tamanho **mínimo** e um **máximo** para uma coluna. Combinada com `repeat(auto-fit, ...)`, ela cria uma grade que **encaixa sozinha** quantas colunas couberem e quebra o resto para a linha de baixo, sem media queries. E a regra de bolso é simples: **Grid** para layouts em **2 dimensões**; **Flexbox** para alinhar em **1 dimensão**.",
+                    },
+                    {
+                        type: "text",
+                        value: '## `minmax()`: um mínimo e um máximo\n\nLembra que o `1fr` deixa uma coluna encolher junto com a tela? O problema é que, numa tela bem estreita, ela pode encolher **demais** e espremer o conteúdo. Seria bom dizer "pode encolher, mas **até certo ponto**". É exatamente isso que a função `minmax()` faz.\n\nEla recebe dois valores: um tamanho **mínimo** e um **máximo**, nessa ordem. Escrever `minmax(200px, 1fr)` significa: "esta coluna **nunca** fica menor que 200px, mas pode crescer livremente até ocupar a sua fração do espaço". É um piso de segurança combinado com um teto flexível.',
+                    },
+                    {
+                        type: "code",
+                        value: "/* A primeira coluna nunca fica menor que 200px, mas pode crescer */\n.grade {\n  display: grid;\n  grid-template-columns: minmax(200px, 1fr) 2fr;\n  gap: 16px;\n}",
+                    },
+                    {
+                        type: "text",
+                        value: '## Uma grade que se adapta sozinha: `auto-fit`\n\nAgora o pulo do gato. Até aqui, você sempre dizia **quantas** colunas queria (`repeat(3, ...)`). Mas e se você não soubesse de antemão? Numa galeria de fotos, o ideal é caber **3 colunas** num monitor largo, talvez **2** num tablet e **1** no celular, sem você ter que decidir cada caso na mão.\n\nA solução é entregar essa decisão ao navegador com a palavra `auto-fit` dentro do `repeat()`. Em vez de um número, você diz: "encaixe **quantas colunas couberem**". Junte isso com `minmax()` para definir o tamanho de cada uma e acontece a mágica:',
+                    },
+                    {
+                        type: "code",
+                        value: '<div class="galeria">\n  <div class="foto">1</div>\n  <div class="foto">2</div>\n  <div class="foto">3</div>\n  <div class="foto">4</div>\n  <div class="foto">5</div>\n  <div class="foto">6</div>\n</div>',
+                    },
+                    {
+                        type: "code",
+                        value: ".galeria {\n  display: grid;\n  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));\n  gap: 16px;\n}",
+                    },
+                    {
+                        type: "text",
+                        value: 'Essa única linha de `grid-template-columns` é uma das mais famosas do CSS moderno, e agora você entende cada pedaço dela. Lendo em voz alta: "repita colunas que tenham no mínimo 200px e no máximo 1 fração, encaixando **quantas couberem**".\n\nNa prática, o navegador faz a conta sozinho o tempo todo. Numa tela de 900px cabem quatro colunas de ~200px; se o visitante encolher a janela para 640px, uma coluna não cabe mais e os itens **descem** para uma nova linha automaticamente; num celular estreito, sobra uma coluna só. Tudo isso **sem escrever nenhuma media query**. Redimensione a janela do navegador e veja a galeria se reorganizando sozinha.',
+                    },
+                    {
+                        type: "text",
+                        value: '## `auto-fit` ou `auto-fill`?\n\nExiste um primo do `auto-fit` chamado `auto-fill`, e a diferença entre os dois é sutil, tanto que costuma confundir até quem já tem experiência. Os dois quebram as colunas do mesmo jeito. A diferença só aparece **quando sobra espaço** e há poucos itens:\n\n- `auto-fill` **mantém** colunas vazias ocupando o espaço que sobra, como se reservasse lugares para itens que não vieram.\n- `auto-fit` **descarta** essas colunas vazias e deixa os itens existentes **esticarem** para preencher a largura.\n\nNa dúvida, para galerias e cartões, o `auto-fit` costuma dar o resultado que a maioria das pessoas espera: o conteúdo preenche a linha. Guarde o `auto-fill` para quando quiser manter o "encaixe" fixo mesmo com poucos itens.',
+                    },
+                    {
+                        type: "code",
+                        value: "/* Sobra espaço e há poucos itens?\n   auto-fill: deixa colunas vazias reservadas (os itens não esticam)\n   auto-fit:  remove as vazias e os itens esticam para preencher */\n\n.galeria {\n  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));\n}",
+                    },
+                    {
+                        type: "text",
+                        value: '## A grande pergunta: Grid ou Flexbox?\n\nChegamos ao momento de amarrar os dois sistemas de layout que você aprendeu. Grid e Flexbox não são rivais; são **companheiros**, cada um bom numa tarefa. A pergunta certa não é "qual é o melhor?", e sim "quantas dimensões eu preciso controlar agora?".\n\n- Precisa alinhar coisas em **uma direção só**, uma fileira de botões, um menu no topo, uma lista de tags lado a lado? Isso é **1 dimensão**: use **Flexbox**.\n- Precisa controlar **linhas e colunas ao mesmo tempo**, o layout da página inteira, uma galeria, um painel com vários blocos? Isso é **2 dimensões**: use **Grid**.\n\nTem até uma forma rápida de decidir: se você consegue resolver pensando só em "linha" **ou** só em "coluna", o Flexbox resolve. Se você precisa dos dois de uma vez, é Grid.',
+                    },
+                    {
+                        type: "table",
+                        value: '[["","Grid","Flexbox"],["Dimensões","2 (linhas e colunas)","1 (linha ou coluna)"],["Pense em...","Um tabuleiro / uma malha","Uma fileira / uma prateleira"],["Melhor para","Layout de página, galerias, painéis","Menus, barras de botões, listas de tags"],["Ponto de partida","O layout guia o conteúdo","O conteúdo guia o layout"],["Você liga com","`display: grid`","`display: flex`"]]',
+                    },
+                    {
+                        type: "text",
+                        value: '## Os dois juntos, na vida real\n\nAqui vai o segredo que os sites profissionais usam: quase nunca é "Grid **ou** Flexbox", e sim os **dois ao mesmo tempo**, cada um na sua camada. O padrão mais comum é usar o **Grid para a estrutura grande** da página e o **Flexbox para alinhar os detalhes dentro** de cada bloco.\n\nPor exemplo: o layout geral (cabeçalho, menu, conteúdo, rodapé) é um **Grid**. Mas, **dentro** do cabeçalho, você tem um logotipo à esquerda e uns links à direita, alinhados numa única fileira, e isso é trabalho para o **Flexbox**. Veja os dois convivendo em paz:',
+                    },
+                    {
+                        type: "code",
+                        value: "/* Grid cuida do layout geral da página */\n.pagina {\n  display: grid;\n  grid-template-columns: 200px 1fr;\n  gap: 10px;\n}\n\n/* Flexbox cuida do alinhamento DENTRO do cabeçalho */\n.cabecalho {\n  display: flex;\n  justify-content: space-between;\n  align-items: center;\n}",
+                    },
+                    {
+                        type: "quote",
+                        value: "**Recapitulando:** `minmax(min, max)` dá um piso e um teto para a coluna. O combo `repeat(auto-fit, minmax(200px, 1fr))` cria uma grade que **encaixa sozinha** quantas colunas couberem e quebra o resto, **sem media queries** (`auto-fit` estica os itens; `auto-fill` mantém colunas vazias). E a regra final: **Flexbox para 1 dimensão** (menus, botões), **Grid para 2 dimensões** (páginas, galerias), muitas vezes os dois juntos. Parabéns, você concluiu o **Módulo 6** e agora domina o Grid!",
+                    },
+                ],
+                questions: [
+                    {
+                        statement: "O que a função `minmax(200px, 1fr)` define para uma coluna?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "Um tamanho mínimo de 200px e um máximo de 1fr; a coluna nunca fica menor que 200px.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Que a coluna terá exatamente 200px e mais nada.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Que existem 200 colunas de 1fr cada.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Uma margem de 200px ao redor da coluna.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "O Grid é feito para layouts de quantas dimensões?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "Duas: linhas e colunas ao mesmo tempo.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Uma: só linhas ou só colunas.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Três: largura, altura e profundidade.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Nenhuma; ele apenas empilha itens.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "O que `repeat(auto-fit, minmax(200px, 1fr))` faz?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Encaixa quantas colunas couberem e quebra o restante para a linha de baixo, adaptando-se sozinho ao tamanho da tela.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Cria sempre exatamente três colunas fixas.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Repete a mesma imagem várias vezes na tela.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Só funciona se você também escrever uma media query.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Para alinhar uma fileira de botões em uma única direção, qual ferramenta é a mais indicada?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Flexbox, que é feito para uma dimensão (1D).",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Grid, que é obrigatório para qualquer alinhamento.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "A função `minmax()`, sozinha.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Nenhuma das duas; use apenas `margin`.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Qual a diferença entre `auto-fit` e `auto-fill` quando há poucos itens e sobra espaço na linha?",
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "`auto-fit` descarta as colunas vazias e estica os itens para preencher a linha; `auto-fill` mantém as colunas vazias reservadas.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`auto-fit` cria colunas fixas e `auto-fill` cria linhas fixas.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`auto-fill` só funciona no celular e `auto-fit` só no computador.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Não há diferença; são exatamente sinônimos.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        titulo: "Módulo 7 - Responsividade",
+        aulas: [
+            {
+                titulo: "O que é design responsivo",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "# O que é design responsivo\n\nBem-vindo ao módulo de **responsividade**, um dos mais importantes de toda a trilha. Até aqui você aprendeu a estilizar elementos, criar caixas, alinhar coisas com flexbox e grid. Agora vamos garantir que tudo isso fique bonito **em qualquer tela**: do celular pequeno na mão de alguém no ônibus até o monitor gigante de um computador.\n\nPode parecer um detalhe, mas é o que separa um site amador de um profissional. E a boa notícia é que, com poucas ideias novas, você já consegue fazer páginas que se adaptam sozinhas. Vamos começar entendendo **o problema** que a responsividade resolve.",
+                    },
+                    {
+                        type: "quote",
+                        value: "**Design responsivo** é a técnica de construir uma página que **se adapta** ao tamanho da tela de quem está olhando. Em vez de fazer um site para o computador e outro para o celular, você faz **um só** que se reorganiza sozinho: as colunas viram uma pilha, as fontes ajustam, as imagens encolhem. Como água, que toma a forma de qualquer copo.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Uma tela só não existe mais\n\nLá no comecinho da web, quase todo mundo acessava a internet por um computador de mesa, com telas de tamanho parecido. Dava para desenhar uma página com uma largura fixa (digamos, 960 pixels) e pronto: ela ficava igual para quase todo mundo.\n\nHoje a realidade é bem diferente. As pessoas abrem o seu site em:\n\n- **Celulares**, com telas estreitas de uns 360 pixels de largura;\n- **Tablets**, num meio-termo confortável;\n- **Notebooks e desktops**, com telas largas de 1920 pixels ou mais;\n- Até **TVs e relógios**, em casos mais específicos.\n\nNa maioria dos sites hoje, **mais da metade** dos acessos vem do celular. Se a sua página só fica boa no computador, você está deixando de fora justamente a maior parte do público.",
+                    },
+                    {
+                        type: "text",
+                        value: "## O que acontece com um site não responsivo\n\nImagine uma página desenhada com largura fixa de 960 pixels, sem nenhum cuidado com responsividade, aberta num celular de 360 pixels. O resultado é aquele site que todo mundo já viu e detestou:\n\n- Ele aparece **inteiro, porém minúsculo**, como se você olhasse de bem longe;\n- Você precisa dar **zoom com os dedos** e arrastar para os lados para ler qualquer coisa;\n- Os botões ficam pequenos demais para acertar com o dedo;\n- Surge uma **barra de rolagem horizontal**, e ninguém gosta de rolar a página para o lado.\n\nDesign responsivo existe justamente para acabar com isso. A página deve **caber** na tela e ser **confortável** de usar, seja qual for o aparelho.",
+                    },
+                    {
+                        type: "text",
+                        value: '## Os três ingredientes da responsividade\n\nUm site responsivo se apoia em três ideias, e você vai aprender cada uma com calma ao longo do módulo:\n\n1. **Layout fluido**: usar unidades que **esticam e encolhem** (como `%` e `rem`) no lugar de larguras fixas em pixels.\n2. **Media queries**: regras de CSS que dizem "**se** a tela for pequena, faça assim; se for grande, faça assado". São o coração da adaptação.\n3. **Imagens flexíveis**: garantir que fotos e vídeos nunca **estourem** os limites da tela.\n\nNesta primeira aula vamos preparar o terreno com uma peça que **liga tudo isso**: a `meta viewport`. Sem ela, nada de responsivo funciona no celular.',
+                    },
+                    {
+                        type: "text",
+                        value: '## A meta viewport: a peça que liga tudo\n\nAqui vai um detalhe que pega muita gente de surpresa: por padrão, o navegador do celular **finge** ter uma tela larga. Ele monta a página como se estivesse num computador de uns 980 pixels e depois **encolhe tudo** para caber na telinha. É por isso que sites antigos aparecem minúsculos no celular.\n\nPara dizer ao navegador "não faça essa mágica, use a largura **real** da tela", existe uma linha que vai no `<head>` do seu HTML:',
+                    },
+                    {
+                        type: "code",
+                        value: '<meta name="viewport" content="width=device-width, initial-scale=1.0">',
+                    },
+                    {
+                        type: "text",
+                        value: 'Vamos traduzir essa linha, que você já tinha visto lá no módulo de HTML sem entender direito:\n\n- `width=device-width`: diz "a largura da página é a **largura real do aparelho**". Num celular de 360 pixels, a página passa a ter 360 pixels de largura, e não 980.\n- `initial-scale=1.0`: define o **zoom inicial** em 100%, ou seja, sem nenhum zoom ao abrir.\n\nSem essa linha, todas as suas media queries e larguras em porcentagem simplesmente **não funcionam** no celular, porque o navegador continua fingindo ter uma tela grande. Por isso ela é **obrigatória** em qualquer página responsiva. Guarde bem: é a primeira coisa a conferir quando "o responsivo não está pegando" no celular.',
+                    },
+                    {
+                        type: "code",
+                        value: '<!DOCTYPE html>\n<html lang="pt-br">\n  <head>\n    <meta charset="UTF-8">\n    <!-- A linha essencial para a responsividade funcionar no celular -->\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>Meu site responsivo</title>\n    <link rel="stylesheet" href="estilo.css">\n  </head>\n  <body>\n    <h1>Agora sim, pronto para qualquer tela</h1>\n  </body>\n</html>',
+                    },
+                    {
+                        type: "text",
+                        value: '## Mobile-first: comece pelo menor\n\nDefinida a viewport, falta escolher uma **estratégia**. Existem duas formas de encarar a construção de um site responsivo, e a diferença está em **por onde você começa**.\n\n- **Desktop-first**: você desenha primeiro para a tela grande e depois vai "consertando" para o celular, removendo e reorganizando coisas.\n- **Mobile-first**: você desenha primeiro para o **celular** (a tela mais apertada) e depois vai **acrescentando** coisas conforme a tela cresce.\n\nA abordagem recomendada hoje é a **mobile-first**, e ela vai ser a nossa bússola no módulo inteiro.',
+                    },
+                    {
+                        type: "text",
+                        value: '## Por que começar pelo celular\n\nPode parecer estranho começar pela tela mais difícil, mas faz muito sentido. Pense em fazer as malas para uma viagem: é bem mais fácil começar com uma **mochila pequena** e escolher só o essencial, e depois, se ganhar uma mala maior, ir **acrescentando** itens. O contrário, pegar tudo o que você tem e tentar **espremer** numa mochilinha, é um sofrimento.\n\nNo site é igual:\n\n- Começando pelo celular, você é **obrigado** a focar no conteúdo essencial. A tela pequena não perdoa excesso.\n- Depois, com mais espaço no tablet e no desktop, você **adiciona** colunas, margens maiores e detalhes.\n\nNa prática, isso significa escrever o CSS "base" pensando no celular e usar media queries para **enriquecer** o layout em telas maiores. É o caminho que vamos trilhar nas próximas aulas.',
+                    },
+                    {
+                        type: "code",
+                        value: "/* Estilo BASE: pensado para o celular (tela estreita). */\n/* Sem nenhuma media query, vale para todo mundo. */\n.container {\n  width: 100%;\n  padding: 16px;\n}\n\n.cartao {\n  /* No celular, cada cartão ocupa a linha inteira. */\n  width: 100%;\n  margin-bottom: 16px;\n}\n\n/* Mais adiante, media queries vão ADICIONAR colunas em telas maiores. */",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Aspecto","Desktop-first","Mobile-first (recomendado)"],["Por onde começa","Pela tela grande","Pela tela do celular"],["Como evolui","Vai removendo coisas para caber","Vai adicionando coisas conforme sobra espaço"],["Foco","Corre o risco de exagerar no conteúdo","Obriga a focar no essencial"],["Media query típica","`max-width` (de tal tamanho para baixo)","`min-width` (de tal tamanho para cima)"]]',
+                    },
+                    {
+                        type: "quote",
+                        value: "**Recapitulando:** **design responsivo** é fazer uma página só que se **adapta** a qualquer tela, como água em qualquer copo. Ele se apoia em **layout fluido**, **media queries** e **imagens flexíveis**. A `<meta viewport>` com `width=device-width` é **obrigatória** para o responsivo funcionar no celular, pois sem ela o navegador finge ter uma tela grande. E a estratégia recomendada é a **mobile-first**: começar pelo celular e ir **acrescentando** conforme a tela cresce.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement: "O que é design responsivo?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "É construir uma única página que se adapta ao tamanho da tela de cada visitante.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "É criar um site separado e totalmente diferente para cada aparelho que existe.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "É deixar o site com cores mais vivas quando aberto no celular.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "É uma linguagem de programação feita só para aplicativos de celular.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Qual linha é essencial no `<head>` para a responsividade funcionar no celular?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: '`<meta name="viewport" content="width=device-width, initial-scale=1.0">`',
+                                isCorrect: true,
+                            },
+                            {
+                                text: '`<meta charset="UTF-8">`',
+                                isCorrect: false,
+                            },
+                            {
+                                text: '`<link rel="stylesheet" href="estilo.css">`',
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`<title>Meu site</title>`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "O que faz o `width=device-width` dentro da meta viewport?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Faz a página usar a largura real do aparelho, em vez de o navegador fingir uma tela larga e encolher tudo.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Define a largura máxima que todas as imagens da página podem ter.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Aumenta o zoom inicial da página para 200% ao abrir.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Impede que o usuário role a página na vertical.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Na estratégia mobile-first, por onde você começa a desenhar o site?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Pela tela do celular, acrescentando elementos conforme a tela cresce.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Pela tela do desktop, removendo elementos conforme a tela diminui.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Pela versão para impressora, para garantir o site em papel primeiro.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Tanto faz: a ordem não muda em nada o resultado final.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            'Um colega diz: "meu site está pronto e bonito no computador, mas no celular aparece tudo minúsculo e preciso dar zoom". Qual é a explicação e a solução mais provável?',
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "Provavelmente falta a `<meta viewport>` com `width=device-width`; sem ela o navegador do celular finge uma tela larga e encolhe a página inteira.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: 'O problema é o `<meta charset="UTF-8">`, que deve ser trocado por `width=device-width`.',
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Não há solução em CSS; é obrigatório criar um segundo site só para o celular.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Basta aumentar todas as fontes para 40px e o site já fica responsivo.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Media queries",
+                blocks: [
+                    {
+                        type: "text",
+                        value: '# Media queries\n\nNa aula anterior você entendeu **por que** um site precisa se adaptar e preparou o terreno com a `meta viewport`. Agora chega a ferramenta mais poderosa da responsividade: as **media queries**.\n\nElas são o interruptor que permite dizer ao CSS: "**quando** a tela tiver tal tamanho, aplique estas regras aqui". É com elas que uma página troca de três colunas para uma só ao passar do desktop para o celular. Vamos entender a sintaxe passo a passo, sem pressa.',
+                    },
+                    {
+                        type: "quote",
+                        value: 'Uma **media query** é um bloco de CSS que só entra em ação **sob uma condição** de tela, quase sempre a **largura**. Você escreve algo como "**se** a tela tiver no mínimo 768px de largura, use estas regras". Pense num interruptor com sensor: as regras lá dentro só "acendem" quando a tela cumpre a condição.',
+                    },
+                    {
+                        type: "text",
+                        value: "## A anatomia de uma media query\n\nToda media query começa com a palavra-chave `@media`, seguida de uma **condição** e, entre chaves, um bloco de regras CSS normais. Olhe a estrutura geral:",
+                    },
+                    {
+                        type: "code",
+                        value: "@media (min-width: 768px) {\n  /* Estas regras só valem quando a tela tem 768px OU MAIS de largura. */\n  body {\n    background: lightblue;\n  }\n}",
+                    },
+                    {
+                        type: "text",
+                        value: 'Vamos separar as peças dessa regra:\n\n- `@media`: a palavra que abre a media query. As regras que dependem da tela sempre começam assim.\n- `(min-width: 768px)`: a **condição**. Aqui ela quer dizer "largura **mínima** de 768 pixels". Enquanto a tela for menor que isso, o bloco é ignorado.\n- `{ ... }`: dentro das chaves vai **CSS comum**, exatamente igual ao que você já escreve. Não há nada de novo aqui dentro; a novidade é só o "envelope" que decide **quando** aplicar.\n\nO único conceito novo, portanto, é a **condição**. E a condição que você mais vai usar envolve duas palavrinhas: `min-width` e `max-width`.',
+                    },
+                    {
+                        type: "text",
+                        value: '## min-width vs max-width\n\nEssas duas condições são as mais comuns, e é fácil confundi-las no começo. A diferença está no **sentido** da comparação:\n\n- `min-width: 768px` significa "**a partir de** 768px **para cima**". Vale para telas **iguais ou maiores**.\n- `max-width: 768px` significa "**até** 768px, **para baixo**". Vale para telas **iguais ou menores**.\n\nUma dica para não esquecer: pense na largura da tela como uma régua. O `min-width` pega tudo o que está **acima** de uma marca; o `max-width` pega tudo o que está **abaixo** dela.',
+                    },
+                    {
+                        type: "code",
+                        value: "/* min-width: aplica DAQUI PARA CIMA (telas largas). */\n@media (min-width: 768px) {\n  .menu {\n    display: flex; /* Em tablets e desktops, o menu vira uma linha. */\n  }\n}",
+                    },
+                    {
+                        type: "code",
+                        value: '/* max-width: aplica DAQUI PARA BAIXO (telas estreitas). */\n@media (max-width: 767px) {\n  .menu {\n    display: none; /* No celular, esconde o menu e mostra o "hambúrguer". */\n  }\n}',
+                    },
+                    {
+                        type: "text",
+                        value: "Repare que os dois exemplos acima resolvem o **mesmo problema** por caminhos opostos: um cuida da tela grande, o outro da pequena. Na prática, você vai escolher **um estilo** e seguir com ele no site inteiro, para não se perder.\n\nComo combinamos seguir o **mobile-first**, a nossa escolha padrão vai ser o `min-width`: escrevemos o estilo base para o celular (sem media query nenhuma) e usamos `min-width` para **ir acrescentando** conforme a tela cresce. O `max-width` fica mais associado ao caminho desktop-first.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Breakpoints: onde o layout muda\n\nO ponto exato em que o layout muda de forma, aquele valor que você coloca no `min-width`, tem um nome: **breakpoint** (ponto de quebra). Não existe uma lista oficial e obrigatória, mas há valores que viraram costume no mercado, mais ou menos alinhados com os tamanhos típicos de celular, tablet e desktop.\n\nA regra de ouro, porém, é: **escolha os breakpoints onde o SEU conteúdo começa a ficar feio**, e não decore números. Ainda assim, esta tabela é um ótimo ponto de partida:",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Aparelho típico","Largura aproximada","Breakpoint comum (`min-width`)"],["Celular (retrato)","360px a 480px","estilo base, sem media query"],["Celular grande / tablet pequeno","600px","`min-width: 600px`"],["Tablet","768px","`min-width: 768px`"],["Notebook / desktop","1024px","`min-width: 1024px`"],["Telas largas","1280px ou mais","`min-width: 1280px`"]]',
+                    },
+                    {
+                        type: "text",
+                        value: "## Mobile-first na prática, do menor para o maior\n\nChegou a hora de juntar tudo num exemplo de verdade. Vamos estilizar uma galeria de cartões seguindo o mobile-first. A lógica é sempre a mesma:\n\n1. Escreva o estilo **base** pensando no celular. Aqui, uma coluna só.\n2. Adicione uma media query `min-width` para o tablet, criando **duas colunas**.\n3. Adicione outra `min-width` para o desktop, criando **três colunas**.\n\nRepare como cada media query só **acrescenta** ou **ajusta** o que veio antes:",
+                    },
+                    {
+                        type: "code",
+                        value: "/* 1. BASE (celular): uma coluna. Sem media query. */\n.galeria {\n  display: grid;\n  grid-template-columns: 1fr;\n  gap: 16px;\n}\n\n/* 2. Tablet: a partir de 768px, duas colunas. */\n@media (min-width: 768px) {\n  .galeria {\n    grid-template-columns: 1fr 1fr;\n  }\n}\n\n/* 3. Desktop: a partir de 1024px, três colunas. */\n@media (min-width: 1024px) {\n  .galeria {\n    grid-template-columns: 1fr 1fr 1fr;\n  }\n}",
+                    },
+                    {
+                        type: "text",
+                        value: "O HTML que acompanha esse CSS é o mais simples possível: um contêiner com vários cartões dentro.",
+                    },
+                    {
+                        type: "code",
+                        value: '<div class="galeria">\n  <div class="cartao">Item 1</div>\n  <div class="cartao">Item 2</div>\n  <div class="cartao">Item 3</div>\n  <div class="cartao">Item 4</div>\n  <div class="cartao">Item 5</div>\n  <div class="cartao">Item 6</div>\n</div>',
+                    },
+                    {
+                        type: "text",
+                        value: 'O navegador lê o CSS **de cima para baixo** e aplica o que for verdadeiro para o tamanho atual da tela:\n\n- Num celular de 400px, **nenhuma** media query bate, então vale só a base: **uma coluna**.\n- Num tablet de 800px, a condição `min-width: 768px` é verdadeira, então valem a base **e** o bloco do tablet: **duas colunas**.\n- Num desktop de 1300px, as duas media queries batem, e a última (`min-width: 1024px`) vence: **três colunas**.\n\nEssa é a mágica do mobile-first: você nunca precisa "desfazer" nada. Cada tela maior apenas soma um pouco mais de layout sobre a anterior.',
+                    },
+                    {
+                        type: "quote",
+                        value: "**Recapitulando:** uma **media query** aplica CSS só quando uma condição de tela é verdadeira, com a sintaxe `@media (condição) { ... }`. O `min-width` vale **a partir de** um tamanho para cima; o `max-width`, **até** um tamanho para baixo. Os pontos onde o layout muda são os **breakpoints** (600, 768 e 1024px são comuns, mas o certo é seguir o seu conteúdo). No **mobile-first**, o estilo base é o do celular e cada `min-width` só **acrescenta** layout conforme a tela cresce.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement: "Qual palavra-chave inicia uma media query no CSS?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`@media`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`@screen`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`@responsive`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`@if`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "O que significa a condição `min-width: 768px`?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "As regras valem para telas com 768px de largura ou mais.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "As regras valem para telas com 768px de largura ou menos.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "A página inteira terá exatamente 768px de largura.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "A fonte terá no mínimo 768px de tamanho.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "No mobile-first, qual condição é a escolha mais natural para ir acrescentando layout conforme a tela cresce?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "`min-width`, porque parte do celular e adiciona regras para telas maiores.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`max-width`, porque parte do desktop e remove regras para telas menores.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`min-height`, porque o que importa é a altura da tela, não a largura.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Nenhuma; media queries não têm relação com mobile-first.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "O que é um breakpoint?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "O ponto (largura) em que o layout muda de forma, definido na condição da media query.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Um erro que quebra o CSS quando a tela fica muito pequena.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Uma pausa que o navegador dá para terminar de carregar as imagens.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O tamanho máximo que uma imagem pode ter na página.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Com o CSS mobile-first `grid-template-columns: 1fr` na base, `1fr 1fr` em `min-width: 768px` e `1fr 1fr 1fr` em `min-width: 1024px`, quantas colunas aparecem numa tela de 800px?",
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "Duas colunas, porque a tela satisfaz o `min-width: 768px`, mas ainda não o `min-width: 1024px`.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Uma coluna, porque só o estilo base é aplicado nessa largura.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Três colunas, porque todas as media queries são aplicadas de uma vez.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Nenhuma coluna, porque 800px não é um breakpoint da lista comum.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Unidades e imagens responsivas",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "# Unidades e imagens responsivas\n\nVocê já tem a `meta viewport` e já sabe usar media queries. Falta um ingrediente para o layout ficar realmente fluido: as **unidades** certas. De que adianta uma media query impecável se as suas caixas têm largura travada em pixels e não esticam junto com a tela?\n\nNesta aula vamos conhecer as unidades que **escalam** (`%`, `vw`, `vh` e `rem`) e resolver de vez o problema clássico da **imagem que estoura a tela**. No fim, você vai conhecer o `object-fit` e ter um primeiro contato com o `srcset`.",
+                    },
+                    {
+                        type: "quote",
+                        value: "Unidades como `px` são **rígidas**: 300px são sempre 300px, não importa a tela. Já unidades **relativas** como `%`, `vw` e `rem` são elásticas: o mesmo valor **encolhe e cresce** junto com o contexto. O segredo de um layout fluido é preferir as unidades elásticas para tamanhos e espaçamentos.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Unidades fixas vs relativas\n\nAté agora você provavelmente usou muito o **pixel** (`px`). Ele é uma unidade **absoluta**: `width: 300px` cria uma caixa de exatamente 300 pixels, seja no celular, seja no monitor gigante. O problema aparece no celular: se a tela tem só 360px, uma caixa de 300px já ocupa quase tudo, e duas lado a lado nem cabem.\n\nAs unidades **relativas** resolvem isso porque o valor delas **depende de outra coisa** (do tamanho da tela, do elemento pai ou da fonte). Elas se ajustam sozinhas. Vamos conhecer as três mais úteis para a responsividade.",
+                    },
+                    {
+                        type: "text",
+                        value: '## Porcentagem: relativa ao elemento pai\n\nA porcentagem (`%`) é a unidade relativa mais intuitiva. Uma largura de `50%` significa "**metade do espaço do elemento pai**". Se o pai encolhe, o filho encolhe junto, mantendo a proporção.\n\nÉ a base de qualquer layout fluido. No exemplo abaixo, o cartão sempre ocupa 80% da largura disponível, seja qual for a tela:',
+                    },
+                    {
+                        type: "code",
+                        value: ".cartao {\n  width: 80%;       /* Sempre 80% da largura do elemento pai. */\n  max-width: 500px; /* Mas nunca passa de 500px em telas grandes. */\n  margin: 0 auto;   /* Centraliza a caixa na horizontal. */\n}",
+                    },
+                    {
+                        type: "text",
+                        value: "Repare no truque de combinar `width: 80%` com `max-width: 500px`. Ele é um dos mais úteis da responsividade:\n\n- No **celular**, os 80% mandam: o cartão encolhe junto com a tela e sempre sobra uma respiração nas laterais.\n- No **desktop**, o `max-width` entra em cena e **trava** o cartão em 500px, para o texto não virar uma linha larguíssima e cansativa de ler.\n\nÉ elasticidade **com limite**. Guarde essa dupla, você vai usá-la o tempo todo.",
+                    },
+                    {
+                        type: "text",
+                        value: '## vw e vh: relativas à tela\n\nAs unidades `vw` e `vh` medem em relação à **janela de visualização** (a área visível da tela), e não ao elemento pai:\n\n- `vw` quer dizer _viewport width_. **1vw = 1% da largura da tela.** Então `100vw` é a largura inteira da tela.\n- `vh` quer dizer _viewport height_. **1vh = 1% da altura da tela.** Então `100vh` é a altura inteira.\n\nElas são ótimas para elementos que precisam ocupar a tela toda, como uma seção de "capa" (hero) que preenche a altura inteira ao abrir a página:',
+                    },
+                    {
+                        type: "code",
+                        value: ".capa {\n  width: 100vw;   /* Largura da tela inteira. */\n  height: 100vh;  /* Altura da tela inteira: a capa ocupa tudo o que se vê. */\n  display: flex;\n  align-items: center;\n  justify-content: center;\n}",
+                    },
+                    {
+                        type: "text",
+                        value: "## rem: relativa à fonte base\n\nVocê talvez já tenha esbarrado no `rem` em módulos anteriores; aqui ele brilha. O `rem` é relativo ao **tamanho da fonte raiz** da página, que por padrão é **16px** no navegador. Então:\n\n- `1rem` = 16px (o padrão);\n- `2rem` = 32px;\n- `0.5rem` = 8px.\n\nPor que isso ajuda na responsividade? Porque, se você definir espaçamentos e fontes em `rem`, tudo escala de forma **coerente** e ainda respeita a preferência de quem aumentou a fonte do navegador (uma questão de acessibilidade). Em vez de dezenas de valores soltos em pixels, você raciocina em múltiplos de uma base única.",
+                    },
+                    {
+                        type: "code",
+                        value: "h1 {\n  font-size: 2rem;      /* 32px, mas escala se o usuário aumentar a fonte. */\n  margin-bottom: 1rem;  /* 16px de respiro embaixo do título. */\n}\n\n.secao {\n  padding: 2rem;        /* Espaçamento interno coerente com o resto. */\n}",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Unidade","Relativa a...","Exemplo","Boa para"],["`%`","O elemento pai","`width: 50%`","Larguras fluidas de caixas"],["`vw`","A largura da tela","`width: 100vw`","Seções que ocupam a tela toda"],["`vh`","A altura da tela","`height: 100vh`","Capas de altura cheia (hero)"],["`rem`","A fonte raiz (16px)","`font-size: 2rem`","Fontes e espaçamentos coerentes"],["`px`","Nada (é fixa)","`width: 300px`","Detalhes que não devem escalar (bordas)"]]',
+                    },
+                    {
+                        type: "text",
+                        value: "## O problema clássico: a imagem que estoura a tela\n\nAgora, o vilão mais famoso da responsividade. Imagine que você coloca na página uma foto de **1200 pixels** de largura e a abre num celular de 360px. Por padrão, a imagem tenta aparecer no tamanho real, gigante, e **empurra** o layout: surge aquela barra de rolagem horizontal, e a página inteira fica torta.\n\nA solução é uma das linhas de CSS mais importantes de toda a responsividade, e você vai colocá-la em praticamente todo projeto:",
+                    },
+                    {
+                        type: "code",
+                        value: "img {\n  max-width: 100%; /* A imagem nunca fica mais larga que o espaço disponível. */\n  height: auto;    /* A altura acompanha, mantendo a proporção (sem distorcer). */\n}",
+                    },
+                    {
+                        type: "text",
+                        value: 'Essas duas linhas resolvem o problema para sempre. Vamos entender cada uma:\n\n- `max-width: 100%` diz "a imagem pode ter o tamanho natural dela, **mas nunca ultrapassar** a largura do espaço onde está". Numa tela larga, ela aparece cheia; num celular, ela **encolhe** para caber. Repare que usamos `max-width`, e não `width: 100%`: assim uma imagem pequena **não é esticada** além do seu tamanho real.\n- `height: auto` deixa a altura se ajustar **proporcionalmente** à largura. Sem ela, a imagem encolheria na largura mas manteria a altura, ficando achatada e distorcida.\n\nGuarde essa dupla como um par inseparável: onde entra `max-width: 100%`, entra `height: auto` junto.',
+                    },
+                    {
+                        type: "text",
+                        value: "## object-fit: encaixar sem distorcer\n\nÀs vezes você precisa que uma imagem ocupe uma caixa de tamanho **exato**, por exemplo uma miniatura quadrada de 200 por 200 pixels, mas as fotos vêm em proporções diferentes. Se você simplesmente forçar largura e altura, a imagem **estica** e fica deformada.\n\nA propriedade `object-fit` resolve isso, controlando como a imagem preenche a caixa dela. Os valores mais usados são:\n\n- `cover`: a imagem **cobre** a caixa inteira, cortando o que sobra nas bordas. Nunca distorce. É o mais usado.\n- `contain`: a imagem aparece **inteira** dentro da caixa, deixando espaços vazios se a proporção não bater.\n- `fill`: a imagem **estica** para preencher (pode distorcer). É o comportamento padrão.",
+                    },
+                    {
+                        type: "code",
+                        value: ".miniatura {\n  width: 200px;\n  height: 200px;\n  object-fit: cover; /* Preenche o quadrado cortando o excesso, sem distorcer. */\n  border-radius: 8px;\n}",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Valor","O que faz","Distorce a imagem?"],["`cover`","Cobre a caixa toda, cortando o excesso","Não"],["`contain`","Mostra a imagem inteira, pode sobrar espaço","Não"],["`fill`","Estica para preencher a caixa (é o padrão)","Sim, pode distorcer"]]',
+                    },
+                    {
+                        type: "text",
+                        value: "## Um passo além: o srcset\n\nFazer a imagem **caber** com `max-width: 100%` resolve o visual, mas há um detalhe de desempenho: mesmo encolhida na tela, o celular ainda **baixa** a foto gigante de 1200px, gastando internet à toa.\n\nO atributo `srcset` (que é do HTML, não do CSS) resolve isso oferecendo **várias versões** da mesma imagem em tamanhos diferentes; o navegador escolhe sozinho a mais adequada para a tela. Você não precisa dominar isso agora, mas vale conhecer a ideia:",
+                    },
+                    {
+                        type: "code",
+                        value: '<!-- O navegador escolhe a versão certa conforme a largura da tela. -->\n<img\n  src="foto-800.jpg"\n  srcset="foto-400.jpg 400w, foto-800.jpg 800w, foto-1200.jpg 1200w"\n  alt="Paisagem com montanhas ao fundo">',
+                    },
+                    {
+                        type: "text",
+                        value: 'Traduzindo esse `srcset`: "existe uma versão de 400px de largura (`400w`), uma de 800px e uma de 1200px; escolha a melhor para a tela atual". Num celular, o navegador baixa a de 400px e economiza dados; num monitor grande, pega a de 1200px para não perder qualidade. O `src` comum continua ali como **reserva**, para navegadores antigos.\n\nNão se preocupe em decorar a sintaxe agora. O importante é saber que ela **existe** e para que serve; você vai aprofundar isso mais para frente.',
+                    },
+                    {
+                        type: "quote",
+                        value: "**Recapitulando:** prefira unidades **relativas** para um layout fluido: `%` (relativa ao pai), `vw`/`vh` (relativas à tela) e `rem` (relativa à fonte base de 16px), deixando o `px` para detalhes que não devem escalar. Combine `width` com `max-width` para ter elasticidade **com limite**. A dupla `img { max-width: 100%; height: auto; }` impede a imagem de **estourar** a tela sem distorcê-la, e o `object-fit: cover` encaixa fotos numa caixa fixa sem deformar. Por fim, o `srcset` faz o navegador baixar a **versão certa** de cada imagem.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement:
+                            "Qual dupla de propriedades impede uma imagem de estourar a largura da tela sem distorcê-la?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`max-width: 100%` com `height: auto`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`width: 1200px` com `height: 800px`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`display: none` com `visibility: hidden`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`position: absolute` com `top: 0`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "A quê a unidade `vw` é relativa?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "À largura da tela (viewport): 1vw = 1% da largura visível.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "À largura do elemento pai.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Ao tamanho da fonte raiz da página.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "À altura da imagem de fundo.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Por que se costuma usar `max-width: 100%` na imagem, em vez de `width: 100%`?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Com `max-width`, a imagem encolhe para caber mas não é esticada além do tamanho real quando é pequena.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`width: 100%` não existe em CSS; só `max-width` é válido para imagens.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`max-width` deixa a imagem colorida e `width` deixa em preto e branco.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Não há diferença nenhuma: as duas fazem exatamente a mesma coisa.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Você quer encaixar fotos de proporções variadas num quadrado de 200x200 sem deformá-las. Qual propriedade resolve?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "`object-fit: cover`, que preenche a caixa cortando o excesso, sem distorcer.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`object-fit: fill`, que é a única opção que nunca distorce a imagem.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`text-align: center`, que centraliza a imagem dentro da caixa.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`float: left`, que ajusta a proporção da imagem automaticamente.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Uma foto de 1200px já aparece bem dimensionada no celular graças ao `max-width: 100%`, mas a página está pesada para carregar. O que o `srcset` acrescenta nesse cenário?",
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "Ele oferece versões menores da imagem para o navegador baixar a mais adequada à tela, economizando dados, algo que o `max-width` sozinho não faz.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Ele substitui o CSS e dispensa a necessidade da `meta viewport`.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Ele aumenta a resolução da imagem no celular para melhorar a qualidade.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Ele serve para distorcer a imagem de propósito e deixá-la menor.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Montando um layout responsivo",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "# Montando um layout responsivo\n\nChegamos à aula que **amarra tudo**. Ao longo do módulo, e da trilha inteira, você aprendeu peças soltas: box model, cores, flexbox, grid, media queries, unidades relativas. Agora vamos **juntar todas elas** para construir, do zero, uma página de verdade que funciona lindamente do celular ao desktop.\n\nVá com calma e acompanhe cada passo montando o arquivo no seu computador. No fim, você vai ter um layout responsivo completo, o tipo de coisa que aparece em portfólios e projetos reais.",
+                    },
+                    {
+                        type: "quote",
+                        value: "Um layout responsivo não é uma técnica única, e sim a **soma** das que você já conhece: HTML bem estruturado, **unidades relativas** para fluir, **imagens flexíveis** para não estourar, **flexbox ou grid** para organizar e **media queries** para reorganizar. O mobile-first amarra tudo: comece pelo celular e vá acrescentando.",
+                    },
+                    {
+                        type: "text",
+                        value: "## O que vamos construir\n\nNosso projeto é a página inicial de um pequeno estúdio de design. Ela tem as partes clássicas de quase qualquer site:\n\n- Um **cabeçalho** (`header`) com o nome e um menu de navegação;\n- Uma **capa** (hero) com um título de boas-vindas;\n- Uma seção de **cartões** de serviços (aquela galeria que vira colunas em telas grandes);\n- Um **rodapé** (`footer`).\n\nO comportamento responsivo é o seguinte: no **celular**, tudo empilha numa coluna só, o menu vira uma lista vertical e os cartões ficam um embaixo do outro. No **desktop**, o menu vira uma linha e os cartões se espalham em **três colunas**. Vamos montar isso em passos.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Passo 1: a estrutura em HTML\n\nPrimeiro o esqueleto, sem estilo nenhum. Repare em duas coisas que já viraram hábito: a `meta viewport` no `<head>` (essencial, como vimos na aula 1) e o uso de tags semânticas como `<header>`, `<main>`, `<section>` e `<footer>`. Aqui está o HTML:",
+                    },
+                    {
+                        type: "code",
+                        value: '<!DOCTYPE html>\n<html lang="pt-br">\n  <head>\n    <meta charset="UTF-8">\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>Estúdio Criativo</title>\n    <link rel="stylesheet" href="estilo.css">\n  </head>\n  <body>\n    <header class="cabecalho">\n      <div class="logo">Estúdio Criativo</div>\n      <nav class="menu">\n        <a href="#">Início</a>\n        <a href="#">Serviços</a>\n        <a href="#">Contato</a>\n      </nav>\n    </header>\n\n    <main>\n      <section class="capa">\n        <h1>Ideias que ganham forma</h1>\n        <p>Design, código e um cafezinho.</p>\n      </section>\n\n      <section class="servicos">\n        <div class="cartao">\n          <h2>Design</h2>\n          <p>Identidade visual do zero.</p>\n        </div>\n        <div class="cartao">\n          <h2>Web</h2>\n          <p>Sites rápidos e responsivos.</p>\n        </div>\n        <div class="cartao">\n          <h2>Branding</h2>\n          <p>Sua marca com personalidade.</p>\n        </div>\n      </section>\n    </main>\n\n    <footer class="rodape">\n      <p>Feito com carinho na ensina.dev</p>\n    </footer>\n  </body>\n</html>',
+                    },
+                    {
+                        type: "text",
+                        value: '## Passo 2: o estilo base, pensando no celular\n\nFiéis ao **mobile-first**, escrevemos primeiro o CSS que vale para a tela mais estreita, **sem nenhuma media query**. No celular, quase tudo empilha naturalmente: o cabeçalho fica em coluna, a capa é centralizada e cada cartão ocupa a linha inteira.\n\nComeçamos com um "reset" básico e os estilos gerais:',
+                    },
+                    {
+                        type: "code",
+                        value: "/* Reset básico e uma caixa mais previsível. */\n* {\n  margin: 0;\n  padding: 0;\n  box-sizing: border-box;\n}\n\nbody {\n  font-family: system-ui, sans-serif;\n  color: #222;\n  line-height: 1.5;\n}\n\n/* Imagens sempre flexíveis (hábito de todo projeto). */\nimg {\n  max-width: 100%;\n  height: auto;\n}\n\n/* Cabeçalho: no celular, empilha em coluna e centraliza. */\n.cabecalho {\n  display: flex;\n  flex-direction: column;\n  align-items: center;\n  gap: 1rem;\n  padding: 1rem;\n  background: #2d2a4a;\n  color: white;\n}\n\n.menu {\n  display: flex;\n  flex-direction: column;\n  align-items: center;\n  gap: 0.5rem;\n}\n\n.menu a {\n  color: white;\n  text-decoration: none;\n}",
+                    },
+                    {
+                        type: "text",
+                        value: "## Passo 3: capa e cartões, ainda no celular\n\nSeguindo na base mobile, estilizamos a capa (usando `vh` para ela ter uma boa altura) e os cartões. No celular eles ficam **empilhados**, um por linha, porque um `grid` de uma coluna é o padrão mais simples:",
+                    },
+                    {
+                        type: "code",
+                        value: "/* Capa: ocupa boa parte da altura da tela e centraliza o texto. */\n.capa {\n  min-height: 60vh;\n  display: flex;\n  flex-direction: column;\n  align-items: center;\n  justify-content: center;\n  text-align: center;\n  gap: 1rem;\n  padding: 2rem;\n  background: #f4f2ff;\n}\n\n.capa h1 {\n  font-size: 2rem;\n}\n\n/* Serviços: grid de UMA coluna no celular. */\n.servicos {\n  display: grid;\n  grid-template-columns: 1fr;\n  gap: 1.5rem;\n  padding: 2rem;\n}\n\n.cartao {\n  background: white;\n  border: 1px solid #e0ddf0;\n  border-radius: 12px;\n  padding: 1.5rem;\n}\n\n.rodape {\n  text-align: center;\n  padding: 1.5rem;\n  background: #2d2a4a;\n  color: white;\n}",
+                    },
+                    {
+                        type: "text",
+                        value: "## Passo 4: as media queries, do menor para o maior\n\nCom a versão mobile pronta e funcional, agora **acrescentamos** layout para as telas maiores, usando `min-width`. Duas mudanças principais:\n\n- No **tablet** (a partir de 768px), o cabeçalho vira uma **linha** (logo de um lado, menu do outro) e os cartões passam a **duas colunas**.\n- No **desktop** (a partir de 1024px), os cartões se espalham em **três colunas**.\n\nRepare que não desfazemos nada: só ajustamos o `flex-direction` e o número de colunas do grid.",
+                    },
+                    {
+                        type: "code",
+                        value: "/* TABLET: a partir de 768px. */\n@media (min-width: 768px) {\n  /* Cabeçalho vira uma linha: logo à esquerda, menu à direita. */\n  .cabecalho {\n    flex-direction: row;\n    justify-content: space-between;\n  }\n\n  .menu {\n    flex-direction: row;\n  }\n\n  /* Cartões em duas colunas. */\n  .servicos {\n    grid-template-columns: 1fr 1fr;\n  }\n}\n\n/* DESKTOP: a partir de 1024px. */\n@media (min-width: 1024px) {\n  /* Cartões em três colunas, com um respiro nas laterais. */\n  .servicos {\n    grid-template-columns: 1fr 1fr 1fr;\n    max-width: 1100px;\n    margin: 0 auto;\n  }\n}",
+                    },
+                    {
+                        type: "text",
+                        value: "## O layout completo, tudo junto\n\nVocê montou por partes para entender cada decisão. Agora, aqui está o **CSS completo**, na ordem certa, pronto para colar no arquivo `estilo.css` ao lado do HTML do Passo 1. Este é o resultado de tudo o que você aprendeu na trilha, reunido num único arquivo que funciona do celular ao desktop:",
+                    },
+                    {
+                        type: "code",
+                        value: "/* ===== BASE (mobile-first): vale para o celular ===== */\n* {\n  margin: 0;\n  padding: 0;\n  box-sizing: border-box;\n}\n\nbody {\n  font-family: system-ui, sans-serif;\n  color: #222;\n  line-height: 1.5;\n}\n\nimg {\n  max-width: 100%;\n  height: auto;\n}\n\n.cabecalho {\n  display: flex;\n  flex-direction: column;\n  align-items: center;\n  gap: 1rem;\n  padding: 1rem;\n  background: #2d2a4a;\n  color: white;\n}\n\n.menu {\n  display: flex;\n  flex-direction: column;\n  align-items: center;\n  gap: 0.5rem;\n}\n\n.menu a {\n  color: white;\n  text-decoration: none;\n}\n\n.capa {\n  min-height: 60vh;\n  display: flex;\n  flex-direction: column;\n  align-items: center;\n  justify-content: center;\n  text-align: center;\n  gap: 1rem;\n  padding: 2rem;\n  background: #f4f2ff;\n}\n\n.capa h1 {\n  font-size: 2rem;\n}\n\n.servicos {\n  display: grid;\n  grid-template-columns: 1fr;\n  gap: 1.5rem;\n  padding: 2rem;\n}\n\n.cartao {\n  background: white;\n  border: 1px solid #e0ddf0;\n  border-radius: 12px;\n  padding: 1.5rem;\n}\n\n.rodape {\n  text-align: center;\n  padding: 1.5rem;\n  background: #2d2a4a;\n  color: white;\n}\n\n/* ===== TABLET: a partir de 768px ===== */\n@media (min-width: 768px) {\n  .cabecalho {\n    flex-direction: row;\n    justify-content: space-between;\n  }\n\n  .menu {\n    flex-direction: row;\n  }\n\n  .servicos {\n    grid-template-columns: 1fr 1fr;\n  }\n}\n\n/* ===== DESKTOP: a partir de 1024px ===== */\n@media (min-width: 1024px) {\n  .servicos {\n    grid-template-columns: 1fr 1fr 1fr;\n    max-width: 1100px;\n    margin: 0 auto;\n  }\n}",
+                    },
+                    {
+                        type: "text",
+                        value: "## Como essa página se transforma\n\nPare um instante para apreciar o que esse código faz sozinho, sem nenhum JavaScript. Conforme a tela cresce, a mesma página se reorganiza:",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Parte da página","No celular (base)","No tablet (≥768px)","No desktop (≥1024px)"],["Cabeçalho","Empilhado e centralizado","Em linha, logo e menu nas pontas","Em linha, logo e menu nas pontas"],["Menu","Lista vertical","Em linha","Em linha"],["Cartões de serviço","1 coluna","2 colunas","3 colunas, centralizadas"]]',
+                    },
+                    {
+                        type: "text",
+                        value: '## Teste você mesmo\n\nSalve os dois arquivos (`index.html` e `estilo.css`) na mesma pasta e abra o HTML no navegador. Agora vem a parte divertida: **arraste a borda da janela** para estreitá-la e alargá-la, ou aperte **F12** e ative o modo de dispositivo (o ícone de celular/tablet) para simular telas diferentes.\n\nVeja a página se reorganizar em tempo real: os cartões saltando de uma para três colunas, o menu deitando e levantando. Não é mágica, é a soma de tudo o que você construiu, unidades relativas, imagens flexíveis, flexbox, grid e media queries, trabalhando junto.\n\n**Parabéns por concluir o módulo de responsividade!** Você agora sabe fazer o que muita gente que "sabe CSS" ainda tropeça: páginas que ficam ótimas em qualquer tela. Esse é um marco de verdade na sua jornada.',
+                    },
+                    {
+                        type: "quote",
+                        value: "**Cheat sheet final:** um layout responsivo é a **soma** das técnicas da trilha. Comece pela `meta viewport` e por um HTML semântico. Escreva o CSS **mobile-first** (base para o celular, sem media query), usando unidades **relativas** e `img { max-width: 100%; height: auto; }`. Organize com **flexbox** (menus, cabeçalhos) e **grid** (galerias de cartões). Depois, com `@media (min-width: ...)`, apenas **acrescente** colunas e ajuste direções conforme a tela cresce. Teste redimensionando a janela ou pelo modo dispositivo do navegador (F12).",
+                    },
+                ],
+                questions: [
+                    {
+                        statement: 'No mobile-first, qual CSS representa o estilo "base"?',
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "O CSS escrito sem nenhuma media query, pensado para o celular.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "O CSS que fica dentro de `@media (min-width: 1024px)`.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O CSS que só vale quando a página é impressa.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O CSS escrito dentro da tag `<title>`.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Quais duas ferramentas de CSS foram usadas para organizar os elementos deste layout (o menu e a galeria de cartões)?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "Flexbox e grid.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Float e clear.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "JavaScript e PHP.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "As tags `<table>` e `<tr>`.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "No exemplo, o cabeçalho muda de `flex-direction: column` para `flex-direction: row` dentro de `@media (min-width: 768px)`. Qual é o efeito?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "No celular o cabeçalho fica empilhado em coluna, e a partir de 768px ele passa a ficar em linha.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "O cabeçalho some completamente em telas maiores que 768px.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O cabeçalho fica em linha no celular e empilhado no desktop.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Nada muda, porque `flex-direction` não afeta o layout.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Por que a regra `img { max-width: 100%; height: auto; }` aparece logo no estilo base do projeto?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Para garantir, desde o celular, que nenhuma imagem estoure a largura da tela nem fique distorcida.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Para deixar todas as imagens em preto e branco no celular.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Para esconder as imagens quando a tela é pequena.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Porque sem ela a `meta viewport` não funciona.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Neste layout mobile-first, o que acontece com a galeria `.servicos` numa tela de 900px de largura?",
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "Fica com 2 colunas: a tela satisfaz o `min-width: 768px` (2 colunas), mas ainda não o `min-width: 1024px` (3 colunas).",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Fica com 3 colunas, porque qualquer tela maior que o celular já aplica a regra do desktop.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Fica com 1 coluna, porque media queries só funcionam abaixo de 768px.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "A galeria desaparece, porque 900px não é um breakpoint definido.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    },
+];
+
+async function seed() {
+    let [trilha] = await db.select().from(trails).where(eq(trails.name, NOME));
+    if (!trilha) {
+        [trilha] = await db
+            .insert(trails)
+            .values({
+                name: NOME,
+                trailLevel: "iniciante",
+                description:
+                    "Trilha de CSS para iniciantes: estilize suas páginas do zero. Seletores, cascata e especificidade, box model, cores e tipografia, e layout moderno com Flexbox, Grid e responsividade, com exemplos práticos.",
+            })
+            .returning();
+    }
+
+    const jaTem = await db
+        .select({ id: modules.id })
+        .from(modules)
+        .where(and(eq(modules.trailId, trilha.id), eq(modules.title, MARCADOR)));
+    if (jaTem.length) {
+        console.log("Trilha CSS já está semeada, nada a fazer.");
+        return;
+    }
+
+    await db.transaction(async (tx) => {
+        const lids = (
+            await tx.select({ id: lessons.id }).from(lessons).where(eq(lessons.trailId, trilha.id))
+        ).map((l) => l.id);
+        if (lids.length) {
+            const qids = (
+                await tx
+                    .select({ id: questions.id })
+                    .from(questions)
+                    .where(inArray(questions.lessonId, lids))
+            ).map((q) => q.id);
+            if (qids.length) {
+                await tx.delete(questionAnswers).where(inArray(questionAnswers.questionId, qids));
+                await tx.delete(questionOptions).where(inArray(questionOptions.questionId, qids));
+                await tx.delete(questions).where(inArray(questions.id, qids));
+            }
+            await tx.delete(lessonProgress).where(inArray(lessonProgress.lessonId, lids));
+            await tx.delete(lessons).where(inArray(lessons.id, lids));
+        }
+        await tx.delete(modules).where(eq(modules.trailId, trilha.id));
+
+        for (let mi = 0; mi < DADOS.length; mi++) {
+            const m = DADOS[mi];
+            const [mod] = await tx
+                .insert(modules)
+                .values({ trailId: trilha.id, title: m.titulo, position: mi + 1 })
+                .returning();
+            for (let li = 0; li < m.aulas.length; li++) {
+                const a = m.aulas[li];
+                const [lesson] = await tx
+                    .insert(lessons)
+                    .values({
+                        trailId: trilha.id,
+                        moduleId: mod.id,
+                        title: a.titulo,
+                        content: null,
+                        contentBlocks: a.blocks,
+                        position: li + 1,
+                        published: true,
+                    })
+                    .returning();
+                for (let qi = 0; qi < a.questions.length; qi++) {
+                    const q = a.questions[qi];
+                    const [questao] = await tx
+                        .insert(questions)
+                        .values({
+                            lessonId: lesson.id,
+                            statement: q.statement,
+                            difficulty: q.difficulty,
+                            position: qi + 1,
+                        })
+                        .returning();
+                    await tx.insert(questionOptions).values(
+                        q.options.map((o, k) => ({
+                            questionId: questao.id,
+                            text: o.text,
+                            isCorrect: o.isCorrect,
+                            position: k + 1,
+                        })),
+                    );
+                }
+            }
+        }
+    });
+    console.log("Trilha CSS construída: " + DADOS.length + " módulos.");
+}
+
+seed()
+    .then(() => process.exit(0))
+    .catch((e) => {
+        console.error("Falha no seed:", e);
+        process.exit(1);
+    });

--- a/backend/scripts/seed-trilha-html.ts
+++ b/backend/scripts/seed-trilha-html.ts
@@ -1,0 +1,4238 @@
+// Trilha de HTML para iniciantes, blocos com quiz de 5 questões por aula.
+// questões por aula. Idempotente pelo marcador "Módulo 1 - Introdução ao HTML", que só
+// existe nesta estrutura nova. É destrutivo: apaga módulos/aulas/questões antigos
+// da trilha antes de recriar (o progresso da trilha AWS é reiniciado).
+//
+// Rodar em prod: docker compose -f docker-compose.prod.yml exec -T backend node scripts/seed-trilha-html.ts
+import { db } from "../db.ts";
+import {
+    trails,
+    modules,
+    lessons,
+    questions,
+    questionOptions,
+    questionAnswers,
+    lessonProgress,
+} from "../schema.ts";
+import { eq, and, inArray } from "drizzle-orm";
+
+const NOME = "HTML";
+const MARCADOR = "Módulo 1 - Introdução ao HTML";
+
+type Bloco = { type: "text" | "code" | "quote" | "table"; value: string };
+type Questao = {
+    statement: string;
+    difficulty: "facil" | "medio" | "dificil";
+    options: { text: string; isCorrect: boolean }[];
+};
+type Aula = { titulo: string; blocks: Bloco[]; questions: Questao[] };
+type Modulo = { titulo: string; aulas: Aula[] };
+
+const DADOS: Modulo[] = [
+    {
+        titulo: "Módulo 1 - Introdução ao HTML",
+        aulas: [
+            {
+                titulo: "O que é HTML e como a web funciona",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "# O que é HTML e como a web funciona\n\nSeja muito bem-vindo à sua primeira aula de HTML! Se você nunca escreveu uma linha de código na vida, pode relaxar: é exatamente para você que esta trilha foi feita. Aqui a gente começa do zero absoluto, sem pressa e sem pular etapas.\n\nToda página que você abre na internet, o Google, o YouTube, o site do seu banco, começou como um arquivo de **HTML**. Entender o que é esse arquivo e o que acontece quando você digita um endereço no navegador é o primeiro passo para construir suas próprias páginas. É isso que vamos destrinchar agora, com calma.",
+                    },
+                    {
+                        type: "quote",
+                        value: '**HTML** quer dizer _HyperText Markup Language_, ou Linguagem de Marcação de Hipertexto. A palavra que importa aqui é **marcação**: o HTML não faz cálculos nem toma decisões, ele apenas **dá nome e estrutura** ao conteúdo, dizendo "isto é um título", "isto é um parágrafo", "isto é uma imagem". Quem lê essa marcação e monta a página é o **navegador**.',
+                    },
+                    {
+                        type: "text",
+                        value: "## O que é uma página web, afinal?\n\nPense em uma página web como uma **folha de documento** que mora em algum computador na internet e que você abre pelo navegador (Chrome, Firefox, Edge, Safari e por aí vai).\n\nEssa folha é, na verdade, um **arquivo de texto** comum, parecido com um bloco de notas, só que escrito seguindo umas regrinhas que o navegador entende. O nome desse arquivo termina em `.html`. Quando você acessa um site, seu navegador **baixa** esse arquivo de texto e o **transforma** naquela página bonita, com títulos, imagens e botões, que aparece na tela.\n\nOu seja: por trás de toda página existe **texto** que alguém escreveu. E é justamente esse texto que você vai aprender a escrever.",
+                    },
+                    {
+                        type: "text",
+                        value: '## Marcação não é programação\n\nMuita gente começa achando que "fazer um site" é a mesma coisa que "programar". Vale separar as duas ideias logo de cara:\n\n- Uma **linguagem de programação** (como Python ou JavaScript) serve para dar **ordens** ao computador: "some estes números", "se o usuário estiver logado, mostre o nome dele", "repita isto 10 vezes". Ela tem lógica, decisões e cálculos.\n- Uma **linguagem de marcação**, como o HTML, serve para **descrever e organizar** um conteúdo. Você não manda o computador "fazer" nada, você **etiqueta** cada pedaço do conteúdo dizendo o que ele é.\n\nUma analogia ajuda: imagine que você recebeu um texto cru e precisa prepará-lo para uma revista. Você pega um marca-texto e anota nas margens: "isto aqui é o título principal", "este trecho é um parágrafo", "esta palavra tem que ficar em destaque". Você não reescreveu o texto nem fez contas, só **marcou** o papel de cada parte. É exatamente isso que o HTML faz com o conteúdo de uma página.',
+                    },
+                    {
+                        type: "code",
+                        value: "<h1>Bolo de cenoura</h1>\n\n<p>Esta é a melhor receita de bolo de cenoura da vovó.</p>\n\n<p>Rende 8 fatias e fica pronto em 40 minutos.</p>",
+                    },
+                    {
+                        type: "text",
+                        value: '## Lendo o exemplo acima\n\nMesmo sem saber HTML ainda, dá para adivinhar bastante coisa nesse código:\n\n- `<h1>Bolo de cenoura</h1>` marca o texto "Bolo de cenoura" como o **título principal** da página. O `h` vem de _heading_, que é cabeçalho em inglês.\n- Cada `<p>...</p>` marca um **parágrafo** de texto (o `p` é de _paragraph_).\n\nRepare no padrão: o texto que vai aparecer na tela fica **no meio**, cercado por essas etiquetas escritas entre `<` e `>`. Essas etiquetas são as **tags**, e são elas que dão significado ao conteúdo. Não precisa decorar nada agora, a gente vai dissecar tag por tag nas próximas aulas.',
+                    },
+                    {
+                        type: "text",
+                        value: "## O trio da web: HTML, CSS e JavaScript\n\nO HTML quase nunca trabalha sozinho. Uma página moderna é feita de **três** tecnologias que se completam. A forma mais fácil de entender o papel de cada uma é pensar numa **pessoa**:\n\n- **HTML** é o **esqueleto**: os ossos, a estrutura que sustenta tudo. Define o que existe na página (títulos, textos, imagens, botões).\n- **CSS** é a **aparência**: a roupa, o cabelo, a cor dos olhos. Cuida de como as coisas se parecem (cores, tamanhos, espaçamentos, fontes).\n- **JavaScript** é o **comportamento**: os músculos que se movem. Faz a página **reagir** (abrir um menu ao clicar, avisar que você esqueceu de preencher um campo, atualizar dados sem recarregar).\n\nNesta trilha o nosso foco é o **HTML**, o esqueleto. Sem um bom esqueleto, não adianta roupa bonita nem movimento. Por isso ele vem primeiro.",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Tecnologia","Cuida de...","Analogia (o corpo)","Exemplo do dia a dia"],["HTML","Estrutura e conteúdo","O esqueleto","Marcar o que é título, parágrafo e imagem"],["CSS","Estilo e aparência","A roupa e a maquiagem","Deixar o título azul e centralizado"],["JavaScript","Comportamento e interação","Os músculos","Mostrar um aviso quando você clica num botão"]]',
+                    },
+                    {
+                        type: "text",
+                        value: "## Um gostinho dos três juntos\n\nVocê não precisa entender CSS e JavaScript agora, mas vale ver como cada um entra. Vamos partir de um simples botão. Só com **HTML**, ele existe:",
+                    },
+                    {
+                        type: "code",
+                        value: "<button>Clique aqui</button>",
+                    },
+                    {
+                        type: "text",
+                        value: "Agora, com um toque de **CSS** (o atributo `style`, que dá a aparência) e de **JavaScript** (o `onclick`, que dá o comportamento), o mesmo botão ganha cor e passa a reagir ao clique:",
+                    },
+                    {
+                        type: "code",
+                        value: '<button style="background: green; color: white;" onclick="alert(\'Olá!\')">Clique aqui</button>',
+                    },
+                    {
+                        type: "text",
+                        value: "Percebe a divisão de tarefas? O fato de **existir** um `<button>` é HTML; o `style` com as cores é CSS; e o `onclick`, que dispara uma ação quando alguém clica, é JavaScript. Cada tecnologia no seu quadrado.",
+                    },
+                    {
+                        type: "text",
+                        value: "## O que o navegador faz com o HTML\n\nQuando o navegador recebe o arquivo `.html`, ele faz um trabalho parecido com o de alguém montando um móvel a partir de um manual:\n\n1. **Lê o texto de cima para baixo**, uma tag de cada vez.\n2. **Interpreta cada tag** para descobrir o que ela significa (isto é um título, aquilo é uma imagem, e assim por diante).\n3. **Monta a página na tela** seguindo essa estrutura. Esse processo tem um nome técnico: **renderização**.\n\nO ponto mais importante: o navegador **não mostra as tags** na tela. As etiquetas `<h1>` e `<p>` são instruções para o navegador, não são conteúdo. O que aparece para o visitante é só o texto que estava _dentro_ das tags, já formatado. Você escreve as etiquetas; o visitante vê o resultado. Por exemplo, você escreve isto:",
+                    },
+                    {
+                        type: "code",
+                        value: "<h1>Minha primeira página</h1>\n<p>Estou aprendendo <strong>HTML</strong>!</p>",
+                    },
+                    {
+                        type: "text",
+                        value: 'E o visitante **vê** na tela apenas duas linhas: o texto "Minha primeira página" grande e destacado (porque é um `<h1>`) e, logo abaixo, "Estou aprendendo HTML!", com a palavra "HTML" em negrito (por causa do `<strong>`, que serve para dar destaque forte). Nenhum `<`, `>` ou nome de tag aparece: eles fizeram o trabalho de organizar o conteúdo e saíram de vista.',
+                    },
+                    {
+                        type: "text",
+                        value: "## Cliente e servidor: quem é quem\n\nFalta uma última peça: como a página **chega** até você? Aqui entram dois personagens.\n\n- O **cliente** é o seu navegador, o programa que **pede** a página.\n- O **servidor** é um computador (quase sempre bem longe, num data center) que fica ligado o tempo todo **guardando** os arquivos e **entregando** quando alguém pede.\n\nA analogia clássica é a de um **restaurante**:\n\n- Você, sentado à mesa, é o **cliente**: faz o pedido.\n- A **cozinha** é o **servidor**: prepara e manda o prato.\n- O **garçom** é a **internet**, que leva o pedido e traz a resposta.\n\nNa prática: você digita `ensina.dev` no navegador (o cliente faz o pedido) e esse pedido viaja pela internet até o servidor. O servidor encontra o arquivo HTML e o envia de volta. O navegador recebe e renderiza a página na sua tela. Tudo isso acontece em uma fração de segundo.",
+                    },
+                    {
+                        type: "quote",
+                        value: "**Recapitulando:** uma página web é um arquivo de **texto** com extensão `.html`. O **HTML** é uma linguagem de **marcação**: ele etiqueta o conteúdo (o que é título, parágrafo, imagem) em vez de programar lógica. Ele forma um trio com o **CSS** (aparência) e o **JavaScript** (comportamento). O **navegador**, que é o **cliente**, baixa o arquivo do **servidor** e o **renderiza**, transformando as tags numa página visível, sem nunca mostrar as etiquetas.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement: "O que significa dizer que o HTML é uma linguagem de marcação?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "Ele etiqueta e estrutura o conteúdo, indicando o que é título, parágrafo ou imagem, sem executar lógica nem cálculos.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Ele executa cálculos e toma decisões, como somar números e repetir tarefas.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Ele cuida das cores, das fontes e dos espaçamentos da página.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Ele guarda os arquivos do site em um servidor na internet.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Na divisão de tarefas da web, qual tecnologia é responsável pela estrutura, o esqueleto da página?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "HTML",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "CSS",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "JavaScript",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O navegador",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "O que o navegador faz com tags como `<h1>` e `<p>` ao exibir a página?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Interpreta essas tags como instruções para montar a página e não as mostra na tela; o visitante vê apenas o conteúdo já formatado.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Mostra as tags na tela junto com o conteúdo, para o visitante conhecer a estrutura.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Apaga todo o texto que estiver escrito dentro das tags.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Envia as tags de volta ao servidor para serem processadas lá.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Na analogia do restaurante para cliente e servidor, o que representa o cliente?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "O navegador, que é quem pede a página.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "O computador distante que fica guardando e entregando o arquivo.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O próprio arquivo `.html`.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "A linguagem CSS, que estiliza a página.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            'Um colega afirma: "fazer uma página em HTML é programar, porque o HTML tem lógica e faz cálculos". Qual resposta corrige melhor essa ideia?',
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "O HTML é uma linguagem de marcação: ele descreve e organiza o conteúdo, mas não tem lógica, decisões nem cálculos, isso é papel de linguagens de programação como o JavaScript.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Está certo: o HTML faz cálculos e toma decisões como qualquer linguagem de programação.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O HTML serve só para deixar o texto colorido; quem estrutura a página é o CSS.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O HTML é um programa que roda no servidor e devolve números para o navegador.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "A estrutura de um documento HTML",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "# A estrutura de um documento HTML\n\nNa aula anterior você viu o que é o HTML. Agora vamos montar o **esqueleto** que toda página HTML tem, do site mais simples ao mais complexo. É um gabarito que você vai repetir a vida inteira, então vale a pena entender o papel de cada linha em vez de só copiar e colar.\n\nA boa notícia é que esse esqueleto é sempre o mesmo. Depois de escrevê-lo umas poucas vezes, ele vira automático.",
+                    },
+                    {
+                        type: "quote",
+                        value: "Todo documento HTML começa com o mesmo **esqueleto**: uma declaração `<!DOCTYPE html>`, o elemento `<html>` que envolve tudo e, dentro dele, dois blocos, o `<head>` (informações sobre a página, que não aparecem na tela) e o `<body>` (o conteúdo visível). Aprenda essa estrutura uma vez e ela serve para sempre.",
+                    },
+                    {
+                        type: "text",
+                        value: "## O esqueleto completo\n\nTodo documento HTML, do mais simples ao mais complexo, começa com esta mesma estrutura. Não precisa entender cada detalhe agora, só observe o formato geral. Vamos destrinchar cada parte logo em seguida:",
+                    },
+                    {
+                        type: "code",
+                        value: '<!DOCTYPE html>\n<html lang="pt-br">\n  <head>\n    <meta charset="UTF-8">\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>Minha primeira página</title>\n  </head>\n  <body>\n    <h1>Olá, mundo!</h1>\n    <p>Esta é a minha primeira página em HTML.</p>\n  </body>\n</html>',
+                    },
+                    {
+                        type: "text",
+                        value: "## Quatro peças, de fora para dentro\n\nRepare que o documento é feito de peças **encaixadas uma dentro da outra**, como caixas dentro de caixas. São quatro peças principais:\n\n1. `<!DOCTYPE html>`: a primeira linha, um aviso para o navegador.\n2. `<html>`: a caixa que envolve **todo** o documento.\n3. `<head>`: dentro do `<html>`, guarda informações sobre a página.\n4. `<body>`: também dentro do `<html>`, guarda o conteúdo visível.\n\nVamos ver uma por uma.",
+                    },
+                    {
+                        type: "text",
+                        value: '## 1. A primeira linha: `<!DOCTYPE html>`\n\nEssa linha esquisita, com um ponto de exclamação, **não é uma tag comum**. Ela é uma **declaração**: avisa o navegador de que o documento usa HTML na sua versão moderna, o HTML5.\n\nVocê não precisa entender a história por trás disso agora. Só guarde: **toda página começa com `<!DOCTYPE html>`, escrito exatamente assim, na primeira linha**. Sem ela, alguns navegadores entram num "modo antigo" e podem exibir a página de um jeito estranho.',
+                    },
+                    {
+                        type: "text",
+                        value: '## 2. `<html>`: a raiz de tudo\n\nLogo depois vem a tag `<html>`, que é aberta no começo e fechada com `</html>` no fim. **Tudo** o que faz parte da página fica dentro dela: é a caixa mais externa, também chamada de **elemento raiz**.\n\nRepare que ela vem com uma informação extra, o `lang="pt-br"`. Isso é um **atributo** (a gente estuda atributos com calma na próxima aula) e serve para dizer que a página está em **português do Brasil**. Isso ajuda leitores de tela a pronunciar as palavras corretamente e navegadores a oferecer tradução. É um detalhe pequeno que faz diferença na acessibilidade.',
+                    },
+                    {
+                        type: "code",
+                        value: '<html lang="pt-br">\n  <!-- todo o resto da página fica aqui dentro -->\n</html>',
+                    },
+                    {
+                        type: "text",
+                        value: "## 3. O `<head>`: os bastidores da página\n\nDentro do `<html>` moram dois blocos. O primeiro é o `<head>` (cabeça, em inglês). Pense nele como os **bastidores** de um teatro: coisas importantíssimas acontecem ali, mas o público não as vê diretamente.\n\nO `<head>` guarda **informações sobre a página**, os chamados **metadados**: qual é o título, qual a codificação de caracteres, quais arquivos de estilo carregar, e assim por diante. **Nada do que está no `<head>` aparece no corpo da página.** Veja um exemplo:",
+                    },
+                    {
+                        type: "code",
+                        value: '<head>\n  <meta charset="UTF-8">\n  <title>Sobre mim</title>\n</head>',
+                    },
+                    {
+                        type: "text",
+                        value: '## Dois itens essenciais do `<head>`\n\n### `<meta charset="UTF-8">`\n\nEssa linha define a **codificação de caracteres** da página. Traduzindo: ela ensina o navegador a entender letras acentuadas e símbolos.\n\nPense assim: o computador guarda tudo como números, e o `charset` é a **tabela** que diz qual número corresponde a qual letra. O `UTF-8` é a tabela mais completa e a mais usada, ela conhece "á", "ç", "ã", "ê" e praticamente qualquer símbolo. Se você esquecer essa linha, é bem provável que os acentos apareçam trocados por símbolos estranhos, tipo "vocÃª" no lugar de "você". Por isso ela nunca deve faltar.\n\n### `<title>`\n\nO `<title>` define o **nome da página**. Esse texto não aparece dentro da página em si, mas sim:\n\n- na **aba do navegador**, lá em cima;\n- no nome que fica salvo quando alguém adiciona a página aos **favoritos**;\n- no **título** que aparece nos resultados de busca do Google.\n\nOu seja, é um texto pequeno, mas que muita gente vê. Capriche nele.',
+                    },
+                    {
+                        type: "text",
+                        value: "## 4. O `<body>`: onde a página acontece\n\nO segundo bloco dentro do `<html>` é o `<body>` (corpo, em inglês). Se o `<head>` são os bastidores, o `<body>` é o **palco**: tudo o que o visitante vê na tela mora aqui, os títulos, os parágrafos, as imagens, os links, os botões.\n\nÉ no `<body>` que você vai passar a maior parte do seu tempo construindo páginas. Um exemplo bem simples de corpo:",
+                    },
+                    {
+                        type: "code",
+                        value: "<body>\n  <h1>Bem-vindo ao meu site</h1>\n  <p>Aqui eu falo sobre as minhas viagens.</p>\n  <p>Fique à vontade para explorar!</p>\n</body>",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Aspecto","`<head>`","`<body>`"],["Papel","Informações sobre a página (metadados)","Conteúdo da página"],["Aparece na tela?","Não","Sim"],["Exemplos do que vai dentro","`<meta charset>`, `<title>`","`<h1>`, `<p>`, imagens, links"],["Analogia (teatro)","Os bastidores","O palco"]]',
+                    },
+                    {
+                        type: "text",
+                        value: '## Indentação: por que o código tem "escadinha"\n\nVocê deve ter reparado que, nos exemplos, o código tem uns **recuos** (espaços no começo das linhas) que formam uma escadinha. Isso se chama **indentação**, e ela é feita de propósito.\n\nA indentação **não muda** o que a página faz: o navegador ignora esses espaços. Ela existe para os **humanos**. Como os elementos ficam encaixados uns dentro dos outros, o recuo mostra visualmente **quem está dentro de quem**. O que está mais para dentro (mais recuado) está contido no que está mais para fora.\n\nA regra prática é simples: cada vez que você entra em um elemento, empurra o conteúdo um pouco mais para a direita (o costume é usar 2 espaços). Compare os dois códigos abaixo. O primeiro funciona, mas é sofrível de ler:',
+                    },
+                    {
+                        type: "code",
+                        value: '<html lang="pt-br">\n<head>\n<title>Bagunçado</title>\n</head>\n<body>\n<h1>Título</h1>\n<p>Um parágrafo perdido.</p>\n</body>\n</html>',
+                    },
+                    {
+                        type: "code",
+                        value: '<html lang="pt-br">\n  <head>\n    <title>Organizado</title>\n  </head>\n  <body>\n    <h1>Título</h1>\n    <p>Um parágrafo bem posicionado.</p>\n  </body>\n</html>',
+                    },
+                    {
+                        type: "quote",
+                        value: '**Cheat sheet do esqueleto:** todo HTML começa com `<!DOCTYPE html>`, seguido de `<html lang="pt-br">`, que envolve tudo. Dentro dele vêm o `<head>` (metadados invisíveis, como `<meta charset="UTF-8">` para os acentos e `<title>` para a aba) e o `<body>` (todo o conteúdo visível). A **indentação** em escadinha não muda nada para o navegador, mas mostra o encaixe dos elementos e mantém o código legível.',
+                    },
+                ],
+                questions: [
+                    {
+                        statement: "Qual elemento define o texto que aparece na aba do navegador?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`<title>`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`<head>`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`<h1>`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`<body>`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "Para que serve a linha `<!DOCTYPE html>` no início do arquivo?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "Avisa o navegador de que o documento usa HTML na versão moderna (HTML5), para ele interpretar a página corretamente.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Cria o título principal que aparece no topo da página.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Importa a folha de estilos CSS da página.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Define a cor de fundo do documento.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Qual é a diferença entre o conteúdo do `<head>` e o do `<body>`?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "O `<head>` guarda informações sobre a página (metadados) que não aparecem na tela; o `<body>` contém o conteúdo visível ao visitante.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "O `<head>` guarda o conteúdo visível e o `<body>` guarda os metadados.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Os dois mostram conteúdo na tela; a única diferença é a ordem em que aparecem.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O `<head>` é usado no computador e o `<body>` só no celular.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            'Por que é importante incluir `<meta charset="UTF-8">` no `<head>`?',
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Para o navegador exibir corretamente acentos e caracteres especiais (á, ç, ã), evitando que apareçam símbolos estranhos.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Para definir o texto que aparece na aba do navegador.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Para deixar todo o texto da página em negrito.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Para fazer a página carregar mais rápido no celular.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Sobre a estrutura de um documento HTML, qual afirmação está correta?",
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "O elemento `<html>` é a raiz que envolve todo o documento, e dentro dele ficam o `<head>` e o `<body>`, nessa ordem.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "O `<body>` deve vir antes do `<head>`, porque o conteúdo é mais importante que os metadados.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "A declaração `<!DOCTYPE html>` deve ser colocada dentro do `<head>`.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: 'O atributo `lang="pt-br"` deve ser colocado na tag `<title>`.',
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Tags, elementos e atributos",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "# Tags, elementos e atributos\n\nVocê já viu tags como `<p>` e `<h1>` aparecerem por aí. Agora vamos **abrir** essas etiquetas e entender exatamente do que elas são feitas. Esta aula é o coração da trilha: quem domina tags, elementos e atributos domina o HTML inteiro, porque **tudo** em HTML é construído a partir dessas três ideias.\n\nVamos com calma, uma ideia de cada vez, sempre com código de verdade para você olhar.",
+                    },
+                    {
+                        type: "quote",
+                        value: 'Um **elemento** de HTML costuma ter três partes: a **tag de abertura** (ex.: `<p>`), o **conteúdo** (o que vai no meio) e a **tag de fechamento** (ex.: `</p>`, com uma barra `/`). O conjunto inteiro é o elemento. Alguns elementos, os **vazios**, não têm conteúdo nem fechamento. E dentro das tags de abertura podem existir **atributos**, informações extras no formato `nome="valor"`.',
+                    },
+                    {
+                        type: "text",
+                        value: "## Anatomia de um elemento\n\nVamos dissecar o elemento mais simples que existe, um parágrafo. Olhe com atenção para o código abaixo:",
+                    },
+                    {
+                        type: "code",
+                        value: "<p>Olá, mundo!</p>",
+                    },
+                    {
+                        type: "text",
+                        value: "Esse pedacinho tem **três partes**:\n\n1. **Tag de abertura**: `<p>`. Marca o **início** do elemento. Fica sempre entre `<` e `>`.\n2. **Conteúdo**: `Olá, mundo!`. É o que aparece na tela, o miolo do elemento.\n3. **Tag de fechamento**: `</p>`. Marca o **fim** do elemento. É igual à de abertura, mas com uma **barra** `/` antes do nome.\n\nO conjunto das três partes é o **elemento** `<p>`. A regra de ouro: quase toda tag que você **abre**, precisa depois **fechar**. Esquecer a tag de fechamento é um dos erros mais comuns de quem está começando.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Aninhamento: elementos dentro de elementos\n\nRaramente uma página tem um elemento só. O normal é colocar uns elementos **dentro** dos outros, feito caixas menores dentro de caixas maiores. Isso se chama **aninhamento**.\n\nVeja uma lista de compras. Temos um título, e uma lista (`<ul>`, de _unordered list_, lista não ordenada) que contém vários itens (`<li>`, de _list item_):",
+                    },
+                    {
+                        type: "code",
+                        value: "<body>\n  <h1>Minha lista de compras</h1>\n  <ul>\n    <li>Arroz</li>\n    <li>Feijão</li>\n    <li>Café</li>\n  </ul>\n</body>",
+                    },
+                    {
+                        type: "text",
+                        value: "Repare no encaixe: cada `<li>` está **dentro** do `<ul>`, que por sua vez está **dentro** do `<body>`. A indentação (a escadinha) mostra exatamente essa hierarquia de quem está dentro de quem.\n\nHá uma **regra de ouro** para aninhar: o elemento que você **abriu por último** deve ser o **primeiro a fechar**. É como fechar caixas, você fecha primeiro a caixa de dentro, depois a de fora. Se as tags se cruzam, o HTML fica inválido.",
+                    },
+                    {
+                        type: "code",
+                        value: "<!-- CERTO: a tag aberta por último (strong) fecha primeiro -->\n<p>Isto é <strong>muito importante</strong>.</p>\n\n<!-- ERRADO: as tags se cruzam (strong abre dentro do p, mas fecha depois dele) -->\n<p>Isto é <strong>muito importante</p></strong>",
+                    },
+                    {
+                        type: "text",
+                        value: 'No exemplo errado acima, a tag `<strong>` foi aberta **dentro** do parágrafo, então ela precisava ser fechada **antes** do `</p>`. Como o `</p>` veio primeiro, as tags se cruzaram. O navegador até tenta "consertar" isso sozinho, mas o resultado costuma sair diferente do que você esperava. Melhor não depender da sorte: feche sempre na ordem inversa da abertura.',
+                    },
+                    {
+                        type: "text",
+                        value: "## Elementos vazios (void)\n\nNem todo elemento envolve um conteúdo. Alguns servem para representar uma coisa que **não tem texto dentro**, como uma quebra de linha ou uma imagem. Esses são os **elementos vazios**, também chamados de **void**. Eles têm **só a tag de abertura**, sem conteúdo e sem tag de fechamento. Os mais comuns:\n\n- `<br>`: uma **quebra de linha** (força o texto a pular para a linha de baixo).\n- `<hr>`: uma **linha divisória** horizontal, para separar seções.\n- `<img>`: uma **imagem**.",
+                    },
+                    {
+                        type: "code",
+                        value: '<p>Primeira linha<br>Segunda linha</p>\n\n<hr>\n\n<img src="gato.jpg" alt="Um gato dormindo no sofá">',
+                    },
+                    {
+                        type: "text",
+                        value: 'Repare que não existe `</br>` nem `</img>`: não faz sentido "fechar" algo que não tem conteúdo dentro. Você pode até encontrar por aí a forma `<br />` (com uma barra no fim), que também é válida, mas hoje em dia o comum é escrever só `<br>`. O importante é lembrar: **elemento vazio não tem tag de fechamento**.',
+                    },
+                    {
+                        type: "text",
+                        value: '## Atributos: informações extras na tag\n\nRepare que, no exemplo do `<img>`, apareceram umas coisinhas dentro da tag: `src="gato.jpg"` e `alt="Um gato dormindo no sofá"`. Isso são **atributos**.\n\nUm atributo é uma **informação extra** que você dá a um elemento, escrita **dentro da tag de abertura**. A ideia é a seguinte: a tag `<img>` diz "aqui vai uma imagem", mas sozinha ela não sabe _qual_ imagem. É o atributo `src` que responde: "a imagem está no arquivo `gato.jpg`". Os atributos deixam os elementos mais específicos.',
+                    },
+                    {
+                        type: "code",
+                        value: '<html lang="pt-br"> ... </html>\n\n<img src="perfil.jpg" alt="Foto de perfil sorrindo">\n\n<a href="https://ensina.dev">Visite a ensina.dev</a>',
+                    },
+                    {
+                        type: "text",
+                        value: 'A sintaxe de um atributo é sempre a mesma: **nome do atributo**, um sinal de **igual** `=`, e o **valor** entre **aspas**.\n\n```\nnome="valor"\n```\n\nAlguns detalhes que valem a pena guardar:\n\n- Os atributos ficam **só na tag de abertura**, nunca na de fechamento.\n- Você pode ter **vários** atributos no mesmo elemento, separados por um **espaço** (como o `<img>`, que tem `src` e `alt`).\n- Sempre coloque o valor **entre aspas**. Nos exemplos: `lang` diz o idioma da página, `src` diz o endereço do arquivo da imagem, `alt` dá uma descrição da imagem, e `href` diz para onde um link (`<a>`, de _anchor_, âncora) leva.',
+                    },
+                    {
+                        type: "table",
+                        value: '[["Atributo","Aparece em...","O que faz"],["`lang`","`<html>`","Informa o idioma da página (ex.: `pt-br`)"],["`src`","`<img>`","Diz o endereço (o arquivo) da imagem a ser exibida"],["`alt`","`<img>`","Descrição em texto da imagem (acessibilidade e reserva)"],["`href`","`<a>`","O endereço de destino para onde o link leva"]]',
+                    },
+                    {
+                        type: "text",
+                        value: '## Um atributo que não pode faltar: o `alt`\n\nVale um destaque para o `alt` da imagem, porque muita gente esquece dele. O `alt` (de _alternative text_, texto alternativo) descreve a imagem em palavras. Ele é importante por dois motivos:\n\n- **Acessibilidade**: pessoas cegas navegam com **leitores de tela**, programas que leem a página em voz alta. Como o programa não "enxerga" a foto, ele lê o `alt`. Sem `alt`, a imagem é um silêncio.\n- **Reserva (fallback)**: se a imagem não carregar (link quebrado, internet lenta), o navegador mostra o texto do `alt` no lugar, e o visitante ao menos sabe o que deveria estar ali.',
+                    },
+                    {
+                        type: "code",
+                        value: '<!-- Bom: descreve o que está na imagem -->\n<img src="cachorro.jpg" alt="Cachorro caramelo correndo na praia">\n\n<!-- Evite: sem alt, quem usa leitor de tela não sabe o que é a imagem -->\n<img src="cachorro.jpg">',
+                    },
+                    {
+                        type: "quote",
+                        value: '**Cheat sheet:** um **elemento** = tag de abertura + conteúdo + tag de fechamento (`<p>Olá</p>`); a de fechamento leva uma `/`. Elementos ficam **aninhados** (último a abrir, primeiro a fechar). Os **vazios/void** (`<br>`, `<hr>`, `<img>`) não têm conteúdo nem fechamento. **Atributos** são informações extras na tag de abertura, no formato `nome="valor"`: `lang`, `src`, `alt`, `href`. E nunca esqueça o `alt` nas imagens.',
+                    },
+                ],
+                questions: [
+                    {
+                        statement: "No elemento `<p>Olá!</p>`, qual é a tag de fechamento?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`</p>`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`<p>`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`Olá!`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`<p></p>`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Qual destes é um elemento vazio (void), ou seja, não tem tag de fechamento?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`<br>`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`<p>`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`<h1>`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`<title>`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "O que é um atributo em HTML e onde ele fica?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: 'É uma informação extra no formato `nome="valor"`, escrita dentro da tag de abertura do elemento.',
+                                isCorrect: true,
+                            },
+                            {
+                                text: "É o texto que aparece entre a tag de abertura e a de fechamento.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "É uma tag especial que sempre vem sozinha, sem nenhum valor.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "É um comentário que o navegador simplesmente ignora.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "Para que serve o atributo `alt` em uma tag `<img>`?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Fornece uma descrição em texto da imagem, usada por leitores de tela e exibida caso a imagem não carregue.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Define o endereço (o arquivo) da imagem que será exibida.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Deixa a imagem alinhada à esquerda da página.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Aumenta a resolução da imagem automaticamente.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "Qual das opções mostra um aninhamento correto de elementos?",
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "`<p>Um texto <strong>em destaque</strong> aqui.</p>`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`<p>Um texto <strong>em destaque</p></strong> aqui.`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`<strong><p>Um texto em destaque</strong></p>`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`<p>Um texto <strong>em destaque<strong> aqui.</p>`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Seu primeiro HTML na prática",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "# Seu primeiro HTML na prática\n\nChega de teoria: hoje você vai **criar e abrir** a sua primeira página de verdade, no seu próprio computador. Vai ver que é mais simples do que parece, não precisa instalar nada complicado nem estar conectado à internet.\n\nAo final desta aula você terá um arquivo HTML funcionando, saberá deixar recados no código com comentários e vai conhecer os tropeços mais comuns de quem está começando, para não cair neles.",
+                    },
+                    {
+                        type: "quote",
+                        value: "Um arquivo HTML é só um **arquivo de texto** salvo com a extensão `.html`. Qualquer editor de texto serve para escrever, e qualquer navegador serve para abrir, com um duplo clique. Não é preciso internet nem servidor para testar uma página no seu próprio computador.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Passo 1: criar o arquivo\n\nAbra um **editor de texto** qualquer, o Bloco de Notas (Windows), o TextEdit (Mac) ou, de preferência, um editor de código como o VS Code (falaremos dele no fim).\n\nCrie um arquivo novo e salve com um nome que termine em `.html`, por exemplo `index.html`. Duas dicas:\n\n- Evite **espaços e acentos** no nome do arquivo (use `index.html`, não `minha página.html`).\n- O nome `index.html` é uma convenção para a **página inicial** de um site. É um bom padrão para começar.",
+                    },
+                    {
+                        type: "text",
+                        value: '## Passo 2: escrever o HTML\n\nDentro do arquivo, digite (ou copie) o documento abaixo. Ele é o esqueleto que você aprendeu na aula 2, agora preenchido com um conteúdo de "sobre mim":',
+                    },
+                    {
+                        type: "code",
+                        value: '<!DOCTYPE html>\n<html lang="pt-br">\n  <head>\n    <meta charset="UTF-8">\n    <title>Sobre mim</title>\n  </head>\n  <body>\n    <h1>Olá, eu sou a Ana</h1>\n    <p>Estou aprendendo HTML na ensina.dev.</p>\n    <p>Meu hobby favorito é andar de bicicleta.</p>\n  </body>\n</html>',
+                    },
+                    {
+                        type: "text",
+                        value: '## Passo 3: abrir no navegador\n\nSalve o arquivo. Agora encontre-o no seu computador e dê **dois cliques** nele, ou arraste-o para uma aba aberta do navegador. Pronto: a sua página aparece na tela!\n\nRepare que, na barra de endereço, aparece algo como `file:///C:/Users/voce/index.html`. Esse `file://` é o jeito de o navegador dizer "estou abrindo um arquivo direto do seu computador". Ou seja, você **não precisa de internet nem de um servidor** para testar: o navegador lê o arquivo local. Sempre que mexer no código, salve e aperte **F5** no navegador para ver a página atualizada.',
+                    },
+                    {
+                        type: "text",
+                        value: "## Entendendo o código linha a linha\n\nAgora que já funcionou, vamos revisitar o mesmo documento com **comentários** explicando o que cada parte faz. (Esses comentários são só para você entender; já já explicamos como eles funcionam.)",
+                    },
+                    {
+                        type: "code",
+                        value: '<!DOCTYPE html>\n<html lang="pt-br">\n  <head>\n    <!-- charset: faz os acentos (á, ç, ã) aparecerem certos -->\n    <meta charset="UTF-8">\n    <!-- title: o nome que aparece na aba do navegador -->\n    <title>Sobre mim</title>\n  </head>\n  <body>\n    <!-- Tudo daqui para baixo aparece na tela -->\n    <h1>Olá, eu sou a Ana</h1>\n    <p>Estou aprendendo HTML na ensina.dev.</p>\n  </body>\n</html>',
+                    },
+                    {
+                        type: "text",
+                        value: '## Comentários em HTML\n\nAqueles trechos entre `<!--` e `-->` são **comentários**. Um comentário é um recado que você deixa no código: o navegador **ignora** completamente o que estiver ali dentro, e ele **não aparece** na página para o visitante.\n\nComentários servem para três coisas principais:\n\n- **Explicar** um trecho do código, para você lembrar depois (ou para outra pessoa entender).\n- **Organizar** o arquivo em seções ("aqui começa o rodapé", por exemplo).\n- **Desativar** temporariamente um pedaço de código sem precisar apagá-lo.',
+                    },
+                    {
+                        type: "code",
+                        value: "<!-- Cabeçalho do site -->\n<h1>Minha loja</h1>\n\n<!-- Lembrete: adicionar a foto do produto aqui depois -->\n\n<!-- Este parágrafo está desativado por enquanto:\n<p>Promoção relâmpago!</p>\n-->",
+                    },
+                    {
+                        type: "text",
+                        value: "No exemplo acima temos os três usos: um comentário que **rotula** uma seção, um que serve de **lembrete** para o futuro, e um que **desativa** um parágrafo (o `<p>` da promoção não vai aparecer na página, porque está dentro de um comentário). Nada disso é exibido para quem visita o site.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Erros comuns de iniciante\n\nSe algo der errado, respire fundo: **todo mundo** passa por esses tropeços no começo. Saber reconhecê-los já resolve metade do problema. Vamos aos clássicos.\n\nO primeiro é **esquecer de fechar uma tag**. Toda tag que abre (menos os elementos vazios) precisa da sua tag de fechamento:",
+                    },
+                    {
+                        type: "code",
+                        value: "<!-- Errado: o primeiro <p> nunca foi fechado -->\n<p>Primeiro parágrafo.\n<p>Segundo parágrafo.</p>\n\n<!-- Certo: cada parágrafo abre e fecha -->\n<p>Primeiro parágrafo.</p>\n<p>Segundo parágrafo.</p>",
+                    },
+                    {
+                        type: "text",
+                        value: 'Quando você esquece de fechar uma tag, o navegador tenta "adivinhar" onde o elemento termina, e o resultado costuma sair torto: espaçamentos estranhos, texto no lugar errado, formatação que "vaza" para onde não devia. Como o navegador não mostra uma mensagem de erro (ele apenas faz o melhor que consegue), esse tipo de problema pode ser confuso. A dica é sempre conferir se cada tag aberta tem a sua correspondente de fechamento.\n\nO segundo erro clássico é **esquecer as aspas** no valor de um atributo:',
+                    },
+                    {
+                        type: "code",
+                        value: '<!-- Errado: sem aspas, o valor "Minha foto" quebra por causa do espaço -->\n<img src=foto.jpg alt=Minha foto>\n\n<!-- Certo: sempre coloque o valor entre aspas -->\n<img src="foto.jpg" alt="Minha foto">',
+                    },
+                    {
+                        type: "table",
+                        value: '[["Erro comum","O que costuma acontecer","Como evitar"],["Esquecer de fechar a tag","Layout torto, formatação vaza para onde não devia","Toda tag que abre, feche (exceto os elementos vazios)"],["Cruzar tags aninhadas","O navegador \\"conserta\\" do jeito dele; resultado imprevisível","Última tag a abrir é a primeira a fechar"],["Valor de atributo sem aspas","Quebra quando o valor tem espaços","Escreva sempre `nome=\\"valor\\"`, com aspas"],["Salvar com a extensão errada (`.txt`)","O navegador mostra o código como texto, não a página","Salve o arquivo como `.html`"]]',
+                    },
+                    {
+                        type: "text",
+                        value: "## Dicas para seguir em frente\n\nVocê acabou de criar sua primeira página, isso é uma conquista de verdade. Antes de continuar, duas dicas que vão facilitar muito a sua vida:\n\n- Troque o Bloco de Notas por um **editor de código** como o **VS Code**: ele é gratuito, colore o código para ficar mais fácil de ler, avisa quando você esquece de fechar uma tag e ajuda a indentar automaticamente.\n- Adote o **ciclo mão na massa**: escreva um pouco, salve, aperte **F5** no navegador e veja o resultado. Errar, ajustar e testar de novo é exatamente assim que se aprende HTML.\n\nParabéns por concluir o **Módulo 1**! No próximo módulo vamos encher a página de conteúdo de verdade: títulos, listas, links, imagens e muito mais.",
+                    },
+                    {
+                        type: "quote",
+                        value: "**Cheat sheet final:** um arquivo HTML é texto salvo como `.html` e abre com duplo clique no navegador (`file://`, sem precisar de internet). **Comentários** vão entre `<!--` e `-->`, não aparecem na tela e servem para explicar, organizar ou desativar trechos. Os erros mais comuns de iniciante são **esquecer de fechar tags**, **cruzar o aninhamento**, **omitir as aspas** dos atributos e **salvar com a extensão errada**. Um bom editor, como o VS Code, ajuda a evitar quase todos eles.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement:
+                            "Com qual extensão você deve salvar um arquivo para que o navegador o abra como uma página web?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`.html`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`.txt`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`.doc`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`.web`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "Como se escreve um comentário em HTML?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`<!-- assim -->`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`// assim`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`/* assim */`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`# assim`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "O que acontece com o texto dentro de um comentário HTML quando a página é aberta no navegador?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Ele é ignorado pelo navegador e não aparece na tela para o visitante.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Ele aparece na tela, escrito em letras cinzas.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Ele aparece apenas no celular, não no computador.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Ele vira o título que aparece na aba do navegador.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Você precisa de conexão com a internet e de um servidor para abrir e testar um arquivo `.html` que está no seu próprio computador?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Não; o navegador abre o arquivo direto do computador (endereço `file:///...`), sem internet nem servidor.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Sim; sem um servidor o navegador não consegue exibir nenhuma página.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Sim; é obrigatório publicar o arquivo online antes de conseguir vê-lo.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Não, mas a página só aparece se a internet estiver conectada.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "No trecho `<p>Primeiro. <p>Segundo.</p>`, o primeiro parágrafo não foi fechado. Qual é a melhor descrição do problema e da correção?",
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "Falta o `</p>` do primeiro parágrafo; o certo é `<p>Primeiro.</p> <p>Segundo.</p>`, fechando cada elemento que foi aberto.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Não há problema algum; tags de parágrafo nunca precisam ser fechadas.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O erro é usar `<p>`; o correto seria escrever `<paragraph>`.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Falta apenas um `<!DOCTYPE html>` antes dos parágrafos, e é só isso.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        titulo: "Módulo 2 - Texto e links",
+        aulas: [
+            {
+                titulo: "Títulos e parágrafos",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "# Títulos e parágrafos\n\nBem-vindo ao Módulo 2! No módulo anterior você montou o esqueleto de uma página e entendeu como tudo se encaixa. Agora começa a parte mais gostosa: **encher a página de conteúdo**. E quase todo conteúdo de texto na web nasce de duas peças básicas, os **títulos** e os **parágrafos**.\n\nNesta aula você vai aprender a organizar um texto em seções com títulos de vários níveis, a escrever parágrafos, a quebrar linhas e a separar trechos com uma linha divisória. E vai descobrir uma característica curiosa: o HTML **não liga** para os espaços e as quebras de linha que você deixa no código.",
+                    },
+                    {
+                        type: "quote",
+                        value: "Os títulos vão de `<h1>` (o mais importante) até `<h6>` (o menos importante) e servem para criar uma **hierarquia** de seções, como o índice de um livro, e não apenas para deixar o texto grande. O `<p>` marca um **parágrafo**. E guarde já: o navegador **colapsa** vários espaços e quebras de linha do código-fonte em um único espaço.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Os seis níveis de título\n\nO HTML oferece **seis** níveis de título, das tags `<h1>` até `<h6>`. O `h` vem de _heading_ (cabeçalho, em inglês) e o número indica a **importância**: o `<h1>` é o título mais importante da página, e a importância vai diminuindo até o `<h6>`, o menos importante.\n\nPor padrão, o navegador mostra o `<h1>` com a letra maior e vai encolhendo até o `<h6>`, o menor. Veja os seis lado a lado:",
+                    },
+                    {
+                        type: "code",
+                        value: "<h1>Título de nível 1</h1>\n<h2>Título de nível 2</h2>\n<h3>Título de nível 3</h3>\n<h4>Título de nível 4</h4>\n<h5>Título de nível 5</h5>\n<h6>Título de nível 6</h6>",
+                    },
+                    {
+                        type: "text",
+                        value: '## Hierarquia, não tamanho\n\nAqui mora o ponto mais importante da aula, e um erro clássico de iniciante. É tentador escolher um título pela **letra grande ou pequena** que ele produz: "quero um texto médio, então uso `<h3>`". **Não faça isso.** Os títulos existem para mostrar a **estrutura** do conteúdo, não a aparência. Quem cuida do tamanho é o CSS, que você vê mais para a frente.\n\nPense num **livro**. Ele tem um título geral (o `<h1>`), que se divide em capítulos (os `<h2>`), que por sua vez têm seções (`<h3>`) e subseções (`<h4>`). Os títulos do HTML montam exatamente esse **índice**. Três regras de ouro:\n\n- Use **um único** `<h1>` por página: é o assunto principal dela.\n- **Não pule níveis** de cima para baixo: depois de um `<h2>`, use `<h3>`, não vá direto para o `<h5>`.\n- Escolha o nível pela **importância** do trecho, nunca pelo tamanho que ele aparenta.',
+                    },
+                    {
+                        type: "code",
+                        value: "<!-- CERTO: a hierarquia desce um degrau por vez -->\n<h1>Meu blog de viagens</h1>\n  <h2>Destinos na América do Sul</h2>\n    <h3>Patagônia</h3>\n    <h3>Deserto do Atacama</h3>\n  <h2>Dicas de bagagem</h2>\n\n<!-- EVITE: pular de h1 direto para h4 quebra o índice da página -->\n<h1>Meu blog de viagens</h1>\n  <h4>Destinos na América do Sul</h4>",
+                    },
+                    {
+                        type: "text",
+                        value: 'Por que isso importa tanto? Por **dois motivos** bem concretos. O primeiro é a **acessibilidade**: quem usa leitor de tela costuma navegar "pulando de título em título" para achar o que procura, e uma hierarquia bagunçada vira um labirinto. O segundo é o **Google**: os buscadores usam os títulos para entender do que a sua página trata. Uma boa estrutura de títulos ajuda o seu site a ser encontrado.',
+                    },
+                    {
+                        type: "text",
+                        value: "## Parágrafos com `<p>`\n\nSe os títulos são as placas que anunciam cada seção, os **parágrafos** são o texto corrido que preenche essas seções. Para marcar um parágrafo usamos a tag `<p>` (de _paragraph_), que você já conhece de vista.\n\nCada bloco de texto que forma uma ideia deve ir no seu **próprio** `<p>`. O navegador dá automaticamente um **espaço** entre um parágrafo e outro, o que deixa o texto respirando e fácil de ler:",
+                    },
+                    {
+                        type: "code",
+                        value: "<p>A pizza nasceu em Nápoles, na Itália, como uma comida simples e barata do povo.</p>\n\n<p>Hoje ela é servida no mundo inteiro, com recheios que variam de país para país.</p>\n\n<p>No Brasil, a pizza de calabresa é uma das mais pedidas.</p>",
+                    },
+                    {
+                        type: "text",
+                        value: "## O HTML engole os espaços\n\nAgora uma característica que costuma pegar todo iniciante de surpresa. No código, você pode caprichar em espaços e quebras de linha para deixar tudo bonito, mas o navegador **não liga** para isso: ele transforma **qualquer sequência** de espaços, tabs e quebras de linha em um **único espaço**. Isso se chama **colapso de espaços em branco** (_whitespace collapsing_).\n\nVeja este parágrafo escrito de um jeito propositalmente bagunçado:",
+                    },
+                    {
+                        type: "code",
+                        value: "<p>Este    texto    tem    muitos    espaços\n   e   várias\n   quebras   de   linha   no   código.</p>",
+                    },
+                    {
+                        type: "text",
+                        value: 'Por mais espalhado que esteja no código, o visitante vê **uma única linha** contínua: "Este texto tem muitos espaços e várias quebras de linha no código." Todos aqueles espaços e quebras viraram **um espaço só** entre cada palavra.\n\nA lição é importante: para o navegador, **você não separa parágrafos nem quebra linhas apertando Enter ou barra de espaço no código**. Quem faz isso são as tags. Para separar blocos de texto, use `<p>`. E, quando quiser forçar uma quebra dentro de um mesmo bloco, existe uma tag específica, que vem a seguir.',
+                    },
+                    {
+                        type: "text",
+                        value: "## Quebra de linha com `<br>`\n\nÀs vezes você quer que o texto **pule para a linha de baixo** sem começar um parágrafo novo. O caso clássico é um **endereço** ou os **versos de um poema**, em que as linhas andam juntas, mas cada uma fica na sua. Para isso existe o `<br>` (de _break_, quebra).\n\nO `<br>` é um daqueles **elementos vazios** que você viu no Módulo 1: não tem conteúdo nem tag de fechamento, é só `<br>`. Cada `<br>` força **uma** quebra de linha ali onde você o coloca:",
+                    },
+                    {
+                        type: "code",
+                        value: "<p>\n  Rua das Flores, 123<br>\n  Bairro Jardim<br>\n  São Paulo - SP\n</p>\n\n<p>\n  Batatinha quando nasce<br>\n  espalha a rama pelo chão.\n</p>",
+                    },
+                    {
+                        type: "text",
+                        value: 'Um cuidado importante: o `<br>` serve para quebras que fazem parte do **conteúdo** (endereços, versos, uma assinatura). Ele **não** é a ferramenta para dar espaço entre parágrafos ou empurrar coisas na página. Encher o código de `<br><br><br>` para "espaçar" é um vício feio, esse tipo de espaçamento é trabalho do CSS. Para separar ideias, o certo continua sendo o `<p>`.',
+                    },
+                    {
+                        type: "text",
+                        value: '## Linha divisória com `<hr>`\n\nPor fim, quando você quer **separar visualmente** dois assuntos, existe o `<hr>` (de _horizontal rule_, régua horizontal). Ele desenha uma **linha horizontal** que atravessa a página, marcando uma mudança de tema, como aquele fio que separa seções de um documento.\n\nAssim como o `<br>`, o `<hr>` é um **elemento vazio**: escreve-se só `<hr>`, sem fechamento. Mais do que um traço bonito, ele carrega um **significado**: "aqui termina um assunto e começa outro".',
+                    },
+                    {
+                        type: "code",
+                        value: "<h2>Sobre o restaurante</h2>\n<p>Somos uma cantina italiana de comida caseira desde 1998.</p>\n\n<hr>\n\n<h2>Nosso cardápio</h2>\n<p>Massas, pizzas e sobremesas feitas na hora.</p>",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Tag","Para que serve","É vazia (sem fechamento)?"],["`<h1>` a `<h6>`","Títulos em ordem de importância (hierarquia)","Não"],["`<p>`","Parágrafo de texto","Não"],["`<br>`","Quebra de linha dentro de um bloco","Sim"],["`<hr>`","Linha divisória entre seções","Sim"]]',
+                    },
+                    {
+                        type: "quote",
+                        value: "**Cheat sheet:** os títulos vão de `<h1>` (mais importante) a `<h6>` (menos importante) e montam a **hierarquia** da página, use um só `<h1>` e não pule níveis. O `<p>` marca parágrafos. O navegador **colapsa** espaços e quebras do código em um espaço só, então quebras de verdade se fazem com tags: `<br>` para pular linha dentro de um bloco (endereços, versos) e `<hr>` para uma linha divisória entre seções. `<br>` e `<hr>` são elementos vazios.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement: "O que os níveis de `<h1>` a `<h6>` representam em uma página?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "Uma hierarquia de importância entre os títulos, do mais importante (`<h1>`) ao menos importante (`<h6>`).",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Apenas seis tamanhos de letra, do maior para o menor, sem outro significado.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Seis cores diferentes de texto.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "A quantidade de parágrafos que cada seção pode ter.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Qual tag força uma quebra de linha dentro de um mesmo bloco de texto, sem iniciar um novo parágrafo?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`<br>`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`<p>`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`<hr>`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`<h1>`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "No código, você escreveu um parágrafo com vários espaços seguidos e algumas quebras de linha. Como o navegador exibe esse texto?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Ele colapsa todos os espaços e quebras em um único espaço entre as palavras, mostrando o texto em linha contínua.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Ele preserva exatamente todos os espaços e quebras de linha como estão no código.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Ele exibe uma mensagem de erro por causa dos espaços extras.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Ele apaga o parágrafo inteiro.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Por que se recomenda escolher o nível do título pela importância do trecho, e não pelo tamanho da letra que ele produz?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Porque os títulos definem a estrutura (o índice) da página, algo usado por leitores de tela e buscadores; o tamanho é papel do CSS.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Porque o `<h1>` é proibido de aparecer mais de três vezes.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Porque o navegador recusa títulos que não estejam em ordem alfabética.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Porque o tamanho da letra muda sozinho a cada visita.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            'Uma página tem um `<h1>` como título principal e, logo abaixo, o autor usou um `<h5>` para a primeira seção só porque achou o tamanho "bonito". Qual é a melhor avaliação?',
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "É um erro de hierarquia: depois do `<h1>` o esperado é um `<h2>`; pular direto para `<h5>` bagunça a estrutura da página. Para ajustar o tamanho, usa-se CSS.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Está perfeito: o nível do título deve ser escolhido sempre pelo tamanho desejado.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Está certo, desde que exista pelo menos um `<h6>` em algum lugar da página.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "É um erro porque não se pode usar `<h5>` nenhuma vez em uma página.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Listas",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "# Listas\n\nOlhe qualquer página que você usa no dia a dia e vai encontrar **listas** por toda parte: os itens de um menu, os passos de uma receita, os resultados de uma busca, os ingredientes de um produto. Sempre que a informação vem em **itens**, o HTML tem uma ferramenta certa para ela.\n\nNesta aula você vai conhecer os três tipos de lista do HTML: a **não ordenada** (com marcadores), a **ordenada** (numerada) e a **lista de definições** (termo e explicação). E vai aprender a encaixar uma lista dentro da outra.",
+                    },
+                    {
+                        type: "quote",
+                        value: "Existem três tipos de lista: a **não ordenada** `<ul>`, com marcadores (bolinhas), para itens sem ordem; a **ordenada** `<ol>`, numerada, para quando a sequência importa; e a **de definições** `<dl>`, que casa um termo (`<dt>`) com a sua descrição (`<dd>`). Em `<ul>` e `<ol>`, cada item vai sempre dentro de um `<li>`.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Lista não ordenada com `<ul>`\n\nA lista **não ordenada** serve para itens em que a **ordem não importa**: uma lista de compras, os ingredientes de uma receita, as vantagens de um produto. Tanto faz o que vem primeiro.\n\nEla é feita com duas tags que andam sempre juntas: o `<ul>` (de _unordered list_, lista não ordenada) envolve a lista inteira, e cada item dentro dela vai em um `<li>` (de _list item_, item de lista). Por padrão, o navegador desenha uma **bolinha** (marcador) na frente de cada item:",
+                    },
+                    {
+                        type: "code",
+                        value: "<ul>\n  <li>Arroz</li>\n  <li>Feijão</li>\n  <li>Café</li>\n  <li>Pão</li>\n</ul>",
+                    },
+                    {
+                        type: "text",
+                        value: "Repare no encaixe, que você viu no Módulo 1: cada `<li>` fica **dentro** do `<ul>`, e a indentação (a escadinha) deixa isso na cara. Uma regra simples: dentro de um `<ul>`, os filhos diretos são sempre `<li>`, você não joga texto solto ali. O texto vai **dentro** de cada `<li>`.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Lista ordenada com `<ol>`\n\nQuando a **ordem importa**, é hora da lista **ordenada**. Pense nos **passos de uma receita**, nas instruções de montagem de um móvel ou na classificação de um campeonato: trocar a ordem muda tudo. Para isso usamos o `<ol>` (de _ordered list_, lista ordenada).\n\nA estrutura é idêntica à da lista não ordenada, os itens continuam em `<li>`, mas agora o navegador coloca **números** (1, 2, 3...) no lugar das bolinhas, e conta sozinho para você:",
+                    },
+                    {
+                        type: "code",
+                        value: "<ol>\n  <li>Quebre os ovos em uma tigela.</li>\n  <li>Adicione a farinha e misture.</li>\n  <li>Despeje na forma untada.</li>\n  <li>Leve ao forno por 40 minutos.</li>\n</ol>",
+                    },
+                    {
+                        type: "text",
+                        value: "## Mudando a numeração: `type` e `start`\n\nA lista ordenada aceita dois atributos úteis. O `type` troca o **estilo** da numeração: em vez de números, você pode usar letras ou algarismos romanos. E o `start` diz em que número a contagem **começa**, para quando você não quer começar do 1.",
+                    },
+                    {
+                        type: "code",
+                        value: '<!-- Numeração com letras maiúsculas: A, B, C... -->\n<ol type="A">\n  <li>Introdução</li>\n  <li>Desenvolvimento</li>\n  <li>Conclusão</li>\n</ol>\n\n<!-- Começando a contagem no 5: 5, 6, 7... -->\n<ol start="5">\n  <li>Quinto colocado</li>\n  <li>Sexto colocado</li>\n</ol>',
+                    },
+                    {
+                        type: "table",
+                        value: '[["Valor de `type`","Como numera","Exemplo"],["`1`","Números (padrão)","1, 2, 3"],["`A`","Letras maiúsculas","A, B, C"],["`a`","Letras minúsculas","a, b, c"],["`I`","Romanos maiúsculos","I, II, III"],["`i`","Romanos minúsculos","i, ii, iii"]]',
+                    },
+                    {
+                        type: "text",
+                        value: "## Listas aninhadas\n\nE se um item da lista tiver, ele mesmo, uma sublista? É só colocar uma lista **dentro** de um `<li>`. Isso se chama lista **aninhada**, e é o jeito de representar subitens, como os tópicos e subtópicos de um índice.\n\nO detalhe que confunde no começo: a lista de dentro **não** fica solta entre os `<li>`, ela vai **dentro** do `<li>` a que pertence, junto com o texto daquele item. Veja:",
+                    },
+                    {
+                        type: "code",
+                        value: "<ul>\n  <li>Frutas\n    <ul>\n      <li>Maçã</li>\n      <li>Banana</li>\n    </ul>\n  </li>\n  <li>Bebidas\n    <ul>\n      <li>Água</li>\n      <li>Suco</li>\n    </ul>\n  </li>\n</ul>",
+                    },
+                    {
+                        type: "text",
+                        value: 'Repare que o `<ul>` de dentro está **entre** a abertura e o fechamento de um `<li>` da lista de fora: primeiro vem o texto ("Frutas"), depois a sublista, e só então o `</li>` fecha o item. A indentação em escadinha vira sua melhor amiga aqui, é ela que deixa claro quem está dentro de quem. E você pode misturar os tipos: nada impede um `<ol>` aninhado dentro de um `<ul>`, ou o contrário.',
+                    },
+                    {
+                        type: "text",
+                        value: '## Lista de definições com `<dl>`\n\nExiste ainda um terceiro tipo, menos famoso, mas muito útil: a **lista de definições**, feita para casar um **termo** com a sua **explicação**. É a estrutura perfeita para um **glossário**, uma lista de perguntas e respostas ou as características de um produto ("Peso: 2 kg", "Cor: azul").\n\nEla usa três tags: o `<dl>` (de _description list_) envolve tudo; o `<dt>` (de _description term_) é o **termo** que está sendo definido; e o `<dd>` (de _description details_) é a **descrição** daquele termo.',
+                    },
+                    {
+                        type: "code",
+                        value: "<dl>\n  <dt>HTML</dt>\n  <dd>Linguagem de marcação que estrutura o conteúdo de uma página.</dd>\n\n  <dt>CSS</dt>\n  <dd>Linguagem que cuida da aparência: cores, tamanhos e espaçamentos.</dd>\n\n  <dt>Navegador</dt>\n  <dd>Programa que lê o HTML e o transforma na página que você vê.</dd>\n</dl>",
+                    },
+                    {
+                        type: "text",
+                        value: 'No exemplo, cada `<dt>` (o termo, como "HTML") vem seguido do seu `<dd>` (a explicação). O navegador costuma mostrar a descrição levemente **recuada** à direita, para deixar claro que ela pertence ao termo logo acima. Um mesmo termo pode ter mais de uma descrição, e você pode ter quantos pares quiser dentro do `<dl>`.',
+                    },
+                    {
+                        type: "table",
+                        value: '[["Lista","Tags","Quando usar"],["Não ordenada","`<ul>` + `<li>`","Itens sem ordem (compras, ingredientes)"],["Ordenada","`<ol>` + `<li>`","Itens em sequência (passos, ranking)"],["De definições","`<dl>` + `<dt>` + `<dd>`","Termo e explicação (glossário, ficha)"]]',
+                    },
+                    {
+                        type: "quote",
+                        value: "**Cheat sheet:** use `<ul>` para listas com marcadores (ordem não importa) e `<ol>` para listas numeradas (a sequência importa); nos dois, cada item vai em um `<li>`. No `<ol>`, o `type` muda o estilo (`A`, `a`, `I`, `i`) e o `start` escolhe o número inicial. Para **aninhar**, coloque a sublista **dentro** de um `<li>`. E, para casar termo e explicação, use a lista de definições `<dl>` com pares de `<dt>` (termo) e `<dd>` (descrição).",
+                    },
+                ],
+                questions: [
+                    {
+                        statement: "Quais tags formam uma lista não ordenada (com marcadores)?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`<ul>` para a lista e `<li>` para cada item.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`<ol>` para a lista e `<li>` para cada item.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`<dl>` para a lista e `<dd>` para cada item.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`<list>` para a lista e `<item>` para cada item.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Em qual situação a lista ordenada `<ol>` é mais adequada que a não ordenada `<ul>`?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "Quando a ordem dos itens importa, como nos passos de uma receita.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Quando os itens não têm nenhuma ordem, como numa lista de compras.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Quando você quer casar um termo com a sua definição.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Quando a lista tem apenas um item.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            'O que faz o atributo `start` em uma lista ordenada, como em `<ol start="5">`?',
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Faz a numeração da lista começar no 5 em vez de 1.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Limita a lista a no máximo 5 itens.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Deixa a lista com 5 espaços de recuo.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Troca os números por letras a partir da quinta posição.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Como se cria uma lista aninhada (uma sublista dentro de outra lista)?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Colocando a sublista completa dentro de um `<li>` da lista de fora.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Colocando a sublista solta, entre dois `<li>` da lista de fora.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Escrevendo dois `<ul>` um ao lado do outro, sem nenhum `<li>`.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Não é possível: listas não podem ficar dentro de outras listas.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Você está montando um glossário em que cada palavra tem uma explicação. Qual estrutura é a mais indicada?",
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "Uma lista de definições `<dl>`, com o termo em `<dt>` e a explicação em `<dd>`.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Uma lista ordenada `<ol>`, com o termo e a explicação no mesmo `<li>`.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Uma sequência de `<h1>` para os termos e `<p>` para as explicações.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Uma lista não ordenada `<ul>` em que cada `<li>` contém só o termo, sem a explicação.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Ênfase e formatação de texto",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "# Ênfase e formatação de texto\n\nNem toda palavra em um texto tem o mesmo peso. Umas você quer **destacar**, outras dizer em voz mais baixa, outras marcar como uma sigla ou um trecho de código. O HTML tem um punhado de tags feitas para dar esse tempero ao texto, e o mais interessante é que muitas delas carregam um **significado**, não só uma aparência.\n\nNesta aula você vai conhecer as tags de ênfase (`<strong>` e `<em>`), entender por que elas são diferentes de `<b>` e `<i>`, e ainda ver como destacar detalhes, mostrar código e citar frases de outras pessoas.",
+                    },
+                    {
+                        type: "quote",
+                        value: "Prefira as tags com **significado**: `<strong>` marca algo **importante** (o navegador mostra em negrito) e `<em>` marca uma **ênfase** de entonação (mostra em itálico). As irmãs `<b>` e `<i>` produzem a mesma aparência, mas **sem** esse sentido, use-as só quando não houver importância nem ênfase de verdade a comunicar.",
+                    },
+                    {
+                        type: "text",
+                        value: "## `<strong>` e `<em>`: ênfase com significado\n\nAs duas tags mais usadas para destacar texto são o `<strong>` e o `<em>`. Elas são **semânticas**, ou seja, comunicam um **significado**, e não apenas um efeito visual:\n\n- `<strong>` marca um conteúdo **importante, sério ou urgente**. O navegador, por padrão, o exibe em **negrito**.\n- `<em>` (de _emphasis_, ênfase) marca uma palavra que você **enfatizaria com a voz** ao falar, mudando o sentido da frase. O navegador o exibe em **itálico**.",
+                    },
+                    {
+                        type: "code",
+                        value: "<p><strong>Atenção:</strong> não deixe seus dados com estranhos.</p>\n\n<p>Eu disse para guardar o <em>seu</em> lápis, não o meu.</p>",
+                    },
+                    {
+                        type: "text",
+                        value: 'Sinta a diferença de sentido. No primeiro exemplo, "Atenção" é uma informação **importante**, por isso o `<strong>`. No segundo, o `<em>` em "seu" muda a **entonação** da frase, é como se você falasse essa palavra mais forte para deixar claro de quem é o lápis. Por que isso importa? Porque um **leitor de tela** pode mudar a voz ao encontrar essas tags, transmitindo a ênfase a quem não enxerga a tela. A aparência é só a ponta do iceberg.',
+                    },
+                    {
+                        type: "text",
+                        value: "## E o `<b>` e o `<i>`?\n\nVocê vai esbarrar em duas tags mais antigas que produzem exatamente o mesmo visual: `<b>` deixa em **negrito** e `<i>` deixa em **itálico**. A diferença é que elas são **puramente visuais**: mudam a aparência **sem** dizer que aquilo é importante ou enfático. Para um leitor de tela, elas passam despercebidas.\n\nA regra prática é simples: se existe **importância** ou **ênfase** de verdade, use `<strong>` ou `<em>`. Reserve `<b>` e `<i>` para casos em que você só quer o efeito visual por convenção, sem nenhum peso extra, como um nome científico em itálico.",
+                    },
+                    {
+                        type: "code",
+                        value: "<!-- Semântico: comunica importância e ênfase -->\n<p><strong>Cuidado:</strong> o piso está <em>muito</em> molhado.</p>\n\n<!-- Só visual: itálico por convenção, sem peso extra -->\n<p>O <i>Panthera onca</i> é a maior onça das Américas.</p>",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Tag","Significado","Aparência padrão","Quando usar"],["`<strong>`","Conteúdo importante","Negrito","Avisos, alertas, o que não pode passar batido"],["`<b>`","Nenhum (só visual)","Negrito","Destaque por estilo, sem importância real"],["`<em>`","Ênfase de entonação","Itálico","Palavra que mudaria o sentido se dita mais forte"],["`<i>`","Nenhum (só visual)","Itálico","Nomes científicos e termos estrangeiros, por convenção"]]',
+                    },
+                    {
+                        type: "text",
+                        value: '## Destaques e detalhes: `<mark>`, `<small>`, `<sup>`, `<sub>`, `<abbr>`\n\nAlém da ênfase, o HTML traz várias tags menores para situações específicas. Vale conhecer as principais:\n\n- `<mark>` **realça** o texto, como se você tivesse passado um marca-texto amarelo por cima.\n- `<small>` marca um texto **secundário**, de letra miúda, como um aviso legal ou um rodapé.\n- `<sup>` joga o texto para **cima** (sobrescrito), útil em expoentes e ordinais, como o "2" de "m²".\n- `<sub>` joga o texto para **baixo** (subscrito), útil em fórmulas químicas, como o "2" de "H₂O".\n- `<abbr>` marca uma **abreviação ou sigla**; com o atributo `title`, mostra o significado quando o mouse para em cima.',
+                    },
+                    {
+                        type: "code",
+                        value: '<p>Esta oferta é <mark>válida só até domingo</mark>.</p>\n\n<p>Preço: R$ 99,90 <small>(frete não incluído)</small></p>\n\n<p>A área do terreno é de 50 m<sup>2</sup>.</p>\n\n<p>A fórmula da água é H<sub>2</sub>O.</p>\n\n<p>A <abbr title="Organização Mundial da Saúde">OMS</abbr> publicou o relatório.</p>',
+                    },
+                    {
+                        type: "text",
+                        value: 'Repare no `<abbr>`: o texto que aparece é a sigla "OMS", mas o atributo `title` guarda o nome por extenso. Quando o visitante para o mouse sobre a sigla, o navegador mostra uma **caixinha** com "Organização Mundial da Saúde". É um jeito elegante de explicar uma abreviação sem poluir o texto.',
+                    },
+                    {
+                        type: "text",
+                        value: '## Mostrando código: `<code>` e `<pre>`\n\nSe a sua página fala sobre programação (como esta trilha!), você vai querer **mostrar código** de um jeito que não se confunda com o texto normal. Duas tags cuidam disso:\n\n- `<code>` marca um trecho de código **dentro de uma frase**, geralmente exibido numa fonte monoespaçada (de largura fixa). É o que dá aquele visual de "código" nas palavras.\n- `<pre>` (de _preformatted_, pré-formatado) preserva os **espaços e as quebras de linha** exatamente como você escreveu. Lembra que o HTML colapsa os espaços? Dentro do `<pre>`, ele **não** colapsa, tudo é respeitado.',
+                    },
+                    {
+                        type: "code",
+                        value: '<p>Para criar um parágrafo, use a tag <code>&lt;p&gt;</code>.</p>\n\n<pre>\nfunction ola() {\n  console.log("Olá!");\n}\n</pre>',
+                    },
+                    {
+                        type: "text",
+                        value: 'Uma dupla poderosa é usar `<code>` **dentro** de um `<pre>` para blocos de código maiores: o `<pre>` guarda a indentação e as quebras, e o `<code>` diz "isto é código". No exemplo apareceu também `&lt;` e `&gt;`: são os jeitos de escrever os sinais `<` e `>` como **texto visível** na página. Sem esse truque, o navegador acharia que `<p>` é uma tag de verdade e não mostraria nada. Guarde essa ideia, ela ganha um capítulo próprio mais para a frente.',
+                    },
+                    {
+                        type: "text",
+                        value: "## Citações: `<blockquote>` e `<q>`\n\nQuando você reproduz as palavras de **outra pessoa ou fonte**, o HTML tem duas tags específicas, uma para citações longas e outra para curtas:\n\n- `<blockquote>` é para uma **citação longa**, um bloco à parte. O navegador costuma exibi-la **recuada**, destacada do resto do texto.\n- `<q>` (de _quote_, citação) é para uma **citação curta**, embutida no meio de uma frase. O navegador adiciona as **aspas** automaticamente para você.",
+                    },
+                    {
+                        type: "code",
+                        value: "<blockquote>\n  O conhecimento é a única coisa que ninguém pode tirar de você.\n</blockquote>\n\n<p>Como diz o ditado, <q>quem não arrisca não petisca</q>.</p>",
+                    },
+                    {
+                        type: "text",
+                        value: 'No `<q>`, você **não** digita as aspas: o navegador as coloca sozinho, e ainda usa o estilo de aspas do idioma da página. Já o `<blockquote>` é ideal para aquele destaque de "frase de efeito" que você vê em artigos e apresentações. As duas tags dizem ao navegador (e aos buscadores) que aquele trecho é uma **citação**, não uma frase sua.',
+                    },
+                    {
+                        type: "quote",
+                        value: '**Cheat sheet:** para dar peso ao texto **com significado**, use `<strong>` (importante, sai em negrito) e `<em>` (ênfase, sai em itálico); `<b>` e `<i>` dão o mesmo visual, mas **sem** semântica. Para detalhes: `<mark>` (realce), `<small>` (letra miúda), `<sup>`/`<sub>` (sobrescrito/subscrito) e `<abbr title="...">` (siglas). Para código, `<code>` no meio da frase e `<pre>` para preservar espaços e quebras. Para citações, `<blockquote>` (longa) e `<q>` (curta, com aspas automáticas).',
+                    },
+                ],
+                questions: [
+                    {
+                        statement:
+                            "Qual tag marca um trecho como importante e, por padrão, o exibe em negrito?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`<strong>`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`<small>`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`<q>`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`<sub>`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Para realçar um texto como se você passasse um marca-texto por cima, qual tag você usa?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`<mark>`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`<abbr>`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`<pre>`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`<em>`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "Qual é a principal diferença entre usar `<em>` e usar `<i>`?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "`<em>` carrega o significado de ênfase (podendo ser lido de forma diferente por leitores de tela), enquanto `<i>` só muda a aparência para itálico, sem esse sentido.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Não há diferença: as duas são idênticas em significado e aparência.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`<em>` deixa o texto em negrito e `<i>` deixa em itálico.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`<em>` só funciona dentro de listas, e `<i>` só dentro de títulos.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "O que acontece quando você usa a tag `<q>` para uma citação curta, como em `<q>bom dia</q>`?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "O navegador adiciona as aspas automaticamente ao redor do texto.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "O texto é exibido recuado em um bloco separado, bem afastado do parágrafo.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O texto some da página, pois `<q>` é um elemento vazio.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O navegador exige que você digite as aspas manualmente, senão dá erro.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            'Você está escrevendo a fórmula da água e precisa que o "2" de "H2O" apareça pequeno e abaixo da linha, como subscrito. Qual tag usar?',
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "`<sub>`, que rebaixa o texto: `H<sub>2</sub>O`.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`<sup>`, que eleva o texto acima da linha.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`<small>`, que apenas diminui o tamanho da letra sem rebaixá-la.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`<mark>`, que realça o número com fundo colorido.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Links e âncoras",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "# Links e âncoras\n\nChegamos à tag que **inventou a web**. O que torna a internet uma teia, e não um monte de páginas soltas, é a capacidade de **clicar** em algo e ir para outro lugar. Esse pulo de uma página para outra é o **link**, e ele é tão central que a própria sigla HTML carrega a palavra _hypertext_ (hipertexto): texto com links.\n\nNesta aula você vai aprender a criar links para outros sites, para outras páginas do seu próprio site e até para uma seção específica da mesma página. E ainda vai ver como fazer um link abrir o programa de e-mail ou o discador do celular.",
+                    },
+                    {
+                        type: "quote",
+                        value: 'O link é feito com a tag `<a>` (de _anchor_, âncora) e o atributo `href`, que aponta o **destino**: `<a href="https://ensina.dev">Visite a ensina.dev</a>`. O texto entre as tags é a parte clicável. Sem o `href`, o `<a>` não leva a lugar nenhum.',
+                    },
+                    {
+                        type: "text",
+                        value: "## O elemento `<a>` e o atributo `href`\n\nTodo link nasce da tag `<a>`, de _anchor_ (âncora). Sozinha, porém, ela não faz nada: quem diz **para onde** o link leva é o atributo `href` (de _hypertext reference_, referência de hipertexto). O texto que você escreve **entre** a abertura e o fechamento da tag é a parte **clicável**, aquela que costuma aparecer sublinhada e colorida.",
+                    },
+                    {
+                        type: "code",
+                        value: '<a href="https://ensina.dev">Visite a ensina.dev</a>\n\n<p>Aprenda a programar na <a href="https://ensina.dev">ensina.dev</a> de graça.</p>',
+                    },
+                    {
+                        type: "text",
+                        value: 'No segundo exemplo, veja como o link vive **dentro** de um parágrafo, misturado ao texto normal: só as palavras "ensina.dev" ficam clicáveis. Escolha sempre um texto de link que **descreva o destino** ("veja nossos preços") e fuja do clássico "clique aqui", que não diz nada a quem usa leitor de tela e navega pulando de link em link.',
+                    },
+                    {
+                        type: "text",
+                        value: '## Link absoluto vs relativo\n\nO valor do `href` pode ser um endereço de dois tipos, e entender a diferença evita muita dor de cabeça:\n\n- Um link **absoluto** traz o **endereço completo**, começando por `https://`. É o que você usa para apontar para **outro site**, um endereço que vale de qualquer lugar do mundo, como o de uma casa com CEP, cidade e estado.\n- Um link **relativo** traz só o **caminho até outro arquivo do seu próprio site**, sem o `https://`. É como dizer "a segunda porta à direita": só faz sentido a partir de onde você já está.',
+                    },
+                    {
+                        type: "code",
+                        value: '<!-- Absoluto: aponta para outro site (endereço completo) -->\n<a href="https://pt.wikipedia.org">Ir para a Wikipédia</a>\n\n<!-- Relativo: aponta para outra página do seu próprio site -->\n<a href="contato.html">Fale conosco</a>\n<a href="paginas/sobre.html">Sobre nós</a>',
+                    },
+                    {
+                        type: "table",
+                        value: '[["Tipo","Como se parece","Para que serve"],["Absoluto","`https://site.com/pagina`","Apontar para outro site (endereço completo)"],["Relativo","`contato.html`","Apontar para outra página do próprio site"]]',
+                    },
+                    {
+                        type: "text",
+                        value: '## Abrindo em nova aba: `target="_blank"` e `rel="noopener"`\n\nPor padrão, o link abre no **lugar** da página atual, o visitante sai da sua página. Às vezes você prefere que ele abra em uma **nova aba**, mantendo a sua página aberta atrás, comum quando o link vai para um site externo. Para isso existe o atributo `target` com o valor `_blank`.\n\nQuando fizer isso, acrescente também `rel="noopener"`. É uma medida de **segurança**: sem ela, a página que abre na nova aba ganha uma brechinha para interferir na sua. Não precisa entender os detalhes agora, só guarde a dupla como um par que anda junto.',
+                    },
+                    {
+                        type: "code",
+                        value: '<a href="https://pt.wikipedia.org" target="_blank" rel="noopener">\n  Abrir a Wikipédia em uma nova aba\n</a>',
+                    },
+                    {
+                        type: "text",
+                        value: 'Uma dica de bom senso: abrir em nova aba nem sempre é o certo. Muita gente prefere decidir isso sozinha (dá para fazer com o clique do meio do mouse). O costume é reservar o `target="_blank"` para links que levam para **fora do seu site**, ou para casos em que tirar o visitante da página atrapalharia, como um formulário sendo preenchido.',
+                    },
+                    {
+                        type: "text",
+                        value: '## Âncoras: pular para uma seção da página\n\nO `<a>` também consegue levar o visitante para um **ponto específico da mesma página**, sem recarregar nada. É assim que funcionam aqueles menus de "índice" no topo de um artigo longo, que te jogam direto para a seção escolhida.\n\nO truque tem duas partes. Primeiro, você dá um **nome** ao destino usando o atributo `id` no elemento de chegada (um `id` é uma etiqueta única, um nome que não se repete na página). Depois, cria um link cujo `href` é uma **cerquilha** `#` seguida desse mesmo nome:',
+                    },
+                    {
+                        type: "code",
+                        value: '<!-- Menu no topo: o link aponta para um id com # -->\n<a href="#contato">Ir para a seção de contato</a>\n\n<!-- Lá embaixo na página, a seção de destino tem o id correspondente -->\n<h2 id="contato">Contato</h2>\n<p>Fale com a gente pelo e-mail abaixo.</p>',
+                    },
+                    {
+                        type: "text",
+                        value: 'Repare no par: o link usa `href="#contato"` (com `#`) e a seção de destino tem `id="contato"` (sem `#`). É o `#` no `href` que avisa "este é um pulo dentro da própria página". Um caso especial útil: o link `<a href="#top">` (ou `href="#"`) costuma levar de volta ao **topo** da página, ótimo para um botão "voltar ao início" no fim de um texto longo.',
+                    },
+                    {
+                        type: "text",
+                        value: "## Links para e-mail e telefone: `mailto:` e `tel:`\n\nPor fim, dois tipos especiais de link muito úteis em uma página de contato. Em vez de um endereço `https://`, o `href` pode começar com `mailto:` para **abrir o programa de e-mail** já com o destinatário preenchido, ou com `tel:` para, no celular, **iniciar uma ligação**.",
+                    },
+                    {
+                        type: "code",
+                        value: '<a href="mailto:contato@ensina.dev">Envie um e-mail</a>\n\n<a href="tel:+5511999998888">Ligue para nós</a>',
+                    },
+                    {
+                        type: "text",
+                        value: 'Ao clicar no primeiro, o navegador abre o aplicativo de e-mail do visitante com o campo "para" já preenchido. No segundo, num celular, aparece a opção de discar aquele número na hora. Repare que o `tel:` costuma vir com o número no formato internacional (o `+55` é o código do Brasil), assim o link funciona para quem liga de qualquer lugar.',
+                    },
+                    {
+                        type: "quote",
+                        value: '**Cheat sheet:** o link é `<a href="destino">texto clicável</a>`. O destino pode ser **absoluto** (`https://...`, outro site) ou **relativo** (`contato.html`, seu próprio site). Para abrir em nova aba, use `target="_blank"` junto de `rel="noopener"`. Para pular a uma seção da mesma página, dê um `id` ao destino e aponte com `href="#id"`. E o `href` ainda aceita `mailto:` (abre o e-mail) e `tel:` (inicia uma ligação no celular).',
+                    },
+                ],
+                questions: [
+                    {
+                        statement:
+                            "Qual atributo da tag `<a>` define o endereço de destino do link?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`href`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`src`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`alt`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`link`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "O que faz um link cujo `href` começa com `mailto:`, como `mailto:contato@ensina.dev`?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "Abre o programa de e-mail do visitante já com o destinatário preenchido.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Envia o e-mail automaticamente, sem abrir nada.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Leva para a página de login do Gmail.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Inicia uma ligação telefônica.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "Qual a diferença entre um link absoluto e um link relativo?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "O absoluto traz o endereço completo (com `https://`) para outro site; o relativo traz só o caminho até outro arquivo do próprio site.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "O absoluto é sempre mais rápido; o relativo é sempre mais lento.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O absoluto só funciona em imagens; o relativo só em textos.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Não há diferença real: os dois apontam sempre para o mesmo lugar.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Para que um link abra em uma nova aba do navegador, qual atributo você adiciona à tag `<a>`?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: '`target="_blank"` (de preferência acompanhado de `rel="noopener"`).',
+                                isCorrect: true,
+                            },
+                            {
+                                text: '`href="_blank"`',
+                                isCorrect: false,
+                            },
+                            {
+                                text: '`new="tab"`',
+                                isCorrect: false,
+                            },
+                            {
+                                text: '`open="nova"`',
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            'Você quer que um link no topo do artigo pule direto para uma seção de "Contato" mais abaixo na mesma página. Como fazer?',
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: 'Dar `id="contato"` ao elemento da seção e criar o link com `href="#contato"`.',
+                                isCorrect: true,
+                            },
+                            {
+                                text: 'Dar `href="contato"` à seção e criar o link com `id="#contato"`.',
+                                isCorrect: false,
+                            },
+                            {
+                                text: 'Usar `target="_blank"` no link, que sozinho já rola a página até a seção.',
+                                isCorrect: false,
+                            },
+                            {
+                                text: 'Criar um link com `href="https://contato"`, pois âncoras precisam do endereço completo.',
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        titulo: "Módulo 3 - Imagens, mídia e tabelas",
+        aulas: [
+            {
+                titulo: "Imagens",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "# Imagens\n\nAté agora as suas páginas eram só texto. A partir de hoje elas ganham cor e vida: você vai aprender a colocar **imagens**, um dos elementos que mais deixam um site interessante.\n\nA boa notícia é que exibir uma imagem em HTML é bem simples, são poucas letras. A parte que exige um pouco mais de atenção, e onde muita gente escorrega, é fazer isso do jeito **certo**: com a imagem certa, no formato certo e com uma descrição que todo mundo consiga entender. É esse pacote completo que vamos ver aqui, com calma.",
+                    },
+                    {
+                        type: "quote",
+                        value: "A imagem entra na página com a tag `<img>`, um elemento **vazio** (sem tag de fechamento). Ela precisa de dois atributos essenciais: o `src`, que diz **qual** arquivo mostrar, e o `alt`, que **descreve a imagem em palavras**. O `alt` não é opcional nem enfeite: é ele que garante que a imagem funcione até para quem não consegue vê-la.",
+                    },
+                    {
+                        type: "text",
+                        value: "## A tag <img>\n\nPara colocar uma imagem, usamos a tag `<img>` (de _image_, imagem). Lembra dos **elementos vazios** que você viu no Módulo 1, como o `<br>`? O `<img>` é um deles: ele não envolve nenhum texto, então **não tem tag de fechamento**. Não existe `</img>`.\n\nSozinha, a tag `<img>` não serve para nada, afinal ela não sabe qual imagem mostrar. Quem responde a essa pergunta é o atributo `src` (de _source_, fonte): ele aponta para o **arquivo** da imagem.",
+                    },
+                    {
+                        type: "code",
+                        value: '<img src="gato.jpg" alt="Um gato laranja dormindo em uma almofada">',
+                    },
+                    {
+                        type: "text",
+                        value: '## O caminho da imagem: src\n\nO valor do `src` é o **caminho** até o arquivo da imagem, o endereço que diz ao navegador onde encontrá-la. Existem dois tipos de caminho, e entender a diferença evita muita imagem quebrada.\n\n- **Caminho relativo**: aponta para um arquivo que está **junto com a sua página**, no seu próprio projeto. É como dar uma direção a partir de onde você está: "a foto está aqui na mesma pasta" ou "a foto está na pasta imagens".\n- **Caminho absoluto**: é o endereço **completo** de uma imagem que está em outro lugar da internet, começando com `https://`. É como dar o endereço postal inteiro, com rua, cidade e CEP.',
+                    },
+                    {
+                        type: "code",
+                        value: '<!-- Relativo: a imagem está na MESMA pasta que a página -->\n<img src="perfil.jpg" alt="Foto de perfil">\n\n<!-- Relativo: a imagem está dentro de uma subpasta chamada imagens -->\n<img src="imagens/perfil.jpg" alt="Foto de perfil">\n\n<!-- Absoluto: a imagem está em outro site, na internet -->\n<img src="https://www.ensina.dev/logo.png" alt="Logo da ensina.dev">',
+                    },
+                    {
+                        type: "text",
+                        value: "## Quando usar cada caminho\n\nNa maior parte do tempo você vai usar **caminhos relativos**, porque as imagens do seu site normalmente ficam guardadas junto com ele, na mesma pasta ou numa subpasta organizada (algo como `imagens/` ou `img/`). Isso mantém tudo junto: se você mover o projeto para outro computador, os caminhos continuam funcionando.\n\nO **caminho absoluto** entra quando a imagem vive em **outro servidor**, por exemplo um logo hospedado em outro site. O cuidado aqui é que, se aquele site sair do ar ou mudar o arquivo de lugar, a sua imagem quebra, porque ela não é sua, você só está apontando para ela.",
+                    },
+                    {
+                        type: "text",
+                        value: '## O alt: a descrição que não pode faltar\n\nVocê já teve um gostinho do `alt` no Módulo 1, mas ele é tão importante que merece um capítulo só dele. O `alt` (de _alternative text_, texto alternativo) é uma **descrição da imagem em palavras**. Ele trabalha em silêncio na maior parte do tempo, mas é essencial em duas situações.\n\n- **Acessibilidade**: pessoas cegas ou com baixa visão navegam com **leitores de tela**, programas que leem a página em voz alta. O leitor não enxerga a foto, então ele lê o `alt`. Sem `alt`, a pessoa só ouve "imagem", sem saber do que se trata.\n- **Fallback (reserva)**: se a imagem não carregar (o arquivo sumiu, o caminho está errado, a internet falhou), o navegador mostra o texto do `alt` no lugar do quadradinho quebrado. Assim o visitante ao menos sabe o que deveria estar ali.',
+                    },
+                    {
+                        type: "code",
+                        value: '<!-- Bom: descreve o conteúdo da imagem de forma útil -->\n<img src="praia.jpg" alt="Pôr do sol alaranjado sobre o mar em uma praia deserta">\n\n<!-- Ruim: não descreve nada, não ajuda ninguém -->\n<img src="praia.jpg" alt="imagem">\n\n<!-- Péssimo: sem alt, o leitor de tela fica mudo e não há fallback -->\n<img src="praia.jpg">',
+                    },
+                    {
+                        type: "text",
+                        value: '## Como escrever um bom alt\n\nUm bom `alt` descreve **o que a imagem mostra e o que ela comunica**, de forma curta e objetiva. Pense assim: se a imagem sumisse, que frase você colocaria no lugar para não perder a informação?\n\nUm detalhe fino: quando a imagem é **puramente decorativa** (um enfeite que não acrescenta informação, como uma linha ondulada de separação), o recomendado é usar um `alt` **vazio**, escrito como `alt=""`. Isso avisa o leitor de tela para **pular** a imagem, em vez de anunciar um nome de arquivo sem sentido. Repare que "sem `alt`" e "`alt` vazio" são coisas diferentes: o `alt` vazio é uma escolha consciente de dizer "aqui não há nada importante para descrever".',
+                    },
+                    {
+                        type: "text",
+                        value: '## Tamanho: width e height\n\nPor padrão, a imagem aparece no seu tamanho original. Você pode definir a largura e a altura com os atributos `width` (largura) e `height` (altura), medidos em **pixels** (os pontinhos que formam a tela).\n\nAlém de controlar o tamanho, informar `width` e `height` tem um benefício menos óbvio: o navegador já **reserva o espaço** da imagem antes mesmo de ela carregar. Sem isso, o texto da página "pula" quando a imagem finalmente aparece e empurra tudo para baixo, aquele efeito irritante de a página dançar enquanto carrega.',
+                    },
+                    {
+                        type: "code",
+                        value: '<!-- Imagem com 300 pixels de largura e 200 de altura -->\n<img src="cachorro.jpg" alt="Cachorro caramelo correndo no gramado" width="300" height="200">\n\n<!-- Informando só a largura: a altura se ajusta sozinha para não distorcer -->\n<img src="cachorro.jpg" alt="Cachorro caramelo correndo no gramado" width="300">',
+                    },
+                    {
+                        type: "text",
+                        value: "## Formatos de imagem: qual usar\n\nNem toda imagem é igual. O trecho final do nome do arquivo (`.jpg`, `.png` e por aí vai) indica o **formato**, e cada formato é bom para um tipo de imagem. Escolher o formato certo deixa a página mais leve e rápida. Os quatro mais comuns na web são:\n\n- **JPG** (ou JPEG): ótimo para **fotografias** e imagens com muitas cores. Comprime bem e fica leve, mas não guarda áreas transparentes.\n- **PNG**: bom para imagens com **áreas transparentes** ou com bordas bem definidas, como logos e ícones. Costuma gerar arquivos maiores que o JPG.\n- **SVG**: formato de **desenho vetorial**, perfeito para logos, ícones e ilustrações. Como é feito de formas matemáticas (e não de pontinhos), ele **não perde qualidade** por mais que você amplie.\n- **WebP**: um formato **moderno** que costuma gerar arquivos menores que JPG e PNG com qualidade parecida, e ainda aceita transparência. É uma ótima escolha para a web de hoje.",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Formato","Melhor para","Transparência?","Observação"],["JPG","Fotografias, imagens com muitas cores","Não","Arquivo leve, mas perde um pouco de qualidade ao comprimir"],["PNG","Logos, ícones, prints com texto","Sim","Nitidez perfeita, mas arquivo mais pesado"],["SVG","Logos, ícones, ilustrações","Sim","Vetorial: amplia sem perder qualidade nenhuma"],["WebP","Uso geral moderno na web","Sim","Costuma ser o mais leve; ótimo padrão hoje em dia"]]',
+                    },
+                    {
+                        type: "text",
+                        value: '## figure e figcaption: imagem com legenda\n\nÀs vezes uma imagem precisa de uma **legenda**, aquele textinho explicativo que costuma aparecer embaixo de fotos em jornais e revistas. Para isso o HTML tem uma dupla feita sob medida: `<figure>` e `<figcaption>`.\n\n- `<figure>` (figura) é uma **caixa** que agrupa a imagem e a sua legenda, deixando claro que as duas formam uma unidade.\n- `<figcaption>` (de _figure caption_, legenda da figura) é a **legenda** em si, escrita dentro da `<figure>`.\n\nUsar essa dupla não muda muito a aparência, mas dá **significado**: você está dizendo ao navegador e aos leitores de tela "esta imagem e este texto andam juntos".',
+                    },
+                    {
+                        type: "code",
+                        value: '<figure>\n  <img src="ponte.jpg" alt="Ponte estaiada iluminada à noite sobre o rio">\n  <figcaption>A ponte da cidade, fotografada durante o pôr do sol.</figcaption>\n</figure>',
+                    },
+                    {
+                        type: "quote",
+                        value: "**Cheat sheet:** a imagem entra com `<img>`, um elemento **vazio** (sem fechamento), sempre com `src` (o caminho do arquivo) e `alt` (a descrição em texto, para acessibilidade e fallback). Caminhos podem ser **relativos** (arquivo junto do projeto) ou **absolutos** (`https://...`, em outro servidor). `width` e `height` definem o tamanho e reservam espaço. Escolha o **formato** pela imagem: **JPG** para fotos, **PNG/SVG** para logos e ícones, **WebP** para um padrão leve e moderno. E use `<figure>` com `<figcaption>` quando a imagem tiver legenda.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement: "Para que serve o atributo `src` na tag `<img>`?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "Indica o caminho do arquivo de imagem que deve ser exibido.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Descreve a imagem em palavras para os leitores de tela.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Define a largura da imagem em pixels.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Cria uma legenda embaixo da imagem.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "Qual afirmação sobre a tag `<img>` está correta?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "É um elemento vazio: não tem conteúdo nem tag de fechamento (não existe `</img>`).",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "É preciso sempre fechá-la com `</img>` no fim.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Ela só funciona dentro de uma tag `<figure>`.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Ela precisa de um `<source>` para exibir qualquer imagem.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "Por que o atributo `alt` é importante em uma imagem?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Leitores de tela leem o `alt` em voz alta para quem não enxerga, e ele aparece como texto de reserva caso a imagem não carregue.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Ele faz a imagem carregar mais rápido.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Ele define em qual pasta o arquivo da imagem está guardado.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Ele centraliza a imagem no meio da página.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Você precisa exibir o logo da empresa, que deve ficar nítido tanto pequeno no menu quanto grande na tela de abertura, sem perder qualidade. Qual formato é o mais indicado?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "SVG, porque é vetorial e não perde qualidade ao ser ampliado.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "JPG, porque é o melhor formato para qualquer imagem.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Um arquivo `.txt`, porque logos são feitos de texto.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Não importa o formato; todos mantêm a qualidade em qualquer tamanho.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            'Qual é a diferença entre uma imagem **sem** o atributo `alt` e uma com `alt=""` (vazio)?',
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "O `alt` vazio é uma escolha consciente que avisa o leitor de tela para pular uma imagem decorativa; sem `alt`, a imagem fica sem descrição alguma e pode confundir quem usa leitor de tela.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Não há diferença nenhuma; as duas formas fazem exatamente a mesma coisa.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O `alt` vazio faz a imagem desaparecer da página; sem `alt`, ela aparece normalmente.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O `alt` vazio aumenta a imagem; sem `alt`, ela fica no tamanho original.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Áudio e vídeo",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "# Áudio e vídeo\n\nDepois das imagens, é hora de colocar as suas páginas para **tocar e reproduzir**: vídeos e áudios direto no HTML. Antigamente isso dependia de programas extras instalados no navegador (você talvez já tenha ouvido falar do antigo Flash). Hoje o HTML faz tudo **sozinho**, com tags nativas, e é muito mais simples do que parece.\n\nNesta aula você vai aprender a colocar um vídeo com botões de play e pause, tocar um áudio, oferecer o arquivo em vários formatos e, no fim, incorporar um vídeo do YouTube na sua página.",
+                    },
+                    {
+                        type: "quote",
+                        value: "O HTML reproduz vídeo com a tag `<video>` e som com a tag `<audio>`. As duas quase sempre vêm com o atributo `controls`, que mostra os botões de play, pause e volume. Para não deixar ninguém de fora, você pode oferecer o mesmo arquivo em vários formatos usando tags `<source>` dentro delas.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Vídeo com a tag <video>\n\nA tag `<video>` coloca um player de vídeo na página. Diferente do `<img>`, ela **não é** um elemento vazio: ela abre e fecha, e no meio pode receber outras coisas.\n\nSozinha, ela mostraria só um quadro parado, sem nenhum botão. Por isso quase sempre adicionamos o atributo `controls`, que faz o navegador desenhar os **controles** do player: o play/pause, a barra de progresso, o volume e a tela cheia. Repare que `controls` é um atributo diferente: ele não tem `=` nem valor. Ou você o escreve (e o recurso liga), ou não escreve. Esses são os **atributos booleanos**, que funcionam como um interruptor de liga/desliga.",
+                    },
+                    {
+                        type: "code",
+                        value: '<video src="ceu.mp4" controls width="640"></video>',
+                    },
+                    {
+                        type: "text",
+                        value: "## Ajustando o vídeo: width e poster\n\nAssim como nas imagens, o atributo `width` define a **largura** do player em pixels (e a altura se ajusta sozinha para não distorcer).\n\nOutro atributo muito útil é o `poster`: ele define uma **imagem de capa**, aquele quadro bonito que aparece **antes** de a pessoa apertar o play. Sem `poster`, o navegador costuma mostrar o primeiro quadro do vídeo, que nem sempre é o mais convidativo. É como a capa de um DVD: um convite para dar play.",
+                    },
+                    {
+                        type: "code",
+                        value: '<video src="viagem.mp4" controls width="640" poster="capa-viagem.jpg"></video>',
+                    },
+                    {
+                        type: "text",
+                        value: "## Áudio com a tag <audio>\n\nPara tocar som (uma música, um podcast, um efeito sonoro), a lógica é a mesma, só muda a tag: usamos `<audio>`. E, de novo, o atributo `controls` é quem mostra os botões de play, pause e volume. Sem ele o player fica invisível, e o visitante não tem como tocar o som.",
+                    },
+                    {
+                        type: "code",
+                        value: '<audio src="podcast-episodio-1.mp3" controls></audio>',
+                    },
+                    {
+                        type: "text",
+                        value: "## Vários formatos com <source>\n\nExiste um detalhe chato do mundo real: nem todo navegador entende todos os **formatos** de vídeo e áudio. Um navegador pode tocar `.mp4` mas engasgar em outro formato, e vice-versa.\n\nA solução elegante é oferecer o mesmo conteúdo em **mais de um formato** e deixar o navegador escolher qual ele consegue tocar. Para isso, em vez de usar o atributo `src` na tag, colocamos várias tags `<source>` **dentro** do `<video>` (ou do `<audio>`). O navegador lê de cima para baixo e usa a **primeira** que ele souber reproduzir. O atributo `type` ajuda dando a dica de qual formato é cada arquivo.\n\nDe quebra, o texto que você escreve entre `<video>` e `</video>` vira uma **mensagem de reserva**: ele só aparece para o visitante cujo navegador seja tão antigo que não entenda a tag `<video>` de jeito nenhum.",
+                    },
+                    {
+                        type: "code",
+                        value: '<video controls width="640" poster="capa.jpg">\n  <source src="video.webm" type="video/webm">\n  <source src="video.mp4" type="video/mp4">\n  Seu navegador não consegue reproduzir este vídeo.\n</video>',
+                    },
+                    {
+                        type: "text",
+                        value: "## Os atributos loop, muted e autoplay\n\nO `<video>` e o `<audio>` têm outros **atributos booleanos** (aqueles de liga/desliga) que ajustam o comportamento da reprodução:\n\n- `loop`: quando o vídeo ou áudio termina, ele **recomeça** sozinho, num looping infinito.\n- `muted`: começa **sem som** (no mudo). A pessoa pode ligar o volume nos controles.\n- `autoplay`: tenta **tocar sozinho** assim que a página carrega, sem esperar o clique.\n\nUm aviso importante sobre o `autoplay`: como vídeo tocando som do nada é irritante, os navegadores **bloqueiam** o autoplay com som. Por isso, na prática, `autoplay` só funciona quando você também usa `muted`. A dupla `autoplay muted` é o segredo daqueles vídeos de fundo que rodam calados no topo de muitos sites.",
+                    },
+                    {
+                        type: "code",
+                        value: '<!-- Vídeo de fundo: toca sozinho, no mudo e em looping -->\n<video src="fundo.mp4" autoplay muted loop width="640"></video>',
+                    },
+                    {
+                        type: "table",
+                        value: '[["Atributo","O que faz","Precisa de valor?"],["`controls`","Mostra os botões de play, pause e volume","Não (booleano)"],["`width`","Define a largura do player em pixels","Sim"],["`poster`","Imagem de capa exibida antes do play (só no vídeo)","Sim"],["`loop`","Recomeça automaticamente ao terminar","Não (booleano)"],["`muted`","Começa sem som, no mudo","Não (booleano)"],["`autoplay`","Tenta tocar sozinho ao carregar (precisa de muted)","Não (booleano)"]]',
+                    },
+                    {
+                        type: "text",
+                        value: "## Incorporar um vídeo do YouTube\n\nE se o vídeo já está no **YouTube**? Aí você não usa a tag `<video>`, porque o arquivo não é seu, ele mora nos servidores do YouTube. Nesse caso, o certo é **incorporar** (em inglês, _embed_) o player do próprio YouTube dentro da sua página, usando a tag `<iframe>`.\n\nPense no `<iframe>` (de _inline frame_, moldura embutida) como uma **janelinha** que exibe outra página inteira dentro da sua. É uma moldura que mostra o player do YouTube por dentro. Você nem precisa escrever esse código na mão: no próprio YouTube, em **Compartilhar > Incorporar**, o site te entrega o `<iframe>` pronto para copiar e colar.",
+                    },
+                    {
+                        type: "code",
+                        value: '<iframe\n  width="560"\n  height="315"\n  src="https://www.youtube.com/embed/ID_DO_VIDEO"\n  title="Player de vídeo do YouTube"\n  allowfullscreen>\n</iframe>',
+                    },
+                    {
+                        type: "quote",
+                        value: "**Cheat sheet:** vídeo vai na tag `<video>` e som na tag `<audio>`, quase sempre com `controls` para mostrar o player. `width` ajusta o tamanho e `poster` põe uma capa no vídeo. Ofereça vários formatos com tags `<source>` (o navegador usa a primeira que entender). `loop`, `muted` e `autoplay` são **booleanos** (sem valor), e o `autoplay` só funciona junto de `muted`. Para vídeos do YouTube, não use `<video>`: incorpore com um `<iframe>` copiado do próprio YouTube.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement:
+                            "Para que serve o atributo `controls` em um `<video>` ou `<audio>`?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "Exibe os botões de play, pause, volume e a barra de progresso do player.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Define a largura do player em pixels.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Faz o vídeo tocar sozinho quando a página carrega.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Coloca uma imagem de capa antes do play.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Qual tag é usada para tocar um arquivo de som, como uma música ou um podcast?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`<audio>`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`<video>`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`<img>`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`<sound>`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Por que às vezes colocamos várias tags `<source>` dentro de um `<video>`?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Porque nem todo navegador entende os mesmos formatos; assim o navegador usa a primeira `<source>` que ele consegue reproduzir.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Para o vídeo tocar em várias telas ao mesmo tempo.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Porque cada `<source>` mostra uma parte diferente do mesmo vídeo, em sequência.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Para aumentar o volume do áudio do vídeo.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Por que, na prática, o atributo `autoplay` costuma vir acompanhado de `muted`?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Porque os navegadores bloqueiam vídeos que tocam com som sozinhos; com `muted`, o autoplay passa a funcionar.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Porque `muted` faz o vídeo carregar mais rápido.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Porque sem `muted` o vídeo fica em preto e branco.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Porque `autoplay` só existe dentro da tag `<audio>`.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Você quer exibir na sua página um vídeo que já está publicado no YouTube. Qual é a forma correta?",
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "Incorporar o player do YouTube com uma tag `<iframe>`, já que o arquivo do vídeo fica nos servidores do YouTube.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Baixar o vídeo e colocá-lo em uma tag `<img>`.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: 'Usar `<video src="...">` apontando direto para a página do YouTube.',
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Não é possível colocar vídeos do YouTube em uma página HTML.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Tabelas: o básico",
+                blocks: [
+                    {
+                        type: "text",
+                        value: '# Tabelas: o básico\n\nSabe aquela planilha de horários, a lista de preços de um plano ou o placar de um campeonato? Tudo isso são **dados organizados em linhas e colunas**, e o HTML tem um conjunto de tags feito exatamente para isso: as **tabelas**.\n\nMontar uma tabela envolve algumas tags novas trabalhando juntas e, no começo, pode parecer um quebra-cabeça. Mas existe uma lógica simples por trás, e depois que você pega o jeito de "linha por linha, célula por célula", vira algo natural. Vamos com calma.',
+                    },
+                    {
+                        type: "quote",
+                        value: "Uma tabela existe para mostrar **dados tabulares**: informações que fazem sentido em **linhas e colunas**, como uma planilha. Ela é construída de fora para dentro com `<table>` (a tabela toda), `<tr>` (cada linha) e, dentro das linhas, as células `<td>` (dados) e `<th>` (cabeçalhos). Tabela é para **dados**, nunca para montar o layout da página.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Quando usar uma tabela (e quando não)\n\nAntes de sair montando tabelas, a regra mais importante: use tabela **só para dados tabulares**, ou seja, informações que se organizam naturalmente em linhas e colunas e que você compararia numa planilha. Alguns bons exemplos:\n\n- uma tabela de preços (produto x valor);\n- um horário de aulas (dia da semana x horário);\n- uma classificação de campeonato (time x pontos).\n\nO que você **não** deve fazer é usar tabela para **posicionar coisas na tela**, tipo criar colunas de layout ou encaixar um menu ao lado do conteúdo. Isso era comum há muitos anos, mas hoje é considerado errado, e a gente vai entender direitinho o porquê na próxima aula. Por ora, guarde a frase: **tabela é para dados, não para layout**.",
+                    },
+                    {
+                        type: "text",
+                        value: '## As três tags fundamentais: table, tr e td\n\nToda tabela nasce da combinação de três tags, encaixadas uma dentro da outra:\n\n- `<table>`: a caixa que envolve a **tabela inteira**.\n- `<tr>` (de _table row_, linha da tabela): representa **uma linha** horizontal. Uma tabela tem vários `<tr>`, um embaixo do outro.\n- `<td>` (de _table data_, dado da tabela): representa **uma célula** de conteúdo, uma "casinha" da tabela. Os `<td>` ficam dentro dos `<tr>`.\n\nA lógica de montagem é sempre a mesma: a tabela é feita de **linhas** (`<tr>`), e cada linha é feita de **células** (`<td>`). Você constrói de cima para baixo, uma linha por vez, e dentro de cada linha vai preenchendo as células da esquerda para a direita.',
+                    },
+                    {
+                        type: "code",
+                        value: "<table>\n  <tr>\n    <td>Arroz</td>\n    <td>R$ 5,00</td>\n  </tr>\n  <tr>\n    <td>Feijão</td>\n    <td>R$ 8,00</td>\n  </tr>\n</table>",
+                    },
+                    {
+                        type: "text",
+                        value: "## Lendo a tabela acima\n\nEsse código cria uma tabela de **duas linhas** e **duas colunas**. Repare no encaixe, que a indentação deixa bem visível:\n\n- Cada `<tr>` é uma **linha** (temos duas: a do arroz e a do feijão).\n- Dentro de cada `<tr>`, cada `<td>` é uma **célula** (temos duas por linha: o produto e o preço).\n\nAs colunas não são declaradas em lugar nenhum: elas **surgem naturalmente** do alinhamento das células. Como toda linha tem duas células, o navegador entende que existem duas colunas e alinha tudo. Simples assim: você cuida das linhas e das células, e as colunas se formam sozinhas.",
+                    },
+                    {
+                        type: "text",
+                        value: '## Cabeçalhos com <th>\n\nNa tabela anterior faltou algo: um **cabeçalho** dizendo o que é cada coluna. Para isso existe a tag `<th>` (de _table header_, cabeçalho da tabela). Ela é uma célula igual ao `<td>`, mas com um papel especial: marca aquele conteúdo como um **título** de coluna ou de linha.\n\nO `<th>` tem duas vantagens sobre o `<td>`. Visualmente, o navegador já o exibe em **negrito e centralizado** por padrão, destacando-o. E, mais importante, ele diz aos leitores de tela "isto aqui é um cabeçalho", o que ajuda quem não enxerga a entender a que coluna cada dado pertence.',
+                    },
+                    {
+                        type: "code",
+                        value: "<table>\n  <tr>\n    <th>Produto</th>\n    <th>Preço</th>\n  </tr>\n  <tr>\n    <td>Arroz</td>\n    <td>R$ 5,00</td>\n  </tr>\n  <tr>\n    <td>Feijão</td>\n    <td>R$ 8,00</td>\n  </tr>\n</table>",
+                    },
+                    {
+                        type: "text",
+                        value: "## Organizando em thead, tbody e tfoot\n\nQuando a tabela cresce, ajuda separar o **cabeçalho** do **corpo** de dados. O HTML oferece três seções para isso, todas colocadas dentro do `<table>`:\n\n- `<thead>` (de _table head_): agrupa a(s) linha(s) de **cabeçalho**, lá no topo.\n- `<tbody>` (de _table body_): agrupa as linhas de **conteúdo**, o miolo da tabela.\n- `<tfoot>` (de _table foot_): agrupa uma linha de **rodapé**, ótima para totais e somas.\n\nNão é obrigatório usar as três, mas elas deixam o código mais **organizado e legível** e dão significado à tabela. Dá até para imaginar como um relatório: tem o topo (thead), o meio (tbody) e a conclusão com o total (tfoot).",
+                    },
+                    {
+                        type: "code",
+                        value: "<table>\n  <thead>\n    <tr>\n      <th>Produto</th>\n      <th>Preço</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <td>Arroz</td>\n      <td>R$ 5,00</td>\n    </tr>\n    <tr>\n      <td>Feijão</td>\n      <td>R$ 8,00</td>\n    </tr>\n  </tbody>\n  <tfoot>\n    <tr>\n      <td>Total</td>\n      <td>R$ 13,00</td>\n    </tr>\n  </tfoot>\n</table>",
+                    },
+                    {
+                        type: "text",
+                        value: "## Um título para a tabela: caption\n\nPor fim, uma tabela costuma ganhar um **título** que explica do que ela trata. Em vez de jogar um `<h2>` solto por cima, o HTML tem a tag certa para isso: `<caption>` (legenda). Ela é a **primeira coisa** dentro do `<table>` e funciona como o nome oficial da tabela.\n\nA vantagem de usar `<caption>` em vez de um título qualquer é que ele fica **grudado** na tabela: os leitores de tela anunciam a legenda antes de ler os dados, então quem não enxerga já sabe do que aquela tabela trata antes de mergulhar nos números.",
+                    },
+                    {
+                        type: "code",
+                        value: "<table>\n  <caption>Preços da feira desta semana</caption>\n  <thead>\n    <tr>\n      <th>Produto</th>\n      <th>Preço</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <td>Arroz</td>\n      <td>R$ 5,00</td>\n    </tr>\n  </tbody>\n</table>",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Tag","O que representa","Onde fica"],["`<table>`","A tabela inteira","Envolve tudo"],["`<caption>`","O título da tabela","Primeira coisa dentro de `<table>`"],["`<tr>`","Uma linha","Dentro de `<table>`, `<thead>`, `<tbody>` ou `<tfoot>`"],["`<th>`","Uma célula de cabeçalho","Dentro de um `<tr>`"],["`<td>`","Uma célula de dados","Dentro de um `<tr>`"],["`<thead>` / `<tbody>` / `<tfoot>`","Seções de topo, corpo e rodapé","Dentro de `<table>`"]]',
+                    },
+                    {
+                        type: "quote",
+                        value: "**Cheat sheet:** tabela é para **dados tabulares** (linhas e colunas), nunca para layout. Monte de fora para dentro: `<table>` envolve tudo, cada `<tr>` é uma **linha** e, dentro dela, `<td>` são células de dados e `<th>` são células de **cabeçalho** (negrito e anunciadas aos leitores de tela). As colunas surgem sozinhas do alinhamento das células. Use `<thead>`, `<tbody>` e `<tfoot>` para separar topo, corpo e rodapé, e `<caption>` como título oficial da tabela.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement: "Em uma tabela HTML, o que a tag `<tr>` representa?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "Uma linha da tabela.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Uma coluna da tabela.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Uma célula de cabeçalho.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O título da tabela.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Qual tag cria uma célula de **cabeçalho**, exibida em negrito e anunciada como título pelos leitores de tela?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`<th>`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`<td>`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`<tr>`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`<caption>`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "Qual é o uso correto de uma tabela em HTML?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Mostrar dados tabulares, que se organizam naturalmente em linhas e colunas, como uma tabela de preços.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Posicionar o menu ao lado do conteúdo, montando o layout da página.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Deixar qualquer texto da página centralizado.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Substituir os parágrafos `<p>` em textos longos.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "Para que serve a tag `<caption>` dentro de uma tabela?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Dá um título à tabela, que fica associado a ela e é anunciado pelos leitores de tela antes dos dados.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Cria a linha de rodapé com o total.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Define a cor de fundo da tabela.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Transforma uma célula comum em cabeçalho.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Qual é o papel das seções `<thead>`, `<tbody>` e `<tfoot>` em uma tabela?",
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "Agrupam, respectivamente, as linhas de cabeçalho, de conteúdo e de rodapé, deixando a tabela mais organizada e com mais significado.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "São três formas diferentes de criar uma única célula.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Definem as cores do topo, do meio e do rodapé da página.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Substituem as tags `<tr>` e `<td>`, que ficam desnecessárias.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Tabelas: combinando células",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "# Tabelas: combinando células\n\nVocê já sabe montar tabelas com linhas e células. Agora vamos aprender um truque que resolve muitos casos do mundo real: **juntar células**. Sabe quando uma tabela tem um título que se estende por cima de várias colunas, ou uma célula que ocupa duas linhas de uma vez? É disso que se trata.\n\nAlém de juntar células, vamos amarrar de vez a acessibilidade das tabelas com o atributo `scope` e fechar o módulo entendendo, com calma, por que ninguém deve usar tabela para montar o layout de uma página.",
+                    },
+                    {
+                        type: "quote",
+                        value: "Duas ferramentas esticam uma célula para ocupar o lugar de outras: `colspan`, que **funde células na horizontal** (a célula avança por várias colunas), e `rowspan`, que **funde na vertical** (a célula desce por várias linhas). O atributo `scope`, nos cabeçalhos `<th>`, diz se aquele cabeçalho manda na **coluna** ou na **linha**, o que ajuda os leitores de tela.",
+                    },
+                    {
+                        type: "text",
+                        value: '## colspan: juntar colunas\n\nO atributo `colspan` (de _column span_, algo como "abrangência de colunas") faz uma célula se **esticar na horizontal**, ocupando o espaço de várias colunas de uma vez. Você escreve `colspan="2"` para a célula valer por duas colunas, `colspan="3"` por três, e assim por diante.\n\nO uso clássico é um **título que cobre a tabela inteira** ou um subtítulo que agrupa colunas. Um detalhe que confunde no começo: quando uma célula ocupa duas colunas, aquela linha precisa de **uma célula a menos**, porque uma só já fez o trabalho de duas.',
+                    },
+                    {
+                        type: "code",
+                        value: '<table>\n  <tr>\n    <th colspan="2">Contato</th>\n  </tr>\n  <tr>\n    <td>E-mail</td>\n    <td>ana@exemplo.com</td>\n  </tr>\n  <tr>\n    <td>Telefone</td>\n    <td>(11) 90000-0000</td>\n  </tr>\n</table>',
+                    },
+                    {
+                        type: "text",
+                        value: '## Lendo o colspan\n\nNa tabela acima, a primeira linha tem **uma única célula**, o `<th colspan="2">Contato</th>`. Como ela usa `colspan="2"`, esse cabeçalho se estica e cobre as **duas colunas** de baixo, virando um título geral para o bloco de contato.\n\nAs outras linhas seguem normais, com duas células cada. Repare no equilíbrio: a linha do título tem uma célula (que vale por duas) e as demais têm duas células (que valem por uma cada). No fim, todas as linhas ocupam a mesma largura de duas colunas.',
+                    },
+                    {
+                        type: "text",
+                        value: '## rowspan: juntar linhas\n\nO primo do `colspan` é o `rowspan` (de _row span_, "abrangência de linhas"). Ele faz o contrário: estica a célula na **vertical**, fazendo-a descer e ocupar várias linhas de uma vez. Você escreve `rowspan="2"` para a célula valer por duas linhas, e assim por diante.\n\nO uso típico é **agrupar linhas que compartilham um mesmo valor**. Por exemplo, dois horários que acontecem no mesmo dia: em vez de repetir "Segunda" duas vezes, uma célula com `rowspan="2"` cobre as duas linhas. O pulo do gato: a célula esticada é escrita **só na primeira** das linhas que ela abrange; as linhas seguintes já não repetem aquela célula, porque o espaço dela já está ocupado.',
+                    },
+                    {
+                        type: "code",
+                        value: '<table>\n  <tr>\n    <th>Dia</th>\n    <th>Horário</th>\n    <th>Matéria</th>\n  </tr>\n  <tr>\n    <td rowspan="2">Segunda</td>\n    <td>08:00</td>\n    <td>Matemática</td>\n  </tr>\n  <tr>\n    <td>10:00</td>\n    <td>História</td>\n  </tr>\n</table>',
+                    },
+                    {
+                        type: "text",
+                        value: '## Lendo o rowspan\n\nRepare na célula `<td rowspan="2">Segunda</td>`: ela desce e ocupa **duas linhas**, agrupando os dois horários daquele dia. Por isso a segunda linha da grade (a das 10:00) tem **só duas células**, e não três: a coluna do "Dia" já está preenchida pela célula "Segunda", que veio da linha de cima.\n\nEsse é o detalhe que mais confunde quem está começando: ao usar `rowspan`, as linhas seguintes ficam com menos células, porque parte do espaço delas já foi ocupada pela célula esticada de cima. Se você contar as células e achar que "está faltando uma", provavelmente é um `rowspan` fazendo o seu trabalho.',
+                    },
+                    {
+                        type: "text",
+                        value: '## Cabeçalhos com scope\n\nNa aula passada você viu que o `<th>` marca uma célula como cabeçalho. Dá para ir além e dizer **de quem** aquele cabeçalho é o título, se de uma **coluna** ou de uma **linha**, com o atributo `scope`:\n\n- `scope="col"`: o `<th>` é o cabeçalho de uma **coluna** inteira (o caso mais comum, no topo).\n- `scope="row"`: o `<th>` é o cabeçalho de uma **linha** (fica na lateral esquerda).\n\nVisualmente o `scope` não muda quase nada, e é justamente por isso que muita gente esquece dele. Mas ele é ouro para a **acessibilidade**: com o `scope`, o leitor de tela consegue dizer algo como "Nota da Ana: 9,5", ligando cada dado ao seu cabeçalho, em vez de só cuspir números soltos. Em tabelas com cabeçalhos na lateral, ele faz toda a diferença.',
+                    },
+                    {
+                        type: "code",
+                        value: '<table>\n  <caption>Notas do bimestre</caption>\n  <tr>\n    <th scope="col">Aluno</th>\n    <th scope="col">Nota</th>\n  </tr>\n  <tr>\n    <th scope="row">Ana</th>\n    <td>9,5</td>\n  </tr>\n  <tr>\n    <th scope="row">Bruno</th>\n    <td>8,0</td>\n  </tr>\n</table>',
+                    },
+                    {
+                        type: "table",
+                        value: '[["Ferramenta","O que faz"],["`colspan`","Estica a célula na horizontal, ocupando várias colunas (ótimo para um título que cobre a tabela)"],["`rowspan`","Estica a célula na vertical, ocupando várias linhas (ótimo para agrupar linhas com um valor em comum)"],["`scope` com `col`","No `<th>`, marca o cabeçalho de uma coluna (fica no topo)"],["`scope` com `row`","No `<th>`, marca o cabeçalho de uma linha (fica na lateral)"]]',
+                    },
+                    {
+                        type: "text",
+                        value: '## Por que NÃO usar tabela para layout\n\nAgora a promessa que ficou pendente. Lá no início das tabelas, ficou o aviso: tabela é para dados, não para layout. Mas por quê?\n\nAntigamente, sem as ferramentas modernas de estilo, era comum montar a página inteira dentro de uma `<table>` gigante: uma célula para o menu, outra para o conteúdo, outra para o rodapé. Funcionava visualmente, mas trazia vários problemas que hoje sabemos evitar:\n\n- **Acessibilidade quebrada**: leitores de tela leem tabelas como dados. Uma página montada em tabela vira uma sopa de "linha 1, coluna 2..." que confunde totalmente quem usa esses programas.\n- **Rigidez no celular**: uma tabela de layout não se adapta bem a telas pequenas, e o site fica difícil de usar no telefone.\n- **Código embolado**: o significado se perde. Ninguém consegue dizer o que é conteúdo de verdade e o que é só "encaixe" visual.\n\nPara **posicionar** as coisas na tela (colunas, menus laterais, grades), a ferramenta certa é o **CSS**, que você vai estudar depois. O HTML cuida do **significado** (isto é um menu, isto é um artigo); o CSS cuida da **posição**. Cada tecnologia no seu quadrado, como você viu no Módulo 1.',
+                    },
+                    {
+                        type: "code",
+                        value: "<!-- Evite: usar tabela só para posicionar o menu ao lado do conteúdo -->\n<table>\n  <tr>\n    <td>Menu do site</td>\n    <td>Conteúdo do artigo</td>\n  </tr>\n</table>\n\n<!-- Melhor: marcar o significado com as tags certas (a posição fica para o CSS) -->\n<nav>Menu do site</nav>\n<article>Conteúdo do artigo</article>",
+                    },
+                    {
+                        type: "quote",
+                        value: '**Cheat sheet:** `colspan="N"` funde células na **horizontal** (a linha fica com menos células) e `rowspan="N"` funde na **vertical** (as linhas de baixo ficam com menos células). Nos cabeçalhos, `scope="col"` e `scope="row"` dizem se o `<th>` manda na coluna ou na linha, um presente para a acessibilidade. E a regra de ouro do módulo: **tabela é para dados tabulares, nunca para layout**, quem posiciona as coisas na página é o CSS.',
+                    },
+                ],
+                questions: [
+                    {
+                        statement: 'O que o atributo `colspan="2"` faz com uma célula de tabela?',
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "Faz a célula se esticar na horizontal, ocupando o espaço de duas colunas.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Faz a célula se esticar na vertical, ocupando duas linhas.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Cria duas tabelas lado a lado.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Pinta a célula com duas cores diferentes.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: 'O que o atributo `rowspan="2"` faz com uma célula de tabela?',
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "Faz a célula se esticar na vertical, ocupando o espaço de duas linhas.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Faz a célula se esticar na horizontal, ocupando duas colunas.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Repete o conteúdo da célula duas vezes.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Divide a linha em duas tabelas.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "Para que serve o atributo `scope` em um `<th>`?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: 'Indica se o cabeçalho é de uma coluna (`scope="col"`) ou de uma linha (`scope="row"`), ajudando os leitores de tela a associar cada dado ao seu cabeçalho.',
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Define quantas colunas a célula vai ocupar.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Muda a cor de fundo do cabeçalho.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Transforma o `<th>` em um `<td>` comum.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Por que não se deve usar uma tabela para montar o layout (a posição das coisas) de uma página?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Porque tabelas são para dados; usá-las como layout quebra a acessibilidade, atrapalha no celular e embola o significado do código. Para posicionar, usa-se o CSS.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Porque tabelas deixam a página colorida demais.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Porque a tag `<table>` foi removida do HTML moderno.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Porque tabelas só funcionam em telas de computador, nunca no navegador.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            'Numa grade de horários, você quer que a célula "Segunda" cubra duas linhas seguidas (dois horários do mesmo dia), sem repetir a palavra. Qual atributo usar, e o que muda na linha de baixo?',
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: 'Usar `rowspan="2"` na célula "Segunda"; a linha de baixo passa a ter uma célula a menos, porque o espaço dela já foi ocupado pela célula esticada de cima.',
+                                isCorrect: true,
+                            },
+                            {
+                                text: 'Usar `colspan="2"` na célula "Segunda"; a linha de baixo ganha uma célula a mais.',
+                                isCorrect: false,
+                            },
+                            {
+                                text: 'Usar `rowspan="2"`, mas ainda assim é preciso repetir a palavra "Segunda" na linha de baixo.',
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Não é possível fazer isso; toda linha precisa ter sempre o mesmo número de células escritas.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        titulo: "Módulo 4 - Formulários",
+        aulas: [
+            {
+                titulo: "Anatomia de um formulário",
+                blocks: [
+                    {
+                        type: "text",
+                        value: '# Anatomia de um formulário\n\nAté agora você aprendeu a **mostrar** conteúdo: títulos, textos, listas, imagens e links. Neste módulo a página deixa de ser uma via de mão única e passa a **conversar** com o visitante. É aqui que entram os **formulários**: caixas de busca, telas de login, campos de cadastro, o "deixe seu comentário". Sempre que um site pede alguma informação para você, tem um formulário por trás.\n\nNesta primeira aula vamos montar o esqueleto de um formulário e entender o papel de cada peça, com calma e do zero.',
+                    },
+                    {
+                        type: "quote",
+                        value: "Um **formulário** é um trecho da página, envolvido pela tag `<form>`, que reúne **campos** para o visitante preencher e um botão para **enviar**. Cada campo costuma ser uma dupla: um `<label>` (o rótulo, que diz o que preencher) e um `<input>` (a caixinha onde se digita). O atributo `action` diz **para onde** os dados vão e o `method` diz **como** eles viajam.",
+                    },
+                    {
+                        type: "text",
+                        value: '## Pense em uma ficha de papel\n\nAntes do computador, para se inscrever em um curso você preenchia uma **ficha de papel**: nome, e-mail, telefone, cada informação numa linha com um rótulo do lado ("Nome: ____"). No fim, você entregava a ficha na secretaria.\n\nUm formulário HTML é exatamente essa ficha, só que na tela:\n\n- A **ficha inteira** é a tag `<form>`.\n- Cada **linha para preencher** é um campo (um `<input>`, por exemplo).\n- O **rótulo** ao lado de cada linha é o `<label>`.\n- **Entregar a ficha na secretaria** é apertar o botão de enviar, que manda os dados para um endereço.\n\nGuarde essa imagem: ela explica quase tudo o que vem a seguir.',
+                    },
+                    {
+                        type: "text",
+                        value: "## O formulário mais simples possível\n\nVamos começar pelo menor formulário que faz sentido: um campo para o nome e um botão para enviar. Não se preocupe com cada detalhe ainda, só observe o formato geral:",
+                    },
+                    {
+                        type: "code",
+                        value: '<form>\n  <label for="nome">Nome:</label>\n  <input id="nome" name="nome" type="text">\n  <button>Enviar</button>\n</form>',
+                    },
+                    {
+                        type: "text",
+                        value: 'Três peças aparecem aí:\n\n- `<form>`: a **ficha inteira**, que envolve tudo. Abre no começo e fecha com `</form>` no fim.\n- A dupla `<label>` + `<input>`: o **rótulo** "Nome:" e a **caixinha** onde se digita.\n- `<button>`: o **botão** que envia a ficha preenchida.\n\nNas próximas seções a gente abre cada uma dessas peças. Comecemos pela mais externa, o `<form>`.',
+                    },
+                    {
+                        type: "text",
+                        value: '## A tag `<form>` e dois atributos importantes\n\nA tag `<form>` sozinha só diz "aqui começa um formulário". Para ela saber o que fazer quando o visitante clicar em enviar, usamos dois atributos:\n\n- `action`: o **endereço** para onde os dados serão enviados (normalmente uma página no servidor que vai recebê-los).\n- `method`: **como** os dados serão enviados. Os dois valores possíveis são `get` e `post`.\n\nVeja os dois juntos:',
+                    },
+                    {
+                        type: "code",
+                        value: '<form action="/cadastro" method="post">\n  <label for="email">E-mail:</label>\n  <input id="email" name="email" type="email">\n  <button>Cadastrar</button>\n</form>',
+                    },
+                    {
+                        type: "text",
+                        value: 'Lendo em português: "quando este formulário for enviado, mande os dados para o endereço `/cadastro`, usando o método `post`". Se você **não** escrever o `action`, o formulário envia para a **própria página** onde ele está. E se não escrever o `method`, o navegador assume `get`.',
+                    },
+                    {
+                        type: "text",
+                        value: '## GET e POST sem complicação\n\nEsses dois métodos são só **duas formas de entregar a ficha**. A diferença prática é onde os dados vão parar:\n\n- Com `method="get"`, os dados viajam **na própria barra de endereço**, coladinhos no fim da URL, depois de um `?`. É como escrever o recado num **cartão-postal**: chega, mas qualquer um que olhar consegue ler. Por isso o GET é ótimo para **buscas** (o que você digita vira parte do link e pode até ser salvo nos favoritos).\n- Com `method="post"`, os dados viajam **escondidos** no corpo do pedido, fora da URL. É como mandar o recado num **envelope lacrado**. É o método certo para **cadastros, logins e senhas**, coisas que não devem ficar à mostra na URL.\n\nUma pista para lembrar: se enviar o formulário **muda alguma coisa** no servidor (cria uma conta, publica um comentário), use `post`. Se só **pede uma informação** sem alterar nada (uma busca), o `get` serve bem.',
+                    },
+                    {
+                        type: "table",
+                        value: '[["","Método `get`","Método `post`"],["Onde os dados vão","Na URL, depois do `?`","Escondidos no corpo do pedido"],["Aparece na barra de endereço?","Sim","Não"],["Analogia","Cartão-postal (à mostra)","Envelope lacrado"],["Bom para","Buscas e filtros","Cadastros, logins, senhas"],["Salva nos favoritos?","Sim","Não"]]',
+                    },
+                    {
+                        type: "text",
+                        value: '## O par `<label>` + `<input>`: por que o rótulo importa\n\nVocê pode até jogar um `<input>` sozinho na página, mas quase sempre ele anda de mãos dadas com um `<label>`. O `<label>` é o **rótulo** do campo, o textinho "Nome:", "E-mail:", "Senha:" que diz ao visitante o que ele deve preencher ali.\n\nPara amarrar um rótulo ao seu campo, usamos dois atributos que se conversam:\n\n- No `<label>`, o atributo `for` (de _for_, "para") aponta para o campo.\n- No `<input>`, o atributo `id` dá um **nome único** àquele campo dentro da página.\n\nO truque é: o valor do `for` tem que ser **igual** ao valor do `id`. É assim que o navegador sabe que aquele rótulo pertence àquele campo.',
+                    },
+                    {
+                        type: "code",
+                        value: '<!-- O for do label é igual ao id do input: eles ficam conectados -->\n<label for="email">E-mail:</label>\n<input id="email" name="email" type="email">',
+                    },
+                    {
+                        type: "text",
+                        value: 'Amarrar o rótulo ao campo traz vantagens concretas:\n\n- **Clicar no rótulo** posiciona o cursor no campo (experimente: clicar na palavra "E-mail:" já joga o foco para a caixinha). Isso aumenta a área clicável, o que ajuda bastante no celular.\n- **Acessibilidade**: leitores de tela leem o rótulo junto com o campo, então uma pessoa cega sabe que aquela caixa é para o e-mail. Sem `<label>`, o campo é um vazio sem explicação.\n\nExiste ainda uma forma alternativa: colocar o `<input>` **dentro** do `<label>`. Aí nem precisa de `for`/`id`, a conexão é automática pelo aninhamento:',
+                    },
+                    {
+                        type: "code",
+                        value: '<!-- Alternativa: o input fica dentro do label, dispensando for e id -->\n<label>\n  E-mail:\n  <input name="email" type="email">\n</label>',
+                    },
+                    {
+                        type: "text",
+                        value: '## O atributo `name`: a etiqueta que vai para o servidor\n\nRepare que os campos vêm com um atributo `name`. Ele é **essencial**: o `name` é o **nome sob o qual o valor digitado é enviado**. Sem `name`, o campo até aparece na tela, mas seu conteúdo **não é enviado** quando o formulário é submetido, como uma linha da ficha que ninguém lê.\n\nPense no par nome/valor como uma etiqueta: se o campo tem `name="email"` e o visitante digita `ana@teste.com`, o que chega ao servidor é o par `email = ana@teste.com`. Num formulário com vários campos, cada um manda o seu par.',
+                    },
+                    {
+                        type: "text",
+                        value: '## Organizando campos com `<fieldset>` e `<legend>`\n\nQuando um formulário cresce, ajuda **agrupar** os campos que têm a ver uns com os outros, tipo separar "Dados pessoais" de "Endereço". Para isso existem duas tags:\n\n- `<fieldset>`: uma **cerca** que agrupa campos relacionados. O navegador costuma desenhar uma bordinha em volta do grupo.\n- `<legend>`: o **título** desse grupo, que aparece encaixado na borda do `<fieldset>`.\n\nVeja um formulário dividido em dois blocos:',
+                    },
+                    {
+                        type: "code",
+                        value: '<form action="/inscricao" method="post">\n  <fieldset>\n    <legend>Dados pessoais</legend>\n    <label for="nome">Nome:</label>\n    <input id="nome" name="nome" type="text">\n    <label for="nasc">Nascimento:</label>\n    <input id="nasc" name="nascimento" type="date">\n  </fieldset>\n\n  <fieldset>\n    <legend>Contato</legend>\n    <label for="email">E-mail:</label>\n    <input id="email" name="email" type="email">\n  </fieldset>\n\n  <button>Enviar inscrição</button>\n</form>',
+                    },
+                    {
+                        type: "text",
+                        value: 'Além de deixar o formulário mais organizado visualmente, o `<fieldset>` com `<legend>` ajuda **muito** na acessibilidade: o leitor de tela anuncia a legenda ao entrar no grupo, então a pessoa entende que os próximos campos são "do bloco Contato", por exemplo. É um caprichinho que faz diferença.',
+                    },
+                    {
+                        type: "quote",
+                        value: "**Cheat sheet:** um formulário vive dentro de `<form>`, que leva `action` (para onde enviar) e `method` (`get`, dados na URL, tipo cartão-postal; ou `post`, dados escondidos, tipo envelope lacrado). Cada campo é uma dupla `<label>` + `<input>`, conectados pelo `for` do label igual ao `id` do input, o que melhora o clique e a acessibilidade. O atributo `name` é o nome com que o valor viaja até o servidor, sem ele o campo não é enviado. Use `<fieldset>` e `<legend>` para agrupar e rotular seções de campos.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement:
+                            "Qual tag envolve todo o formulário, agrupando os campos e o botão de envio?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`<form>`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`<label>`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`<input>`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`<fieldset>`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "Para que serve o atributo `action` na tag `<form>`?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "Indica o endereço para onde os dados do formulário serão enviados.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Define a cor de fundo do formulário.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Cria o rótulo de cada campo.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Impede que o formulário seja enviado.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            'Qual é a diferença central entre `method="get"` e `method="post"`?',
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "No `get`, os dados vão na URL (visíveis); no `post`, vão escondidos no corpo do pedido, melhor para dados sensíveis como senhas.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "No `get` os dados são enviados e no `post` não são.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O `get` só funciona em celulares e o `post` só em computadores.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Não há diferença; os dois são a mesma coisa escrita de formas diferentes.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            'No par rótulo + campo, como o `<label for="...">` fica conectado ao `<input>`?',
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "O valor do `for` do label deve ser igual ao valor do `id` do input.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "O valor do `for` deve ser igual ao `name` do input.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O label precisa vir sempre depois do input, na mesma linha.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Basta que os dois estejam dentro do mesmo `<form>`.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            'Um `<input type="text">` aparece na tela e o visitante digita seu nome, mas ao enviar o formulário esse dado não chega ao servidor. Qual é a causa mais provável?',
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "O `<input>` está sem o atributo `name`, e campos sem `name` não são enviados.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Faltou fechar a tag `<input>` com `</input>`.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: 'O formulário usa `method="post"` em vez de `get`.',
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O `<label>` do campo está com o `for` errado.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Tipos de input",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "# Tipos de input\n\nNa aula passada você conheceu o `<input>`, a caixinha onde o visitante digita. O que talvez surpreenda é que **existe basicamente uma tag `<input>` só**, e ela se transforma em coisas bem diferentes conforme um único atributo: o `type`.\n\nUm `<input>` pode ser um campo de texto, uma caixa de senha, um seletor de data, uma caixa de marcar, um botão de escolha... Tudo depende do `type`. Nesta aula vamos passear pelos tipos mais úteis, um a um, com exemplos de verdade.",
+                    },
+                    {
+                        type: "quote",
+                        value: "O `<input>` é um **camaleão**: o atributo `type` decide o que ele vira. Tipos como `text`, `email`, `password`, `number`, `tel`, `url` e `date` produzem campos de digitação com pequenos superpoderes. Já `checkbox` (caixa de marcar) e `radio` (escolha única) servem para **escolher** opções, `file` para **enviar arquivos** e `hidden` para carregar um dado **invisível** junto do formulário.",
+                    },
+                    {
+                        type: "text",
+                        value: '## Um input, muitos tipos\n\nPense no `<input>` como um **canivete suíço**: é uma ferramenta só, mas você abre a lâmina que precisa. A "lâmina" aqui é o atributo `type`. Se você escrever `type="text"`, tem um campo de texto comum; se trocar para `type="date"`, o mesmo `<input>` vira um seletor de data com calendário.\n\nSe você **esquecer** o `type`, o navegador assume `type="text"`. Mas escolher o tipo certo vale muito a pena: além de mudar a aparência, muitos tipos **ajudam quem preenche** (mostram um teclado mais adequado no celular, oferecem um calendário) e **conferem** o que foi digitado (veremos isso na aula de validação).',
+                    },
+                    {
+                        type: "text",
+                        value: '## Os tipos que são "caixas de texto"\n\nVários tipos se parecem com um campo de texto, mas cada um tem um detalhe a mais. Veja os quatro mais comuns:',
+                    },
+                    {
+                        type: "code",
+                        value: '<label for="nome">Nome:</label>\n<input id="nome" name="nome" type="text">\n\n<label for="email">E-mail:</label>\n<input id="email" name="email" type="email">\n\n<label for="senha">Senha:</label>\n<input id="senha" name="senha" type="password">\n\n<label for="idade">Idade:</label>\n<input id="idade" name="idade" type="number">',
+                    },
+                    {
+                        type: "text",
+                        value: 'O que muda de um para o outro:\n\n- `type="text"`: texto livre, o tipo mais genérico. Serve para nome, apelido, cidade.\n- `type="email"`: espera um endereço de e-mail. No celular, o teclado já aparece com o `@` à mão, e o navegador confere se tem cara de e-mail.\n- `type="password"`: esconde o que é digitado, mostrando bolinhas ou asteriscos no lugar das letras. Ótimo para senhas (mas lembre: esconder na tela não é o mesmo que enviar com segurança, isso é papel do `method="post"` e do servidor).\n- `type="number"`: aceita **apenas números** e costuma vir com setinhas para aumentar e diminuir o valor.',
+                    },
+                    {
+                        type: "text",
+                        value: "## Mais três tipos úteis: `tel`, `url` e `date`\n\nAlém desses, três tipos aparecem bastante em cadastros:",
+                    },
+                    {
+                        type: "code",
+                        value: '<label for="tel">Telefone:</label>\n<input id="tel" name="telefone" type="tel">\n\n<label for="site">Site:</label>\n<input id="site" name="site" type="url">\n\n<label for="nasc">Data de nascimento:</label>\n<input id="nasc" name="nascimento" type="date">',
+                    },
+                    {
+                        type: "text",
+                        value: '- `type="tel"`: para telefones. No celular, faz aparecer o **teclado numérico**. Ele não exige um formato fixo (telefones variam muito de país para país), mas já melhora a digitação.\n- `type="url"`: para endereços de sites. O navegador confere se o que foi digitado tem jeito de link (começando com `http://` ou `https://`).\n- `type="date"`: para datas. Aqui o ganho é grande: o navegador mostra um **calendário** para o visitante escolher o dia, em vez de ele digitar a data na mão e errar o formato.',
+                    },
+                    {
+                        type: "table",
+                        value: '[["`type`","Serve para","Superpoder"],["`text`","Texto livre (nome, cidade)","Nenhum, é o campo genérico"],["`email`","Endereço de e-mail","Teclado com `@` e conferência do formato"],["`password`","Senhas","Esconde os caracteres na tela"],["`number`","Quantidades, idade","Só aceita números, com setinhas"],["`tel`","Telefone","Abre o teclado numérico no celular"],["`url`","Endereço de site","Confere se parece um link"],["`date`","Datas","Mostra um calendário para escolher"]]',
+                    },
+                    {
+                        type: "text",
+                        value: '## Caixas de marcar: `type="checkbox"`\n\nNem tudo é digitar. Às vezes o visitante só precisa **marcar** algo. A **checkbox** (caixa de marcar) é um quadradinho que fica ligado ou desligado, perfeito para um "sim/não" ("aceito os termos") ou para deixar a pessoa escolher **vários** itens de uma lista.',
+                    },
+                    {
+                        type: "code",
+                        value: '<!-- Uma sozinha, para um sim/não -->\n<label>\n  <input type="checkbox" name="termos" value="aceito">\n  Li e aceito os termos de uso\n</label>\n\n<!-- Várias, para escolher quantas quiser -->\n<p>Seus interesses:</p>\n<label><input type="checkbox" name="interesses" value="esportes"> Esportes</label>\n<label><input type="checkbox" name="interesses" value="musica"> Música</label>\n<label><input type="checkbox" name="interesses" value="cinema" checked> Cinema</label>',
+                    },
+                    {
+                        type: "text",
+                        value: 'Dois detalhes importantes:\n\n- O atributo `value` diz **o que será enviado** se a caixa estiver marcada. Na primeira caixa, se marcada, vai `termos = aceito`.\n- O atributo `checked` (escrito sozinho, sem valor) faz a caixa **já começar marcada**. Repare que "Cinema" vem com `checked`.\n\nAs checkboxes são **independentes**: marcar uma não desmarca as outras. É por isso que elas servem quando a pessoa pode escolher **mais de uma** opção ao mesmo tempo.',
+                    },
+                    {
+                        type: "text",
+                        value: '## Escolha única: `type="radio"`\n\nE quando a pessoa só pode escolher **uma** opção entre várias (como marcar um único item numa prova de múltipla escolha)? Aí entram os **botões de rádio** (`type="radio"`). O nome vem dos antigos rádios de carro, em que apertar um botão soltava todos os outros.\n\nO segredo dos radios está no atributo `name`: **todos os botões do mesmo grupo compartilham o mesmo `name`**. É isso que os torna "colegas" que se excluem, marcar um desmarca automaticamente os outros do grupo.',
+                    },
+                    {
+                        type: "code",
+                        value: '<p>Qual seu plano?</p>\n\n<label>\n  <input type="radio" name="plano" value="gratis" checked>\n  Grátis\n</label>\n\n<label>\n  <input type="radio" name="plano" value="pro">\n  Pro\n</label>\n\n<label>\n  <input type="radio" name="plano" value="empresa">\n  Empresa\n</label>',
+                    },
+                    {
+                        type: "text",
+                        value: 'Repare que os três `<input>` têm o **mesmo** `name="plano"`, mas `value` diferentes. Por isso só um pode ficar marcado: eles formam **um grupo**. Quando o formulário for enviado, vai um único par, por exemplo `plano = pro`, com o `value` da opção escolhida.\n\nSe você desse `name` diferentes a cada um, eles deixariam de ser um grupo e a pessoa conseguiria marcar todos, o que derruba a ideia de "escolha única". Por isso, o `name` compartilhado é o coração do radio.',
+                    },
+                    {
+                        type: "text",
+                        value: '## Enviar arquivos: `type="file"`\n\nPara o visitante **anexar um arquivo** (uma foto de perfil, um currículo em PDF), existe o `type="file"`. Ele vira um botão do tipo "Escolher arquivo" que abre o explorador de arquivos do computador ou celular.',
+                    },
+                    {
+                        type: "code",
+                        value: '<label for="foto">Foto de perfil:</label>\n<input id="foto" name="foto" type="file" accept="image/*">\n\n<label for="docs">Documentos (pode escolher vários):</label>\n<input id="docs" name="docs" type="file" multiple>',
+                    },
+                    {
+                        type: "text",
+                        value: 'Dois atributos ajudam bastante:\n\n- `accept` limita os **tipos de arquivo** aceitos. `accept="image/*"` só deixa escolher imagens; `accept=".pdf"` só PDFs.\n- `multiple` (escrito sozinho) permite escolher **mais de um arquivo** de uma vez.\n\nUm detalhe: formulários que enviam arquivos precisam, no `<form>`, do atributo `enctype="multipart/form-data"` para o arquivo viajar inteiro. Você não precisa decorar isso agora, só saber que existe quando for mexer com upload de verdade.',
+                    },
+                    {
+                        type: "text",
+                        value: '## Dados invisíveis: `type="hidden"`\n\nO último tipo desta aula é curioso: o `type="hidden"` cria um campo que **não aparece na tela** para o visitante, mas que **é enviado** junto com o formulário. É como um bilhete escondido dentro do envelope.\n\nPara que serve algo assim? Para o site mandar junto uma informação que o **próprio sistema** precisa, mas que não faz sentido a pessoa digitar, como o número de identificação de um produto ou uma marca da página de origem.',
+                    },
+                    {
+                        type: "code",
+                        value: '<form action="/comentario" method="post">\n  <!-- O visitante não vê este campo, mas ele viaja junto -->\n  <input type="hidden" name="id_do_artigo" value="42">\n\n  <label for="texto">Seu comentário:</label>\n  <textarea id="texto" name="comentario"></textarea>\n\n  <button>Comentar</button>\n</form>',
+                    },
+                    {
+                        type: "text",
+                        value: 'No exemplo, quando alguém comenta, o formulário envia o comentário **e** o `id_do_artigo = 42`, para o servidor saber em qual artigo o comentário deve entrar, sem incomodar o visitante com esse número.\n\nUm aviso importante: `hidden` significa "escondido na tela", **não** "secreto". Qualquer pessoa consegue ver e até mudar esse valor olhando o código da página. Por isso, **nunca** guarde senhas ou dados sensíveis num campo `hidden`.',
+                    },
+                    {
+                        type: "quote",
+                        value: "**Cheat sheet:** o `<input>` muda de forma pelo atributo `type`. Para digitação: `text`, `email`, `password` (esconde as letras), `number`, `tel`, `url` e `date` (mostra calendário). Para escolher: `checkbox` (marca vários, independentes) e `radio` (escolha única, todos com o **mesmo `name`** para se excluírem). O `value` define o que cada opção envia e `checked` já a deixa marcada. `file` anexa arquivos (`accept` filtra o tipo, `multiple` permite vários) e `hidden` leva um dado invisível, mas nunca secreto, junto do envio.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement:
+                            "Qual atributo do `<input>` decide se ele será um campo de texto, uma senha ou um seletor de data?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`type`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`name`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`value`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`id`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Qual `type` de input esconde os caracteres digitados, mostrando bolinhas ou asteriscos?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`password`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`text`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`hidden`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`email`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Por que todos os botões de um grupo de `radio` devem ter o mesmo atributo `name`?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "É o `name` compartilhado que os torna um grupo de escolha única: marcar um desmarca os outros.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Porque o `name` define a cor dos botões.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Porque sem o mesmo `name` eles não aparecem na tela.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Porque o `name` igual permite marcar vários ao mesmo tempo.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "Qual a diferença de comportamento entre `checkbox` e `radio`?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Checkboxes são independentes e permitem marcar várias; radios do mesmo grupo permitem escolher só uma.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Checkbox só aceita números e radio só aceita texto.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Radio permite marcar várias opções e checkbox só uma.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Não há diferença; os dois fazem exatamente a mesma coisa.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: 'Sobre o `type="hidden"`, qual afirmação está correta?',
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "Ele não aparece na tela, mas é enviado com o formulário; como o valor pode ser visto no código, não deve guardar dados sensíveis.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Ele é totalmente secreto e seguro para armazenar senhas.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Ele aparece na tela, mas não é enviado ao servidor.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Ele serve para esconder um campo apenas no celular.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Selects, textarea e outros controles",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "# Selects, textarea e outros controles\n\nO `<input>` dá conta de muita coisa, mas não de tudo. Quando você precisa oferecer uma **lista de opções** para escolher, um espaço para **texto longo** ou um **seletor de cor**, entram em cena outros controles de formulário.\n\nNesta aula vamos conhecer os principais: a lista suspensa `<select>`, a área de texto `<textarea>`, as sugestões do `<datalist>`, o controle deslizante `range`, o seletor `color` e o pequeno grande ajudante `placeholder`.",
+                    },
+                    {
+                        type: "quote",
+                        value: "Além do `<input>`, o HTML traz controles próprios para tarefas específicas: `<select>` (com seus `<option>`) monta uma **lista suspensa** de onde se escolhe uma opção; `<textarea>` oferece uma **caixa de texto grande**, de várias linhas; `<datalist>` dá **sugestões** enquanto se digita; e os tipos `range` (um controle **deslizante**) e `color` (um **seletor de cores**) resolvem casos bem particulares.",
+                    },
+                    {
+                        type: "text",
+                        value: "## A lista suspensa: `<select>`\n\nQuando há **muitas opções** e a pessoa deve escolher **uma**, encher a tela de botões de rádio fica ruim. Melhor usar uma **lista suspensa** (aquela caixinha que abre para baixo mostrando as opções). Ela é feita com duas tags trabalhando juntas:\n\n- `<select>`: a caixa em si, que envolve as opções.\n- `<option>`: cada uma das opções dentro da lista.",
+                    },
+                    {
+                        type: "code",
+                        value: '<label for="estado">Estado:</label>\n<select id="estado" name="estado">\n  <option value="sp">São Paulo</option>\n  <option value="rj">Rio de Janeiro</option>\n  <option value="mg" selected>Minas Gerais</option>\n  <option value="ba">Bahia</option>\n</select>',
+                    },
+                    {
+                        type: "text",
+                        value: 'Repare em cada `<option>`:\n\n- O que fica **entre** as tags ("São Paulo") é o que o visitante **vê** na lista.\n- O atributo `value` ("sp") é o que **será enviado** ao servidor quando aquela opção for escolhida. Assim, a pessoa lê "São Paulo" mas o sistema recebe o código enxuto `sp`.\n- O atributo `selected` (na de Minas Gerais) marca qual opção **já vem escolhida** por padrão. Sem ele, a lista começa na primeira opção.\n\nUm truque comum é usar a primeira `<option>` como uma instrução, deixando-a sem valor útil:',
+                    },
+                    {
+                        type: "code",
+                        value: '<select name="estado">\n  <option value="">Selecione um estado...</option>\n  <option value="sp">São Paulo</option>\n  <option value="rj">Rio de Janeiro</option>\n</select>',
+                    },
+                    {
+                        type: "text",
+                        value: "## Agrupando opções com `<optgroup>`\n\nSe a lista é comprida, dá para **agrupar** opções parecidas sob um título usando `<optgroup>` e seu atributo `label`. Os títulos servem só de organização, não são escolhíveis:",
+                    },
+                    {
+                        type: "code",
+                        value: '<label for="time">Time do coração:</label>\n<select id="time" name="time">\n  <optgroup label="Sudeste">\n    <option value="pal">Palmeiras</option>\n    <option value="fla">Flamengo</option>\n  </optgroup>\n  <optgroup label="Sul">\n    <option value="gre">Grêmio</option>\n    <option value="int">Internacional</option>\n  </optgroup>\n</select>',
+                    },
+                    {
+                        type: "text",
+                        value: '## Texto longo: `<textarea>`\n\nO `<input type="text">` é uma linha só. Para textos **grandes**, um comentário, uma mensagem, uma biografia, use o `<textarea>`, uma caixa de **várias linhas** que ainda pode ser esticada pelo canto.\n\nUma diferença importante em relação ao `<input>`: o `<textarea>` **tem tag de fechamento**, e o texto inicial (se houver) vai **entre** as tags, não num atributo `value`.',
+                    },
+                    {
+                        type: "code",
+                        value: '<label for="msg">Sua mensagem:</label>\n<textarea id="msg" name="mensagem" rows="5" cols="40"></textarea>\n\n<!-- Com um texto que já vem preenchido -->\n<label for="bio">Bio:</label>\n<textarea id="bio" name="bio" rows="3">Escreva algo sobre você.</textarea>',
+                    },
+                    {
+                        type: "text",
+                        value: "Os atributos `rows` e `cols` definem o tamanho inicial da caixa: `rows` é o número de **linhas** de altura e `cols`, a largura em **caracteres**. Eles só dão o tamanho de partida, o visitante geralmente pode redimensionar a caixa arrastando o cantinho. E, como no `<input>`, você continua usando o `<label>` para rotular e o `name` para o valor ser enviado.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Sugestões enquanto digita: `<datalist>`\n\nE se você quisesse o melhor dos dois mundos: **sugerir** algumas opções, mas deixar a pessoa **digitar livremente** se nenhuma servir? Esse é o papel do `<datalist>`. Ele se liga a um `<input>` comum pelo atributo `list` (do input) casado com o `id` do datalist.",
+                    },
+                    {
+                        type: "code",
+                        value: '<label for="fruta">Fruta favorita:</label>\n<input id="fruta" name="fruta" list="frutas">\n\n<datalist id="frutas">\n  <option value="Maçã">\n  <option value="Banana">\n  <option value="Laranja">\n  <option value="Manga">\n</datalist>',
+                    },
+                    {
+                        type: "text",
+                        value: 'A diferença para o `<select>` é sutil, mas importante: no `<select>`, a pessoa é **obrigada** a escolher uma das opções da lista. No `<datalist>`, as opções são apenas **sugestões** que aparecem enquanto se digita, mas nada impede escrever algo fora da lista ("Jabuticaba", por exemplo). Use `<select>` quando as opções forem fechadas e `<datalist>` quando forem só um atalho.',
+                    },
+                    {
+                        type: "text",
+                        value: '## Deslizando valores: `type="range"`\n\nPara escolher um número dentro de uma faixa **sem precisar digitar**, existe o `type="range"`, aquele controle **deslizante** (uma bolinha que você arrasta numa trilha). É bom para coisas como volume, nível de satisfação ou brilho, quando o valor exato não importa tanto quanto a sensação de "mais ou menos".',
+                    },
+                    {
+                        type: "code",
+                        value: '<label for="volume">Volume:</label>\n<input id="volume" name="volume" type="range" min="0" max="100" step="10" value="30">',
+                    },
+                    {
+                        type: "text",
+                        value: "Os atributos definem a faixa: `min` é o valor mínimo, `max` o máximo, `step` o **tamanho do salto** a cada movimento (de 10 em 10, no exemplo) e `value` a posição inicial. Um detalhe: o controle deslizante **não mostra** o número escolhido na tela por conta própria, então, na prática, costuma-se exibir o valor ao lado com um toque de JavaScript (assunto para depois).",
+                    },
+                    {
+                        type: "text",
+                        value: '## Escolhendo cores: `type="color"`\n\nUm tipo simpático e bem específico: o `type="color"` abre o **seletor de cores** do sistema (aquela paleta) e guarda a cor escolhida. O `value` inicial é um código de cor em hexadecimal, aquele formato que começa com `#`, que você vai encontrar bastante quando estudar CSS.',
+                    },
+                    {
+                        type: "code",
+                        value: '<label for="cor">Escolha uma cor:</label>\n<input id="cor" name="cor" type="color" value="#3366ff">',
+                    },
+                    {
+                        type: "text",
+                        value: "## Uma dica em todo campo: `placeholder`\n\nPor fim, um atributo que serve para vários campos de texto: o `placeholder`. Ele mostra um **texto de exemplo** acinzentado **dentro** do campo, que desaparece assim que a pessoa começa a digitar. Serve para dar uma **dica de formato** ou um exemplo do que se espera.",
+                    },
+                    {
+                        type: "code",
+                        value: '<label for="email">E-mail:</label>\n<input id="email" name="email" type="email" placeholder="voce@exemplo.com">\n\n<label for="busca">Buscar:</label>\n<input id="busca" name="busca" type="text" placeholder="Digite um termo e aperte Enter">',
+                    },
+                    {
+                        type: "text",
+                        value: "Um cuidado importante: o `placeholder` **não substitui o `<label>`**. O texto do placeholder some quando a pessoa começa a digitar, então, se ele fosse o único rótulo, ela ficaria sem saber o que aquele campo pedia no meio do preenchimento. Além disso, o placeholder acinzentado costuma ter contraste baixo, o que atrapalha a leitura. Regra de ouro: use `placeholder` como uma **dica extra**, sempre com um `<label>` de verdade acompanhando.",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Controle","Para que serve","Detalhe-chave"],["`<select>` + `<option>`","Escolher uma opção de uma lista fechada","`value` no option é o que vai; `selected` marca o padrão"],["`<optgroup>`","Agrupar opções sob um título","O `label` nomeia o grupo (não é escolhível)"],["`<textarea>`","Texto longo, de várias linhas","Tem fechamento; texto vai entre as tags"],["`<datalist>`","Sugerir opções sem obrigar","Liga-se ao input pelo `list`/`id`"],["`range`","Escolher número numa faixa, deslizando","Usa `min`, `max` e `step`"],["`color`","Escolher uma cor","`value` é um hexadecimal (ex.: `#3366ff`)"]]',
+                    },
+                    {
+                        type: "quote",
+                        value: '**Cheat sheet:** use `<select>` com `<option>` para uma **lista suspensa** de opções fechadas (o `value` do option é o que se envia; `selected` marca o padrão; `<optgroup label="...">` agrupa). `<textarea>` é a caixa de **texto longo** (tem fechamento, e o conteúdo vai entre as tags). `<datalist>` **sugere** opções sem obrigar, ligado ao input pelo `list`. `type="range"` desliza dentro de `min`/`max`/`step`, e `type="color"` abre a paleta de cores. O `placeholder` dá uma **dica** dentro do campo, mas nunca substitui o `<label>`.',
+                    },
+                ],
+                questions: [
+                    {
+                        statement: "Qual controle cria uma lista suspensa (dropdown) de opções?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`<select>` com `<option>`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`<textarea>`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: '`<input type="range">`',
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`<datalist>` sozinho",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Para um texto longo de várias linhas, como um comentário, qual elemento é o mais indicado?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`<textarea>`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: '`<input type="text">`',
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`<select>`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: '`<input type="color">`',
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            'Numa `<option value="sp">São Paulo</option>`, o que é enviado ao servidor se essa opção for escolhida?',
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "`sp`, o conteúdo do atributo `value`.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`São Paulo`, o texto que aparece na tela.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Tanto `sp` quanto `São Paulo`.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Nada, porque `<option>` não envia valor.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Qual a diferença entre um `<select>` e um `<input>` ligado a um `<datalist>`?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "No `<select>` a pessoa deve escolher uma opção da lista; com `<datalist>` as opções são só sugestões e ela pode digitar algo fora delas.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Não há diferença; os dois obrigam a escolher da lista.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O `<datalist>` só funciona com números.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O `<select>` permite digitar livremente e o `<datalist>` não.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Por que o `placeholder` não deve ser usado como único rótulo de um campo?",
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "Porque ele desaparece quando a pessoa começa a digitar e tem contraste baixo, então convém sempre acompanhá-lo de um `<label>` de verdade.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Porque o `placeholder` não pode ser usado em campos de e-mail.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Porque o `placeholder` impede o envio do formulário.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Porque o `placeholder` só aparece depois que a pessoa digita algo.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Botões e envio dos dados",
+                blocks: [
+                    {
+                        type: "text",
+                        value: '# Botões e envio dos dados\n\nVocê já montou os campos; agora falta a parte que **coloca a ficha em movimento**: o botão de enviar. Nesta aula vamos entender os botões de um formulário, o que exatamente acontece quando a pessoa clica em "enviar" e como desligar um botão ou campo quando ele não deve ser usado.\n\nÉ uma aula curtinha, mas resolve uma dúvida que pega muita gente: "escrevi o formulário, cliquei no botão... e agora?".',
+                    },
+                    {
+                        type: "quote",
+                        value: 'Todo formulário precisa de uma forma de ser **enviado**. O jeito mais comum é um botão de envio, feito com `<button>` ou com `<input type="submit">`. Ao clicar, o navegador recolhe o valor de cada campo (pelo seu `name`), monta os pares `name=valor` e os manda para o `action` do `<form>`, usando o `method` escolhido. O atributo `disabled` **desliga** um botão ou campo, e o que está desligado nem é clicável nem é enviado.',
+                    },
+                    {
+                        type: "text",
+                        value: "## O botão que envia\n\nA estrela do envio é o `<button>`. Colocado **dentro** de um `<form>`, ele já vem, por padrão, com o papel de **enviar o formulário**: é só clicar.",
+                    },
+                    {
+                        type: "code",
+                        value: '<form action="/login" method="post">\n  <label for="user">Usuário:</label>\n  <input id="user" name="usuario" type="text">\n\n  <label for="pass">Senha:</label>\n  <input id="pass" name="senha" type="password">\n\n  <button>Entrar</button>\n</form>',
+                    },
+                    {
+                        type: "text",
+                        value: '## Os três tipos de botão\n\nAssim como o `<input>`, o `<button>` também tem um atributo `type`, mas aqui ele só assume três valores, cada um com um comportamento:\n\n- `type="submit"`: **envia** o formulário. É o **padrão**, ou seja, um `<button>` sem `type` já se comporta assim.\n- `type="reset"`: **limpa** o formulário, devolvendo todos os campos aos valores iniciais.\n- `type="button"`: um botão "neutro", que **não faz nada sozinho**. Ele existe para ser acionado por JavaScript (abrir um menu, somar um item), fora do fluxo de envio.',
+                    },
+                    {
+                        type: "code",
+                        value: '<form action="/cadastro" method="post">\n  <input name="nome" type="text">\n\n  <button type="submit">Enviar</button>\n  <button type="reset">Limpar</button>\n  <button type="button">Só decoração (precisa de JavaScript)</button>\n</form>',
+                    },
+                    {
+                        type: "text",
+                        value: 'Um alerta que evita dor de cabeça: como `submit` é o **padrão**, se você escrever um `<button>` sem `type` dentro de um formulário achando que ele "não faz nada", surpresa, ele **envia** o formulário. Quando quiser um botão que não envie, seja explícito com `type="button"`.',
+                    },
+                    {
+                        type: "text",
+                        value: '## Dois jeitos de fazer um botão de envio\n\nExiste um segundo caminho para o botão de enviar: o `<input type="submit">`. Ele faz o mesmo que `<button type="submit">`, com uma diferença na forma de escrever o rótulo. Compare:',
+                    },
+                    {
+                        type: "code",
+                        value: '<!-- Opção 1: com <button> (o texto vai entre as tags) -->\n<button type="submit">Enviar cadastro</button>\n\n<!-- Opção 2: com <input> (o texto vai no atributo value) -->\n<input type="submit" value="Enviar cadastro">',
+                    },
+                    {
+                        type: "text",
+                        value: 'As duas mostram um botão escrito "Enviar cadastro" e enviam o formulário do mesmo jeito. A diferença prática:\n\n- No `<input type="submit">`, o rótulo do botão vem do atributo `value`. Como é um elemento vazio, ele não pode ter conteúdo dentro.\n- No `<button>`, o rótulo vai **entre as tags**, e isso permite colocar ali **outros elementos HTML**, como um ícone ao lado do texto. Por ser mais flexível, o `<button>` é o preferido hoje em dia.\n\nO mesmo vale para `reset`: existe `<input type="reset">` como equivalente ao `<button type="reset">`.',
+                    },
+                    {
+                        type: "table",
+                        value: '[["","Tag `<button>`","Tag `<input>` de envio"],["Como se define o rótulo","Entre as tags de abertura e fechamento","No atributo `value`"],["Pode ter ícone/HTML dentro?","Sim","Não (é elemento vazio)"],["Precisa de tag de fechamento?","Sim (`</button>`)","Não"],["Recomendação atual","Preferido, por ser flexível","Ainda funciona, mas menos usado"]]',
+                    },
+                    {
+                        type: "text",
+                        value: "## `name` e `value`: quando o próprio botão vira um dado\n\nAqui vem um detalhe que surpreende: um botão de envio também pode ter `name` e `value`, e aí **o botão clicado vira mais um par enviado**. Isso é útil quando o mesmo formulário tem **dois caminhos de envio** e o servidor precisa saber qual foi escolhido.",
+                    },
+                    {
+                        type: "code",
+                        value: '<form action="/post" method="post">\n  <textarea name="texto"></textarea>\n\n  <!-- Dois botões de envio, diferenciados por name/value -->\n  <button type="submit" name="acao" value="rascunho">Salvar rascunho</button>\n  <button type="submit" name="acao" value="publicar">Publicar</button>\n</form>',
+                    },
+                    {
+                        type: "text",
+                        value: "Os dois botões enviam o formulário, mas mandam pares diferentes: clicar no primeiro envia `acao = rascunho`; clicar no segundo, `acao = publicar`. Só o par do botão **efetivamente clicado** é enviado. Assim, o servidor lê o valor de `acao` e decide se guarda como rascunho ou se publica de vez, tudo com o mesmo formulário.",
+                    },
+                    {
+                        type: "text",
+                        value: "## O que acontece, passo a passo, ao enviar\n\nQuando a pessoa clica no botão de envio, o navegador faz uma sequência bem definida:\n\n1. **Confere a validação** dos campos (assunto da próxima aula). Se algo obrigatório está vazio ou fora do formato, ele **barra o envio** e aponta o erro.\n2. **Recolhe os valores** de cada campo que tenha `name`, montando os pares `name=valor`.\n3. **Monta o pedido** para o endereço do `action`, no formato definido pelo `method` (`get` põe os pares na URL; `post` os coloca no corpo).\n4. **Envia** e normalmente **carrega a resposta** que o servidor devolver, o que costuma trocar a página.\n\nComo o navegador cuida de tudo isso sozinho, um formulário simples funciona **sem uma linha de JavaScript**. O HTML sozinho já envia dados.",
+                    },
+                    {
+                        type: "text",
+                        value: '## Desligando com `disabled`\n\nÀs vezes um botão ou campo **não deve** ser usado num certo momento, por exemplo, o botão "Enviar" antes de a pessoa aceitar os termos. Para isso existe o atributo `disabled` (escrito sozinho, sem valor), que **desativa** o elemento.',
+                    },
+                    {
+                        type: "code",
+                        value: '<!-- Botão desativado: aparece apagado e não pode ser clicado -->\n<button disabled>Enviar</button>\n\n<!-- Campo desativado: não dá para digitar e não é enviado -->\n<label for="cupom">Cupom:</label>\n<input id="cupom" name="cupom" type="text" value="BEMVINDO" disabled>',
+                    },
+                    {
+                        type: "text",
+                        value: 'Um elemento `disabled` tem três características:\n\n- Aparece **apagado** (acinzentado), sinalizando que está fora do ar.\n- **Não pode** ser clicado nem editado.\n- **Não é enviado** com o formulário, mesmo que tenha um `value`. Repare nisso: o campo cupom acima, apesar de ter `value="BEMVINDO"`, não manda nada enquanto estiver `disabled`.\n\nNa prática, um pouco de JavaScript costuma **ligar e desligar** o `disabled` conforme a situação (habilitar o "Enviar" só depois que os termos forem aceitos, por exemplo). Mas a marcação de partida é esse atributo simples do HTML.',
+                    },
+                    {
+                        type: "quote",
+                        value: '**Cheat sheet:** um `<button>` dentro do `<form>` **envia** por padrão (é `type="submit"`). Os tipos são `submit` (envia), `reset` (limpa) e `button` (neutro, só com JavaScript). `<button>` e `<input type="submit">` fazem o mesmo, mas o `<button>` é mais flexível (aceita HTML dentro; o input usa o `value` como rótulo). Botões com `name`/`value` mandam qual foi clicado, útil para "salvar" vs "publicar". Ao enviar, o navegador valida, recolhe os pares `name=valor` e os manda ao `action` pelo `method`. O `disabled` apaga o elemento: ele não é clicável nem enviado.',
+                    },
+                ],
+                questions: [
+                    {
+                        statement:
+                            "Qual é o `type` padrão de um `<button>` dentro de um formulário (o que ele faz se você não escrever o `type`)?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`submit`, ou seja, ele envia o formulário.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`reset`, ele limpa o formulário.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`button`, ele não faz nada.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`text`, ele vira um campo de texto.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Qual atributo desativa um botão, deixando-o apagado e não clicável?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`disabled`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`hidden`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`readonly`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`reset`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            'Qual a diferença entre `type="reset"` e `type="submit"` num botão?',
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "`submit` envia o formulário; `reset` limpa os campos, devolvendo-os aos valores iniciais.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`submit` limpa e `reset` envia.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Os dois enviam o formulário, só muda a cor.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`reset` só funciona com JavaScript e `submit` não.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            'Uma vantagem do `<button>` sobre o `<input type="submit">` é que:',
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "O `<button>` aceita outros elementos HTML dentro (como um ícone), enquanto o `<input>` usa apenas o atributo `value` como rótulo.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Só o `<button>` consegue enviar formulários.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: '`<input type="submit">` não funciona em celulares.',
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O `<button>` dispensa a tag `<form>`.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            'Um campo `<input type="text" name="cupom" value="BEMVINDO" disabled>` está dentro de um formulário. O que acontece com esse campo ao enviar?',
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "Ele aparece apagado, não pode ser editado e não é enviado, mesmo tendo um `value`.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Ele é enviado normalmente, pois tem um `value` preenchido.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: 'Ele é enviado, mas só quando o formulário usa `method="get"`.',
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Ele impede que o formulário inteiro seja enviado.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Validação nativa do HTML",
+                blocks: [
+                    {
+                        type: "text",
+                        value: '# Validação nativa do HTML\n\nImagine um cadastro em que a pessoa deixa o e-mail em branco, digita "abc" no lugar da idade ou esquece a senha. Seria péssimo descobrir isso só lá no servidor, depois de enviar. O ideal é **avisar na hora**, ainda na tela, antes de mandar qualquer coisa.\n\nA boa notícia é que o HTML faz boa parte dessa conferência **sozinho**, sem JavaScript. Basta você adicionar alguns atributos aos campos. Isso se chama **validação nativa**, e é o assunto desta aula, que fecha o módulo de formulários.',
+                    },
+                    {
+                        type: "quote",
+                        value: "O próprio navegador consegue **conferir os campos** antes de enviar o formulário, de graça, só com atributos no HTML. `required` torna o campo **obrigatório**; `minlength`/`maxlength` limitam o **tamanho do texto**; `min`/`max`/`step` limitam **números**; `pattern` exige um **formato** específico; e tipos como `email` e `url` já **checam o formato** sozinhos. Quando algo está errado, o navegador **barra o envio** e mostra uma **bolha de erro** apontando o campo.",
+                    },
+                    {
+                        type: "text",
+                        value: '## O que é "validar" um formulário\n\n**Validar** é conferir se o que foi preenchido está **aceitável** antes de enviar: campos obrigatórios não podem ficar vazios, um e-mail precisa ter cara de e-mail, uma idade precisa ser um número dentro de uma faixa razoável, e assim por diante.\n\nAntigamente isso exigia código. Hoje, para as regras mais comuns, você só **descreve a regra com um atributo** e o navegador cuida do resto: se algo não bate, ele **impede o envio** e explica o problema para a pessoa. Vamos ver os atributos mais úteis.',
+                    },
+                    {
+                        type: "text",
+                        value: "## Campo obrigatório: `required`\n\nO mais usado de todos. O atributo `required` (escrito sozinho, sem valor) marca um campo como **obrigatório**: o formulário **não é enviado** enquanto ele estiver vazio.",
+                    },
+                    {
+                        type: "code",
+                        value: '<form action="/cadastro" method="post">\n  <label for="nome">Nome:</label>\n  <input id="nome" name="nome" type="text" required>\n\n  <label for="email">E-mail:</label>\n  <input id="email" name="email" type="email" required>\n\n  <button>Cadastrar</button>\n</form>',
+                    },
+                    {
+                        type: "text",
+                        value: 'Se a pessoa clicar em "Cadastrar" com o nome em branco, o navegador **não envia**: ele para no primeiro campo obrigatório vazio, coloca o foco nele e mostra uma mensagem tipo "Preencha este campo". O `required` funciona em quase todos os campos: caixas de texto, `email`, `select`, `checkbox` (aí a caixa passa a ser de marcação obrigatória, como um "aceito os termos") e outros.',
+                    },
+                    {
+                        type: "text",
+                        value: "## Tamanho do texto: `minlength` e `maxlength`\n\nPara campos de texto, dá para exigir um **número mínimo** e limitar um **número máximo** de caracteres:\n\n- `minlength`: a quantidade **mínima** de caracteres.\n- `maxlength`: a quantidade **máxima** de caracteres.",
+                    },
+                    {
+                        type: "code",
+                        value: '<label for="senha">Senha (mínimo 8 caracteres):</label>\n<input id="senha" name="senha" type="password" minlength="8" required>\n\n<label for="apelido">Apelido (até 15 caracteres):</label>\n<input id="apelido" name="apelido" type="text" maxlength="15">',
+                    },
+                    {
+                        type: "text",
+                        value: "Os dois se comportam de um jeito um pouco diferente:\n\n- O `maxlength` é um **teto rígido**: o campo simplesmente **não deixa** digitar além do limite. A pessoa nem consegue passar de 15 letras no apelido.\n- O `minlength` é conferido **na hora de enviar**: se a senha tiver menos de 8 caracteres, o navegador barra o envio e avisa que faltou.\n\nJuntos, eles são úteis para senhas, apelidos, mensagens com limite e por aí vai.",
+                    },
+                    {
+                        type: "text",
+                        value: '## Faixa de números: `min`, `max` e `step`\n\nQuando o campo é numérico (`type="number"` ou `type="range"`), três atributos controlam quais números valem:\n\n- `min`: o **menor** valor aceito.\n- `max`: o **maior** valor aceito.\n- `step`: o **salto** permitido entre um valor e outro.',
+                    },
+                    {
+                        type: "code",
+                        value: '<label for="idade">Idade (de 18 a 120):</label>\n<input id="idade" name="idade" type="number" min="18" max="120" required>\n\n<label for="qtd">Quantidade (de 2 em 2):</label>\n<input id="qtd" name="qtd" type="number" min="0" max="10" step="2">',
+                    },
+                    {
+                        type: "text",
+                        value: 'Com isso, o navegador recusa uma idade de 15 (abaixo do `min`) ou de 200 (acima do `max`), avisando a faixa permitida. O `step="2"` no segundo campo faz o valor andar de 2 em 2 (0, 2, 4, 6...), então um número ímpar como 3 seria rejeitado. É uma forma enxuta de garantir que o número faça sentido antes mesmo de sair da tela.',
+                    },
+                    {
+                        type: "text",
+                        value: '## Tipos que já validam sozinhos: `email` e `url`\n\nLembra dos tipos de input da aula 2? Alguns deles **já validam o formato** de brinde, sem nenhum atributo a mais. O caso clássico é o `type="email"`: o navegador confere se o texto tem **jeito de e-mail** (um nome, um `@`, um domínio). Se a pessoa digitar `ana.teste.com` (sem o `@`), o envio é barrado.',
+                    },
+                    {
+                        type: "code",
+                        value: '<label for="email">E-mail:</label>\n<input id="email" name="email" type="email" required>\n\n<label for="site">Site:</label>\n<input id="site" name="site" type="url">',
+                    },
+                    {
+                        type: "text",
+                        value: 'Repare que basta escolher o `type` certo. O `type="email"` sozinho já recusa um texto sem `@`; some o `required` e o campo passa a ser, ao mesmo tempo, **obrigatório** e **conferido no formato**. O `type="url"` faz o mesmo para links, exigindo algo com cara de endereço (como `https://...`). É a validação mais barata que existe: você não escreveu nenhuma regra, só escolheu o tipo adequado do campo.',
+                    },
+                    {
+                        type: "text",
+                        value: '## Formatos sob medida: `pattern`\n\nE quando a regra é bem específica, um CEP de 8 dígitos, um nome de usuário só com letras? Aí entra o `pattern`, que permite descrever um **molde** que o texto precisa seguir. Esse molde é escrito numa linguagenzinha de padrões (as "expressões regulares"), que você vai estudar com calma mais para a frente; por ora, veja a ideia:',
+                    },
+                    {
+                        type: "code",
+                        value: '<!-- Só aceita exatamente 8 dígitos (ex.: um CEP sem traço) -->\n<label for="cep">CEP:</label>\n<input id="cep" name="cep" type="text" pattern="[0-9]{8}"\n       title="Digite os 8 números do CEP, sem traço" required>\n\n<!-- Só aceita letras (sem números ou símbolos) -->\n<label for="user">Usuário:</label>\n<input id="user" name="usuario" type="text" pattern="[A-Za-z]+"\n       title="Use apenas letras">',
+                    },
+                    {
+                        type: "text",
+                        value: 'Não se assuste com o `[0-9]{8}`: por enquanto, basta entender que ele significa "oito caracteres, cada um de 0 a 9". O importante é o **conceito**: o `pattern` diz um formato exato e o navegador recusa tudo que não encaixe.\n\nUm par indispensável do `pattern` é o atributo `title`: use-o para **explicar a regra em português**. Quando o texto não bate com o padrão, o navegador mostra esse `title` na mensagem de erro, então, sem ele, a pessoa fica sem saber o que corrigir.',
+                    },
+                    {
+                        type: "text",
+                        value: '## A bolha de erro do navegador\n\nVocê já deve ter esbarrado nela: aquela **bolhinha** que salta do campo dizendo "Preencha este campo" ou "Inclua um @ no endereço de e-mail". Ela é a cara da validação nativa. Quando um envio é barrado, o navegador:\n\n1. **Impede** o formulário de ser enviado.\n2. **Leva o foco** para o primeiro campo com problema.\n3. **Mostra a bolha** com uma explicação (a mensagem padrão, ou o seu `title`, no caso do `pattern`).\n\nDuas observações que valem ouro:\n\n- A mensagem sai **no idioma do navegador** da pessoa, e o visual da bolha muda de um navegador para outro, você ganha tudo isso de graça.\n- Essa checagem acontece **no navegador** (do lado de quem preenche). Ela melhora a experiência, mas **pode ser burlada** por alguém mal-intencionado. Por isso, todo dado ainda precisa ser **conferido de novo no servidor**. A validação do HTML é a primeira barreira, não a única.',
+                    },
+                    {
+                        type: "table",
+                        value: '[["Atributo","O que garante","Exemplo de uso"],["`required`","O campo não pode ficar vazio","Campo obrigatório"],["`minlength` / `maxlength`","Mínimo e máximo de caracteres","Senha com no mínimo 8"],["`min` / `max`","Menor e maior número aceito","Idade de 18 a 120"],["`step`","De quanto em quanto o número anda","De 2 em 2"],["`pattern`","Um formato exato (com `title` explicando)","CEP com 8 dígitos"],["Tipo `email` / `url`","Formato de e-mail ou de link","Confere o `@` sozinho"]]',
+                    },
+                    {
+                        type: "quote",
+                        value: "**Cheat sheet:** o HTML valida campos sozinho, sem JavaScript. `required` obriga a preencher; `minlength`/`maxlength` limitam o tamanho do texto (`maxlength` nem deixa passar; `minlength` confere no envio); `min`/`max`/`step` limitam números; `pattern` exige um formato exato (sempre com um `title` explicando a regra); e tipos como `email` e `url` já conferem o formato de brinde. Ao falhar, o navegador barra o envio e mostra a **bolha de erro** no campo. Lembre-se: isso roda no navegador e é uma conveniência, o **servidor precisa validar tudo de novo**.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement: "Qual atributo torna o preenchimento de um campo obrigatório?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`required`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`pattern`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`min`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`disabled`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Sem escrever nenhuma regra extra, qual `type` de input já confere sozinho se o texto tem cara de e-mail (com `@`)?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: '`type="email"`',
+                                isCorrect: true,
+                            },
+                            {
+                                text: '`type="text"`',
+                                isCorrect: false,
+                            },
+                            {
+                                text: '`type="password"`',
+                                isCorrect: false,
+                            },
+                            {
+                                text: '`type="number"`',
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Qual a diferença de comportamento entre `maxlength` e `minlength` num campo de texto?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "`maxlength` impede digitar além do limite; `minlength` é conferido na hora de enviar.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Os dois impedem a digitação além/aquém do limite em tempo real.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`minlength` limita números e `maxlength` limita letras.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Não há diferença; os dois só funcionam ao enviar.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Ao usar `pattern`, por que é importante incluir também o atributo `title`?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Porque o navegador mostra o `title` na mensagem de erro, ajudando a pessoa a entender o formato esperado.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Porque sem `title` o `pattern` não funciona.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Porque o `title` define o número mínimo de caracteres.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Porque o `title` envia o campo ao servidor.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Um site confia apenas na validação nativa do HTML (`required`, `pattern` etc.) e não confere nada no servidor. Por que isso é arriscado?",
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "Porque a validação do HTML roda no navegador e pode ser burlada; o servidor sempre deve revalidar os dados recebidos.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Porque a validação do HTML só funciona em celulares.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Porque `required` e `pattern` não podem ser usados juntos.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Porque a validação nativa apaga os dados enviados.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        titulo: "Módulo 5 - HTML semântico e boas práticas",
+        aulas: [
+            {
+                titulo: "HTML semântico",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "# HTML semântico\n\nAté aqui você aprendeu a montar páginas com títulos, parágrafos, listas, links e imagens. Tudo funcionando! Mas existe uma diferença enorme entre um HTML que *funciona* e um HTML *bem escrito*. É sobre essa diferença que este módulo inteiro fala, e a gente começa pela ideia mais importante de todas: a **semântica**.\n\nCalma que o nome assusta mais do que a coisa. Ao final desta aula você vai olhar para um monte de `<div>` e sentir que dá para fazer melhor, com tags que realmente *dizem alguma coisa* sobre o conteúdo.",
+                    },
+                    {
+                        type: "quote",
+                        value: '**Semântica** é usar a tag **certa** para cada tipo de conteúdo: uma tag que descreve o **papel** daquilo na página, e não só uma caixa qualquer. Um `<nav>` diz "isto é a navegação"; um `<header>` diz "isto é o cabeçalho". Escrever HTML semântico é dar **significado** à estrutura, para que pessoas, leitores de tela e o Google entendam a sua página.',
+                    },
+                    {
+                        type: "text",
+                        value: '## O que é semântica, afinal?\n\nA palavra **semântica** vem do estudo do **significado**. No mundo do HTML, escrever de forma semântica quer dizer **escolher a tag pelo significado do conteúdo**, e não pela aparência.\n\nUma analogia ajuda. Imagine uma mudança de casa. Você pode empacotar tudo em caixas idênticas, sem nada escrito nelas. Vai funcionar: a tralha chega ao destino. Mas na hora de desempacotar é um pesadelo, porque você precisa abrir cada caixa para descobrir o que tem dentro. Agora imagine que cada caixa tem uma **etiqueta**: "cozinha", "livros", "banheiro". O conteúdo é o mesmo, mas de repente tudo faz sentido, e qualquer pessoa (o carregador, ou você daqui a um ano) sabe o que é cada coisa só de bater o olho.\n\nAs tags semânticas são essas **etiquetas**. Uma `<div>` é a caixa sem nome; um `<header>` é a caixa escrita "cabeçalho".',
+                    },
+                    {
+                        type: "text",
+                        value: '## Por que isso importa (três motivos fortes)\n\nVocê pode estar pensando: "mas se funciona do mesmo jeito, por que me preocupar?". Porque o HTML semântico traz três ganhos bem concretos:\n\n- **Acessibilidade**: pessoas cegas navegam com **leitores de tela**. Essas ferramentas usam as tags semânticas para deixar a pessoa **pular** direto para o menu, para o conteúdo principal ou para o rodapé. Com um mar de `<div>`, esses atalhos somem.\n- **SEO** (aparecer bem no Google): os buscadores leem o seu HTML para entender do que a página trata. Quando você marca o conteúdo principal como `<main>` e o menu como `<nav>`, você **entrega essa estrutura de bandeja** para o buscador.\n- **Manutenção**: seis meses depois, quando você (ou outra pessoa) abrir o código, `<header>`, `<main>` e `<footer>` contam a história da página num relance. Um monte de `<div>` aninhada não conta nada.',
+                    },
+                    {
+                        type: "text",
+                        value: '## O problema da "sopa de divs"\n\nAntes das tags semânticas, era comum montar a página inteira só com `<div>`. O resultado é o que a comunidade apelidou de **"sopa de divs"** (_div soup_): um empilhado de caixas genéricas que funciona, mas não diz nada sobre o conteúdo. Olhe este cabeçalho de site montado só com `<div>`:',
+                    },
+                    {
+                        type: "code",
+                        value: '<div class="cabecalho">\n  <div class="logo">Minha Loja</div>\n  <div class="menu">\n    <a href="/">Início</a>\n    <a href="/produtos">Produtos</a>\n    <a href="/contato">Contato</a>\n  </div>\n</div>',
+                    },
+                    {
+                        type: "text",
+                        value: 'Funciona? Funciona. Mas repare que **só as classes** (`cabecalho`, `menu`) dão alguma pista do papel de cada bloco, e classe é algo que **só o desenvolvedor lê**. Para o navegador, o leitor de tela e o Google, tudo ali é "uma caixa dentro de outra caixa". A informação de que aquilo é um cabeçalho com uma navegação simplesmente **não existe** para as máquinas.\n\nAgora vamos conhecer as tags que resolvem isso.',
+                    },
+                    {
+                        type: "text",
+                        value: "## As tags de estrutura da página\n\nO HTML5 trouxe um conjunto de tags feitas para marcar as **grandes regiões** de uma página. São elas que substituem boa parte das `<div>`:",
+                    },
+                    {
+                        type: "table",
+                        value: '[["Tag","Marca...","Pense nela como"],["`<header>`","O cabeçalho (topo) de uma página ou seção","A capa de um caderno"],["`<nav>`","Um bloco de navegação (menu de links)","O índice / sumário"],["`<main>`","O conteúdo principal e único da página","O miolo do assunto"],["`<section>`","Uma seção temática do conteúdo","Um capítulo"],["`<article>`","Um conteúdo que faz sentido sozinho","Uma reportagem de revista"],["`<aside>`","Um conteúdo lateral, complementar","Uma nota na margem"],["`<footer>`","O rodapé (base) de uma página ou seção","A contracapa"]]',
+                    },
+                    {
+                        type: "text",
+                        value: "## A mesma página, agora com significado\n\nVeja como fica o esqueleto de uma página de blog usando essas tags. Não precisa entender cada detalhe ainda; repare só em como as tags **já contam** onde começa o topo, o menu, o conteúdo e o rodapé:",
+                    },
+                    {
+                        type: "code",
+                        value: '<body>\n  <header>\n    <h1>Blog da Ana</h1>\n  </header>\n\n  <nav>\n    <a href="/">Início</a>\n    <a href="/sobre">Sobre</a>\n  </nav>\n\n  <main>\n    <article>\n      <h2>Minha viagem ao Japão</h2>\n      <p>Foram duas semanas inesquecíveis...</p>\n    </article>\n  </main>\n\n  <footer>\n    <p>Feito com carinho pela Ana, 2026.</p>\n  </footer>\n</body>',
+                    },
+                    {
+                        type: "text",
+                        value: "## header, nav e main de perto\n\nVamos entender as três primeiras, que aparecem em praticamente todo site:\n\n- **`<header>`**: o **cabeçalho**. Costuma guardar o logo, o título do site e, às vezes, o menu. Um detalhe: você pode ter **mais de um** `<header>` na página, porque cada `<article>` ou `<section>` pode ter o seu próprio cabeçalho.\n- **`<nav>`**: um bloco de **navegação**, ou seja, um conjunto de links importantes para se locomover pelo site (o menu principal, por exemplo). Nem todo link precisa estar num `<nav>`; ele é para os **grupos** de navegação.\n- **`<main>`**: o **conteúdo principal** da página, aquilo que é único dela. Aqui a regra é diferente: deve existir **apenas um** `<main>` por página, e ele não deve conter coisas que se repetem no site inteiro (como o menu ou o rodapé).",
+                    },
+                    {
+                        type: "code",
+                        value: '<header>\n  <h1>Padaria do Zé</h1>\n  <nav>\n    <a href="/">Início</a>\n    <a href="/cardapio">Cardápio</a>\n    <a href="/contato">Contato</a>\n  </nav>\n</header>',
+                    },
+                    {
+                        type: "text",
+                        value: '## section, article, aside e footer\n\nE as outras quatro:\n\n- **`<section>`**: agrupa um conteúdo por **tema**, como um capítulo de um livro. Costuma começar com um título (um `<h2>`, por exemplo) que dá nome à seção.\n- **`<article>`**: marca um conteúdo que **faz sentido sozinho**, que você poderia recortar e publicar em outro lugar sem perder o sentido: um post de blog, uma notícia, um comentário, um card de produto.\n- **`<aside>`**: um conteúdo **paralelo**, ligado ao assunto mas que não faz parte dele diretamente: uma barra lateral, uma caixa de "leia também", um anúncio.\n- **`<footer>`**: o **rodapé**. Fica na base e costuma trazer autoria, direitos, contatos e links secundários. Assim como o `<header>`, pode haver mais de um.\n\nA dúvida clássica é "`<section>` ou `<article>`?". A regra de bolso: se o bloco faria sentido **publicado sozinho, fora da página**, é `<article>`; se é só um **trecho temático** dentro de um todo maior, é `<section>`.',
+                    },
+                    {
+                        type: "code",
+                        value: "<main>\n  <article>\n    <h2>Bolo de cenoura da vovó</h2>\n    <p>Uma receita simples e infalível para o café da tarde.</p>\n\n    <aside>\n      <h3>Você também vai gostar</h3>\n      <p>Veja a nossa receita de brigadeiro caseiro.</p>\n    </aside>\n  </article>\n</main>\n\n<footer>\n  <p>© 2026 Receitas da Vovó. Todos os direitos reservados.</p>\n</footer>",
+                    },
+                    {
+                        type: "text",
+                        value: "## E as div e span? Continuam existindo!\n\nSemântica é ótima, mas às vezes você precisa mesmo de uma **caixa neutra**, sem significado nenhum, só para agrupar coisas e depois estilizar com CSS. Para isso servem a `<div>` e a `<span>`. Elas são as tags **sem semântica** de propósito:\n\n- **`<div>`**: uma caixa **de bloco** (ocupa a linha inteira). Serve para agrupar pedaços maiores quando não existe uma tag semântica adequada.\n- **`<span>`**: uma caixa **em linha** (fica no meio do texto, sem quebrar a linha). Serve para marcar um pedacinho de texto, geralmente para estilizar só aquele trecho.\n\nPense na `<div>` e na `<span>` como **recipientes transparentes**: elas não mudam o significado do que está dentro, só embrulham. Use-as quando **nenhuma** tag semântica se encaixar.",
+                    },
+                    {
+                        type: "code",
+                        value: '<!-- div: agrupa um bloco (a linha inteira) -->\n<div class="cartao">\n  <h3>Plano Premium</h3>\n  <p>Acesso a todos os cursos.</p>\n</div>\n\n<!-- span: marca um trecho no meio do texto -->\n<p>Este produto custa <span class="preco">R$ 99</span> à vista.</p>',
+                    },
+                    {
+                        type: "text",
+                        value: '## div genérica vs tag semântica: como decidir\n\nA pergunta que fica é: "quando uso `<div>` e quando uso uma tag semântica?". A regra é simples e vale a pena guardar: **primeiro procure uma tag semântica que descreva o conteúdo; só use `<div>` (ou `<span>`) quando nenhuma servir.**\n\nSe aquilo é o cabeçalho, use `<header>`; se é o menu, use `<nav>`; se é o rodapé, use `<footer>`. Repare no "antes e depois" abaixo: as duas versões aparecem **idênticas** na tela, mas só a segunda **conta a sua história** para as máquinas.',
+                    },
+                    {
+                        type: "code",
+                        value: '<!-- Antes: tudo div, nada de significado -->\n<div class="topo">\n  <div class="titulo">Meu Site</div>\n</div>\n<div class="conteudo">\n  <div class="post">Meu primeiro post</div>\n</div>\n<div class="rodape">Contato: ola@site.com</div>\n\n<!-- Depois: as tags certas para cada papel -->\n<header>\n  <h1>Meu Site</h1>\n</header>\n<main>\n  <article>Meu primeiro post</article>\n</main>\n<footer>Contato: ola@site.com</footer>',
+                    },
+                    {
+                        type: "quote",
+                        value: "**Cheat sheet:** escrever HTML **semântico** é escolher a tag pelo **significado** do conteúdo. As grandes regiões da página têm tags próprias: `<header>` (topo), `<nav>` (menu), `<main>` (conteúdo principal e único), `<section>` (seção temática), `<article>` (conteúdo independente), `<aside>` (conteúdo lateral) e `<footer>` (rodapé). A `<div>` (bloco) e a `<span>` (em linha) são caixas **neutras**: use-as só quando nenhuma tag semântica servir. Semântica melhora **acessibilidade**, **SEO** e **manutenção** de uma vez só.",
+                    },
+                ],
+                questions: [
+                    {
+                        statement: "O que é HTML semântico?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "Escolher a tag pelo significado do conteúdo (como `<header>`, `<nav>` e `<main>`), dando sentido à estrutura da página.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Deixar o código colorido dentro do editor de texto.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Usar só `<div>` para tudo, porque é mais rápido de escrever.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Escrever o CSS junto do HTML, no mesmo arquivo.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Qual tag marca o conteúdo principal e único de uma página, devendo aparecer só uma vez?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "`<main>`",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`<header>`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`<div>`",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`<aside>`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Qual é a diferença entre `<div>`/`<span>` e as tags semânticas?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "`<div>` e `<span>` são caixas neutras, sem significado; as tags semânticas descrevem o papel do conteúdo.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`<div>` e `<span>` descrevem o conteúdo; as tags semânticas é que são neutras.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Não há diferença: são apenas nomes diferentes para a mesma coisa.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`<div>` e `<span>` só funcionam no celular; as semânticas só no computador.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Por que vale a pena usar tags semânticas em vez de montar tudo com `<div>`?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Porque dão significado à estrutura, melhorando de uma vez a acessibilidade, o SEO e a manutenção do código.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Porque deixam a página com cores mais bonitas automaticamente.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Porque fazem a internet inteira ficar mais rápida.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Não vale: é só uma questão de estética do código, sem efeito real.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Você vai marcar o menu de navegação, o conteúdo principal e uma barra lateral de 'posts relacionados'. Quais tags usar?",
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "`<nav>` para o menu, `<main>` para o conteúdo principal e `<aside>` para a barra lateral.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "`<div>` para os três, já que a semântica não muda nada no resultado.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`<main>` para o menu, `<nav>` para a barra lateral e `<header>` para o conteúdo.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`<footer>` para o menu, `<section>` para o conteúdo e `<header>` para a barra lateral.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Acessibilidade básica",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "# Acessibilidade básica\n\nNa aula anterior você viu que o HTML semântico ajuda quem usa **leitores de tela**. Isso é parte de um assunto maior e importantíssimo: a **acessibilidade**. Uma página acessível é uma página que **todo mundo** consegue usar, inclusive quem enxerga pouco, quem não usa o mouse e quem tem alguma limitação motora.\n\nA melhor notícia é que boa parte da acessibilidade **sai de graça** quando você escreve um HTML caprichado. Nesta aula você vai aprender um punhado de hábitos simples que abrem a sua página para muito mais gente.",
+                    },
+                    {
+                        type: "quote",
+                        value: "**Acessibilidade** é construir páginas que **qualquer pessoa** consiga usar, inclusive quem depende de um leitor de tela ou navega só pelo teclado. A base não é nenhum truque avançado: é HTML bem escrito, com `alt` nas imagens, `label` nos formulários, títulos em ordem e as tags semânticas no lugar certo.",
+                    },
+                    {
+                        type: "text",
+                        value: "## Para quem a gente constrói\n\nQuando você faz uma página, é fácil imaginar só uma pessoa igual a você: enxergando a tela e usando o mouse. Mas a web é usada de muitos jeitos:\n\n- Pessoas **cegas ou com baixa visão** usam **leitores de tela**, programas que leem o conteúdo em voz alta (ou o enviam para um display em braile).\n- Pessoas com **limitações motoras** podem não usar o mouse e navegar tudo pelo **teclado**.\n- Pessoas com **daltonismo** podem não distinguir certas cores.\n- E há a situação de todo mundo: internet ruim, tela pequena, sol batendo no celular.\n\nFazer acessibilidade é lembrar dessas pessoas. E o alicerce de tudo é o HTML bem marcado, exatamente o que você já vem aprendendo.",
+                    },
+                    {
+                        type: "text",
+                        value: '## 1. O alt das imagens\n\nVocê já viu o `alt` lá no módulo de imagens, mas ele é tão central para a acessibilidade que merece a revisão. O `alt` (de _alternative text_) é a **descrição em texto** de uma imagem. Quando uma pessoa cega chega numa `<img>`, o leitor de tela **lê o alt em voz alta**: é assim que ela "vê" a imagem.\n\nDuas regras de ouro:\n\n- Descreva o que a imagem **mostra e significa** naquele contexto, de forma curta e direta.\n- Se a imagem é **puramente decorativa** (um enfeite que não acrescenta informação), use `alt=""` (vazio). Assim o leitor de tela **pula** a imagem, em vez de anunciar um nome de arquivo sem sentido.',
+                    },
+                    {
+                        type: "code",
+                        value: '<!-- Boa descrição: informativa e curta -->\n<img src="grafico.png" alt="Vendas subiram 30% em 2026">\n\n<!-- Imagem decorativa: alt vazio, o leitor de tela ignora -->\n<img src="enfeite.png" alt="">\n\n<!-- Evite: sem alt, o leitor lê o nome do arquivo ou nada -->\n<img src="IMG_4821.png">',
+                    },
+                    {
+                        type: "text",
+                        value: '## 2. O label nos formulários\n\nTodo campo de formulário (`<input>`, `<textarea>` e afins) precisa de um **rótulo** que diga o que se espera ali: "Nome", "E-mail", "Senha". Esse rótulo é a tag `<label>`.\n\nMas não basta escrever o texto solto ao lado do campo: você precisa **conectar** o `<label>` ao `<input>`. Isso se faz com um par de atributos: o `for` do label recebe o mesmo valor do `id` do input. Assim o leitor de tela sabe que aquele rótulo pertence àquele campo, e de quebra, clicar no texto já foca o campo (ótimo no celular).',
+                    },
+                    {
+                        type: "code",
+                        value: '<!-- O for do label combina com o id do input -->\n<label for="email">Seu e-mail</label>\n<input type="email" id="email" name="email">\n\n<label for="senha">Sua senha</label>\n<input type="password" id="senha" name="senha">',
+                    },
+                    {
+                        type: "text",
+                        value: 'Repare no encaixe: `for="email"` no `<label>` aponta para `id="email"` no `<input>`. Os dois valores precisam ser **iguais** para o par se formar. Sem essa conexão, quem usa leitor de tela chega num campo em branco sem saber o que digitar ali.',
+                    },
+                    {
+                        type: "text",
+                        value: "## 3. A hierarquia dos títulos (headings)\n\nOs títulos vão de `<h1>` a `<h6>`, do mais importante ao menos importante. Eles não servem só para deixar o texto grande: montam o **índice** da página. Leitores de tela conseguem listar todos os títulos e pular de um para o outro, então uma hierarquia bem feita é como um sumário bem organizado.\n\nAs regras de uma boa hierarquia:\n\n- Use **um** `<h1>` por página, o título principal.\n- **Não pule níveis** ao descer: depois de um `<h1>` venha um `<h2>`, não um `<h3>`.\n- Escolha o nível pelo **significado** (a importância do título), nunca pelo tamanho da letra. Tamanho é trabalho do CSS.",
+                    },
+                    {
+                        type: "code",
+                        value: "<!-- Certo: hierarquia sem furos -->\n<h1>Livro de receitas</h1>\n  <h2>Bolos</h2>\n    <h3>Bolo de cenoura</h3>\n    <h3>Bolo de fubá</h3>\n  <h2>Tortas</h2>\n    <h3>Torta de limão</h3>\n\n<!-- Errado: pulou do h1 direto para o h3 -->\n<h1>Livro de receitas</h1>\n  <h3>Bolo de cenoura</h3>",
+                    },
+                    {
+                        type: "text",
+                        value: '## 4. Landmarks: os pontos de referência da página\n\nLembra das tags semânticas da aula passada? Elas têm um superpoder na acessibilidade: viram **landmarks** (marcos, pontos de referência). O leitor de tela oferece uma lista dessas regiões, e a pessoa **salta** direto para a que interessa, sem ouvir a página inteira do começo.\n\nÉ por isso que um `<nav>` vale muito mais do que uma `<div class="menu">`: o `<nav>` é um marco que a pessoa reconhece; a `<div>` é invisível para a navegação.',
+                    },
+                    {
+                        type: "table",
+                        value: '[["Tag semântica","Landmark (região) que ela cria"],["`<header>`","Cabeçalho / topo (banner)"],["`<nav>`","Navegação"],["`<main>`","Conteúdo principal"],["`<aside>`","Conteúdo complementar"],["`<footer>`","Rodapé (informações do site)"]]',
+                    },
+                    {
+                        type: "text",
+                        value: '## 5. Uma pitada de ARIA: o aria-label\n\nNa imensa maioria dos casos, um bom HTML semântico já resolve. Mas às vezes um elemento **não tem texto visível** que o descreva, e aí o leitor de tela fica sem saber o que anunciar. O exemplo clássico é um botão que mostra só um ícone, como um "x" de fechar ou uma lupa de busca.\n\nPara esses casos existe o **ARIA** (_Accessible Rich Internet Applications_), um conjunto de atributos extras de acessibilidade. O mais útil para começar é o **`aria-label`**: ele dá um **nome em texto** ao elemento, um nome que não aparece na tela, mas que o leitor de tela lê.',
+                    },
+                    {
+                        type: "code",
+                        value: '<!-- Botão só com um "x": sem texto de verdade, o aria-label dá o nome -->\n<button aria-label="Fechar">×</button>\n\n<!-- Dando nome a uma navegação, para distinguir de outras -->\n<nav aria-label="Menu principal">\n  <a href="/">Início</a>\n  <a href="/blog">Blog</a>\n</nav>',
+                    },
+                    {
+                        type: "text",
+                        value: 'Uma ressalva importante: o ARIA é um **remendo** para quando o HTML sozinho não dá conta. A primeira escolha é sempre usar a tag certa e um texto de verdade. Os especialistas costumam dizer: "nenhum ARIA é melhor do que um ARIA errado". Comece pelo HTML bem feito e recorra ao `aria-label` só quando faltar texto.',
+                    },
+                    {
+                        type: "text",
+                        value: '## 6. Foco e navegação por teclado\n\nMuita gente navega **sem mouse**, só com o teclado: aperta **Tab** para pular de um elemento interativo para o outro (links, botões, campos) e **Enter** ou **espaço** para ativar. O ponto onde o teclado "está" naquele momento é o **foco**, e os navegadores mostram um contorninho ao redor do elemento focado.\n\nDuas atitudes garantem quase toda a navegação por teclado de graça:\n\n- **Use os elementos nativos certos.** Um `<a>` para link, um `<button>` para botão, um `<input>` para campo. Eles já são focáveis e respondem ao teclado sozinhos.\n- **Não esconda o contorno de foco.** É comum ver gente removendo aquele contorno por achar feio, mas ele é o que permite à pessoa **enxergar onde está**. Sem ele, navegar por teclado vira um chute no escuro.',
+                    },
+                    {
+                        type: "code",
+                        value: '<!-- Certo: button nativo, já funciona com Tab e Enter -->\n<button onclick="enviar()">Enviar</button>\n\n<!-- Errado: uma div "fingindo" ser botão não recebe foco\n     nem responde ao teclado -->\n<div onclick="enviar()">Enviar</div>',
+                    },
+                    {
+                        type: "quote",
+                        value: '**Cheat sheet:** acessibilidade é deixar a página utilizável por **todo mundo**, e quase tudo nasce de um HTML bem escrito. Ponha `alt` descritivo nas imagens (`alt=""` nas decorativas); conecte cada `<label>` ao seu campo com `for` e `id` iguais; monte os títulos de `<h1>` a `<h6>` **sem pular níveis**; use as tags semânticas, que viram **landmarks** para saltar pela página; recorra ao `aria-label` só quando faltar texto visível; e prefira elementos nativos (`<a>`, `<button>`), mantendo o **contorno de foco** para quem navega pelo teclado.',
+                    },
+                ],
+                questions: [
+                    {
+                        statement: "Para que serve o atributo `alt` de uma imagem?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "Fornecer uma descrição em texto da imagem, lida por leitores de tela e exibida caso a imagem não carregue.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Alinhar a imagem no centro da página.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Aumentar automaticamente a qualidade da imagem.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Definir a cor de fundo por trás da imagem.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "O que conecta um `<label>` ao seu `<input>`?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "O atributo `for` do label com o mesmo valor do `id` do input.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Basta escrever o texto do rótulo perto do campo.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O atributo `alt` colocado nos dois elementos.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Eles se conectam sozinhos se estiverem na mesma linha.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "Como é uma boa hierarquia de títulos (headings)?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Um `<h1>` por página e descer sem pular níveis (`<h1>`, `<h2>`, `<h3>`...), escolhendo o nível pelo significado, não pelo tamanho da letra.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Vários `<h1>` na página, escolhendo cada nível pelo tamanho de letra que se quer.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Começar sempre pelo `<h6>` e ir subindo até o `<h1>`.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Usar só `<h1>`, que é o único heading que os leitores de tela entendem.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "Para que serve o `aria-label`?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Dar um nome em texto (não visível na tela) a um elemento sem texto próprio, como um botão só com ícone, para o leitor de tela conseguir anunciá-lo.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Deixar o texto do botão em negrito.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Substituir todo o HTML semântico da página.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Criar uma dica que aparece só quando o mouse passa por cima.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Por que é melhor usar um `<button>` do que uma `<div>` clicável para um botão?",
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "Porque o `<button>` nativo já recebe foco e responde ao teclado (Tab e Enter); a `<div>` clicável não, ficando inacessível para quem não usa mouse.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Não faz diferença: `<div>` e `<button>` são idênticos para a acessibilidade.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "A `<div>` é melhor, porque os leitores de tela preferem `<div>` a `<button>`.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O `<button>` só funciona se tiver um `aria-label`; sem ele, é igual à `<div>`.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "O head e os metadados",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "# O head e os metadados\n\nLá no começo da trilha você montou o esqueleto do HTML e conheceu o `<head>`, os **bastidores** da página, aquela parte que o visitante não vê. Naquele momento a gente só espiou por cima. Agora é hora de entrar nos bastidores e conhecer os **metadados**: as informações que você coloca no `<head>` para o navegador, o celular e o Google fazerem o trabalho deles direito.\n\nNada aqui aparece no corpo da página, mas cada linha tem um efeito bem concreto, de mostrar os acentos certos a definir o textinho que aparece no Google.",
+                    },
+                    {
+                        type: "quote",
+                        value: "O `<head>` guarda os **metadados** da página: informações **sobre** ela que não aparecem na tela, mas que navegadores, celulares e buscadores leem. Alguns são praticamente obrigatórios (`charset`, `viewport`, `title`); outros melhoram como a página aparece por aí (`description`, favicon). É também no `<head>` que você conecta o **CSS** e, muitas vezes, o **JavaScript**.",
+                    },
+                    {
+                        type: "text",
+                        value: '## Relembrando: o que é metadado\n\n**Metadado** é "dado sobre o dado". Se o conteúdo da página (os textos, as imagens) é o dado, o metadado é a informação **a respeito** desse conteúdo: em que idioma está, qual é o título, qual a descrição, como ler os caracteres.\n\nQuase todos os metadados moram em tags `<meta>` e afins, dentro do `<head>`. Vamos conhecer os principais, um por um, e no fim juntar tudo num `<head>` completo.',
+                    },
+                    {
+                        type: "text",
+                        value: '## 1. meta charset: os acentos certos\n\nVocê já viu esta linha. Ela define a **codificação de caracteres**, ou seja, ensina o navegador a entender letras acentuadas e símbolos. O valor `UTF-8` é a tabela mais completa e conhece "á", "ç", "ã", "ê" e praticamente qualquer caractere.\n\nSem ela (ou com o valor errado), os acentos viram salada: "informação" pode aparecer como "informaÃ§Ã£o". Por isso o `charset` deve ser a **primeira** coisa dentro do `<head>`.',
+                    },
+                    {
+                        type: "code",
+                        value: '<meta charset="UTF-8">',
+                    },
+                    {
+                        type: "text",
+                        value: '## 2. meta viewport: a página no celular\n\nEsta é nova e importantíssima hoje em dia, com tanta gente acessando pelo celular. Sem ela, o celular finge que a tela é larga como a de um computador e mostra a página toda **encolhida**, minúscula, obrigando a pessoa a dar zoom para ler qualquer coisa.\n\nA linha do **viewport** avisa o celular: "a largura da página é a largura real da tela do aparelho". Assim o conteúdo se ajusta ao tamanho do dispositivo. Você vai copiar esta linha em toda página que fizer:',
+                    },
+                    {
+                        type: "code",
+                        value: '<meta name="viewport" content="width=device-width, initial-scale=1.0">',
+                    },
+                    {
+                        type: "text",
+                        value: 'Decifrando o `content`: `width=device-width` diz "use a largura real do aparelho" e `initial-scale=1.0` diz "comece sem zoom, no tamanho natural". Não precisa decorar os detalhes; guarde a linha inteira como uma receita, ela é sempre igual. Sem ela, o seu site simplesmente não funciona bem no celular.',
+                    },
+                    {
+                        type: "text",
+                        value: "## 3. title: o nome da página\n\nO `<title>` define o **nome da página**. Ele não aparece no corpo, mas surge em três lugares que muita gente vê:\n\n- na **aba** do navegador, lá em cima;\n- no nome salvo quando alguém guarda a página nos **favoritos**;\n- como o **título azul clicável** nos resultados de busca do Google.\n\nPor isso o `<title>` é peça-chave também para o SEO (assunto da próxima aula). Faça-o curto, específico e único para cada página.",
+                    },
+                    {
+                        type: "code",
+                        value: "<title>Bolo de cenoura da vovó | Receitas da Ana</title>",
+                    },
+                    {
+                        type: "text",
+                        value: "## 4. meta description: a chamada no Google\n\nA **description** é um resumo curto da página, de uma ou duas frases. Ela também não aparece na sua página, mas o Google costuma exibi-la como o **textinho cinza** logo abaixo do título nos resultados de busca. É a sua chance de convencer a pessoa a clicar.\n\nUma boa description tem entre uns 120 e 160 caracteres, descreve com sinceridade o que a pessoa vai encontrar e, de preferência, é diferente em cada página.",
+                    },
+                    {
+                        type: "code",
+                        value: '<meta name="description" content="Aprenda a fazer o bolo de cenoura mais fofinho, com cobertura de brigadeiro, em 40 minutos. Receita simples, passo a passo.">',
+                    },
+                    {
+                        type: "text",
+                        value: "## 5. favicon: o iconezinho da aba\n\nO **favicon** é aquela imagenzinha que aparece na **aba** do navegador, ao lado do título, e nos favoritos. É um detalhe pequeno que deixa o site com cara de profissional e ajuda a pessoa a achar a sua aba no meio de dez abertas.\n\nVocê conecta o favicon com uma tag `<link>`, apontando para o arquivo da imagem (geralmente um `.ico` ou um `.png`):",
+                    },
+                    {
+                        type: "code",
+                        value: '<link rel="icon" href="favicon.ico">',
+                    },
+                    {
+                        type: "text",
+                        value: "## 6. Onde entram o CSS e o JavaScript\n\nLembra do trio HTML, CSS e JavaScript? É no `<head>` (na maioria das vezes) que você **conecta** os outros dois ao seu HTML.\n\n- O **CSS** entra por uma tag `<link>`, parecida com a do favicon, mas apontando para o seu arquivo de estilos (normalmente um `.css`).\n- O **JavaScript** entra por uma tag `<script>`, apontando para o seu arquivo de código (um `.js`). É muito comum colocar o `<script>` com o atributo `defer`, que manda o navegador carregar o código sem travar a exibição da página.",
+                    },
+                    {
+                        type: "code",
+                        value: '<!-- Conecta a folha de estilos CSS -->\n<link rel="stylesheet" href="estilo.css">\n\n<!-- Conecta o arquivo de JavaScript (defer = não trava a página) -->\n<script src="script.js" defer></script>',
+                    },
+                    {
+                        type: "table",
+                        value: '[["Elemento","Para que serve","Aparece na tela?"],["`<meta charset>`","Codificação (acentos e símbolos)","Não"],["`<meta viewport>`","Ajustar a página ao celular","Não"],["`<title>`","Nome da página (aba, favoritos, Google)","Na aba, não no corpo"],["`<meta description>`","Resumo exibido no Google","Não (só no buscador)"],["`<link rel=icon>`","Favicon (ícone da aba)","Na aba"],["`<link rel=stylesheet>`","Conecta o arquivo de CSS","Efeito visual, via CSS"],["`<script>`","Conecta o arquivo de JavaScript","Não (dá comportamento)"]]',
+                    },
+                    {
+                        type: "text",
+                        value: "## Juntando tudo num head completo\n\nAgora veja um `<head>` de verdade, com tudo o que aprendemos, na ordem que costuma ser usada. Este é um ótimo modelo para copiar no começo de qualquer projeto:",
+                    },
+                    {
+                        type: "code",
+                        value: '<head>\n  <meta charset="UTF-8">\n  <meta name="viewport" content="width=device-width, initial-scale=1.0">\n  <title>Bolo de cenoura da vovó | Receitas da Ana</title>\n  <meta name="description" content="Receita simples de bolo de cenoura fofinho com cobertura de brigadeiro.">\n  <link rel="icon" href="favicon.ico">\n  <link rel="stylesheet" href="estilo.css">\n  <script src="script.js" defer></script>\n</head>',
+                    },
+                    {
+                        type: "quote",
+                        value: '**Cheat sheet:** o `<head>` reúne os **metadados** da página. Os obrigatórios: `<meta charset="UTF-8">` (acentos, sempre primeiro), `<meta name="viewport" ...>` (ajusta ao celular) e `<title>` (nome na aba e no Google). Os que melhoram a sua presença: `<meta name="description">` (resumo no buscador) e o **favicon** via `<link rel="icon">`. E é aqui que você conecta o **CSS** (`<link rel="stylesheet">`) e o **JavaScript** (`<script src="..." defer>`). Nada disso aparece no corpo, mas tudo tem efeito concreto.',
+                    },
+                ],
+                questions: [
+                    {
+                        statement:
+                            "Qual metadado faz os acentos e caracteres especiais aparecerem corretamente?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: '`<meta charset="UTF-8">`',
+                                isCorrect: true,
+                            },
+                            {
+                                text: '`<meta name="viewport">`',
+                                isCorrect: false,
+                            },
+                            {
+                                text: '`<meta name="description">`',
+                                isCorrect: false,
+                            },
+                            {
+                                text: "`<title>`",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "O que a tag `<title>` define?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "O nome da página, que aparece na aba do navegador, nos favoritos e como título nos resultados do Google.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "O título principal que aparece grande dentro do corpo da página.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "A cor de fundo da página.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "O idioma em que a página está escrita.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "Para que serve a `<meta>` viewport?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Fazer a página se ajustar ao tamanho real da tela, essencial para ela funcionar bem no celular.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Definir a codificação de acentos e caracteres especiais.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Escrever o resumo que aparece nos resultados do Google.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Colocar o ícone (favicon) na aba do navegador.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "Onde costuma aparecer o texto da `<meta>` description?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Como o resumo (texto cinza) logo abaixo do título nos resultados de busca do Google.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Como o título grande no topo do corpo da página.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Dentro da aba do navegador, ao lado do favicon.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "No rodapé de todas as páginas do site.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Como se conecta uma folha de estilos CSS externa dentro do `<head>`?",
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: 'Com `<link rel="stylesheet" href="estilo.css">`.',
+                                isCorrect: true,
+                            },
+                            {
+                                text: 'Com `<script src="estilo.css">`.',
+                                isCorrect: false,
+                            },
+                            {
+                                text: 'Com `<meta name="css" content="estilo.css">`.',
+                                isCorrect: false,
+                            },
+                            {
+                                text: 'Com `<style src="estilo.css">`.',
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                titulo: "Boas práticas e SEO básico",
+                blocks: [
+                    {
+                        type: "text",
+                        value: "# Boas práticas e SEO básico\n\nChegamos à última aula do módulo, e também ao fecho da nossa trilha de HTML. Você já sabe montar páginas, deixá-las semânticas, acessíveis e com um `<head>` caprichado. Agora vamos amarrar tudo com um conjunto de **boas práticas**: pequenos hábitos que separam um código amador de um código profissional, e que ainda ajudam a sua página a ser **encontrada** no Google.\n\nNada aqui é difícil. São mais atitudes do que técnicas, e uma vez incorporadas, viram automáticas.",
+                    },
+                    {
+                        type: "quote",
+                        value: "**Boas práticas** em HTML são hábitos que deixam o seu código **limpo e legível** para humanos e **claro** para as máquinas. As duas coisas caminham juntas: um HTML bem indentado, válido e semântico é justamente o que os buscadores entendem melhor, e essa é a base do **SEO** (aparecer bem nos resultados de busca).",
+                    },
+                    {
+                        type: "text",
+                        value: '## 1. Código indentado e legível\n\nVocê já conhece a **indentação**, aquela "escadinha" que mostra quem está dentro de quem. Ela é a boa prática número um, porque o navegador ignora esses espaços, mas os **humanos** dependem deles para entender o código. Além da indentação, alguns outros hábitos deixam o HTML muito mais fácil de ler:\n\n- Escreva os nomes de tags e atributos em **minúsculas** (`<section>`, não `<SECTION>`).\n- Sempre ponha os valores dos atributos entre **aspas** (`class="cartao"`).\n- Deixe **linhas em branco** separando os grandes blocos, para o código respirar.\n- Use **comentários** para marcar as seções importantes.\n\nCompare os dois trechos a seguir. Os dois geram a mesma página, mas um é um convite e o outro é um castigo:',
+                    },
+                    {
+                        type: "code",
+                        value: '<!-- Difícil de ler: sem indentação, tudo grudado -->\n<section><h2>Contato</h2><p>Fale com a gente pelo e-mail\nabaixo.</p><a href="mailto:ola@site.com">ola@site.com</a></section>\n\n<!-- Fácil de ler: indentado, organizado, respirando -->\n<section>\n  <h2>Contato</h2>\n  <p>Fale com a gente pelo e-mail abaixo.</p>\n  <a href="mailto:ola@site.com">ola@site.com</a>\n</section>',
+                    },
+                    {
+                        type: "text",
+                        value: '## 2. O validador do W3C\n\nComo o navegador tenta "consertar" os seus erros silenciosamente, é fácil deixar passar uma tag mal fechada ou um aninhamento torto sem perceber. Para pegar esses problemas existe uma ferramenta gratuita e oficial: o **validador do W3C** (o W3C é a organização que cuida dos padrões da web).\n\nVocê acessa o endereço **validator.w3.org**, cola o seu HTML (ou envia o arquivo) e ele lista todos os erros e avisos, com o número da linha de cada um. É como um corretor ortográfico, só que para o seu HTML.',
+                    },
+                    {
+                        type: "code",
+                        value: "<!-- Um HTML com problemas que o validador apontaria: -->\n\n<!-- 1. faltou fechar os <li> -->\n<ul>\n  <li>Item um\n  <li>Item dois\n</ul>\n\n<!-- 2. aninhamento cruzado -->\n<p>Texto <strong>em destaque</p></strong>\n\n<!-- 3. atributo sem aspas -->\n<img src=foto.jpg alt=Minha foto>",
+                    },
+                    {
+                        type: "text",
+                        value: "Rodar o validador de vez em quando é um ótimo hábito, principalmente enquanto você está aprendendo. Ele te ensina a enxergar os próprios erros e te dá a segurança de que a página está bem formada. Um HTML válido também é um HTML que os navegadores e buscadores interpretam com mais confiança.",
+                    },
+                    {
+                        type: "text",
+                        value: "## 3. SEO on-page básico\n\n**SEO** quer dizer _Search Engine Optimization_, ou otimização para mecanismos de busca. Em português claro: é o conjunto de cuidados que ajudam a sua página a **aparecer bem** quando alguém pesquisa no Google. Uma parte grande do SEO é o chamado **on-page**, que é tudo aquilo que você controla dentro do próprio HTML.\n\nE aqui vem a melhor notícia desta trilha: você **já aprendeu** quase todo o SEO on-page básico. Ele é feito das mesmas boas práticas que a gente vem repetindo:",
+                    },
+                    {
+                        type: "text",
+                        value: "- **`<title>` bom**: único, específico e com as palavras que descrevem a página. É um dos sinais mais fortes para o Google e o que a pessoa vê primeiro no resultado.\n- **`<meta description>` convidativa**: não muda a posição, mas melhora a chance de a pessoa clicar.\n- **Títulos (`<h1>`...`<h6>`) bem usados**: um `<h1>` claro e uma hierarquia sem furos ajudam o buscador a entender a estrutura do conteúdo.\n- **`alt` nas imagens**: além de acessível, permite que o Google entenda (e mostre na busca de imagens) as suas fotos.\n- **HTML semântico**: `<main>`, `<article>`, `<nav>` e companhia entregam a estrutura da página de bandeja para o buscador.\n\nPercebe? SEO on-page básico e HTML bem escrito são quase a **mesma coisa**.",
+                    },
+                    {
+                        type: "code",
+                        value: '<!-- Uma página amiga do SEO reúne o que você já aprendeu -->\n<head>\n  <meta charset="UTF-8">\n  <meta name="viewport" content="width=device-width, initial-scale=1.0">\n  <title>Bolo de cenoura fofinho | Receitas da Ana</title>\n  <meta name="description" content="Receita passo a passo do bolo de cenoura mais fofinho, pronto em 40 minutos.">\n</head>\n<body>\n  <main>\n    <article>\n      <h1>Bolo de cenoura fofinho</h1>\n      <img src="bolo.jpg" alt="Fatia de bolo de cenoura com cobertura de brigadeiro">\n      <h2>Ingredientes</h2>\n      <p>...</p>\n    </article>\n  </main>\n</body>',
+                    },
+                    {
+                        type: "table",
+                        value: '[["Elemento de SEO on-page","Por que ajuda a ser encontrado"],["`<title>` único e claro","É o texto principal do resultado e um forte sinal do tema"],["`<meta description>`","Melhora a taxa de cliques no resultado"],["Hierarquia de `<h1>`–`<h6>`","Mostra ao buscador a estrutura do conteúdo"],["`alt` nas imagens","Deixa as imagens compreensíveis e pesquisáveis"],["HTML semântico","Entrega a estrutura da página ao buscador"]]',
+                    },
+                    {
+                        type: "text",
+                        value: "## 4. Nomes de arquivo e organização de pastas\n\nConforme o seu site cresce, você acumula vários arquivos: páginas, imagens, estilos, scripts. Organizá-los bem desde o começo evita uma bagunça difícil de desfazer depois. Algumas convenções valiosas:\n\n- Nomes de arquivo em **minúsculas**, **sem espaços e sem acentos**. Use hífen para separar palavras: `sobre-nos.html`, e não `Sobre Nós.html`. Isso evita links quebrados e dores de cabeça nos servidores.\n- A página inicial se chama **`index.html`** por convenção: é o arquivo que o servidor abre por padrão.\n- Separe os tipos de arquivo em **pastas**: uma para o CSS, uma para o JavaScript, uma para as imagens. Os nomes mais comuns são `css/`, `js/` e `img/` (ou `imagens/`).",
+                    },
+                    {
+                        type: "code",
+                        value: "meu-site/\n├── index.html\n├── sobre-nos.html\n├── css/\n│   └── estilo.css\n├── js/\n│   └── script.js\n└── img/\n    └── logo.png",
+                    },
+                    {
+                        type: "text",
+                        value: "Com as pastas organizadas, você aponta um arquivo para o outro usando o **caminho** até ele. A partir do `index.html`, entrar numa pasta é só escrever o nome dela seguido de uma barra. Veja como o `<head>` conecta o CSS e a imagem guardados nas subpastas:",
+                    },
+                    {
+                        type: "code",
+                        value: '<!-- A partir do index.html, o caminho passa pela pasta -->\n<link rel="stylesheet" href="css/estilo.css">\n<img src="img/logo.png" alt="Logo do meu site">\n\n<!-- Um link para outra página na mesma pasta é só o nome do arquivo -->\n<a href="sobre-nos.html">Sobre nós</a>',
+                    },
+                    {
+                        type: "text",
+                        value: "## Parabéns: você chegou ao fim da trilha!\n\nFaça uma pausa para reconhecer o quanto você caminhou. Você começou sem saber o que era uma tag e agora sabe estruturar uma página inteira, com conteúdo bem marcado, semântica, acessibilidade, um `<head>` completo e boas práticas de código e de SEO. Isso é uma base sólida de verdade.\n\nO próximo passo natural é dar **vida visual** a tudo isso com o **CSS** (cores, espaçamentos, layout) e depois adicionar interação com o **JavaScript**. Mas o esqueleto, a parte que sustenta tudo, você já domina. Continue praticando: crie páginas sobre coisas de que você gosta, quebre, conserte, valide. É assim que o aprendizado vira habilidade. Foi um prazer construir essa base com você!",
+                    },
+                    {
+                        type: "quote",
+                        value: "**Cheat sheet final:** boas práticas deixam o código legível e a página encontrável. **Indente** o HTML, use **minúsculas** e **aspas** nos atributos, e valide o resultado no **validator.w3.org**. O **SEO on-page** básico é quase um resumo da trilha: bom `<title>`, `<meta description>` convidativa, hierarquia de títulos, `alt` nas imagens e HTML **semântico**. Organize os arquivos com nomes em **minúsculas, sem espaços nem acentos** (use hífen), a página inicial como **`index.html`**, e separe **CSS**, **JS** e **imagens** em pastas. Base construída: agora é partir para o CSS!",
+                    },
+                ],
+                questions: [
+                    {
+                        statement: "Para que serve a indentação (a 'escadinha') no HTML?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "Deixar o código legível para humanos, mostrando o encaixe dos elementos; o navegador ignora esses espaços.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Fazer a página carregar mais rápido no navegador.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Mudar as cores e as fontes da página.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "É obrigatória: sem ela a página simplesmente não funciona.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "O que é o validador do W3C?",
+                        difficulty: "facil",
+                        options: [
+                            {
+                                text: "Uma ferramenta gratuita e oficial que verifica o HTML e aponta erros e avisos, como um corretor.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Um editor de código que apenas colore o HTML.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Um navegador especial feito só para testar páginas.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Um servidor onde você publica o site na internet.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "O que significa SEO?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Otimização para mecanismos de busca: um conjunto de cuidados para a página aparecer bem no Google.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Um programa que hospeda e guarda o site na internet.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Uma linguagem de programação usada para criar sites.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Um formato de imagem otimizado para a web.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement: "Qual é uma boa prática para nomear arquivos de um site?",
+                        difficulty: "medio",
+                        options: [
+                            {
+                                text: "Minúsculas, sem espaços nem acentos, usando hífen para separar palavras (ex.: `sobre-nos.html`).",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Com letras maiúsculas e espaços, para ficar mais bonito (ex.: `Sobre Nós.html`).",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Sempre terminar os arquivos em `.txt`.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Usar acentos e símbolos para deixar cada nome bem único.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                    {
+                        statement:
+                            "Você quer melhorar o SEO on-page da sua página. Qual conjunto de ações realmente ajuda?",
+                        difficulty: "dificil",
+                        options: [
+                            {
+                                text: "Um `<title>` claro e único, uma `<meta description>` boa, hierarquia de títulos correta, `alt` nas imagens e HTML semântico.",
+                                isCorrect: true,
+                            },
+                            {
+                                text: "Encher a página de `<div>` e repetir a mesma palavra escondida cem vezes.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Remover o `<title>` e a description para a página carregar mais rápido.",
+                                isCorrect: false,
+                            },
+                            {
+                                text: "Trocar todas as tags semânticas por `<div>` genéricas.",
+                                isCorrect: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    },
+];
+
+async function seed() {
+    let [trilha] = await db.select().from(trails).where(eq(trails.name, NOME));
+    if (!trilha) {
+        [trilha] = await db
+            .insert(trails)
+            .values({
+                name: NOME,
+                trailLevel: "iniciante",
+                description:
+                    "Trilha de HTML para iniciantes: do primeiro documento à estrutura semântica. Tags, texto, links, imagens, mídia, tabelas, formulários e boas práticas de acessibilidade e SEO, com muito código pra praticar.",
+            })
+            .returning();
+    }
+
+    const jaTem = await db
+        .select({ id: modules.id })
+        .from(modules)
+        .where(and(eq(modules.trailId, trilha.id), eq(modules.title, MARCADOR)));
+    if (jaTem.length) {
+        console.log("Trilha HTML já está semeada, nada a fazer.");
+        return;
+    }
+
+    await db.transaction(async (tx) => {
+        const lids = (
+            await tx.select({ id: lessons.id }).from(lessons).where(eq(lessons.trailId, trilha.id))
+        ).map((l) => l.id);
+        if (lids.length) {
+            const qids = (
+                await tx
+                    .select({ id: questions.id })
+                    .from(questions)
+                    .where(inArray(questions.lessonId, lids))
+            ).map((q) => q.id);
+            if (qids.length) {
+                await tx.delete(questionAnswers).where(inArray(questionAnswers.questionId, qids));
+                await tx.delete(questionOptions).where(inArray(questionOptions.questionId, qids));
+                await tx.delete(questions).where(inArray(questions.id, qids));
+            }
+            await tx.delete(lessonProgress).where(inArray(lessonProgress.lessonId, lids));
+            await tx.delete(lessons).where(inArray(lessons.id, lids));
+        }
+        await tx.delete(modules).where(eq(modules.trailId, trilha.id));
+
+        for (let mi = 0; mi < DADOS.length; mi++) {
+            const m = DADOS[mi];
+            const [mod] = await tx
+                .insert(modules)
+                .values({ trailId: trilha.id, title: m.titulo, position: mi + 1 })
+                .returning();
+            for (let li = 0; li < m.aulas.length; li++) {
+                const a = m.aulas[li];
+                const [lesson] = await tx
+                    .insert(lessons)
+                    .values({
+                        trailId: trilha.id,
+                        moduleId: mod.id,
+                        title: a.titulo,
+                        content: null,
+                        contentBlocks: a.blocks,
+                        position: li + 1,
+                        published: true,
+                    })
+                    .returning();
+                for (let qi = 0; qi < a.questions.length; qi++) {
+                    const q = a.questions[qi];
+                    const [questao] = await tx
+                        .insert(questions)
+                        .values({
+                            lessonId: lesson.id,
+                            statement: q.statement,
+                            difficulty: q.difficulty,
+                            position: qi + 1,
+                        })
+                        .returning();
+                    await tx.insert(questionOptions).values(
+                        q.options.map((o, k) => ({
+                            questionId: questao.id,
+                            text: o.text,
+                            isCorrect: o.isCorrect,
+                            position: k + 1,
+                        })),
+                    );
+                }
+            }
+        }
+    });
+    console.log("Trilha HTML construída: " + DADOS.length + " módulos.");
+}
+
+seed()
+    .then(() => process.exit(0))
+    .catch((e) => {
+        console.error("Falha no seed:", e);
+        process.exit(1);
+    });


### PR DESCRIPTION
Duas trilhas novas de front-end básico, abrindo a vertente de desenvolvimento web na plataforma (as outras são de certificação cloud).

## HTML (`seed-trilha-html.ts`)
5 módulos, 21 aulas, 105 questões: introdução ao HTML, texto e links, imagens/mídia/tabelas, formulários, e HTML semântico com boas práticas de acessibilidade e SEO.

## CSS (`seed-trilha-css.ts`)
7 módulos, 28 aulas, 140 questões: introdução ao CSS, seletores/cascata/especificidade, box model e unidades, tipografia e backgrounds, Flexbox, Grid e responsividade.

Nível iniciante, tom acolhedor e do zero, com muito código HTML/CSS copiável e quiz de 5 questões por aula. Autorado com um módulo-piloto de régua e revisado por amostragem. Mesmo formato idempotente das outras trilhas, e compila no tsc.

## Deploy
Rodar os dois seeds depois do deploy (idempotentes, sem migration): `node scripts/seed-trilha-html.ts` e `node scripts/seed-trilha-css.ts`.
