### PR TITLE
feat: filtros de trilha, responsividade mobile e topbar única do estúdio

### DIFF
--- a/backend/scripts/seed-categorias-trilhas.ts
+++ b/backend/scripts/seed-categorias-trilhas.ts
@@ -1,0 +1,61 @@
+// Cria as tags de categoria e as associa às trilhas (idempotente). Reaproveita o
+// sistema de tags que já existe (tabela tags + trail_tags), sem migração.
+//
+// Rodar em prod: docker compose -f docker-compose.prod.yml exec -T backend node scripts/seed-categorias-trilhas.ts
+import { db } from "../db.ts";
+import { trails, tags, trailTags } from "../schema.ts";
+import { eq } from "drizzle-orm";
+
+const MAPA: Record<string, string[]> = {
+    "AWS CLF-C02": ["Nuvem"],
+    "AWS DVA-C02": ["Nuvem"],
+    "AZURE AZ-900": ["Nuvem"],
+    "AZURE DP-900": ["Nuvem", "Dados"],
+    "AZURE AI-900": ["Nuvem", "IA"],
+    "AZURE AI-901": ["Nuvem", "IA"],
+    "AZURE SC-900": ["Nuvem", "Cibersegurança"],
+    HTML: ["Front-end"],
+    CSS: ["Front-end"],
+    JavaScript: ["Front-end"],
+    "UI/UX Design": ["Front-end"],
+    "Fundamentos de Cibersegurança": ["Cibersegurança"],
+    "Segurança de Aplicações Web": ["Cibersegurança", "Front-end"],
+};
+
+async function seed() {
+    const nomes = [...new Set(Object.values(MAPA).flat())];
+    const idPorTag = new Map<string, string>();
+    for (const nome of nomes) {
+        let [tag] = await db.select().from(tags).where(eq(tags.name, nome));
+        if (!tag) {
+            [tag] = await db.insert(tags).values({ name: nome }).returning();
+            console.log("Tag criada: " + nome);
+        }
+        idPorTag.set(nome, tag.id);
+    }
+
+    let assoc = 0;
+    for (const [nomeTrilha, cats] of Object.entries(MAPA)) {
+        const [trilha] = await db.select().from(trails).where(eq(trails.name, nomeTrilha));
+        if (!trilha) {
+            console.log("Trilha não encontrada, pulando: " + nomeTrilha);
+            continue;
+        }
+        for (const cat of cats) {
+            const inserida = await db
+                .insert(trailTags)
+                .values({ trailId: trilha.id, tagId: idPorTag.get(cat)! })
+                .onConflictDoNothing()
+                .returning();
+            if (inserida.length) assoc++;
+        }
+    }
+    console.log(`Concluído: ${nomes.length} tags garantidas, ${assoc} novas associações.`);
+}
+
+seed()
+    .then(() => process.exit(0))
+    .catch((e) => {
+        console.error("Falha ao categorizar trilhas:", e);
+        process.exit(1);
+    });

--- a/backend/src/controllers/TrailController.ts
+++ b/backend/src/controllers/TrailController.ts
@@ -313,9 +313,11 @@ export const createQuestion = async (req: Request, res: Response, next: NextFunc
     }
 };
 
-export const listTrails = async (_req: Request, res: Response, next: NextFunction) => {
+export const listTrails = async (req: Request, res: Response, next: NextFunction) => {
     try {
-        res.json(await listarTrilhas());
+        const level = typeof req.query.level === "string" ? req.query.level : undefined;
+        const categoria = typeof req.query.categoria === "string" ? req.query.categoria : undefined;
+        res.json(await listarTrilhas({ level, categoria }));
     } catch (err) {
         next(err);
     }

--- a/backend/src/services/trail.service.ts
+++ b/backend/src/services/trail.service.ts
@@ -10,7 +10,7 @@ import {
     questionOptions,
     questionAnswers,
 } from "../../schema.ts";
-import { eq, asc, count, inArray } from "drizzle-orm";
+import { eq, asc, count, inArray, and } from "drizzle-orm";
 import type { z } from "zod";
 import type { createTrailSchema, updateTrailSchema } from "../schemas/trail.schemas.ts";
 import { AppError } from "../errors/AppError.ts";
@@ -109,7 +109,23 @@ export async function excluirTrilha(trailId: string) {
     });
 }
 
-export async function listarTrilhas() {
+const NIVEIS_VALIDOS = new Set(["iniciante", "intermediario", "avancado"]);
+
+export async function listarTrilhas(filtros: { level?: string; categoria?: string } = {}) {
+    const filtroNivel =
+        filtros.level && NIVEIS_VALIDOS.has(filtros.level)
+            ? eq(trails.trailLevel, filtros.level as "iniciante" | "intermediario" | "avancado")
+            : undefined;
+    const filtroCategoria = filtros.categoria
+        ? inArray(
+              trails.id,
+              db
+                  .select({ id: trailTags.trailId })
+                  .from(trailTags)
+                  .innerJoin(tags, eq(tags.id, trailTags.tagId))
+                  .where(eq(tags.name, filtros.categoria)),
+          )
+        : undefined;
     const lista = await db
         .select({
             id: trails.id,
@@ -120,6 +136,7 @@ export async function listarTrilhas() {
         })
         .from(trails)
         .leftJoin(lessons, eq(lessons.trailId, trails.id))
+        .where(and(filtroNivel, filtroCategoria))
         .groupBy(trails.id);
 
     const vinculos = await db

--- a/frontend/src/components/EstudioTopbar.tsx
+++ b/frontend/src/components/EstudioTopbar.tsx
@@ -1,0 +1,49 @@
+import type { ReactNode } from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import { Logo } from './Logo';
+import { MobileMenu } from './MobileMenu';
+import { NAV_ESTUDIO } from '../data/nav';
+
+interface Props {
+  crumb?: ReactNode;
+  actions?: ReactNode;
+  badge?: string;
+  nav?: boolean;
+}
+
+export function EstudioTopbar({ crumb, actions, badge = 'Estúdio', nav = true }: Props) {
+  const { pathname } = useLocation();
+  const casa = (to: string) => pathname === to || pathname.startsWith(to + '/');
+  const ativo = NAV_ESTUDIO.filter((i) => casa(i.to)).reduce(
+    (melhor, i) => (i.to.length > melhor.length ? i.to : melhor),
+    '',
+  );
+
+  return (
+    <header className="topbar studio__bar">
+      <MobileMenu items={NAV_ESTUDIO} />
+      <div className="studio__brand">
+        <Logo variant="solid" size={19} />
+        <span className="studio__badge">{badge}</span>
+      </div>
+      {crumb && (
+        <>
+          <span className="studio__divider" />
+          <div className="studio__crumb">{crumb}</div>
+        </>
+      )}
+      <div className="topbar__spacer" />
+      {actions}
+      {nav &&
+        NAV_ESTUDIO.map((item) => (
+          <Link
+            key={item.to}
+            to={item.to}
+            className={`btn btn--ghost studio__btn studio__navbtn${item.to === ativo ? ' studio__btn--active' : ''}`}
+          >
+            {item.label}
+          </Link>
+        ))}
+    </header>
+  );
+}

--- a/frontend/src/components/MobileMenu.tsx
+++ b/frontend/src/components/MobileMenu.tsx
@@ -6,11 +6,14 @@ import { X } from './Icons';
 import { NAV_PRINCIPAL as NAV } from '../data/nav';
 
 // Hambúrguer + drawer lateral, visíveis só no telefone (controlados por CSS).
-export function MobileMenu() {
+export function MobileMenu({ items = NAV }: { items?: { to: string; label: string }[] }) {
   const [aberto, setAberto] = useState(false);
   const { pathname } = useLocation();
   const fechar = () => setAberto(false);
-  const ativo = (to: string) => pathname === to || pathname.startsWith(to + '/');
+  const casa = (to: string) => pathname === to || pathname.startsWith(to + '/');
+  const ativo = items
+    .filter((i) => casa(i.to))
+    .reduce((melhor, i) => (i.to.length > melhor.length ? i.to : melhor), '');
 
   return (
     <>
@@ -40,12 +43,12 @@ export function MobileMenu() {
                 <X size={20} />
               </button>
             </div>
-            {NAV.map((item) => (
+            {items.map((item) => (
               <Link
                 key={item.to}
                 to={item.to}
                 onClick={fechar}
-                className={`drawer__item${ativo(item.to) ? ' drawer__item--active' : ''}`}
+                className={`drawer__item${item.to === ativo ? ' drawer__item--active' : ''}`}
               >
                 {item.label}
               </Link>

--- a/frontend/src/data/nav.ts
+++ b/frontend/src/data/nav.ts
@@ -8,3 +8,11 @@ export const NAV_PRINCIPAL = [
   { label: 'Ranking', to: '/ranking' },
   { label: 'Comunidade', to: '/comunidade' },
 ];
+
+export const NAV_ESTUDIO = [
+  { label: 'Trilhas', to: '/estudio' },
+  { label: 'Usuários', to: '/estudio/usuarios' },
+  { label: 'Simulados', to: '/estudio/simulados' },
+  { label: 'Desafios', to: '/estudio/desafios' },
+  { label: 'Voltar ao app', to: '/home' },
+];

--- a/frontend/src/pages/Configuracoes/index.tsx
+++ b/frontend/src/pages/Configuracoes/index.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { Link } from 'react-router-dom';
-import { Logo } from '../../components/Logo';
+import { EstudioTopbar } from '../../components/EstudioTopbar';
 import { useRequisicao } from '../../hooks/useRequisicao';
 import { Plus, Pencil, Trash, Check, IconeConquista, CHAVES_ICONE } from '../../components/Icons';
 import {
@@ -725,20 +724,7 @@ export function Configuracoes() {
   const [aba, setAba] = useState<(typeof ABAS_CFG)[number]['key']>('tags');
   return (
     <div className="home">
-      <header className="topbar studio__bar">
-        <div className="studio__brand">
-          <Logo variant="solid" size={19} />
-          <span className="studio__badge">Configurações</span>
-        </div>
-        <span className="studio__divider" />
-        <div className="studio__crumb">
-          <b>Tags, linguagens, conquistas e glossário</b>
-        </div>
-        <div className="topbar__spacer" />
-        <Link className="btn btn--ghost studio__btn" to="/home">
-          Voltar ao app
-        </Link>
-      </header>
+      <EstudioTopbar badge="Configurações" crumb={<b>Tags, linguagens, conquistas e glossário</b>} />
 
       <div className="estudio-home">
         <div className="cfg-tabs">

--- a/frontend/src/pages/DesafiosAdmin/Editor.tsx
+++ b/frontend/src/pages/DesafiosAdmin/Editor.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
+import { EstudioTopbar } from '../../components/EstudioTopbar';
 import { Link, useParams, useNavigate } from 'react-router-dom';
-import { Logo } from '../../components/Logo';
 import { Plus, Trash } from '../../components/Icons';
 import { useToast } from '../../contexts/ToastContext';
 import { mensagemErro } from '../../utils/erro';
@@ -193,25 +193,26 @@ export function DesafioEditor() {
   }
 
   const cabecalho = (
-    <header className="topbar studio__bar">
-      <div className="studio__brand">
-        <Logo variant="solid" size={19} />
-        <span className="studio__badge">Estúdio</span>
-      </div>
-      <span className="studio__divider" />
-      <div className="studio__crumb">
-        <Link to="/estudio/desafios">Desafios</Link>
-        <span>/</span>
-        <b>{novo ? 'Novo desafio' : form?.title || 'Editar'}</b>
-      </div>
-      <div className="topbar__spacer" />
-      <button className="btn btn--accent studio__btn" disabled={salvando || !form} onClick={salvar}>
-        {salvando ? 'Salvando...' : 'Salvar'}
-      </button>
-      <Link className="btn btn--ghost studio__btn" to="/estudio/desafios">
-        Voltar
-      </Link>
-    </header>
+    <EstudioTopbar
+      nav={false}
+      crumb={
+        <>
+          <Link to="/estudio/desafios">Desafios</Link>
+          <span>/</span>
+          <b>{novo ? 'Novo desafio' : form?.title || 'Editar'}</b>
+        </>
+      }
+      actions={
+        <>
+          <button className="btn btn--accent studio__btn" disabled={salvando || !form} onClick={salvar}>
+            {salvando ? 'Salvando...' : 'Salvar'}
+          </button>
+          <Link className="btn btn--ghost studio__btn" to="/estudio/desafios">
+            Voltar
+          </Link>
+        </>
+      }
+    />
   );
 
   if (carregando) {

--- a/frontend/src/pages/DesafiosAdmin/index.tsx
+++ b/frontend/src/pages/DesafiosAdmin/index.tsx
@@ -1,5 +1,5 @@
-import { Link, useNavigate } from 'react-router-dom';
-import { Logo } from '../../components/Logo';
+import { useNavigate } from 'react-router-dom';
+import { EstudioTopbar } from '../../components/EstudioTopbar';
 import { Plus, Pencil, Trash, ChevronRight, Target } from '../../components/Icons';
 import { useRequisicao } from '../../hooks/useRequisicao';
 import { useToast } from '../../contexts/ToastContext';
@@ -33,26 +33,7 @@ export function DesafiosAdmin() {
 
   return (
     <div className="home">
-      <header className="topbar studio__bar">
-        <div className="studio__brand">
-          <Logo variant="solid" size={19} />
-          <span className="studio__badge">Estúdio</span>
-        </div>
-        <span className="studio__divider" />
-        <div className="studio__crumb">
-          <b>Desafios</b>
-        </div>
-        <div className="topbar__spacer" />
-        <Link className="btn btn--ghost studio__btn" to="/estudio">
-          Trilhas
-        </Link>
-        <Link className="btn btn--ghost studio__btn" to="/estudio/simulados">
-          Simulados
-        </Link>
-        <Link className="btn btn--ghost studio__btn" to="/home">
-          Voltar ao app
-        </Link>
-      </header>
+      <EstudioTopbar crumb={<b>Desafios</b>} />
 
       <div className="estudio-home">
         <div className="estudio-home__head">

--- a/frontend/src/pages/Estudio/index.tsx
+++ b/frontend/src/pages/Estudio/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
+import { EstudioTopbar } from '../../components/EstudioTopbar';
 import { Link, useParams } from 'react-router-dom';
-import { Logo } from '../../components/Logo';
 import { Eye, Trash, Plus, Minus, Check, ChevronRight } from '../../components/Icons';
 import { mensagemErro } from '../../utils/erro';
 import {
@@ -312,36 +312,37 @@ export function Estudio() {
 
   return (
     <div className="home">
-      <header className="topbar studio__bar">
-        <div className="studio__brand">
-          <Logo variant="solid" size={19} />
-          <span className="studio__badge">Estúdio</span>
-        </div>
-        <span className="studio__divider" />
-        <div className="studio__crumb">
-          <Link to="/trilhas">Trilhas</Link>
-          <span className="studio__crumb-sep">/</span>
-          <b>{outline?.name ?? '...'}</b>
-        </div>
-        <div className="topbar__spacer" />
-        {aula && salvo && (
-          <span className="studio__saved">
-            <i /> Rascunho salvo
-          </span>
-        )}
-        {aula && (
-          <Link className="btn btn--ghost studio__btn" to={`/trilhas/${trailId}/aula/${aula.id}`}>
-            <Eye size={15} /> Pré-visualizar
-          </Link>
-        )}
-        <button
-          className="btn btn--accent studio__btn"
-          disabled={!aula || salvando}
-          onClick={() => aula && salvar(!aula.published)}
-        >
-          {salvando ? 'Salvando...' : aula?.published ? 'Despublicar' : 'Publicar'}
-        </button>
-      </header>
+      <EstudioTopbar
+        nav={false}
+        crumb={
+          <>
+            <Link to="/trilhas">Trilhas</Link>
+            <span className="studio__crumb-sep">/</span>
+            <b>{outline?.name ?? '...'}</b>
+          </>
+        }
+        actions={
+          <>
+            {aula && salvo && (
+              <span className="studio__saved">
+                <i /> Rascunho salvo
+              </span>
+            )}
+            {aula && (
+              <Link className="btn btn--ghost studio__btn" to={`/trilhas/${trailId}/aula/${aula.id}`}>
+                <Eye size={15} /> Pré-visualizar
+              </Link>
+            )}
+            <button
+              className="btn btn--accent studio__btn"
+              disabled={!aula || salvando}
+              onClick={() => aula && salvar(!aula.published)}
+            >
+              {salvando ? 'Salvando...' : aula?.published ? 'Despublicar' : 'Publicar'}
+            </button>
+          </>
+        }
+      />
 
       {carregando ? (
         <p className="lesson__loading">Carregando estúdio...</p>

--- a/frontend/src/pages/EstudioHome/index.tsx
+++ b/frontend/src/pages/EstudioHome/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
-import { Logo } from '../../components/Logo';
+import { useNavigate } from 'react-router-dom';
+import { EstudioTopbar } from '../../components/EstudioTopbar';
 import { ChevronRight, Plus, Pencil, Trash } from '../../components/Icons';
 import { useRequisicao } from '../../hooks/useRequisicao';
 import {
@@ -116,29 +116,7 @@ export function EstudioHome() {
 
   return (
     <div className="home">
-      <header className="topbar studio__bar">
-        <div className="studio__brand">
-          <Logo variant="solid" size={19} />
-          <span className="studio__badge">Estúdio</span>
-        </div>
-        <span className="studio__divider" />
-        <div className="studio__crumb">
-          <b>Painel do administrador</b>
-        </div>
-        <div className="topbar__spacer" />
-        <Link className="btn btn--ghost studio__btn" to="/estudio/usuarios">
-          Usuários
-        </Link>
-        <Link className="btn btn--ghost studio__btn" to="/estudio/simulados">
-          Simulados
-        </Link>
-        <Link className="btn btn--ghost studio__btn" to="/estudio/desafios">
-          Desafios
-        </Link>
-        <Link className="btn btn--ghost studio__btn" to="/home">
-          Voltar ao app
-        </Link>
-      </header>
+      <EstudioTopbar crumb={<b>Painel do administrador</b>} />
 
       <div className="estudio-home">
         <div className="estudio-home__head">

--- a/frontend/src/pages/SimuladosAdmin/Editor.tsx
+++ b/frontend/src/pages/SimuladosAdmin/Editor.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
+import { EstudioTopbar } from '../../components/EstudioTopbar';
 import { Link, useParams } from 'react-router-dom';
-import { Logo } from '../../components/Logo';
 import { Plus, Trash, Check, Minus } from '../../components/Icons';
 import { mensagemErro } from '../../utils/erro';
 import { useToast } from '../../contexts/ToastContext';
@@ -125,29 +125,30 @@ export function SimuladoEditor() {
 
   return (
     <div className="home">
-      <header className="topbar studio__bar">
-        <div className="studio__brand">
-          <Logo variant="solid" size={19} />
-          <span className="studio__badge">Estúdio</span>
-        </div>
-        <span className="studio__divider" />
-        <div className="studio__crumb">
-          <Link to="/estudio/simulados">Simulados</Link>
-          <span className="studio__crumb-sep">/</span>
-          <b>{nome || '...'}</b>
-        </div>
-        <div className="topbar__spacer" />
-        <button
-          className="btn btn--accent studio__btn"
-          disabled={salvandoTudo || carregando}
-          onClick={salvarTudo}
-        >
-          {salvandoTudo ? 'Salvando...' : 'Salvar tudo'}
-        </button>
-        <Link className="btn btn--ghost studio__btn" to="/estudio/simulados">
-          Voltar
-        </Link>
-      </header>
+      <EstudioTopbar
+        nav={false}
+        crumb={
+          <>
+            <Link to="/estudio/simulados">Simulados</Link>
+            <span className="studio__crumb-sep">/</span>
+            <b>{nome || '...'}</b>
+          </>
+        }
+        actions={
+          <>
+            <button
+              className="btn btn--accent studio__btn"
+              disabled={salvandoTudo || carregando}
+              onClick={salvarTudo}
+            >
+              {salvandoTudo ? 'Salvando...' : 'Salvar tudo'}
+            </button>
+            <Link className="btn btn--ghost studio__btn" to="/estudio/simulados">
+              Voltar
+            </Link>
+          </>
+        }
+      />
 
       <div className="studio__editor">
         <div className="studio__section">

--- a/frontend/src/pages/SimuladosAdmin/index.tsx
+++ b/frontend/src/pages/SimuladosAdmin/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
-import { Logo } from '../../components/Logo';
+import { EstudioTopbar } from '../../components/EstudioTopbar';
+import { useNavigate } from 'react-router-dom';
 import { Plus, Pencil, Trash, ChevronRight, GradCap } from '../../components/Icons';
 import { useRequisicao } from '../../hooks/useRequisicao';
 import { mensagemErro } from '../../utils/erro';
@@ -112,23 +112,7 @@ export function SimuladosAdmin() {
 
   return (
     <div className="home">
-      <header className="topbar studio__bar">
-        <div className="studio__brand">
-          <Logo variant="solid" size={19} />
-          <span className="studio__badge">Estúdio</span>
-        </div>
-        <span className="studio__divider" />
-        <div className="studio__crumb">
-          <b>Simulados</b>
-        </div>
-        <div className="topbar__spacer" />
-        <Link className="btn btn--ghost studio__btn" to="/estudio">
-          Trilhas
-        </Link>
-        <Link className="btn btn--ghost studio__btn" to="/home">
-          Voltar ao app
-        </Link>
-      </header>
+      <EstudioTopbar crumb={<b>Simulados</b>} />
 
       <div className="estudio-home">
         <div className="estudio-home__head">

--- a/frontend/src/pages/Trilhas/index.tsx
+++ b/frontend/src/pages/Trilhas/index.tsx
@@ -207,36 +207,31 @@ export function Trilhas() {
           )}
 
           {/* Filtros */}
-          <div className="filters filters--tight">
-            <span className="filters__label">Nível</span>
-            {NIVEIS.map((n) => (
-              <button
-                key={n.v}
-                className={`filter${nivel === n.v ? ' filter--active' : ''}`}
-                onClick={() => setNivel(n.v)}
-              >
-                {n.label}
-              </button>
-            ))}
+          <div className="filters">
+            <label className="select-filtro">
+              <span className="filters__label">Nível</span>
+              <select value={nivel} onChange={(e) => setNivel(e.target.value)}>
+                {NIVEIS.map((n) => (
+                  <option key={n.v} value={n.v}>
+                    {n.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="select-filtro">
+              <span className="filters__label">Categoria</span>
+              <select value={categoria} onChange={(e) => setCategoria(e.target.value)}>
+                <option value="">Todas</option>
+                {tagsDisp.map((t) => (
+                  <option key={t.id} value={t.name}>
+                    {t.name}
+                  </option>
+                ))}
+              </select>
+            </label>
             <div className="topbar__spacer" />
             <span className="filters__count">{trilhas.length} trilhas</span>
           </div>
-          {tagsDisp.length > 0 && (
-            <div className="filters">
-              <span className="filters__label">Categoria</span>
-              {[{ v: '', label: 'Todas' }, ...tagsDisp.map((t) => ({ v: t.name, label: t.name }))].map(
-                (c) => (
-                  <button
-                    key={c.v || 'todas'}
-                    className={`filter${categoria === c.v ? ' filter--active' : ''}`}
-                    onClick={() => setCategoria(c.v)}
-                  >
-                    {c.label}
-                  </button>
-                ),
-              )}
-            </div>
-          )}
 
           {carregando && <p className="track__desc">Carregando trilhas...</p>}
           {erro && <div className="auth__alert">{erro}</div>}

--- a/frontend/src/pages/Trilhas/index.tsx
+++ b/frontend/src/pages/Trilhas/index.tsx
@@ -38,6 +38,13 @@ const LEVEL_TINT: Record<'light' | 'dark', Record<TrailLevel, Tint>> = {
   },
 };
 
+const NIVEIS: { v: string; label: string }[] = [
+  { v: '', label: 'Todos' },
+  { v: 'iniciante', label: 'Iniciante' },
+  { v: 'intermediario', label: 'Intermediário' },
+  { v: 'avancado', label: 'Avançado' },
+];
+
 function Metric({ value, label, accent }: { value: string; label: string; accent?: boolean }) {
   return (
     <div className="metric">
@@ -78,18 +85,17 @@ export function Trilhas() {
   const [erro, setErro] = useState('');
   const [xp, setXp] = useState(0);
   const [tagsDisp, setTagsDisp] = useState<Tag[]>([]);
-  const [filtro, setFiltro] = useState('Todas');
+  const [nivel, setNivel] = useState('');
+  const [categoria, setCategoria] = useState('');
 
   useEffect(() => {
     async function carregar() {
       try {
-        const [todas, doUsuario, stats, tg] = await Promise.all([
-          listarTrilhas(),
+        const [doUsuario, stats, tg] = await Promise.all([
           listarMinhasTrilhas(),
           obterXp(),
           listarTags(),
         ]);
-        setTrilhas(todas);
         setMinhas(doUsuario);
         setXp(stats.xp);
         setTagsDisp(tg);
@@ -102,6 +108,12 @@ export function Trilhas() {
     carregar();
   }, []);
 
+  useEffect(() => {
+    listarTrilhas(nivel || undefined, categoria || undefined)
+      .then(setTrilhas)
+      .catch(() => setErro('Não foi possível carregar as trilhas.'));
+  }, [nivel, categoria]);
+
   // Card de destaque: a trilha em andamento mais avançada (mas nao concluida).
   const continuar = minhas
     .filter((t) => t.done > 0 && t.done < t.lessons)
@@ -109,9 +121,6 @@ export function Trilhas() {
 
   const aulasConcluidas = minhas.reduce((soma, t) => soma + t.done, 0);
   const emAndamento = minhas.filter((t) => t.done < t.lessons).length;
-
-  const trilhasFiltradas =
-    filtro === 'Todas' ? trilhas : trilhas.filter((t) => t.tags.includes(filtro));
 
   return (
     <div className="home-shell">
@@ -198,29 +207,50 @@ export function Trilhas() {
           )}
 
           {/* Filtros */}
-          <div className="filters">
-            {['Todas', ...tagsDisp.map((t) => t.name)].map((f) => (
+          <div className="filters filters--tight">
+            <span className="filters__label">Nível</span>
+            {NIVEIS.map((n) => (
               <button
-                key={f}
-                className={`filter${filtro === f ? ' filter--active' : ''}`}
-                onClick={() => setFiltro(f)}
+                key={n.v}
+                className={`filter${nivel === n.v ? ' filter--active' : ''}`}
+                onClick={() => setNivel(n.v)}
               >
-                {f}
+                {n.label}
               </button>
             ))}
             <div className="topbar__spacer" />
-            <span className="filters__count">{trilhasFiltradas.length} trilhas</span>
+            <span className="filters__count">{trilhas.length} trilhas</span>
           </div>
+          {tagsDisp.length > 0 && (
+            <div className="filters">
+              <span className="filters__label">Categoria</span>
+              {[{ v: '', label: 'Todas' }, ...tagsDisp.map((t) => ({ v: t.name, label: t.name }))].map(
+                (c) => (
+                  <button
+                    key={c.v || 'todas'}
+                    className={`filter${categoria === c.v ? ' filter--active' : ''}`}
+                    onClick={() => setCategoria(c.v)}
+                  >
+                    {c.label}
+                  </button>
+                ),
+              )}
+            </div>
+          )}
 
           {carregando && <p className="track__desc">Carregando trilhas...</p>}
           {erro && <div className="auth__alert">{erro}</div>}
           {!carregando && !erro && trilhas.length === 0 && (
-            <p className="track__desc">Nenhuma trilha disponível ainda.</p>
+            <p className="track__desc">
+              {nivel || categoria
+                ? 'Nenhuma trilha com esse filtro.'
+                : 'Nenhuma trilha disponível ainda.'}
+            </p>
           )}
 
           {/* Grade */}
           <div className="track-grid">
-            {trilhasFiltradas.map((catalogo) => {
+            {trilhas.map((catalogo) => {
               // Cruza o catalogo com o progresso do usuario (done vem de /me/trails).
               const progresso = minhas.find((m) => m.id === catalogo.id);
               const t = { ...catalogo, done: progresso?.done ?? 0 };

--- a/frontend/src/pages/Usuarios/index.tsx
+++ b/frontend/src/pages/Usuarios/index.tsx
@@ -1,6 +1,5 @@
 import { useMemo, useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
-import { Logo } from '../../components/Logo';
+import { EstudioTopbar } from '../../components/EstudioTopbar';
 import { useRequisicao } from '../../hooks/useRequisicao';
 import { obterVisaoGeral, listarUsuariosCrm, type UsuarioCrm } from '../../services/admin';
 import { GraficoCrescimento } from './GraficoCrescimento';
@@ -95,29 +94,7 @@ export function Usuarios() {
 
   return (
     <div className="home painel-page">
-      <header className="topbar studio__bar">
-        <div className="studio__brand">
-          <Logo variant="solid" size={19} />
-          <span className="studio__badge">Estúdio</span>
-        </div>
-        <span className="studio__divider" />
-        <div className="studio__crumb">
-          <b>Usuários</b>
-        </div>
-        <div className="topbar__spacer" />
-        <Link className="btn btn--ghost studio__btn" to="/estudio">
-          Trilhas
-        </Link>
-        <Link className="btn btn--ghost studio__btn" to="/estudio/simulados">
-          Simulados
-        </Link>
-        <Link className="btn btn--ghost studio__btn" to="/estudio/desafios">
-          Desafios
-        </Link>
-        <Link className="btn btn--ghost studio__btn" to="/home">
-          Voltar ao app
-        </Link>
-      </header>
+      <EstudioTopbar crumb={<b>Usuários</b>} />
 
       <div className="estudio-home">
         <div className="estudio-home__head">

--- a/frontend/src/services/trails.ts
+++ b/frontend/src/services/trails.ts
@@ -47,8 +47,11 @@ function adaptar(t: TrailApi): Trail & { id: string } {
   };
 }
 
-export async function listarTrilhas() {
-  const { data } = await api.get<TrailApi[]>('/trails');
+export async function listarTrilhas(level?: string, categoria?: string) {
+  const params: Record<string, string> = {};
+  if (level) params.level = level;
+  if (categoria) params.categoria = categoria;
+  const { data } = await api.get<TrailApi[]>('/trails', { params });
   return data.map(adaptar);
 }
 

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1421,6 +1421,17 @@
   margin-bottom: 18px;
   flex-wrap: wrap;
 }
+
+.filters--tight {
+  margin-bottom: 10px;
+}
+
+.filters__label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--muted);
+  margin-right: 2px;
+}
 .filter {
   height: 34px;
   padding: 0 15px;

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1422,15 +1422,37 @@
   flex-wrap: wrap;
 }
 
-.filters--tight {
-  margin-bottom: 10px;
-}
-
 .filters__label {
   font-size: 13px;
   font-weight: 600;
   color: var(--muted);
   margin-right: 2px;
+}
+
+.select-filtro {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.select-filtro select {
+  height: 40px;
+  padding: 0 14px;
+  border-radius: var(--r-lg);
+  border: 1px solid var(--border-strong);
+  background: var(--input);
+  color: var(--text);
+  font-size: 14px;
+  cursor: pointer;
+  outline: none;
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.select-filtro select:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 16%, transparent);
 }
 .filter {
   height: 34px;
@@ -1592,7 +1614,7 @@
 /* ===================== TELA DE AULA ===================== */
 .lesson {
   display: grid;
-  grid-template-columns: 288px 1fr;
+  grid-template-columns: 320px 1fr;
   align-items: start;
 }
 .lesson__nav {
@@ -1666,8 +1688,8 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  height: 36px;
-  padding: 0 8px;
+  min-height: 36px;
+  padding: 7px 8px;
   border-radius: 9px;
   margin-bottom: 2px;
 }
@@ -1685,9 +1707,7 @@
   min-width: 0;
   font-size: 13.5px;
   font-weight: 500;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  line-height: 1.3;
 }
 .lesson__item--done .lesson__bullet {
   background: var(--success);
@@ -2335,6 +2355,10 @@
 .studio__btn {
   flex: none;
   height: 40px;
+}
+.studio__btn.studio__btn--active {
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
 }
 
 .studio {
@@ -4030,6 +4054,21 @@
 }
 
 /* ===================== RESPONSIVO / MOBILE ===================== */
+/* Estúdio tem muitos botões de nav: vira hambúrguer já a partir de 900px. */
+@media (max-width: 900px) {
+  .studio__bar {
+    gap: 10px;
+    padding: 0 14px;
+  }
+  .studio__bar .hamburguer {
+    display: flex;
+  }
+  .studio__bar .studio__divider,
+  .studio__bar .studio__crumb,
+  .studio__navbtn {
+    display: none;
+  }
+}
 /* Topbar no telefone: o nav inline e a busca somem, e aparece o hambúrguer. */
 @media (max-width: 640px) {
   .topbar {
@@ -4206,6 +4245,22 @@
 /* Telefone: cabeçalho do ranking empilha e as abas ocupam a linha; a linha de
    progressão das ligas some (não faz sentido com os emblemas empilhados). */
 @media (max-width: 640px) {
+  .pf-head {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 0 18px 20px;
+  }
+  .pf-id__row {
+    flex-wrap: wrap;
+  }
+  .pf-actions {
+    width: 100%;
+  }
+  .pf-actions__btn,
+  .pf-save {
+    flex: 1;
+  }
   .rk-head {
     flex-direction: column;
     gap: 12px;


### PR DESCRIPTION
O catálogo estava sem filtro (só "Todas") e já são 12 trilhas. Agora tem filtro por **nível** e por **categoria**, ambos **server-side**.

## O que mudou
- **Filtro de nível** (Iniciante / Intermediário / Avançado): usa o campo `level` que já existia.
- **Filtro de categoria** (Nuvem, Front-end, Cibersegurança, Dados, IA): reaproveita o sistema de **tags** que já existia no modelo (tabelas `tags` + `trail_tags`), então **sem migração**. Um script idempotente (`seed-categorias-trilhas.ts`) cria as tags e as associa às trilhas, multi-tag (SC-900 = Nuvem + Cibersegurança; DP-900 = Nuvem + Dados; AI-900/901 = Nuvem + IA).
- Ambos aplicados **no servidor**: o `/trails` aceita `?level=` e `?categoria=`, e o front refaz a busca quando o filtro muda, em vez de filtrar no cliente.

## Validação
Backend e frontend tsc + lint limpos. Testei o filtro direto no serviço: 11 trilhas no total, 10 iniciante / 1 intermediário, e a categoria Cibersegurança retorna exatamente as 3 certas (Fundamentos, AppSec, SC-900). O script de categorias é idempotente.

## Pós-deploy (produção)
Depois do merge e do deploy, rodar `seed-categorias-trilhas.ts` em prod para criar as tags e categorizar as 12 trilhas. As tags aparecem no filtro automaticamente (o front já lista as tags existentes).


---

## Ajustes de UX e responsividade (adicionados nesta rodada)
Feitos em cima do filtro, após revisão local no mobile:

- **Filtro em select:** os chips viraram dois selects (nível e categoria) no estilo dos inputs do sistema, mais enxuto conforme as categorias crescem.
- **Responsividade:** os títulos das aulas quebram linha em vez de cortar; o cabeçalho do perfil empilha no celular; a topbar do estúdio vira hambúrguer + drawer a partir de 900px.
- **Topbar do estúdio componentizada (`EstudioTopbar`):** antes duplicada em 8 páginas com listas de links inconsistentes. Agora é um componente único: as listas mostram todas as seções sempre (a atual destacada) e os editores ficam focados (breadcrumb + salvar). O `MobileMenu` virou reaproveitável e destaca só a rota mais específica como ativa.
