### PR TITLE
feat: torna o username obrigatório mesmo no login social

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -29,7 +29,7 @@ import { OAuthCallback } from './pages/OAuthCallback';
 import { CompletarPerfil } from './pages/CompletarPerfil';
 import { Placeholder } from './pages/Placeholder';
 
-function PrivateRoute({ children }: { children: React.JSX.Element }) {
+function AuthRoute({ children }: { children: React.JSX.Element }) {
   const { isAuthenticated, loading } = useAuth();
 
   if (loading) return <div>Carregando...</div>;
@@ -37,11 +37,21 @@ function PrivateRoute({ children }: { children: React.JSX.Element }) {
   return isAuthenticated ? children : <Navigate to="/" />;
 }
 
+function PrivateRoute({ children }: { children: React.JSX.Element }) {
+  const { isAuthenticated, user, loading } = useAuth();
+
+  if (loading) return <div>Carregando...</div>;
+  if (!isAuthenticated) return <Navigate to="/" />;
+  if (!user?.username) return <Navigate to="/completar-perfil" replace />;
+  return children;
+}
+
 function AdminRoute({ children }: { children: React.JSX.Element }) {
   const { user, isAuthenticated, loading } = useAuth();
 
   if (loading) return <div>Carregando...</div>;
   if (!isAuthenticated) return <Navigate to="/" />;
+  if (!user?.username) return <Navigate to="/completar-perfil" replace />;
   return user?.role === 'admin' ? children : <Navigate to="/home" />;
 }
 
@@ -59,9 +69,9 @@ function AppRoutes() {
       <Route
         path="/completar-perfil"
         element={
-          <PrivateRoute>
+          <AuthRoute>
             <CompletarPerfil />
-          </PrivateRoute>
+          </AuthRoute>
         }
       />
 

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -4,6 +4,7 @@ import api from '../services/api';
 interface User {
   id: string;
   name: string;
+  username?: string | null;
   email: string;
   gender: string;
   phone: string;

--- a/frontend/src/pages/CompletarPerfil/index.tsx
+++ b/frontend/src/pages/CompletarPerfil/index.tsx
@@ -10,6 +10,7 @@ import {
 } from '../../components/ProfileCompletionFields';
 import { Check } from '../../components/Icons';
 import { mensagemErro } from '../../utils/erro';
+import { useAuth } from '../../contexts/AuthContext';
 
 type Erros = Record<string, string>;
 
@@ -17,6 +18,7 @@ type Erros = Record<string, string>;
 // não fornece (nascimento, gênero e telefone).
 export function CompletarPerfil() {
   const navigate = useNavigate();
+  const { atualizarUsuario } = useAuth();
   const [username, setUsername] = useState('');
   const [birthDate, setBirthDate] = useState('');
   const [gender, setGender] = useState('');
@@ -45,6 +47,7 @@ export function CompletarPerfil() {
         gender,
         phone: phone.trim(),
       });
+      atualizarUsuario({ username, gender, phone: phone.trim() });
       navigate('/home', { replace: true });
     } catch (e: unknown) {
       const msg = mensagemErro(e, 'Não foi possível salvar. Tente novamente.');


### PR DESCRIPTION
Fecha o buraco que deixou 25 usuários sem username. Quem entra por login social (Google/GitHub) era criado sem username e conseguia usar o app sem completar o perfil, porque o guard de rota (`PrivateRoute`) só checava se a pessoa estava logada, não se o perfil estava completo.

## O que mudou
- `PrivateRoute` e `AdminRoute` agora exigem `username`: sem ele, a pessoa é redirecionada pra `/completar-perfil` antes de acessar qualquer tela do app.
- A tela `/completar-perfil` passou a usar um guard só de login (`AuthRoute`), senão o próprio guard entraria em loop de redirecionamento.
- Ao completar o perfil, o usuário no contexto é atualizado na hora (state + localStorage), então não há loop nem flicker no reload.
- O tipo `User` ganhou o campo `username` (o `/me` já retornava).

Vale também pras contas antigas sem username: no próximo acesso elas caem na tela de completar perfil.

## Nota
Isto é enforcement no frontend, que cobre o fluxo normal do app. Se você quiser blindagem contra chamada direta na API, dá pra adicionar um middleware no backend que bloqueia as rotas protegidas até o perfil estar completo. Posso fazer numa próxima.
