### PR TITLE
fix: correções de segurança do CodeQL (escaping, origem e permissões do CI)

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -11,6 +11,9 @@ concurrency:
   group: pipeline-${{ github.ref }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   backend-tests:
     runs-on: ubuntu-latest

--- a/backend/src/middlewares/origem.ts
+++ b/backend/src/middlewares/origem.ts
@@ -1,0 +1,11 @@
+import type { Request, Response, NextFunction } from "express";
+import { env } from "../config/env.ts";
+
+export function mesmaOrigem(req: Request, res: Response, next: NextFunction) {
+    if (env.NODE_ENV !== "production") return next();
+    const origem = req.headers.origin;
+    if (origem && origem !== env.FRONTEND_URL) {
+        return res.status(403).json({ error: "Origem não permitida" });
+    }
+    next();
+}

--- a/backend/src/routes/auth.routes.ts
+++ b/backend/src/routes/auth.routes.ts
@@ -17,13 +17,14 @@ import {
     forgotPasswordLimiter,
     resetPasswordLimiter,
 } from "../middlewares/rateLimit.ts";
+import { mesmaOrigem } from "../middlewares/origem.ts";
 
 const router = Router();
 
 router.post("/login", loginLimiter, login);
 router.post("/register", registerLimiter, register);
-router.post("/refresh", refreshLimiter, refresh);
-router.post("/logout", refreshLimiter, logout);
+router.post("/refresh", mesmaOrigem, refreshLimiter, refresh);
+router.post("/logout", mesmaOrigem, refreshLimiter, logout);
 router.post("/verify-email", verifyEmailLimiter, verifyEmail);
 router.post("/forgot-password", forgotPasswordLimiter, forgotPassword);
 router.post("/reset-password", resetPasswordLimiter, resetPassword);

--- a/backend/src/services/estudio.service.ts
+++ b/backend/src/services/estudio.service.ts
@@ -254,7 +254,8 @@ function tabelaParaMarkdown(value: string): string {
     try {
         const grid = JSON.parse(value);
         if (!Array.isArray(grid) || grid.length === 0) return "";
-        const celula = (c: unknown) => String(c ?? "").replace(/\|/g, "\\|").replace(/\n/g, " ");
+        const celula = (c: unknown) =>
+            String(c ?? "").replace(/\\/g, "\\\\").replace(/\|/g, "\\|").replace(/\n/g, " ");
         const linha = (r: unknown[]) => "| " + r.map(celula).join(" | ") + " |";
         const [cabecalho, ...corpo] = grid as unknown[][];
         const separador = "| " + cabecalho.map(() => "---").join(" | ") + " |";


### PR DESCRIPTION
Três achados do CodeQL, tratados conforme o risco real de cada um.

## 1. Escaping incompleto de tabela (`js/incomplete-sanitization`)
`tabelaParaMarkdown` (estudio.service.ts) escapava o pipe (`|`) mas não a barra invertida (`\`). Como a barra é o próprio caractere de escape, uma célula com `\|` virava `\\|` na saída (barra escapada seguida de pipe livre), quebrando a tabela markdown renderizada para o aluno. Fix: escapar a barra primeiro. Severidade baixa (conteúdo autorado por admin no estúdio), fix de uma linha.

## 2. Missing CSRF middleware (defesa em profundidade)
Na prática era falso positivo: a auth da API é por Bearer token (imune a CSRF) e o cookie de refresh já é SameSite=Strict. Ainda assim adicionei o middleware `mesmaOrigem` nas rotas `/refresh` e `/logout` (as únicas que confiam no cookie), que recusa `Origin` cross-site em produção; em dev é no-op. Não usei `csurf` (redundante com SameSite=Strict e deprecado).

## 3. Workflow sem bloco de permissões (`actions/missing-workflow-permissions`)
Sem `permissions:` explícito, o `GITHUB_TOKEN` do pipeline herdava o default do repositório (read-write em repos antigos). Todos os jobs só precisam de leitura para o checkout (o job de deploy nem faz checkout: usa SSH e secrets, não o token), então declarei `permissions: contents: read` no topo, o mínimo que mantém o pipeline funcionando.

## Validação
Backend tsc passa, o backend sobe saudável com o middleware, e testei a lógica do escaping (o caso `\|` preserva a tabela). O `mesmaOrigem` é no-op em dev, sem mudar o fluxo local de refresh. A mudança no pipeline é só a declaração de permissões.
