### PR TITLE
feat: adiciona painel/CRM interno de usuários no estúdio

### DIFF
--- a/backend/app.ts
+++ b/backend/app.ts
@@ -6,6 +6,7 @@ import userRoutes from "./src/routes/user.routes.ts";
 import trailRoutes from "./src/routes/trail.routes.ts";
 import simuladoRoutes from "./src/routes/simulado.routes.ts";
 import desafioRoutes from "./src/routes/desafio.routes.ts";
+import adminRoutes from "./src/routes/admin.routes.ts";
 import { errorMiddleware } from "./src/middlewares/error.ts";
 import { apiLimiter } from "./src/middlewares/rateLimit.ts";
 import helmet from "helmet";
@@ -47,6 +48,7 @@ app.use(userRoutes);
 app.use(trailRoutes);
 app.use(simuladoRoutes);
 app.use(desafioRoutes);
+app.use(adminRoutes);
 
 app.get("/health", (_req, res) => res.json({ status: "ok" }));
 

--- a/backend/src/controllers/AdminController.ts
+++ b/backend/src/controllers/AdminController.ts
@@ -1,0 +1,18 @@
+import type { Request, Response, NextFunction } from "express";
+import { visaoGeral, usuariosCrm } from "../services/admin.service.ts";
+
+export const getVisaoGeral = async (_req: Request, res: Response, next: NextFunction) => {
+    try {
+        res.json(await visaoGeral());
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const getUsuariosCrm = async (_req: Request, res: Response, next: NextFunction) => {
+    try {
+        res.json(await usuariosCrm());
+    } catch (err) {
+        next(err);
+    }
+};

--- a/backend/src/controllers/AdminController.ts
+++ b/backend/src/controllers/AdminController.ts
@@ -9,9 +9,10 @@ export const getVisaoGeral = async (_req: Request, res: Response, next: NextFunc
     }
 };
 
-export const getUsuariosCrm = async (_req: Request, res: Response, next: NextFunction) => {
+export const getUsuariosCrm = async (req: Request, res: Response, next: NextFunction) => {
     try {
-        res.json(await usuariosCrm());
+        const q = typeof req.query.q === "string" ? req.query.q : undefined;
+        res.json(await usuariosCrm(q));
     } catch (err) {
         next(err);
     }

--- a/backend/src/routes/admin.routes.ts
+++ b/backend/src/routes/admin.routes.ts
@@ -1,0 +1,11 @@
+import { Router } from "express";
+import { autenticar, exigirAdmin } from "../middlewares/auth.ts";
+import { getVisaoGeral, getUsuariosCrm } from "../controllers/AdminController.ts";
+
+const router = Router();
+
+// Painel/CRM interno: leitura agregada, só admin.
+router.get("/admin/overview", autenticar, exigirAdmin, getVisaoGeral);
+router.get("/admin/users", autenticar, exigirAdmin, getUsuariosCrm);
+
+export default router;

--- a/backend/src/services/admin.service.ts
+++ b/backend/src/services/admin.service.ts
@@ -1,0 +1,131 @@
+import { db } from "../../db.ts";
+import { sql } from "drizzle-orm";
+import { calcularXp } from "../domain/xp.ts";
+
+// Linha de atividade unificada (aula, simulado, desafio, conquista). Serve para
+// derivar "última atividade" e "usuários ativos" sem uma coluna de last-seen.
+const ATIVIDADE = sql`
+    select user_id, completed_at ts from lessons_progress
+    union all select user_id, submitted_at from simulado_attempts
+    union all select user_id, created_at from challenge_submissions
+    union all select user_id, earned_at from user_achievements
+`;
+
+export async function visaoGeral() {
+    const usuarios = (
+        await db.execute(sql`
+            select
+                count(*)::int total,
+                count(*) filter (where username is not null and username <> '')::int perfil_completo,
+                count(*) filter (where password_hash is null)::int social,
+                count(*) filter (where created_at >= now() - interval '7 days')::int novos_7d,
+                count(*) filter (where created_at >= now() - interval '30 days')::int novos_30d
+            from users
+        `)
+    ).rows[0] as Record<string, number>;
+
+    const ativos = (
+        await db.execute(sql`
+            select
+                count(distinct user_id) filter (where ts >= now() - interval '7 days')::int ativos_7d,
+                count(distinct user_id) filter (where ts >= now() - interval '30 days')::int ativos_30d
+            from (${ATIVIDADE}) z
+        `)
+    ).rows[0] as Record<string, number>;
+
+    const conteudo = (
+        await db.execute(sql`
+            select
+                (select count(*) from lessons_progress)::int aulas_concluidas,
+                (select count(*) from simulado_attempts)::int simulados_feitos,
+                (select count(*) from challenge_submissions where xp_earned > 0)::int desafios_resolvidos,
+                (select count(*) from trails)::int trilhas,
+                (select count(*) from lessons)::int aulas_total
+        `)
+    ).rows[0] as Record<string, number>;
+
+    const cadastros = (
+        await db.execute(sql`
+            select created_at::date dia, count(*)::int n
+            from users
+            where created_at >= now() - interval '30 days'
+            group by dia
+            order by dia
+        `)
+    ).rows as { dia: string; n: number }[];
+
+    return {
+        usuarios: usuarios.total,
+        perfilCompleto: usuarios.perfil_completo,
+        social: usuarios.social,
+        novos7d: usuarios.novos_7d,
+        novos30d: usuarios.novos_30d,
+        ativos7d: ativos.ativos_7d,
+        ativos30d: ativos.ativos_30d,
+        aulasConcluidas: conteudo.aulas_concluidas,
+        simuladosFeitos: conteudo.simulados_feitos,
+        desafiosResolvidos: conteudo.desafios_resolvidos,
+        trilhas: conteudo.trilhas,
+        aulasTotal: conteudo.aulas_total,
+        cadastrosPorDia: cadastros,
+    };
+}
+
+// Métricas por usuário para o CRM, agregadas em uma query só (sem N+1).
+export async function usuariosCrm() {
+    const { rows } = await db.execute(sql`
+        select
+            u.id, u.name, u.username, u.email, u.created_at,
+            (u.password_hash is null) as social,
+            coalesce(ap.n, 0)::int aulas,
+            coalesce(ac.n, 0)::int questoes,
+            coalesce(ds.n, 0)::int desafios,
+            coalesce(ds.xp, 0)::int desafios_xp,
+            coalesce(sa.n, 0)::int simulados,
+            coalesce(cq.n, 0)::int conquistas,
+            coalesce(ta.n, 0)::int trilhas,
+            la.ultima as ultima_atividade
+        from users u
+        left join (select user_id, count(*) n from lessons_progress group by user_id) ap on ap.user_id = u.id
+        left join (select user_id, count(*) n from question_answers where is_correct group by user_id) ac on ac.user_id = u.id
+        left join (
+            select user_id, count(*) n, sum(xp_earned) xp
+            from challenge_submissions where xp_earned > 0 group by user_id
+        ) ds on ds.user_id = u.id
+        left join (select user_id, count(*) n from simulado_attempts group by user_id) sa on sa.user_id = u.id
+        left join (select user_id, count(*) n from user_achievements group by user_id) cq on cq.user_id = u.id
+        left join (
+            select f.user_id, count(*) n
+            from (
+                select lp.user_id, l.trail_id, count(distinct lp.lesson_id) f
+                from lessons_progress lp
+                join lessons l on l.id = lp.lesson_id
+                group by lp.user_id, l.trail_id
+            ) f
+            join (select trail_id, count(*) t from lessons group by trail_id) tot on tot.trail_id = f.trail_id
+            where f.f >= tot.t
+            group by f.user_id
+        ) ta on ta.user_id = u.id
+        left join (
+            select user_id, max(ts) ultima from (${ATIVIDADE}) z group by user_id
+        ) la on la.user_id = u.id
+        order by u.created_at desc
+    `);
+
+    return (rows as Record<string, any>[]).map((r) => ({
+        id: r.id as string,
+        name: r.name as string,
+        username: (r.username as string | null) ?? null,
+        email: r.email as string,
+        origem: r.social ? "social" : "email",
+        criadoEm: r.created_at as string,
+        ultimaAtividade: (r.ultima_atividade as string | null) ?? null,
+        aulas: r.aulas as number,
+        trilhas: r.trilhas as number,
+        simulados: r.simulados as number,
+        desafios: r.desafios as number,
+        conquistas: r.conquistas as number,
+        questoesCertas: r.questoes as number,
+        xp: calcularXp({ aulas: r.aulas, questoes: r.questoes, desafiosXp: r.desafios_xp }),
+    }));
+}

--- a/backend/src/services/admin.service.ts
+++ b/backend/src/services/admin.service.ts
@@ -48,7 +48,6 @@ export async function visaoGeral() {
         await db.execute(sql`
             select created_at::date dia, count(*)::int n
             from users
-            where created_at >= now() - interval '30 days'
             group by dia
             order by dia
         `)
@@ -72,7 +71,12 @@ export async function visaoGeral() {
 }
 
 // Métricas por usuário para o CRM, agregadas em uma query só (sem N+1).
-export async function usuariosCrm() {
+// A busca por nome/username/email é feita no servidor.
+export async function usuariosCrm(busca?: string) {
+    const termo = busca?.trim();
+    const filtro = termo
+        ? sql`where u.name ilike ${`%${termo}%`} or u.username ilike ${`%${termo}%`} or u.email ilike ${`%${termo}%`}`
+        : sql``;
     const { rows } = await db.execute(sql`
         select
             u.id, u.name, u.username, u.email, u.created_at,
@@ -109,6 +113,7 @@ export async function usuariosCrm() {
         left join (
             select user_id, max(ts) ultima from (${ATIVIDADE}) z group by user_id
         ) la on la.user_id = u.id
+        ${filtro}
         order by u.created_at desc
     `);
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { Trilhas } from './pages/Trilhas';
 import { Aula } from './pages/Aula';
 import { Estudio } from './pages/Estudio';
 import { EstudioHome } from './pages/EstudioHome';
+import { Usuarios } from './pages/Usuarios';
 import { Configuracoes } from './pages/Configuracoes';
 import { Perfil } from './pages/Perfil';
 import { Ranking } from './pages/Ranking';
@@ -93,6 +94,14 @@ function AppRoutes() {
         element={
           <AdminRoute>
             <EstudioHome />
+          </AdminRoute>
+        }
+      />
+      <Route
+        path="/estudio/usuarios"
+        element={
+          <AdminRoute>
+            <Usuarios />
           </AdminRoute>
         }
       />

--- a/frontend/src/pages/EstudioHome/index.tsx
+++ b/frontend/src/pages/EstudioHome/index.tsx
@@ -126,6 +126,9 @@ export function EstudioHome() {
           <b>Painel do administrador</b>
         </div>
         <div className="topbar__spacer" />
+        <Link className="btn btn--ghost studio__btn" to="/estudio/usuarios">
+          Usuários
+        </Link>
         <Link className="btn btn--ghost studio__btn" to="/estudio/simulados">
           Simulados
         </Link>

--- a/frontend/src/pages/Usuarios/GraficoCrescimento.tsx
+++ b/frontend/src/pages/Usuarios/GraficoCrescimento.tsx
@@ -1,0 +1,172 @@
+import { useMemo, useRef, useState, type MouseEvent as ReactMouseEvent } from 'react';
+
+interface Cadastro {
+  dia: string;
+  n: number;
+}
+
+const DIA = 86400000;
+const PERIODOS = [
+  { chave: '7d', label: '7D', dias: 7 },
+  { chave: '30d', label: '30D', dias: 30 },
+  { chave: '3m', label: '3M', dias: 90 },
+  { chave: '6m', label: '6M', dias: 180 },
+  { chave: '1a', label: '1A', dias: 365 },
+  { chave: 'max', label: 'Máx', dias: Infinity },
+] as const;
+
+const W = 820;
+const H = 240;
+const PADL = 44;
+const PADR = 14;
+const PADT = 16;
+const PADB = 26;
+
+const fmtDia = (t: number) =>
+  new Date(t).toLocaleDateString('pt-BR', { day: '2-digit', month: 'short' });
+const fmtCompleto = (t: number) =>
+  new Date(t).toLocaleDateString('pt-BR', { day: '2-digit', month: 'short', year: 'numeric' });
+
+export function GraficoCrescimento({ cadastros }: { cadastros: Cadastro[] }) {
+  const [periodo, setPeriodo] = useState<string>('30d');
+  const [hover, setHover] = useState<number | null>(null);
+  const svgRef = useRef<SVGSVGElement>(null);
+
+  const grafico = useMemo(() => {
+    if (cadastros.length === 0) return null;
+    const ordenado = cadastros.toSorted((a, b) => a.dia.localeCompare(b.dia));
+    const cumul = ordenado.reduce<{ t: number; v: number }[]>((arr, c) => {
+      const v = (arr.at(-1)?.v ?? 0) + c.n;
+      return [...arr, { t: new Date(`${c.dia}T00:00:00`).getTime(), v }];
+    }, []);
+
+    const agora = cumul[cumul.length - 1].t;
+    const per = PERIODOS.find((p) => p.chave === periodo)!;
+    const inicio = per.dias === Infinity ? cumul[0].t - DIA : agora - per.dias * DIA;
+
+    const baseline = cumul.filter((c) => c.t < inicio).at(-1)?.v ?? 0;
+    const dentro = cumul.filter((c) => c.t >= inicio);
+    const serie = [{ t: inicio, v: baseline }, ...dentro];
+
+    const t0 = serie[0].t;
+    const spanT = agora - t0 || 1;
+    const vmin = Math.min(...serie.map((s) => s.v));
+    const vmax = Math.max(...serie.map((s) => s.v));
+    const spanV = vmax - vmin || 1;
+
+    const px = (t: number) => PADL + ((t - t0) / spanT) * (W - PADL - PADR);
+    const py = (v: number) => PADT + (1 - (v - vmin) / spanV) * (H - PADT - PADB);
+    const pts = serie.map((s) => ({ ...s, x: px(s.t), y: py(s.v) }));
+
+    const linha = pts.map((p, i) => `${i ? 'L' : 'M'}${p.x.toFixed(1)},${p.y.toFixed(1)}`).join(' ');
+    const base = H - PADB;
+    const ult = pts[pts.length - 1];
+    const area = `${linha} L${ult.x.toFixed(1)},${base} L${pts[0].x.toFixed(1)},${base} Z`;
+
+    const ticks = Array.from({ length: 4 }, (_, i) => {
+      const v = Math.round(vmin + (spanV * i) / 3);
+      return { v, y: py(v) };
+    });
+    const nLab = Math.min(5, Math.max(2, pts.length));
+    const xlabs = Array.from({ length: nLab }, (_, i) => {
+      const p = pts[Math.round((i * (pts.length - 1)) / (nLab - 1))];
+      return { t: p.t, x: p.x };
+    });
+
+    return { pts, linha, area, ticks, xlabs };
+  }, [cadastros, periodo]);
+
+  function aoMover(e: ReactMouseEvent) {
+    if (!svgRef.current || !grafico) return;
+    const rect = svgRef.current.getBoundingClientRect();
+    const x = ((e.clientX - rect.left) / rect.width) * W;
+    let melhor = 0;
+    let dist = Infinity;
+    grafico.pts.forEach((p, i) => {
+      const d = Math.abs(p.x - x);
+      if (d < dist) {
+        dist = d;
+        melhor = i;
+      }
+    });
+    setHover(melhor);
+  }
+
+  const ativo = hover != null && grafico ? grafico.pts[hover] : null;
+
+  return (
+    <div className="painel-graf">
+      <div className="painel-graf__head">
+        <div className="painel-graf__titulo">Usuários ao longo do tempo</div>
+        <div className="painel-graf__periodos">
+          {PERIODOS.map((p) => (
+            <button
+              key={p.chave}
+              className={`painel-graf__periodo${periodo === p.chave ? ' is-ativo' : ''}`}
+              onClick={() => setPeriodo(p.chave)}
+            >
+              {p.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {!grafico ? (
+        <p className="track__desc">Sem cadastros ainda.</p>
+      ) : (
+        <>
+          <div className="painel-graf__leitura">
+            {ativo ? (
+              <>
+                <b>{ativo.v}</b> usuários em {fmtCompleto(ativo.t)}
+              </>
+            ) : (
+              <span>Passe o mouse para ver o total em cada data</span>
+            )}
+          </div>
+          <svg
+            ref={svgRef}
+            className="painel-graf__svg"
+            viewBox={`0 0 ${W} ${H}`}
+            onMouseMove={aoMover}
+            onMouseLeave={() => setHover(null)}
+          >
+            <defs>
+              <linearGradient id="graf-crescimento" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor="var(--accent)" stopOpacity="0.22" />
+                <stop offset="100%" stopColor="var(--accent)" stopOpacity="0" />
+              </linearGradient>
+            </defs>
+            {grafico.ticks.map((tk) => (
+              <g key={tk.v}>
+                <line className="painel-graf__grid" x1={PADL} y1={tk.y} x2={W - PADR} y2={tk.y} />
+                <text className="painel-graf__ylab" x={PADL - 8} y={tk.y + 4} textAnchor="end">
+                  {tk.v}
+                </text>
+              </g>
+            ))}
+            <path d={grafico.area} fill="url(#graf-crescimento)" />
+            <path className="painel-graf__linha" d={grafico.linha} />
+            {grafico.xlabs.map((l) => (
+              <text className="painel-graf__xlab" key={l.t} x={l.x} y={H - 8} textAnchor="middle">
+                {fmtDia(l.t)}
+              </text>
+            ))}
+            {ativo && (
+              <>
+                <line
+                  className="painel-graf__cross"
+                  x1={ativo.x}
+                  y1={PADT}
+                  x2={ativo.x}
+                  y2={H - PADB}
+                />
+                <circle className="painel-graf__dot" cx={ativo.x} cy={ativo.y} r="4" />
+              </>
+            )}
+          </svg>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/Usuarios/index.tsx
+++ b/frontend/src/pages/Usuarios/index.tsx
@@ -1,8 +1,9 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { Logo } from '../../components/Logo';
 import { useRequisicao } from '../../hooks/useRequisicao';
 import { obterVisaoGeral, listarUsuariosCrm, type UsuarioCrm } from '../../services/admin';
+import { GraficoCrescimento } from './GraficoCrescimento';
 import '../../styles/painel.css';
 
 const fmtData = (s: string | null) =>
@@ -41,23 +42,24 @@ function Th({
 
 export function Usuarios() {
   const { dados: overview } = useRequisicao(obterVisaoGeral, []);
-  const { dados: usuariosData, carregando } = useRequisicao(listarUsuariosCrm, []);
   const [busca, setBusca] = useState('');
+  const [buscaDeb, setBuscaDeb] = useState('');
   const [ordem, setOrdem] = useState<{ col: Coluna; desc: boolean }>({ col: 'criadoEm', desc: true });
 
+  useEffect(() => {
+    const id = setTimeout(() => setBuscaDeb(busca), 350);
+    return () => clearTimeout(id);
+  }, [busca]);
+
+  const { dados: usuariosData, carregando } = useRequisicao(
+    () => listarUsuariosCrm(buscaDeb),
+    [buscaDeb],
+  );
+
   const filtrados = useMemo(() => {
-    const usuarios = usuariosData ?? [];
-    const q = busca.trim().toLowerCase();
-    const base = q
-      ? usuarios.filter(
-          (u) =>
-            u.name.toLowerCase().includes(q) ||
-            (u.username ?? '').toLowerCase().includes(q) ||
-            u.email.toLowerCase().includes(q),
-        )
-      : usuarios;
+    const base = usuariosData ?? [];
     const { col, desc } = ordem;
-    return [...base].sort((a, b) => {
+    return base.toSorted((a, b) => {
       const va = a[col] ?? '';
       const vb = b[col] ?? '';
       const cmp =
@@ -66,7 +68,7 @@ export function Usuarios() {
           : String(va).localeCompare(String(vb));
       return desc ? -cmp : cmp;
     });
-  }, [usuariosData, busca, ordem]);
+  }, [usuariosData, ordem]);
 
   function ordenarPor(col: Coluna) {
     setOrdem((o) => (o.col === col ? { col, desc: !o.desc } : { col, desc: true }));
@@ -91,10 +93,8 @@ export function Usuarios() {
       ]
     : [];
 
-  const maxCad = Math.max(1, ...(overview?.cadastrosPorDia ?? []).map((d) => d.n));
-
   return (
-    <div className="home">
+    <div className="home painel-page">
       <header className="topbar studio__bar">
         <div className="studio__brand">
           <Logo variant="solid" size={19} />
@@ -137,18 +137,7 @@ export function Usuarios() {
           ))}
         </div>
 
-        {overview && overview.cadastrosPorDia.length > 0 && (
-          <div className="painel-chart">
-            <div className="painel-chart__titulo">Cadastros nos últimos 30 dias</div>
-            <div className="painel-chart__bars">
-              {overview.cadastrosPorDia.map((d) => (
-                <div key={d.dia} className="painel-chart__col" title={`${fmtData(d.dia)}: ${d.n} cadastro(s)`}>
-                  <div className="painel-chart__bar" style={{ height: `${(d.n / maxCad) * 100}%` }} />
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
+        {overview && <GraficoCrescimento cadastros={overview.cadastrosPorDia} />}
 
         <div className="painel-toolbar">
           <input

--- a/frontend/src/pages/Usuarios/index.tsx
+++ b/frontend/src/pages/Usuarios/index.tsx
@@ -1,0 +1,216 @@
+import { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Logo } from '../../components/Logo';
+import { useRequisicao } from '../../hooks/useRequisicao';
+import { obterVisaoGeral, listarUsuariosCrm, type UsuarioCrm } from '../../services/admin';
+import '../../styles/painel.css';
+
+const fmtData = (s: string | null) =>
+  s ? new Date(s).toLocaleDateString('pt-BR', { day: '2-digit', month: '2-digit', year: '2-digit' }) : '—';
+
+type Coluna = keyof Pick<
+  UsuarioCrm,
+  'name' | 'aulas' | 'trilhas' | 'simulados' | 'desafios' | 'conquistas' | 'xp' | 'ultimaAtividade' | 'criadoEm'
+>;
+
+const COLS_NUM = new Set<Coluna>(['aulas', 'trilhas', 'simulados', 'desafios', 'conquistas', 'xp']);
+
+function Th({
+  col,
+  label,
+  ordem,
+  onClick,
+}: {
+  col: Coluna;
+  label: string;
+  ordem: { col: Coluna; desc: boolean };
+  onClick: (c: Coluna) => void;
+}) {
+  const ativa = ordem.col === col;
+  const num = COLS_NUM.has(col);
+  return (
+    <th
+      className={`painel-th${num ? ' num' : ''}${ativa ? ' painel-th--ativa' : ''}`}
+      onClick={() => onClick(col)}
+    >
+      {label}
+      {ativa ? (ordem.desc ? ' ↓' : ' ↑') : ''}
+    </th>
+  );
+}
+
+export function Usuarios() {
+  const { dados: overview } = useRequisicao(obterVisaoGeral, []);
+  const { dados: usuariosData, carregando } = useRequisicao(listarUsuariosCrm, []);
+  const [busca, setBusca] = useState('');
+  const [ordem, setOrdem] = useState<{ col: Coluna; desc: boolean }>({ col: 'criadoEm', desc: true });
+
+  const filtrados = useMemo(() => {
+    const usuarios = usuariosData ?? [];
+    const q = busca.trim().toLowerCase();
+    const base = q
+      ? usuarios.filter(
+          (u) =>
+            u.name.toLowerCase().includes(q) ||
+            (u.username ?? '').toLowerCase().includes(q) ||
+            u.email.toLowerCase().includes(q),
+        )
+      : usuarios;
+    const { col, desc } = ordem;
+    return [...base].sort((a, b) => {
+      const va = a[col] ?? '';
+      const vb = b[col] ?? '';
+      const cmp =
+        typeof va === 'number' && typeof vb === 'number'
+          ? va - vb
+          : String(va).localeCompare(String(vb));
+      return desc ? -cmp : cmp;
+    });
+  }, [usuariosData, busca, ordem]);
+
+  function ordenarPor(col: Coluna) {
+    setOrdem((o) => (o.col === col ? { col, desc: !o.desc } : { col, desc: true }));
+  }
+
+  const cards = overview
+    ? [
+        {
+          label: 'Usuários',
+          valor: overview.usuarios,
+          sub: `${overview.perfilCompleto} com username · ${overview.social} social`,
+        },
+        { label: 'Ativos (30d)', valor: overview.ativos30d, sub: `${overview.ativos7d} nos últimos 7 dias` },
+        { label: 'Novos (30d)', valor: overview.novos30d, sub: `${overview.novos7d} nos últimos 7 dias` },
+        {
+          label: 'Aulas concluídas',
+          valor: overview.aulasConcluidas,
+          sub: `${overview.aulasTotal} aulas publicadas`,
+        },
+        { label: 'Simulados feitos', valor: overview.simuladosFeitos, sub: '' },
+        { label: 'Desafios resolvidos', valor: overview.desafiosResolvidos, sub: '' },
+      ]
+    : [];
+
+  const maxCad = Math.max(1, ...(overview?.cadastrosPorDia ?? []).map((d) => d.n));
+
+  return (
+    <div className="home">
+      <header className="topbar studio__bar">
+        <div className="studio__brand">
+          <Logo variant="solid" size={19} />
+          <span className="studio__badge">Estúdio</span>
+        </div>
+        <span className="studio__divider" />
+        <div className="studio__crumb">
+          <b>Usuários</b>
+        </div>
+        <div className="topbar__spacer" />
+        <Link className="btn btn--ghost studio__btn" to="/estudio">
+          Trilhas
+        </Link>
+        <Link className="btn btn--ghost studio__btn" to="/estudio/simulados">
+          Simulados
+        </Link>
+        <Link className="btn btn--ghost studio__btn" to="/estudio/desafios">
+          Desafios
+        </Link>
+        <Link className="btn btn--ghost studio__btn" to="/home">
+          Voltar ao app
+        </Link>
+      </header>
+
+      <div className="estudio-home">
+        <div className="estudio-home__head">
+          <div>
+            <h1 className="estudio-home__title">Usuários</h1>
+            <p className="estudio-home__sub">Visão geral da base e o progresso de cada aluno.</p>
+          </div>
+        </div>
+
+        <div className="painel-cards">
+          {cards.map((c) => (
+            <div key={c.label} className="painel-card">
+              <span className="painel-card__valor">{c.valor}</span>
+              <span className="painel-card__label">{c.label}</span>
+              {c.sub && <span className="painel-card__sub">{c.sub}</span>}
+            </div>
+          ))}
+        </div>
+
+        {overview && overview.cadastrosPorDia.length > 0 && (
+          <div className="painel-chart">
+            <div className="painel-chart__titulo">Cadastros nos últimos 30 dias</div>
+            <div className="painel-chart__bars">
+              {overview.cadastrosPorDia.map((d) => (
+                <div key={d.dia} className="painel-chart__col" title={`${fmtData(d.dia)}: ${d.n} cadastro(s)`}>
+                  <div className="painel-chart__bar" style={{ height: `${(d.n / maxCad) * 100}%` }} />
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <div className="painel-toolbar">
+          <input
+            className="estudio-form__input"
+            style={{ margin: 0, maxWidth: 340 }}
+            placeholder="Buscar por nome, username ou email..."
+            value={busca}
+            onChange={(e) => setBusca(e.target.value)}
+          />
+          <span className="painel-toolbar__contagem">{filtrados.length} usuários</span>
+        </div>
+
+        {carregando ? (
+          <p className="track__desc">Carregando...</p>
+        ) : (
+          <div className="painel-tabela-wrap">
+            <table className="painel-tabela">
+              <thead>
+                <tr>
+                  <Th col="name" label="Usuário" ordem={ordem} onClick={ordenarPor} />
+                  <th>Origem</th>
+                  <Th col="aulas" label="Aulas" ordem={ordem} onClick={ordenarPor} />
+                  <Th col="trilhas" label="Trilhas" ordem={ordem} onClick={ordenarPor} />
+                  <Th col="simulados" label="Simul." ordem={ordem} onClick={ordenarPor} />
+                  <Th col="desafios" label="Desaf." ordem={ordem} onClick={ordenarPor} />
+                  <Th col="conquistas" label="Conq." ordem={ordem} onClick={ordenarPor} />
+                  <Th col="xp" label="XP" ordem={ordem} onClick={ordenarPor} />
+                  <Th col="ultimaAtividade" label="Últ. atividade" ordem={ordem} onClick={ordenarPor} />
+                </tr>
+              </thead>
+              <tbody>
+                {filtrados.map((u) => (
+                  <tr key={u.id}>
+                    <td>
+                      <div className="painel-user__nome">{u.name}</div>
+                      <div className="painel-user__sub">
+                        {u.username ? (
+                          `@${u.username}`
+                        ) : (
+                          <span className="painel-user__semuser">sem username</span>
+                        )}
+                      </div>
+                    </td>
+                    <td>
+                      <span className={`painel-tag painel-tag--${u.origem}`}>
+                        {u.origem === 'social' ? 'Social' : 'Email'}
+                      </span>
+                    </td>
+                    <td className="num">{u.aulas}</td>
+                    <td className="num">{u.trilhas}</td>
+                    <td className="num">{u.simulados}</td>
+                    <td className="num">{u.desafios}</td>
+                    <td className="num">{u.conquistas}</td>
+                    <td className="num">{u.xp}</td>
+                    <td>{fmtData(u.ultimaAtividade)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/services/admin.ts
+++ b/frontend/src/services/admin.ts
@@ -38,7 +38,9 @@ export async function obterVisaoGeral() {
   return data;
 }
 
-export async function listarUsuariosCrm() {
-  const { data } = await api.get<UsuarioCrm[]>('/admin/users');
+export async function listarUsuariosCrm(busca?: string) {
+  const { data } = await api.get<UsuarioCrm[]>('/admin/users', {
+    params: busca ? { q: busca } : undefined,
+  });
   return data;
 }

--- a/frontend/src/services/admin.ts
+++ b/frontend/src/services/admin.ts
@@ -1,0 +1,44 @@
+import api from './api';
+
+export interface VisaoGeral {
+  usuarios: number;
+  perfilCompleto: number;
+  social: number;
+  novos7d: number;
+  novos30d: number;
+  ativos7d: number;
+  ativos30d: number;
+  aulasConcluidas: number;
+  simuladosFeitos: number;
+  desafiosResolvidos: number;
+  trilhas: number;
+  aulasTotal: number;
+  cadastrosPorDia: { dia: string; n: number }[];
+}
+
+export interface UsuarioCrm {
+  id: string;
+  name: string;
+  username: string | null;
+  email: string;
+  origem: 'email' | 'social';
+  criadoEm: string;
+  ultimaAtividade: string | null;
+  aulas: number;
+  trilhas: number;
+  simulados: number;
+  desafios: number;
+  conquistas: number;
+  questoesCertas: number;
+  xp: number;
+}
+
+export async function obterVisaoGeral() {
+  const { data } = await api.get<VisaoGeral>('/admin/overview');
+  return data;
+}
+
+export async function listarUsuariosCrm() {
+  const { data } = await api.get<UsuarioCrm[]>('/admin/users');
+  return data;
+}

--- a/frontend/src/styles/painel.css
+++ b/frontend/src/styles/painel.css
@@ -1,0 +1,174 @@
+/* Painel/CRM do admin: cards de visão geral, gráfico de cadastros e tabela de usuários. */
+
+.painel-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.painel-card {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 14px 16px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+}
+
+.painel-card__valor {
+  font-size: 26px;
+  font-weight: 700;
+  color: var(--text);
+  line-height: 1.1;
+}
+
+.painel-card__label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.painel-card__sub {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.painel-chart {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 14px 16px 10px;
+  margin-bottom: 20px;
+}
+
+.painel-chart__titulo {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--muted);
+  margin-bottom: 10px;
+}
+
+.painel-chart__bars {
+  display: flex;
+  align-items: flex-end;
+  gap: 3px;
+  height: 90px;
+}
+
+.painel-chart__col {
+  flex: 1;
+  height: 100%;
+  display: flex;
+  align-items: flex-end;
+}
+
+.painel-chart__bar {
+  width: 100%;
+  min-height: 2px;
+  background: var(--accent);
+  border-radius: 3px 3px 0 0;
+  transition: opacity 0.15s;
+}
+
+.painel-chart__col:hover .painel-chart__bar {
+  opacity: 0.7;
+}
+
+.painel-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.painel-toolbar__contagem {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.painel-tabela-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+}
+
+.painel-tabela {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+.painel-tabela th,
+.painel-tabela td {
+  padding: 10px 12px;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+}
+
+.painel-tabela thead th {
+  background: var(--surface-2);
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 600;
+  position: sticky;
+  top: 0;
+}
+
+.painel-tabela tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.painel-tabela tbody tr:hover {
+  background: var(--surface-2);
+}
+
+.painel-tabela .num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.painel-th {
+  cursor: pointer;
+  user-select: none;
+}
+
+.painel-th:hover {
+  color: var(--text);
+}
+
+.painel-th--ativa {
+  color: var(--accent);
+}
+
+.painel-user__nome {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.painel-user__sub {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.painel-user__semuser {
+  color: #d9536b;
+  font-style: italic;
+}
+
+.painel-tag {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  border: 1px solid var(--border-strong);
+  color: var(--muted);
+}
+
+.painel-tag--social {
+  border-color: var(--accent);
+  color: var(--accent);
+}

--- a/frontend/src/styles/painel.css
+++ b/frontend/src/styles/painel.css
@@ -1,5 +1,9 @@
 /* Painel/CRM do admin: cards de visão geral, gráfico de cadastros e tabela de usuários. */
 
+.painel-page {
+  background: var(--surface);
+}
+
 .painel-cards {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
@@ -35,45 +39,102 @@
   color: var(--muted);
 }
 
-.painel-chart {
+.painel-graf {
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 12px;
-  padding: 14px 16px 10px;
+  padding: 14px 16px 8px;
   margin-bottom: 20px;
 }
 
-.painel-chart__titulo {
+.painel-graf__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.painel-graf__titulo {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.painel-graf__periodos {
+  display: flex;
+  gap: 2px;
+}
+
+.painel-graf__periodo {
+  padding: 4px 10px;
+  border: none;
+  background: none;
+  color: var(--muted);
   font-size: 13px;
   font-weight: 600;
+  border-radius: 7px;
+  cursor: pointer;
+}
+
+.painel-graf__periodo:hover {
+  background: var(--surface-2);
+  color: var(--text);
+}
+
+.painel-graf__periodo.is-ativo {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.painel-graf__leitura {
+  font-size: 13px;
   color: var(--muted);
-  margin-bottom: 10px;
+  min-height: 20px;
+  margin: 4px 0;
 }
 
-.painel-chart__bars {
-  display: flex;
-  align-items: flex-end;
-  gap: 3px;
-  height: 90px;
+.painel-graf__leitura b {
+  color: var(--text);
+  font-size: 15px;
 }
 
-.painel-chart__col {
-  flex: 1;
-  height: 100%;
-  display: flex;
-  align-items: flex-end;
-}
-
-.painel-chart__bar {
+.painel-graf__svg {
   width: 100%;
-  min-height: 2px;
-  background: var(--accent);
-  border-radius: 3px 3px 0 0;
-  transition: opacity 0.15s;
+  height: auto;
+  display: block;
+  overflow: visible;
 }
 
-.painel-chart__col:hover .painel-chart__bar {
-  opacity: 0.7;
+.painel-graf__grid {
+  stroke: var(--border);
+  stroke-width: 1;
+}
+
+.painel-graf__linha {
+  fill: none;
+  stroke: var(--accent);
+  stroke-width: 2;
+  stroke-linejoin: round;
+  stroke-linecap: round;
+}
+
+.painel-graf__ylab,
+.painel-graf__xlab {
+  fill: var(--muted);
+  font-size: 11px;
+}
+
+.painel-graf__cross {
+  stroke: var(--border-strong);
+  stroke-width: 1;
+  stroke-dasharray: 3 3;
+}
+
+.painel-graf__dot {
+  fill: var(--accent);
+  stroke: var(--surface);
+  stroke-width: 2;
 }
 
 .painel-toolbar {


### PR DESCRIPTION
Painel/CRM interno no estúdio (`/estudio/usuarios`), só admin, pra ter controle da base de usuários.

## Visão geral
Cards com os totais: usuários (quantos com username e quantos de login social), ativos em 7 e 30 dias, novos em 7 e 30 dias, aulas concluídas, simulados feitos e desafios resolvidos. Mais um gráfico de cadastros nos últimos 30 dias.

## Tabela de usuários
Cada aluno com nome, username (destacando quem está sem), origem (email/social), aulas concluídas, trilhas concluídas, simulados, desafios, conquistas, XP e última atividade. Com busca (nome/username/email) e ordenação por qualquer coluna clicando no cabeçalho.

## Como foi feito
Tudo em cima do que já existe, sem tabela nova. As métricas saem de poucas queries agregadas (sem N+1), e "última atividade" é derivada do maior timestamp de atividade (aula, simulado, desafio ou conquista), então não precisou de coluna de last-seen. Endpoints `GET /admin/overview` e `GET /admin/users`, ambos admin-gated e cobertos pelo rate limit. Validado rodando o service direto contra o banco (o overview e as métricas por usuário batem com a realidade, testei inclusive na prod com os 347 usuários).

Sem migration. Se depois você quiser "último login" preciso (e não só última atividade), a gente adiciona uma coluna `last_seen_at` numa próxima.
