### PR TITLE
feat: adiciona a trilha e o simulado do ISC2 CC (Certified in Cybersecurity)

### DIFF
--- a/backend/scripts/seed-categorias-trilhas.ts
+++ b/backend/scripts/seed-categorias-trilhas.ts
@@ -20,6 +20,7 @@ const MAPA: Record<string, string[]> = {
     "UI/UX Design": ["Front-end"],
     "Fundamentos de Cibersegurança": ["Cibersegurança"],
     "Segurança de Aplicações Web": ["Cibersegurança", "Front-end"],
+    "ISC2 Certified in Cybersecurity (CC)": ["Cibersegurança"],
 };
 
 async function seed() {

--- a/backend/scripts/seed-isc2-cc.ts
+++ b/backend/scripts/seed-isc2-cc.ts
@@ -1,0 +1,2176 @@
+// Seed do simulado ISC2 Certified in Cybersecurity (CC).
+// Idempotente: se o simulado ja tiver questoes, nao faz nada.
+//
+// Rodar em prod: docker compose -f docker-compose.prod.yml exec -T backend node scripts/seed-isc2-cc.ts
+import { db } from "../db.ts";
+import { simulados, simuladoQuestions, simuladoOptions } from "../schema.ts";
+import { eq, count } from "drizzle-orm";
+
+const SLUG = "isc2-cc";
+
+type Questao = {
+    statement: string;
+    explanation: string;
+    topic: string;
+    options: [string, boolean][];
+};
+
+const QUESTOES: Questao[] = [
+    {
+        "statement": "Um hospital armazena prontuários eletrônicos de pacientes em um servidor. Para impedir que pessoas não autorizadas leiam esses dados, mesmo que consigam acesso físico ao disco rígido, a equipe de TI aplica criptografia nos arquivos. Qual princípio da tríade CIA essa medida protege prioritariamente?",
+        "explanation": "A criptografia de dados em repouso impede que pessoas não autorizadas leiam a informação, protegendo a confidencialidade, pilar da tríade CIA voltado a impedir acesso e divulgação indevidos. Integridade trata da exatidão dos dados, não de quem pode lê-los, disponibilidade trata do acesso pelos usuários autorizados no momento necessário, e não repúdio não faz parte da tríade CIA, sendo um conceito relacionado a garantir que uma ação não possa ser negada por quem a praticou.",
+        "topic": "Princípios de Segurança",
+        "options": [
+            [
+                "Confidencialidade",
+                true
+            ],
+            [
+                "Integridade",
+                false
+            ],
+            [
+                "Disponibilidade",
+                false
+            ],
+            [
+                "Não repúdio",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Durante a transferência de um arquivo crítico entre dois servidores, a equipe de segurança calcula um hash do arquivo antes do envio e compara com o hash calculado após o recebimento. Se os valores forem diferentes, o arquivo foi corrompido ou alterado no caminho. Essa prática protege principalmente qual pilar da tríade CIA?",
+        "explanation": "O hash permite detectar qualquer alteração não autorizada no conteúdo do arquivo, o que protege a integridade, isto é, a garantia de que a informação permanece exata e completa. Confidencialidade diz respeito a impedir leitura por quem não deveria ter acesso, disponibilidade trata do acesso no momento necessário, e autenticidade, embora relacionada, não é um dos três pilares da tríade CIA cobrados no exame CC.",
+        "topic": "Princípios de Segurança",
+        "options": [
+            [
+                "Integridade",
+                true
+            ],
+            [
+                "Confidencialidade",
+                false
+            ],
+            [
+                "Disponibilidade",
+                false
+            ],
+            [
+                "Autenticidade",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Uma empresa de comércio eletrônico investe em servidores redundantes, geradores de energia de backup e um plano de mitigação contra ataques de negação de serviço para garantir que o site continue funcionando mesmo diante de falhas ou ataques. Essas medidas têm como foco principal qual pilar da tríade CIA?",
+        "explanation": "Redundância, energia de backup e mitigação de ataques de negação de serviço existem para manter o sistema acessível aos usuários autorizados quando eles precisarem, o que é a definição de disponibilidade. Confidencialidade e integridade tratam de quem pode ler e da exatidão dos dados, respectivamente, e privacidade é um conceito distinto voltado ao tratamento adequado de dados pessoais, não à continuidade do serviço.",
+        "topic": "Princípios de Segurança",
+        "options": [
+            [
+                "Disponibilidade",
+                true
+            ],
+            [
+                "Confidencialidade",
+                false
+            ],
+            [
+                "Integridade",
+                false
+            ],
+            [
+                "Privacidade",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Ao fazer login em um sistema, um funcionário digita seu nome de usuário e uma senha que só ele deveria conhecer. Essa senha representa qual fator de autenticação?",
+        "explanation": "Senha é conhecimento memorizado pelo usuário, por isso se enquadra na categoria algo que você sabe. O fator algo que você tem refere-se a um objeto físico, como um token ou cartão inteligente. O fator algo que você é refere-se a características biométricas, como impressão digital. Algo que você faz não é um dos três fatores de autenticação reconhecidos pelo exame CC.",
+        "topic": "Princípios de Segurança",
+        "options": [
+            [
+                "Algo que você sabe",
+                true
+            ],
+            [
+                "Algo que você tem",
+                false
+            ],
+            [
+                "Algo que você é",
+                false
+            ],
+            [
+                "Algo que você faz",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Para acessar o sistema financeiro da empresa, além da senha, o analista precisa inserir um código gerado a cada 30 segundos por um aplicativo instalado em seu celular pessoal. Esse código representa qual fator de autenticação?",
+        "explanation": "O código gerado por um aplicativo autenticador depende da posse de um dispositivo físico específico, o celular com o app instalado, caracterizando o fator algo que você tem. O fator algo que você sabe seria a senha memorizada, algo que você é seria uma característica biométrica, e localização geográfica não é um dos três fatores de autenticação clássicos cobrados no exame CC.",
+        "topic": "Princípios de Segurança",
+        "options": [
+            [
+                "Algo que você tem",
+                true
+            ],
+            [
+                "Algo que você sabe",
+                false
+            ],
+            [
+                "Algo que você é",
+                false
+            ],
+            [
+                "Algo relacionado à sua localização geográfica",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Um smartphone permite que o proprietário desbloqueie a tela apenas apontando a câmera para o próprio rosto. Esse mecanismo de autenticação se baseia em qual fator?",
+        "explanation": "O reconhecimento facial usa uma característica física do próprio usuário, o que caracteriza o fator algo que você é, também chamado de biometria. Algo que você tem envolve a posse de um objeto físico, algo que você sabe envolve conhecimento memorizado, e algo que você faz não integra os três fatores clássicos de autenticação do exame CC.",
+        "topic": "Princípios de Segurança",
+        "options": [
+            [
+                "Algo que você é",
+                true
+            ],
+            [
+                "Algo que você tem",
+                false
+            ],
+            [
+                "Algo que você sabe",
+                false
+            ],
+            [
+                "Algo que você faz",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Um funcionário teve a senha do e-mail corporativo descoberta em um vazamento de dados de outro site, já que reutilizava a mesma senha em vários lugares. Mesmo assim, o invasor não conseguiu acessar a conta porque o sistema exigiu também um código enviado por aplicativo autenticador. Esse cenário demonstra o principal benefício de qual prática de segurança?",
+        "explanation": "A autenticação multifator combina dois ou mais fatores diferentes, de forma que o comprometimento de um único fator, como a senha, não seja suficiente para o invasor acessar a conta. Criptografia de disco protege dados armazenados, segregação de funções divide responsabilidades entre pessoas para evitar fraude interna, e classificação de dados organiza informações por nível de sensibilidade, nenhuma dessas medidas evitaria o acesso nesse cenário específico.",
+        "topic": "Princípios de Segurança",
+        "options": [
+            [
+                "Autenticação multifator (MFA)",
+                true
+            ],
+            [
+                "Criptografia de disco",
+                false
+            ],
+            [
+                "Segregação de funções",
+                false
+            ],
+            [
+                "Classificação de dados",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Uma empresa implementa assinatura digital em contratos eletrônicos, de forma que, uma vez assinado, o signatário não possa alegar posteriormente que não realizou aquela assinatura. Esse controle está associado a qual conceito de segurança?",
+        "explanation": "Não repúdio é a garantia de que uma pessoa não pode negar ter realizado uma ação, como assinar um documento, geralmente comprovada por assinatura digital e registros de auditoria. Confidencialidade protege contra leitura indevida, disponibilidade garante acesso quando necessário, e privacidade trata do tratamento adequado de dados pessoais, nenhum desses conceitos trata diretamente da impossibilidade de negar uma ação.",
+        "topic": "Princípios de Segurança",
+        "options": [
+            [
+                "Não repúdio",
+                true
+            ],
+            [
+                "Confidencialidade",
+                false
+            ],
+            [
+                "Disponibilidade",
+                false
+            ],
+            [
+                "Privacidade",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Uma empresa trata como segredo comercial a fórmula de um produto e, separadamente, também protege os dados de CPF e endereço de seus clientes. Qual é a principal diferença entre proteger a fórmula, um caso de confidencialidade, e proteger os dados dos clientes, um caso de privacidade?",
+        "explanation": "Privacidade é um conceito focado especificamente em como dados pessoais de indivíduos são coletados, usados, armazenados e compartilhados, muitas vezes regulado por lei, como a LGPD. Confidencialidade é um princípio mais amplo da tríade CIA, aplicável a qualquer informação sensível, pessoal ou não, como uma fórmula de produto. As demais opções descrevem relações incorretas entre os conceitos ou responsabilidades que não refletem a prática de segurança.",
+        "topic": "Princípios de Segurança",
+        "options": [
+            [
+                "Privacidade trata especificamente do tratamento adequado de dados pessoais de indivíduos, enquanto confidencialidade é um conceito mais amplo aplicável a qualquer informação sensível",
+                true
+            ],
+            [
+                "Não existe diferença prática entre os dois conceitos, ambos significam exatamente a mesma coisa",
+                false
+            ],
+            [
+                "Privacidade se aplica somente a informações financeiras, enquanto confidencialidade se aplica a qualquer outro tipo de dado",
+                false
+            ],
+            [
+                "Confidencialidade é responsabilidade exclusiva do time jurídico, enquanto privacidade é responsabilidade exclusiva do time de TI",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Um cliente envia um e-mail para uma empresa brasileira solicitando a exclusão de seus dados pessoais armazenados no sistema de marketing, alegando que não deseja mais receber comunicações. Sob a ótica da LGPD, essa solicitação representa o exercício de qual conceito?",
+        "explanation": "A LGPD garante ao titular dos dados o direito de solicitar acesso, correção ou eliminação de suas informações pessoais, e empresas que atuam no Brasil devem ter processos de governança para atender esse tipo de pedido. Não se trata de incidente de disponibilidade nem de integridade, e tratar a solicitação como engenharia social ignoraria um direito legítimo previsto em lei.",
+        "topic": "Princípios de Segurança",
+        "options": [
+            [
+                "O direito do titular dos dados sobre suas próprias informações pessoais",
+                true
+            ],
+            [
+                "Uma violação de disponibilidade que deve ser tratada como incidente de segurança",
+                false
+            ],
+            [
+                "Uma quebra de integridade que exige recálculo de hash nos registros",
+                false
+            ],
+            [
+                "Uma tentativa de engenharia social que deve ser recusada por padrão",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Um servidor web está rodando uma versão desatualizada de software com uma falha conhecida e ainda não corrigida. Um grupo de invasores está ativamente escaneando a internet em busca de servidores com exatamente essa falha para explorar. Como esse cenário deve ser descrito em termos de gestão de risco?",
+        "explanation": "No vocabulário do exame CC, vulnerabilidade é uma fraqueza que pode ser explorada, nesse caso a falha não corrigida, ameaça é o agente ou evento capaz de explorar essa fraqueza, nesse caso o grupo de invasores, e risco é a combinação da probabilidade de exploração com o impacto potencial ao negócio. As demais opções invertem essas definições ou tratam os termos como sinônimos, o que é tecnicamente incorreto.",
+        "topic": "Princípios de Segurança",
+        "options": [
+            [
+                "A falha não corrigida é a vulnerabilidade, o grupo de invasores é a ameaça, e a possibilidade de exploração com impacto ao negócio é o risco",
+                true
+            ],
+            [
+                "A falha não corrigida é a ameaça, e o grupo de invasores é a vulnerabilidade",
+                false
+            ],
+            [
+                "O servidor desatualizado é o risco, e a exploração da falha é a ameaça",
+                false
+            ],
+            [
+                "Ameaça, vulnerabilidade e risco são sinônimos e podem ser usados indistintamente nesse cenário",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Antes de decidir quais medidas de segurança implementar, uma organização primeiro cataloga seus ativos e possíveis ameaças, depois analisa a probabilidade e o impacto de cada risco identificado, e só então decide como tratar cada um. Esse processo ordenado descreve qual etapa fundamental da gestão de risco?",
+        "explanation": "A gestão de risco segue uma sequência lógica: primeiro identificar ativos e ameaças, depois avaliar, analisando probabilidade e impacto, e só então decidir o tratamento adequado. Aceitação e transferência são apenas duas das possíveis formas de tratamento, não etapas iniciais do processo, e auditoria de conformidade é uma atividade de verificação distinta da avaliação de risco.",
+        "topic": "Princípios de Segurança",
+        "options": [
+            [
+                "Identificação e avaliação de risco, que devem ocorrer antes da decisão sobre tratamento",
+                true
+            ],
+            [
+                "Aceitação de risco, que deve ser sempre a primeira etapa do processo",
+                false
+            ],
+            [
+                "Transferência de risco, que substitui a necessidade de identificação prévia",
+                false
+            ],
+            [
+                "Auditoria de conformidade, que só ocorre depois que todos os controles já foram implementados",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Uma pequena empresa avalia o risco de incêndio em seu escritório e decide contratar um seguro contra incêndio, em vez de investir pesadamente em sistemas de supressão automática. Qual estratégia de tratamento de risco essa decisão representa?",
+        "explanation": "Contratar um seguro transfere o impacto financeiro do risco para um terceiro, a seguradora, caracterizando a transferência de risco. Mitigação envolveria reduzir a probabilidade ou o impacto agindo diretamente sobre o risco, como instalar sistemas de supressão automática, aceitação significaria conviver com o risco sem ação adicional, e evitar o risco significaria eliminar a atividade que o gera, por exemplo encerrando a operação naquele local. Nenhuma dessas três últimas opções descreve a contratação de um seguro.",
+        "topic": "Princípios de Segurança",
+        "options": [
+            [
+                "Transferência do risco",
+                true
+            ],
+            [
+                "Mitigação do risco",
+                false
+            ],
+            [
+                "Aceitação do risco",
+                false
+            ],
+            [
+                "Evitar o risco",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "A diretoria de uma empresa define que está disposta a aceitar um nível moderado de risco em novos projetos de inovação, mas também estabelece limites específicos de variação aceitável para cada tipo de risco antes que uma ação corretiva se torne obrigatória. Esses dois conceitos representam, respectivamente, o quê?",
+        "explanation": "Apetite a risco é o nível geral e estratégico de risco que a organização aceita perseguir em busca de seus objetivos, enquanto tolerância a risco define os limites operacionais e específicos de variação aceitável dentro desse apetite. As demais opções invertem os conceitos, os tratam como sinônimos ou os confundem com estratégias de tratamento de risco, que são conceitos diferentes.",
+        "topic": "Princípios de Segurança",
+        "options": [
+            [
+                "Apetite a risco, o nível geral que a organização está disposta a aceitar, e tolerância a risco, os limites aceitáveis de variação em torno desse apetite",
+                true
+            ],
+            [
+                "Tolerância a risco e, em seguida, apetite a risco, na ordem inversa da descrita",
+                false
+            ],
+            [
+                "Ambos os conceitos descrevem exatamente a mesma coisa, apenas com nomes diferentes",
+                false
+            ],
+            [
+                "Mitigação de risco e transferência de risco",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Uma empresa configura uma lista de controle de acesso em seu firewall para permitir tráfego apenas de endereços IP previamente autorizados. Esse tipo de controle é classificado como qual categoria?",
+        "explanation": "Regras de firewall e listas de controle de acesso são implementadas por meio de tecnologia, o que as classifica como controles técnicos, também chamados de lógicos. Controles administrativos são políticas e procedimentos, controles físicos protegem o ambiente tangível, e controle de integridade mistura a classificação de controles por tipo com os pilares da tríade CIA, que são conceitos relacionados mas distintos: a regra de firewall é, por natureza, um controle técnico, independentemente de qual pilar da tríade ela apoia.",
+        "topic": "Princípios de Segurança",
+        "options": [
+            [
+                "Controle técnico (lógico)",
+                true
+            ],
+            [
+                "Controle administrativo",
+                false
+            ],
+            [
+                "Controle físico",
+                false
+            ],
+            [
+                "Controle de integridade",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Antes de contratar um novo funcionário para o setor financeiro, o RH exige a verificação de antecedentes criminais e a assinatura de um termo de confidencialidade. Esse procedimento é um exemplo de qual tipo de controle?",
+        "explanation": "Verificação de antecedentes e assinatura de termos fazem parte de políticas e procedimentos organizacionais relacionados a pessoas, o que caracteriza um controle administrativo. Controles técnicos dependem de tecnologia aplicada a sistemas, controles físicos protegem o ambiente tangível, e controle de detecção automatizada normalmente se refere a ferramentas tecnológicas de monitoramento, não a processos de RH.",
+        "topic": "Princípios de Segurança",
+        "options": [
+            [
+                "Controle administrativo",
+                true
+            ],
+            [
+                "Controle técnico",
+                false
+            ],
+            [
+                "Controle físico",
+                false
+            ],
+            [
+                "Controle de detecção automatizada",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Um data center exige que visitantes passem por uma catraca com leitor de crachá e depois por uma segunda porta controlada antes de ter acesso à sala de servidores, impedindo que mais de uma pessoa entre por vez com uma única credencial. Esse conjunto de medidas é um exemplo de qual tipo de controle?",
+        "explanation": "Catracas, leitores de crachá em portas físicas e câmaras de entrada controlada são barreiras tangíveis que restringem o acesso ao ambiente físico, caracterizando controles físicos. Controles administrativos são políticas e processos, controles técnicos envolvem tecnologia aplicada a sistemas e dados, e controle corretivo é uma classificação por função, usada para restaurar a normalidade após um incidente, diferente da classificação por natureza usada nesse contexto.",
+        "topic": "Princípios de Segurança",
+        "options": [
+            [
+                "Controle físico",
+                true
+            ],
+            [
+                "Controle administrativo",
+                false
+            ],
+            [
+                "Controle técnico",
+                false
+            ],
+            [
+                "Controle corretivo",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Um profissional certificado pela ISC2 se depara com uma situação em que cumprir uma instrução direta de seu gestor entraria em conflito com a proteção do bem comum e da infraestrutura pública. De acordo com o Código de Ética da ISC2, como esse profissional deve resolver esse conflito?",
+        "explanation": "O Código de Ética da ISC2 estabelece que os cânones devem ser seguidos em ordem de precedência quando entram em conflito, e o primeiro cânone, proteger a sociedade, o bem comum, a confiança pública e a infraestrutura, tem prioridade sobre interesses organizacionais internos. Priorizar cegamente a instrução do gestor, ignorar o código ou simplesmente se omitir sem buscar orientação contrariam o compromisso ético esperado de um profissional certificado.",
+        "topic": "Princípios de Segurança",
+        "options": [
+            [
+                "Seguindo a ordem de precedência dos cânones, priorizando proteger a sociedade, o bem comum, a confiança pública e a infraestrutura acima de interesses internos da organização",
+                true
+            ],
+            [
+                "Sempre priorizando a instrução do gestor, já que a hierarquia organizacional está acima do Código de Ética",
+                false
+            ],
+            [
+                "Ignorando o Código de Ética nesse caso, pois ele só se aplica a situações técnicas, não a decisões de gestão",
+                false
+            ],
+            [
+                "Recusando-se a agir e mantendo sigilo absoluto sobre o conflito, sem buscar orientação",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Um profissional de segurança descobre uma vulnerabilidade grave em um sistema que, se explorada, poderia afetar a infraestrutura crítica de fornecimento de energia de uma região. Qual cânone do Código de Ética da ISC2 orienta diretamente a conduta esperada nesse caso?",
+        "explanation": "O primeiro cânone do Código de Ética da ISC2 trata diretamente da proteção da sociedade, do bem comum, da confiança pública e da infraestrutura, o que se aplica diretamente a um cenário envolvendo infraestrutura crítica de energia. Os demais cânones também são válidos e fazem parte do código, mas tratam de conduta pessoal, qualidade do serviço prestado e valorização da profissão, sendo menos diretamente relacionados à proteção da infraestrutura nesse cenário específico.",
+        "topic": "Princípios de Segurança",
+        "options": [
+            [
+                "Proteger a sociedade, o bem comum, a confiança pública necessária e a infraestrutura",
+                true
+            ],
+            [
+                "Agir de forma honrosa, honesta, justa, responsável e legal",
+                false
+            ],
+            [
+                "Prestar serviço diligente e competente aos protegidos",
+                false
+            ],
+            [
+                "Avançar e proteger a profissão",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Durante uma entrevista de emprego, um candidato já certificado pela ISC2 exagera suas certificações e sua experiência para parecer mais qualificado do que realmente é. Essa atitude estaria em desacordo com qual cânone do Código de Ética?",
+        "explanation": "Exagerar qualificações é um ato de desonestidade pessoal, o que viola diretamente o cânone que exige agir de forma honrosa, honesta, justa, responsável e legal. Os outros cânones tratam de proteção da sociedade e da infraestrutura, qualidade técnica do serviço prestado e valorização da profissão como um todo, temas relacionados mas que não descrevem especificamente o ato de mentir sobre as próprias credenciais.",
+        "topic": "Princípios de Segurança",
+        "options": [
+            [
+                "Agir de forma honrosa, honesta, justa, responsável e legal",
+                true
+            ],
+            [
+                "Proteger a sociedade, o bem comum, a confiança pública necessária e a infraestrutura",
+                false
+            ],
+            [
+                "Prestar serviço diligente e competente aos protegidos",
+                false
+            ],
+            [
+                "Avançar e proteger a profissão",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "A empresa publica um documento de alto nível assinado pela diretoria estabelecendo que todos os dados de clientes devem ser protegidos contra acesso não autorizado, e um segundo documento detalhando que senhas devem ter no mínimo 12 caracteres, incluindo letras, números e símbolos. Esses dois documentos representam, respectivamente, quais elementos da governança de segurança?",
+        "explanation": "Política é a diretriz geral e de alto nível que define a intenção da organização, enquanto padrão especifica requisitos obrigatórios e mensuráveis para cumprir essa política, como o tamanho mínimo de senha. Procedimento seria o passo a passo de como executar uma tarefa, diretriz seria uma recomendação não obrigatória, e lei ou regulamento são exigências externas impostas por um governo, não documentos internos da organização.",
+        "topic": "Princípios de Segurança",
+        "options": [
+            [
+                "Política, a diretriz geral de alto nível, e padrão, a exigência específica e obrigatória",
+                true
+            ],
+            [
+                "Procedimento e diretriz, nessa ordem",
+                false
+            ],
+            [
+                "Lei e regulamento, nessa ordem",
+                false
+            ],
+            [
+                "Ambos os documentos são exemplos de políticas, apenas com níveis diferentes de detalhe",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Uma empresa brasileira que também atende clientes na União Europeia precisa cumprir simultaneamente a LGPD e o GDPR, mesmo que suas próprias políticas internas de privacidade sejam mais permissivas. Isso ilustra qual característica das leis e regulamentos dentro da estrutura de governança de segurança?",
+        "explanation": "Leis e regulamentos, como a LGPD e o GDPR, são impostos por governos ou blocos regulatórios externos à organização e devem ser cumpridos independentemente do que dizem as políticas internas, que precisam se adequar a eles e não o contrário. As demais opções descrevem incorretamente leis como algo opcional, dispensável ou de origem interna, o que não corresponde à realidade da governança de segurança.",
+        "topic": "Princípios de Segurança",
+        "options": [
+            [
+                "Leis e regulamentos são exigências externas e obrigatórias que prevalecem sobre políticas internas da organização",
+                true
+            ],
+            [
+                "Leis e regulamentos podem ser ignorados sempre que a política interna da empresa for mais recente",
+                false
+            ],
+            [
+                "Leis e regulamentos têm o mesmo peso que diretrizes internas e podem ser tratados como opcionais",
+                false
+            ],
+            [
+                "Leis e regulamentos são criados pela própria empresa para uso exclusivamente interno",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Um sistema de segurança percebe que um usuário, que normalmente faz login a partir de São Paulo em horário comercial, tentou acessar a conta às 3 da manhã a partir de um país diferente, usando um dispositivo nunca antes registrado. O sistema automaticamente bloqueia o acesso e solicita verificação adicional. Essa capacidade é um exemplo do uso de qual tecnologia na autenticação?",
+        "explanation": "Sistemas modernos usam inteligência artificial para aprender o padrão normal de comportamento de um usuário, como local, horário e dispositivo, e identificar automaticamente desvios que indicam possível comprometimento da conta, solicitando verificação adicional. Criptografia simétrica protege dados em trânsito ou em repouso, segregação de funções divide responsabilidades entre pessoas, e controle físico de perímetro protege o ambiente tangível, nenhum desses conceitos explica a detecção automática de comportamento anômalo de login.",
+        "topic": "Princípios de Segurança",
+        "options": [
+            [
+                "Inteligência artificial aplicada à análise comportamental para detecção de anomalias de login",
+                true
+            ],
+            [
+                "Criptografia simétrica aplicada ao tráfego de rede",
+                false
+            ],
+            [
+                "Segregação de funções aplicada ao controle de acesso",
+                false
+            ],
+            [
+                "Um controle físico de perímetro",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Funcionários de uma empresa começaram a colar trechos de documentos internos confidenciais em uma ferramenta pública de inteligência artificial generativa para obter resumos rapidamente, sem que a empresa tivesse conhecimento ou controle sobre esse uso. Do ponto de vista de governança, qual é a ação mais adequada para reduzir esse risco?",
+        "explanation": "A governança de segurança deve acompanhar o surgimento de novas tecnologias, e criar uma política de uso aceitável de IA, comunicada e reforçada por treinamento, é a forma correta de reduzir o risco de vazamento de dados confidenciais em ferramentas públicas de IA generativa. Ignorar o risco desconsidera um problema real de exposição de dados, proibir toda a tecnologia digital é uma reação desproporcional e inviável, e transferir toda a responsabilidade ao fornecedor externo ignora o dever da organização de proteger suas próprias informações.",
+        "topic": "Princípios de Segurança",
+        "options": [
+            [
+                "Criar e comunicar uma política de uso aceitável de IA, definindo claramente quais dados podem ou não ser inseridos em ferramentas externas",
+                true
+            ],
+            [
+                "Ignorar a situação, já que ferramentas de IA pública não representam risco algum de vazamento de dados",
+                false
+            ],
+            [
+                "Proibir totalmente o uso de qualquer tecnologia digital na empresa, incluindo e-mail e navegadores",
+                false
+            ],
+            [
+                "Transferir toda a responsabilidade para o fornecedor da ferramenta de IA, sem necessidade de ação interna",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Uma clínica odontológica de médio porte quer garantir que, mesmo diante de uma enchente que danifique seu escritório principal, o atendimento a pacientes e o faturamento continuem operando, ainda que de forma reduzida, em outro local. Qual conceito está mais diretamente relacionado a esse objetivo?",
+        "explanation": "A Continuidade de Negócios (BC) tem como propósito manter as funções essenciais do negócio operando durante e depois de uma interrupção, exatamente o que a clínica busca ao continuar atendendo pacientes e faturando em outro local. A Recuperação de Desastres (DR) é mais restrita: foca na restauração da infraestrutura de TI e dos sistemas técnicos, não do negócio como um todo. A Resposta a Incidentes (IR) trata da identificação e do tratamento de incidentes de segurança, o que não é o caso de uma enchente. Já a Análise de Impacto no Negócio (BIA) é uma ferramenta usada dentro do planejamento de BC para identificar processos críticos, mas não é o conceito guarda-chuva que a situação descreve.",
+        "topic": "Continuidade, DR e Resposta a Incidentes",
+        "options": [
+            [
+                "Continuidade de Negócios (BC)",
+                true
+            ],
+            [
+                "Recuperação de Desastres (DR)",
+                false
+            ],
+            [
+                "Resposta a Incidentes (IR)",
+                false
+            ],
+            [
+                "Análise de Impacto no Negócio (BIA)",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Durante o planejamento de continuidade de negócios de uma empresa de comércio eletrônico, a equipe responsável precisa identificar quais processos são mais críticos, como o processamento de pagamentos, e estimar o impacto financeiro e operacional caso cada um fique indisponível por diferentes períodos de tempo. Essa atividade corresponde a:",
+        "explanation": "A Análise de Impacto no Negócio (BIA) é exatamente o processo de identificar os processos críticos e medir o impacto de sua indisponibilidade ao longo do tempo, servindo de base para definir prioridades de recuperação, incluindo RTO e RPO. O Plano de Recuperação de Desastres (DRP) é o documento técnico com os passos de restauração de sistemas, elaborado depois que os critérios de criticidade já foram definidos. O teste de invasão avalia vulnerabilidades técnicas exploráveis, sem relação direta com impacto de indisponibilidade de processos de negócio. A auditoria de conformidade verifica aderência a normas e regulamentos, não a criticidade operacional dos processos.",
+        "topic": "Continuidade, DR e Resposta a Incidentes",
+        "options": [
+            [
+                "Análise de Impacto no Negócio (BIA)",
+                true
+            ],
+            [
+                "Plano de Recuperação de Desastres (DRP)",
+                false
+            ],
+            [
+                "Teste de invasão (pentest)",
+                false
+            ],
+            [
+                "Auditoria de conformidade regulatória",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "O sistema de emissão de notas fiscais de uma empresa é considerado crítico. Depois de conversar com as áreas de negócio, a equipe de TI define que esse sistema precisa voltar a funcionar em, no máximo, 4 horas após uma interrupção, independentemente da quantidade de dados que possa ser perdida nesse intervalo. Esse prazo de 4 horas representa:",
+        "explanation": "O RTO (Recovery Time Objective) é o tempo máximo aceitável para que um sistema ou processo volte a funcionar após uma interrupção, o que corresponde exatamente às 4 horas do cenário. O RPO (Recovery Point Objective) mede outra coisa: a quantidade máxima de dados que a empresa tolera perder, e não o tempo de restabelecimento do serviço. O SLA é um acordo mais amplo sobre níveis de serviço, que pode até mencionar prazos de disponibilidade, mas o conceito específico usado para expressar o tempo máximo de indisponibilidade é o RTO. O MTBF é uma métrica de confiabilidade que mede o tempo médio entre falhas de um equipamento, não o tempo de recuperação.",
+        "topic": "Continuidade, DR e Resposta a Incidentes",
+        "options": [
+            [
+                "RTO (Recovery Time Objective)",
+                true
+            ],
+            [
+                "RPO (Recovery Point Objective)",
+                false
+            ],
+            [
+                "SLA (Service Level Agreement)",
+                false
+            ],
+            [
+                "MTBF (Mean Time Between Failures)",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Uma instituição financeira define que, em caso de falha catastrófica no banco de dados de transações, não pode perder mais do que 15 minutos de dados, o que exige que os backups ou a replicação ocorram com frequência compatível com essa janela. Esse limite de 15 minutos representa:",
+        "explanation": "O RPO (Recovery Point Objective) define a quantidade máxima de dados, medida em tempo, que a organização tolera perder em caso de falha, determinando diretamente a frequência necessária de backup ou replicação, exatamente o que o cenário descreve. O RTO trata da duração máxima de indisponibilidade do sistema, não da perda de dados. O MTD é o tempo máximo que o negócio consegue sobreviver sem determinada função antes de sofrer danos graves, um conceito relacionado ao RTO, mas não à perda de dados. A BIA é o processo de análise que pode ajudar a chegar a esse número, mas o valor de 15 minutos em si é o RPO, não a análise que o originou.",
+        "topic": "Continuidade, DR e Resposta a Incidentes",
+        "options": [
+            [
+                "RPO (Recovery Point Objective)",
+                true
+            ],
+            [
+                "RTO (Recovery Time Objective)",
+                false
+            ],
+            [
+                "MTD (Maximum Tolerable Downtime)",
+                false
+            ],
+            [
+                "BIA (Business Impact Analysis)",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Depois que um incêndio destrói a sala de servidores de uma empresa, a equipe de TI segue um documento técnico com os passos para restaurar os servidores, recuperar os backups e realocar a infraestrutura em um site alternativo. Esse documento é conhecido como:",
+        "explanation": "O Plano de Recuperação de Desastres (DRP) é o documento técnico focado especificamente em restaurar sistemas, dados e infraestrutura de TI depois de um desastre, o que combina exatamente com os passos descritos. O Plano de Continuidade de Negócios (BCP) é mais amplo, cobrindo a continuidade do negócio como um todo, incluindo pessoas, processos, instalações e fornecedores, e não apenas os passos técnicos de restauração de servidores. O Plano de Resposta a Incidentes (IRP) trata do tratamento de incidentes de segurança, como invasões ou vazamentos, não de desastres físicos como incêndio. Uma política de segurança da informação estabelece regras e diretrizes gerais, mas não traz o passo a passo técnico de recuperação.",
+        "topic": "Continuidade, DR e Resposta a Incidentes",
+        "options": [
+            [
+                "Plano de Recuperação de Desastres (DRP)",
+                true
+            ],
+            [
+                "Plano de Continuidade de Negócios (BCP)",
+                false
+            ],
+            [
+                "Plano de Resposta a Incidentes (IRP)",
+                false
+            ],
+            [
+                "Política de Segurança da Informação",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Uma empresa de processamento de pagamentos não pode tolerar mais do que poucos minutos de indisponibilidade. Por isso, mantém um site alternativo com servidores ativos, dados replicados quase em tempo real e toda a infraestrutura pronta para assumir as operações quase imediatamente após um desastre no site principal. Esse tipo de site alternativo é chamado de:",
+        "explanation": "O site quente (hot site) mantém infraestrutura totalmente equipada e dados sincronizados quase em tempo real, permitindo failover quase imediato, o que atende a exigências de RTO e RPO muito baixos como no cenário. O site morno (warm site) tem parte do equipamento e dos dados prontos, mas ainda exige horas de trabalho para ficar totalmente operacional. O site frio (cold site) oferece apenas espaço físico, energia e conectividade básica, sem sistemas pré instalados, levando dias ou semanas para entrar em operação. O acordo recíproco é um arranjo em que duas organizações concordam em se apoiar mutuamente em caso de desastre, geralmente mais lento e menos confiável do que manter um site quente dedicado.",
+        "topic": "Continuidade, DR e Resposta a Incidentes",
+        "options": [
+            [
+                "Site quente (hot site)",
+                true
+            ],
+            [
+                "Site morno (warm site)",
+                false
+            ],
+            [
+                "Site frio (cold site)",
+                false
+            ],
+            [
+                "Acordo recíproco entre empresas (reciprocal agreement)",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Durante um incidente de ransomware, a equipe de resposta a incidentes já identificou quais sistemas foram afetados e agora está isolando esses sistemas da rede para impedir que o ransomware se espalhe para outros servidores, antes de removê-lo definitivamente. Essa ação corresponde a qual fase do ciclo de vida de resposta a incidentes?",
+        "explanation": "A contenção consiste em isolar os sistemas afetados para impedir que o incidente se espalhe antes de eliminar a ameaça, exatamente o que está sendo feito no cenário. A erradicação é a etapa seguinte, quando a causa raiz e o próprio ransomware são efetivamente removidos dos sistemas. A detecção e análise já havia ocorrido antes, quando a equipe identificou quais sistemas foram afetados. As lições aprendidas acontecem somente depois que o incidente é totalmente resolvido, quando a equipe revisa o que funcionou e o que pode melhorar.",
+        "topic": "Continuidade, DR e Resposta a Incidentes",
+        "options": [
+            [
+                "Contenção",
+                true
+            ],
+            [
+                "Erradicação",
+                false
+            ],
+            [
+                "Detecção e análise",
+                false
+            ],
+            [
+                "Lições aprendidas",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Antes de qualquer incidente ocorrer, uma empresa define papéis e responsabilidades da equipe de resposta, elabora playbooks para os tipos de incidentes mais prováveis e garante que as ferramentas de monitoramento estejam configuradas corretamente. Essas atividades pertencem a qual fase do ciclo de vida de resposta a incidentes?",
+        "explanation": "A preparação é a fase que antecede qualquer incidente, dedicada a definir papéis, responsabilidades, playbooks e ferramentas, para que a equipe esteja pronta para agir quando algo acontecer, exatamente o que o cenário descreve. A contenção ocorre durante um incidente já em andamento, isolando sistemas afetados. A recuperação acontece depois da erradicação, quando os sistemas voltam à operação normal. A detecção e análise é a fase em que a equipe percebe que um incidente está ocorrendo e avalia sua extensão, o que também pressupõe que o incidente já começou.",
+        "topic": "Continuidade, DR e Resposta a Incidentes",
+        "options": [
+            [
+                "Preparação",
+                true
+            ],
+            [
+                "Contenção",
+                false
+            ],
+            [
+                "Recuperação",
+                false
+            ],
+            [
+                "Detecção e análise",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Uma seguradora usa um modelo de inteligência artificial para detectar automaticamente solicitações de sinistro fraudulentas. Com o passar dos meses, o comportamento dos fraudadores muda, e o modelo, treinado com dados antigos, passa a errar cada vez mais, deixando de identificar fraudes reais. Do ponto de vista de continuidade de negócios, esse fenômeno de degradação de desempenho do modelo ao longo do tempo deve ser tratado como:",
+        "explanation": "O model drift, ou degradação do modelo, reduz de forma silenciosa a confiabilidade de um serviço do qual o negócio depende, então deve ser monitorado, medido e mitigado, por exemplo com retreinamento periódico, como qualquer outro risco que ameace a disponibilidade ou a qualidade de um processo crítico, dentro da lógica de continuidade de negócios. Tratá-lo como problema exclusivo da ciência de dados ignora o impacto direto na operação e no risco da empresa. Também não é o mesmo que um ataque de segurança: o drift normalmente decorre da mudança natural dos dados ao longo do tempo, não de uma ação maliciosa direta contra o modelo. Esperar o modelo parar de funcionar por completo para agir contraria o princípio de gestão proativa de riscos, permitindo que fraudes passem despercebidas por meses.",
+        "topic": "Continuidade, DR e Resposta a Incidentes",
+        "options": [
+            [
+                "Um risco de continuidade que precisa ser monitorado e mitigado, de forma semelhante a outros riscos que afetam a disponibilidade de um serviço crítico",
+                true
+            ],
+            [
+                "Um problema exclusivamente técnico do time de ciência de dados, sem relação com os processos de continuidade de negócios",
+                false
+            ],
+            [
+                "Uma falha de segurança que só deve ser tratada pela equipe de resposta a incidentes, como se fosse um ataque",
+                false
+            ],
+            [
+                "Um evento que só precisa ser corrigido quando o modelo parar de funcionar completamente",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Em um escritório corporativo, cada funcionário recebe um crachá com foto e um chip de proximidade que precisa ser aproximado do leitor para liberar a catraca de entrada. Esse crachá é um exemplo de qual tipo de controle de acesso?",
+        "explanation": "O crachá com leitor de proximidade é um controle físico, pois sua função é restringir a entrada em um espaço físico (o prédio ou uma sala). Controles lógicos atuam sobre sistemas e dados, como senhas e permissões em um servidor. Chamá-lo de controle administrativo está errado porque controle administrativo se refere a políticas e procedimentos, não ao mecanismo em si. E RBAC é um modelo de controle de acesso lógico baseado em papéis dentro de sistemas, não se aplica a catracas físicas.",
+        "topic": "Controle de Acesso",
+        "options": [
+            [
+                "Controle de acesso lógico, pois envolve autenticação em um sistema",
+                false
+            ],
+            [
+                "Controle administrativo, pois depende de uma política escrita",
+                false
+            ],
+            [
+                "Controle de acesso físico, pois regula a entrada de pessoas em um ambiente real",
+                true
+            ],
+            [
+                "Controle de acesso lógico baseado em papéis (RBAC)",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Uma empresa de tecnologia identificou que funcionários frequentemente seguravam a porta para colegas entrarem sem que cada um passasse individualmente pelo leitor de crachá, prática conhecida como piggybacking (ou tailgating). Qual controle físico é mais eficaz para impedir especificamente esse comportamento?",
+        "explanation": "A mantrap é projetada justamente para impedir que mais de uma pessoa passe por vez, forçando cada indivíduo a autenticar sua própria entrada, o que elimina o piggybacking na prática. CFTV grava e ajuda a detectar o comportamento depois, mas não impede na hora. Trocar o método de autenticação não resolve o problema, porque a pessoa mal-intencionada continuaria aproveitando a porta aberta por outra. E avisos e políticas escritas são controles administrativos que dependem da adesão voluntária das pessoas, sendo bem menos eficazes que uma barreira física.",
+        "topic": "Controle de Acesso",
+        "options": [
+            [
+                "Instalar uma mantrap (eclusa de segurança), câmara com duas portas que permite passagem de apenas uma pessoa por vez",
+                true
+            ],
+            [
+                "Aumentar o número de câmeras de CFTV na entrada",
+                false
+            ],
+            [
+                "Trocar os crachás de proximidade por senhas numéricas",
+                false
+            ],
+            [
+                "Publicar um aviso lembrando os funcionários da política de segurança",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "O CFTV (circuito fechado de televisão) instalado nos corredores de um data center é classificado, do ponto de vista funcional, principalmente como um controle de que tipo?",
+        "explanation": "O CFTV é primariamente um controle detectivo: ele grava o que acontece e permite identificar e investigar eventos após ocorrerem, servindo de evidência. Ele não impede fisicamente a entrada de ninguém (isso seria função de uma porta trancada ou de um guarda), por isso não é preventivo. Também não corrige nada sozinho, pois não restaura o ambiente após um incidente, apenas registra. E embora câmeras visíveis possam desestimular alguns comportamentos, resumir sua função a 'apenas dissuasivo' ignora seu papel central de detecção e registro.",
+        "topic": "Controle de Acesso",
+        "options": [
+            [
+                "Preventivo, porque impede fisicamente a entrada de pessoas não autorizadas",
+                false
+            ],
+            [
+                "Corretivo, porque restaura o ambiente ao estado anterior após um incidente",
+                false
+            ],
+            [
+                "Dissuasivo apenas, sem nenhuma outra função",
+                false
+            ],
+            [
+                "Detectivo, porque registra e permite identificar eventos que já ocorreram",
+                true
+            ]
+        ]
+    },
+    {
+        "statement": "Comparado a uma fechadura eletrônica programada, um guarda de segurança posicionado na entrada de um prédio tem como principal vantagem:",
+        "explanation": "A grande vantagem de um controle humano, como um guarda, é a capacidade de julgamento e adaptação a situações imprevistas que um sistema automatizado simplesmente não reconheceria, por exemplo, decidir se libera a entrada de alguém que esqueceu o crachá mas é claramente reconhecido. Guardas normalmente custam mais para manter ao longo do tempo do que um sistema eletrônico, então a opção de custo está invertida. Pessoas também estão sujeitas a erros de julgamento, fadiga e engenharia social, então não são imunes a falhas. E, diferentemente de um sistema eletrônico, guardas precisam de escalas, intervalos e trocas de turno, não funcionam de forma totalmente automática e ininterrupta.",
+        "topic": "Controle de Acesso",
+        "options": [
+            [
+                "Custo de manutenção sempre menor do que o de um sistema eletrônico",
+                false
+            ],
+            [
+                "A capacidade de usar julgamento humano para avaliar situações inesperadas, como verificar a identidade de um visitante sem crachá",
+                true
+            ],
+            [
+                "Imunidade a erros, já que pessoas não cometem falhas de avaliação",
+                false
+            ],
+            [
+                "Funcionamento automático 24 horas sem necessidade de escala ou intervalo",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Um sensor de movimento conectado a um sistema que dispara um alarme sonoro sempre que detecta atividade em uma sala de servidores fora do horário comercial é um exemplo de controle físico do tipo:",
+        "explanation": "O alarme detecta a presença de alguém e sinaliza o evento em tempo real, o que o caracteriza como um controle detectivo. Ele não trava a porta nem impede fisicamente ninguém de entrar, então não é preventivo por si só, costuma trabalhar junto com uma porta trancada. Também não é um controle administrativo, porque administrativo diz respeito a políticas e procedimentos, e aqui o alarme é um mecanismo físico e tecnológico. E não é compensatório, porque compensatório é um controle alternativo usado quando o controle principal não pode ser aplicado, e o alarme não substitui a necessidade de fechaduras e controle de acesso, ele complementa.",
+        "topic": "Controle de Acesso",
+        "options": [
+            [
+                "Preventivo, pois impede fisicamente a entrada na sala",
+                false
+            ],
+            [
+                "Administrativo, pois depende de uma norma interna para funcionar",
+                false
+            ],
+            [
+                "Detectivo, pois identifica e sinaliza uma possível violação enquanto ela está ocorrendo",
+                true
+            ],
+            [
+                "Compensatório, pois substitui a necessidade de controle de acesso físico à sala",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Manter registros detalhados de quem entrou e saiu de uma sala restrita, com data, hora e identificação da pessoa, atende principalmente a qual objetivo de segurança?",
+        "explanation": "Os logs de acesso existem principalmente para permitir accountability, ou seja, saber exatamente quem fez o quê e quando, o que é essencial para investigar incidentes e para auditorias de conformidade. Eles não impedem fisicamente a entrada de ninguém, esse é o papel de fechaduras, catracas e guardas. Os logs também não substituem crachás e leitores, pelo contrário, eles normalmente são gerados a partir do uso desses mecanismos. E logs de acesso físico não têm relação direta com a disponibilidade dos sistemas, que é uma preocupação de continuidade operacional, não de rastreabilidade de entrada.",
+        "topic": "Controle de Acesso",
+        "options": [
+            [
+                "Responsabilização (accountability) e possibilidade de auditoria e investigação posterior",
+                true
+            ],
+            [
+                "Impedir fisicamente que pessoas não autorizadas entrem na sala",
+                false
+            ],
+            [
+                "Substituir a necessidade de crachás e leitores de proximidade",
+                false
+            ],
+            [
+                "Garantir a disponibilidade dos sistemas hospedados na sala",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "O conceito de CPTED (Crime Prevention Through Environmental Design, ou Prevenção ao Crime Através do Desenho Ambiental) propõe reduzir riscos de segurança física principalmente por meio de:",
+        "explanation": "CPTED trata do desenho físico do ambiente (iluminação adequada, visibilidade, paisagismo que não crie esconderijos, definição clara de territórios) para tornar comportamentos indevidos mais visíveis e arriscados para quem tenta praticá-los, é uma abordagem preventiva baseada em arquitetura e urbanismo. Não se trata de eliminar guardas e substituí-los por câmeras, CPTED é sobre o desenho do espaço, não sobre qual tecnologia de vigilância usar. Também não tem relação com criptografia de dados, que é um controle lógico voltado à proteção da informação, não do ambiente físico. E não envolve exigir mais senhas em sistemas, isso é controle de acesso lógico, fora do escopo do CPTED.",
+        "topic": "Controle de Acesso",
+        "options": [
+            [
+                "Substituição total de guardas humanos por câmeras de vigilância",
+                false
+            ],
+            [
+                "Criptografia dos dados armazenados nos servidores do prédio",
+                false
+            ],
+            [
+                "Aumento do número de senhas exigidas para acessar sistemas internos",
+                false
+            ],
+            [
+                "Elementos do próprio ambiente construído, como iluminação, paisagismo e linhas de visão, que aumentam a vigilância natural e desestimulam condutas indevidas",
+                true
+            ]
+        ]
+    },
+    {
+        "statement": "Qual das práticas a seguir melhor reduz o risco de acesso físico não autorizado por parte de visitantes em um escritório?",
+        "explanation": "O cadastro, o crachá temporário com validade limitada e o acompanhamento por um funcionário (escort) garantem que o visitante seja identificado, tenha acesso restrito apenas às áreas necessárias e esteja sempre sob supervisão, reduzindo bastante o risco. Permitir circulação livre com base apenas em informação verbal não autentica nem restringe nada, é essencialmente não ter controle. Emitir um crachá permanente igual ao dos funcionários apaga a distinção entre pessoal autorizado permanente e visitante temporário, o que é o oposto do que se busca. E deixar a recepção sem controle em qualquer horário, mesmo fora do pico, cria uma janela de exposição desnecessária.",
+        "topic": "Controle de Acesso",
+        "options": [
+            [
+                "Permitir que qualquer visitante circule livremente desde que informe verbalmente o nome de quem vai visitar",
+                false
+            ],
+            [
+                "Exigir cadastro do visitante na recepção, emitir um crachá temporário e exigir acompanhamento por um funcionário durante toda a visita",
+                true
+            ],
+            [
+                "Emitir um crachá permanente idêntico ao dos funcionários para agilizar visitas recorrentes",
+                false
+            ],
+            [
+                "Deixar a recepção sem controle de entrada fora do horário de pico para não atrapalhar o fluxo",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "O princípio do menor privilégio (least privilege) estabelece que um usuário deve receber:",
+        "explanation": "Menor privilégio significa dar exatamente o necessário para a função, nem mais, nem menos, o que reduz a superfície de ataque e o estrago possível em caso de comprometimento da conta. Dar o maior número possível de permissões antecipadamente é o oposto do princípio e aumenta o risco desnecessariamente. Dar as mesmas permissões a todos de um departamento ignora que pessoas no mesmo setor podem ter funções diferentes com necessidades de acesso diferentes. E acesso administrativo total revisado raramente é um risco grave, viola tanto o menor privilégio quanto boas práticas de revisão periódica de acesso.",
+        "topic": "Controle de Acesso",
+        "options": [
+            [
+                "O maior número possível de permissões, para evitar solicitações futuras de acesso",
+                false
+            ],
+            [
+                "As mesmas permissões de todos os outros usuários do mesmo departamento, sem exceção",
+                false
+            ],
+            [
+                "Apenas as permissões estritamente necessárias para realizar as tarefas do seu cargo, nada além disso",
+                true
+            ],
+            [
+                "Acesso administrativo total, revisado apenas uma vez por ano",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Em um departamento financeiro, a mesma pessoa é responsável por cadastrar novos fornecedores no sistema e por aprovar os pagamentos para esses fornecedores. Isso representa uma violação de qual princípio de controle de acesso?",
+        "explanation": "Esse é um caso clássico de violação da segregação de funções: quando uma única pessoa pode cadastrar um fornecedor e também aprovar pagamentos para ele, abre-se a possibilidade de fraude, como criar um fornecedor fictício e aprovar pagamentos para si mesmo, sem nenhum segundo controle independente. Não tem relação com menor privilégio, que trata de limitar permissões, não de dar mais poder a uma única pessoa. Também não é uma questão de MAC, que é um modelo baseado em rótulos de sigilo e não está em discussão aqui. E não é sobre não repúdio, que trata da capacidade de provar a autoria de uma ação, e não sobre concentração indevida de poder em uma única função.",
+        "topic": "Controle de Acesso",
+        "options": [
+            [
+                "Segregação de funções (separation of duties), pois tarefas críticas e conflitantes deveriam ser divididas entre pessoas diferentes",
+                true
+            ],
+            [
+                "Menor privilégio, pois a pessoa deveria ter ainda mais permissões para concluir o processo sozinha",
+                false
+            ],
+            [
+                "Controle de acesso obrigatório (MAC), pois faltam rótulos de classificação nos fornecedores",
+                false
+            ],
+            [
+                "Não repúdio, pois não é possível provar quem cadastrou o fornecedor",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "No modelo de Controle de Acesso Discricionário (DAC), quem decide quais outros usuários podem acessar um determinado recurso?",
+        "explanation": "DAC significa justamente isso: o dono do recurso (por exemplo, quem criou um arquivo) tem a discricionariedade de decidir quem mais pode acessá-lo e com que permissões, como acontece em sistemas operacionais comuns ao compartilhar uma pasta. Um administrador central seguindo rótulos de classificação descreve o MAC, não o DAC. O sistema decidir automaticamente com base no cargo descreve o RBAC. E a ideia de um comitê aprovando cada solicitação individualmente não corresponde a nenhum dos três modelos clássicos citados no exame, foge da definição de DAC.",
+        "topic": "Controle de Acesso",
+        "options": [
+            [
+                "Um administrador central, seguindo rótulos de classificação definidos pela organização",
+                false
+            ],
+            [
+                "O sistema operacional, automaticamente, com base no cargo do usuário",
+                false
+            ],
+            [
+                "O proprietário do recurso, que tem discricionariedade para conceder ou revogar acesso a outros usuários",
+                true
+            ],
+            [
+                "Um comitê de segurança que aprova cada solicitação individualmente",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "No modelo de Controle de Acesso Obrigatório (MAC), o acesso a um recurso é concedido com base em:",
+        "explanation": "MAC é chamado de 'obrigatório' justamente porque o acesso é determinado por uma política central, com rótulos de classificação (como confidencial, secreto, ultrassecreto) e níveis de habilitação dos usuários, e nem o dono do recurso nem o usuário comum podem mudar essas regras por conta própria, é o modelo típico de ambientes militares e governamentais. A decisão pessoal do criador do arquivo descreve o DAC, o oposto do MAC. Basear o acesso em papel ou cargo descreve o RBAC. E não existe modelo de votação da equipe entre os modelos clássicos de controle de acesso cobrados no exame.",
+        "topic": "Controle de Acesso",
+        "options": [
+            [
+                "Decisão pessoal do criador do arquivo, que pode compartilhar livremente com quem quiser",
+                false
+            ],
+            [
+                "Rótulos de classificação e níveis de habilitação (clearance) definidos centralmente pela organização, que o usuário não pode alterar",
+                true
+            ],
+            [
+                "Papel ou cargo do usuário dentro da estrutura organizacional",
+                false
+            ],
+            [
+                "Votação da equipe sobre quem deve ter acesso a cada novo arquivo",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Uma empresa organiza as permissões de sistema de forma que todo usuário com o papel 'Analista Financeiro' recebe automaticamente o mesmo conjunto de acessos, e todo usuário com o papel 'Gerente de RH' recebe outro conjunto específico. Esse é um exemplo de qual modelo de controle de acesso?",
+        "explanation": "No RBAC, as permissões são associadas a papéis (roles) que refletem funções dentro da organização, e cada usuário recebe as permissões do papel que ocupa, o que facilita muito a administração em empresas com muitos funcionários. Não é DAC, porque no DAC quem decide o acesso é o dono individual de cada recurso, não uma definição de papel corporativo. Também não é MAC, que se baseia em rótulos de classificação de sigilo e níveis de habilitação, não em cargos funcionais do dia a dia. E CPTED nem é um modelo de controle de acesso lógico, é um conceito de segurança física relacionado ao desenho do ambiente.",
+        "topic": "Controle de Acesso",
+        "options": [
+            [
+                "DAC (Discretionary Access Control), controle de acesso discricionário",
+                false
+            ],
+            [
+                "MAC (Mandatory Access Control), controle de acesso obrigatório",
+                false
+            ],
+            [
+                "RBAC (Role-Based Access Control), controle de acesso baseado em papéis",
+                true
+            ],
+            [
+                "CPTED, prevenção ao crime através do desenho ambiental",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Uma agência de inteligência governamental precisa garantir que documentos classificados como 'ultrassecreto' só sejam acessados por pessoas com a habilitação de segurança correspondente, e que nenhum usuário, nem mesmo o autor do documento, possa reduzir esse nível de restrição por conta própria. Qual modelo de controle de acesso é mais adequado a esse cenário?",
+        "explanation": "O cenário descreve exatamente a essência do MAC: rótulos de classificação (ultrassecreto) e níveis de habilitação definidos de forma centralizada e obrigatória, sem que o usuário individual, nem mesmo o criador do documento, possa flexibilizar essas regras. O DAC está descartado justamente porque o requisito é impedir que o autor tenha esse poder de decisão, que é a característica central do DAC. RBAC baseia-se em papéis funcionais e não captura a granularidade de níveis de sigilo como ultrassecreto, secreto e confidencial, então não atende sozinho ao requisito. E depender de um acordo verbal não é um controle de acesso formal nem oferece nenhuma garantia técnica de que o documento não será acessado indevidamente.",
+        "topic": "Controle de Acesso",
+        "options": [
+            [
+                "MAC (Mandatory Access Control), pois o nível de acesso é definido centralmente e não pode ser alterado pelo usuário individual",
+                true
+            ],
+            [
+                "DAC (Discretionary Access Control), pois o autor do documento pode ajustar o acesso conforme julgar necessário",
+                false
+            ],
+            [
+                "RBAC (Role-Based Access Control), pois basta atribuir o mesmo papel a todos os funcionários da agência",
+                false
+            ],
+            [
+                "Nenhum modelo formal é necessário, desde que haja um acordo verbal de confidencialidade entre os envolvidos",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Uma empresa de médio porte está tendo dificuldade para administrar permissões porque, a cada novo funcionário contratado, o time de TI precisa configurar manualmente dezenas de acessos individuais, e erros de concessão de permissão são frequentes. Qual modelo de controle de acesso tende a resolver melhor esse problema operacional?",
+        "explanation": "RBAC resolve exatamente esse tipo de problema operacional, porque, ao definir papéis padronizados com os acessos já mapeados, basta associar o novo funcionário ao papel correto em vez de configurar dezenas de permissões manualmente, o que reduz erros e acelera o processo. MAC é um modelo pesado, típico de ambientes militares e governamentais com níveis de sigilo, e não foi desenhado para resolver agilidade operacional em uma empresa comum. DAC pioraria o problema, porque descentraliza ainda mais a decisão, deixando a cargo de cada colega individual, o que tende a gerar mais inconsistência, não menos. E CPTED é um conceito de segurança física de ambiente, não tem relação com administração de permissões em sistemas.",
+        "topic": "Controle de Acesso",
+        "options": [
+            [
+                "MAC, exigindo que cada novo funcionário receba um nível de habilitação de segurança nacional antes de começar a trabalhar",
+                false
+            ],
+            [
+                "DAC, deixando que cada colega decida individualmente o que compartilhar com o novo funcionário",
+                false
+            ],
+            [
+                "CPTED, redesenhando o layout físico do escritório para facilitar a supervisão dos novos funcionários",
+                false
+            ],
+            [
+                "RBAC, atribuindo permissões a papéis padronizados por função, de forma que um novo funcionário só precise ser associado ao papel correto",
+                true
+            ]
+        ]
+    },
+    {
+        "statement": "Para reduzir o risco de que um administrador de sistemas malicioso apague os próprios registros de auditoria depois de realizar uma ação indevida, qual controle é mais apropriado?",
+        "explanation": "Segregar a administração do sistema da gestão dos logs de auditoria é a aplicação clássica de segregação de funções para esse risco específico: se o mesmo administrador não tem controle sobre os próprios registros de auditoria, ele não consegue apagar as evidências de uma ação indevida sozinho. Dar acesso irrestrito a tudo, incluindo os logs, é o oposto da solução e aumenta o risco. Eliminar os logs de auditoria remove justamente a ferramenta de rastreabilidade e responsabilização, piorando a postura de segurança. E trocar a senha periodicamente sem mudar as permissões não resolve o problema de fundo, que é o excesso de poder concentrado em uma única função.",
+        "topic": "Controle de Acesso",
+        "options": [
+            [
+                "Dar ao administrador acesso irrestrito a tudo, incluindo os logs, para que ele possa corrigir qualquer problema rapidamente",
+                false
+            ],
+            [
+                "Segregar a função de administração do sistema da função de gestão dos logs de auditoria, atribuindo-as a pessoas ou equipes diferentes",
+                true
+            ],
+            [
+                "Eliminar os logs de auditoria, já que eles podem ser apagados de qualquer forma",
+                false
+            ],
+            [
+                "Trocar a senha do administrador semanalmente, sem alterar suas permissões",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Um estagiário foi contratado para dar suporte apenas ao sistema de tickets de atendimento ao cliente. O gestor de TI, para 'facilitar' futuras tarefas, cogita conceder a ele acesso também ao sistema financeiro e ao servidor de RH, mesmo sem necessidade imediata. Do ponto de vista de controle de acesso, essa prática:",
+        "explanation": "Conceder acesso a sistemas que não são necessários para a função atual do estagiário viola diretamente o princípio do menor privilégio, e também o conceito relacionado de 'necessidade de conhecer' (need to know), aumentando desnecessariamente a superfície de ataque e o dano possível em caso de uso indevido ou comprometimento da conta. Não tem relação com segregação de funções, que busca justamente dividir responsabilidades entre pessoas diferentes, e não concentrar múltiplos sistemas em uma só. Antecipar acessos 'para facilitar' é uma justificativa comum, mas tecnicamente equivocada, já que o acesso deve ser concedido quando a necessidade surgir, não antes. E um termo de confidencialidade é um controle administrativo complementar, mas não elimina o risco técnico criado por permissões desnecessárias.",
+        "topic": "Controle de Acesso",
+        "options": [
+            [
+                "É uma boa prática de segregação de funções, pois centraliza vários sistemas sob uma única pessoa",
+                false
+            ],
+            [
+                "É recomendada, pois antecipar acessos futuros reduz a carga de trabalho do time de TI",
+                false
+            ],
+            [
+                "Viola o princípio do menor privilégio, pois concede acesso além do estritamente necessário para a função atual",
+                true
+            ],
+            [
+                "Não representa nenhum risco, desde que o estagiário assine um termo de confidencialidade",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Em uma pequena empresa que usa um servidor de arquivos onde cada funcionário pode compartilhar suas próprias pastas com quem quiser, um funcionário descontente compartilhou uma pasta confidencial com um concorrente antes de sair da empresa. Esse incidente evidencia principalmente uma fraqueza característica de qual modelo de controle de acesso?",
+        "explanation": "O incidente mostra exatamente a fraqueza típica do DAC: como o próprio usuário decide com quem compartilhar seus recursos, sem uma autoridade central validando cada decisão, um funcionário mal-intencionado consegue vazar informação sem que exista um controle que exija aprovação de terceiros. Não é uma fraqueza do MAC, porque no MAC o próprio ponto é impedir esse tipo de decisão individual descontrolada, então citar MAC aqui inverte a lógica do problema. RBAC também não é a causa, porque o cenário descreve compartilhamento discricionário por pasta individual, não atribuição de papéis, e dizer que RBAC 'impede qualquer' compartilhamento indevido é uma generalização exagerada. E CPTED trata do ambiente físico, sem relação com um incidente de compartilhamento de arquivo em um servidor.",
+        "topic": "Controle de Acesso",
+        "options": [
+            [
+                "DAC, pois a discricionariedade do dono do recurso permite decisões de compartilhamento sem supervisão central",
+                true
+            ],
+            [
+                "MAC, pois rótulos de classificação não podem ser definidos por usuários individuais",
+                false
+            ],
+            [
+                "RBAC, pois papéis organizacionais impedem qualquer tipo de compartilhamento indevido",
+                false
+            ],
+            [
+                "CPTED, pois o ambiente físico do escritório não foi projetado corretamente",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Um sistema de segurança usa Inteligência Artificial para aprender o padrão normal de acesso de cada funcionário (horários habituais, localização, recursos acessados) e gerar um alerta automático quando um comportamento foge muito desse padrão, como um login às 3h da manhã vindo de outro país. Essa capacidade é conhecida como:",
+        "explanation": "O cenário descreve UEBA (User and Entity Behavior Analytics), uma aplicação de IA que aprende o comportamento habitual de cada usuário e sinaliza desvios significativos, como horários incomuns ou localizações inesperadas, funcionando como uma camada extra de detecção de possíveis contas comprometidas ou uso indevido. Não é DAC, que é um modelo de concessão de permissões baseado na discricionariedade do dono do recurso, e não tem relação com análise comportamental de padrões de uso. Também não é CPTED, que é um conceito de segurança física do ambiente construído, sem qualquer aplicação a redes ou sistemas. E não é segregação de funções, que trata da divisão de responsabilidades entre pessoas, e não da separação física de sistemas por IA.",
+        "topic": "Controle de Acesso",
+        "options": [
+            [
+                "Controle de Acesso Discricionário (DAC), pois o próprio sistema decide sozinho quem pode acessar cada recurso",
+                false
+            ],
+            [
+                "CPTED, pois o ambiente de rede foi redesenhado para reduzir riscos",
+                false
+            ],
+            [
+                "Segregação de funções automatizada, pois separa fisicamente os sistemas acessados",
+                false
+            ],
+            [
+                "Detecção de anomalias de acesso baseada em análise comportamental (UEBA), que identifica desvios do padrão normal de uso",
+                true
+            ]
+        ]
+    },
+    {
+        "statement": "Uma organização implementou um mecanismo em que a Inteligência Artificial calcula, em tempo real, um nível de risco para cada tentativa de acesso (considerando dispositivo, localização e horário) e, com base nesse risco, decide se libera o acesso direto, exige uma verificação adicional (como MFA) ou bloqueia a tentativa. Esse uso de IA está associado principalmente a qual finalidade dentro do controle de acesso?",
+        "explanation": "Esse é um exemplo de autorização adaptativa apoiada por IA (também chamada de acesso baseado em risco), em que o sistema ajusta dinamicamente a exigência de autenticação e a decisão de liberar ou não o acesso, com base no risco calculado para aquela tentativa específica, indo além de uma regra estática de tudo ou nada. Esse tipo de mecanismo atua no mundo lógico e não substitui controles de acesso físico, que continuam necessários para proteger instalações e equipamentos. Também não elimina a necessidade de senhas ou outros fatores, pelo contrário, muitas vezes reforça a exigência de um fator adicional quando o risco é considerado alto. E nenhum sistema de IA é infalível, então dizer que jamais haverá falsos positivos é uma afirmação irreal sobre a tecnologia.",
+        "topic": "Controle de Acesso",
+        "options": [
+            [
+                "Substituição definitiva da necessidade de qualquer controle de acesso físico no ambiente",
+                false
+            ],
+            [
+                "Apoio à decisão de autorização de forma adaptativa (risco calculado dinamicamente), tornando o processo mais flexível do que uma regra fixa",
+                true
+            ],
+            [
+                "Eliminação total da necessidade de senhas ou outros fatores de autenticação",
+                false
+            ],
+            [
+                "Garantia de que nenhum falso positivo jamais ocorrerá durante a análise",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Um roteador recebe um pacote e decide para qual rede encaminhá-lo com base no endereço IP de destino. Esse processo de encaminhamento acontece em qual camada do modelo OSI?",
+        "explanation": "A camada de rede (camada 3) é responsável pelo endereçamento lógico (IP) e pelo roteamento de pacotes entre redes diferentes, exatamente a função descrita. A camada de enlace de dados (2) trata do endereçamento físico (MAC) e da entrega dentro do mesmo segmento de rede, não do roteamento entre redes distintas. A camada de transporte (4) cuida da entrega fim a fim e do controle por portas (TCP/UDP), sem decidir o caminho do pacote pela rede. A camada de aplicação (7) é onde ficam os protocolos usados pelos programas, como HTTP e DNS, sem relação direta com o encaminhamento de pacotes.",
+        "topic": "Segurança de Redes",
+        "options": [
+            [
+                "Camada de rede (camada 3)",
+                true
+            ],
+            [
+                "Camada de enlace de dados (camada 2)",
+                false
+            ],
+            [
+                "Camada de transporte (camada 4)",
+                false
+            ],
+            [
+                "Camada de aplicação (camada 7)",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Ao comparar o modelo OSI de 7 camadas com o modelo TCP/IP, uma estudante percebe que o modelo TCP/IP tem menos camadas. Isso ocorre porque o modelo TCP/IP:",
+        "explanation": "O modelo TCP/IP é mais enxuto porque agrupa as responsabilidades das camadas de aplicação, apresentação e sessão do OSI em uma única camada de aplicação, além de combinar enlace e física em uma camada de acesso à rede. Ele continua usando endereçamento IP normalmente, então dizer que elimina essa necessidade está errado. Ele também não substitui a camada de transporte por segurança, TCP e UDP continuam existindo nela normalmente. E ele não adiciona nenhuma camada nova, na verdade reduz o número de camadas em relação ao modelo OSI.",
+        "topic": "Segurança de Redes",
+        "options": [
+            [
+                "Combina as funções das camadas de aplicação, apresentação e sessão do OSI em uma única camada de aplicação",
+                true
+            ],
+            [
+                "Elimina completamente a necessidade de endereçamento IP",
+                false
+            ],
+            [
+                "Substitui a camada de transporte por uma camada de segurança",
+                false
+            ],
+            [
+                "Adiciona uma camada extra entre a camada física e a de enlace",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Uma pequena empresa configura sua rede interna usando endereços como 192.168.1.10 e 192.168.1.11 para os computadores dos funcionários. Para que esses computadores acessem a internet, o roteador da empresa precisa traduzir esses endereços privados para um endereço público. Qual tecnologia realiza essa tradução?",
+        "explanation": "NAT (Network Address Translation) é a tecnologia que traduz endereços IP privados, como os da faixa 192.168.x.x reservada para uso interno, para um endereço IP público, permitindo que vários dispositivos internos compartilhem uma única saída para a internet. DHCP apenas distribui endereços IP automaticamente aos dispositivos da rede, mas não faz tradução de endereços. DNS traduz nomes de domínio, como exemplo.com, em endereços IP, e não endereços privados em públicos. VLAN é usada para segmentar uma rede local em sub-redes lógicas isoladas, sem relação com tradução de endereços.",
+        "topic": "Segurança de Redes",
+        "options": [
+            [
+                "NAT (Network Address Translation)",
+                true
+            ],
+            [
+                "DHCP (Dynamic Host Configuration Protocol)",
+                false
+            ],
+            [
+                "DNS (Domain Name System)",
+                false
+            ],
+            [
+                "VLAN (Virtual Local Area Network)",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "O IPv4 utiliza endereços de 32 bits, o que limita o total de endereços possíveis a cerca de 4,3 bilhões, número já insuficiente para a quantidade de dispositivos conectados à internet atualmente. Qual é a principal razão para a adoção crescente do IPv6?",
+        "explanation": "O IPv6 usa endereços de 128 bits, o que gera um espaço de endereçamento muito maior, resolvendo o problema de escassez de endereços do IPv4. Ele não elimina a necessidade de criptografia, os recursos de segurança continuam sendo aplicados nas camadas de transporte e aplicação como antes. Ele funciona tanto em redes locais quanto na internet pública, exatamente como o IPv4, não é restrito a redes locais. E ele não substitui o TCP, que continua sendo o protocolo de transporte confiável usado acima da camada de rede, tanto em IPv4 quanto em IPv6.",
+        "topic": "Segurança de Redes",
+        "options": [
+            [
+                "Ele usa endereços de 128 bits, o que amplia enormemente o espaço de endereços disponíveis",
+                true
+            ],
+            [
+                "Ele elimina a necessidade de qualquer tipo de criptografia na rede",
+                false
+            ],
+            [
+                "Ele funciona exclusivamente em redes locais, sem acesso à internet",
+                false
+            ],
+            [
+                "Ele substitui o protocolo TCP por um protocolo mais rápido",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "O administrador de uma empresa bloqueia a porta 443 no firewall de borda por engano, durante uma manutenção. Qual será o impacto mais provável para os funcionários?",
+        "explanation": "A porta 443 é a porta padrão do HTTPS, usada para tráfego web criptografado com TLS, então bloqueá-la impede o acesso à maioria dos sites atuais. SMTP usa as portas 25 ou 587, não a 443, então o envio de e-mail não seria afetado diretamente por esse bloqueio específico. DNS usa a porta 53, responsável pela resolução de nomes, também não relacionada à 443. SSH usa a porta 22 para acesso remoto seguro a servidores, outra porta distinta da 443.",
+        "topic": "Segurança de Redes",
+        "options": [
+            [
+                "Eles não conseguirão acessar sites HTTPS, já que essa é a porta padrão do tráfego web criptografado",
+                true
+            ],
+            [
+                "Eles não conseguirão mais receber e-mails, já que essa é a porta padrão do protocolo SMTP",
+                false
+            ],
+            [
+                "Eles não conseguirão resolver nomes de domínio, já que essa é a porta padrão do DNS",
+                false
+            ],
+            [
+                "Eles não conseguirão acessar servidores remotamente via SSH, já que essa é a porta padrão desse protocolo",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "O site de uma loja virtual fica fora do ar depois de receber um volume anormal de requisições simultâneas, originadas de milhares de dispositivos diferentes ao redor do mundo, ao mesmo tempo. Qual tipo de ataque melhor descreve essa situação?",
+        "explanation": "O ataque de negação de serviço distribuída (DDoS) usa um grande número de dispositivos comprometidos, uma botnet, espalhados pelo mundo para sobrecarregar um servidor ou serviço com tráfego, tirando-o do ar, exatamente o cenário descrito. Phishing é uma técnica de engenharia social para enganar vítimas e roubar credenciais ou dados, sem relação com sobrecarga de tráfego. Ataque de força bruta tenta adivinhar senhas testando várias combinações, não gera indisponibilidade por volume de requisições distribuídas. Ransomware é um malware que criptografa arquivos da vítima para exigir resgate, um tipo de ataque totalmente diferente do descrito.",
+        "topic": "Segurança de Redes",
+        "options": [
+            [
+                "Negação de serviço distribuída (DDoS)",
+                true
+            ],
+            [
+                "Phishing",
+                false
+            ],
+            [
+                "Ataque de força bruta",
+                false
+            ],
+            [
+                "Ransomware",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Um funcionário baixa uma planilha infectada e a executa em seu computador. O código malicioso se anexa a outros arquivos executáveis do sistema e só se espalha para outros computadores quando esses arquivos infectados são compartilhados e abertos por outras pessoas. Que tipo de malware descreve melhor esse comportamento?",
+        "explanation": "Um vírus precisa se anexar a um arquivo hospedeiro e depende da ação humana, como compartilhar e abrir o arquivo infectado, para se propagar, exatamente como descrito no cenário. Um worm se diferencia por se propagar sozinho pela rede, explorando vulnerabilidades, sem precisar de um arquivo hospedeiro nem de ação do usuário. Spyware é um malware voltado a monitorar e coletar informações da vítima de forma oculta, não a se replicar por meio de arquivos infectados. Ataque de canal lateral nem é um tipo de malware, é uma técnica que explora características físicas de um sistema, como tempo de processamento ou consumo de energia, para obter informações sensíveis.",
+        "topic": "Segurança de Redes",
+        "options": [
+            [
+                "Vírus",
+                true
+            ],
+            [
+                "Worm",
+                false
+            ],
+            [
+                "Spyware",
+                false
+            ],
+            [
+                "Ataque de canal lateral",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Durante uma investigação, a equipe de segurança descobre dois incidentes distintos. No primeiro, um malware se espalhou sozinho pela rede corporativa explorando uma vulnerabilidade não corrigida, sem qualquer ação dos usuários. No segundo, um funcionário instalou um programa que parecia ser um utilitário legítimo, mas que na verdade abriu uma porta de acesso remoto para um invasor. Como esses dois malwares são classificados, respectivamente?",
+        "explanation": "O primeiro caso é um worm, malware capaz de se autopropagar pela rede explorando vulnerabilidades, sem depender de ação humana. O segundo é um trojan (cavalo de troia), que se disfarça de programa legítimo para enganar o usuário e, uma vez executado, abre acesso indevido ao sistema, como uma porta dos fundos. Inverter as classificações descreveria os comportamentos ao contrário, já que trojan não se autopropaga e worm não depende de disfarce. Vírus exigiria um arquivo hospedeiro e ação do usuário para se propagar, o que não bate com o primeiro caso. Ransomware exige resgate para liberar dados sequestrados e spyware monitora a vítima secretamente, nenhum dos dois corresponde aos comportamentos descritos.",
+        "topic": "Segurança de Redes",
+        "options": [
+            [
+                "Worm e trojan (cavalo de troia)",
+                true
+            ],
+            [
+                "Trojan e worm",
+                false
+            ],
+            [
+                "Vírus e worm",
+                false
+            ],
+            [
+                "Ransomware e spyware",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Um funcionário se conecta a uma rede Wi-Fi aberta em um aeroporto para acessar o sistema interno da empresa. Um invasor, conectado à mesma rede, consegue posicionar seu dispositivo entre o funcionário e o servidor, interceptando e possivelmente alterando os dados trocados sem que nenhum dos dois perceba. Que tipo de ataque é esse?",
+        "explanation": "No ataque man in the middle (MITM), o invasor se posiciona entre duas partes que se comunicam, interceptando e às vezes alterando o tráfego sem que elas percebam, exatamente o cenário de rede Wi-Fi aberta descrito. O ataque de negação de serviço busca tirar um serviço do ar por sobrecarga de tráfego, não interceptar uma comunicação em andamento. Engenharia social manipula pessoas para que revelem informações ou realizem ações, sem necessariamente interceptar tráfego de rede. Ataque de dicionário é uma técnica de quebra de senha que testa palavras comuns, sem relação com interceptação de comunicação em tempo real.",
+        "topic": "Segurança de Redes",
+        "options": [
+            [
+                "Ataque man in the middle (MITM)",
+                true
+            ],
+            [
+                "Ataque de negação de serviço",
+                false
+            ],
+            [
+                "Engenharia social",
+                false
+            ],
+            [
+                "Ataque de dicionário",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Um pesquisador de segurança consegue descobrir parte de uma chave criptográfica secreta apenas medindo o tempo que um dispositivo leva para processar diferentes operações e a variação no consumo de energia durante esse processamento, sem explorar nenhuma falha no código do software. Que tipo de ataque é esse?",
+        "explanation": "O ataque de canal lateral (side-channel) explora características físicas indiretas de um sistema, como tempo de execução, consumo de energia ou emissões eletromagnéticas, para deduzir informações sensíveis, sem atacar diretamente uma falha de software, exatamente o que foi descrito. Injeção de SQL explora falhas em consultas de banco de dados mal validadas, um tipo de vulnerabilidade de software, não uma medição física. Ataque de força bruta tenta adivinhar a chave diretamente, testando combinações, e não por meio de medições físicas indiretas. Sequestro de sessão rouba um token de sessão já autenticado para se passar pelo usuário, uma técnica completamente diferente da descrita.",
+        "topic": "Segurança de Redes",
+        "options": [
+            [
+                "Ataque de canal lateral (side-channel)",
+                true
+            ],
+            [
+                "Injeção de SQL",
+                false
+            ],
+            [
+                "Ataque de força bruta",
+                false
+            ],
+            [
+                "Sequestro de sessão (session hijacking)",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Uma empresa quer uma solução que não apenas identifique tráfego malicioso na rede, mas também bloqueie automaticamente esse tráfego em tempo real, antes que ele alcance os sistemas internos. Qual tecnologia atende a essa necessidade, e não apenas a detecção com alerta?",
+        "explanation": "O IPS (Intrusion Prevention System) fica em linha com o tráfego e pode bloquear automaticamente atividades maliciosas em tempo real, sem depender de intervenção manual, exatamente a necessidade descrita. Já o IDS (Intrusion Detection System) apenas monitora e gera alertas quando identifica atividade suspeita, mas não tem a capacidade de bloquear o tráfego sozinho. VPN cria um túnel criptografado para conexões remotas seguras, sem função de detecção ou bloqueio de ataques. DMZ é uma sub-rede isolada para hospedar serviços expostos à internet, também sem essa função de prevenção ativa.",
+        "topic": "Segurança de Redes",
+        "options": [
+            [
+                "IPS (Intrusion Prevention System)",
+                true
+            ],
+            [
+                "IDS (Intrusion Detection System)",
+                false
+            ],
+            [
+                "VPN (Virtual Private Network)",
+                false
+            ],
+            [
+                "DMZ (Zona Desmilitarizada)",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Uma equipe de segurança quer monitorar continuamente os arquivos de sistema e os registros de eventos de um servidor crítico específico, detectando alterações não autorizadas diretamente naquele host. Qual solução é mais adequada para esse objetivo?",
+        "explanation": "O HIDS (Host-based Intrusion Detection System) é instalado diretamente no host e monitora arquivos de sistema, registros de eventos e outras atividades locais daquele equipamento específico, identificando alterações não autorizadas, exatamente a necessidade descrita. O NIDS (Network-based Intrusion Detection System) monitora o tráfego que passa pela rede como um todo, e não o estado interno de um host específico. NAC controla quais dispositivos podem se conectar à rede com base em critérios de conformidade, sem monitorar arquivos de um servidor. O firewall de borda filtra o tráfego que entra e sai da rede com base em regras, sem visibilidade sobre alterações de arquivos dentro de um host.",
+        "topic": "Segurança de Redes",
+        "options": [
+            [
+                "HIDS (Host-based Intrusion Detection System)",
+                true
+            ],
+            [
+                "NIDS (Network-based Intrusion Detection System)",
+                false
+            ],
+            [
+                "NAC (Network Access Control)",
+                false
+            ],
+            [
+                "Firewall de borda (perimeter firewall)",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Um administrador de rede configura uma regra para permitir apenas tráfego de entrada nas portas 80 e 443, bloqueando todas as outras portas não autorizadas na borda da rede corporativa. Qual dispositivo de segurança é responsável por aplicar esse tipo de regra?",
+        "explanation": "O firewall é o dispositivo responsável por filtrar o tráfego de rede com base em regras predefinidas, como liberar ou bloquear portas específicas, controlando o que entra e sai da rede. O IDS apenas monitora e alerta sobre atividades suspeitas, sem aplicar regras de bloqueio de portas por padrão. O antivírus protege dispositivos individuais contra malware, mas não filtra tráfego de rede por porta. Um access point apenas fornece conectividade sem fio aos dispositivos, sem função de filtragem de tráfego baseada em regras.",
+        "topic": "Segurança de Redes",
+        "options": [
+            [
+                "Firewall",
+                true
+            ],
+            [
+                "IDS",
+                false
+            ],
+            [
+                "Antivírus",
+                false
+            ],
+            [
+                "Access point (ponto de acesso Wi-Fi)",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Uma empresa quer isolar o tráfego de rede do setor financeiro do restante dos funcionários, por questões de segurança, mas sem instalar cabeamento físico separado para cada setor. Qual solução permite essa segmentação lógica usando a infraestrutura de rede já existente?",
+        "explanation": "A VLAN permite segmentar logicamente uma rede física em sub-redes isoladas, como separar o tráfego do setor financeiro do restante dos funcionários, sem precisar de cabeamento físico adicional. A VPN cria um túnel criptografado para conexões remotas seguras pela internet, não é a ferramenta usada para segmentar uma rede interna já cabeada. NAT traduz endereços IP privados em públicos, sem relação com isolamento de tráfego entre setores. A DMZ é uma sub-rede específica para isolar servidores expostos à internet do restante da rede interna, um propósito diferente do isolamento entre departamentos internos.",
+        "topic": "Segurança de Redes",
+        "options": [
+            [
+                "VLAN (Virtual Local Area Network)",
+                true
+            ],
+            [
+                "VPN (Virtual Private Network)",
+                false
+            ],
+            [
+                "NAT (Network Address Translation)",
+                false
+            ],
+            [
+                "DMZ (Zona Desmilitarizada)",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Uma empresa precisa disponibilizar um servidor web acessível pelo público na internet, mas quer garantir que, se esse servidor for comprometido, o invasor não tenha acesso direto à rede interna onde ficam os dados sensíveis. Qual solução de design de rede atende a essa necessidade?",
+        "explanation": "A DMZ é uma sub-rede isolada, posicionada entre a rede interna e a internet, criada justamente para hospedar serviços públicos como servidores web, de forma que, se comprometidos, não deem acesso direto à rede interna. Colocar o servidor na mesma VLAN dos funcionários misturaria tráfego público com a rede interna sensível, aumentando o risco. Conectar o servidor diretamente à rede interna sem segmentação exporia todos os recursos internos em caso de comprometimento do servidor. Exigir VPN dos visitantes não é viável para um site público, que precisa ser acessível a qualquer pessoa na internet, e não resolve o problema de isolamento da rede interna.",
+        "topic": "Segurança de Redes",
+        "options": [
+            [
+                "Colocar o servidor em uma DMZ (zona desmilitarizada)",
+                true
+            ],
+            [
+                "Colocar o servidor na mesma VLAN dos computadores dos funcionários",
+                false
+            ],
+            [
+                "Conectar o servidor diretamente à rede interna sem nenhuma segmentação",
+                false
+            ],
+            [
+                "Exigir que todos os visitantes do site usem uma VPN antes de acessar",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Uma funcionária que trabalha remotamente precisa acessar sistemas internos da empresa pela internet com segurança, como se seu computador estivesse fisicamente conectado à rede corporativa. Qual tecnologia permite isso, criando um túnel criptografado entre o dispositivo dela e a rede da empresa?",
+        "explanation": "A VPN cria um túnel criptografado entre o dispositivo remoto e a rede da empresa, permitindo que a funcionária acesse recursos internos com segurança pela internet, como se estivesse fisicamente na rede corporativa. O NAC verifica se um dispositivo cumpre requisitos de segurança antes de liberar acesso à rede, mas não é ele quem cria o túnel de conexão remota. A DMZ é uma sub-rede para isolar serviços públicos, sem relação com acesso remoto seguro de funcionários. O IPS previne intrusões bloqueando tráfego malicioso, mas não é a tecnologia usada para estabelecer conexões remotas criptografadas.",
+        "topic": "Segurança de Redes",
+        "options": [
+            [
+                "VPN (Virtual Private Network)",
+                true
+            ],
+            [
+                "NAC (Network Access Control)",
+                false
+            ],
+            [
+                "DMZ (Zona Desmilitarizada)",
+                false
+            ],
+            [
+                "IPS (Intrusion Prevention System)",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Uma empresa decide não depender apenas do firewall de borda para se proteger e passa a combinar firewall, IDS/IPS, antivírus nos endpoints, segmentação de rede e treinamento de conscientização dos funcionários, de forma que, se uma camada falhar, as outras ainda ofereçam proteção. Esse conceito é conhecido como:",
+        "explanation": "A defesa em profundidade é o conceito de aplicar múltiplas camadas independentes de controle de segurança, de forma que a falha de uma camada não deixe o sistema totalmente exposto, exatamente o cenário descrito. Privilégio mínimo é o princípio de dar a cada usuário apenas o acesso necessário para sua função, um conceito de controle de acesso, não de camadas de defesa de rede. Segregação de funções divide tarefas críticas entre pessoas diferentes para evitar fraude ou erro, também não relacionado a camadas de controles técnicos. Redundância geográfica se refere a manter recursos em locais fisicamente distintos para continuidade de negócios, um conceito de recuperação de desastres, não de defesa em camadas.",
+        "topic": "Segurança de Redes",
+        "options": [
+            [
+                "Defesa em profundidade",
+                true
+            ],
+            [
+                "Privilégio mínimo",
+                false
+            ],
+            [
+                "Segregação de funções",
+                false
+            ],
+            [
+                "Redundância geográfica",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Uma empresa quer garantir que somente dispositivos com antivírus atualizado e patches de segurança em dia consigam se conectar à rede corporativa, verificando automaticamente essa conformidade antes de liberar o acesso. Qual solução atende a essa necessidade?",
+        "explanation": "O NAC (Network Access Control) verifica automaticamente se um dispositivo atende a critérios de segurança definidos, como antivírus atualizado e patches em dia, antes de permitir sua conexão à rede, exatamente a necessidade descrita. O IDS apenas detecta e alerta sobre atividades suspeitas depois que o tráfego já está circulando na rede, sem controlar a entrada de dispositivos. A DMZ isola serviços expostos à internet, sem relação com verificação de conformidade de dispositivos internos. Um antivírus centralizado ajuda a gerenciar a proteção dos endpoints, mas sozinho não impede que um dispositivo fora de conformidade se conecte à rede.",
+        "topic": "Segurança de Redes",
+        "options": [
+            [
+                "NAC (Network Access Control)",
+                true
+            ],
+            [
+                "IDS (Intrusion Detection System)",
+                false
+            ],
+            [
+                "DMZ (Zona Desmilitarizada)",
+                false
+            ],
+            [
+                "Antivírus centralizado",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Uma empresa passa a usar um sistema de e-mail acessado inteiramente pelo navegador, sem instalar nenhum servidor, sem gerenciar sistema operacional e sem se preocupar com atualizações da aplicação, que ficam totalmente a cargo do provedor. Esse é um exemplo de qual modelo de serviço em nuvem?",
+        "explanation": "No SaaS (Software as a Service), o provedor entrega a aplicação pronta para uso, cuidando de toda a infraestrutura, do sistema operacional e das atualizações, enquanto o cliente apenas usa o software pelo navegador, exatamente o cenário descrito. No IaaS, o cliente aluga a infraestrutura, como servidores e armazenamento, mas ainda precisa instalar e gerenciar o sistema operacional e as aplicações. No PaaS, o provedor entrega uma plataforma para o cliente desenvolver e implantar suas próprias aplicações, sem gerenciar a infraestrutura, mas ainda envolve gestão de código pelo cliente. MSP é um termo mais amplo para empresas terceirizadas que gerenciam serviços de TI, não é, por si só, um dos três modelos clássicos de serviço em nuvem.",
+        "topic": "Segurança de Redes",
+        "options": [
+            [
+                "SaaS (Software as a Service)",
+                true
+            ],
+            [
+                "IaaS (Infrastructure as a Service)",
+                false
+            ],
+            [
+                "PaaS (Platform as a Service)",
+                false
+            ],
+            [
+                "MSP (Managed Service Provider)",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Uma equipe de desenvolvimento quer alugar máquinas virtuais na nuvem para ter controle total sobre o sistema operacional, as configurações de rede e o software instalado, responsabilizando-se por tudo acima da camada de infraestrutura física. Qual modelo de serviço em nuvem essa equipe está utilizando?",
+        "explanation": "No IaaS (Infrastructure as a Service), o provedor entrega apenas a infraestrutura básica, como servidores virtuais, armazenamento e rede, e o cliente é responsável por instalar e gerenciar o sistema operacional e tudo que roda sobre ele, exatamente o cenário descrito. No PaaS, o provedor já entrega uma plataforma com sistema operacional e ferramentas de desenvolvimento prontas, e o cliente foca apenas na aplicação, sem gerenciar o sistema operacional. No SaaS, o cliente só usa uma aplicação pronta, sem nenhum controle sobre infraestrutura ou sistema operacional. SLA é um acordo contratual que define níveis de serviço garantidos, como disponibilidade, não um modelo de entrega de serviço em nuvem.",
+        "topic": "Segurança de Redes",
+        "options": [
+            [
+                "IaaS (Infrastructure as a Service)",
+                true
+            ],
+            [
+                "PaaS (Platform as a Service)",
+                false
+            ],
+            [
+                "SaaS (Software as a Service)",
+                false
+            ],
+            [
+                "SLA (Service Level Agreement)",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Um firewall tradicional, baseado apenas em regras fixas de porta e endereço IP, não consegue identificar um ataque totalmente novo, sem assinatura conhecida. Uma empresa passa a usar um firewall com recursos de inteligência artificial, que analisa padrões de tráfego e comportamento para identificar atividades suspeitas mesmo sem uma assinatura prévia. Qual é a principal vantagem dessa abordagem em relação ao firewall tradicional?",
+        "explanation": "A principal vantagem da inteligência artificial aplicada a firewalls é a capacidade de reconhecer padrões de comportamento anômalos e identificar ameaças novas, sem assinatura conhecida, algo que regras estáticas não conseguem fazer sozinhas. A IA não elimina a necessidade de revisão humana, pois analistas ainda precisam validar alertas e ajustar o sistema, especialmente para reduzir falsos positivos. Nenhuma tecnologia, incluindo IA, garante proteção absoluta contra todos os ataques, seria uma promessa irreal. E recursos de IA em segurança não têm relação com redução de custo de conexão à internet, um benefício que não faz sentido no contexto de detecção de ameaças.",
+        "topic": "Segurança de Redes",
+        "options": [
+            [
+                "Capacidade de detectar ameaças novas e desconhecidas com base em padrões de comportamento, não apenas em regras e assinaturas fixas",
+                true
+            ],
+            [
+                "Eliminação total da necessidade de qualquer revisão humana das configurações de segurança",
+                false
+            ],
+            [
+                "Garantia de que nenhum ataque jamais conseguirá comprometer a rede",
+                false
+            ],
+            [
+                "Redução do custo de conexão à internet da empresa",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "A equipe de segurança de uma empresa reclama que o IDS tradicional gera um volume enorme de alertas, muitos deles falsos positivos, tornando difícil identificar rapidamente os incidentes reais em meio a tanto ruído. Como o uso de inteligência artificial no IDS pode ajudar a resolver esse problema?",
+        "explanation": "Sistemas de IDS com inteligência artificial aprendem o comportamento normal da rede ao longo do tempo e conseguem priorizar e contextualizar alertas com maior chance de serem ameaças reais, reduzindo o ruído de falsos positivos e agilizando a resposta da equipe. Desligar o IDS quando há muitos alertas deixaria a rede sem monitoramento justamente quando mais precisa dele, o oposto do desejado. Bloquear permanentemente qualquer usuário que gere um alerta puniria também os falsos positivos, prejudicando pessoas legítimas sem necessidade. E a IA apoia a equipe de segurança, mas não substitui completamente o julgamento humano, que continua necessário para decisões mais complexas e para validar as recomendações do sistema.",
+        "topic": "Segurança de Redes",
+        "options": [
+            [
+                "Aprendendo o padrão normal de tráfego da rede e priorizando alertas com maior probabilidade de serem ameaças reais, reduzindo o ruído de falsos positivos",
+                true
+            ],
+            [
+                "Desligando automaticamente o IDS sempre que o volume de alertas fica muito alto",
+                false
+            ],
+            [
+                "Bloqueando permanentemente qualquer usuário que gere um alerta, mesmo que seja falso positivo",
+                false
+            ],
+            [
+                "Substituindo completamente a necessidade de uma equipe de segurança monitorar a rede",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Uma empresa de armazenamento em nuvem precisa criptografar um volume de dados de 500 terabytes em repouso, priorizando o menor impacto possível no desempenho. Qual tipo de criptografia é mais indicado para esse cenário?",
+        "explanation": "A criptografia simétrica usa uma única chave para cifrar e decifrar, o que exige bem menos processamento do que a assimétrica, sendo a escolha natural para cifrar grandes volumes de dados em repouso. A criptografia assimétrica é mais lenta e costuma ser usada para troca de chaves ou assinaturas, não para cifrar diretamente grandes massas de dados. Hashing não é reversível, então não serve para proteger dados que precisam ser recuperados depois. Assinatura digital garante integridade e autenticidade, não confidencialidade.",
+        "topic": "Operações de Segurança",
+        "options": [
+            [
+                "Criptografia simétrica, porque usa a mesma chave para cifrar e decifrar e tem desempenho melhor em grandes volumes de dados",
+                true
+            ],
+            [
+                "Criptografia assimétrica, porque o par de chaves pública e privada elimina a necessidade de proteger uma chave compartilhada",
+                false
+            ],
+            [
+                "Hashing, porque transforma os dados em um valor de tamanho fixo que pode ser revertido quando necessário",
+                false
+            ],
+            [
+                "Assinatura digital, porque garante que os dados não foram alterados durante o armazenamento",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Duas empresas que nunca compartilharam nenhuma informação antes precisam estabelecer uma comunicação segura pela internet, sem ter tido qualquer canal seguro anterior para combinar uma chave secreta. Qual recurso de criptografia resolve esse problema?",
+        "explanation": "A criptografia assimétrica usa um par de chaves, uma pública e outra privada, que permite a duas partes que nunca se encontraram estabelecer uma comunicação segura e combinar uma chave de sessão sem precisar de um canal seguro anterior. A criptografia simétrica, ao contrário, exige que a mesma chave já esteja compartilhada de forma segura entre as partes, o que é justamente o problema do cenário. Hashing não cria nem troca chaves, apenas gera um valor de verificação a partir de dados já existentes. E uma VPN também depende de troca de chaves nos bastidores para formar o túnel seguro, então não elimina o problema, apenas o resolve usando o mesmo princípio de criptografia assimétrica por trás.",
+        "topic": "Operações de Segurança",
+        "options": [
+            [
+                "Criptografia simétrica, que usa uma única chave compartilhada e simplifica a distribuição inicial dessa chave entre as partes",
+                false
+            ],
+            [
+                "Hashing, que gera um valor fixo a partir dos dados e permite que as partes validem a chave combinada entre si",
+                false
+            ],
+            [
+                "Criptografia assimétrica, que usa um par de chaves pública e privada para permitir a troca segura de uma chave sem um canal seguro anterior",
+                true
+            ],
+            [
+                "Uma VPN, que cria um túnel seguro automaticamente entre as duas redes, sem qualquer necessidade de troca de chaves nos bastidores",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Um desenvolvedor está implementando o cadastro de usuários de um sistema e precisa decidir como armazenar as senhas no banco de dados, de forma que, mesmo se o banco for comprometido, um invasor não consiga recuperar a senha original diretamente. Qual é a abordagem correta?",
+        "explanation": "Uma função de hash com salt é unidirecional: não é possível reverter o valor de hash para obter a senha original, e o salt evita que senhas iguais gerem o mesmo hash, dificultando ataques com tabelas prontas de senhas conhecidas (rainbow tables). Criptografar a senha, seja com algoritmo simétrico ou assimétrico, é reversível: quem tiver acesso à chave correspondente consegue recuperar a senha original, o que é justamente o risco que se quer evitar. Guardar a senha em texto puro é uma prática insegura mesmo com controle de acesso à tabela, pois qualquer falha de configuração ou vazamento expõe as senhas diretamente.",
+        "topic": "Operações de Segurança",
+        "options": [
+            [
+                "Criptografar a senha com um algoritmo simétrico, guardando a chave de decriptação na mesma tabela do banco de dados",
+                false
+            ],
+            [
+                "Criptografar a senha com a chave pública da empresa, permitindo que apenas a chave privada correspondente a decifre depois",
+                false
+            ],
+            [
+                "Armazenar a senha em texto puro, mas restringir o acesso à tabela apenas para administradores do banco de dados",
+                false
+            ],
+            [
+                "Aplicar uma função de hash com salt sobre a senha antes de armazená-la, já que o hash não pode ser revertido ao valor original",
+                true
+            ]
+        ]
+    },
+    {
+        "statement": "Uma empresa organiza suas informações em quatro níveis de classificação: pública, interna, confidencial e restrita. Um analista encontra uma planilha com nomes completos, CPFs e dados de cartão de crédito de clientes. Em qual nível essa planilha deve ser classificada?",
+        "explanation": "Dados pessoais e financeiros de clientes, como CPF e número de cartão de crédito, estão entre os mais sensíveis que uma empresa manuseia, por isso pertencem ao nível mais alto de classificação (confidencial ou restrita), com controles adicionais de acesso, criptografia e monitoramento. Classificar como interna subestima o risco, porque esse nível costuma ser reservado a informações de uso corporativo sem alta sensibilidade. Classificar como pública ignora completamente a exposição de dados de clientes a qualquer pessoa. E dizer que a classificação não é necessária contraria o próprio propósito do manuseio de dados, que usa a classificação para definir os controles adequados a cada tipo de informação, além do simples controle de acesso ao sistema de arquivos.",
+        "topic": "Operações de Segurança",
+        "options": [
+            [
+                "Interna, pois o acesso já é limitado aos funcionários da empresa, o que é suficiente para proteger dados de clientes",
+                false
+            ],
+            [
+                "Restrita ou confidencial, já que dados pessoais e financeiros de clientes exigem o mais alto grau de proteção e controle de acesso",
+                true
+            ],
+            [
+                "Pública, porque a planilha não contém segredos comerciais nem propriedade intelectual da empresa",
+                false
+            ],
+            [
+                "A classificação não é necessária nesse caso, pois o controle de acesso ao sistema de arquivos já protege o conteúdo",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Uma empresa vai descartar um lote de HDs antigos que armazenaram dados financeiros de clientes por anos. Qual é a prática mais adequada antes do descarte físico desses discos?",
+        "explanation": "A destruição segura, por métodos como desmagnetização ou trituração física, garante que os dados não possam ser recuperados depois do descarte, o que é essencial quando o disco guardou informações sensíveis. Formatar o disco ou apagar arquivos manualmente não remove os dados de fato: eles continuam recuperáveis com ferramentas forenses, porque essas operações só removem as referências aos arquivos, não o conteúdo gravado. Guardar os discos indefinidamente não resolve o problema, apenas adia o risco, além de contrariar boas práticas de retenção, que recomendam descartar dados que não têm mais motivo para existir.",
+        "topic": "Operações de Segurança",
+        "options": [
+            [
+                "Realizar a destruição segura dos dados, como desmagnetização (degaussing) ou trituração física dos discos, conforme a política de descarte da empresa",
+                true
+            ],
+            [
+                "Formatar os discos pelo sistema operacional e depois descartá-los normalmente",
+                false
+            ],
+            [
+                "Excluir manualmente os arquivos visíveis nos discos antes do descarte",
+                false
+            ],
+            [
+                "Guardar os discos indefinidamente em um local seguro em vez de descartá-los, para evitar qualquer risco de vazamento",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "O time de segurança de uma empresa percebe que os registros (logs) de firewalls, servidores e estações de trabalho ficam armazenados apenas localmente, cada um em seu próprio equipamento. Qual é o principal problema de segurança dessa abordagem?",
+        "explanation": "Quando os logs ficam espalhados, cada um isolado em seu próprio equipamento, o time de segurança perde a visão do todo: um ataque que passa por firewall, servidor e estação de trabalho deixa rastros separados, difíceis de conectar sem uma visão centralizada, que é justamente o papel de um SIEM ao agregar e correlacionar logs de múltiplas fontes. O custo de armazenamento é uma questão secundária, não o principal risco de segurança. Acesso remoto a logs locais costuma ser possível por outras vias, e a criptografia automática de logs pelo sistema operacional não é um comportamento padrão nem o problema central do cenário.",
+        "topic": "Operações de Segurança",
+        "options": [
+            [
+                "Os logs locais ocupam mais espaço em disco do que logs armazenados remotamente, o que aumenta o custo de armazenamento",
+                false
+            ],
+            [
+                "Os logs locais não podem ser lidos por administradores sem acesso físico ao equipamento",
+                false
+            ],
+            [
+                "Os logs locais são criptografados automaticamente pelo sistema operacional, o que dificulta a auditoria",
+                false
+            ],
+            [
+                "Fica muito mais difícil correlacionar eventos entre sistemas diferentes e detectar um ataque que passe por vários equipamentos",
+                true
+            ]
+        ]
+    },
+    {
+        "statement": "Durante uma investigação, o time de segurança percebe que os logs de um servidor comprometido foram apagados pelo próprio invasor para esconder seus rastros. Qual prática de logging poderia ter evitado essa perda de evidências?",
+        "explanation": "Enviar os logs em tempo real para um servidor centralizado, fora do alcance do sistema comprometido, é a prática que protege as evidências: mesmo que o invasor apague os registros locais, uma cópia já estará em um local que ele não controla. Aumentar o tamanho do arquivo local não impede que o invasor, já com acesso ao servidor, apague ou altere os logs. Gerar logs só quando um alerta dispara reduz a visibilidade geral e pode deixar de registrar justamente as ações do invasor antes de o alerta existir. Restringir a leitura ao administrador local não protege contra um invasor que já obteve esse mesmo nível de acesso no servidor comprometido.",
+        "topic": "Operações de Segurança",
+        "options": [
+            [
+                "Aumentar o tamanho máximo do arquivo de log local, para que ele nunca precise ser rotacionado",
+                false
+            ],
+            [
+                "Configurar o sistema para gerar logs apenas quando um alerta de segurança for disparado",
+                false
+            ],
+            [
+                "Enviar os logs em tempo real para um servidor centralizado e protegido, separado do sistema que gera os registros",
+                true
+            ],
+            [
+                "Restringir a leitura dos logs apenas ao administrador do próprio servidor",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Antes de colocar um novo servidor em produção, a equipe de TI precisa aplicar hardening no sistema operacional recém-instalado. Qual das ações a seguir é um exemplo correto dessa prática?",
+        "explanation": "Hardening consiste em reduzir a superfície de ataque de um sistema antes de colocá-lo em uso, o que inclui desativar serviços, portas e contas que não são necessários, além de substituir senhas e configurações padrão de fábrica, que costumam ser públicas e conhecidas. Instalar mais ferramentas de administração remota aumenta, em vez de reduzir, a superfície de ataque. Manter configurações de fábrica é um erro comum, pois elas priorizam facilidade de uso, não segurança. E esperar o servidor entrar em produção para revisar isso expõe o sistema durante todo esse intervalo, quando o hardening deveria ser aplicado antes de o sistema ficar acessível.",
+        "topic": "Operações de Segurança",
+        "options": [
+            [
+                "Instalar o maior número possível de ferramentas de administração remota, para facilitar o suporte técnico no futuro",
+                false
+            ],
+            [
+                "Desativar serviços e portas que não são necessários para a função do servidor e trocar as contas e senhas padrão de fábrica",
+                true
+            ],
+            [
+                "Manter as configurações padrão de fábrica, já que o fabricante já testou a segurança dessas configurações",
+                false
+            ],
+            [
+                "Aguardar até o servidor entrar em produção para então revisar quais serviços podem ser desativados",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Um fornecedor libera uma atualização crítica de segurança para um sistema usado pela empresa. Qual é a prática mais recomendada antes de aplicar esse patch em todos os servidores de produção?",
+        "explanation": "Mesmo quando um patch é crítico, a prática recomendada é testá-lo primeiro em um ambiente de homologação, que reproduz a produção sem os mesmos riscos, para identificar problemas de compatibilidade antes de uma aplicação ampla. Aplicar direto em produção, sem teste, pode causar indisponibilidade caso o patch tenha algum efeito colateral, trocando um risco de segurança por um risco operacional. Esperar o ciclo trimestral de manutenção é perigoso demais para uma atualização crítica, que pode estar corrigindo uma vulnerabilidade já explorada ativamente. Desativar o sistema até uma nova versão completa não é uma prática real de gestão de patches e deixaria a empresa sem o serviço por tempo indeterminado.",
+        "topic": "Operações de Segurança",
+        "options": [
+            [
+                "Testar o patch em um ambiente de homologação, separado da produção, para verificar compatibilidade antes de aplicá-lo amplamente",
+                true
+            ],
+            [
+                "Aplicar o patch imediatamente em todos os servidores de produção, já que se trata de uma atualização crítica de segurança",
+                false
+            ],
+            [
+                "Esperar o próximo ciclo trimestral de manutenção programada, já que patches podem sempre ser aplicados em lote depois",
+                false
+            ],
+            [
+                "Desativar o sistema até que a próxima versão completa do software seja lançada, evitando aplicar patches isolados",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Um funcionário passa a usar o e-mail corporativo para divulgar e vender produtos de um negócio pessoal fora do horário de trabalho. Qual política define claramente se esse uso é permitido ou não?",
+        "explanation": "A Política de Uso Aceitável (Acceptable Use Policy, AUP) é o documento que define o que é e o que não é permitido no uso dos recursos de TI da empresa, como e-mail corporativo, internet e equipamentos, incluindo o uso para fins pessoais. A política de BYOD trata especificamente de dispositivos pessoais dos funcionários, não do uso de recursos corporativos. A gestão de mudanças trata da aprovação de alterações técnicas em sistemas, sem relação com conduta de uso. E a política de privacidade regula o tratamento de dados pessoais de terceiros, não o comportamento do próprio funcionário com os recursos da empresa.",
+        "topic": "Operações de Segurança",
+        "options": [
+            [
+                "Política de BYOD, que trata do uso de dispositivos pessoais para acessar recursos corporativos",
+                false
+            ],
+            [
+                "Política de gestão de mudanças, que define como alterações em sistemas de produção devem ser aprovadas",
+                false
+            ],
+            [
+                "Política de privacidade, que define como os dados pessoais de clientes e funcionários são tratados",
+                false
+            ],
+            [
+                "Política de Uso Aceitável (AUP), que estabelece as regras de uso apropriado dos recursos de TI da empresa",
+                true
+            ]
+        ]
+    },
+    {
+        "statement": "Uma empresa decide permitir que os funcionários acessem o e-mail corporativo e alguns sistemas internos pelo próprio celular pessoal. Qual controle é mais indicado para reduzir o risco de segurança dessa prática, dentro de uma política de BYOD?",
+        "explanation": "Uma solução de MDM permite aplicar políticas de segurança no dispositivo pessoal, como exigência de senha e criptografia, e principalmente a possibilidade de apagar remotamente apenas os dados corporativos em caso de perda, roubo ou desligamento do funcionário, sem afetar os dados pessoais dele. Proibir bloqueio de tela vai na direção contrária da segurança. Permitir acesso sem nenhum controle ignora que o dispositivo passará a acessar dados corporativos sensíveis, independentemente de quem é o dono do aparelho. E exigir um segundo celular exclusivo descaracteriza o próprio conceito de BYOD, que é justamente usar o dispositivo pessoal já existente.",
+        "topic": "Operações de Segurança",
+        "options": [
+            [
+                "Proibir qualquer tipo de senha ou bloqueio de tela no celular pessoal, para agilizar o acesso aos dados da empresa",
+                false
+            ],
+            [
+                "Permitir o acesso sem qualquer controle adicional, já que o dispositivo pertence ao funcionário e não à empresa",
+                false
+            ],
+            [
+                "Exigir a inscrição do dispositivo em uma solução de gerenciamento de dispositivos móveis (MDM), com opção de apagar remotamente apenas os dados corporativos",
+                true
+            ],
+            [
+                "Exigir que o funcionário compre um segundo celular exclusivo para uso pessoal, mantendo o primeiro somente para a empresa",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Uma empresa mantém uma política que obriga os funcionários a trocar a senha a cada 30 dias, com o requisito mínimo de apenas 6 caracteres. Na prática, muitos funcionários passam a usar padrões previsíveis, como acrescentar um número no final da mesma senha a cada troca. Qual mudança de política melhoraria a segurança de forma mais eficaz?",
+        "explanation": "Diretrizes atuais de segurança mostram que senhas mais longas, como frases secretas, combinadas com autenticação multifator, protegem muito mais do que a troca forçada frequente, que na prática incentiva os usuários a criarem padrões previsíveis e fáceis de adivinhar, como no cenário descrito. Reduzir ainda mais o intervalo de troca reforça esse comportamento problemático, piorando a situação. Proibir apenas uma palavra específica é uma medida cosmética que não resolve o padrão previsível criado pela troca frequente. Substituir por um PIN de 4 dígitos reduz drasticamente o espaço de combinações possíveis, tornando a senha muito mais fácil de quebrar.",
+        "topic": "Operações de Segurança",
+        "options": [
+            [
+                "Reduzir o intervalo de troca de senha para a cada 15 dias, mantendo o requisito mínimo de 6 caracteres",
+                false
+            ],
+            [
+                "Exigir senhas mais longas (como uma frase secreta) e habilitar a autenticação multifator, reduzindo a dependência da troca frequente como principal controle",
+                true
+            ],
+            [
+                "Manter a política atual, mas proibir apenas o uso da palavra \"senha\" como parte da senha",
+                false
+            ],
+            [
+                "Eliminar completamente qualquer requisito de senha, substituindo por apenas um PIN numérico de 4 dígitos para simplificar o acesso",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Um funcionário recebe uma ligação de alguém se identificando como técnico do suporte de TI, que afirma precisar da senha do funcionário para resolver com urgência uma falha no sistema. Que tipo de ataque esse cenário representa?",
+        "explanation": "O cenário descreve pretexting, uma técnica de engenharia social em que o atacante inventa um pretexto (nesse caso, se passar por suporte técnico) para convencer a vítima a entregar informações sensíveis, como uma senha. Não há tentativa de adivinhar a senha por múltiplas combinações, o que descartaria força bruta. Também não há interceptação de comunicação entre duas partes legítimas, o que descartaria man in the middle. E não há sobrecarga de um sistema para tirá-lo do ar, o que descartaria negação de serviço.",
+        "topic": "Operações de Segurança",
+        "options": [
+            [
+                "Engenharia social, mais especificamente pretexting, em que o atacante cria uma história falsa para convencer a vítima a fornecer informações sensíveis",
+                true
+            ],
+            [
+                "Ataque de força bruta, em que o atacante tenta adivinhar a senha testando diversas combinações possíveis",
+                false
+            ],
+            [
+                "Man in the middle, em que o atacante intercepta a comunicação entre o funcionário e o servidor de e-mail",
+                false
+            ],
+            [
+                "Ataque de negação de serviço, em que o atacante sobrecarrega o sistema de suporte técnico com ligações falsas",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Depois de um ano realizando campanhas simuladas de phishing e treinamentos periódicos de conscientização, uma empresa percebe que a taxa de funcionários que clicam em links maliciosos simulados caiu significativamente. O que esse resultado demonstra sobre o papel do treinamento de segurança?",
+        "explanation": "A queda na taxa de cliques em phishing simulado mostra que o treinamento contínuo funciona: pessoas bem treinadas reconhecem e reportam tentativas de engenharia social com mais frequência, reduzindo a chance de um ataque real ter sucesso. Isso não significa que o risco foi eliminado, nem que outros controles técnicos deixaram de ser necessários, treinamento é uma camada a mais de defesa, não um substituto. Reduzir a frequência dos treinamentos por causa de um bom resultado tende a reverter o ganho obtido, já que a conscientização precisa ser reforçada continuamente. E abandonar o treinamento humano em favor de filtros técnicos contraria o próprio resultado positivo descrito no cenário.",
+        "topic": "Operações de Segurança",
+        "options": [
+            [
+                "O treinamento eliminou totalmente o risco de engenharia social na empresa, tornando desnecessários outros controles técnicos",
+                false
+            ],
+            [
+                "A queda na taxa de cliques mostra que a empresa já pode reduzir a frequência dos treinamentos, já que o problema foi resolvido",
+                false
+            ],
+            [
+                "O resultado indica que a empresa deveria substituir o treinamento humano por filtros técnicos de e-mail, já que as pessoas continuam sendo o maior risco",
+                false
+            ],
+            [
+                "Treinar continuamente os funcionários reduz o risco de engenharia social, porque as pessoas aprendem a reconhecer e reportar tentativas de ataque",
+                true
+            ]
+        ]
+    },
+    {
+        "statement": "O centro de operações de segurança (SOC) de uma empresa recebe milhares de alertas por dia vindos de firewalls, antivírus e sistemas de detecção de intrusão, e a maioria são falsos positivos. Os poucos analistas da equipe não conseguem revisar tudo manualmente. Como a inteligência artificial em uma ferramenta de SIEM pode ajudar nesse cenário?",
+        "explanation": "A IA aplicada a um SIEM ajuda justamente a lidar com o volume alto de alertas: ela correlaciona eventos de diferentes fontes, identifica padrões que indicam ameaças reais e prioriza o que merece atenção humana, reduzindo a fadiga de alertas da equipe. Isso não elimina a necessidade de analistas, que continuam responsáveis por investigar e decidir sobre os alertas priorizados. A ferramenta também não impede ataques sozinha: ela apoia a detecção e a análise, enquanto a prevenção depende de outros controles, como firewalls e IPS. E a IA depende diretamente dos logs e eventos coletados para funcionar: sem esses dados, não haveria nada para correlacionar ou analisar.",
+        "topic": "Operações de Segurança",
+        "options": [
+            [
+                "Eliminando totalmente a necessidade de analistas humanos revisarem qualquer alerta gerado pelo SIEM",
+                false
+            ],
+            [
+                "Correlacionando automaticamente os eventos de múltiplas fontes e priorizando os alertas com maior probabilidade de serem ameaças reais, reduzindo o volume que precisa de análise manual",
+                true
+            ],
+            [
+                "Impedindo automaticamente qualquer tentativa futura de ataque, sem a necessidade de outros controles de segurança",
+                false
+            ],
+            [
+                "Substituindo a necessidade de logs detalhados dos sistemas, já que a IA consegue prever ameaças sem dados históricos",
+                false
+            ]
+        ]
+    },
+    {
+        "statement": "Um desenvolvedor cola um trecho do código-fonte proprietário da empresa, incluindo uma chave de API interna, em um chatbot de IA generativa disponível publicamente na internet, para pedir ajuda a depurar um erro. Qual é o principal risco de segurança dessa ação?",
+        "explanation": "Serviços públicos de IA generativa podem reter, registrar ou até usar os dados enviados para treinar futuros modelos, dependendo dos termos do serviço, o que tira da empresa o controle sobre informações sensíveis, como código-fonte proprietário e chaves de API, caracterizando um vazamento de dados. O chatbot recusar a resposta seria apenas um inconveniente, não o risco de segurança em questão. Não é verdade que o uso dessas ferramentas seja proibido por lei em todo lugar: o problema é o tipo de dado compartilhado, não a ferramenta em si. E o código-fonte continua funcionando normalmente depois de ser colado em um chatbot. Isso não tem relação com o risco real do cenário, que é o vazamento de informação confidencial.",
+        "topic": "Operações de Segurança",
+        "options": [
+            [
+                "O chatbot pode se recusar a responder perguntas técnicas sobre código-fonte, o que atrasaria a resolução do problema",
+                false
+            ],
+            [
+                "O uso de ferramentas de IA generativa é sempre proibido por lei em qualquer país, independentemente do conteúdo enviado",
+                false
+            ],
+            [
+                "Os dados enviados podem ser armazenados ou usados pelo provedor do serviço de IA, expondo informações confidenciais da empresa fora do controle dela",
+                true
+            ],
+            [
+                "O código-fonte enviado deixa de funcionar corretamente depois de ser processado pela IA",
+                false
+            ]
+        ]
+    }
+];
+
+async function seed() {
+    let [simulado] = await db.select().from(simulados).where(eq(simulados.slug, SLUG));
+    if (!simulado) {
+        [simulado] = await db
+            .insert(simulados)
+            .values({
+                slug: SLUG,
+                name: "ISC2 Certified in Cybersecurity (CC)",
+                provider: "isc2",
+                code: "CC",
+                level: "Fundamental",
+                description: "Simulado no formato da prova CC da ISC2: 90 minutos, corte de 70%.",
+                durationMinutes: 90,
+                questionCount: 65,
+                passPercent: 70,
+                published: true,
+            })
+            .returning();
+        console.log("Simulado criado: " + simulado.slug);
+    }
+    await db
+        .update(simulados)
+        .set({ provider: "isc2", code: "CC", level: "Fundamental" })
+        .where(eq(simulados.id, simulado.id));
+
+    const [{ n }] = await db
+        .select({ n: count() })
+        .from(simuladoQuestions)
+        .where(eq(simuladoQuestions.simuladoId, simulado.id));
+    if (Number(n) > 0) {
+        console.log("Simulado ja tem " + n + " questoes, nada a fazer.");
+        return;
+    }
+
+    for (let i = 0; i < QUESTOES.length; i++) {
+        const q = QUESTOES[i];
+        const [questao] = await db
+            .insert(simuladoQuestions)
+            .values({
+                simuladoId: simulado.id,
+                statement: q.statement,
+                explanation: q.explanation,
+                topic: q.topic,
+            })
+            .returning();
+        await db.insert(simuladoOptions).values(
+            q.options.map(([text, isCorrect], idx) => ({
+                questionId: questao.id,
+                text,
+                isCorrect,
+                position: idx + 1,
+            })),
+        );
+    }
+    console.log("Seed concluido: " + QUESTOES.length + " questoes inseridas.");
+}
+
+seed()
+    .then(() => process.exit(0))
+    .catch((e) => {
+        console.error("Falha no seed:", e);
+        process.exit(1);
+    });

--- a/backend/scripts/seed-trilha-isc2-cc.ts
+++ b/backend/scripts/seed-trilha-isc2-cc.ts
@@ -1,0 +1,5177 @@
+// Seed da trilha ISC2 Certified in Cybersecurity (CC) (iniciante). Idempotente e
+// nao destrutivo: se a trilha ja tiver aulas, nao faz nada.
+//
+// Rodar em prod: docker compose -f docker-compose.prod.yml exec -T backend node scripts/seed-trilha-isc2-cc.ts
+import { db } from "../db.ts";
+import { trails, modules, lessons, questions, questionOptions } from "../schema.ts";
+import { eq } from "drizzle-orm";
+
+const NOME = "ISC2 Certified in Cybersecurity (CC)";
+const DESCRICAO =
+    "Preparação para a certificação ISC2 Certified in Cybersecurity (CC), o certificado de entrada em segurança da informação, vendor-neutral e sem pré-requisito. Cobre os cinco domínios do exame (princípios de segurança, continuidade e resposta a incidentes, controle de acesso, segurança de redes e operações de segurança), já com os conceitos de IA do novo outline.";
+
+type Bloco = { type: "text" | "code" | "quote" | "table"; value: string };
+type Questao = {
+    statement: string;
+    difficulty: "facil" | "medio" | "dificil";
+    options: { text: string; isCorrect: boolean }[];
+};
+type Aula = { titulo: string; blocks: Bloco[]; questions: Questao[] };
+type Modulo = { titulo: string; aulas: Aula[] };
+
+const MODULOS: Modulo[] = [
+    {
+        "titulo": "Módulo 1 - Princípios de Segurança: a tríade e a identidade",
+        "aulas": [
+            {
+                "titulo": "A Tríade CIA: os pilares da segurança da informação",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# A Tríade CIA: os pilares da segurança da informação\n\nEste é o primeiro módulo da trilha de preparação para a certificação **ISC2 Certified in Cybersecurity (CC)** e cobre a primeira parte do Domínio 1 do exame: os princípios de segurança da informação. Nesta aula você vai conhecer o modelo mais fundamental da área, a tríade CIA, que serve de base para praticamente toda decisão de segurança que vem depois dela.\n\n## O que é segurança da informação\n\nSegurança da informação é a prática de proteger dados e sistemas contra acesso, uso, divulgação, alteração ou destruição não autorizados. Não se trata apenas de \"impedir hackers\": envolve proteger informação em qualquer forma, seja um arquivo digital, um documento impresso ou uma conversa. O ponto de partida para organizar esse objetivo é um modelo conhecido como tríade CIA."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Confidencialidade (Confidentiality)\n\nConfidencialidade é a garantia de que a informação só é acessada por quem tem autorização para acessá-la. É o pilar mais lembrado quando se fala em segurança, porque está ligado diretamente à ideia de sigilo.\n\nPense no prontuário médico de um paciente. Só deveriam ler esse prontuário o próprio paciente, os profissionais de saúde responsáveis pelo atendimento e, em alguns casos, o convênio. Se um funcionário do hospital sem relação com o atendimento acessa esse prontuário por curiosidade, a confidencialidade foi quebrada, mesmo que nada tenha sido alterado ou apagado.\n\nControles típicos que sustentam a confidencialidade:\n- Criptografia de dados em repouso e em trânsito\n- Listas de controle de acesso (ACLs) e permissões de arquivo\n- Princípio do menor privilégio, em que a pessoa só recebe acesso ao que precisa para o trabalho\n- Classificação da informação (pública, interna, confidencial, restrita)\n\nUm ataque clássico contra a confidencialidade é o vazamento de dados: um invasor rouba um banco de dados de clientes e o vende ou publica. A informação continua íntegra e disponível para quem não deveria vê-la, mas o sigilo foi perdido."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Integridade (Integrity)\n\nIntegridade é a garantia de que a informação é precisa, completa e não foi alterada de forma não autorizada ou acidental. Enquanto a confidencialidade cuida de quem pode ver o dado, a integridade cuida de saber se o dado continua confiável.\n\nUm exemplo direto: se alguém invade o sistema de um banco e muda o saldo de uma conta de R$ 1.000 para R$ 10.000, isso não é um problema de confidencialidade (ninguém indevido leu o saldo), é um problema de integridade, porque o dado foi corrompido.\n\nControles típicos que sustentam a integridade:\n- Funções de hash, que geram uma espécie de impressão digital do arquivo para detectar qualquer alteração\n- Assinaturas digitais\n- Controle de versão\n- Validação de entrada em sistemas, para evitar que dados malformados corrompam um banco de dados\n- Trilhas de auditoria que registram quem alterou o quê e quando\n\nA integridade também cobre alterações acidentais, não só ataques: um funcionário que edita a planilha errada, uma falha de hardware que corrompe um arquivo durante a gravação. O objetivo do controle é o mesmo nos dois casos: detectar e, se possível, impedir a alteração indevida."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Disponibilidade (Availability)\n\nDisponibilidade é a garantia de que a informação e os sistemas estão acessíveis e utilizáveis quando quem tem autorização precisa deles. De nada adianta um dado perfeitamente confidencial e íntegro se o sistema está fora do ar no momento em que é necessário.\n\nO exemplo mais citado é o ataque de negação de serviço distribuído (DDoS), em que o invasor sobrecarrega um servidor com tráfego falso até ele parar de responder. Ninguém rouba nem altera dado nenhum, mas o serviço fica indisponível para os usuários legítimos, e isso já é, por si só, um incidente de segurança.\n\nControles típicos que sustentam a disponibilidade:\n- Redundância de servidores, links de internet e fontes de energia\n- Backups regulares e testados\n- Balanceamento de carga\n- Proteção contra DDoS\n- Manutenção preventiva e gestão de capacidade\n\nDisponibilidade também aparece em situações do dia a dia bem menos dramáticas que um ataque: um disco rígido que falha, um data center que perde energia, uma atualização mal aplicada que derruba um sistema. Todos esses casos são, antes de qualquer coisa, problemas de disponibilidade."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Atributo\",\"Pergunta que responde\",\"Ameaça comum\",\"Exemplo de controle\"],[\"Confidencialidade\",\"Quem pode ver esta informação?\",\"Vazamento de dados, espionagem, engenharia social\",\"Criptografia, controle de acesso, menor privilégio\"],[\"Integridade\",\"Este dado ainda é confiável?\",\"Alteração indevida, corrupção de arquivo, fraude\",\"Hashing, assinatura digital, trilha de auditoria\"],[\"Disponibilidade\",\"O sistema está acessível quando eu preciso?\",\"DDoS, falha de hardware, desastre natural\",\"Redundância, backup, plano de continuidade\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O equilíbrio entre os três pilares\n\nNa prática, os três pilares da tríade CIA competem por atenção e recursos. Aumentar um deles quase sempre tem custo sobre os outros, e reconhecer esse equilíbrio é uma das habilidades mais importantes de quem trabalha com segurança.\n\nUm cofre de banco enterrado em concreto, sem nenhuma porta, seria extremamente confidencial (ninguém entra) e íntegro (nada é alterado), mas completamente indisponível, porque nem o próprio banco conseguiria acessar o conteúdo. No outro extremo, um sistema sem nenhuma senha é totalmente disponível para qualquer pessoa, mas não oferece confidencialidade nenhuma.\n\nPor isso, toda decisão de segurança deve considerar o contexto do negócio. Um sistema de saúde que monitora sinais vitais em tempo real vai priorizar disponibilidade acima de tudo, porque um atraso pode custar uma vida. Já um sistema que guarda segredos industriais de uma empresa vai priorizar confidencialidade, mesmo que isso signifique processos de acesso mais lentos. Não existe uma resposta única: existe a resposta certa para cada contexto."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "A tríade CIA (Confidencialidade, Integridade e Disponibilidade) é a base para pensar qualquer problema de segurança da informação. Diante de um incidente, a primeira pergunta de um profissional CC deve ser: qual desses três pilares foi afetado, e o que isso significa para o negócio?"
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Um invasor consegue interceptar e ler e-mails corporativos sem que ninguém perceba, mas não altera nenhuma mensagem. Qual pilar da tríade CIA foi diretamente comprometido?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Confidencialidade",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Integridade",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Disponibilidade",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não repúdio",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um ataque de negação de serviço distribuído (DDoS) deixa o site de uma loja virtual fora do ar por seis horas durante a Black Friday. Qual pilar da tríade CIA foi diretamente afetado?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Disponibilidade",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Confidencialidade",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Integridade",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Privacidade",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um funcionário mal-intencionado altera o valor de um pedido no sistema de vendas antes que ele seja processado, sem acessar dados de forma não autorizada e sem tirar o sistema do ar. Qual pilar da tríade CIA foi violado?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Integridade",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Confidencialidade",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Disponibilidade",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Autenticação",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um hospital, preocupado com vazamento de prontuários, passa a exigir múltiplas camadas de autenticação e um processo de aprovação manual toda vez que um médico precisa acessar o histórico de um paciente internado. Sob a ótica da tríade CIA, qual é o principal risco introduzido por essa medida?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Redução da disponibilidade da informação em situações de urgência",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Redução da confidencialidade dos prontuários",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Redução da integridade dos dados clínicos",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Aumento do não repúdio das ações médicas",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um ataque de ransomware criptografa todos os arquivos do servidor de arquivos de uma empresa, tornando-os inacessíveis até o pagamento de um resgate. Não há evidência de que os arquivos tenham sido copiados ou publicados. Sob a ótica da tríade CIA, qual é a análise mais precisa desse incidente?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O impacto principal é sobre a disponibilidade, já que os arquivos ficaram inacessíveis; sem evidência de exfiltração, a confidencialidade não é necessariamente comprometida",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O impacto principal é sobre a confidencialidade, já que os arquivos foram criptografados e não podem mais ser lidos por ninguém",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O impacto é exclusivamente sobre a integridade, porque o conteúdo dos arquivos foi tecnicamente modificado pela criptografia",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não há impacto sobre a tríade CIA, pois nenhum dado foi roubado nem alterado permanentemente",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Identificação e Autenticação: provando quem você é",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Identificação e Autenticação: provando quem você é\n\nDepois de entender o que a tríade CIA protege, o próximo passo é entender como um sistema sabe quem está do outro lado da tela. Esse processo envolve dois conceitos que costumam ser confundidos: identificação e autenticação.\n\n**Identificação** é o ato de afirmar quem você é, geralmente digitando um nome de usuário, um CPF ou um endereço de e-mail. **Autenticação** é a prova dessa afirmação: o sistema verifica se você realmente é quem diz ser. Pense em um crachá de visitante: dizer seu nome na recepção é identificação; mostrar o documento com foto para confirmar aquele nome é autenticação.\n\nA autenticação é um dos objetivos centrais do exame CC e também um dos temas mais aplicados do dia a dia de qualquer pessoa que usa tecnologia, então vale entender bem cada mecanismo por trás dela."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Fator 1: algo que você sabe\n\nO fator de conhecimento é o mais comum e o mais antigo: senha, PIN, frase secreta ou a resposta para uma pergunta de segurança. A ideia é simples: só a pessoa autorizada deveria saber aquela informação.\n\nO problema é que esse fator também é o mais frágil. Senhas são reutilizadas em vários sites, são anotadas em post-it, são adivinhadas por meio de engenharia social ou capturadas em vazamentos de outras empresas. Um ataque de força bruta testa milhares de combinações por segundo até acertar; um ataque de dicionário testa palavras comuns e variações previsíveis, como trocar a letra \"a\" por \"@\".\n\nBoas práticas de senha continuam relevantes mesmo com a existência de fatores mais modernos: senhas longas (o comprimento pesa mais que a complexidade forçada), únicas por serviço, armazenadas em um gerenciador de senhas, e nunca reaproveitadas entre contas pessoais e corporativas."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Fator 2: algo que você tem\n\nO fator de posse depende de um objeto físico ou digital que só a pessoa autorizada deveria ter em mãos: um cartão inteligente (smart card), um token gerador de códigos, uma chave de segurança USB (como uma YubiKey) ou o próprio celular recebendo um código por aplicativo autenticador ou por SMS.\n\nA vantagem desse fator é que um invasor remoto, do outro lado do mundo, não tem como simplesmente adivinhar ou vazar um objeto físico: ele precisaria roubá-lo ou clona-lo. A desvantagem é o risco de perda: se você perde o celular ou o token, perde também o meio de autenticação, o que exige um processo de recuperação de conta bem desenhado.\n\nVale um alerta importante para o exame: nem todo \"algo que você tem\" tem o mesmo nível de segurança. Um código por SMS pode ser interceptado por meio de troca de chip fraudulenta (SIM swap), enquanto um aplicativo autenticador baseado em código de uso único por tempo (TOTP) ou uma chave física seguem padrões mais resistentes a esse tipo de ataque."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Fator 3: algo que você é\n\nO fator de inerência usa características físicas ou comportamentais da própria pessoa: impressão digital, reconhecimento facial, leitura de íris ou retina, geometria da mão, voz. É chamado tecnicamente de biometria.\n\nA grande vantagem é a comodidade: você não precisa lembrar de nada nem carregar nada além de si mesmo. A limitação é que a biometria não pode ser trocada como uma senha. Se um banco de dados de impressões digitais vaza, aquela impressão digital fica comprometida para sempre, porque a pessoa não pode simplesmente gerar uma digital nova.\n\nOutro ponto técnico cobrado no exame é a qualidade do sensor biométrico, medida por duas taxas:\n- Taxa de falsa aceitação (FAR): a frequência com que o sistema aceita, por engano, uma pessoa não autorizada\n- Taxa de falsa rejeição (FRR): a frequência com que o sistema rejeita, por engano, uma pessoa autorizada\n\nUm bom sistema biométrico busca equilibrar as duas taxas: FAR muito alta compromete a segurança, FRR muito alta compromete a usabilidade e frustra usuários legítimos."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Fator\",\"Exemplo\",\"Vantagem principal\",\"Limitação principal\"],[\"Algo que você sabe\",\"Senha, PIN, frase secreta\",\"Fácil de implementar e de trocar\",\"Pode ser esquecido, roubado ou adivinhado\"],[\"Algo que você tem\",\"Token, smart card, app autenticador\",\"Difícil de replicar remotamente\",\"Pode ser perdido ou roubado fisicamente\"],[\"Algo que você é\",\"Digital, face, íris, voz\",\"Não precisa lembrar nem carregar nada\",\"Não pode ser trocado se for comprometido\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## De fator único a múltiplos fatores\n\nQuando a autenticação usa apenas um desses três fatores, ela é chamada de autenticação de fator único (single-factor authentication). É o caso mais comum e também o mais vulnerável, porque basta comprometer aquele único fator para o invasor ter acesso completo.\n\nUm erro conceitual comum, e bastante cobrado em prova, é achar que usar duas senhas diferentes, ou senha mais pergunta de segurança, já é autenticação multifator. Não é: os dois seguem sendo \"algo que você sabe\". Multifator de verdade exige fatores de categorias diferentes, que é exatamente o assunto da próxima aula."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Identificação é a afirmação de quem você é; autenticação é a prova. Toda prova se apoia em pelo menos um de três fatores: algo que você sabe, algo que você tem ou algo que você é. Misturar fatores da mesma categoria não aumenta a robustez da autenticação, mesmo que pareça mais seguro à primeira vista."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "No processo de acesso a um sistema, qual é a diferença correta entre identificação e autenticação?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Identificação é a afirmação de quem o usuário diz ser; autenticação é a prova dessa afirmação",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Identificação é a prova de quem o usuário é; autenticação é apenas o registro do nome de usuário",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Identificação e autenticação são sinônimos e podem ser usados de forma intercambiável",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Identificação ocorre depois da autenticação, como uma confirmação final de acesso",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual das opções abaixo é um exemplo do fator de autenticação 'algo que você tem'?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Um token físico que gera códigos de uso único",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Uma senha memorizada pelo usuário",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma leitura de impressão digital",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma pergunta de segurança sobre o nome do primeiro animal de estimação",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um sistema exige que o usuário digite a senha e, em seguida, responda a uma pergunta de segurança previamente cadastrada para liberar o acesso. Do ponto de vista dos fatores de autenticação, como esse mecanismo deve ser classificado?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Autenticação de fator único, pois ambas as etapas usam o fator 'algo que você sabe'",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Autenticação multifator, pois há duas etapas de verificação",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Autenticação de fator único, pois usa apenas o fator 'algo que você tem'",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Autenticação multifator, pois envolve dois sistemas diferentes",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma empresa quer adotar biometria facial para liberar o acesso ao datacenter. Durante os testes, o sistema passa a recusar o acesso de funcionários autorizados com frequência incômoda, embora nunca tenha liberado o acesso de alguém não autorizado. Qual métrica técnica descreve esse comportamento?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Taxa de falsa rejeição (FRR) alta",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Taxa de falsa aceitação (FAR) alta",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Baixa disponibilidade do sistema biométrico",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Baixa integridade do sensor biométrico",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um banco quer aumentar a segurança do login em seu aplicativo sem prejudicar demais a experiência do cliente comum. A equipe de segurança propõe usar reconhecimento facial somado à leitura de digital como dois passos de verificação. Do ponto de vista técnico dos fatores de autenticação, qual é o principal problema dessa proposta?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Ambos os métodos pertencem ao mesmo fator, algo que você é, então a combinação não configura autenticação multifator real",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Biometria nunca deve ser usada em aplicativos bancários por não ser confiável",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A combinação de dois métodos biométricos elimina completamente a taxa de falsa aceitação",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Reconhecimento facial e leitura de digital não podem coexistir no mesmo dispositivo móvel",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Autenticação Multifator (MFA) e o papel da Inteligência Artificial",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Autenticação Multifator (MFA) e o papel da Inteligência Artificial\n\nA autenticação multifator, ou MFA (multifactor authentication), é a prática de exigir pelo menos dois fatores de categorias diferentes antes de liberar o acesso a um sistema. Se um invasor descobre sua senha, mas não tem acesso ao seu celular para aprovar o código de confirmação, o acesso continua bloqueado.\n\nA lógica por trás do MFA é reduzir a chance de um único ponto de falha comprometer toda a conta. Como vimos na aula anterior, senha mais pergunta de segurança não é MFA. Senha mais código enviado a um aplicativo autenticador no celular é MFA, porque combina algo que você sabe com algo que você tem."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## MFA na prática\n\nA forma mais comum de MFA no dia a dia é a autenticação em duas etapas (2FA, two-factor authentication), um subconjunto do MFA que usa exatamente dois fatores. Exemplos comuns:\n\n- Senha mais código de uso único gerado por aplicativo autenticador (TOTP)\n- Senha mais notificação push aprovada no celular\n- Senha mais chave de segurança física conectada por USB ou por aproximação (NFC)\n- Cartão do caixa eletrônico (algo que você tem) mais senha numérica (algo que você sabe), um exemplo de MFA que existe há décadas, bem antes de o termo se popularizar\n\nOrganizações mais maduras aplicam ainda o conceito de autenticação em etapas (step-up authentication): o sistema pede um fator adicional apenas quando a ação é sensível, como uma transferência bancária de valor alto ou uma alteração de senha, mantendo o login comum mais simples. Isso equilibra segurança e usabilidade sem exigir MFA em toda e qualquer interação."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Inteligência artificial na autenticação\n\nSistemas modernos de autenticação usam inteligência artificial para ir além da simples pergunta \"a senha está correta?\". A autenticação adaptativa, também chamada de autenticação baseada em risco (risk-based authentication), usa modelos de IA para calcular, em tempo real, o quanto uma tentativa de login parece legítima antes de decidir o que exigir do usuário.\n\nO modelo de IA considera sinais como: se o dispositivo já foi usado antes por essa conta, se o endereço IP e a localização geográfica são compatíveis com o histórico do usuário, se o horário da tentativa é compatível com o padrão de uso, e se a velocidade de digitação e o comportamento de navegação combinam com sessões anteriores. Com base nesse cálculo de risco, o sistema decide: liberar o acesso direto, pedir um fator adicional de MFA, ou bloquear a tentativa e alertar um analista de segurança.\n\nUma extensão desse conceito é a biometria comportamental: em vez de medir uma característica física fixa, como impressão digital, o sistema aprende o padrão de comportamento da pessoa, como o ritmo de digitação, a pressão sobre a tela de celulares sensíveis ao toque, o jeito de segurar o aparelho ou o padrão de movimento do mouse. Esse padrão se torna, na prática, um quarto fator de autenticação, às vezes chamado de \"algo que você faz\"."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Detecção de anomalias de login\n\nA mesma inteligência artificial usada na autenticação adaptativa alimenta um segundo uso muito importante: a detecção de anomalias de comportamento depois que o acesso já foi liberado. O sistema constrói um perfil de comportamento normal para cada conta e passa a comparar cada nova sessão contra esse perfil.\n\nExemplos de anomalias que costumam disparar um alerta ou uma ação automática:\n- Login a partir de um país onde a conta nunca acessou antes, poucos minutos depois de um login em outro país, um padrão fisicamente impossível para a mesma pessoa, chamado de \"viagem impossível\"\n- Volume incomum de downloads ou consultas em um curto período\n- Acesso fora do horário de trabalho habitual daquele usuário\n- Tentativas de acesso a sistemas que a conta nunca utilizou antes\n\nA vantagem de usar IA aqui, em vez de um conjunto fixo de regras escritas manualmente, é a capacidade de aprender o padrão específico de cada usuário e de se adaptar com o tempo, reduzindo a quantidade de alertas falsos que regras rígidas costumam gerar."
+                    },
+                    {
+                        "type": "code",
+                        "value": "evento: tentativa_login\nusuario: joana.silva\ndispositivo_reconhecido: nao\nlocalizacao: Lisboa, Portugal (historico: Sao Paulo, Brasil)\nintervalo_desde_ultimo_login: 42 minutos\nconclusao_motor_risco: viagem impossivel detectada\npontuacao_de_risco: 92/100\nacao_automatica: bloquear login e solicitar verificacao adicional por email\nnotificacao: analista de seguranca alertado"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Limitações e cuidados com a IA na autenticação\n\nApesar dos benefícios, a IA aplicada à autenticação não é infalível e exige cuidado profissional. Alguns pontos de atenção relevantes para o exame CC:\n\n- Falsos positivos: um funcionário viajando a trabalho pode ser bloqueado por um padrão que parece anômalo, mas é legítimo, gerando atrito e custo de suporte.\n- Falsos negativos: um invasor que estuda o comportamento da vítima, por meio de engenharia social ou de vazamento prévio de dados, pode tentar imitar padrões conhecidos.\n- Viés e qualidade dos dados de treinamento: um modelo de IA treinado com dados pouco diversos pode ter desempenho pior para certos grupos de usuários, um risco de governança de IA que volta a aparecer nos módulos seguintes.\n- IA como camada adicional, não substituta: ela reforça o MFA e a política de senha, mas não elimina a necessidade dos fundamentos básicos de autenticação vistos nesta e na aula anterior."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "MFA combina fatores de categorias diferentes para reduzir o risco de um único ponto de falha. A inteligência artificial reforça essa proteção ao calcular o risco de cada tentativa de login em tempo real e ao aprender o comportamento normal de cada usuário para detectar anomalias, mas continua sendo um complemento aos fundamentos de autenticação, não um substituto."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual das combinações abaixo representa corretamente um exemplo de autenticação multifator (MFA)?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Senha mais código de uso único enviado por um aplicativo autenticador no celular",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Senha mais pergunta de segurança sobre o nome de solteira da mãe",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Duas senhas diferentes cadastradas para a mesma conta",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Login com o mesmo usuário em dois navegadores diferentes",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O que é 'autenticação baseada em risco' (risk-based authentication)?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Um método que usa sinais como localização, dispositivo e horário para calcular o risco de uma tentativa de login e decidir a resposta apropriada",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um método que elimina totalmente a necessidade de senha para qualquer usuário",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um seguro contratado pela empresa contra incidentes de vazamento de senha",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um método que bloqueia permanentemente a conta após uma única tentativa de login incorreta",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um sistema de e-commerce percebe que a conta de um cliente, que sempre compra de São Paulo em horário comercial, registrou dois logins com apenas 40 minutos de diferença: um em São Paulo e outro em um país da Europa. O motor de detecção de anomalias baseado em IA classifica esse padrão como de altíssimo risco. Qual conceito descreve exatamente esse padrão?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Viagem impossível (impossible travel)",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Falsa aceitação biométrica",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ataque de força bruta",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Autenticação de fator único",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um funcionário que costuma viajar a trabalho é bloqueado repetidamente pelo sistema de autenticação adaptativa da empresa ao tentar acessar o e-mail corporativo a partir de hotéis em diferentes cidades, mesmo sendo o usuário legítimo. Que problema esse cenário exemplifica?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Um falso positivo do modelo de detecção de anomalias",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um falso negativo do modelo de detecção de anomalias",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma falha de disponibilidade do fator algo que você tem",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma quebra de não repúdio causada pela IA",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe de segurança avalia implantar biometria comportamental (padrão de digitação e de uso do mouse) como camada adicional de autenticação contínua, além do login inicial com senha e aplicativo autenticador. Qual é a principal vantagem dessa camada adicional em comparação a validar a identidade apenas no momento do login?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Ela permite detectar, ao longo da sessão, se o controle da conta foi assumido por outra pessoa depois de um login legítimo",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Ela substitui completamente a necessidade de senha em qualquer sistema",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ela elimina totalmente a taxa de falsa aceitação de qualquer sistema biométrico",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ela garante, sozinha, o não repúdio de todas as ações realizadas na sessão",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Não repúdio: garantindo que a ação não possa ser negada",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Não repúdio: garantindo que a ação não possa ser negada\n\nImagine que um funcionário aprove eletronicamente uma transferência bancária de alto valor e, depois, diante de uma investigação, alegue que nunca fez aquilo. Como a empresa prova que foi ele? É exatamente esse problema que o conceito de não repúdio (non-repudiation) resolve.\n\nNão repúdio é a garantia de que uma pessoa não pode negar, de forma válida, ter realizado uma ação, como enviar uma mensagem, assinar um documento ou aprovar uma transação. É diferente de autenticação: autenticação prova quem você é no momento do login; não repúdio garante que uma ação específica, feita depois daquele login, seja atribuível a você de um jeito que resista a uma negação posterior."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Como o não repúdio é implementado tecnicamente\n\nO não repúdio normalmente combina três ingredientes: prova de identidade (autenticação), prova de integridade (o conteúdo não foi alterado) e um registro confiável, com carimbo de tempo (timestamp), de que aquela ação ocorreu.\n\nOs mecanismos mais usados são:\n\n- Assinatura digital: usa criptografia de chave pública para vincular matematicamente uma pessoa, dona de uma chave privada, a um documento específico. Qualquer alteração no documento invalida a assinatura, e apenas o dono da chave privada poderia ter gerado aquela assinatura.\n- Certificados digitais: emitidos por uma autoridade certificadora confiável, atestam que uma chave pública realmente pertence a determinada pessoa ou organização, dando confiança à assinatura digital.\n- Logs de auditoria com timestamp: registros de sistema que gravam quem fez o quê e quando, protegidos contra alteração posterior.\n\nUm módulo mais adiante na trilha aprofunda como a criptografia por trás da assinatura digital funciona por dentro. Por enquanto, o importante é entender o papel dela: provar autoria de um jeito que a pessoa não consiga negar de forma crível."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Não repúdio no dia a dia\n\nO não repúdio aparece com mais frequência do que parece:\n\n- Ao assinar um contrato por uma plataforma de assinatura eletrônica, o sistema registra a identidade do signatário, o conteúdo exato assinado e o momento da assinatura, tudo ligado por criptografia.\n- Um comprovante de transferência via Pix, com identificação das contas, valor e horário, serve como evidência de que a transação foi autorizada por quem tinha acesso àquela conta.\n- Logs de acesso a um sistema corporativo, mostrando o usuário, o horário e a ação realizada (leitura, alteração, exclusão), servem de base para investigações internas e processos disciplinares.\n\nEm todos os casos, o valor do não repúdio aparece quando existe uma disputa: alguém alega que não fez algo, e a organização precisa de evidência técnica, não apenas da palavra de alguém, para provar o contrário."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Mecanismo\",\"O que garante\",\"Exemplo de uso\"],[\"Assinatura digital\",\"Autoria e integridade de um documento específico\",\"Contrato assinado eletronicamente\"],[\"Certificado digital\",\"Que uma chave pública pertence a quem alega ser o dono\",\"Validação de identidade em site (HTTPS) ou em assinatura\"],[\"Log de auditoria com timestamp\",\"Registro confiável de quem fez o quê e quando\",\"Investigação de incidente de segurança\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O modelo IAAA\n\nUm jeito útil de amarrar tudo que vimos até aqui é o modelo IAAA, usado com frequência na literatura de segurança da informação e de gestão de identidade e acesso:\n\n- Identificação: quem você diz ser (usuário, CPF, e-mail)\n- Autenticação: a prova de que você é quem diz ser (senha, token, biometria, MFA)\n- Autorização: o que você tem permissão para fazer depois de autenticado, tema que volta com força no módulo de controle de acesso\n- Accountability (responsabilização, apoiada por logs de auditoria): a capacidade de reconstruir quem fez o quê\n\nO não repúdio se apoia fortemente na accountability: só é possível provar que alguém não pode negar uma ação se existir um registro confiável e íntegro dessa ação. Sem log de auditoria consistente, sem carimbo de tempo confiável e sem controle rígido sobre quem tem acesso a qual chave privada, o não repúdio deixa de existir na prática, mesmo que exista no papel."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Quando o não repúdio falha\n\nO não repúdio depende inteiramente da qualidade dos controles que o sustentam. Alguns cenários que quebram essa garantia:\n\n- Contas compartilhadas: se várias pessoas usam o mesmo login, é impossível provar individualmente quem executou a ação, mesmo com um log perfeito.\n- Chave privada mal protegida: se a chave privada de assinatura digital de alguém é roubada ou fica salva em um computador que outras pessoas usam, a assinatura deixa de provar autoria com segurança.\n- Logs sem proteção de integridade: se um administrador de sistema consegue editar livremente os registros de auditoria, esses registros não sustentam nenhuma alegação de não repúdio diante de uma disputa.\n\nPor isso, um programa de segurança maduro trata identidade individual, proteção de credenciais e integridade de logs como pré-requisitos para qualquer garantia real de não repúdio."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Não repúdio é a garantia de que uma ação não pode ser negada de forma crível por quem a praticou. Ele depende da combinação de identidade comprovada, integridade do registro e um carimbo de tempo confiável, e fica frágil sempre que contas são compartilhadas ou logs podem ser alterados."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que é não repúdio (non-repudiation) em segurança da informação?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "A garantia de que uma pessoa não pode negar de forma válida ter realizado determinada ação",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A garantia de que um sistema estará sempre disponível para o usuário",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A garantia de que uma senha nunca poderá ser adivinhada",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A garantia de que um dado nunca será acessado por pessoas não autorizadas",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual mecanismo está mais diretamente associado à garantia de não repúdio em documentos eletrônicos?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Assinatura digital",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Firewall",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Backup em nuvem",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Antivírus",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma empresa descobre que várias pessoas da equipe de suporte usam o mesmo login genérico 'suporte01' para acessar o sistema de tickets dos clientes. Após um incidente em que dados de um cliente foram alterados indevidamente, a empresa não consegue identificar qual pessoa fez a alteração. Qual princípio de segurança foi comprometido pela prática de contas compartilhadas?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Não repúdio, porque não é possível atribuir a ação a um indivíduo específico",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Disponibilidade, porque o sistema de tickets ficou fora do ar",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Confidencialidade, porque os dados do cliente foram lidos por pessoas não autorizadas",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Autenticação, porque a senha do login genérico era fraca",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um cliente nega ter autorizado uma transferência via internet banking, alegando que sua conta foi invadida. O banco apresenta um log mostrando o horário, o endereço IP, o dispositivo reconhecido e o código de confirmação por aplicativo autenticador usado naquela transação. Esse conjunto de evidências serve, principalmente, para sustentar qual princípio?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Não repúdio",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Disponibilidade",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Privacidade",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Segregação de funções",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma empresa implementa assinatura digital para contratos, mas armazena a chave privada de cada gestor em um arquivo compartilhado na rede interna, acessível por toda a equipe de TI, para 'facilitar o suporte'. Do ponto de vista de não repúdio, qual é o principal problema dessa prática?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "A chave privada deixa de comprovar com segurança que apenas o gestor específico gerou aquela assinatura, enfraquecendo o não repúdio",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O armazenamento compartilhado aumenta a disponibilidade da chave, o que fortalece o não repúdio",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Assinaturas digitais não dependem de proteção de chave privada, então a prática não traz problema algum",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O problema é exclusivamente de confidencialidade, sem qualquer relação com não repúdio",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Privacidade: dados pessoais, LGPD e o cuidado com a IA",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Privacidade: dados pessoais, LGPD e o cuidado com a IA\n\nAté aqui, falamos sobre proteger informação de forma geral. Privacidade é um recorte mais específico desse tema: trata do direito de uma pessoa controlar como os próprios dados pessoais são coletados, usados, armazenados e compartilhados.\n\nÉ comum confundir privacidade com segurança, mas são conceitos complementares, não sinônimos. Segurança é o conjunto de controles técnicos e organizacionais, como os que vimos até aqui, que protege qualquer informação. Privacidade é o conjunto de princípios e direitos que regula especificamente o tratamento de dados pessoais, ou seja, dados que identificam ou podem identificar uma pessoa (Personally Identifiable Information, PII). É perfeitamente possível ter segurança sem privacidade, como uma empresa que protege muito bem um banco de dados de clientes, mas usa esses dados para fins que o cliente nunca autorizou."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que é PII e por que ela importa\n\nInformação de identificação pessoal (PII) é qualquer dado que, sozinho ou combinado com outros, permite identificar uma pessoa: nome completo, CPF, endereço, e-mail, número de telefone, dados de geolocalização, características biométricas e até um conjunto de dados de comportamento que, juntos, apontam para um indivíduo específico.\n\nAlguns princípios amplamente aceitos em programas de privacidade, presentes tanto na legislação brasileira quanto em referências internacionais:\n\n- Finalidade: os dados só devem ser coletados para um propósito específico e legítimo, informado ao titular\n- Necessidade e minimização: coletar apenas o dado estritamente necessário para aquele propósito, nada além disso\n- Transparência: o titular do dado deve saber o que é coletado, por quê e por quanto tempo\n- Consentimento: em muitos casos, o titular precisa autorizar o uso do dado de forma livre e informada\n- Direitos do titular: acesso, correção e, em muitos regimes, exclusão dos próprios dados"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## LGPD no Brasil e o contexto internacional\n\nNo Brasil, a Lei Geral de Proteção de Dados (LGPD, Lei 13.709/2018) regula o tratamento de dados pessoais por empresas e órgãos públicos, trazendo para a lei brasileira princípios como finalidade, necessidade, transparência e os direitos do titular listados acima. A LGPD se aplica sempre que uma organização trata dados de pessoas localizadas no Brasil, mesmo que a empresa esteja sediada em outro país.\n\nComo o exame CC tem alcance internacional, vale conhecer também o Regulamento Geral de Proteção de Dados europeu (GDPR, General Data Protection Regulation), referência global em privacidade e inspiração direta para a LGPD e para diversas outras leis de proteção de dados ao redor do mundo. Os dois regimes compartilham a mesma espinha dorsal de princípios, ainda que existam diferenças pontuais em prazos, penalidades e órgãos de fiscalização, como a Autoridade Nacional de Proteção de Dados (ANPD) no caso brasileiro.\n\nPara quem trabalha com segurança da informação, o ponto prático é que privacidade deixou de ser apenas um tema jurídico: leis como a LGPD exigem controles técnicos concretos, como os vistos neste módulo, para serem cumpridas na prática."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Privacy by design e o papel do profissional de segurança\n\nUm conceito central em privacidade é o \"privacy by design\" (privacidade desde a concepção): em vez de tratar privacidade como uma etapa final de conformidade, o ideal é incorporar proteção de dados pessoais desde o primeiro desenho de um sistema, produto ou processo.\n\nNa prática, isso significa perguntas como: este sistema realmente precisa coletar a data de nascimento completa, ou bastaria confirmar a maioridade? Este relatório precisa exibir o CPF completo, ou um formato mascarado, como XXX.XXX.XXX-45, já resolve o propósito?\n\nO profissional de segurança da informação frequentemente vira parceiro direto da área jurídica e de compliance nesse trabalho, porque muitos dos controles técnicos que garantem privacidade são os mesmos que sustentam a tríade CIA: criptografia, controle de acesso, classificação de dados e trilhas de auditoria. Privacidade e segurança, nesse sentido, se reforçam mutuamente."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Privacidade e o uso de inteligência artificial\n\nOs recursos de IA vistos na aula anterior, como autenticação adaptativa e biometria comportamental, trazem um ponto de atenção importante para privacidade: eles dependem de coletar e analisar continuamente dados sensíveis sobre o comportamento das pessoas, como padrão de digitação, localização e horários de uso.\n\nIsso levanta perguntas legítimas de privacidade: por quanto tempo esses dados comportamentais ficam armazenados? Quem mais, dentro da empresa ou em fornecedores terceiros, tem acesso a esse perfil de comportamento? O titular do dado sabe que está sendo monitorado dessa forma, e para qual finalidade exatamente?\n\nUm sistema de segurança que usa IA para proteger contas, mas coleta e retém dados comportamentais além do necessário, ou sem transparência com o usuário, pode ao mesmo tempo fortalecer a segurança e enfraquecer a privacidade. O profissional de segurança precisa considerar as duas dimensões juntas: aplicar minimização de dados também aos modelos de IA, retendo só o necessário pelo tempo necessário, e ser transparente sobre o uso de análise comportamental, em vez de tratar isso como um detalhe técnico invisível ao usuário."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Conceito\",\"Definição rápida\",\"Exemplo\"],[\"PII\",\"Dado que identifica ou pode identificar uma pessoa\",\"CPF, e-mail, geolocalização\"],[\"LGPD\",\"Lei brasileira de proteção de dados pessoais\",\"Consentimento para uso de dados de clientes\"],[\"Privacy by design\",\"Incorporar privacidade desde a concepção do sistema\",\"Coletar só a data de nascimento se for realmente necessário\"],[\"Privacidade e IA\",\"Cuidado com dados comportamentais coletados por modelos de IA\",\"Definir retenção e transparência sobre biometria comportamental\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Privacidade regula como dados pessoais são coletados, usados e compartilhados, e depende dos mesmos controles de segurança vistos neste módulo para se tornar realidade prática, não apenas texto de lei. Com a tríade CIA, os fatores de autenticação, o não repúdio e a privacidade, você já tem a base do Domínio 1 do exame CC; o próximo módulo constrói sobre essa base ao tratar risco, controles, ética e governança."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que caracteriza uma informação como PII (Personally Identifiable Information)?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "O fato de permitir, sozinha ou combinada com outros dados, identificar uma pessoa específica",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O fato de estar armazenada em um banco de dados criptografado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O fato de pertencer exclusivamente a um funcionário público",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O fato de ter sido coletada há mais de cinco anos",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual é a lei brasileira que regula o tratamento de dados pessoais por empresas e órgãos públicos?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "LGPD",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Marco Civil da Internet",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "GDPR",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Código de Defesa do Consumidor",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma empresa de varejo online passa a exigir a data de nascimento completa e o número do RG de todo cliente apenas para permitir a criação de uma conta simples de compras, sem nenhum produto restrito por idade. Qual princípio de privacidade essa prática viola mais diretamente?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Minimização e necessidade, pois coleta mais dados do que o propósito exige",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Disponibilidade, pois o cadastro fica mais lento",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não repúdio, pois o cliente pode negar ter se cadastrado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Integridade, pois os dados podem ser alterados posteriormente",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe de segurança implementa um sistema de biometria comportamental para reforçar a autenticação de funcionários, mas retém indefinidamente todos os dados de comportamento coletados, mesmo depois de o funcionário deixar a empresa, e não informa claramente essa prática no processo de admissão. Sob a ótica de privacidade, qual é o principal problema dessa implementação?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Falta de transparência e de minimização de dados, mesmo com um objetivo legítimo de segurança",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A biometria comportamental é, por definição, incompatível com qualquer princípio de segurança",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O uso de IA nesse contexto é sempre proibido pela LGPD, independentemente da finalidade",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Retenção indefinida de dados comportamentais fortalece automaticamente o não repúdio da empresa",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma clínica médica protege muito bem seu banco de dados de pacientes com criptografia forte, controle de acesso rígido e backups redundantes, mas compartilha os históricos clínicos com uma empresa de marketing para campanhas direcionadas, sem informar ou obter consentimento dos pacientes para essa finalidade específica. Como esse cenário deve ser analisado sob os conceitos de segurança e privacidade?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "A clínica mantém um bom nível de segurança da informação, mas viola princípios de privacidade ao usar os dados além da finalidade autorizada pelo paciente",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A clínica viola tanto segurança quanto privacidade, já que os controles técnicos descritos são insuficientes",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não há problema de privacidade, pois os dados continuam confidenciais dentro da empresa de marketing",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A situação descreve exclusivamente uma falha de integridade dos dados clínicos",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 2 - Risco, Controles, Ética e Governança",
+        "aulas": [
+            {
+                "titulo": "Ameaça, Vulnerabilidade e Risco: Fundamentos da Gestão de Risco",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Módulo 2 - Risco, Controles, Ética e Governança\n\n## Aula 1: Ameaça, Vulnerabilidade e Risco: Fundamentos da Gestão de Risco\n\nNenhuma empresa consegue eliminar todo o risco de segurança. Por mais cadeados, firewalls e políticas que existam, sempre sobra algum grau de exposição. Por isso, a segurança da informação não trabalha com a ideia de risco zero: ela trabalha com **gestão de risco**, um processo contínuo de identificar, avaliar e tratar os riscos até um nível que a organização considere aceitável.\n\nPense em uma casa. Trocar a fechadura da porta (um controle) reduz a chance de um assalto, mas não elimina o risco por completo: ainda existe janela, ainda existe a possibilidade de alguém arrombar a porta. O trabalho de um profissional de segurança é parecido, reduzir o risco a um nível gerenciável, não fingir que ele desapareceu."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Os três ingredientes do risco\n\nPara entender gestão de risco, é preciso separar bem três palavras que, no dia a dia, muita gente usa como sinônimos: ameaça, vulnerabilidade e risco.\n\n- **Ativo**: qualquer coisa de valor para a organização, um banco de dados de clientes, um servidor, a reputação da marca, um funcionário com conhecimento crítico.\n- **Ameaça**: qualquer agente ou evento capaz de causar dano a um ativo. Pode ser um invasor, um vírus, um funcionário insatisfeito, um incêndio ou uma enchente.\n- **Vulnerabilidade**: uma fraqueza que uma ameaça pode explorar. Um sistema sem atualização, uma senha fraca, uma porta destrancada, um funcionário que nunca recebeu treinamento sobre phishing.\n- **Risco**: o que existe no encontro entre uma ameaça e uma vulnerabilidade correspondente, considerando a probabilidade de acontecer e o impacto que causaria caso aconteça.\n\nUma forma simples de fixar essa relação: a ameaça é o agente capaz de atacar, a vulnerabilidade é a porta aberta que permite o ataque, e o risco é a chance real de isso acontecer somada ao tamanho do estrago."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Um risco só existe quando ameaça encontra vulnerabilidade\n\nImagine uma empresa que guarda dados de clientes em um servidor com o sistema operacional desatualizado há meses. O ativo é o banco de dados, a vulnerabilidade é a falta de atualização, e a ameaça é qualquer invasor disposto a explorar falhas conhecidas nesse tipo de sistema. A combinação das três coisas gera o risco de vazamento de dados.\n\nAgora pense em uma ameaça real, como um terremoto, aplicada a uma empresa cujos servidores ficam em uma região plana, sem histórico geológico de abalos sísmicos. A ameaça existe (terremotos acontecem em algum lugar do mundo), mas não há vulnerabilidade correspondente naquela localização específica. Sem vulnerabilidade, não há risco relevante vindo dessa ameaça, mesmo que ela seja real em outros contextos.\n\nO mesmo raciocínio vale para riscos mais novos. Um sistema de inteligência artificial usado para triagem de currículos pode não ter nenhuma falha técnica, nenhuma porta aberta, nenhuma senha fraca, e ainda assim carregar uma vulnerabilidade real: ter sido treinado com dados históricos que refletem preconceitos de contratações passadas. Essa fragilidade pode ser explorada pelo próprio funcionamento do sistema e gerar decisões discriminatórias, o que representa risco legal e reputacional para a empresa, mesmo sem nenhum ataque externo envolvido."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Tipo de ameaça\", \"Exemplos\"], [\"Humana intencional\", \"Invasor, funcionário mal-intencionado, espionagem corporativa, ataque de ransomware\"], [\"Humana não intencional\", \"Erro de configuração, clique em link de phishing, exclusão acidental de arquivos\"], [\"Natural\", \"Enchente, incêndio, terremoto, tempestade\"], [\"Técnica ou ambiental\", \"Falha de hardware, queda de energia, falha de software, pane no sistema de refrigeração\"]]"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Fase\", \"O que envolve\"], [\"Identificação\", \"Levantar ativos, ameaças e vulnerabilidades relevantes para o negócio\"], [\"Avaliação\", \"Estimar a probabilidade e o impacto de cada risco identificado\"], [\"Tratamento\", \"Decidir e aplicar a resposta adequada a cada risco (evitar, mitigar, transferir ou aceitar)\"], [\"Monitoramento\", \"Acompanhar continuamente se os riscos mudaram e se os controles seguem eficazes\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Risco nasce do encontro entre uma ameaça (o agente de dano) e uma vulnerabilidade (a fraqueza que permite o dano). Gerenciar risco não significa eliminar ameaças, isso quase nunca está ao alcance de uma empresa, e sim reduzir vulnerabilidades e se preparar para o impacto, seguindo um processo contínuo de identificação, avaliação, tratamento e monitoramento."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Uma auditoria interna descobre que o sistema operacional dos servidores de um hospital não recebe atualizações de segurança há oito meses. Esse achado representa, no vocabulário de gestão de risco, um exemplo de:",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Uma vulnerabilidade",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Uma ameaça",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um risco residual",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um apetite a risco",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe de segurança descobre que um grupo de invasores vem tentando explorar sistemas de empresas do mesmo setor. Isoladamente, esse grupo de invasores representa qual elemento na relação de risco?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Uma ameaça",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Uma vulnerabilidade",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um controle compensatório",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um risco aceito",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma empresa mantém seus data centers apenas em regiões planas, sem qualquer histórico de terremotos na área. Mesmo sabendo que terremotos são uma ameaça real no setor de tecnologia, por que esse cenário representa risco praticamente irrelevante para essa empresa?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque não existe, nesse local, uma vulnerabilidade que a ameaça de terremoto possa explorar",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque ameaças naturais nunca entram no processo de gestão de risco",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o apetite a risco da empresa elimina automaticamente qualquer ameaça natural",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque ameaças só geram risco quando partem de uma ação humana intencional",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de mapear os ativos, as ameaças e as vulnerabilidades de um sistema, uma analista de segurança passa a estimar a probabilidade de cada risco ocorrer e o impacto que ele causaria ao negócio. Essa atividade corresponde a qual fase do processo de gestão de risco?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Avaliação",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Identificação",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Tratamento",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Monitoramento",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um sistema de recrutamento baseado em IA foi treinado com dados históricos de contratação que refletem preconceitos do passado. Mesmo sem nenhuma falha técnica de segurança, como uma porta aberta ou uma senha fraca, especialistas apontam esse sistema como fonte de risco para a empresa. Sob a ótica de gestão de risco, esse viés nos dados de treinamento se encaixa melhor em qual elemento?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Uma vulnerabilidade, por ser uma fragilidade do próprio sistema que pode resultar em decisões discriminatórias e passivos legais",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Uma ameaça, por se tratar de um agente externo que ataca deliberadamente o sistema",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um controle administrativo, por envolver uma política interna da empresa",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um risco residual, por só aparecer depois da aplicação de controles técnicos",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Avaliação e Tratamento de Risco: Apetite, Tolerância e Respostas ao Risco",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Aula 2: Avaliação e Tratamento de Risco: Apetite, Tolerância e Respostas ao Risco\n\nDepois de identificar ativos, ameaças e vulnerabilidades, a pergunta natural é: e agora, o que fazer com cada risco encontrado? Antes de responder, a organização precisa avaliar esses riscos, entender qual é mais grave e qual pode esperar, para só então decidir a resposta adequada a cada um. É isso que fazem as fases de avaliação e tratamento de risco."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Como avaliar um risco\n\nAvaliar um risco significa estimar duas coisas: a **probabilidade** de ele acontecer e o **impacto** que ele causaria se acontecesse. Existem duas abordagens comuns para isso.\n\nNa avaliação **qualitativa**, a mais usada no dia a dia da maioria das empresas, probabilidade e impacto são descritos em escalas simples, como baixo, médio e alto. É rápida de aplicar e fácil de entender, mesmo para quem não é da área técnica.\n\nNa avaliação **quantitativa**, probabilidade e impacto ganham valores numéricos, muitas vezes financeiros, como dizer que um risco tem 10% de chance de ocorrer no próximo ano e, se ocorrer, custaria em torno de R$ 2 milhões à empresa. É mais precisa, mas exige mais dados históricos e mais tempo de análise.\n\nCruzando probabilidade e impacto, seja pela via qualitativa ou quantitativa, a organização consegue priorizar: riscos de alta probabilidade e alto impacto exigem atenção imediata, enquanto riscos de baixa probabilidade e baixo impacto podem esperar."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Probabilidade / Impacto\", \"Impacto baixo\", \"Impacto médio\", \"Impacto alto\"], [\"Probabilidade baixa\", \"Risco baixo\", \"Risco baixo\", \"Risco médio\"], [\"Probabilidade média\", \"Risco baixo\", \"Risco médio\", \"Risco alto\"], [\"Probabilidade alta\", \"Risco médio\", \"Risco alto\", \"Risco alto\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Apetite a risco e tolerância a risco\n\nDuas expressões aparecem o tempo todo na gestão de risco corporativa, e é comum confundir uma com a outra.\n\n**Apetite a risco** é o quanto de risco, de forma geral, a organização está disposta a aceitar para perseguir seus objetivos. É uma postura estratégica, normalmente definida pela alta direção. Uma fintech que compete em velocidade de lançamento de produtos pode ter apetite a risco mais alto do que um banco tradicional, por exemplo.\n\n**Tolerância a risco** é o limite prático e mensurável aceito para um risco específico, dentro daquele apetite geral. Uma instituição financeira pode declarar apetite baixo a risco cibernético como postura geral e, ao mesmo tempo, definir uma tolerância bem concreta para o sistema de internet banking: no máximo quatro horas de indisponibilidade não planejada por ano. O apetite dá a direção, a tolerância marca até onde dá para ir sem sair da rota."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## As quatro respostas possíveis a um risco\n\nDepois de avaliado, todo risco recebe uma decisão de tratamento. Existem quatro respostas clássicas:\n\n- **Evitar**: eliminar a atividade ou exposição que gera o risco. Por exemplo, não lançar um recurso do aplicativo que os testes de segurança apontaram como arriscado demais.\n- **Mitigar (ou reduzir)**: aplicar controles que diminuam a probabilidade ou o impacto do risco. É a resposta mais comum no dia a dia, aplicar um patch, treinar a equipe, instalar um firewall.\n- **Transferir (ou compartilhar)**: repassar parte do risco a terceiros, por meio de um seguro cibernético ou de um contrato com um fornecedor especializado, por exemplo.\n- **Aceitar**: decidir conscientemente conviver com o risco, porque o custo de tratá-lo supera o benefício ou porque ele já está dentro da tolerância definida. Aceitar um risco não é ignorá-lo, exige registro formal da decisão e um responsável identificado por ela.\n\nNenhum controle zera o risco por completo. O que sobra depois de aplicada a resposta escolhida se chama **risco residual**, e esse resíduo também precisa ser conhecido e, formalmente, aceito por alguém com autoridade para isso."
+                    },
+                    {
+                        "type": "code",
+                        "value": "Registro de risco #042\nAtivo: Banco de dados de clientes\nAmeaça: Invasor explorando falha conhecida\nVulnerabilidade: Servidor sem atualização de segurança há 8 meses\nProbabilidade: Alta\nImpacto: Alto\nResposta escolhida: Mitigar\nAção definida: Aplicar atualização de segurança em até 15 dias; habilitar varredura semanal de vulnerabilidades\nRisco residual: Médio\nAceito por: Diretoria de TI, em 10/03/2026"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Apetite a risco define quanto risco a organização topa correr; tolerância marca os limites aceitáveis dentro desse apetite para um risco específico. Depois de avaliar cada risco, a organização escolhe entre evitar, mitigar, transferir ou aceitar, e o que sobra depois disso é o risco residual, que também precisa ser formalmente reconhecido."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Depois de identificar um risco, uma analista de segurança estima que ele tem alta probabilidade de ocorrer e causaria impacto financeiro alto ao negócio. Essa atividade de estimar probabilidade e impacto corresponde a qual etapa da gestão de risco?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Avaliação de risco",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Identificação de risco",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Tratamento de risco",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Apetite a risco",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma empresa contrata um seguro cibernético para cobrir os custos financeiros de um eventual vazamento de dados, em vez de investir pesadamente em novos controles técnicos. Essa decisão exemplifica qual resposta ao risco?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Transferência do risco",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Mitigação do risco",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Aceitação do risco",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Evitar o risco",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma companhia aérea decide não lançar um novo aplicativo de check-in depois que a equipe de segurança conclui que os riscos de fraude superam os benefícios esperados do projeto. Essa decisão de não seguir adiante representa qual resposta ao risco?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Evitar o risco",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Mitigar o risco",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Transferir o risco",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Aceitar o risco",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma instituição financeira define, em nível de diretoria, que sua postura geral é de baixo apetite a risco cibernético. Já para o sistema de internet banking especificamente, a área de TI estabelece que interrupções não planejadas não podem ultrapassar quatro horas por ano. Essa segunda definição, mais específica e mensurável, representa o conceito de:",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Tolerância a risco",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Apetite a risco",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Risco residual",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ameaça persistente",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de aplicar atualizações de segurança, firewall e treinamento de conscientização, uma empresa reconhece que ainda existe uma chance pequena, porém real, de um ataque bem-sucedido explorar uma falha não corrigida. A diretoria analisa essa chance remanescente, conclui que está dentro do apetite a risco da empresa e formaliza por escrito a decisão de não investir mais recursos nesse ponto. O que a diretoria fez, nesse caso?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Aceitou formalmente o risco residual",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Transferiu o risco residual para terceiros",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Eliminou completamente o risco por meio de mitigação",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ignorou o risco sem seguir o processo de gestão de risco",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Tipos de Controle: Físico, Técnico e Administrativo",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Aula 3: Tipos de Controle: Físico, Técnico e Administrativo\n\nQuando a resposta escolhida para um risco é mitigar, a organização precisa aplicar um **controle**: uma salvaguarda ou contramedida capaz de reduzir a probabilidade de um incidente acontecer ou o impacto causado por ele. Os controles de segurança costumam ser organizados em três categorias, de acordo com a forma como atuam: **físicos**, **técnicos (ou lógicos)** e **administrativos**. Entender essa divisão ajuda a enxergar por que a segurança de uma empresa nunca depende de uma única linha de defesa."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Controles físicos\n\nControles físicos protegem o ambiente e os ativos tangíveis: prédios, salas de servidores, equipamentos, documentos em papel. Eles atuam no mundo real, não dentro de um sistema.\n\nExemplos comuns: cercas, catracas, crachás de acesso, câmeras de CFTV (também chamado de CCTV), guardas patrimoniais, fechaduras, iluminação de segurança, cofres e sistemas de supressão de incêndio. Se alguém precisa passar por uma catraca e mostrar um crachá para entrar na sala dos servidores, esse é um controle físico em ação."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Controles técnicos (ou lógicos)\n\nControles técnicos, também chamados de lógicos, são implementados por meio de tecnologia, hardware ou software, para proteger sistemas e dados. Eles atuam dentro do ambiente digital.\n\nExemplos comuns: firewall, criptografia, autenticação multifator, antivírus, listas de controle de acesso em um sistema, IDS e IPS, e o bloqueio automático de tela após alguns minutos de inatividade. Uma senha exigida para acessar um sistema, ou um firewall que bloqueia tráfego suspeito, são controles técnicos."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Controles administrativos\n\nControles administrativos são implementados por meio de políticas, procedimentos e processos que orientam o comportamento das pessoas dentro da organização. Eles não travam uma porta nem bloqueiam um pacote de rede: eles definem regras, responsabilidades e expectativas.\n\nExemplos comuns: política de segurança da informação, treinamento de conscientização, verificação de antecedentes na contratação, segregação de funções (dividir uma tarefa crítica entre pessoas diferentes, para que nenhuma delas tenha controle total sozinha) e plano de resposta a incidentes. Controles administrativos costumam ser a base que sustenta os outros dois tipos: de nada adianta ter um ótimo firewall se ninguém foi treinado para reconhecer um golpe de phishing."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Tipo de controle\", \"O que protege\", \"Exemplos\"], [\"Físico\", \"O ambiente e os ativos tangíveis\", \"Cerca, catraca, crachá de acesso, CFTV, guarda patrimonial, fechadura, sistema de supressão de incêndio\"], [\"Técnico (lógico)\", \"Sistemas e dados por meio de tecnologia\", \"Firewall, criptografia, autenticação multifator, antivírus, IDS e IPS, controle de acesso em sistema\"], [\"Administrativo\", \"O comportamento das pessoas e os processos da organização\", \"Política de segurança, treinamento de conscientização, verificação de antecedentes, segregação de funções, plano de resposta a incidentes\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Outra forma de olhar para os controles: pela função\n\nAlém de classificar controles por tipo (físico, técnico ou administrativo), também é comum classificá-los pela função que exercem. Um controle pode ser **preventivo** (evita que o incidente aconteça, como uma fechadura ou um firewall bem configurado), **detectivo** (identifica que algo está ou já aconteceu, como uma câmera ou um log de auditoria), **corretivo** (restaura a normalidade depois do incidente, como restaurar um backup), **dissuasório** (desencoraja a tentativa, como uma placa avisando que o local é monitorado) ou **compensatório** (substitui um controle ideal quando ele não é viável no momento, como reforçar o monitoramento manual em um sistema antigo que não suporta autenticação multifator).\n\nEssas duas classificações se combinam. Um sistema de reconhecimento facial com IA usado para liberar a catraca de um data center é, ao mesmo tempo, um controle físico (protege o acesso ao ambiente), técnico (depende de um sistema de reconhecimento) e majoritariamente preventivo (impede a entrada de quem não está autorizado). E ele só funciona bem se existir, por trás, uma política definindo quem tem autorização de acesso e quem revisa os alertas gerados pelo sistema, ou seja, um controle administrativo sustentando os outros dois."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Controle físico protege o ambiente, controle técnico protege os sistemas, controle administrativo orienta as pessoas e os processos. Nenhum dos três, sozinho, sustenta a segurança de uma organização: é a combinação dos três tipos, e das funções preventiva, detectiva, corretiva, dissuasória e compensatória que cada um pode exercer, que forma uma defesa consistente."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Uma empresa instala catracas e exige o uso de crachás de acesso na entrada do escritório para impedir a entrada de pessoas não autorizadas. Esse é um exemplo de controle:",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Físico",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Técnico",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Administrativo",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Compensatório",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O uso de firewall e criptografia para proteger os dados que trafegam na rede de uma empresa é um exemplo de controle:",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Técnico (lógico)",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Físico",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Administrativo",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Dissuasório",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma empresa exige que todo novo funcionário passe por verificação de antecedentes antes da contratação e assine um termo de responsabilidade sobre o uso de dados sensíveis. Quanto ao tipo, essa exigência se classifica como um controle:",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Administrativo",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Físico",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Técnico",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Detectivo",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de um incidente de ransomware, a equipe de TI restaura os sistemas afetados a partir de backups limpos para retomar a operação normal da empresa. Quanto à função, essa ação exemplifica um controle:",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Corretivo",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Preventivo",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Dissuasório",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Detectivo",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um sistema legado essencial para a produção de uma fábrica não é compatível com autenticação multifator, e substituir esse sistema levaria cerca de dois anos. Enquanto isso, a empresa decide reforçar o monitoramento manual dos acessos a esse sistema, com uma equipe dedicada revisando os registros a cada hora. Esse monitoramento reforçado é um exemplo de controle:",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Compensatório",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Preventivo",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Físico",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Dissuasório",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "O Código de Ética da (ISC)²",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Aula 4: O Código de Ética da (ISC)²\n\nUm profissional de segurança da informação costuma ter acesso a dados sigilosos, sistemas críticos e informações que, se usadas de forma errada, causam dano real a pessoas e organizações. Essa posição de confiança é o motivo pelo qual a (ISC)², entidade responsável pela certificação CC, exige que todo profissional certificado concorde formalmente em seguir um Código de Ética. Não é uma sugestão: violar o código é motivo para investigação e pode levar à revogação da certificação.\n\nO código é composto por um preâmbulo e quatro cânones. Os cânones são listados em ordem de prioridade: quando dois deles entram em conflito em uma situação real, resolve-se o conflito seguindo a ordem em que aparecem, o primeiro cânone prevalece sobre o segundo, o segundo sobre o terceiro, e assim por diante."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "A ideia central do preâmbulo do código é esta: a segurança e o bem-estar da sociedade, a confiança pública necessária e o dever para com quem contrata nossos serviços, e uns para com os outros, exigem que sigamos, e sejamos vistos seguindo, os mais altos padrões de conduta ética. Por isso, seguir esse código à risca é condição para manter a certificação."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Cânone (em ordem de prioridade)\", \"O que significa na prática\"], [\"1. Proteger a sociedade, o bem comum, a confiança pública necessária e a infraestrutura\", \"O dever com a sociedade vem antes de qualquer outro interesse, inclusive antes do interesse do empregador ou cliente\"], [\"2. Agir de forma honrosa, honesta, justa, responsável e legal\", \"Manter integridade em qualquer circunstância, mesmo quando é mais difícil ou menos conveniente\"], [\"3. Prestar um serviço diligente e competente aos contratantes\", \"Só assumir trabalho para o qual está realmente qualificado, manter-se atualizado e agir com zelo\"], [\"4. Avançar e proteger a profissão\", \"Cuidar da reputação da profissão de segurança e contribuir para a formação de outros profissionais\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Quando os cânones entram em conflito\n\nA ordem dos cânones existe justamente para os momentos difíceis, quando cumprir um deles significa, na prática, deixar de cumprir outro. Imagine um profissional contratado para testar a segurança de um sistema de saúde pública, sob um contrato de confidencialidade que proíbe divulgar qualquer informação sobre o teste sem autorização prévia. Durante o trabalho, ele encontra uma falha grave que, se explorada por um invasor, colocaria em risco a segurança de milhões de pacientes.\n\nNesse caso, o primeiro cânone (proteger a sociedade) tem prioridade sobre o terceiro (prestar serviço ao contratante). Isso não significa sair divulgando a falha publicamente, o que violaria o segundo cânone, agir de forma legal e responsável, e sim buscar, dentro dos meios éticos e legais disponíveis, garantir que o risco à sociedade seja tratado, inclusive escalando a questão para quem tem autoridade para agir, mesmo que isso extrapole os limites originais do contrato."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O código no dia a dia do profissional\n\nO Código de Ética não aparece só em dilemas extremos. Ele também orienta decisões comuns da rotina: não usar um acesso privilegiado para fins pessoais, comunicar vulnerabilidades encontradas de forma responsável (avisando quem precisa corrigir, em vez de explorá-las ou expô-las publicamente sem aviso prévio), não exagerar nem mentir sobre certificações e experiência profissional, e reportar à (ISC)² caso tome conhecimento de uma violação grave cometida por outro profissional certificado.\n\nA (ISC)² mantém um processo formal para investigar denúncias de violação do código. Um profissional considerado culpado pode ter a certificação suspensa ou revogada, o que reforça que o código não é apenas uma declaração de intenções: é uma condição real para continuar certificado."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Os quatro cânones, em ordem de prioridade, são: proteger a sociedade, o bem comum, a confiança pública e a infraestrutura; agir de forma honrosa, honesta, justa, responsável e legal; prestar serviço diligente e competente aos contratantes; e avançar e proteger a profissão. Em qualquer conflito entre eles, vence o cânone que aparece primeiro na lista."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual das opções lista corretamente os quatro cânones do Código de Ética da (ISC)², na ordem de prioridade usada para resolver conflitos entre eles?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Proteger a sociedade; agir de forma honrosa e legal; prestar serviço competente aos contratantes; avançar a profissão",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Prestar serviço competente aos contratantes; proteger a sociedade; avançar a profissão; agir de forma honrosa e legal",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Avançar a profissão; agir de forma honrosa e legal; proteger a sociedade; prestar serviço competente aos contratantes",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Agir de forma honrosa e legal; prestar serviço competente aos contratantes; avançar a profissão; proteger a sociedade",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Durante um teste de segurança contratado por uma empresa, um profissional certificado descobre uma falha grave que, se explorada, colocaria em risco a segurança de usuários de um sistema de saúde pública usado por milhões de pessoas. O contrato assinado proíbe divulgar qualquer informação sobre o teste sem autorização prévia da empresa. Segundo a ordem de prioridade dos cânones do Código de Ética da (ISC)², qual conduta é mais adequada?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Buscar, dentro dos meios éticos e legais disponíveis, garantir que o risco à sociedade seja tratado, mesmo que isso exija ultrapassar os limites originais do contrato",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Respeitar rigorosamente o contrato de confidencialidade em qualquer circunstância, já que o dever com o contratante tem prioridade máxima",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Divulgar a falha publicamente nas redes sociais para pressionar a empresa a agir com rapidez",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ignorar o achado, já que ele estava fora do escopo original combinado no contrato",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "De acordo com o Código de Ética da (ISC)², o termo 'contratantes', mencionado no terceiro cânone, refere-se a quem?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Empregadores, clientes e outras partes para as quais o profissional presta serviço",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Apenas o governo do país onde o profissional atua",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Somente os colegas de equipe do profissional",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Exclusivamente os acionistas da empresa contratante",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um profissional certificado pela (ISC)² é formalmente investigado e considerado culpado de uma violação grave do Código de Ética. Qual é a consequência mais direta prevista para esse tipo de caso?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "A suspensão ou revogação da certificação pela (ISC)²",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Apenas uma advertência verbal, sem qualquer registro formal",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Nenhuma consequência prática, já que o código não é obrigatório",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A obrigatoriedade de refazer o exame de certificação no ano seguinte, sem qualquer outra medida",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um profissional certificado espalha informações exageradas e alarmistas sobre ameaças de segurança em uma rede social, apenas para promover os próprios serviços de consultoria, mesmo sabendo que está distorcendo a gravidade real dos riscos. Além de ferir a honestidade exigida pelo segundo cânone, essa prática de gerar medo e desinformação para ganho pessoal prejudica de forma direta qual outro cânone?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Avançar e proteger a profissão",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Prestar serviço diligente aos contratantes",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Proteger a sociedade",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Nenhum: é uma prática comum e aceitável no mercado de segurança",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Governança: Políticas, Padrões, Procedimentos e Conformidade de IA",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Aula 5: Governança: Políticas, Padrões, Procedimentos e Conformidade de IA\n\nGovernança, no contexto de segurança da informação, é o conjunto de estruturas, papéis e documentos que uma organização usa para direcionar e controlar como a segurança é gerida, garantindo que decisões de risco (como as que vimos nas primeiras aulas deste módulo) e princípios éticos se transformem em regras concretas, conhecidas e cobradas de todos.\n\nA espinha dorsal da governança interna é formada por quatro tipos de documento, organizados numa hierarquia: **política**, **padrão**, **procedimento** e **diretriz**. Cada um tem um papel diferente, e entender essa diferença é essencial para quem trabalha com segurança."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Documento\", \"Obrigatório?\", \"Propósito\", \"Exemplo (tema: senha)\"], [\"Política\", \"Sim\", \"Declarar a intenção e as regras gerais, definidas pela alta direção\", \"Todos os usuários devem usar senhas fortes para proteger o acesso aos sistemas da empresa\"], [\"Padrão\", \"Sim\", \"Especificar requisitos técnicos mensuráveis que apoiam a política\", \"A senha deve ter no mínimo 14 caracteres, incluindo letras, números e símbolos\"], [\"Procedimento\", \"Sim\", \"Descrever o passo a passo para executar uma tarefa ou cumprir a política\", \"Os passos para redefinir a senha pelo portal de TI, incluindo verificação por autenticação multifator\"], [\"Diretriz\", \"Não, é uma recomendação\", \"Oferecer boas práticas e sugestões flexíveis, sem caráter obrigatório\", \"Recomenda-se não reutilizar a mesma senha em contas pessoais e corporativas\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Leis e regulamentos: uma camada diferente de governança\n\nPolítica, padrão, procedimento e diretriz são documentos internos: a própria organização os escreve e pode alterá-los. Leis e regulamentos são diferentes, vêm de um governo ou órgão regulador externo, são obrigatórios independentemente da vontade da empresa, e o descumprimento pode gerar multa e outras sanções legais.\n\nPara quem trabalha com segurança da informação, duas leis de proteção de dados pessoais aparecem constantemente: a **LGPD** (Lei Geral de Proteção de Dados, no Brasil) e o **GDPR** (General Data Protection Regulation, na União Europeia). Ambas partem da mesma lógica: dados pessoais pertencem à pessoa a quem se referem (o titular dos dados), que passa a ter direitos sobre eles, e as organizações que tratam esses dados precisam adotar medidas de segurança adequadas, notificar incidentes e podem ser responsabilizadas em caso de vazamento. Uma empresa brasileira que atende clientes na Europa, por exemplo, pode precisar cumprir as duas leis ao mesmo tempo."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Aspecto\", \"LGPD (Brasil)\", \"GDPR (União Europeia)\"], [\"Abrangência\", \"Tratamento de dados pessoais de pessoas no Brasil\", \"Tratamento de dados pessoais de pessoas na União Europeia\"], [\"Órgão regulador\", \"ANPD (Autoridade Nacional de Proteção de Dados)\", \"Autoridades nacionais de proteção de dados de cada país membro\"], [\"Direitos do titular\", \"Acesso, correção, eliminação e portabilidade dos próprios dados, entre outros\", \"Acesso, retificação, apagamento (direito ao esquecimento) e portabilidade, entre outros\"], [\"Multa máxima por infração\", \"Até 2% do faturamento da empresa no Brasil, limitada a R$ 50 milhões por infração\", \"Até 4% do faturamento global anual ou 20 milhões de euros, o que for maior\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Governança e conformidade de inteligência artificial\n\nA mesma lógica de governança se aplica quando a organização passa a usar inteligência artificial, seja um chatbot para atendimento, um modelo de triagem de currículos ou um sistema de recomendação. A IA não fica de fora das políticas, padrões, procedimentos e diretrizes: ela normalmente exige a criação de novos, ou a atualização dos existentes.\n\nUma empresa que libera o uso de ferramentas de IA generativa, por exemplo, costuma precisar de: uma **política de uso de IA**, definindo quais ferramentas são permitidas e para quais finalidades; um **padrão** especificando que tipos de dado nunca podem ser digitados em uma ferramenta de IA pública (dados de clientes, código-fonte proprietário, informações financeiras não públicas); um **procedimento** para avaliar e aprovar uma nova ferramenta de IA antes da adoção; e **diretrizes** com boas práticas de uso, como revisar sempre a resposta gerada antes de usá-la.\n\nAlém dos documentos, a governança de IA envolve preocupações mais específicas: **transparência e explicabilidade** (entender, ao menos em linhas gerais, como o modelo chega a uma decisão), **responsabilização** (uma pessoa, não o sistema, responde pelas decisões tomadas com apoio de IA), **supervisão humana** (revisão de uma pessoa antes de decisões de alto impacto, como negar um crédito ou reprovar um candidato) e **cuidado com os dados de treinamento** (de onde vêm, se contêm dados pessoais, se foram usados com consentimento adequado)."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O cenário regulatório para IA\n\nAssim como aconteceu com a proteção de dados pessoais, governos ao redor do mundo têm criado regras específicas para IA. A União Europeia aprovou o AI Act, que classifica sistemas de IA por nível de risco (inaceitável, alto, limitado e mínimo) e impõe obrigações mais rígidas quanto maior o risco do sistema, o mesmo raciocínio de probabilidade e impacto que vimos nas primeiras aulas deste módulo, agora aplicado especificamente à IA. O Brasil segue um movimento parecido, com a discussão do Marco Legal da Inteligência Artificial no Congresso, que deve estabelecer regras específicas para sistemas de IA, principalmente os de maior risco.\n\nUm ponto importante: enquanto uma lei específica sobre IA não está em vigor, isso não significa ausência de regras. A LGPD já se aplica a qualquer tratamento de dados pessoais, incluindo o feito por sistemas de IA, desde hoje. Uma empresa que usa IA para decidir automaticamente a concessão de crédito, por exemplo, já precisa cumprir a LGPD nesse processo, com ou sem uma lei de IA específica. Muitas organizações também adotam frameworks voluntários, como o NIST AI Risk Management Framework, para estruturar a governança de IA de forma mais organizada."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Política diz o quê e por quê, padrão diz o quanto, procedimento diz o como, e diretriz sugere o melhor caminho. Leis como a LGPD e o GDPR não são escolha da empresa, são obrigação legal. A IA não muda essa lógica: ela apenas adiciona um novo tipo de ativo que precisa das mesmas perguntas de sempre, quem é responsável, como isso é auditado, e quais dados estão envolvidos."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Uma empresa publica um documento de alto nível, aprovado pela diretoria, afirmando que todos os dados de clientes devem ser protegidos contra acesso não autorizado. Sem entrar em detalhes técnicos, esse documento é melhor classificado como:",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Uma política",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um padrão",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um procedimento",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma diretriz",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual das opções abaixo descreve corretamente a principal diferença entre uma política interna de segurança e uma lei como a LGPD?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "A lei é imposta por um órgão externo e seu cumprimento é obrigatório independentemente da vontade da empresa, enquanto a política é definida e pode ser alterada pela própria organização",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A política é sempre mais rígida e detalhada do que qualquer lei",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A lei só se aplica a empresas do setor de tecnologia",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Política e lei têm exatamente a mesma função e podem substituir uma à outra",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um documento interno define que a senha corporativa deve ter no mínimo 14 caracteres, incluindo letras, números e símbolos. Esse tipo de exigência específica e mensurável, que apoia uma política mais ampla, é chamado de:",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Padrão",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Política",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Diretriz",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Regulamento",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma empresa permite que os funcionários usem uma ferramenta pública de IA generativa para agilizar tarefas do dia a dia, mas ainda não definiu nenhuma regra sobre quais tipos de informação podem ou não ser digitados nessa ferramenta. Do ponto de vista de governança, qual é o principal risco imediato dessa lacuna?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Funcionários podem inserir dados sensíveis ou pessoais em um serviço externo, sem controle sobre como esses dados serão usados ou armazenados",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A ferramenta de IA vai automaticamente violar a LGPD assim que for instalada, independentemente do uso",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ferramentas de IA generativa não representam nenhum risco de governança, apenas risco técnico",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O principal risco é apenas a perda de produtividade dos funcionários",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma empresa brasileira que utiliza um sistema de IA para tomar decisões automatizadas de concessão de crédito afirma que não precisa se preocupar com proteção de dados pessoais enquanto uma lei específica sobre inteligência artificial não for sancionada no Brasil. Do ponto de vista de conformidade, essa afirmação está correta?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Não, porque a LGPD já se aplica a qualquer tratamento de dados pessoais, inclusive quando feito por sistemas de IA, independentemente da existência de uma lei específica sobre IA",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Sim, porque leis de proteção de dados pessoais não têm relação com sistemas de inteligência artificial",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Sim, porque a LGPD só é válida para tratamento de dados feito diretamente por seres humanos, não por sistemas automatizados",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não, mas apenas porque toda empresa brasileira deve seguir automaticamente o GDPR europeu",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 3 - Continuidade, Desastres e Resposta a Incidentes",
+        "aulas": [
+            {
+                "titulo": "Continuidade de Negócios: propósito, importância e componentes do plano",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Módulo 3 - Continuidade, Desastres e Resposta a Incidentes\n\n## Aula 1: Continuidade de Negócios: propósito, importância e componentes do plano\n\nToda empresa vai ter um dia ruim. Pode ser uma queda de energia, um incêndio no data center, um ataque de ransomware ou uma pandemia que impede o time inteiro de ir ao escritório. A pergunta que separa uma organização madura de uma despreparada não é \"isso vai acontecer?\", e sim \"quando acontecer, a gente consegue continuar funcionando?\".\n\nÉ disso que trata a **Continuidade de Negócios**, ou **Business Continuity (BC)**: o conjunto de processos, políticas e planos que garantem que as funções essenciais de uma organização continuem operando, ou voltem a operar rapidamente, durante e depois de um evento disruptivo.\n\nNo Domínio 2 do exame CC da ISC2, esse é um dos temas centrais. Você precisa entender o propósito, a importância e os componentes da continuidade de negócios, da recuperação de desastres e da resposta a incidentes. Vamos começar pelo BC."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Propósito e importância do BC\n\nO propósito da continuidade de negócios é manter as funções críticas do negócio funcionando durante uma interrupção, minimizando o impacto financeiro, operacional, legal e reputacional.\n\nPense em um hospital. Se o sistema de prontuário eletrônico cai, os médicos não podem simplesmente parar de atender pacientes. Um plano de continuidade bem feito prevê, por exemplo, um processo manual em papel para as primeiras horas, enquanto a equipe de TI restaura o sistema. Isso é continuidade: o serviço essencial (atender o paciente) não para, mesmo que a ferramenta que normalmente o sustenta esteja fora do ar.\n\nA importância do BC aparece em várias frentes:\n\n- **Sobrevivência financeira**: cada hora de parada tem um custo, seja em vendas perdidas, multas contratuais ou produtividade parada.\n- **Obrigações legais e regulatórias**: setores como saúde e financeiro têm exigências específicas de continuidade.\n- **Reputação e confiança**: clientes e parceiros perdem confiança em empresas que somem no primeiro incidente.\n- **Segurança das pessoas**: em setores como saúde, energia e transporte, a continuidade está ligada diretamente à segurança física de quem depende do serviço."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Componentes do plano de continuidade de negócios (BCP)\n\nUm Business Continuity Plan (BCP) não é um documento único e parado no tempo: é um programa vivo, formado por vários componentes que se complementam.\n\n- **Política de continuidade de negócios**: documento de alto nível, aprovado pela liderança, que declara o compromisso da organização com a continuidade e define responsabilidades gerais.\n- **Análise de Impacto no Negócio (BIA)**: processo que identifica quais funções são críticas e qual o impacto de cada uma ficar indisponível. Vamos detalhar isso na próxima aula.\n- **Estratégias de recuperação**: as opções definidas para restaurar cada função crítica, envolvendo pessoas, processos, sistemas e instalações.\n- **Planos específicos**: documentos operacionais, como o próprio plano de continuidade, o plano de recuperação de desastres (próxima aula) e o plano de resposta a incidentes.\n- **Papéis e responsabilidades**: quem faz o quê durante uma crise, definido com antecedência, nunca improvisado no meio do caos.\n- **Treinamento e conscientização**: de nada adianta um plano perfeito se ninguém sabe que ele existe ou como executá-lo.\n- **Testes e exercícios**: simulações periódicas, como exercícios de mesa (tabletop) e simulações completas, que validam se o plano realmente funciona na prática."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Componente\", \"Objetivo principal\"], [\"Política de continuidade\", \"Formalizar o compromisso da liderança e as diretrizes gerais\"], [\"BIA\", \"Identificar funções críticas e o impacto da indisponibilidade de cada uma\"], [\"Estratégias de recuperação\", \"Definir como cada função crítica será restaurada\"], [\"Planos operacionais\", \"Detalhar passo a passo o que fazer durante a crise\"], [\"Treinamento\", \"Garantir que as pessoas saibam executar o plano\"], [\"Testes e exercícios\", \"Validar e aprimorar o plano continuamente\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Continuidade não é tarefa só da TI\n\nUm erro comum é achar que continuidade de negócios é responsabilidade exclusiva da área de TI. Na prática, o BC é um processo de negócio, patrocinado pela alta liderança, que envolve todas as áreas: operações, jurídico, comunicação, recursos humanos, financeiro e, claro, tecnologia.\n\nUm exemplo ajuda a entender: durante um incêndio que danifica o escritório, a TI cuida dos sistemas, o RH localiza e comunica os funcionários, o jurídico avalia obrigações contratuais com clientes afetados, e a comunicação cuida da mensagem para o público. Continuidade bem-sucedida é um esforço coordenado entre áreas, não uma tarefa isolada do time técnico."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "A continuidade de negócios existe para manter as funções essenciais da empresa funcionando durante e depois de uma interrupção. Ela se apoia em política, BIA, estratégias de recuperação, planos, papéis definidos, treinamento e testes, e é responsabilidade de toda a organização, não só da TI."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual é o propósito principal da continuidade de negócios (BC)?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Eliminar completamente qualquer possibilidade de incidente de segurança.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Garantir que as funções essenciais da organização continuem operando, ou voltem a operar rapidamente, durante e depois de um evento disruptivo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Substituir a necessidade de backups de dados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Definir exclusivamente as regras de acesso físico aos data centers.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma empresa de varejo online percebe que, durante uma falha de energia na região onde fica seu data center principal, o site de vendas fica fora do ar por seis horas, gerando perda de receita e reclamações de clientes. Isso ilustra principalmente a importância de qual prática?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Segregação de funções, para dividir tarefas entre funcionários.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Controle de acesso físico, para impedir a entrada de pessoas não autorizadas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Criptografia de dados em trânsito.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Continuidade de negócios, para manter ou restaurar rapidamente as funções críticas durante interrupções.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "A liderança de uma empresa aprovou um documento de alto nível que declara o compromisso da organização com a continuidade e atribui responsabilidades gerais, mas não entra em detalhes operacionais. Esse documento corresponde a qual componente do BCP?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Política de continuidade de negócios.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Análise de Impacto no Negócio (BIA).",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Plano de resposta a incidentes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Relatório de teste de recuperação de desastres.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que a continuidade de negócios é considerada responsabilidade de toda a organização, e não apenas da área de TI?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque a área de TI não tem conhecimento técnico suficiente para lidar com incidentes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o custo de um plano de continuidade deve ser dividido igualmente entre todas as áreas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque uma interrupção afeta múltiplas áreas, como operações, jurídico, comunicação e RH, que precisam agir de forma coordenada para manter o negócio funcionando.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque cada área deve manter um plano de continuidade totalmente independente das demais, sem necessidade de coordenação.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma indústria farmacêutica está revisando seu programa de continuidade de negócios. A equipe de TI já implementou backups automatizados e redundância de servidores, mas a auditoria interna aponta que o programa ainda é considerado incompleto. Qual lacuna mais provavelmente está sendo apontada?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "A falta de um antivírus instalado nos servidores de produção.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A ausência de treinamento das equipes e de testes periódicos que validem se os planos funcionam na prática.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A ausência de um firewall de próxima geração na borda da rede.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A falta de criptografia simétrica nos backups armazenados localmente.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Análise de Impacto no Negócio (BIA), RTO e RPO: medindo o que a empresa não pode perder",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Aula 2: Análise de Impacto no Negócio (BIA), RTO e RPO: medindo o que a empresa não pode perder\n\nNa aula anterior você viu que a Análise de Impacto no Negócio, ou **Business Impact Analysis (BIA)**, é um dos componentes centrais do plano de continuidade. Agora vamos abrir esse processo e entender como as organizações descobrem, de forma estruturada, o que realmente não pode parar, e por quanto tempo.\n\nA BIA responde a perguntas como: quais processos são críticos? O que acontece se cada um ficar indisponível por uma hora, um dia, uma semana? Qual o limite de dados que a empresa pode perder sem comprometer a operação? As respostas alimentam diretamente os planos de continuidade e de recuperação de desastres."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que a BIA faz, na prática\n\nA BIA é um processo, não um documento único. Normalmente segue estas etapas:\n\n1. **Identificar os processos de negócio** e os ativos (sistemas, dados, pessoas, instalações) que os sustentam.\n2. **Determinar o impacto da indisponibilidade** de cada processo ao longo do tempo (financeiro, operacional, legal, reputacional). O impacto de uma hora fora do ar costuma ser bem diferente do impacto de uma semana.\n3. **Priorizar os processos críticos**, criando uma ordem de recuperação: o que precisa voltar primeiro?\n4. **Definir metas de recuperação** para cada processo crítico, entre elas o RTO e o RPO.\n\nO resultado da BIA orienta decisões caras, como quanto investir em um site de recuperação de desastres ou com que frequência fazer backup de um sistema específico."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## RTO e RPO: dois relógios diferentes\n\nDois conceitos aparecem sempre que se fala em BIA, e é comum confundir um com o outro:\n\n- **RTO (Recovery Time Objective, ou Objetivo de Tempo de Recuperação)**: quanto tempo o processo pode ficar fora do ar até que o impacto se torne inaceitável. Responde à pergunta \"em quanto tempo esse sistema precisa voltar a funcionar?\".\n- **RPO (Recovery Point Objective, ou Objetivo de Ponto de Recuperação)**: quanto dado a organização tolera perder, medido em tempo. Responde à pergunta \"até que ponto no passado eu consigo restaurar os dados?\".\n\nUma forma simples de lembrar: o RTO olha para frente (quanto tempo até voltar a funcionar), o RPO olha para trás (até onde no tempo dá para recuperar os dados). Se um sistema de vendas tem RPO de quatro horas, o backup precisa ocorrer, no mínimo, a cada quatro horas, porque perder mais que isso seria inaceitável."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Métrica\", \"O que mede\", \"Pergunta que responde\"], [\"RTO (Recovery Time Objective)\", \"Tempo máximo tolerável para restaurar um processo ou sistema\", \"Em quanto tempo precisamos voltar a funcionar?\"], [\"RPO (Recovery Point Objective)\", \"Quantidade máxima de dados que se pode perder, medida em tempo\", \"Até que momento no passado conseguimos recuperar os dados?\"], [\"MTD (Maximum Tolerable Downtime)\", \"Tempo total máximo que um processo pode ficar indisponível antes de causar dano irreversível ao negócio\", \"Qual o limite absoluto antes do dano se tornar irreparável?\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Um risco novo para a BIA: o model drift\n\nCada vez mais processos críticos dependem de modelos de inteligência artificial: detecção de fraude, análise de crédito, priorização de atendimento, detecção de anomalias em acessos e redes. Isso traz um tipo de risco que uma BIA tradicional pode não enxergar de cara: o **model drift**, ou degradação de modelo.\n\nModel drift acontece quando a precisão de um modelo de IA cai ao longo do tempo, porque os dados do mundo real mudam e deixam de se parecer com os dados usados para treinar o modelo. Um modelo de detecção de fraude treinado com padrões de transações de dois anos atrás pode não reconhecer as fraudes de hoje. Um modelo de detecção de anomalias de rede pode parar de identificar comportamentos suspeitos porque o tráfego normal da empresa mudou, por exemplo depois da adoção em massa de trabalho remoto.\n\nA diferença para um incidente clássico é que o model drift não derruba o sistema: o serviço continua disponível, respondendo normalmente, só que cada vez mais errado. É uma degradação silenciosa, sem alarme óbvio de indisponibilidade, o que a torna perigosa do ponto de vista de continuidade."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Tratando o model drift como risco de continuidade\n\nUma organização madura trata o model drift como trataria qualquer outro risco identificado na BIA:\n\n- **Monitoramento contínuo** da performance do modelo em produção, não só no momento do lançamento, com métricas de acurácia e alertas de degradação.\n- **Metas mínimas de qualidade**, parecidas em espírito com um RTO ou RPO: por exemplo, se a taxa de acerto do modelo cair abaixo de um limite definido, isso passa a ser tratado como uma indisponibilidade do processo.\n- **Plano de contingência**, como reverter para uma versão anterior validada do modelo ou acionar um processo manual de revisão, enquanto o modelo é retreinado.\n- **Retreinamento periódico** com dados atualizados, incluído no ciclo normal de manutenção do sistema, e não tratado como algo excepcional.\n\nIncluir esse tipo de cenário na BIA é reconhecer que, na era da IA, continuar disponível não basta: o serviço também precisa continuar confiável."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "A BIA identifica os processos críticos do negócio e mede o impacto da sua indisponibilidade ao longo do tempo. O RTO define quanto tempo até restaurar, o RPO define quanto dado se pode perder. E, na era da IA, a degradação silenciosa de um modelo, o model drift, também é um risco de continuidade que exige monitoramento e plano de contingência."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual é o principal objetivo da Análise de Impacto no Negócio (BIA)?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Identificar os processos críticos do negócio e medir o impacto de sua indisponibilidade ao longo do tempo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Substituir a necessidade de um plano de resposta a incidentes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Definir exclusivamente as senhas e permissões de acesso dos usuários.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Escolher o fornecedor de antivírus da organização.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual das definições a seguir descreve corretamente o RTO (Recovery Time Objective)?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "A quantidade máxima de dados que a organização aceita perder, medida em tempo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O custo total de recuperação de um desastre.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O tempo máximo tolerável para restaurar um processo ou sistema após uma interrupção.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O tempo médio que a equipe leva para detectar um incidente de segurança.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um banco define que o sistema de processamento de pagamentos não pode perder mais de quinze minutos de dados em caso de falha, o que exige backups ou replicação praticamente contínuos. Essa exigência está definindo qual métrica?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "RTO",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "MTD",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "SLA de disponibilidade contratado com o provedor de nuvem",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "RPO",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma fintech usa um modelo de IA para aprovar ou negar pedidos de crédito automaticamente. Seis meses após o lançamento, o modelo continua respondendo normalmente e o sistema está no ar o tempo todo, mas a taxa de aprovações incorretas vem crescendo mês a mês, gerando prejuízo. Do ponto de vista de continuidade de negócios, esse cenário é melhor descrito como:",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Uma violação de confidencialidade, já que dados de clientes foram expostos publicamente.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Model drift, uma degradação silenciosa da qualidade do modelo que deve ser monitorada e tratada como risco de continuidade, mesmo sem indisponibilidade do sistema.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um problema de RPO, porque a empresa está perdendo dados de transações.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma falha de controle de acesso físico ao data center.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma empresa de e-commerce concluiu sua BIA e definiu que o processo de checkout tem RTO de duas horas e RPO de quinze minutos. Qual das ações abaixo está mais alinhada especificamente com o RPO definido?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Configurar replicação ou backup dos dados de transação com frequência de, no máximo, quinze minutos.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Contratar um site de recuperação totalmente equipado que restaure a operação em minutos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Treinar a equipe de suporte para atender clientes durante a indisponibilidade.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Definir a ordem de prioridade de recuperação entre os sistemas da empresa.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Recuperação de Desastres: propósito, componentes e sites alternativos",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Aula 3: Recuperação de Desastres: propósito, componentes e sites alternativos\n\nSe a continuidade de negócios é o guarda-chuva que garante que a empresa continue funcionando, a **Recuperação de Desastres**, ou **Disaster Recovery (DR)**, é o conjunto de ações técnicas focadas em restaurar a infraestrutura de TI (servidores, dados, rede, aplicações) depois de um evento que a tenha derrubado.\n\nDR é um subconjunto da continuidade de negócios, focado no lado técnico. Enquanto o BC pergunta \"como o negócio continua funcionando?\", o DR pergunta \"como eu restauro os sistemas que sustentam esse negócio?\"."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Propósito e importância do DR\n\nO propósito do DR é restaurar sistemas, dados e infraestrutura de TI ao estado operacional dentro dos objetivos de tempo e ponto de recuperação (RTO e RPO) definidos na BIA. Um plano de recuperação de desastres, o **Disaster Recovery Plan (DRP)**, documenta os passos técnicos para isso: como restaurar um servidor, de onde vêm os backups, qual a ordem de restauração dos sistemas, quem executa cada etapa.\n\nA importância do DR fica óbvia quando ele falta. Empresas que sofrem um desastre (incêndio, enchente, ataque de ransomware que criptografa tudo, falha catastrófica de hardware) sem um DRP testado costumam descobrir, na pior hora possível, que os backups estavam corrompidos, incompletos ou nem existiam. Um DRP bem construído transforma uma corrida contra o tempo em pânico em uma execução de checklist."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Componentes de um plano de recuperação de desastres\n\n- **Inventário de ativos críticos**: o que precisa ser recuperado, como servidores, bancos de dados, aplicações e arquivos de configuração.\n- **Estratégia de backup**: o que é copiado, com que frequência (alinhada ao RPO) e onde os backups ficam armazenados.\n- **Site alternativo**: onde a operação de TI roda enquanto o local principal está indisponível (o assunto da próxima seção).\n- **Procedimentos de restauração**: passo a passo técnico, em ordem de prioridade, de como trazer cada sistema de volta.\n- **Equipe de recuperação**: papéis e responsabilidades específicos para a execução técnica do DRP.\n- **Testes do plano**: exercícios periódicos que comprovam que os backups realmente restauram e que a equipe sabe executar o plano sob pressão."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Sites alternativos: onde a operação roda durante o desastre\n\nQuando o local principal fica inutilizável, a organização precisa de um lugar alternativo para operar. Existem três categorias clássicas, que variam principalmente em custo e velocidade de retomada:\n\n- **Hot site**: réplica quase completa do ambiente de produção, com hardware, software e dados sincronizados ou quase em tempo real. Permite retomar a operação em minutos a poucas horas. É o mais caro de manter.\n- **Warm site**: tem a infraestrutura básica pronta, como hardware e conectividade, mas os dados e sistemas precisam ser atualizados ou restaurados no momento do desastre. Leva de várias horas a um ou dois dias para ficar operacional. Custo intermediário.\n- **Cold site**: oferece apenas a estrutura física básica (espaço, energia, refrigeração, conectividade), sem hardware pronto. Pode levar dias ou semanas para ficar operacional. É o mais barato, mas o mais lento.\n\nHoje, muitas empresas complementam ou substituem esses modelos tradicionais por **DR na nuvem (DRaaS, Disaster Recovery as a Service)**, replicando ambientes em provedores de nuvem, o que reduz custo fixo e aumenta a flexibilidade de escala durante a recuperação."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Tipo de site\", \"Tempo de retomada\", \"Custo\", \"Prontidão\"], [\"Hot site\", \"Minutos a poucas horas\", \"Alto\", \"Réplica quase completa, dados atualizados\"], [\"Warm site\", \"Horas a um ou dois dias\", \"Médio\", \"Infraestrutura pronta, dados precisam ser restaurados\"], [\"Cold site\", \"Dias a semanas\", \"Baixo\", \"Apenas espaço físico e utilidades básicas\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Escolhendo o site certo: uma decisão de negócio, não só técnica\n\nA escolha entre hot, warm e cold site não é uma preferência técnica isolada: precisa estar alinhada ao RTO definido na BIA. Não faz sentido pagar por um hot site caríssimo para um sistema que a empresa consegue tolerar ficar fora do ar por uma semana. Da mesma forma, um sistema de missão crítica com RTO de minutos não pode depender de um cold site.\n\nExiste ainda a opção de **acordos recíprocos**, em que duas organizações com infraestrutura semelhante combinam ceder espaço uma à outra em caso de desastre. Funciona, mas exige disciplina para manter as infraestruturas compatíveis ao longo do tempo, por isso é uma opção menos comum hoje em dia."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "DR é o braço técnico da continuidade de negócios: restaura sistemas, dados e infraestrutura dentro do RTO e do RPO definidos. A escolha entre hot, warm e cold site, ou DR na nuvem, deve refletir quanto tempo de indisponibilidade cada sistema realmente tolera, não o orçamento disponível no momento."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual é o principal foco da Recuperação de Desastres (DR) dentro do programa de continuidade de negócios?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Definir as políticas de senha da organização.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Substituir integralmente o processo de resposta a incidentes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Gerenciar a comunicação com clientes e imprensa durante a crise.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Restaurar tecnicamente sistemas, dados e infraestrutura de TI dentro dos objetivos de tempo e ponto de recuperação definidos.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual tipo de site alternativo oferece apenas espaço físico, energia e conectividade básica, exigindo que hardware e dados sejam providenciados no momento do desastre?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Hot site",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Cold site",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Warm site",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Acordo recíproco entre duas empresas com infraestrutura semelhante.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma bolsa de valores precisa que seu sistema de negociação volte a operar em, no máximo, poucos minutos após qualquer falha catastrófica, dado o impacto financeiro de cada minuto parado. Qual estratégia de site alternativo melhor atende a essa exigência?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Hot site, com réplica quase em tempo real do ambiente de produção.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Cold site, por ter menor custo de manutenção.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Warm site, por oferecer equilíbrio entre custo e velocidade.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Acordo recíproco com outra bolsa de valores da região.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma clínica de diagnóstico por imagem sofreu um incêndio que destruiu seu servidor local. Ao tentar restaurar os exames a partir dos backups, a equipe descobre que os arquivos mais recentes estavam corrompidos e nunca haviam sido testados antes. Isso evidencia principalmente a ausência de qual componente do plano de recuperação de desastres?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Inventário de ativos críticos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Site alternativo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Testes periódicos do plano e dos backups.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Política de continuidade de negócios.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma empresa de médio porte tem um sistema de RH com RTO de três dias, considerado não crítico para a operação diária. Atualmente, ela mantém um hot site custoso dedicado a esse sistema. Do ponto de vista de gestão de continuidade, qual ação é mais recomendada?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Manter o hot site, pois quanto mais rápida a recuperação, melhor em qualquer cenário.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Eliminar completamente os backups do sistema de RH, já que ele não é crítico.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Transferir a responsabilidade pelo sistema de RH para a equipe de resposta a incidentes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Migrar o sistema de RH para um warm site ou cold site, já que o RTO de três dias não justifica o custo de um hot site.",
+                                "isCorrect": true
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Resposta a Incidentes: propósito, componentes e papéis da equipe",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Aula 4: Resposta a Incidentes: propósito, componentes e papéis da equipe\n\nAté aqui você viu como a organização se prepara para continuar funcionando (BC) e como restaura sua infraestrutura técnica (DR). Mas antes de qualquer recuperação, alguém precisa perceber que algo deu errado, entender o que está acontecendo e agir para conter o problema. Essa é a função da **Resposta a Incidentes**, ou **Incident Response (IR)**.\n\nUm incidente de segurança é qualquer evento que viole, ou ameace violar, a confidencialidade, a integridade ou a disponibilidade de um ativo de informação. Pode ser um ataque de ransomware, um vazamento de dados, um funcionário que clicou em um link malicioso ou um acesso indevido a um sistema crítico."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Propósito e importância da resposta a incidentes\n\nO propósito da resposta a incidentes é detectar, conter e resolver incidentes de segurança de forma rápida e organizada, reduzindo o dano, o custo e o tempo de recuperação. Sem um processo definido, cada incidente vira uma reação improvisada, e isso quase sempre piora a situação: evidências são destruídas sem querer, a comunicação sai desalinhada, e decisões importantes, como desligar um servidor comprometido, são tomadas sem considerar o impacto no negócio.\n\nA resposta a incidentes é importante porque a pergunta relevante não é mais \"vamos sofrer um incidente?\", e sim \"quando sofrermos, quão rápido e quão bem vamos reagir?\". Organizações com um processo de IR maduro reduzem bastante o tempo entre a detecção e a contenção de um ataque, o que limita diretamente o estrago."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Componentes de um programa de resposta a incidentes\n\n- **Política de resposta a incidentes**: documento de alto nível que define o que conta como incidente, a autoridade da equipe de resposta e o compromisso da organização com o processo.\n- **Plano de resposta a incidentes**: o \"como fazer\" operacional, detalhando o ciclo de vida do incidente (assunto da próxima aula).\n- **Equipe de resposta a incidentes**: pessoas com papéis definidos, treinadas para agir sob pressão.\n- **Ferramentas e recursos**: sistemas de monitoramento, SIEM, e canais de comunicação reservados para uso durante uma crise, que idealmente não dependem da infraestrutura que pode estar comprometida.\n- **Critérios de classificação e priorização**: nem todo incidente é igual. Um phishing isolado não recebe a mesma resposta que um ransomware ativo se espalhando pela rede.\n- **Procedimentos de comunicação**: para dentro (liderança, equipe técnica) e para fora (clientes, reguladores, imprensa, autoridades), incluindo, no Brasil, as obrigações de notificação relacionadas à LGPD em casos de vazamento de dados pessoais."
+                    },
+                    {
+                        "type": "code",
+                        "value": "Exemplo de critério de classificação de severidade de incidentes:\n\nSEV-1 (Crítico): sistema de produção totalmente indisponível ou dados sensíveis expostos publicamente. Resposta imediata, equipe completa acionada.\nSEV-2 (Alto): funcionalidade crítica degradada ou incidente de segurança confirmado, sem exposição pública ainda. Resposta em até 1 hora.\nSEV-3 (Médio): incidente isolado, impacto limitado a poucos usuários ou sistemas não críticos. Resposta em até 4 horas.\nSEV-4 (Baixo): evento suspeito sem confirmação de comprometimento. Monitoramento reforçado, resposta em até 24 horas."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Quem faz parte da equipe de resposta a incidentes\n\nA equipe de resposta a incidentes, muitas vezes chamada de **CSIRT (Computer Security Incident Response Team)** ou **IRT (Incident Response Team)**, reúne pessoas de diferentes áreas, porque um incidente sério nunca é só um problema técnico:\n\n- **Gestor do incidente (Incident Manager)**: coordena a resposta, toma decisões e é o ponto central de comando durante a crise.\n- **Analistas de segurança / equipe técnica**: investigam, contêm e erradicam a causa do incidente.\n- **Jurídico**: avalia obrigações legais, contratuais e regulatórias, incluindo notificações obrigatórias.\n- **Comunicação / relações públicas**: cuida da mensagem para clientes, imprensa e público.\n- **Recursos humanos**: envolvido quando o incidente tem origem interna, como um funcionário.\n- **Liderança executiva (sponsor)**: garante recursos e toma decisões de alto impacto, como pagar ou não um resgate de ransomware.\n\nEm empresas menores, uma mesma pessoa pode acumular mais de um papel, mas os papéis em si continuam existindo e precisam estar claros antes que o incidente aconteça."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Papel\", \"Responsabilidade principal\"], [\"Gestor do incidente\", \"Coordenar a resposta e centralizar as decisões durante a crise\"], [\"Analista de segurança / técnico\", \"Investigar, conter e erradicar a causa do incidente\"], [\"Jurídico\", \"Avaliar obrigações legais, contratuais e regulatórias\"], [\"Comunicação\", \"Gerenciar a mensagem para clientes, imprensa e público\"], [\"Recursos humanos\", \"Atuar quando o incidente envolve funcionários\"], [\"Liderança executiva\", \"Garantir recursos e aprovar decisões de alto impacto\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "A resposta a incidentes existe para detectar, conter e resolver eventos de segurança de forma rápida e organizada, reduzindo dano e tempo de recuperação. Ela depende de uma política, um plano operacional, critérios claros de classificação e uma equipe multidisciplinar com papéis definidos antes que a crise comece."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que caracteriza um incidente de segurança?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Apenas ataques realizados por invasores externos à organização.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Somente eventos que resultam em perda financeira comprovada.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Qualquer evento que viole, ou ameace violar, a confidencialidade, a integridade ou a disponibilidade de um ativo de informação.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Qualquer falha de hardware, mesmo sem qualquer impacto na segurança da informação.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual é o propósito principal da resposta a incidentes (IR)?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Detectar, conter e resolver incidentes de segurança de forma rápida e organizada, reduzindo dano e tempo de recuperação.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Eliminar permanentemente a possibilidade de novos incidentes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Substituir o plano de recuperação de desastres.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Definir o orçamento anual de segurança da informação.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Durante um ataque de ransomware em andamento, a equipe técnica quer desligar imediatamente todos os servidores, mas essa decisão pode causar perda de dados em transações não finalizadas e afetar clientes em tempo real. Segundo as boas práticas de resposta a incidentes, quem deve centralizar esse tipo de decisão de alto impacto?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O primeiro analista de segurança que perceber o ataque, para agilizar a resposta.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A equipe de comunicação, por ser responsável pela imagem da empresa perante o público.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O time de recursos humanos, por lidar com questões internas da equipe.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O gestor do incidente (Incident Manager), que coordena a resposta considerando os diferentes impactos envolvidos.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma empresa brasileira sofre um vazamento de dados pessoais de clientes. Além da contenção técnica do incidente, qual outra ação é esperada em função da LGPD?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Aguardar seis meses antes de qualquer comunicação, para evitar alarde desnecessário.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Avaliar e, se aplicável, cumprir a obrigação de notificação às autoridades competentes e aos titulares afetados.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Divulgar publicamente as credenciais dos titulares afetados para transparência total.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Transferir automaticamente a responsabilidade legal para o provedor de nuvem contratado.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma pequena empresa de tecnologia não tem um CSIRT dedicado; um mesmo analista de TI acumula funções técnicas e de comunicação durante incidentes. Do ponto de vista de resposta a incidentes, qual afirmação está correta sobre essa situação?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "A empresa está automaticamente fora de conformidade, já que resposta a incidentes exige uma equipe dedicada de tempo integral.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Nesse caso, a resposta a incidentes deve ser totalmente terceirizada para um fornecedor externo, sem exceção.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "É aceitável que uma pessoa acumule papéis em empresas pequenas, desde que os papéis estejam claramente definidos e a pessoa esteja preparada para exercê-los.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Os papéis de resposta a incidentes só se aplicam a empresas com mais de quinhentos funcionários.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "O ciclo de vida da resposta a incidentes: da preparação às lições aprendidas",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Aula 5: O ciclo de vida da resposta a incidentes: da preparação às lições aprendidas\n\nNa aula anterior você conheceu o propósito, os componentes e os papéis da resposta a incidentes. Agora é hora de entender a sequência de fases que guia a equipe do início ao fim de um incidente, o ciclo de vida da resposta a incidentes. O exame CC da ISC2 espera que você reconheça e saiba aplicar seis fases: preparação, detecção, contenção, erradicação, recuperação e lições aprendidas.\n\nVale lembrar que esse ciclo raramente é uma linha reta. É comum voltar a uma fase anterior, por exemplo descobrir durante a erradicação que a contenção não foi completa, antes de seguir adiante."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## 1. Preparação\n\nA preparação acontece antes de qualquer incidente, e é a fase que mais determina o sucesso das demais. Inclui criar e manter a política e o plano de resposta a incidentes, montar e treinar a equipe, definir ferramentas de monitoramento e comunicação, e realizar exercícios simulados.\n\nUma equipe bem preparada sabe, sem precisar pensar, qual o primeiro telefonema a fazer e qual o primeiro log a consultar. Isso só existe porque foi ensaiado antes."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## 2. Detecção\n\nA detecção é o momento em que a organização percebe que algo fora do padrão está acontecendo: um alerta de um sistema de monitoramento, um usuário relatando um comportamento estranho, um analista de SOC notando tráfego incomum. Nessa fase, a equipe também faz uma análise inicial para confirmar se realmente é um incidente de segurança, e não, por exemplo, uma falha de configuração sem intenção maliciosa, além de avaliar a gravidade e o escopo do problema.\n\nQuanto mais cedo um incidente é detectado, menor tende a ser o dano. Por isso, o investimento em monitoramento contínuo, incluindo ferramentas de segurança apoiadas por IA capazes de identificar padrões anômalos mais rápido que uma análise manual, é parte central dessa fase."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## 3. Contenção e 4. Erradicação\n\n**Contenção** é limitar o dano, impedindo que o incidente se espalhe ou piore, sem necessariamente já ter resolvido a causa raiz. Pode envolver isolar uma máquina infectada da rede, desabilitar uma conta comprometida ou bloquear um endereço IP malicioso. Boas práticas costumam separar contenção de curto prazo (uma ação rápida para estancar o problema, como desconectar um cabo de rede) de contenção de longo prazo (uma medida mais estruturada, como aplicar um patch temporário, enquanto a solução definitiva é preparada).\n\n**Erradicação** é remover completamente a causa do incidente do ambiente: eliminar o malware, fechar a vulnerabilidade explorada, remover contas ou acessos criados indevidamente pelo invasor. Erradicar sem antes conter bem o incidente é um erro comum, porque o invasor pode ainda ter outros pontos de acesso ativos."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## 5. Recuperação e 6. Lições aprendidas\n\n**Recuperação** é restaurar os sistemas afetados ao funcionamento normal, de forma controlada, com monitoramento reforçado para garantir que o problema não volte. Aqui, a resposta a incidentes se conecta diretamente com a recuperação de desastres: restaurar um servidor a partir de um backup limpo, validar a integridade dos dados e só então liberar o sistema de volta à produção.\n\n**Lições aprendidas** é a última fase, muitas vezes negligenciada sob a pressão do dia a dia. Consiste em revisar o que aconteceu: o que funcionou, o que falhou, o que poderia ter sido detectado mais cedo. O resultado é um relatório pós-incidente que alimenta melhorias reais na política, no plano, nas ferramentas e no treinamento. Pular essa fase é condenar a organização a repetir os mesmos erros no próximo incidente."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Fase\", \"Objetivo principal\"], [\"Preparação\", \"Criar políticas, planos, equipe treinada e ferramentas antes que um incidente aconteça\"], [\"Detecção\", \"Identificar e confirmar que um evento é, de fato, um incidente de segurança\"], [\"Contenção\", \"Limitar o dano e impedir que o incidente se espalhe\"], [\"Erradicação\", \"Eliminar completamente a causa raiz do incidente do ambiente\"], [\"Recuperação\", \"Restaurar os sistemas afetados ao funcionamento normal com segurança\"], [\"Lições aprendidas\", \"Revisar o incidente e transformar os aprendizados em melhorias concretas\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "O ciclo de vida da resposta a incidentes segue seis fases: preparação, detecção, contenção, erradicação, recuperação e lições aprendidas. A preparação define o quão bem a equipe reage, e as lições aprendidas garantem que cada incidente deixe a organização mais forte para o próximo."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Quais são as seis fases do ciclo de vida da resposta a incidentes, segundo o corpo de conhecimento do CC?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Preparação, detecção, contenção, erradicação, recuperação e lições aprendidas.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Planejamento, execução, monitoramento, controle e encerramento.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Identificação, classificação, criptografia, backup e auditoria.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Prevenção, detecção, resposta, mitigação e certificação.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Em qual fase do ciclo de vida a equipe de resposta a incidentes cria e mantém a política, o plano, e treina as pessoas antes de qualquer incidente acontecer?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Detecção",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Contenção",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Lições aprendidas",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Preparação",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um analista percebe um ransomware se espalhando pela rede interna e imediatamente desconecta o cabo de rede da máquina infectada, sem ainda remover o malware. Essa ação corresponde a qual fase do ciclo de vida da resposta a incidentes?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Detecção",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Contenção",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Erradicação",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Recuperação",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de restaurar os sistemas afetados por um incidente e encerrar a crise, a equipe de segurança se reúne com as áreas envolvidas para discutir o que funcionou, o que falhou e quais melhorias implementar no plano de resposta. Essa reunião corresponde a qual fase?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Lições aprendidas",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Recuperação",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Erradicação",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Preparação",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Durante a resposta a um incidente, a equipe técnica remove rapidamente o malware de todos os servidores afetados, mas não isola previamente os sistemas comprometidos da rede. Dias depois, os mesmos servidores voltam a ser infectados pela mesma ameaça. Qual erro no ciclo de vida da resposta a incidentes melhor explica essa recorrência?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "A fase de detecção foi executada rápido demais, sem tempo suficiente de monitoramento.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A fase de lições aprendidas não gerou nenhum relatório escrito.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A erradicação foi feita antes de uma contenção adequada, permitindo que o invasor mantivesse outros pontos de acesso ativos na rede.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A equipe pulou a fase de recuperação e foi direto para a fase de preparação.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 4 - Controle de Acesso",
+        "aulas": [
+            {
+                "titulo": "Fundamentos do Controle de Acesso e o Modelo AAA",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Módulo 4 - Controle de Acesso\n\n## Aula 1: Fundamentos do Controle de Acesso e o Modelo AAA\n\nControle de acesso é a área da segurança que responde a uma pergunta simples de enunciar e difícil de implementar bem: quem pode fazer o quê, em qual recurso, e sob quais condições. Essa pergunta vale tanto para um prédio (quem pode entrar na sala de servidores) quanto para um sistema (quem pode ler ou alterar um cadastro de clientes).\n\nNo exame CC da ISC2, o Domínio 3 trata exatamente disso: os conceitos que sustentam o controle de acesso físico e o controle de acesso lógico. Os dois mundos usam a mesma lógica de fundo, e é essa lógica que vamos construir nesta aula antes de entrar nos detalhes de cada tipo de controle nas próximas aulas."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O modelo AAA\n\nA maioria dos sistemas de controle de acesso, físicos ou lógicos, pode ser descrita em quatro etapas conhecidas como AAA: Identificação, Autenticação, Autorização e Auditoria (Accounting).\n\n- **Identificação**: a pessoa declara quem ela é. É apresentar um crachá com nome, digitar um nome de usuário, ou informar um número de matrícula.\n- **Autenticação**: a pessoa prova que é quem diz ser. É a senha, a biometria, o PIN do crachá, o token. Já vimos os fatores de autenticação (algo que você sabe, tem ou é) no Módulo 1, e eles se aplicam integralmente aqui.\n- **Autorização**: definido quem a pessoa é, o sistema decide o que ela pode fazer. Ter um crachá válido não significa que ele abre todas as portas do prédio, assim como ter uma senha válida não significa acesso a todos os sistemas.\n- **Auditoria (accounting)**: o sistema registra o que foi feito, por quem e quando. É o que permite reconstruir os fatos depois de um incidente."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Etapa\", \"Pergunta que responde\", \"Exemplo físico\", \"Exemplo lógico\"], [\"Identificação\", \"Quem você diz que é?\", \"Nome no crachá\", \"Nome de usuário\"], [\"Autenticação\", \"Você é mesmo essa pessoa?\", \"Biometria na catraca\", \"Senha ou token MFA\"], [\"Autorização\", \"O que você pode fazer?\", \"Crachá abre só o andar do seu setor\", \"Perfil de usuário permite editar, mas não excluir\"], [\"Auditoria\", \"O que foi feito, quando e por quem?\", \"Log de entrada e saída da catraca\", \"Log de eventos do sistema\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Controle físico e controle lógico trabalham juntos\n\nControle de acesso físico protege espaços, pessoas e equipamentos: quem entra em um prédio, em uma sala, em um datacenter. Controle de acesso lógico protege dados e sistemas: quem lê um arquivo, quem executa um programa, quem administra um servidor.\n\nOs dois não são alternativas um ao outro, são camadas complementares. Um datacenter bem protegido normalmente exige um crachá válido para entrar fisicamente na sala e, dentro dela, ainda exige login e senha para acessar qualquer servidor. Se um invasor conseguir contornar o controle físico, o controle lógico continua sendo a segunda barreira, e vice versa. Essa combinação de camadas independentes é uma aplicação direta do conceito de defesa em profundidade."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Por que isso importa na prática\n\nA maior parte dos incidentes de controle de acesso não acontece porque a tecnologia falhou, acontece porque um processo foi ignorado ou mal desenhado. Alguém segura a porta para um desconhecido sem crachá. Uma conta de ex-funcionário continua ativa meses depois do desligamento. Um usuário recebe acesso de administrador porque era mais rápido do que configurar o perfil certo.\n\nNas próximas aulas vamos detalhar o controle físico (Aulas 2 e 3) e o controle lógico, incluindo os modelos DAC, MAC e RBAC e o papel da inteligência artificial na detecção de anomalias de acesso (Aulas 4 e 5)."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Controle de acesso é sempre a mesma pergunta aplicada a contextos diferentes: quem é você (identificação), como provar isso (autenticação), o que você pode fazer (autorização) e como isso fica registrado (auditoria). Domine essas quatro etapas e o resto do domínio fica muito mais fácil de encaixar."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "No modelo AAA de controle de acesso, o que a etapa de autenticação verifica?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Se a pessoa é realmente quem ela diz ser, por meio de uma prova como senha, biometria ou token",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Quais recursos a pessoa está autorizada a acessar depois de entrar no sistema",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O histórico de ações que a pessoa realizou no sistema",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O nome de usuário que a pessoa digitou para se identificar",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma empresa exige crachá válido para abrir a porta da sala de servidores e, dentro dela, exige login e senha para acessar qualquer servidor. Essa combinação de duas barreiras independentes é um exemplo de:",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Defesa em profundidade, combinando controle de acesso físico e lógico",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Redundância desnecessária, já que um dos dois controles poderia ser removido",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Violação do princípio do menor privilégio",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Substituição do controle lógico pelo controle físico",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de um incidente de segurança, a equipe analisa os registros de conexões VPN para descobrir quem se conectou e em que horário. Essa análise corresponde a qual etapa do modelo AAA?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Autorização",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Autenticação",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Auditoria (accounting)",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Identificação",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Ao fazer login em um sistema, um usuário primeiro digita o nome de usuário \"jsilva\" e depois digita sua senha. Essas duas ações correspondem, respectivamente, a quais etapas do controle de acesso?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Identificação, seguida de autenticação",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Autenticação, seguida de autorização",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Autorização, seguida de auditoria",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Identificação, seguida de autorização",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma empresa investe em fechaduras robustas, crachás e câmeras em todas as portas, mas concede a todos os funcionários autenticados acesso de administrador a todos os sistemas internos. Qual é o principal risco dessa combinação?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O controle físico está fraco demais para compensar a falta de controle lógico",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A ausência de um controle lógico adequado permite acesso amplo demais aos sistemas para qualquer funcionário autenticado, mesmo com o ambiente físico bem protegido",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "As câmeras se tornam desnecessárias quando o acesso físico já é forte",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A auditoria deixa de ser necessária quando o controle físico é robusto",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Controle de Acesso Físico: Barreiras, Prevenção e CPTED",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Aula 2: Controle de Acesso Físico: Barreiras, Prevenção e CPTED\n\nControle de acesso físico é o conjunto de medidas que restringe fisicamente quem entra em um local: um prédio, um escritório, uma sala de servidores. O objetivo não é só impedir a entrada de estranhos mal intencionados, é também garantir que pessoas autorizadas só cheguem às áreas que realmente precisam, seguindo o mesmo princípio de menor privilégio que vamos formalizar na Aula 4.\n\nNesta aula o foco está nos controles preventivos, aqueles que existem para impedir ou dificultar o acesso indevido antes que ele aconteça. Na Aula 3 entramos nos controles de monitoramento e detecção."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## CPTED: prevenção ao crime pelo desenho do ambiente\n\nCPTED (Crime Prevention Through Environmental Design, prevenção ao crime através do desenho ambiental) é uma abordagem que usa a arquitetura e o paisagismo do próprio ambiente para reduzir oportunidades de invasão, antes de qualquer câmera ou guarda entrar em cena. A ideia central é que o espaço físico, bem desenhado, já desestimula comportamento indevido.\n\nQuatro princípios sustentam o CPTED:\n\n- **Vigilância natural**: manter linhas de visão abertas (iluminação adequada, paisagismo baixo, janelas voltadas para áreas de circulação) para que qualquer pessoa em um espaço consiga enxergar e ser vista.\n- **Controle de acesso natural**: usar a própria disposição física (uma única entrada principal, corredores que direcionam o fluxo até a recepção) para guiar visitantes por um caminho previsível, sem depender só de placas ou guardas.\n- **Reforço territorial**: marcar visualmente onde termina o espaço público e começa o espaço privado, com cercas baixas, calçadas diferenciadas ou portões, para que qualquer pessoa perceba que está entrando em uma área controlada.\n- **Manutenção**: um ambiente limpo, bem cuidado e sem sinais de abandono transmite a mensagem de que o local é monitorado e cuidado, o que por si só reduz a atratividade para invasores (o mesmo raciocínio da teoria das janelas quebradas)."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Princípio de CPTED\", \"O que significa\", \"Exemplo prático\"], [\"Vigilância natural\", \"Permitir que as pessoas vejam e sejam vistas\", \"Iluminação forte no estacionamento e recepção com vidro\"], [\"Controle de acesso natural\", \"Guiar o fluxo de pessoas por um caminho único\", \"Um só portão de entrada que leva direto à recepção\"], [\"Reforço territorial\", \"Sinalizar a transição de área pública para privada\", \"Cerca baixa e portão na entrada do terreno\"], [\"Manutenção\", \"Ambiente cuidado desestimula invasões\", \"Jardim aparado e lâmpadas trocadas assim que queimam\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Mecanismos de controle físico\n\nAlém do desenho do ambiente, o controle de acesso físico usa mecanismos concretos para restringir a entrada:\n\n- **Crachás (badges)**: identificam o portador e, quando combinados com um leitor eletrônico, autenticam e autorizam a entrada em áreas específicas.\n- **Catracas (turnstiles)**: barreiras físicas que só liberam a passagem de uma pessoa por vez, mediante credencial válida.\n- **Portais de dupla checagem (mantraps ou access control vestibules)**: uma pequena câmara com duas portas que nunca abrem ao mesmo tempo. A primeira porta só libera a segunda depois de fechar e validar a credencial, o que impede que duas pessoas passem juntas com uma única autenticação.\n- **Guardas de segurança**: além de vigiar, verificam credenciais, respondem a incidentes e aplicam julgamento humano em situações que um sistema automatizado não resolveria sozinho.\n- **Fechaduras, cercas e portões**: barreiras físicas básicas, mas ainda essenciais como primeira camada de dissuasão e atraso.\n\nCada um desses mecanismos pode ser classificado nos tipos de controle que vimos no Módulo 2: a maioria é preventiva (impede o acesso antes que aconteça), mas alguns também têm função detectiva quando geram registro do que aconteceu."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Pessoal autorizado x não autorizado\n\nUm programa de controle de acesso físico só funciona se a organização souber, a qualquer momento, quem tem autorização para estar em cada área. Isso envolve:\n\n- **Gestão de visitantes**: todo visitante se identifica, assina um registro de entrada, recebe um crachá temporário claramente diferente do crachá de funcionário, e idealmente é acompanhado (escoltado) enquanto estiver nas dependências.\n- **Escolta obrigatória em áreas sensíveis**: em salas de servidores ou áreas restritas, mesmo um visitante com crachá temporário não deve circular sozinho.\n- **Revisão periódica de quem tem crachá ativo**: crachás de ex-funcionários ou prestadores de serviço que já encerraram contrato precisam ser desativados imediatamente, não em uma revisão trimestral.\n\nO ataque clássico contra esse tipo de controle é o **tailgating** (também chamado de piggybacking): uma pessoa sem credencial entra logo atrás de alguém autorizado, aproveitando a porta que ainda não fechou. Catracas e mantraps existem justamente para tornar esse tipo de ataque mais difícil, já que limitam fisicamente a passagem a uma pessoa por validação."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Controle de acesso físico preventivo não depende de uma única barreira, e sim da combinação de desenho do ambiente (CPTED), mecanismos físicos (crachá, catraca, mantrap) e processo (gestão de visitantes, desligamento de acesso). Tire qualquer uma dessas camadas e o tailgating vira o caminho mais fácil para entrar."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que é uma catraca (turnstile) no contexto de controle de acesso físico?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Uma barreira que libera a passagem de apenas uma pessoa por vez, mediante credencial válida",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um sistema de câmeras que grava continuamente a entrada de um prédio",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um software que autentica usuários em sistemas internos da empresa",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um tipo de alarme sonoro acionado por movimento",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual das situações a seguir é um exemplo de tailgating (piggybacking)?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Uma pessoa sem crachá entra no prédio logo atrás de um funcionário autorizado, aproveitando a porta que ainda não fechou",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um visitante assina o livro de registro na recepção antes de entrar",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um funcionário passa o próprio crachá duas vezes seguidas na mesma catraca",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um guarda revista a bolsa de um visitante antes da entrada",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma empresa quer reduzir o tailgating na entrada do datacenter sem depender exclusivamente da atenção constante de um guarda. Qual controle é mais eficaz para esse objetivo específico?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Aumentar a iluminação externa do prédio",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Instalar um portal de dupla checagem (mantrap) que só libera a segunda porta depois que a primeira fecha e valida uma única credencial por vez",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Adicionar mais câmeras de CFTV na área de entrada",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Trocar as fechaduras das portas por modelos mais robustos",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma empresa reformou o estacionamento e a entrada do prédio para ter linhas de visão abertas, paisagismo baixo e iluminação melhor, sem adicionar câmeras ou guardas novos. Qual princípio de CPTED essa mudança aplica principalmente?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Reforço territorial",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Vigilância natural",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Controle de acesso natural",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Manutenção",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Na recepção de uma empresa, visitantes assinam um livro de registro e recebem um crachá temporário de \"visitante\", mas depois disso circulam pelo prédio sem qualquer acompanhamento. Qual é a principal fragilidade desse processo?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O crachá temporário deveria ter uma cor diferente do crachá de funcionário",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A ausência de acompanhamento (escolta) permite que o visitante circule livremente por áreas não autorizadas, mesmo estando formalmente identificado",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um livro de registro em papel é sempre menos seguro que um sistema eletrônico",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A recepção deveria ficar em um andar mais alto do prédio",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Controle de Acesso Físico: Monitoramento, Detecção e Resposta",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Aula 3: Controle de Acesso Físico: Monitoramento, Detecção e Resposta\n\nNenhuma barreira física é perfeita. Cercas são escaladas, catracas falham, crachás são clonados ou emprestados. Por isso um programa maduro de segurança física não aposta tudo na prevenção: ele também monitora, detecta e responde quando algo foge do esperado.\n\nUm modelo clássico para organizar essas camadas é pensar em quatro funções: **dissuadir** (deter), **detectar**, **atrasar** (delay) e **responder**. A Aula 2 cobriu principalmente dissuasão e atraso. Esta aula cobre detecção e resposta."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## CFTV / CCTV\n\nO circuito fechado de televisão (CFTV, ou CCTV em inglês) é o uso de câmeras para monitorar e gravar áreas físicas. Ele cumpre três papéis ao mesmo tempo:\n\n- **Dissuasão**: a simples presença visível de câmeras já reduz a disposição de alguém tentar um acesso indevido.\n- **Detecção em tempo real**: quando monitorado ao vivo por um guarda ou central de segurança, permite reagir enquanto o evento ainda está acontecendo.\n- **Evidência**: gravações permitem reconstruir o que aconteceu durante uma investigação, mesmo que ninguém tenha visto o evento ao vivo.\n\nDuas decisões práticas importam bastante: por quanto tempo as gravações ficam retidas (retenção) e se as câmeras são só gravadas ou também monitoradas ao vivo. Câmera não monitorada e sem retenção adequada perde boa parte do seu valor como controle detectivo."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Alarmes e sensores\n\nAlarmes de intrusão usam sensores para detectar eventos fora do esperado: sensor de abertura de porta ou janela, sensor de movimento em uma área que deveria estar vazia fora do expediente, sensor de quebra de vidro. Quando acionado, o alarme deve gerar uma resposta, seja o deslocamento de um guarda, uma notificação para a central de monitoramento, ou o acionamento de autoridades externas.\n\nVale destacar também os **alarmes de coação (duress alarms)**, botões de pânico discretos que um funcionário pode acionar em uma situação de ameaça, sem alertar visivelmente quem está causando o problema. Como qualquer controle detectivo, um alarme só tem valor se houver um processo de resposta definido do outro lado."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Componente\", \"Categoria principal\", \"Exemplo de uso\"], [\"Guarda de segurança\", \"Preventivo e detectivo\", \"Patrulha, verificação de crachás, resposta a alarmes\"], [\"CFTV / CCTV\", \"Detectivo\", \"Gravação contínua da entrada principal\"], [\"Alarme de intrusão\", \"Detectivo\", \"Sensor aciona ao detectar porta aberta fora do horário\"], [\"Catraca e crachá\", \"Preventivo\", \"Bloqueia entrada sem credencial válida\"], [\"Log de acesso físico\", \"Detectivo\", \"Registra quem entrou, onde e quando\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Logs de acesso físico\n\nTodo evento relevante de entrada e saída deveria gerar um registro: qual credencial foi usada, em qual porta, em que horário, se o acesso foi concedido ou negado. Esses logs são o que permite, depois de um incidente, responder perguntas como quem esteve em uma sala ontem à noite, ou se um determinado crachá foi usado em dois lugares ao mesmo tempo, o que é fisicamente impossível e sugere clonagem.\n\nO valor de um log de acesso cresce quando ele é correlacionado com outras fontes, principalmente o CFTV: o log diz quem e quando, a imagem confirma se foi realmente aquela pessoa usando aquela credencial."
+                    },
+                    {
+                        "type": "code",
+                        "value": "Exemplo simplificado de log de acesso físico:\n\n2026-07-08 08:12:03 | Crachá #4521 | Ana Souza | Porta Principal | Entrada AUTORIZADA\n2026-07-08 08:12:47 | Crachá #4521 | Ana Souza | Sala de Servidores | Entrada NEGADA (sem permissão para esta área)\n2026-07-08 19:47:12 | Crachá #4521 | Ana Souza | Porta Principal | Entrada AUTORIZADA (fora do horário habitual deste usuário)"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Prevenção reduz a chance de um acesso indevido acontecer, mas é a combinação de CFTV, alarmes e logs que permite perceber quando algo passou pela prevenção, e reunir as evidências para investigar. Guarde este exemplo de log: vamos retomar exatamente esse tipo de padrão anômalo na Aula 5, quando falarmos de IA aplicada à detecção de anomalias de acesso."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual é a principal função do CFTV (circuito fechado de TV) em um programa de segurança física?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Impedir fisicamente a entrada de pessoas não autorizadas",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Permitir monitoramento e registro de atividades para dissuasão, detecção e investigação",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Autenticar funcionários por biometria facial em toda porta do prédio",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Substituir totalmente a necessidade de guardas de segurança",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O que um alarme de intrusão tipicamente detecta?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Tentativas de login malsucedidas em sistemas corporativos",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Eventos como abertura de porta fora do horário esperado ou quebra de vidro",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Vulnerabilidades em aplicações web",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Falhas de energia no datacenter",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de um furto de equipamentos na sala de servidores durante a madrugada, a equipe de segurança quer reconstruir o que aconteceu. Qual combinação de fontes de informação física é mais útil nessa investigação?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Apenas as gravações de CFTV, já que elas registram tudo sozinhas",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os logs de acesso físico correlacionados com as gravações de CFTV do mesmo horário",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Somente o livro de registro de visitantes da recepção",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Apenas a política interna de emissão de crachás",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma cerca alta com iluminação forte ao redor do perímetro de um datacenter cumpre principalmente qual papel no modelo de camadas de segurança física (dissuasão, detecção, atraso, resposta)?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Detecção",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Dissuasão e, em menor grau, atraso",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Resposta",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Auditoria",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Os logs mostram que o crachá de um funcionário teve entrada negada na sala de servidores às 8h12 (sem permissão para a área) e entrada autorizada pela porta principal às 19h47, fora do horário habitual desse funcionário. Qual é a ação mais adequada diante desse padrão?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Ignorar, já que o acesso à sala de servidores foi corretamente negado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Investigar o padrão como uma possível anomalia de comportamento, já que combina uma tentativa de acesso não autorizado com um horário atípico",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Desativar o CFTV da área, já que os logs já registraram o necessário",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Trocar a fechadura da porta principal imediatamente, sem investigar o padrão",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Controle de Acesso Lógico: Privilégio Mínimo e Segregação de Funções",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Aula 4: Controle de Acesso Lógico: Privilégio Mínimo e Segregação de Funções\n\nControle de acesso lógico (também chamado de controle de acesso técnico) é o conjunto de mecanismos que restringe o acesso a sistemas, redes e dados: login e senha, permissões de arquivo, perfis de usuário em uma aplicação, regras de firewall. É o mesmo tipo de controle técnico que vimos no Módulo 2, agora aplicado especificamente à pergunta de quem pode acessar o quê dentro dos sistemas.\n\nAntes de chegar aos modelos formais de controle de acesso (DAC, MAC e RBAC, que veremos na Aula 5), esta aula cobre dois princípios que deveriam orientar qualquer decisão de acesso lógico, independente do modelo escolhido: menor privilégio e segregação de funções."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Princípio do menor privilégio\n\nO princípio do menor privilégio (least privilege) estabelece que cada usuário, processo ou sistema deve receber apenas o nível mínimo de acesso necessário para realizar sua função, nada além disso.\n\nPense em um prédio onde cada funcionário recebe apenas as chaves das salas que precisa usar no dia a dia, em vez de um molho com a chave mestra do prédio inteiro. Se uma dessas chaves for perdida ou copiada, o dano possível fica limitado àquela sala, não ao prédio todo. O mesmo raciocínio vale para uma conta de sistema: se um analista de suporte só tem acesso ao sistema de chamados, uma senha vazada dele não compromete o banco de dados financeiro.\n\nUm conceito próximo e complementar é o de **necessidade de conhecer (need-to-know)**: mesmo dentro do que o cargo permitiria, uma pessoa só deveria ver uma informação específica se ela realmente precisar dela para o trabalho no momento. Um investigador de fraudes pode ter permissão de sistema para abrir qualquer caso, mas na prática só deveria abrir os casos que estão sob sua responsabilidade."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Segregação de funções (Segregation of Duties)\n\nSegregação de funções, também chamada de separação de funções (SoD), é o princípio de que nenhuma pessoa sozinha deveria controlar todas as etapas de um processo crítico, do início ao fim. O objetivo é duplo: dificultar fraude (seria necessário que duas ou mais pessoas se conluiassem) e reduzir erro (uma segunda pessoa revisando o trabalho tende a detectar enganos).\n\nExemplos clássicos:\n\n- A pessoa que **solicita** uma compra não deveria ser a mesma que **aprova** o pagamento.\n- O desenvolvedor que **escreve** o código não deveria ser o único que **aprova e publica** essa mudança em produção, mesmo em uma esteira de entrega ágil.\n- Quem **administra** contas de usuário não deveria ser a mesma pessoa que **audita** os logs dessas contas.\n\nEm empresas pequenas, separar completamente essas funções nem sempre é viável por falta de gente. Nesses casos, controles compensatórios como uma segunda aprovação eventual, auditoria externa ou trilhas de log mais rigorosas ajudam a reduzir o risco que a segregação de funções trataria diretamente."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Conceito\", \"Definição\", \"Exemplo prático\"], [\"Menor privilégio\", \"Cada usuário recebe só o acesso mínimo necessário\", \"Analista de suporte acessa o sistema de chamados, não o de RH\"], [\"Necessidade de conhecer\", \"Acesso a uma informação específica só quando necessário\", \"Investigador só abre os casos atribuídos a ele\"], [\"Segregação de funções\", \"Nenhuma pessoa controla um processo crítico sozinha do início ao fim\", \"Quem solicita a compra não é quem aprova o pagamento\"], [\"Negação padrão (default deny)\", \"O acesso é bloqueado por padrão até ser explicitamente concedido\", \"Firewall bloqueia todo tráfego que não está liberado nas regras\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Provisionamento, desprovisionamento e revisão de acesso\n\nAplicar menor privilégio e segregação de funções no dia da contratação não é suficiente se ninguém mantiver isso ao longo do tempo. Três processos sustentam o controle de acesso lógico na prática:\n\n- **Provisionamento**: conceder o acesso certo quando alguém entra na empresa ou muda de função, nem mais nem menos do que o cargo exige.\n- **Desprovisionamento**: revogar o acesso imediatamente quando alguém sai da empresa ou muda de função, exatamente como vimos no exemplo do crachá desativado na Aula 2, só que agora para contas de sistema, VPN, e-mail e aplicações.\n- **Revisão periódica (recertificação)**: auditar de tempos em tempos se os acessos de cada pessoa ainda fazem sentido. Sem essa revisão, é comum que alguém acumule permissões de todas as áreas por onde já passou, um problema conhecido como **acúmulo de privilégios (privilege creep)**, que na prática anula o princípio do menor privilégio."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Menor privilégio limita o que uma única conta pode fazer. Segregação de funções garante que nenhuma pessoa sozinha controle um processo inteiro. Juntos, os dois princípios não impedem todo incidente, mas limitam o estrago que um erro, um abuso interno ou uma conta comprometida pode causar."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O princípio do menor privilégio estabelece que:",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Todos os usuários devem ter o mesmo nível de acesso, para simplificar a administração",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Cada usuário deve receber apenas o acesso mínimo necessário para exercer sua função",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Somente administradores de sistema podem acessar dados sensíveis",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O acesso deve ser revisado apenas uma vez, no momento da contratação",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O que caracteriza a segregação de funções (segregation of duties)?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Dividir uma tarefa entre duas pessoas apenas para concluí-la mais rápido",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Garantir que nenhuma pessoa sozinha controle todas as etapas de um processo crítico",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Atribuir várias funções administrativas à mesma pessoa para reduzir custos",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Permitir que qualquer funcionário aprove suas próprias solicitações de acesso",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Em uma pequena empresa, o mesmo funcionário solicita a compra de um equipamento, aprova o pagamento e recebe a mercadoria. Qual princípio de controle de acesso lógico está sendo violado?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Menor privilégio",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Segregação de funções",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Necessidade de conhecer",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Negação padrão",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um analista trabalhou em três equipes diferentes ao longo de cinco anos e, a cada mudança, recebeu novos acessos sem que os antigos fossem removidos, acumulando hoje permissões de todas as áreas por onde passou. Qual prática deveria ter evitado esse cenário?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Exigir autenticação multifator em todos os sistemas",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Realizar revisões periódicas de acesso (recertificação) para identificar e remover privilégios que não são mais necessários",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Instalar câmeras de CFTV na área de TI",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Aumentar o tempo de expiração das senhas",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe de desenvolvimento quer que os próprios desenvolvedores revisem, aprovem e publiquem suas alterações de código diretamente em produção, alegando que isso agiliza as entregas. Do ponto de vista de controle de acesso lógico, qual é o principal risco dessa proposta e como mitigá-lo sem eliminar a agilidade?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Não há risco relevante, já que desenvolvedores são tecnicamente qualificados para essa responsabilidade",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O risco é a ausência de segregação de funções entre quem escreve e quem aprova o código; a mitigação é exigir revisão e aprovação por outra pessoa antes do deploy, mesmo em um fluxo ágil",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O risco é apenas de desempenho do sistema, e a mitigação é aumentar a capacidade dos servidores",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O risco é exclusivamente físico, relacionado ao acesso ao datacenter onde os servidores ficam",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Modelos de Controle de Acesso: DAC, MAC, RBAC e IA na Detecção de Anomalias",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Aula 5: Modelos de Controle de Acesso: DAC, MAC, RBAC e IA na Detecção de Anomalias\n\nOs princípios da Aula 4 (menor privilégio, segregação de funções) dizem como as decisões de acesso deveriam ser, mas não dizem quem toma essas decisões nem com base em quê. É para isso que existem os modelos formais de controle de acesso. O exame CC cobre três: **DAC**, **MAC** e **RBAC**. Eles respondem à mesma pergunta (quem pode acessar o quê) de formas estruturalmente diferentes, e a diferença entre eles é um dos pontos mais cobrados do Domínio 3."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## DAC: Controle de Acesso Discricionário\n\nNo **DAC (Discretionary Access Control)**, o dono do recurso decide quem tem acesso a ele. \"Discricionário\" vem exatamente daí: a decisão fica a critério (discrição) de quem criou ou possui o arquivo, pasta ou recurso.\n\nExemplo do dia a dia: você cria uma planilha no Google Drive e decide, você mesmo, quem pode visualizar e quem pode editar. Compartilhar uma pasta de rede no Windows com um colega específico é a mesma lógica. É o modelo mais flexível e mais fácil de usar no dia a dia, e por isso é o padrão na maioria dos sistemas operacionais e serviços de nuvem para uso comum.\n\nA flexibilidade tem um preço: como cada usuário decide por conta própria, permissões se espalham de forma inconsistente, é difícil garantir uma política única para toda a organização, e nada impede que um usuário compartilhe algo sensível com quem não deveria ter acesso, mesmo sem má intenção."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## MAC: Controle de Acesso Mandatório\n\nNo **MAC (Mandatory Access Control)**, quem decide o acesso não é o dono do recurso, é uma autoridade central, geralmente representada por um sistema que aplica uma política fixa com base em **rótulos de sensibilidade** e **níveis de habilitação (clearance)**.\n\nExemplo clássico: um documento governamental classificado como \"Secreto\" só pode ser aberto por alguém com habilitação de segurança \"Secreto\" ou superior, e ainda assim só se essa pessoa tiver necessidade de conhecer aquele conteúdo específico. O criador do documento não tem poder de simplesmente liberar o acesso para alguém sem a habilitação certa, diferente do que aconteceria no DAC. Um exemplo técnico real de sistema operacional com MAC é o SELinux, usado em ambientes Linux que exigem esse nível de controle.\n\nMAC é o modelo mais rígido e mais seguro dos três, e por isso é comum em ambientes militares, governamentais e outros contextos de altíssima sensibilidade. O custo dessa segurança é a complexidade: rótulos e habilitações precisam ser definidos, mantidos e administrados centralmente, o que exige mais esforço operacional do que o DAC."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## RBAC: Controle de Acesso Baseado em Papéis\n\nNo **RBAC (Role-Based Access Control)**, o acesso não é concedido diretamente a uma pessoa, é concedido a um **papel (role)**, e a pessoa recebe acesso ao ser associada a esse papel. Papéis típicos em uma empresa: \"Analista Financeiro\", \"Recursos Humanos\", \"Suporte Técnico\", \"Administrador de TI\".\n\nExemplo prático: em um sistema ERP, o papel \"Financeiro\" tem acesso aos módulos de contas a pagar e a receber, o papel \"RH\" tem acesso a folha de pagamento e dados de funcionários, e um mesmo colaborador pode acumular mais de um papel se a função exigir. Quando alguém muda de cargo, basta trocar o papel associado a essa pessoa, e todas as permissões antigas somem e as novas aparecem automaticamente, sem precisar caçar acesso arquivo por arquivo, sistema por sistema.\n\nÉ o modelo mais comum em empresas de médio e grande porte hoje, porque equilibra bem segurança e praticidade administrativa: como o acesso está amarrado ao papel, e não à pessoa, fica muito mais fácil aplicar menor privilégio e segregação de funções de forma consistente, e auditar quem pode fazer o quê basta olhar os papéis, não cada usuário individualmente."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Modelo\", \"Quem decide o acesso\", \"Base da decisão\", \"Exemplo típico\"], [\"DAC\", \"O dono do recurso\", \"Discrição (critério) do proprietário\", \"Compartilhar uma pasta ou planilha no Google Drive\"], [\"MAC\", \"Autoridade central / sistema\", \"Rótulo de sensibilidade e nível de habilitação\", \"Documento \\\"Secreto\\\" em sistema governamental ou militar\"], [\"RBAC\", \"Administrador do sistema, via papel\", \"Papel/função da pessoa na organização\", \"Sistema ERP com papéis \\\"Financeiro\\\", \\\"RH\\\", \\\"TI\\\"\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## IA na detecção de anomalias de acesso\n\nNenhum modelo de controle de acesso, sozinho, garante que um acesso tecnicamente autorizado seja um acesso legítimo. Uma conta com credenciais corretas e papel válido no RBAC ainda pode estar sendo usada por alguém que não deveria (credencial roubada, conta comprometida, ou até um funcionário legítimo agindo fora do padrão esperado).\n\nÉ aqui que entram ferramentas de **análise comportamental de usuários e entidades (UEBA, User and Entity Behavior Analytics)**, apoiadas por modelos de IA e aprendizado de máquina. A lógica é parecida com a que vimos no Módulo 1 para autenticação, só que aplicada de forma mais ampla, a todo o comportamento de acesso: o sistema aprende um padrão normal para cada usuário (quais recursos costuma acessar, em que horário, de qual local, que volume de dados) e sinaliza desvios relevantes desse padrão.\n\nLembra do log de exemplo na Aula 3, com um acesso negado à sala de servidores seguido de um acesso autorizado fora do horário habitual? Esse é exatamente o tipo de combinação que uma ferramenta de UEBA sinalizaria automaticamente, correlacionando eventos que, isolados, pareceriam pouco relevantes. O mesmo princípio vale para acesso lógico: um usuário do papel \"Financeiro\" baixando um volume incomum de arquivos de RH de madrugada é uma anomalia digna de investigação, mesmo que o RBAC não tenha bloqueado tecnicamente o acesso.\n\nUm ponto importante para o exame: essas ferramentas de IA funcionam como **apoio à decisão**, elas priorizam e contextualizam alertas para revisão humana, não substituem o julgamento humano na decisão final de bloquear uma conta ou escalar um incidente. Falsos positivos existem, e uma resposta automática mal calibrada pode bloquear gente legítima com a mesma facilidade com que impediria um ataque real."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "DAC deixa a decisão com o dono do recurso, MAC centraliza a decisão em rótulos e habilitações definidos por uma autoridade, e RBAC amarra o acesso ao papel que a pessoa exerce na organização. Nenhum dos três, sozinho, detecta quando um acesso tecnicamente válido está sendo usado de forma anômala, e é exatamente essa lacuna que ferramentas de IA aplicadas a padrões de comportamento vêm ajudando a fechar, sempre com revisão humana na decisão final."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "No modelo DAC (Controle de Acesso Discricionário), quem decide quem pode acessar um recurso?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Uma autoridade central, com base em rótulos de classificação",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O próprio dono ou criador do recurso",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um algoritmo de inteligência artificial",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O cargo hierárquico do usuário na empresa",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "No RBAC (Controle de Acesso Baseado em Papéis), as permissões são concedidas principalmente com base em quê?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Na decisão individual de cada dono de arquivo",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "No papel ou função que a pessoa exerce na organização",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "No nível de classificação de sigilo do documento",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "No horário em que o acesso é solicitado",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um sistema governamental exige que, para abrir um documento classificado como \"Secreto\", o usuário tenha habilitação de segurança \"Secreto\" ou superior, independentemente de quem criou o documento ou de sua vontade de compartilhá-lo. Isso é um exemplo de qual modelo de controle de acesso?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "DAC",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "MAC",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "RBAC",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Nenhum modelo formal, apenas uma política interna informal",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma empresa de médio porte, com centenas de funcionários, quer que a mudança de cargo de um funcionário ajuste automaticamente todos os seus acessos ao novo cargo, sem depender de cada colega decidir manualmente compartilhar ou revogar acesso a arquivos. Qual modelo atende melhor a essa necessidade?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "DAC, por ser o modelo mais flexível",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "MAC, por ser o modelo mais rígido",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "RBAC, pois associa permissões a papéis organizacionais que podem ser reatribuídos de forma centralizada",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Nenhum modelo resolve esse problema; é preciso revisar cada arquivo manualmente",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma ferramenta de IA aprende o padrão normal de acesso de cada funcionário (recursos acessados, horários, volume de dados) e passa a sinalizar desvios para investigação. Ela sinaliza que um funcionário com papel \"Financeiro\" no RBAC baixou um volume incomum de arquivos da área de RH às 3h da manhã. Qual é a ação mais adequada, considerando o papel da IA como apoio à decisão?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "A ferramenta deve bloquear automática e permanentemente a conta do funcionário, sem revisão humana",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O alerta deve ser tratado como falso positivo por padrão, já que o funcionário tem um papel válido no sistema",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O alerta deve ser priorizado para investigação humana, pois combina acesso a um recurso fora do papel do usuário com um horário atípico, mas a decisão final cabe à equipe de segurança",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A empresa deveria abandonar o RBAC e migrar imediatamente para DAC",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 5 - Fundamentos de Redes",
+        "aulas": [
+            {
+                "titulo": "O modelo OSI: as sete camadas de uma rede",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Fundamentos de Redes\n\nTodo profissional de segurança precisa entender como os dados trafegam de um computador a outro antes de conseguir protegê-los de verdade. Pense em uma rede como o sistema de correios de uma cidade: uma carta precisa ser escrita, colocada em um envelope, endereçada, despachada por diferentes meios de transporte e finalmente entregue na caixa de correio certa. O **modelo OSI** (Open Systems Interconnection, ou Interconexão de Sistemas Abertos) descreve esse processo de comunicação em rede dividindo o trabalho em sete camadas, cada uma com uma responsabilidade bem definida.\n\nO modelo foi criado pela ISO (International Organization for Standardization) como uma referência conceitual. Ele não é uma tecnologia que se instala, é um mapa mental: ajuda a entender onde cada protocolo, cada dispositivo de rede e, principalmente, cada tipo de ataque ou controle de segurança atua. Essa é uma das primeiras habilidades que qualquer profissional de segurança de redes precisa desenvolver."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## As sete camadas, de baixo para cima\n\nO modelo é numerado da camada 1, a mais próxima do cabo ou do sinal de rádio, até a camada 7, a mais próxima do usuário e dos programas que ele usa. Uma regra importante: cada camada só se comunica diretamente com a camada imediatamente acima e a imediatamente abaixo dela. Quando um dado é enviado, ele desce pelas camadas do computador de origem, uma a uma, até virar sinal elétrico ou onda de rádio. No destino, o processo é inverso: o sinal sobe pelas camadas até virar, por exemplo, uma página carregada no navegador."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Camada\", \"Nome\", \"Função principal\", \"Exemplos\"], [\"7\", \"Aplicação\", \"Interface entre o usuário e a rede, onde os programas trocam dados\", \"HTTP, HTTPS, DNS, SMTP\"], [\"6\", \"Apresentação\", \"Traduz, formata, criptografa e comprime os dados para um formato comum\", \"Criptografia TLS, JPEG, ASCII\"], [\"5\", \"Sessão\", \"Abre, mantém e encerra a conversa entre dois programas\", \"NetBIOS, RPC, controle de sessão\"], [\"4\", \"Transporte\", \"Garante a entrega confiável (TCP) ou rápida (UDP) e controla as portas\", \"TCP, UDP\"], [\"3\", \"Rede\", \"Define o endereçamento lógico (IP) e escolhe o melhor caminho até o destino\", \"IP, ICMP, roteadores\"], [\"2\", \"Enlace\", \"Organiza os bits em quadros e usa endereços físicos (MAC)\", \"Ethernet, Wi-Fi, switches\"], [\"1\", \"Física\", \"Transmite os bits como sinais elétricos, pulsos de luz ou ondas de rádio\", \"Cabos, fibra óptica, hubs, conectores\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Um jeito de fixar a ordem\n\nUma forma comum de memorizar a sequência de baixo para cima (Física, Enlace, Rede, Transporte, Sessão, Apresentação, Aplicação) é a frase em inglês usada em diversos cursos de certificação: **Please Do Not Throw Sausage Pizza Away** (Physical, Data Link, Network, Transport, Session, Presentation, Application). O importante não é decorar a frase em si, e sim internalizar a lógica: o dado nasce como informação da aplicação (um clique, um formulário preenchido) e vai sendo empacotado camada a camada até virar um sinal físico que percorre o cabo ou o ar."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Por que isso importa para quem trabalha com segurança\n\nCada camada tem seu próprio conjunto de ameaças e, por consequência, seu próprio conjunto de defesas. Um ataque de spoofing de endereço MAC explora a camada 2. Um ataque de negação de serviço volumétrico costuma sobrecarregar as camadas 3 e 4. Já um ataque de injeção de SQL contra um formulário de login explora uma falha na camada 7, dentro da própria aplicação.\n\nEssa mesma lógica se aplica às defesas: um firewall tradicional filtra tráfego olhando para endereços IP e portas, ou seja, atua nas camadas 3 e 4. Já um firewall de aplicação web (WAF) analisa o conteúdo das requisições HTTP, atuando na camada 7. Saber identificar em qual camada um problema, ou uma solução, se encontra é o primeiro passo para investigar incidentes e escolher o controle certo."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "O modelo OSI organiza a comunicação em rede em 7 camadas, da Física (bits) até a Aplicação (o que o usuário vê na tela). Ele funciona como um mapa conceitual, usado para localizar onde um protocolo atua e onde uma ameaça ou uma defesa realmente acontece."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Em qual camada do modelo OSI um switch de rede opera principalmente, utilizando endereços MAC para encaminhar os quadros entre os dispositivos conectados a ele?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Camada 2 (Enlace)",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Camada 3 (Rede)",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Camada 4 (Transporte)",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Camada 7 (Aplicação)",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual das opções a seguir apresenta corretamente a ordem das camadas do modelo OSI, partindo da camada mais próxima do usuário até a mais próxima do meio físico de transmissão?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Aplicação, Apresentação, Sessão, Transporte, Rede, Enlace, Física",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Física, Enlace, Rede, Sessão, Transporte, Apresentação, Aplicação",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Aplicação, Transporte, Sessão, Apresentação, Rede, Enlace, Física",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Aplicação, Rede, Transporte, Sessão, Apresentação, Enlace, Física",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um analista percebe que dois dispositivos na mesma rede local conseguem se comunicar normalmente, mas pacotes destinados a uma rede diferente não estão sendo encaminhados, mesmo com o cabeamento físico e os switches funcionando sem erros. Em qual camada do modelo OSI é mais provável que esteja o problema?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Camada 3 (Rede), responsável pelo roteamento entre redes diferentes",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Camada 1 (Física), responsável pela transmissão dos sinais elétricos",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Camada 2 (Enlace), responsável pela comunicação dentro da mesma rede local",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Camada 6 (Apresentação), responsável pela formatação dos dados",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma aplicação web utiliza TLS para criptografar e formatar os dados antes de enviá-los pela rede. No modelo OSI clássico, essa função de tradução, formatação e criptografia dos dados é atribuída a qual camada?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Camada 6, Apresentação",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Camada 5, Sessão",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Camada 4, Transporte",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Camada 7, Aplicação",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Durante uma investigação, a equipe de segurança descobre que um invasor conectado à mesma rede local enviou respostas ARP falsas para se passar pelo gateway legítimo, conseguindo interceptar o tráfego de outros dispositivos (um ataque de ARP spoofing). Esse ataque explora principalmente qual camada do modelo OSI?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Camada 2 (Enlace), onde o mapeamento entre endereços IP e MAC é resolvido",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Camada 3 (Rede), onde ocorre o roteamento entre redes",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Camada 4 (Transporte), onde as portas TCP e UDP são controladas",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Camada 7 (Aplicação), onde os programas do usuário funcionam",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "O modelo TCP/IP e a jornada dos dados",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## O modelo TCP/IP e a jornada dos dados\n\nO modelo OSI é uma referência teórica excelente para estudar redes, mas quem realmente faz a internet funcionar é o **modelo TCP/IP**. Ele foi desenvolvido pelo Departamento de Defesa dos Estados Unidos ainda nos anos 1970, antes mesmo do modelo OSI existir, e continua sendo a base prática de toda comunicação na internet até hoje. Em vez de sete camadas, o TCP/IP organiza a comunicação em apenas quatro, agrupando funções que o OSI separa."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Camada TCP/IP\", \"Camadas OSI equivalentes\", \"Exemplos de protocolos\"], [\"Aplicação\", \"Aplicação, Apresentação e Sessão\", \"HTTP, HTTPS, DNS, SMTP, SSH\"], [\"Transporte\", \"Transporte\", \"TCP, UDP\"], [\"Internet\", \"Rede\", \"IP, ICMP, ARP\"], [\"Acesso à rede\", \"Enlace e Física\", \"Ethernet, Wi-Fi, drivers de placa de rede\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Encapsulamento: como um clique vira um sinal elétrico\n\nConforme o dado desce pelas camadas do modelo TCP/IP, cada uma acrescenta suas próprias informações de controle antes de repassar o pacote adiante. Esse processo se chama **encapsulamento**, e é como colocar uma carta dentro de um envelope, o envelope dentro de uma caixa, e a caixa dentro do caminhão de entrega. Cada camada tem um nome próprio para a unidade de dados que ela manipula:\n\n- Na camada de aplicação, os dados são simplesmente **dados** (por exemplo, uma requisição HTTP).\n- Na camada de transporte, o TCP ou o UDP acrescenta um cabeçalho com as portas de origem e destino, formando um **segmento**.\n- Na camada de internet, o IP acrescenta os endereços de origem e destino, formando um **pacote**.\n- Na camada de acesso à rede, o protocolo de enlace acrescenta o endereço MAC de origem e destino, formando um **quadro**, que finalmente é transmitido como **bits**."
+                    },
+                    {
+                        "type": "code",
+                        "value": "Aplicação:        [ Dados: GET /login HTTP/1.1 ]\nTransporte (TCP):  [ Cabeçalho TCP: porta origem 51422, porta destino 443 | Dados ]\nInternet (IP):     [ Cabeçalho IP: origem 10.0.0.5, destino 200.10.1.1 | Segmento TCP ]\nAcesso à rede:     [ Cabeçalho MAC: origem AA:BB:CC:11:22:33, destino DD:EE:FF:44:55:66 | Pacote IP | Trailer ]\nFísica:            [ 01011010110010001101... ]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## TCP e UDP: confiabilidade contra velocidade\n\nNa camada de transporte, dois protocolos dominam quase todo o tráfego da internet, e cada um faz uma escolha diferente de projeto. O **TCP** (Transmission Control Protocol) é orientado a conexão: antes de trocar qualquer dado, os dois lados executam um processo chamado three-way handshake, no qual o cliente envia um pacote SYN, o servidor responde com SYN/ACK e o cliente confirma com ACK. A partir daí, o TCP garante que todos os pacotes cheguem, na ordem certa, retransmitindo o que se perder pelo caminho.\n\nJá o **UDP** (User Datagram Protocol) não estabelece conexão nenhuma: ele simplesmente envia os dados e não garante entrega, ordem ou confirmação. Isso o torna mais rápido e com menos overhead, sendo a escolha certa quando velocidade importa mais do que perfeição, como em uma ligação de voz ou vídeo em tempo real."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Característica\", \"TCP\", \"UDP\"], [\"Conexão\", \"Orientado a conexão (three-way handshake)\", \"Sem conexão\"], [\"Confiabilidade\", \"Garante entrega e ordem, com retransmissão\", \"Melhor esforço, sem garantias\"], [\"Velocidade\", \"Mais lento, por causa do controle extra\", \"Mais rápido, menos overhead\"], [\"Usos comuns\", \"Navegação web, e-mail, SSH, transferência de arquivos\", \"Streaming, chamadas de voz e vídeo, consultas DNS, jogos online\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "O modelo TCP/IP é o que realmente faz a internet funcionar: quatro camadas mais enxutas que as sete do modelo OSI. Na camada de transporte, o TCP troca velocidade por confiabilidade (handshake, ordenação, retransmissão), enquanto o UDP troca confiabilidade por velocidade."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual protocolo de transporte estabelece uma conexão por meio do three-way handshake (SYN, SYN/ACK, ACK) antes de trocar dados, garantindo entrega confiável e ordenada?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "TCP",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "UDP",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "ICMP",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "ARP",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Em quantas camadas o modelo TCP/IP organiza a comunicação de rede?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Quatro",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Sete",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Três",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Cinco",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma empresa está desenvolvendo uma aplicação de videochamada em tempo real, na qual um pequeno atraso na transmissão prejudica mais a experiência do usuário do que a perda ocasional de um pacote de vídeo. Qual protocolo de transporte é mais adequado para esse cenário?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "UDP, porque prioriza velocidade e não introduz atrasos com retransmissão",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "TCP, porque garante que nenhum pacote seja perdido durante a chamada",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "HTTP, porque é o protocolo padrão para qualquer aplicação que use a internet",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "FTP, porque foi projetado especificamente para transmissão de mídia em tempo real",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Durante o encapsulamento dos dados, a camada de internet do modelo TCP/IP adiciona um cabeçalho com os endereços IP de origem e destino antes de repassar a unidade de dados para a camada de acesso à rede. Como essa unidade de dados é chamada nessa etapa?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Pacote",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Quadro",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Segmento",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Bit",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um administrador de redes analisa uma captura de tráfego e observa a seguinte sequência entre um cliente e um servidor web, antes de qualquer dado HTTP ser trocado: um pacote com a flag SYN, seguido de um pacote de resposta com as flags SYN e ACK, seguido de um pacote do cliente com a flag ACK. O que essa sequência representa?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O estabelecimento de uma conexão TCP, conhecido como three-way handshake",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Uma tentativa de ataque de negação de serviço contra o servidor",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O processo de resolução de nomes de domínio via DNS",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O encerramento normal de uma sessão UDP entre cliente e servidor",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Endereçamento IP: IPv4 e IPv6",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Endereçamento IP: IPv4 e IPv6\n\nAssim como toda casa precisa de um endereço para receber correspondência, todo dispositivo em uma rede precisa de um **endereço IP** único para ser localizado e trocar dados. O endereçamento IP funciona na camada 3 (Rede) do modelo OSI, e é ele que permite que um pacote saia de um computador em uma rede e chegue a um servidor do outro lado do mundo, atravessando diversos roteadores no caminho.\n\nExistem hoje duas versões do protocolo IP em uso: o **IPv4**, criado nos anos 1980 e ainda dominante, e o **IPv6**, criado para resolver as limitações do IPv4."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## IPv4: o endereço clássico\n\nUm endereço IPv4 tem 32 bits, escritos como quatro grupos de números de 0 a 255 separados por pontos, por exemplo 192.168.1.10. Com 32 bits, o IPv4 oferece cerca de 4,3 bilhões de endereços possíveis, um número que parecia enorme nos anos 1980, mas que se mostrou pequeno diante do crescimento da internet e da quantidade de dispositivos conectados hoje.\n\nPara lidar com essa escassez, uma parte dos endereços IPv4 é reservada para uso **privado**, dentro de redes internas (casas, escritórios, empresas), e não é roteável diretamente na internet pública. Esses endereços privados só conseguem acessar a internet por meio de uma tradução chamada **NAT** (Network Address Translation), que converte os endereços privados internos em um único endereço público compartilhado."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Faixa de endereços privados\", \"Uso comum\"], [\"10.0.0.0 até 10.255.255.255\", \"Redes corporativas grandes\"], [\"172.16.0.0 até 172.31.255.255\", \"Redes de médio porte\"], [\"192.168.0.0 até 192.168.255.255\", \"Redes domésticas e pequenos escritórios\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Máscara de sub-rede, DHCP e o endereço de loopback\n\nTodo endereço IPv4 é acompanhado de uma **máscara de sub-rede** (por exemplo, 255.255.255.0, também escrita como /24 na notação CIDR), que define qual parte do endereço identifica a rede e qual parte identifica o dispositivo dentro dela. Configurar esse endereço manualmente em cada dispositivo seria inviável em uma rede grande, por isso a maioria das redes usa o **DHCP** (Dynamic Host Configuration Protocol), um serviço que atribui automaticamente um endereço IP, a máscara de sub-rede e outras configurações a cada dispositivo que entra na rede.\n\nVale conhecer também o endereço **127.0.0.1**, chamado de loopback: ele sempre aponta para o próprio dispositivo, e é usado para testes locais, sem que o tráfego chegue a sair para a rede."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## IPv6: resolvendo o esgotamento\n\nO **IPv6** usa endereços de 128 bits, escritos como oito grupos de quatro dígitos hexadecimais separados por dois-pontos, por exemplo 2001:0db8:85a3:0000:0000:8a2e:0370:7334. Isso resulta em aproximadamente 340 undecilhões de endereços possíveis, um espaço tão grande que praticamente elimina qualquer preocupação com esgotamento, ao contrário do que acontece hoje com o IPv4.\n\nPara facilitar a leitura, o IPv6 permite duas abreviações: zeros à esquerda dentro de cada grupo podem ser omitidos, e uma sequência de grupos totalmente zerados e consecutivos pode ser substituída por :: (dois-pontos duplos), mas apenas uma vez no mesmo endereço, para evitar ambiguidade. A adoção do IPv6 é impulsionada, entre outros fatores, pela explosão de dispositivos conectados nos últimos anos: sensores, câmeras, assistentes de voz e outros dispositivos de IoT, muitos deles hoje incorporando algum tipo de processamento de IA, o que multiplica a quantidade de endereços necessários em qualquer rede."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Característica\", \"IPv4\", \"IPv6\"], [\"Tamanho do endereço\", \"32 bits\", \"128 bits\"], [\"Formato\", \"4 grupos decimais (ex: 192.168.1.1)\", \"8 grupos hexadecimais (ex: 2001:db8::1)\"], [\"Total aproximado de endereços\", \"4,3 bilhões\", \"340 undecilhões\"], [\"Necessidade de NAT\", \"Comum, para contornar a escassez\", \"Não é necessária, pelo espaço abundante\"], [\"Broadcast\", \"Existe\", \"Não existe, substituído por multicast\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Todo dispositivo em uma rede precisa de um endereço IP único para ser localizado. O IPv4 (32 bits) está se esgotando diante da explosão de dispositivos conectados, e o IPv6 (128 bits) resolve isso com um espaço de endereçamento praticamente inesgotável."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Quantos bits compõem um endereço IPv4?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "32 bits",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "64 bits",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "128 bits",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "16 bits",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual das faixas de endereços a seguir é reservada para uso em redes privadas, não sendo roteável diretamente na internet pública?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "192.168.0.0 até 192.168.255.255",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "8.8.8.0 até 8.8.8.255",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "203.0.113.0 até 203.0.113.255",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "198.51.100.0 até 198.51.100.255",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Vários computadores em uma rede doméstica, cada um com um endereço IP privado diferente, conseguem acessar a internet ao mesmo tempo utilizando um único endereço IP público fornecido pelo provedor de internet. Qual tecnologia torna isso possível?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "NAT (Network Address Translation)",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "DNS",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "DHCP",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "SSH",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual é a principal razão para a adoção gradual do IPv6 no lugar do IPv4?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O esgotamento do espaço de endereços do IPv4 diante do crescimento de dispositivos conectados à internet",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O IPv4 não é compatível com redes Wi-Fi modernas",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O IPv6 é exigido por lei em qualquer rede corporativa",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O IPv4 não permite o uso do protocolo HTTPS",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um técnico precisa escrever, de forma abreviada e válida, o endereço IPv6 completo 2001:0db8:0000:0000:0000:0000:0000:0001. Qual das opções a seguir representa essa abreviação corretamente?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "2001:db8::1",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "2001:db8:0:0:1",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "2001::db8::1",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "2001:db8:1::",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Portas e protocolos de rede comuns",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Portas e protocolos de rede comuns\n\nUm endereço IP identifica um dispositivo na rede, mas um único dispositivo costuma rodar vários serviços ao mesmo tempo: um servidor pode hospedar um site, receber conexões de administração remota e enviar e-mails, tudo simultaneamente. Para diferenciar esses serviços, a camada de transporte usa **portas**, números de 0 a 65535 que funcionam como o número do apartamento dentro de um prédio (o prédio sendo o endereço IP). Uma conexão de rede é sempre identificada pela combinação de endereço IP mais porta, tanto na origem quanto no destino."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Faixas de portas\n\nAs portas são divididas em três faixas. As **portas conhecidas** (0 a 1023) são reservadas pela IANA para os protocolos mais tradicionais, como HTTP e SSH. As **portas registradas** (1024 a 49151) podem ser usadas por aplicações específicas, geralmente registradas junto à IANA. E as **portas dinâmicas ou privadas** (49152 a 65535) são atribuídas temporariamente pelo sistema operacional, geralmente como porta de origem em uma conexão de saída."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Protocolo\", \"Porta\", \"Transporte\", \"Função\"], [\"HTTP\", \"80\", \"TCP\", \"Transfere páginas web sem criptografia\"], [\"HTTPS\", \"443\", \"TCP\", \"Transfere páginas web com criptografia TLS\"], [\"DNS\", \"53\", \"TCP/UDP\", \"Traduz nomes de domínio em endereços IP\"], [\"SSH\", \"22\", \"TCP\", \"Acesso remoto criptografado à linha de comando\"], [\"Telnet\", \"23\", \"TCP\", \"Acesso remoto sem criptografia (obsoleto e inseguro)\"], [\"FTP\", \"20 e 21\", \"TCP\", \"Transferência de arquivos sem criptografia\"], [\"SMTP\", \"25\", \"TCP\", \"Envio de e-mails entre servidores\"], [\"POP3\", \"110\", \"TCP\", \"Baixa e-mails do servidor para o cliente local\"], [\"DHCP\", \"67 e 68\", \"UDP\", \"Atribui automaticamente endereços IP aos dispositivos\"], [\"RDP\", \"3389\", \"TCP\", \"Acesso remoto gráfico à área de trabalho\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## HTTP e HTTPS: a diferença que protege o usuário\n\nO HTTP transfere páginas web em texto claro, sem qualquer proteção. Qualquer pessoa capaz de observar o tráfego da rede, como em um ataque de sniffing, consegue ler tudo o que é enviado, incluindo senhas digitadas em formulários. O HTTPS resolve isso adicionando uma camada de criptografia TLS sobre o HTTP, protegendo a confidencialidade e a integridade dos dados em trânsito. É por isso que navegadores modernos alertam o usuário quando um site usa HTTP puro, e por isso que sites que lidam com login, pagamento ou dados pessoais devem sempre usar HTTPS."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## SSH substituiu o Telnet, e o motivo é segurança\n\nO Telnet permite acesso remoto à linha de comando de um servidor, mas transmite tudo, inclusive usuário e senha, sem nenhuma criptografia. Qualquer um que capture esse tráfego consegue ler as credenciais. O SSH (Secure Shell) foi criado exatamente para resolver esse problema: ele criptografa toda a sessão, incluindo a autenticação, e se tornou o padrão de mercado para administração remota segura. Hoje, encontrar a porta 23 (Telnet) aberta em um servidor exposto à internet é considerado um sinal de alerta em qualquer auditoria de segurança.\n\nVale reforçar que ferramentas modernas de monitoramento de rede já usam inteligência artificial para aprender o padrão normal de tráfego em cada porta de um ambiente, como o volume esperado de conexões na porta 22 vindas da rede administrativa. Quando esse padrão foge do esperado, por exemplo um pico repentino de tentativas de conexão fora do horário comercial, o sistema pode sinalizar automaticamente uma possível tentativa de força bruta. Esse tipo de detecção de anomalias é aprofundado no próximo módulo, junto com firewalls e sistemas de detecção de intrusão."
+                    },
+                    {
+                        "type": "code",
+                        "value": "Exemplo de regras de firewall baseadas em porta:\n\nALLOW  tcp  porta 443  entrada                            (HTTPS, tráfego web protegido por TLS)\nALLOW  tcp  porta 22   entrada, somente da rede administrativa   (SSH)\nDENY   tcp  porta 23   entrada                            (Telnet bloqueado, protocolo sem criptografia)\nDENY   tcp  porta 21   entrada                            (FTP bloqueado, sem criptografia)"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Uma porta identifica qual serviço, dentro de um mesmo endereço IP, deve receber os dados. Conhecer os protocolos e portas mais comuns, como 443 para HTTPS, 22 para SSH e 53 para DNS, ajuda a reconhecer tráfego legítimo e a identificar o que não deveria estar aberto."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual porta é utilizada, por padrão, pelo protocolo HTTPS para o tráfego web criptografado?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "443",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "80",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "22",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "25",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual protocolo é responsável por traduzir um nome de domínio, como ensina.dev, no endereço IP que os computadores utilizam para estabelecer a conexão?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "DNS",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "DHCP",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "SMTP",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "RDP",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um administrador de sistemas precisa acessar remotamente, pela internet, a linha de comando de um servidor Linux, sem que a senha de acesso trafegue em texto claro pela rede. Qual protocolo ele deve utilizar?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "SSH",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Telnet",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "FTP",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "HTTP",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Durante uma auditoria de segurança, um analista encontra a porta 23 aberta em um servidor exposto diretamente à internet. Qual é a principal preocupação de segurança associada a essa porta?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O protocolo Telnet, associado a essa porta, transmite dados, incluindo credenciais, sem nenhuma criptografia",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A porta 23 é usada exclusivamente por ataques de negação de serviço",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Essa porta é reservada para vírus se replicarem automaticamente entre servidores",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Essa porta aceita apenas conexões UDP, o que a torna insegura por padrão",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma empresa mantém seus próprios servidores de e-mail. O servidor responsável por transmitir as mensagens entre os servidores de e-mail usa um determinado protocolo, enquanto os funcionários usam outro protocolo para baixar as mensagens da caixa de entrada para o cliente de e-mail local. Quais são, respectivamente, esses dois protocolos?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "SMTP e POP3",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "DNS e DHCP",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "HTTP e HTTPS",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "FTP e SSH",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Redes Wi-Fi e a evolução da segurança sem fio",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Redes Wi-Fi e a evolução da segurança sem fio\n\nO Wi-Fi é a tecnologia que substitui o cabo de rede por ondas de rádio, definida pela família de padrões **IEEE 802.11**. Uma rede Wi-Fi é formada, no mínimo, por um ponto de acesso (access point, ou AP), que transmite e recebe os sinais, e pelos dispositivos clientes que se conectam a ele. Toda rede Wi-Fi tem um **SSID** (Service Set Identifier), o nome que aparece na lista de redes disponíveis de um celular ou notebook.\n\nO Wi-Fi opera principalmente em duas faixas de frequência, cada uma com vantagens e desvantagens diferentes."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Faixa de frequência\", \"Alcance\", \"Velocidade\", \"Interferência\"], [\"2,4 GHz\", \"Maior alcance, atravessa paredes com mais facilidade\", \"Mais lenta\", \"Mais suscetível, faixa compartilhada com outros aparelhos\"], [\"5 GHz\", \"Menor alcance\", \"Mais rápida\", \"Menos suscetível a interferência\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## A evolução dos padrões 802.11\n\nAo longo dos anos, o Wi-Fi passou por diversas gerações de padrões técnicos, cada uma trazendo mais velocidade e suporte a mais dispositivos conectados simultaneamente: 802.11b e 802.11g nos primeiros anos, depois 802.11n (também chamado de Wi-Fi 4), 802.11ac (Wi-Fi 5) e, mais recentemente, 802.11ax (Wi-Fi 6). Do ponto de vista de segurança, o que realmente importa não é qual geração de velocidade está em uso, mas sim qual protocolo de criptografia protege a rede."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Protocolo\", \"Criptografia\", \"Situação atual\"], [\"WEP\", \"RC4, com chave estática e fraca\", \"Obsoleto e inseguro, não deve ser usado em nenhuma rede\"], [\"WPA\", \"TKIP, solução de transição\", \"Obsoleto, foi substituído pelo WPA2\"], [\"WPA2\", \"AES/CCMP, criptografia forte\", \"Ainda amplamente usado, considerado seguro quando bem configurado\"], [\"WPA3\", \"AES com SAE, resistente a ataques offline de dicionário\", \"Padrão atual recomendado para redes novas\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Boas práticas de segurança em redes Wi-Fi\n\nConfigurar uma rede Wi-Fi com segurança envolve decisões simples, mas que fazem grande diferença:\n\n- Usar sempre WPA2 ou, de preferência, WPA3. Nunca WEP.\n- Definir uma senha de rede longa e exclusiva, diferente da senha de administração do roteador.\n- Trocar as credenciais padrão de fábrica do painel de administração do roteador ou access point, que muitas vezes são públicas e conhecidas.\n- Manter o firmware do equipamento sempre atualizado.\n- Desativar o WPS (Wi-Fi Protected Setup), um recurso de conexão facilitada que já teve falhas graves exploradas por invasores.\n\nVale um alerta importante: ocultar o SSID de uma rede não é um controle de segurança real, é apenas obscuridade. Um dispositivo com as ferramentas certas ainda consegue descobrir o nome da rede escondida, então essa prática não substitui uma criptografia forte."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Os riscos das redes Wi-Fi públicas\n\nRedes abertas, como as de aeroportos, cafés e hotéis, costumam não ter nenhuma criptografia ou usar uma senha compartilhada com todo mundo, o que facilita a interceptação do tráfego por qualquer pessoa conectada à mesma rede. Um risco adicional é o ataque conhecido como *evil twin*, em que um invasor cria um ponto de acesso falso com o mesmo nome de uma rede legítima, tentando enganar os usuários para que se conectem a ele em vez da rede verdadeira.\n\nA recomendação prática para quem precisa usar uma rede pública é conectar-se por meio de uma VPN, que criptografa todo o tráfego entre o dispositivo e um ponto confiável, mesmo que a rede local usada no caminho não seja confiável."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "O Wi-Fi trocou o cabo por ondas de rádio, mas trouxe consigo novos riscos. A segurança de uma rede sem fio depende, acima de tudo, do protocolo de criptografia usado: WPA3 ou WPA2 são as escolhas corretas hoje, WEP nunca deveria ser usado, e redes públicas exigem cuidado redobrado."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual é o protocolo de segurança para redes Wi-Fi atualmente recomendado como padrão para redes novas, por oferecer criptografia mais forte e resistência a ataques offline de dicionário?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "WPA3",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "WEP",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "WPA",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Rede aberta, sem nenhuma criptografia",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O que é o SSID de uma rede Wi-Fi?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "O nome que identifica a rede sem fio para os dispositivos que tentam se conectar a ela",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O endereço físico (MAC) do ponto de acesso",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A senha de acesso à rede sem fio",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O protocolo de criptografia usado pela rede",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um administrador está configurando o Wi-Fi de um pequeno escritório e precisa escolher entre WEP e WPA2 para proteger a rede. Qual é a decisão tecnicamente correta?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Usar WPA2, porque o WEP utiliza criptografia fraca e é considerado obsoleto e vulnerável",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Usar WEP, porque é mais rápido de configurar e oferece o mesmo nível de segurança",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Usar WEP, porque é compatível com mais dispositivos antigos, e isso compensa a criptografia mais fraca",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Tanto faz, já que os dois protocolos entregam o mesmo nível de criptografia",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um funcionário se conecta à rede Wi-Fi gratuita de um aeroporto para verificar e-mails corporativos antes de embarcar. Qual é a prática mais recomendada para reduzir o risco de interceptação dos dados nessa situação?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Conectar-se por meio de uma VPN, que criptografa o tráfego mesmo em uma rede pública não confiável",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Desativar o antivírus temporariamente para acelerar a conexão",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ocultar o SSID do próprio celular enquanto estiver usando a rede pública",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Utilizar apenas sites em HTTP para reduzir o consumo de processamento do aparelho",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Em um ataque conhecido como evil twin, um invasor cria um ponto de acesso Wi-Fi falso com o mesmo nome (SSID) de uma rede legítima, como a de uma cafeteria, para atrair usuários desavisados. Qual é o principal risco desse tipo de ataque?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O invasor pode interceptar e manipular todo o tráfego dos dispositivos que se conectarem ao ponto de acesso falso pensando que é a rede legítima",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O invasor consegue apenas descobrir a senha do roteador legítimo, sem acessar os dados dos usuários",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O ataque só é possível se a vítima estiver conectada por cabo de rede",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O ataque altera fisicamente o hardware do roteador da rede legítima",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 6 - Ameaças e Defesa de Rede",
+        "aulas": [
+            {
+                "titulo": "Ameaças e Ataques à Rede",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Ameaças e Ataques à Rede\n\nNo Módulo 5 você aprendeu como uma rede é construída: o modelo OSI, o TCP/IP, endereços IP, portas e protocolos. Agora é hora de olhar para o outro lado da moeda. De que adianta entender como uma rede funciona se você não sabe como ela pode ser atacada?\n\nNeste módulo você vai estudar a segunda metade do Domínio 4 do exame CC: as ameaças mais comuns contra redes, como detectá-las, como preveni-las e como a infraestrutura de segurança (física e em nuvem) sustenta tudo isso. Vamos começar pelo começo: quais são, de fato, os ataques que você precisa conhecer para a prova e para o dia a dia de trabalho?\n\nNesta aula você vai conhecer seis ameaças clássicas: os três tipos de malware mais cobrados (vírus, worm e trojan), o ataque de negação de serviço distribuída (DDoS), o ataque do intermediário (man-in-the-middle) e o ataque de canal lateral. São conceitos que aparecem com frequência no exame, então vale a pena entender bem a diferença entre eles."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Vírus, worm e trojan: três malwares que se parecem, mas são diferentes\n\nEsses três nomes costumam ser usados como sinônimos no dia a dia: \"meu computador pegou um vírus\" vira uma expressão genérica para qualquer malware. Mas, para o exame CC, a diferença entre eles é exatamente o que importa.\n\n**Vírus** é um código malicioso que se anexa a um arquivo ou programa legítimo (o \"hospedeiro\"). Ele só é ativado quando uma pessoa executa esse arquivo infectado, por exemplo, abrindo um anexo de e-mail ou rodando um programa pirata. Sem essa ação humana, o vírus fica inerte. É como uma gripe que só pega se alguém realmente entrar em contato: precisa de um hospedeiro e de uma ação para se espalhar.\n\n**Worm** (verme) é parecido, mas com uma diferença crucial: ele não precisa se anexar a nenhum arquivo, e não precisa que ninguém clique em nada. Um worm é um programa completo e independente, capaz de se replicar sozinho e se espalhar pela rede explorando falhas de segurança em outros sistemas. Uma vez dentro de uma máquina vulnerável, ele já procura a próxima vítima na rede, sem esperar ação humana. É por isso que worms costumam se espalhar muito mais rápido que vírus: o exemplo histórico mais citado é o WannaCry, que se espalhou pelo mundo explorando uma falha em um protocolo de compartilhamento de arquivos do Windows.\n\n**Trojan** (cavalo de troia) usa outra estratégia: engano. Ele se disfarça de programa legítimo e útil (um \"antivírus grátis\", um jogo pirata, uma planilha aparentemente inofensiva) para convencer a própria vítima a instalá-lo voluntariamente. Diferente do vírus e do worm, o trojan não se replica sozinho. Seu objetivo costuma ser abrir uma porta dos fundos (backdoor) para acesso remoto do atacante, ou roubar dados silenciosamente. O nome é uma referência direta à lenda do cavalo de Troia: o perigo não está na força, está em ser convidado para dentro."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Malware\", \"Precisa de um arquivo hospedeiro?\", \"Precisa de ação da vítima?\", \"Como se espalha\", \"Objetivo típico\"], [\"Vírus\", \"Sim, se anexa a um arquivo ou programa\", \"Sim, alguém precisa executar o arquivo infectado\", \"Compartilhamento de arquivos infectados\", \"Corromper, destruir ou espalhar mais cópias\"], [\"Worm\", \"Não, é um programa independente\", \"Não, se propaga sozinho pela rede\", \"Exploração automática de vulnerabilidades\", \"Replicar em massa, sobrecarregar redes\"], [\"Trojan\", \"Não, mas se disfarça de programa legítimo\", \"Sim, a vítima precisa instalar por engano\", \"Engenharia social (o usuário baixa e instala)\", \"Abrir backdoor, roubar dados\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## DDoS: quando o objetivo é derrubar, não invadir\n\nNem todo ataque quer roubar dados ou controlar sua máquina. Às vezes, o objetivo é simplesmente tirar um serviço do ar. É isso que faz o **DDoS**, sigla para Distributed Denial of Service (negação de serviço distribuída).\n\nA lógica é simples de entender com uma analogia: imagine uma loja com uma porta só. Se um grupo de pessoas mal-intencionadas se posiciona na porta e não deixa mais ninguém entrar, mesmo sem roubar nada, a loja para de vender. Um ataque DDoS faz isso com um servidor ou serviço online: inunda o alvo com uma quantidade enorme de tráfego ou requisições, até esgotar sua capacidade de banda, processamento ou conexões simultâneas. O resultado é que usuários legítimos não conseguem mais acessar o serviço.\n\nO \"distribuído\" do nome é a parte que torna o ataque difícil de conter: em vez de vir de um único computador (o que caracterizaria apenas um DoS), o ataque parte de milhares de dispositivos ao mesmo tempo, geralmente máquinas comprometidas por malware e organizadas em uma rede chamada **botnet**, controlada remotamente pelo atacante sem que os donos dos dispositivos percebam. Bloquear um único endereço IP não resolve nada quando o ataque vem de dezenas de milhares de endereços diferentes ao mesmo tempo."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Man-in-the-middle: o intruso na conversa\n\nO ataque do intermediário, mais conhecido pela sigla em inglês **MITM** (man-in-the-middle), acontece quando um atacante se posiciona entre duas partes que acreditam estar se comunicando diretamente uma com a outra, sem perceber que alguém está espionando ou até alterando a conversa no meio do caminho.\n\nPense em uma carta que passa pelas mãos de um carteiro desonesto: ele pode simplesmente ler o conteúdo antes de entregar (quebra de confidencialidade), ou pior, reescrever a carta e entregar uma versão alterada (quebra de integridade), e nenhuma das duas pontas percebe que algo mudou.\n\nNo mundo da rede, um caso muito comum é o **ponto de acesso Wi-Fi falso** (às vezes chamado de \"evil twin\"): o atacante cria uma rede Wi-Fi pública com nome parecido ao de uma rede legítima (por exemplo, \"Aeroporto_WiFi_Free\"), e quando a vítima se conecta, todo o tráfego passa pelo equipamento do atacante antes de seguir para a internet. Outras técnicas incluem a manipulação de tabelas ARP dentro de uma rede local, para fazer o tráfego de outros dispositivos passar pela máquina do atacante, e o rebaixamento de conexões HTTPS para HTTP, retirando a criptografia da comunicação sem que a vítima perceba de imediato."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Ataques de canal lateral: roubando segredos sem quebrar o cadeado\n\nO último ataque desta aula é o mais sutil, e também o mais mal compreendido. Um **ataque de canal lateral** (side-channel attack) não tenta quebrar a matemática por trás de um algoritmo de criptografia, nem explorar uma falha de programação. Em vez disso, ele observa os efeitos colaterais físicos que um sistema produz enquanto realiza uma operação, e usa essas pistas indiretas para deduzir uma informação secreta, como uma chave criptográfica.\n\nEsses efeitos colaterais podem ser o tempo que uma operação leva para ser concluída, o consumo de energia de um chip, a emissão eletromagnética de um circuito, ou até o som que um componente produz. Um exemplo clássico é medir minúsculas variações no consumo de energia de um cartão inteligente enquanto ele processa uma chave criptográfica: a variação no consumo, analisada estatisticamente, pode revelar bit a bit o valor da chave, sem que o atacante precise quebrar o algoritmo de criptografia em si.\n\nÉ um bom lembrete de que segurança não é só sobre o algoritmo estar correto no papel. A forma como ele é implementado fisicamente também pode vazar segredos."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "**Recapitulando:** vírus, worm e trojan são famílias de malware que se diferenciam pela forma como se espalham (hospedeiro e ação humana, autopropagação, ou engano). DDoS ataca a disponibilidade inundando um alvo com tráfego vindo de uma botnet. MITM se posiciona no meio de uma comunicação para espionar ou alterar dados em trânsito. E o ataque de canal lateral extrai segredos observando pistas físicas indiretas (tempo, energia, emissão eletromagnética), não falhas no algoritmo. Conhecer bem essas ameaças é o primeiro passo para entender como se defender delas, o que vamos ver nas próximas aulas."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual a principal diferença entre um vírus e um worm?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "O worm sempre se disfarça de programa legítimo, enquanto o vírus nunca engana o usuário.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O vírus precisa se anexar a um arquivo hospedeiro e depende de uma ação humana para ser executado, enquanto o worm se propaga sozinho pela rede, explorando vulnerabilidades.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O vírus só ataca redes sem fio, enquanto o worm só ataca redes cabeadas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não existe diferença técnica: os dois termos descrevem exatamente o mesmo tipo de ataque.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O que caracteriza um ataque de DDoS?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Um programa que se disfarça de aplicativo legítimo para enganar o usuário a instalá-lo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma técnica de leitura do consumo de energia de um dispositivo para extrair uma chave criptográfica.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um grande volume de tráfego ou requisições, vindo de múltiplas fontes simultaneamente (geralmente uma botnet), que esgota os recursos de um alvo e o torna indisponível para usuários legítimos.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um único invasor que rouba silenciosamente dados de um banco de dados sem ser percebido.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um funcionário baixa, de um site não oficial, um programa gratuito que promete converter arquivos de vídeo. Depois de instalado, o programa até funciona como conversor, mas, sem que a vítima perceba, um atacante remoto passa a ter acesso à máquina através de uma porta dos fundos criada pelo próprio instalador. Que tipo de malware melhor descreve esse caso?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Worm, porque se replicou sozinho para outras máquinas da rede sem ação do usuário.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "DDoS, porque o objetivo foi tirar o serviço de conversão de vídeo do ar.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ataque de canal lateral, porque explorou o consumo de energia do computador da vítima.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Trojan, porque se disfarçou de programa legítimo e útil para convencer a vítima a instalá-lo voluntariamente.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Ana se conecta a uma rede Wi-Fi pública em um aeroporto chamada \"Aeroporto_WiFi_Gratis\", sem perceber que essa rede foi criada por um atacante para imitar a rede oficial do local. A partir daí, todo o tráfego do celular de Ana passa pelo equipamento do atacante antes de seguir para a internet. Que tipo de ataque está ocorrendo?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "DDoS, porque o objetivo é sobrecarregar o roteador do aeroporto com tráfego excessivo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Man-in-the-middle (MITM), porque o atacante se posicionou entre Ana e a internet para interceptar e potencialmente alterar sua comunicação.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Worm, porque o malware está se replicando automaticamente para outros celulares próximos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Vírus, porque Ana precisou executar um arquivo infectado para que o ataque acontecesse.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Pesquisadores demonstram que é possível descobrir a chave criptográfica usada por um cartão inteligente (smart card) apenas medindo, com equipamento especializado, as minúsculas variações no consumo de energia do chip enquanto ele realiza operações criptográficas, sem explorar nenhuma falha matemática no algoritmo usado. Esse tipo de ataque é conhecido como:",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Ataque man-in-the-middle, pois o atacante intercepta a comunicação entre o cartão e o leitor.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ataque DDoS, pois sobrecarrega o processamento do cartão até ele falhar.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ataque de trojan, pois um software malicioso foi instalado no cartão inteligente.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ataque de canal lateral, pois extrai informação sensível a partir de efeitos físicos colaterais da implementação (como o consumo de energia), e não de uma falha no algoritmo.",
+                                "isCorrect": true
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Identificação e Prevenção de Ameaças",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Identificação e Prevenção de Ameaças\n\nAgora que você já conhece os principais tipos de ataque, a pergunta natural é: como uma organização percebe que está sendo atacada, e como ela evita que o ataque dê certo? São duas perguntas diferentes, e a resposta para cada uma envolve ferramentas diferentes.\n\nDetectar é perceber que algo suspeito está acontecendo e avisar alguém. Prevenir é impedir que a ameaça sequer chegue a causar dano. Lembre-se do que você aprendeu no Módulo 2 sobre tipos de controle: um controle detectivo identifica um incidente depois (ou durante) que ele começa, enquanto um controle preventivo tenta bloquear o incidente antes que ele aconteça. Nesta aula, você vai ver essa mesma lógica aplicada à segurança de rede: de um lado, os sistemas de detecção de intrusão (IDS, HIDS, NIDS), do outro, as ferramentas de prevenção (antivírus, varreduras de vulnerabilidade, firewall e IPS)."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## IDS: o sistema que fica de olho\n\nUm **IDS** (Intrusion Detection System, ou sistema de detecção de intrusão) monitora o tráfego de uma rede ou a atividade de um sistema em busca de sinais de ataque ou de violação de política, e emite um alerta quando encontra algo suspeito. O ponto chave é que um IDS **detecta e avisa, mas não bloqueia** o tráfego por conta própria: ele é um controle detectivo, como uma câmera de segurança que grava e aciona um alarme, mas não tranca a porta sozinha.\n\nExistem dois tipos principais de IDS, e o exame CC gosta de cobrar a diferença entre eles:\n\n- **HIDS** (Host-based IDS): instalado em um único host (um servidor, uma estação de trabalho), monitora o que acontece especificamente naquela máquina: logs do sistema operacional, integridade de arquivos críticos, processos em execução. Enxerga tudo o que acontece dentro daquele host, mas não vê o tráfego de outras máquinas da rede.\n- **NIDS** (Network-based IDS): posicionado em um ponto estratégico da rede (por exemplo, conectado a uma porta de espelhamento de tráfego em um switch), monitora o tráfego que passa por aquele ponto, olhando para pacotes de múltiplos hosts ao mesmo tempo. Enxerga o que trafega na rede, mas não tem visibilidade do que acontece dentro de cada máquina individualmente.\n\nNa prática, as duas abordagens se complementam: o NIDS cobre a rede como um todo, enquanto o HIDS cobre em detalhe hosts críticos, como um servidor de banco de dados.\n\nAlém de onde o IDS é instalado, existe também a questão de **como** ele detecta uma ameaça. A detecção **baseada em assinatura** compara o tráfego ou a atividade com um banco de padrões de ataques já conhecidos: é precisa contra ameaças conhecidas, mas fica cega diante de algo totalmente novo. Já a detecção **baseada em anomalia** cria uma linha de base do que é comportamento \"normal\" para aquele ambiente, e dispara um alerta quando algo foge desse padrão, o que permite pegar ataques inéditos (mesmo um zero-day), ao custo de gerar mais falsos positivos."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Ferramenta\", \"Onde atua\", \"O que faz\", \"Bloqueia tráfego sozinha?\"], [\"HIDS\", \"Um host específico\", \"Monitora logs, arquivos e processos daquela máquina\", \"Não\"], [\"NIDS\", \"Um ponto da rede\", \"Monitora o tráfego que passa por aquele ponto\", \"Não\"], [\"IDS (em geral)\", \"Fora do caminho do tráfego (passivo)\", \"Detecta e alerta sobre atividade suspeita\", \"Não\"], [\"IPS\", \"Diretamente no caminho do tráfego (inline)\", \"Detecta e bloqueia ou descarta tráfego malicioso em tempo real\", \"Sim\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Firewall: o porteiro da rede\n\nSe o IDS é a câmera de segurança, o **firewall** é o porteiro: ele decide, com base em um conjunto de regras, o que pode entrar e o que pode sair de uma rede (ou de um segmento dela). As regras costumam considerar endereço IP de origem e destino, porta e protocolo, e às vezes a aplicação envolvida.\n\nOs firewalls evoluíram em gerações. Os mais simples, de **filtragem de pacotes**, olham cada pacote isoladamente, cabeçalho por cabeçalho, sem entender o contexto da conexão. Os firewalls **de inspeção de estado** (stateful) já acompanham o estado de cada conexão: sabem, por exemplo, que um pacote de resposta faz parte de uma conexão que a própria rede interna iniciou, e por isso conseguem tomar decisões mais inteligentes. E os **firewalls de próxima geração** (NGFW, next-generation firewall) vão além, combinando inspeção profunda de pacotes, reconhecimento de aplicações e, muitas vezes, um IPS embutido, tudo em um único equipamento.\n\nUm princípio fundamental de configuração de firewall, muito cobrado no exame, é a política de **negação padrão** (default deny): bloquear tudo por padrão, e liberar explicitamente somente o tráfego necessário. É o oposto de permitir tudo e bloquear só o que já se sabe que é malicioso (uma abordagem de lista negra, mais frágil, porque não protege contra ameaças novas e desconhecidas)."
+                    },
+                    {
+                        "type": "code",
+                        "value": "Exemplo simplificado de um conjunto de regras de firewall\nPolítica padrão: negar tudo (default deny)\n\nREGRA 1: PERMITIR  origem=QUALQUER      destino=SERVIDOR_WEB  porta=443 (HTTPS)  protocolo=TCP\nREGRA 2: PERMITIR  origem=QUALQUER      destino=SERVIDOR_WEB  porta=80  (HTTP)   protocolo=TCP\nREGRA 3: PERMITIR  origem=REDE_INTERNA  destino=SERVIDOR_DNS  porta=53           protocolo=UDP\nREGRA 4: PERMITIR  origem=REDE_INTERNA  destino=QUALQUER      porta=443 (HTTPS)  protocolo=TCP\nREGRA 5: NEGAR     origem=QUALQUER      destino=QUALQUER      porta=QUALQUER     protocolo=QUALQUER\n\nA REGRA 5 é a política padrão: qualquer tráfego que não se encaixou em\nnenhuma regra anterior é bloqueado automaticamente."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## IPS, antivírus e varreduras: fechando o cerco\n\nO **IPS** (Intrusion Prevention System, sistema de prevenção de intrusão) é o parente do IDS que age. Ele usa a mesma lógica de detecção (assinatura ou anomalia), mas é posicionado diretamente no caminho do tráfego (inline), o que permite bloquear, descartar ou rejeitar um pacote malicioso no exato momento em que ele é identificado, sem depender de uma pessoa reagir ao alerta. É um controle preventivo, não apenas detectivo.\n\nO **antivírus** (ou antimalware) atua no host, não na rede: é o software instalado em um computador ou servidor que busca, bloqueia e remove arquivos e processos maliciosos. Assim como o IDS, ele combina detecção baseada em assinatura (reconhece malwares já catalogados) com técnicas heurísticas e comportamentais, que analisam o que um programa está tentando fazer para identificar ameaças novas.\n\nJá as **varreduras de vulnerabilidade** (vulnerability scans) são ferramentas automatizadas que verificam sistemas e redes em busca de fraquezas conhecidas: patches de segurança faltando, configurações incorretas, versões de software desatualizadas. O resultado é um relatório que ajuda a equipe a priorizar o que corrigir primeiro. É importante não confundir uma varredura de vulnerabilidade com um teste de invasão (pentest): a varredura é ampla, automatizada e frequente, apenas identifica e cataloga fraquezas, enquanto o pentest é um exercício mais profundo, manual e pontual, que efetivamente tenta explorar as falhas para simular um ataque real."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "**Recapitulando:** o IDS (nas formas HIDS e NIDS) detecta e alerta, mas não bloqueia sozinho, enquanto o IPS faz a mesma detecção só que posicionado inline, com poder de bloquear em tempo real. O firewall filtra tráfego por regras, idealmente seguindo a política de negação padrão. O antivírus protege o host contra malware, e as varreduras de vulnerabilidade mapeiam fraquezas antes que alguém as explore. Juntas, essas ferramentas formam a primeira linha de defesa técnica de uma rede."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual a principal diferença entre um IDS e um IPS?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "O IDS detecta e alerta sobre atividade suspeita, mas não bloqueia o tráfego sozinho, enquanto o IPS é posicionado no caminho do tráfego e pode bloqueá-lo ativamente em tempo real.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O IDS só funciona em redes sem fio, enquanto o IPS só funciona em redes cabeadas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O IDS bloqueia todo o tráfego da rede por padrão, enquanto o IPS libera todo o tráfego por padrão.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não há diferença prática: os dois termos descrevem exatamente a mesma ferramenta.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe de segurança quer monitorar, em detalhe, a integridade de arquivos do sistema operacional e os logs de um servidor de banco de dados específico. Qual ferramenta é mais adequada para esse objetivo?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "NIDS, porque monitora o tráfego de toda a rede a partir de um único ponto.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Firewall, porque filtra pacotes com base em porta e protocolo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "VPN, porque cria um túnel criptografado até o servidor.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "HIDS, porque é instalado no próprio host e monitora logs, arquivos e processos daquela máquina especificamente.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de sofrer um ataque em que o tráfego malicioso só foi percebido horas depois, uma empresa decide investir em uma solução capaz de bloquear automaticamente pacotes maliciosos assim que forem identificados, sem esperar a intervenção de um analista. Qual solução atende a essa necessidade?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "IDS, porque gera alertas detalhados para a equipe analisar posteriormente.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Varredura de vulnerabilidade, porque identifica falhas de configuração antes que sejam exploradas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "IPS, porque atua inline no caminho do tráfego e pode bloquear pacotes maliciosos em tempo real, sem depender de ação manual.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "HIDS, porque monitora arquivos e processos de um único host.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um sistema de detecção de intrusão de uma empresa identifica um ataque totalmente novo, nunca antes catalogado, porque o tráfego observado se desviava muito do padrão normal de comportamento da rede. Que tipo de detecção tornou isso possível?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Detecção baseada em assinatura, que compara o tráfego com um banco de padrões de ataques já catalogados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Filtragem de pacotes stateless, que analisa cada pacote isoladamente sem considerar o contexto.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Varredura de vulnerabilidade, que verifica patches de segurança ausentes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Detecção baseada em anomalia, que compara a atividade observada com uma linha de base do comportamento normal e alerta sobre desvios, mesmo de ameaças desconhecidas.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um administrador de rede está decidindo como configurar as regras do firewall de perímetro de uma empresa. A opção A é permitir todo o tráfego por padrão e bloquear apenas o que for identificado como malicioso. A opção B é bloquear todo o tráfego por padrão e liberar explicitamente apenas o que for necessário para o negócio. Por que a opção B (negação padrão) é considerada a prática mais segura?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Porque exige menos regras configuradas e por isso é mais simples de administrar no dia a dia.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque elimina completamente a necessidade de um IDS ou IPS complementar na rede.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque garante que nenhum usuário legítimo jamais terá seu acesso bloqueado por engano.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque reduz a superfície de ataque ao permitir apenas o tráfego explicitamente necessário, incluindo proteção contra ameaças novas e ainda não catalogadas, ao contrário de uma abordagem de lista negra que só bloqueia o que já é conhecido.",
+                                "isCorrect": true
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Infraestrutura Física de Segurança de Rede",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Infraestrutura Física de Segurança de Rede\n\nAté agora você viu ameaças e ferramentas digitais de defesa. Mas todo firewall, todo servidor e todo IDS precisa rodar em algum lugar físico. E esse lugar também precisa ser protegido, não só contra invasores (isso você já viu no Módulo 4, com crachás, catracas e câmeras), mas contra algo igualmente perigoso: falhas de energia, calor, incêndio e falta de redundância.\n\nPense assim: de nada adianta ter a melhor equipe de segurança digital do mundo se uma queda de energia derruba o datacenter inteiro, ou se um superaquecimento destrói os servidores. Nesta aula, você vai entender os elementos físicos que sustentam a disponibilidade (o \"D\" da tríade CIA) de uma infraestrutura de rede."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O datacenter: o coração físico da rede\n\nUm **datacenter** é a instalação física projetada especificamente para abrigar servidores, equipamentos de rede e sistemas de armazenamento de uma organização. Pode ser um datacenter próprio (on-premises, dentro das instalações da empresa), um datacenter comercial contratado, ou, como você verá na Aula 5, capacidade alugada de um provedor de nuvem.\n\nDiferente de uma sala de escritório comum, um datacenter é projetado desde o início para sustentar a disponibilidade dos sistemas que ele hospeda. Isso envolve muito mais do que colocar servidores em uma prateleira: envolve energia redundante, controle rígido de temperatura e umidade, sistemas de combate a incêndio que não danifiquem o próprio equipamento, e eliminação de pontos únicos de falha. É exatamente sobre esses quatro pilares (energia, HVAC, supressão de incêndio e redundância) que o resto desta aula vai tratar."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Energia: a base que ninguém pode deixar faltar\n\nSem energia elétrica, não existe servidor, não existe rede, não existe nada. Por isso, datacenters investem pesado em garantir que a energia nunca falte, com uma combinação de camadas:\n\n- **UPS** (Uninterruptible Power Supply, ou nobreak): um sistema com baterias que assume a carga instantaneamente caso a energia da concessionária falhe, sem interrupção perceptível para os equipamentos. O UPS também condiciona a energia, protegendo contra picos e quedas de tensão. Sua autonomia costuma ser curta, geralmente minutos, o suficiente para cobrir uma queda rápida ou para dar tempo de outra fonte assumir.\n- **Geradores**: para quedas de energia mais longas, entram em cena os geradores (normalmente movidos a diesel), que assumem a carga depois que o UPS cobre a transição inicial, e conseguem manter o datacenter funcionando por horas ou dias, desde que haja combustível disponível.\n- **PDU** (Power Distribution Unit): as unidades que distribuem a energia já estabilizada para os racks e equipamentos individuais dentro do datacenter.\n\nA ideia central é ter camadas: a concessionária de energia é a primeira fonte, o UPS cobre o intervalo até a segunda fonte assumir, e o gerador sustenta o funcionamento por um período prolongado."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## HVAC e supressão de incêndio: temperatura e fogo sob controle\n\nServidores trabalhando a todo vapor geram uma quantidade enorme de calor. Sem um controle rigoroso de temperatura e umidade, o hardware superaquece, falha e pode ter sua vida útil reduzida drasticamente, o que é, na prática, um problema de disponibilidade. É esse o papel do **HVAC** (Heating, Ventilation and Air Conditioning, ou aquecimento, ventilação e ar-condicionado): manter a temperatura e a umidade do datacenter dentro de faixas seguras para o equipamento. Umidade baixa demais favorece o acúmulo de eletricidade estática (que pode danificar componentes eletrônicos), e umidade alta demais favorece condensação e corrosão. Por isso o controle é sempre dos dois fatores juntos, não só da temperatura.\n\nJá a **supressão de incêndio** em um datacenter é bem diferente do sistema de um prédio comum. Chuveiros automáticos com água, comuns em escritórios, seriam desastrosos em uma sala cheia de servidores: a água destruiria o equipamento tentando salvar a sala. Por isso, datacenters normalmente usam **sistemas de agente limpo** (gases como FM-200 ou Novec 1230, ou gases inertes), que apagam o fogo removendo oxigênio ou interrompendo a reação química da combustão, sem deixar resíduo e sem molhar nada. Em alguns projetos, sistemas de sprinkler de pré-ação são usados como camada adicional exigida por norma predial, configurados para exigir duas condições antes de liberar água, reduzindo o risco de disparo acidental. Em qualquer caso, a prioridade número um de qualquer sistema de supressão de incêndio é sempre a vida das pessoas, e só depois vem a proteção do equipamento."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Nível de redundância\", \"O que significa\", \"Exemplo\"], [\"N\", \"Capacidade mínima necessária, sem redundância nenhuma\", \"Um único link de internet, uma única fonte de energia\"], [\"N+1\", \"A capacidade necessária, mais um componente extra de reserva\", \"Três geradores que sustentam a carga, mais um quarto gerador reserva\"], [\"2N\", \"Sistema totalmente duplicado, cada metade capaz de sustentar 100% da carga sozinha\", \"Dois circuitos elétricos independentes, cada um com sua própria UPS e gerador\"], [\"2N+1\", \"Sistema totalmente duplicado, com um componente extra de reserva em cada metade\", \"Dois circuitos independentes, cada um já com um gerador reserva próprio\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Redundância: eliminando pontos únicos de falha\n\nRedundância é o princípio de duplicar componentes críticos para que a falha de um único elemento não derrube o sistema inteiro. Um **ponto único de falha** (single point of failure) é qualquer componente cuja falha sozinha é capaz de parar toda a operação: por exemplo, um único link de internet, uma única fonte de energia, ou um único servidor sem réplica.\n\nA tabela acima mostra os níveis mais citados no mercado (e no exame): N é a linha de base sem folga nenhuma, N+1 adiciona uma peça reserva, e 2N duplica a estrutura inteira de forma independente. Quanto maior a redundância, maior a resiliência e, geralmente, maior o custo. Cabe à organização decidir, com base na criticidade do serviço, quanto de redundância faz sentido pagar, o que conecta diretamente com o que você aprendeu sobre RTO e RPO no Módulo 3: sistemas com tolerância a indisponibilidade muito baixa justificam investir em 2N, enquanto sistemas menos críticos podem operar com N+1 ou até N."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "**Recapitulando:** o datacenter é a base física que sustenta a disponibilidade da rede. Energia redundante (UPS para o curto prazo, gerador para o longo prazo), HVAC para manter temperatura e umidade controladas, supressão de incêndio com agentes limpos que não destroem o equipamento, e redundância (N, N+1, 2N) para eliminar pontos únicos de falha: juntos, esses elementos garantem que a infraestrutura continue de pé mesmo quando algo dá errado."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual é a função principal de um UPS (nobreak) em um datacenter?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Resfriar os servidores para evitar superaquecimento.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Assumir a carga elétrica instantaneamente em caso de falha da energia da concessionária, cobrindo o intervalo até outra fonte (como um gerador) assumir.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Detectar tráfego malicioso na rede interna do datacenter.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Apagar incêndios sem usar água, para não danificar os equipamentos.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que datacenters normalmente evitam usar chuveiros automáticos de água como sistema de combate a incêndio?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Porque chuveiros de água são proibidos por lei em qualquer tipo de construção.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque a água aumenta a velocidade de propagação do fogo em ambientes com eletricidade.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque chuveiros de água só funcionam em temperaturas abaixo de zero grau.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque a água danificaria os servidores e equipamentos eletrônicos, mesmo que ajudasse a apagar o fogo, por isso preferem sistemas de agente limpo (gases).",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma empresa nota que, em dias muito quentes, seus servidores começam a apresentar falhas e desligamentos inesperados, mesmo sem nenhum sinal de ataque ou pico de tráfego incomum. Qual elemento da infraestrutura física provavelmente está com problema?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Firewall, porque é o responsável por filtrar o tráfego de rede que entra e sai do datacenter.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "UPS, porque é o responsável por fornecer energia em caso de queda da concessionária.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "NAC, porque é o responsável por controlar quais dispositivos podem se conectar à rede.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "HVAC, porque é o sistema responsável por manter a temperatura e a umidade do datacenter dentro de faixas seguras para o hardware.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma empresa mantém todos os seus servidores críticos conectados a um único provedor de internet e a uma única entrada de energia elétrica, sem nenhum backup. Do ponto de vista de infraestrutura de segurança de rede, qual é o principal risco dessa configuração?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "A configuração cria pontos únicos de falha (single points of failure): a queda do único link de internet ou da única fonte de energia derruba toda a operação, comprometendo a disponibilidade.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A configuração aumenta o risco de ataques de canal lateral contra os servidores.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A configuração torna o firewall da empresa incapaz de aplicar a política de negação padrão.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A configuração impede fisicamente a instalação de um HIDS nos servidores.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um datacenter é projetado com dois circuitos elétricos completamente independentes: cada um com sua própria entrada de energia da concessionária, seu próprio UPS e seu próprio gerador, sendo que qualquer um dos dois circuitos, sozinho, é capaz de sustentar 100% da carga do datacenter. Que nível de redundância essa configuração representa?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "N, porque representa apenas a capacidade mínima necessária, sem nenhuma folga.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "N+1, porque existe apenas um componente extra além do estritamente necessário.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "2N, porque a estrutura inteira está duplicada de forma independente, e cada metade consegue sustentar sozinha a carga total.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Redundância de dados, porque o foco está na duplicação de informações armazenadas, não de energia.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Design de Segurança de Rede",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Design de Segurança de Rede\n\nVocê já sabe que existem ameaças (Aula 1), ferramentas de detecção e prevenção (Aula 2), e uma base física que sustenta tudo isso (Aula 3). Agora falta uma peça: como desenhar a arquitetura da rede em si, de um jeito que limite o estrago quando (não se) alguma dessas defesas falhar.\n\nA ideia central desta aula está resumida em um ditado que você provavelmente já ouviu em outro contexto: não coloque todos os ovos na mesma cesta. Uma rede plana, onde qualquer dispositivo conectado enxerga e alcança qualquer outro, é uma cesta só. Se um único computador for comprometido, o atacante caminha livremente até o servidor mais crítico da empresa. O design de segurança de rede existe para evitar exatamente isso."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Segmentação e VLAN: dividir para proteger\n\n**Segmentação de rede** é a prática de dividir uma rede em pedaços menores (segmentos ou zonas), cada um isolado dos demais por um dispositivo que controla o tráfego entre eles, geralmente um firewall ou uma lista de controle de acesso (ACL) em um roteador. O objetivo é limitar o **movimento lateral**: mesmo que um atacante comprometa um dispositivo em um segmento, ele não consegue simplesmente pular para os outros segmentos sem passar por um ponto de controle.\n\nA ferramenta mais comum para segmentar uma rede é a **VLAN** (Virtual Local Area Network, ou rede local virtual). Uma VLAN separa logicamente os dispositivos em domínios de broadcast diferentes, mesmo que todos estejam fisicamente conectados aos mesmos switches. Por exemplo, uma empresa pode colocar os computadores do time financeiro em uma VLAN, as impressoras em outra, e os dispositivos de convidados em uma terceira, tudo usando a mesma infraestrutura de cabos e switches físicos. A vantagem prática é enorme: não é preciso passar um cabeamento físico separado para cada área da empresa para obter isolamento. E, como o tráfego entre VLANs diferentes precisa necessariamente passar por um dispositivo de camada 3 (um roteador ou um firewall), esse é exatamente o ponto onde é possível aplicar regras e inspecionar o que passa de uma VLAN para outra."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## DMZ: a zona de amortecimento\n\nToda empresa que expõe algum serviço para a internet (um site, um servidor de e-mail, um servidor DNS público) enfrenta um dilema: esse serviço precisa ser alcançável de fora, mas a rede interna não pode ficar exposta junto com ele. A solução clássica para esse dilema é a **DMZ** (Demilitarized Zone, ou zona desmilitarizada).\n\nA DMZ é um segmento de rede intermediário, posicionado entre a internet (não confiável) e a rede interna (confiável), que hospeda justamente os servidores que precisam ser acessados publicamente. A arquitetura mais didática para entender isso é a de **firewall com três interfaces** (ou dois firewalls em sequência): uma interface olha para a internet, outra para a DMZ, e outra para a rede interna, com regras diferentes em cada fronteira. O tráfego da internet pode alcançar os servidores da DMZ nas portas necessárias, mas não pode alcançar diretamente a rede interna. E os servidores da DMZ, mesmo que comprometidos, não têm passagem livre até a rede interna, porque essa fronteira também é controlada por regra de firewall.\n\nPense na DMZ como a recepção de um prédio corporativo: visitantes externos conseguem entrar na recepção e resolver o que precisam ali, mas não têm acesso direto aos andares internos onde ficam os times da empresa."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Microssegmentação: indo além das zonas\n\nVLAN e DMZ segmentam a rede em zonas relativamente grandes: financeiro, DMZ, convidados. A **microssegmentação** leva essa ideia a um nível muito mais granular, aplicando políticas de controle de tráfego entre cargas de trabalho individuais (workloads), como máquinas virtuais ou contêineres específicos, mesmo que estejam dentro do mesmo segmento tradicional.\n\nNa prática, isso costuma ser implementado por software, através de redes definidas por software (SDN), em vez de depender só de switches e roteadores físicos. O ganho é grande em ambientes virtualizados e de nuvem, onde dezenas ou centenas de workloads convivem no mesmo datacenter: em vez de dizer apenas \"a VLAN do financeiro pode falar com a VLAN de aplicações\", a microssegmentação permite dizer \"esta máquina virtual específica só pode conversar com aquela outra máquina virtual específica, e somente em determinada porta\". É a mesma lógica de defesa contra movimento lateral vista na segmentação tradicional, só que aplicada em uma escala muito mais fina, algo que se conecta diretamente com o princípio de confiança zero (não confiar automaticamente em nada só porque está \"dentro\" da rede)."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## VPN e NAC: controlando quem e como se conecta\n\nDuas outras peças completam o design de segurança de rede, cada uma cuidando de um momento diferente da conexão.\n\nA **VPN** (Virtual Private Network, ou rede privada virtual) cria um túnel criptografado sobre uma rede não confiável, como a internet pública, conectando um usuário remoto (ou uma filial inteira) à rede privada da organização como se estivesse fisicamente ali dentro. Existem duas variações comuns: a **VPN de acesso remoto**, usada por um funcionário individual trabalhando de casa ou de um hotel, e a **VPN site a site**, que conecta duas redes inteiras (por exemplo, a matriz e uma filial) de forma permanente. Em ambos os casos, o objetivo é preservar a confidencialidade e a integridade do tráfego enquanto ele atravessa um meio que não é confiável.\n\nJá o **NAC** (Network Access Control, ou controle de acesso à rede) atua um passo antes: ele decide se um dispositivo pode sequer entrar na rede. Antes de liberar a conexão, o NAC verifica a postura do dispositivo (se o antivírus está atualizado, se o sistema operacional tem os patches mais recentes, se a máquina pertence à empresa ou é um dispositivo desconhecido). Dispositivos que não atendem aos critérios podem ser colocados em quarentena, isolados em uma VLAN separada com acesso limitado, até serem corrigidos. É como um controle de acesso físico (que você viu no Módulo 4), só que aplicado à porta lógica da rede, em vez da porta de entrada do prédio."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Camada\", \"Exemplo de controle\", \"O que protege\"], [\"Física\", \"Crachá, catraca, CFTV, controles ambientais do datacenter\", \"Acesso físico às instalações e equipamentos\"], [\"Perímetro\", \"Firewall de borda, DMZ\", \"Fronteira entre a rede interna e redes não confiáveis\"], [\"Rede interna\", \"VLAN, segmentação, microssegmentação, NAC\", \"Movimento lateral dentro da rede\"], [\"Host\", \"Antivírus, HIDS, hardening do sistema operacional\", \"Cada servidor ou estação individualmente\"], [\"Aplicação\", \"Validação de entrada, testes de segurança de código\", \"Falhas na própria aplicação\"], [\"Dados\", \"Criptografia, controle de acesso, backup\", \"A informação em si, mesmo se as demais camadas falharem\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "**Recapitulando:** defesa em profundidade é o princípio que une tudo o que você viu nesta aula: em vez de depender de um único controle perfeito, uma rede segura se apoia em várias camadas independentes (física, perímetro, rede, host, aplicação, dados), de forma que a falha de uma camada não signifique comprometimento total. VLAN e segmentação limitam movimento lateral, a DMZ isola serviços públicos, a microssegmentação refina esse controle a nível de workload, a VPN protege dados em trânsito por redes não confiáveis, e o NAC decide quem entra na rede desde o primeiro momento."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual é o principal objetivo de colocar servidores acessíveis pela internet (como um site público) em uma DMZ, em vez de deixá-los diretamente na rede interna?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Isolar esses servidores em um segmento intermediário, de forma que, mesmo comprometidos, não tenham passagem livre até a rede interna.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Aumentar a velocidade de acesso dos usuários externos ao site.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Eliminar a necessidade de um firewall entre a internet e a empresa.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Permitir que qualquer dispositivo da rede interna acesse a internet sem restrições.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O que uma VLAN permite fazer em uma rede?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Criptografar todo o tráfego que passa por um link de internet público.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Verificar se um dispositivo tem antivírus atualizado antes de liberar sua conexão à rede.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Detectar automaticamente ataques de negação de serviço distribuída.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Separar logicamente dispositivos em domínios de broadcast diferentes, mesmo que compartilhem a mesma infraestrutura física de switches.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma empresa precisa que seus funcionários, trabalhando de casa, acessem com segurança arquivos armazenados em um servidor interno, protegendo a confidencialidade dos dados enquanto trafegam pela internet. Qual tecnologia atende diretamente a essa necessidade?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "DMZ, porque isola servidores públicos da rede interna.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Microssegmentação, porque controla o tráfego entre máquinas virtuais individuais.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "VPN de acesso remoto, porque cria um túnel criptografado entre o dispositivo do funcionário e a rede interna da empresa.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "VLAN, porque separa domínios de broadcast dentro da rede local.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "A política de segurança de uma empresa exige que qualquer notebook, antes de ser autorizado a entrar na rede corporativa, seja verificado quanto a antivírus atualizado e patches de sistema operacional em dia. Notebooks que não atendem a esses critérios são automaticamente isolados em uma VLAN de quarentena com acesso limitado. Qual tecnologia implementa esse controle?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "IPS, porque bloqueia pacotes maliciosos identificados em tempo real.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "DMZ, porque isola servidores acessíveis publicamente da rede interna.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "HIDS, porque monitora logs e arquivos de um host específico.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "NAC (Network Access Control), porque avalia a postura de segurança de um dispositivo antes de liberar (ou restringir) seu acesso à rede.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Em um ambiente de nuvem com dezenas de máquinas virtuais na mesma VLAN, uma empresa que adota princípios de confiança zero quer impedir que uma máquina virtual comprometida se comunique livremente com as demais máquinas virtuais do mesmo segmento, permitindo apenas as conexões estritamente necessárias entre workloads específicos. Qual abordagem de design atende melhor a esse objetivo?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "VLAN, porque já separa domínios de broadcast diferentes dentro da rede.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "VPN site a site, porque conecta duas redes inteiras de forma criptografada.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Redundância 2N, porque duplica os componentes críticos da infraestrutura.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Microssegmentação, porque aplica políticas de controle de tráfego no nível de cada workload individual, inclusive entre máquinas dentro do mesmo segmento tradicional.",
+                                "isCorrect": true
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Segurança de Rede na Nuvem e o Papel da IA",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Segurança de Rede na Nuvem e o Papel da IA\n\nAs quatro aulas anteriores trataram de uma rede que, em boa parte, a própria empresa possui e administra fisicamente. Mas hoje é cada vez mais comum que parte (ou toda) a infraestrutura de uma organização não esteja em um datacenter próprio, e sim na nuvem, rodando em servidores de terceiros como AWS, Azure ou Google Cloud. Essa mudança não elimina a necessidade de segurança de rede, ela só muda quem é responsável por qual parte dela.\n\nNesta última aula do módulo, você vai entender os principais modelos de nuvem cobrados pelo exame CC (SaaS, PaaS, IaaS e nuvem híbrida), os conceitos de SLA e MSP, e vai fechar o Domínio 4 vendo como a inteligência artificial está mudando a forma como firewalls e sistemas de detecção de intrusão identificam ameaças."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## IaaS, PaaS e SaaS: quanto cada um gerencia\n\nOs três modelos de serviço em nuvem mais cobrados no exame se diferenciam por uma pergunta simples: quanto da pilha de tecnologia o cliente precisa gerenciar, e quanto fica por conta do provedor?\n\n**IaaS** (Infrastructure as a Service, infraestrutura como serviço) aluga a infraestrutura básica: servidores virtuais, armazenamento e rede. O provedor cuida do hardware físico, da virtualização e da conectividade, mas o cliente ainda instala e gerencia o sistema operacional, os aplicativos e os dados. É como alugar um terreno com fundação pronta: você ainda constrói e mobilia a casa do seu jeito. Exemplo: uma máquina virtual na AWS EC2 ou no Azure Virtual Machines.\n\n**PaaS** (Platform as a Service, plataforma como serviço) vai um passo além: o provedor já entrega um ambiente pronto para rodar aplicações (sistema operacional, runtime, ferramentas de banco de dados), e o cliente só se preocupa em desenvolver e implantar o próprio código. É como alugar um apartamento mobiliado: a estrutura já está pronta, você só traz suas coisas. Exemplo: Azure App Service, ou plataformas como Heroku.\n\n**SaaS** (Software as a Service, software como serviço) entrega o aplicativo pronto para uso: o cliente só usa, sem se preocupar com servidor, sistema operacional ou nem mesmo o código da aplicação. É como se hospedar em um hotel: tudo já está pronto, você só chega e usa. Exemplos: Gmail, Microsoft 365, Salesforce."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Camada\", \"IaaS\", \"PaaS\", \"SaaS\"], [\"Hardware e datacenter\", \"Provedor\", \"Provedor\", \"Provedor\"], [\"Rede e virtualização\", \"Provedor\", \"Provedor\", \"Provedor\"], [\"Sistema operacional\", \"Cliente\", \"Provedor\", \"Provedor\"], [\"Runtime e middleware\", \"Cliente\", \"Provedor\", \"Provedor\"], [\"Aplicação\", \"Cliente\", \"Cliente\", \"Provedor\"], [\"Dados e controle de acesso\", \"Cliente\", \"Cliente\", \"Cliente\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Nuvem híbrida e MSP: combinando modelos e terceirizando gestão\n\nNem toda empresa escolhe um único caminho. A **nuvem híbrida** combina infraestrutura on-premises (própria, como você viu na Aula 3) com recursos de nuvem pública, integrados entre si. É uma escolha comum para organizações que precisam manter certos dados ou sistemas críticos sob controle direto (por exigência regulatória, por exemplo), mas querem aproveitar a elasticidade e o custo da nuvem para o restante da operação. Uma empresa pode, por exemplo, manter o banco de dados de clientes em um datacenter próprio, e usar a nuvem pública para hospedar o site institucional, que recebe picos de acesso variáveis.\n\nOutra decisão comum é contratar um **MSP** (Managed Service Provider, provedor de serviços gerenciados): uma empresa terceirizada que assume a operação de parte ou de toda a infraestrutura de TI e segurança do cliente, incluindo, muitas vezes, o monitoramento de rede e a resposta a incidentes. A vantagem é ter acesso a uma equipe especializada sem precisar contratá-la internamente, o que costuma sair mais barato e mais rápido para empresas menores. A contrapartida é a dependência: a segurança da empresa passa a depender também da qualidade e da confiabilidade do MSP contratado, o que exige critério na hora de escolher o parceiro e clareza contratual sobre responsabilidades."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## SLA: o contrato que define o nível de serviço\n\nSeja com um provedor de nuvem ou com um MSP, a relação entre cliente e fornecedor deveria sempre ser formalizada por um **SLA** (Service Level Agreement, ou acordo de nível de serviço). O SLA é o documento que define, em termos mensuráveis, o que o cliente pode esperar do fornecedor: percentual garantido de disponibilidade (uptime), tempo de resposta a incidentes, prazos de suporte, e as penalidades caso esses níveis não sejam cumpridos.\n\nUm SLA bem definido é o que transforma uma promessa vaga de manter o serviço no ar em um compromisso mensurável e cobrável, com número, prazo e consequência clara em caso de descumprimento. Vale reforçar um ponto que já apareceu na tabela de responsabilidade compartilhada: contratar nuvem ou um MSP não elimina a responsabilidade da empresa pela segurança, apenas redistribui quem cuida de qual camada. A empresa continua sendo, no fim das contas, responsável pelos próprios dados."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## IA em firewalls e IDS: detecção automatizada de ameaças\n\nO volume de tráfego e a velocidade dos ataques modernos ultrapassaram há tempos a capacidade de qualquer equipe humana de analisar tudo manualmente. É nesse ponto que a inteligência artificial vem sendo incorporada a firewalls de próxima geração e a sistemas de detecção e prevenção de intrusão.\n\nNa prática, isso significa complementar a detecção baseada em assinatura (eficiente contra ameaças já conhecidas, mas cega para o que é novo) com modelos de aprendizado de máquina que constroem uma linha de base do comportamento normal de uma rede ou de um usuário, e sinalizam desvios em tempo real, muitas vezes identificando ataques nunca vistos antes (zero-day) só pelo padrão anômalo de tráfego. Esses sistemas também correlacionam sinais de múltiplas fontes ao mesmo tempo (tráfego de rede, logs de host, comportamento de usuário) em uma escala que seria inviável para analistas humanos revisarem um por um, e podem automatizar parte da resposta, como isolar um host suspeito automaticamente enquanto aguarda revisão humana.\n\nMas vale um alerta importante para o exame e para a prática: IA não substitui julgamento humano na segurança. Modelos podem gerar falsos positivos (bloquear tráfego legítimo) e falsos negativos (deixar passar algo malicioso), e atacantes mais sofisticados já estudam como enganar deliberadamente esses modelos. Por isso, a abordagem mais responsável continua sendo a IA acelerando e ampliando a capacidade de detecção, com um analista humano supervisionando decisões críticas, não a IA tomando decisões de segurança sozinha e sem nenhuma revisão."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "**Recapitulando:** IaaS, PaaS e SaaS diferem por quanto da infraestrutura o cliente gerencia versus o provedor, a nuvem híbrida combina infraestrutura própria com nuvem pública, o MSP terceiriza a operação de TI e segurança, e o SLA formaliza em números o nível de serviço prometido. Independente do modelo escolhido, a responsabilidade pela segurança dos dados nunca desaparece por completo, apenas se redistribui. E, cada vez mais, firewalls e sistemas de detecção usam inteligência artificial para identificar ameaças em uma escala e velocidade que nenhuma equipe humana sozinha conseguiria acompanhar, sempre com supervisão humana nas decisões mais críticas. Com isso, você fecha o Domínio 4 do exame CC: dos fundamentos de rede até a defesa contra ameaças, da infraestrutura física à nuvem."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O Gmail é um exemplo de qual modelo de serviço em nuvem?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "IaaS, porque o cliente precisa instalar e configurar o próprio sistema operacional.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "PaaS, porque o cliente precisa desenvolver e implantar sua própria aplicação de e-mail.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "SaaS, porque entrega o aplicativo pronto para uso, sem que o cliente precise gerenciar servidor, sistema operacional ou o código da aplicação.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Nuvem híbrida, porque combina infraestrutura própria com infraestrutura de terceiros.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O que um SLA (Service Level Agreement) define?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "As regras de firewall que determinam qual tráfego é permitido ou bloqueado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os níveis de serviço mensuráveis que o fornecedor se compromete a entregar, como disponibilidade garantida, tempo de resposta e penalidades por descumprimento.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A quantidade de memória RAM que uma máquina virtual deve ter.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O algoritmo de criptografia usado para proteger os dados em trânsito.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma empresa quer ter controle total sobre o sistema operacional e o middleware das suas aplicações, mas não quer se preocupar em comprar, manter ou substituir servidores físicos. Qual modelo de nuvem atende melhor a essa necessidade?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "SaaS, porque entrega o software pronto para uso, sem qualquer gerenciamento por parte do cliente.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "PaaS, porque o provedor já gerencia o sistema operacional e o middleware.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "IaaS, porque o provedor cuida do hardware físico e da virtualização, enquanto o cliente continua gerenciando sistema operacional, aplicações e dados.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "MSP, porque terceiriza toda a operação de TI para uma empresa especializada.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma pequena empresa, sem equipe própria de segurança, contrata uma empresa terceirizada para monitorar sua rede e responder a incidentes de segurança vinte e quatro horas por dia. Que tipo de arranjo é esse, e qual é uma contrapartida importante a se considerar?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Adoção de nuvem híbrida; a contrapartida é a necessidade de manter dois datacenters próprios em paralelo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Implementação de microssegmentação; a contrapartida é o aumento do tráfego entre VLANs.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Migração para SaaS; a contrapartida é a perda total de acesso aos próprios dados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Contratação de um MSP (Managed Service Provider); a contrapartida é que a segurança da empresa passa a depender também da qualidade e confiabilidade do provedor contratado, o que exige um SLA e critério claros na escolha.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um sistema de detecção de intrusão com inteligência artificial identifica, em poucos segundos, um padrão de ataque nunca antes catalogado, ao perceber que o comportamento de um usuário se desviava fortemente da linha de base normal, e isola automaticamente o host suspeito. Qual afirmação melhor descreve a forma correta de encarar esse tipo de sistema segundo as boas práticas discutidas no exame CC?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O sistema elimina totalmente a necessidade de qualquer revisão humana, já que a inteligência artificial nunca comete erros de classificação.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O sistema deve ser desligado sempre que identificar uma ameaça nova, porque modelos de IA só funcionam corretamente contra ameaças já conhecidas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O sistema substitui integralmente a necessidade de firewalls e de segmentação de rede na organização.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O sistema amplia a velocidade e a escala da detecção de ameaças, mas ainda está sujeito a falsos positivos e falsos negativos, por isso decisões críticas continuam exigindo supervisão humana.",
+                                "isCorrect": true
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 7 - Operações de Segurança",
+        "aulas": [
+            {
+                "titulo": "Criptografia: simétrica, assimétrica e hashing",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Módulo 7 - Operações de Segurança\n\nOs módulos anteriores explicaram como avaliar riscos, controlar o acesso e defender a rede. Este módulo trata do que as equipes de segurança fazem no dia a dia para manter tudo isso funcionando: proteger os dados, manter os sistemas atualizados, aplicar políticas claras e preparar as pessoas para reconhecer ameaças. É o domínio de Operações de Segurança, o maior do exame CC, porque reúne boa parte da rotina prática da profissão.\n\n## Criptografia: transformando dados em segredo\n\nUm arquivo guardado em um servidor ou uma mensagem trafegando pela rede pode ser lido por qualquer pessoa com acesso a ele, a menos que esteja protegido. A criptografia resolve isso: ela transforma informação legível (texto claro) em informação ilegível (texto cifrado) usando um algoritmo matemático e uma chave. Só quem possui a chave correta consegue reverter o processo e ler o conteúdo original.\n\nExistem três mecanismos que todo profissional de segurança precisa dominar: criptografia simétrica, criptografia assimétrica e hashing. Cada um resolve um problema diferente, e na prática eles costumam ser usados em conjunto."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Criptografia simétrica\n\nNa criptografia simétrica, a mesma chave é usada para cifrar e para decifrar a informação. É rápida e eficiente, por isso é a escolha natural para proteger grandes volumes de dados, como um disco inteiro ou um arquivo grande. Exemplos conhecidos são o AES (Advanced Encryption Standard, o padrão atual) e o DES (Data Encryption Standard, considerado obsoleto por usar uma chave curta demais para os padrões de hoje).\n\nO problema da criptografia simétrica é a distribuição da chave. Se duas pessoas em lugares diferentes precisam se comunicar, como combinar a chave secreta sem que alguém a intercepte no caminho? Compartilhar a chave por um canal inseguro anula a proteção. Esse é exatamente o problema que a criptografia assimétrica resolve."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Criptografia assimétrica\n\nA criptografia assimétrica usa um par de chaves matematicamente relacionadas: uma chave pública, que pode ser distribuída livremente, e uma chave privada, que o dono nunca compartilha. O que uma chave cifra, só a outra chave do mesmo par consegue decifrar.\n\nSe alguém quer enviar uma mensagem confidencial para você, usa a sua chave pública para cifrá-la. Só a sua chave privada consegue abrir essa mensagem, então mesmo que a chave pública seja interceptada, o conteúdo continua protegido. O exemplo mais conhecido é o RSA. A criptografia assimétrica também é a base da assinatura digital: o remetente cifra um resumo da mensagem com a própria chave privada, e qualquer pessoa pode verificar a autenticidade usando a chave pública correspondente, o que garante não-repúdio (o remetente não pode negar que enviou).\n\nO custo dessa flexibilidade é o desempenho: algoritmos assimétricos são muito mais lentos que os simétricos, por isso raramente são usados para cifrar grandes volumes de dados."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Hashing\n\nHashing é diferente dos dois anteriores porque não existe para esconder informação, e sim para verificar integridade. Um algoritmo de hash pega uma entrada de qualquer tamanho e gera uma saída de tamanho fixo, chamada de hash ou resumo criptográfico. Esse processo é unidirecional: não é possível reverter um hash para recuperar a entrada original, por isso hashing não é criptografia no sentido de cifrar e decifrar.\n\nQualquer alteração mínima na entrada, mesmo de um único caractere, produz um hash completamente diferente. É por isso que hashing serve para verificar se um arquivo foi alterado, para armazenar senhas com segurança (o sistema guarda o hash da senha, nunca a senha em si) e para compor assinaturas digitais. O SHA-256 é o algoritmo padrão recomendado hoje. O MD5, muito usado no passado, hoje é considerado fraco, porque pesquisadores já conseguiram gerar duas entradas diferentes com o mesmo hash (uma colisão), o que quebra a garantia de integridade."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Mecanismo\", \"Chaves\", \"Velocidade\", \"Uso típico\"], [\"Simétrica\", \"Uma chave compartilhada\", \"Rápida\", \"Cifrar grandes volumes de dados (disco, arquivo)\"], [\"Assimétrica\", \"Par de chaves (pública e privada)\", \"Lenta\", \"Troca de chaves, assinatura digital, comunicação inicial\"], [\"Hashing\", \"Nenhuma chave (função unidirecional)\", \"Muito rápida\", \"Verificar integridade, armazenar senhas\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Os três trabalhando juntos\n\nNa prática, sistemas seguros combinam os três mecanismos. Um bom exemplo é o HTTPS, que protege a navegação na web: quando o navegador se conecta a um site, ele usa criptografia assimétrica para negociar com segurança uma chave simétrica temporária (a chave de sessão). A partir daí, toda a comunicação passa a usar criptografia simétrica, muito mais rápida, e cada mensagem trocada é acompanhada de um hash para garantir que não foi alterada no caminho. Esse modelo, que usa a assimétrica para trocar a chave e a simétrica para o volume de dados, é chamado de criptografia híbrida."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Criptografia simétrica é rápida mas tem o desafio de distribuir a chave com segurança. Criptografia assimétrica resolve a distribuição usando um par de chaves, mas é mais lenta. Hashing não esconde dado nenhum, ele garante integridade, mostrando se algo foi alterado. Sistemas seguros de verdade combinam os três."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual a principal diferença entre criptografia simétrica e criptografia assimétrica?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Na simétrica, a mesma chave cifra e decifra a informação; na assimétrica, um par de chaves diferentes (pública e privada) é usado.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Na simétrica os dados não podem ser recuperados; na assimétrica sim.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A simétrica só funciona para texto; a assimétrica funciona para qualquer tipo de arquivo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A simétrica usa hash e a assimétrica usa cifra.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O que o hashing garante quando aplicado a um arquivo?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Integridade, permitindo verificar se o arquivo foi alterado.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Confidencialidade, escondendo o conteúdo do arquivo de quem não tem a chave.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Disponibilidade, garantindo que o arquivo nunca fique inacessível.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Distribuição segura de chaves entre duas partes.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe precisa proteger um banco de dados de 500 GB com informações de clientes, com leitura e gravação constantes e prioridade em desempenho. Qual abordagem é mais adequada?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Usar criptografia simétrica (como AES) para cifrar o volume de dados.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Usar criptografia assimétrica (como RSA) para cifrar diretamente todo o banco de dados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Usar apenas hashing para proteger o conteúdo do banco de dados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não cifrar o banco de dados e confiar apenas no controle de acesso ao servidor.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma empresa quer que um contrato assinado digitalmente não possa ser negado pelo remetente (não-repúdio) e que qualquer alteração no documento seja detectável. Qual combinação de mecanismos atende a essa necessidade?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Hash do documento cifrado com a chave privada do remetente, formando uma assinatura digital.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Cifrar o documento inteiro com uma chave simétrica compartilhada entre as partes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Gerar apenas um hash do documento, sem uso de criptografia assimétrica.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Cifrar o documento com a própria chave pública do remetente.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que o MD5 é considerado inadequado atualmente para verificar a integridade de arquivos críticos?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Porque pesquisadores demonstraram colisões, ou seja, entradas diferentes que geram o mesmo hash, comprometendo a garantia de integridade.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o MD5 é reversível, permitindo recuperar a entrada original a partir do hash.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o MD5 exige uma chave privada que pode ser roubada.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o MD5 é mais lento que o SHA-256, o que compromete o desempenho do sistema.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Manuseio de dados: classificação, rotulagem, retenção e descarte",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Manuseio de dados: classificação, rotulagem, retenção e descarte\n\nNem todo dado tem o mesmo valor. O texto público de uma empresa em seu site institucional não precisa da mesma proteção que a folha de pagamento dos funcionários ou o código-fonte de um produto ainda não lançado. Por isso, antes de decidir como proteger um dado, a organização precisa saber o que ele é e o quanto ele importa. Esse é o papel do manuseio de dados (data handling): um conjunto de práticas que acompanha a informação desde a criação até o descarte final."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Classificação de dados\n\nClassificar dados significa atribuir um nível de sensibilidade a cada informação, com base no impacto que sua exposição indevida causaria ao negócio, aos indivíduos ou, em contextos governamentais, à segurança nacional. Quem decide a classificação é o dono do dado (data owner), a pessoa ou área responsável por aquela informação, não a equipe de TI.\n\nO setor público e o setor privado costumam usar escalas diferentes, e cada organização pode ajustar os nomes, mas a lógica de níveis crescentes de sensibilidade se repete. No governo, uma escala comum é: Ultrassecreto (Top Secret), Secreto, Confidencial e Não classificado (ou Sensível mas não classificado). No setor privado, uma escala comum é: Confidencial/Proprietário (o nível mais alto, como segredos de negócio), Privado (dados pessoais de indivíduos), Sensível (informação que exige proteção mas não é tão crítica) e Público (sem risco relevante na divulgação)."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Setor\", \"Do mais crítico ao menos crítico\"], [\"Governo\", \"Ultrassecreto > Secreto > Confidencial > Não classificado\"], [\"Privado\", \"Confidencial/Proprietário > Privado > Sensível > Público\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Rotulagem e retenção\n\nDepois de classificado, o dado precisa ser rotulado (labeling): uma marcação visível ou embutida que indica o nível de classificação, como um cabeçalho \"CONFIDENCIAL\" em um documento, uma cor de pasta física ou uma etiqueta de metadado em um arquivo digital. A rotulagem é o que permite que pessoas e ferramentas automatizadas, como soluções de DLP (Data Loss Prevention), reconheçam o dado e apliquem o tratamento correto, por exemplo bloqueando o envio de um arquivo marcado como confidencial para fora da empresa.\n\nA retenção define por quanto tempo cada tipo de dado deve ser mantido antes de poder (ou dever) ser descartado. Essa política de retenção normalmente é definida por exigências legais, contratuais ou regulatórias, não por preferência da equipe de TI. Guardar dado além do necessário aumenta o risco e o custo de armazenamento; guardar por menos tempo do que a lei exige pode gerar sanção. No Brasil, a LGPD reforça esse princípio ao determinar que dados pessoais só devem ser mantidos pelo tempo necessário para cumprir a finalidade para a qual foram coletados."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Descarte seguro\n\nQuando um dado chega ao fim do seu ciclo de vida, ele precisa ser destruído de forma que não possa mais ser recuperado. Simplesmente apagar um arquivo ou formatar um disco não é suficiente: essas ações geralmente removem apenas a referência ao dado no sistema de arquivos, mas o conteúdo continua fisicamente gravado na mídia e pode ser recuperado com ferramentas forenses. Esse fenômeno é chamado de remanência de dados.\n\nO descarte seguro varia conforme o nível de sensibilidade e o tipo de mídia. Para papel, a trituração física é suficiente. Para mídias magnéticas, a desmagnetização (degauss) neutraliza o campo magnético que armazena os dados. Para dispositivos que serão reaproveitados, existe a sobrescrita lógica, que grava dados aleatórios por cima dos originais diversas vezes. Quando a mídia não será mais usada e o dado é altamente sensível, a destruição física (trituração, incineração ou desintegração do disco) é o método mais confiável."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Método\", \"Como funciona\", \"Quando usar\"], [\"Sobrescrita (wipe)\", \"Grava dados aleatórios por cima dos originais várias vezes\", \"Disco será reaproveitado ou reutilizado\"], [\"Desmagnetização (degauss)\", \"Aplica campo magnético forte para apagar mídias magnéticas\", \"HDs e fitas que não serão mais usados\"], [\"Destruição física\", \"Tritura, incinera ou perfura a mídia\", \"Dados de altíssima sensibilidade, mídia descartada definitivamente\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Classificar diz o quanto um dado importa, rotular avisa quem encontra o dado sobre isso, retenção diz por quanto tempo guardar, e descarte seguro garante que, quando o dado não for mais necessário, ele realmente deixe de existir, não fique apenas escondido."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Quem deve ser responsável por definir a classificação de um dado dentro de uma organização?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "O dono do dado (data owner), a área responsável pela informação.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A equipe de TI, por ser responsável pela infraestrutura de armazenamento.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Qualquer funcionário que tiver acesso ao arquivo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O fornecedor do software usado para armazenar o dado.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual é a função da rotulagem (labeling) no manuseio de dados?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Marcar visivelmente ou em metadados o nível de classificação do dado, permitindo que pessoas e ferramentas apliquem o tratamento correto.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Definir por quanto tempo o dado deve ser armazenado antes do descarte.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Cifrar o conteúdo do dado para impedir acesso não autorizado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Determinar qual algoritmo de hash será usado para verificar o dado.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma empresa está desativando um lote de discos rígidos que armazenavam dados financeiros altamente sensíveis e não serão mais reaproveitados. Qual é o método de descarte mais adequado?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Destruição física dos discos (trituração ou perfuração).",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Apenas formatar os discos pelo sistema operacional.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Excluir os arquivos e esvaziar a lixeira do sistema.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Renomear os arquivos para dificultar a localização.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um analista encontra um servidor de arquivos com relatórios de projetos encerrados há mais de dez anos, sem qualquer exigência legal ou contratual de retenção para esse tipo de conteúdo. O que essa situação normalmente indica?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Uma possível violação da política de retenção, já que os dados foram mantidos além do necessário.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Que os dados estão automaticamente reclassificados como públicos por causa do tempo decorrido.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que os dados não precisam mais de rotulagem, pois perderam a validade.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que o descarte seguro é opcional para esse tipo de dado.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que simplesmente apagar um arquivo ou formatar um disco não é considerado um método confiável de descarte seguro?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Porque essas ações costumam remover apenas a referência ao arquivo no sistema, deixando o conteúdo fisicamente recuperável (remanência de dados).",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque apagar um arquivo altera automaticamente sua classificação para confidencial.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque a formatação sempre cifra os dados remanescentes com uma chave desconhecida.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o sistema operacional impede qualquer tentativa futura de reformatação do disco.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Logging, monitoramento de eventos e SIEM com IA",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Logging, monitoramento de eventos e SIEM com IA\n\nDe nada adianta classificar dados e cifrar sistemas se ninguém percebe quando algo sai do padrão. Registrar o que acontece nos sistemas (logging) e observar esses registros de perto (monitoramento) é o que permite detectar um incidente cedo, investigar o que aconteceu depois de um ataque e comprovar conformidade com regulamentações. Um log é um registro cronológico de eventos: quem fez o quê, quando, de onde e com qual resultado."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que registrar e de onde vêm os logs\n\nUma organização gera logs em praticamente todos os componentes de sua infraestrutura: servidores, estações de trabalho, firewalls, roteadores, sistemas de IDS/IPS, aplicações e serviços de nuvem. Entre os eventos mais importantes para segurança estão: tentativas de autenticação (bem-sucedidas e, principalmente, malsucedidas), mudanças de privilégio de um usuário, acesso a dados sensíveis, alterações de configuração em sistemas críticos e erros ou falhas incomuns.\n\nUm ponto frequentemente esquecido é que os próprios logs precisam ser protegidos. Um invasor que compromete um sistema costuma tentar apagar ou alterar os logs locais para esconder seus rastros. Por isso, a prática recomendada é centralizar os logs em um servidor separado, com acesso restrito, para que fiquem fora do alcance de quem invadiu o sistema de origem."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## SIEM: juntando as peças\n\nCom dezenas ou centenas de sistemas gerando logs o tempo todo, olhar cada um manualmente é inviável. É aí que entra o SIEM (Security Information and Event Management): uma plataforma que coleta logs de múltiplas fontes, normaliza esses dados em um formato comum, correlaciona eventos que parecem desconexos mas juntos indicam um ataque, e gera alertas para a equipe de segurança.\n\nUm exemplo clássico de correlação: um login malsucedido isolado não chama atenção, mas cem tentativas de login malsucedidas em contas diferentes vindas do mesmo endereço IP, seguidas de um login bem-sucedido, formam um padrão que sugere um ataque de força bruta seguido de comprometimento. Um analista lendo log por log dificilmente notaria essa conexão a tempo; o SIEM existe exatamente para isso."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## SIEM com inteligência artificial\n\nSIEMs tradicionais dependem muito de regras e assinaturas definidas previamente: \"se acontecer X, gere um alerta\". O problema é que ataques novos, sem regra programada para reconhecê-los, passam despercebidos, e ambientes muito grandes acabam gerando um volume enorme de alertas, muitos deles falsos positivos, o que cansa a equipe e faz alertas reais passarem batido (fadiga de alertas).\n\nSIEMs modernos incorporam inteligência artificial e aprendizado de máquina para lidar com isso de outra forma: em vez de depender só de regras fixas, o sistema aprende o comportamento normal de cada usuário e de cada sistema (uma linha de base) e passa a sinalizar desvios desse padrão, mesmo que ninguém tenha escrito uma regra específica para aquele desvio. Essa abordagem é chamada de UEBA (User and Entity Behavior Analytics). Por exemplo, se um funcionário do financeiro que sempre acessa o sistema em horário comercial, de São Paulo, de repente faz login às três da manhã e baixa uma quantidade incomum de arquivos, a IA sinaliza esse comportamento como anômalo, mesmo sem nenhuma regra explícita dizendo \"bloquear downloads às três da manhã\". A IA também ajuda a priorizar alertas por nível de risco e a agrupar eventos relacionados em um único incidente, reduzindo o tempo que o analista gasta separando o que é ruído do que é ameaça real."
+                    },
+                    {
+                        "type": "code",
+                        "value": "2026-07-08T03:14:22Z host=fin-ws-014 user=jsilva event=login result=success origin_ip=201.45.12.8 geo=Sao_Paulo,BR\n2026-07-08T03:15:01Z host=fin-ws-014 user=jsilva event=file_download count=214 destination=usb_removivel\n2026-07-08T03:15:03Z siem_ai alert=behavior_anomaly score=91 reason=\"Volume de download 40x acima da media do usuario; horario fora do padrao habitual\""
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Aspecto\", \"SIEM tradicional (baseado em regras)\", \"SIEM com IA\"], [\"Detecção\", \"Depende de regras e assinaturas conhecidas\", \"Aprende o comportamento normal e detecta desvios (UEBA)\"], [\"Ameaças novas\", \"Difícil detectar o que não tem regra definida\", \"Pode sinalizar padrões inéditos, sem regra prévia\"], [\"Alertas\", \"Alto volume, muitos falsos positivos\", \"Prioriza por risco, agrupa eventos relacionados\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Logging registra o que aconteceu, monitoramento observa isso de perto, e o SIEM correlaciona eventos de todas as fontes para enxergar o que nenhum log sozinho mostraria. Com inteligência artificial, o SIEM deixa de depender só de regras fixas e passa a reconhecer comportamento fora do padrão, mesmo em ameaças que ninguém tinha visto antes."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual é o principal motivo para centralizar logs em um servidor separado dos sistemas de origem?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Proteger os registros contra alteração ou exclusão por um invasor que tenha comprometido o sistema de origem.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Reduzir o espaço em disco usado pelos sistemas de origem.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Eliminar a necessidade de monitorar tentativas de autenticação.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Permitir que qualquer funcionário acesse os logs livremente.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O que é um SIEM (Security Information and Event Management)?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Uma plataforma que coleta, normaliza e correlaciona logs de múltiplas fontes, gerando alertas de segurança.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um algoritmo de criptografia usado para proteger logs armazenados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um tipo de firewall que bloqueia tráfego malicioso na borda da rede.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um documento de política que define como os dados devem ser classificados.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe de segurança percebe que o SIEM tradicional da empresa gera milhares de alertas por dia, a maioria falsos positivos, e os analistas começaram a ignorar notificações por cansaço. Qual característica de um SIEM com IA ajudaria diretamente esse problema?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Priorização de alertas por nível de risco e agrupamento de eventos relacionados em um único incidente.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Substituição total da necessidade de logging nos sistemas de origem.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Eliminação da necessidade de qualquer intervenção humana na resposta a incidentes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Criptografia automática de todos os logs coletados pela plataforma.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual é a principal vantagem do UEBA (User and Entity Behavior Analytics) em relação a um SIEM baseado apenas em regras fixas?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Consegue detectar desvios de comportamento mesmo quando não existe uma regra específica escrita para aquele padrão de ataque.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Elimina totalmente a necessidade de coletar logs de autenticação.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Garante que nenhum alerta falso positivo seja gerado pela plataforma.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Substitui a necessidade de centralizar logs em um único local.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um usuário do setor financeiro, que historicamente acessa o sistema apenas em horário comercial e nunca baixa mais do que alguns arquivos por dia, é registrado baixando centenas de arquivos às três da manhã. Um SIEM tradicional baseado somente em regras fixas provavelmente:",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Não geraria alerta algum, a menos que exista uma regra explícita cobrindo esse volume ou horário específico de download.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Bloquearia automaticamente a conta do usuário sem qualquer configuração prévia.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Classificaria o evento automaticamente como violação da política de retenção de dados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Geraria um alerta de anomalia comportamental baseado em aprendizado de máquina.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Hardening de sistemas, gestão de mudanças e políticas de segurança",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Hardening de sistemas, gestão de mudanças e políticas de segurança\n\nUm sistema recém-instalado, com as configurações padrão de fábrica, é um alvo fácil: contas padrão com senhas conhecidas, serviços que ninguém usa mas continuam ativos, portas abertas sem necessidade. Hardening é o processo de reduzir essa superfície de ataque, deixando o sistema apenas com o que é estritamente necessário para funcionar. É uma das atividades mais constantes da operação de segurança, porque nunca termina: sistema novo, hardening novo; atualização instalada, hardening revisado."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Baseline de configuração e gestão de configuração\n\nUma baseline de configuração é o conjunto documentado de configurações seguras que um determinado tipo de sistema deve ter antes de entrar em produção: quais serviços ficam ativos, quais portas ficam abertas, quais contas existem, quais permissões cada uma tem. Organizações costumam se apoiar em guias de referência publicados por entidades especializadas, como os benchmarks do CIS (Center for Internet Security), em vez de criar cada baseline do zero.\n\nDefinir a baseline não é suficiente se ela não for mantida ao longo do tempo. É aí que entra a gestão de configuração: o processo contínuo de rastrear a configuração de cada sistema, comparar com a baseline aprovada e identificar quando um sistema se desviou do padrão esperado, o que é chamado de configuration drift. Um servidor que teve uma porta aberta manualmente para resolver um problema pontual, e nunca mais foi fechada, é um exemplo clássico de drift."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Atualizações e gestão de patches\n\nVulnerabilidades são descobertas o tempo todo em sistemas operacionais e aplicações. Quando o fabricante corrige uma vulnerabilidade, ele libera um patch (uma atualização de correção). Sistemas sem esse patch aplicado ficam expostos a uma vulnerabilidade conhecida publicamente, um dos vetores de ataque mais comuns, justamente porque não exige nenhuma sofisticação do invasor: a falha já está documentada.\n\nA gestão de patches segue um ciclo: identificar que um patch novo está disponível, testá-lo em ambiente controlado antes de aplicar em produção (para garantir que não quebra nenhum sistema dependente), aplicar de forma programada, normalmente em uma janela de manutenção, e por fim verificar se a atualização foi aplicada com sucesso. Quando uma vulnerabilidade é explorada antes de existir um patch disponível para corrigi-la, chamamos isso de ataque de dia zero (zero-day), o cenário mais difícil de se defender porque não há correção pronta."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Gestão de mudanças\n\nAplicar um patch, alterar uma regra de firewall ou reconfigurar um servidor são todas mudanças, e mudanças feitas sem controle são uma das maiores causas de indisponibilidade em ambientes de TI. A gestão de mudanças (change management) é o processo formal que garante que toda alteração relevante em um sistema passe por solicitação documentada, avaliação de impacto e risco, aprovação (muitas vezes por um comitê chamado CAB, Change Advisory Board) e um plano de reversão (rollback) caso algo dê errado.\n\nNão é burocracia pela burocracia: uma mudança não planejada, aplicada às pressas em um sistema de produção, pode causar uma indisponibilidade tão grave quanto um ataque. A gestão de mudanças conecta diretamente com o hardening e a gestão de patches, porque toda atualização de segurança também é uma mudança que precisa ser controlada."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Políticas de segurança\n\nNenhum controle técnico funciona sozinho sem uma política que defina as regras do jogo e sem que as pessoas saibam quais são elas. Algumas políticas centrais que todo profissional de segurança precisa conhecer:\n\n- **Política de manuseio de dados:** formaliza como cada nível de classificação deve ser tratado (quem pode acessar, como armazenar, como transmitir, como descartar).\n- **Política de senha:** define requisitos mínimos como comprimento, complexidade e uso de autenticação multifator. A orientação mais recente do setor tem priorizado senhas longas (frases secretas) combinadas com MFA, em vez de trocas forçadas muito frequentes, que na prática levam as pessoas a criar senhas fracas e previsíveis.\n- **AUP (Acceptable Use Policy, política de uso aceitável):** define o que é permitido e o que é proibido no uso de recursos da empresa, como e-mail corporativo, internet e equipamentos.\n- **Política de BYOD (Bring Your Own Device):** regula o uso de dispositivos pessoais dos funcionários para acessar recursos corporativos, normalmente exigindo controles mínimos de segurança (como criptografia e capacidade de apagar dados remotamente) como condição para o dispositivo ser autorizado.\n- **Política de privacidade:** define como dados pessoais são coletados, usados e protegidos, alinhada a leis como a LGPD no Brasil e o GDPR na União Europeia."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Política\", \"O que define\"], [\"Manuseio de dados\", \"Como tratar cada nível de classificação (acesso, armazenamento, transmissão, descarte)\"], [\"Senha\", \"Requisitos mínimos de criação e proteção de credenciais\"], [\"AUP\", \"Uso aceitável dos recursos de TI da empresa\"], [\"BYOD\", \"Regras para dispositivos pessoais acessarem recursos corporativos\"], [\"Gestão de mudanças\", \"Como solicitar, avaliar, aprovar e reverter alterações em sistemas\"], [\"Privacidade\", \"Como dados pessoais são coletados, usados e protegidos\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Hardening reduz o que pode ser atacado, a gestão de configuração garante que essa redução se mantenha ao longo do tempo, patches corrigem falhas conhecidas, gestão de mudanças controla como tudo isso é aplicado, e as políticas escrevem essas regras de um jeito que todo mundo na empresa consegue entender e seguir."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que é uma baseline de configuração?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "O conjunto documentado de configurações seguras que um tipo de sistema deve ter antes de entrar em produção.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A lista de vulnerabilidades conhecidas de um sistema operacional.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O registro de todos os logs gerados por um servidor em um dia.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O relatório final de um teste de invasão.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual é o objetivo principal da política de uso aceitável (AUP)?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Definir o que é permitido e o que é proibido no uso dos recursos de TI da empresa.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Definir por quanto tempo os dados devem ser retidos antes do descarte.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Definir quais algoritmos de criptografia devem ser usados pela empresa.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Definir os requisitos mínimos de senha dos usuários.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um administrador identifica que um servidor de produção tem uma porta de rede aberta que não consta na baseline de configuração aprovada para aquele tipo de sistema, e ninguém sabe explicar quando ou por que ela foi aberta. Esse cenário é um exemplo de:",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Configuration drift, um desvio da configuração em relação à baseline aprovada.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um ataque de dia zero em andamento no servidor.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma falha no processo de rotulagem de dados do servidor.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma violação da política de privacidade da empresa.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe de TI precisa aplicar um patch crítico de segurança em um sistema de produção. Qual sequência de passos está mais alinhada às boas práticas de gestão de patches e de mudanças?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Testar o patch em ambiente controlado, obter aprovação formal da mudança, aplicar em janela de manutenção com plano de reversão, e verificar o resultado.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Aplicar o patch imediatamente em produção assim que ele for lançado pelo fabricante, sem testes prévios.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Aguardar a próxima auditoria anual para decidir se o patch deve ser aplicado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Aplicar o patch apenas nas estações de trabalho dos usuários, sem tocar nos servidores.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que uma vulnerabilidade explorada antes da existência de um patch corretivo (ataque de dia zero) é considerada particularmente difícil de se defender?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Porque não existe correção oficial disponível no momento do ataque, tornando ineficaz a defesa baseada apenas em atualização de patches.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque esse tipo de ataque só pode ser realizado por meio de engenharia social.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque ataques de dia zero sempre ocorrem fora do horário comercial, dificultando a detecção.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque esse tipo de vulnerabilidade nunca é registrado nos logs do sistema.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Treinamento, conscientização e o risco da IA generativa",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Treinamento, conscientização e o risco da IA generativa\n\nO controle técnico mais sofisticado do mundo não impede um funcionário de clicar em um link malicioso, entregar a senha por telefone para alguém convincente ou colar dados confidenciais em uma ferramenta pública na internet. Por isso o último pilar das operações de segurança é o mais humano de todos: treinamento e conscientização. As pessoas costumam ser descritas como o elo mais fraco da segurança, mas, quando bem treinadas, também são a melhor linha de defesa, porque conseguem reconhecer e reportar uma tentativa de ataque antes que ela cause dano."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Engenharia social\n\nEngenharia social é a manipulação de pessoas para que revelem informações confidenciais ou realizem ações que comprometam a segurança, explorando características humanas como confiança, urgência, medo, autoridade ou curiosidade, em vez de explorar uma falha técnica. É por isso que nenhum firewall bloqueia um ataque de engenharia social bem executado: ele não ataca o sistema, ataca a pessoa.\n\nAs formas mais comuns incluem: phishing (e-mails fraudulentos em massa, tentando enganar o destinatário), spear phishing (a mesma ideia, mas direcionada a uma pessoa ou empresa específica, com informações que tornam a mensagem mais convincente), whaling (spear phishing direcionado a executivos de alto escalão), vishing (o mesmo golpe aplicado por telefone) e smishing (aplicado por SMS). Também existem ataques presenciais, como o tailgating (seguir uma pessoa autorizada por uma porta de acesso controlado sem usar credencial própria) e o pretexting (criar uma história falsa e convincente para obter informação ou acesso, como se passar por um técnico de suporte)."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Tipo\", \"Como funciona\"], [\"Phishing\", \"E-mail fraudulento enviado em massa, tentando enganar qualquer destinatário\"], [\"Spear phishing\", \"Phishing direcionado a uma pessoa ou empresa específica, com informações personalizadas\"], [\"Whaling\", \"Spear phishing direcionado a executivos e outras figuras de alto escalão\"], [\"Vishing\", \"Engenharia social aplicada por telefone\"], [\"Pretexting\", \"Criação de uma história falsa e convincente para obter dados ou acesso\"], [\"Tailgating\", \"Seguir uma pessoa autorizada por um ponto de acesso físico controlado, sem credencial própria\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Por que o treinamento precisa ser contínuo\n\nUm treinamento de segurança feito uma única vez, no primeiro dia de trabalho, tem efeito quase nenhum meses depois. Programas eficazes de conscientização são contínuos: reforçam o conteúdo periodicamente, usam simulações práticas de phishing para medir se as pessoas realmente reconhecem uma tentativa de ataque no dia a dia, e criam uma cultura em que reportar algo suspeito é incentivado, não motivo de constrangimento. Uma organização em que o funcionário tem medo de admitir que clicou em um link suspeito perde um tempo precioso de resposta, porque o incidente só é descoberto depois, quando o estrago já é maior."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O risco de vazar dados usando IA pública\n\nUma das ameaças mais recentes que os programas de conscientização precisam cobrir não vem de um invasor externo, e sim de um uso bem-intencionado, porém descuidado, de ferramentas de inteligência artificial generativa. É cada vez mais comum um funcionário colar um trecho de contrato, um código-fonte proprietário ou dados de clientes em um serviço público de IA para pedir ajuda a redigir um texto, revisar um código ou resumir um documento.\n\nO problema é que, ao fazer isso, esse dado sai do controle da organização e passa a estar sujeito aos termos de uso do serviço de IA, que em muitos casos permitem que o conteúdo seja armazenado ou até usado para treinar versões futuras do modelo. Isso configura vazamento de dados mesmo sem qualquer intenção maliciosa, e é especialmente grave quando o dado envolvido é confidencial, proprietário ou pessoal (o que também pode representar violação da LGPD, se envolver dados de clientes). A mitigação passa por três frentes que se reforçam: uma política clara (a AUP e a política de manuseio de dados devem dizer explicitamente o que pode e o que não pode ser inserido em ferramentas de IA), ferramentas de IA corporativas aprovadas, com garantias contratuais de proteção de dados, no lugar das versões públicas e gratuitas, e treinamento que mostre esse risco de forma concreta, porque para a maioria das pessoas ele simplesmente não é óbvio."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Sinais de alerta que todo treinamento deveria ensinar\n\nIndependentemente do canal (e-mail, telefone, mensagem ou presencial), a maioria dos ataques de engenharia social compartilha sinais parecidos: um senso artificial de urgência (\"responda em 10 minutos ou sua conta será bloqueada\"), uma autoridade que não bate com o canal usado (um \"diretor\" pedindo uma transferência urgente por mensagem de texto), pedidos fora do padrão normal de trabalho, e pequenos detalhes que não fecham, como um endereço de e-mail parecido mas não idêntico ao domínio real da empresa. Ensinar as pessoas a reconhecer esses sinais, em vez de decorar uma lista de golpes específicos, é o que torna um programa de conscientização eficaz mesmo contra ataques que ainda não existem hoje."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Nenhum sistema técnico substitui uma pessoa treinada para desconfiar na hora certa. Engenharia social ataca a confiança, não o código, e o mesmo cuidado vale para as novas ferramentas de IA: um dado confidencial colado em um serviço público de IA pode vazar tão facilmente quanto um dado clicado em um link malicioso."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que caracteriza um ataque de engenharia social?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "A manipulação de pessoas, explorando confiança, urgência ou autoridade, para obter informações ou acesso indevido.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A exploração de uma falha técnica não corrigida em um sistema operacional.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O uso de força bruta para descobrir senhas por tentativa e erro.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A interceptação de tráfego de rede não criptografado.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual é a diferença entre phishing e spear phishing?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Phishing é enviado em massa para qualquer destinatário; spear phishing é direcionado a uma pessoa ou empresa específica, com informações personalizadas.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Phishing é feito por telefone; spear phishing é feito por e-mail.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Phishing ataca sistemas; spear phishing ataca apenas dispositivos móveis.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Phishing é sempre bem-sucedido; spear phishing raramente funciona.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um funcionário recebe uma ligação de alguém se identificando como técnico do suporte de TI, que afirma precisar da senha dele imediatamente para corrigir uma falha crítica no sistema. Esse é um exemplo de qual técnica de engenharia social?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Vishing (engenharia social por telefone) combinado com pretexting (uso de uma história falsa e convincente).",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Tailgating, por explorar um ponto de acesso físico controlado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Whaling, por ser direcionado especificamente a um executivo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Configuration drift, por envolver uma mudança de configuração sem autorização.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um analista de marketing cola o texto completo de um contrato ainda não divulgado publicamente em um serviço gratuito de IA generativa disponível na internet, pedindo ajuda para resumir o documento para uma reunião. Qual é o principal risco de segurança dessa ação?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O conteúdo do contrato pode sair do controle da empresa e ficar sujeito aos termos de uso do serviço de IA, incluindo possível armazenamento ou uso para treinar o modelo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O serviço de IA vai automaticamente classificar o documento como confidencial e notificar a empresa.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A ação viola exclusivamente a política de senha da empresa.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não existe risco relevante, já que serviços públicos de IA nunca armazenam o conteúdo enviado pelos usuários.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que um programa de conscientização de segurança que ensina apenas uma lista fixa de golpes conhecidos tende a ser menos eficaz do que um que ensina a reconhecer sinais de alerta gerais (como urgência artificial ou autoridade incompatível com o canal usado)?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Porque golpes evoluem constantemente, e reconhecer padrões gerais de manipulação prepara a pessoa até mesmo contra ataques que ainda não existiam quando o treinamento foi feito.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque listas fixas de golpes são proibidas por lei em programas de treinamento corporativo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque sinais de alerta gerais eliminam completamente a necessidade de qualquer controle técnico.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque golpes conhecidos nunca se repetem sob uma forma diferente.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+];
+
+async function seed() {
+    let [trilha] = await db.select().from(trails).where(eq(trails.name, NOME));
+    if (!trilha) {
+        [trilha] = await db
+            .insert(trails)
+            .values({ name: NOME, trailLevel: "iniciante", description: DESCRICAO })
+            .returning();
+        console.log("Trilha criada: " + trilha.name);
+    }
+
+    const existentes = await db.select().from(lessons).where(eq(lessons.trailId, trilha.id));
+    if (existentes.length > 0) {
+        console.log("Trilha " + NOME + " ja tem " + existentes.length + " aulas. Nada a fazer.");
+        return;
+    }
+
+    let totalAulas = 0;
+    let totalQuestoes = 0;
+    for (let mi = 0; mi < MODULOS.length; mi++) {
+        const m = MODULOS[mi];
+        const [mod] = await db
+            .insert(modules)
+            .values({ trailId: trilha.id, title: m.titulo, position: mi + 1 })
+            .returning();
+        for (let li = 0; li < m.aulas.length; li++) {
+            const a = m.aulas[li];
+            const [lesson] = await db
+                .insert(lessons)
+                .values({
+                    trailId: trilha.id,
+                    moduleId: mod.id,
+                    title: a.titulo,
+                    content: null,
+                    contentBlocks: a.blocks,
+                    position: li + 1,
+                    published: true,
+                })
+                .returning();
+            for (let qi = 0; qi < a.questions.length; qi++) {
+                const q = a.questions[qi];
+                const [questao] = await db
+                    .insert(questions)
+                    .values({
+                        lessonId: lesson.id,
+                        statement: q.statement,
+                        difficulty: q.difficulty,
+                        position: qi + 1,
+                    })
+                    .returning();
+                await db.insert(questionOptions).values(
+                    q.options.map((o, k) => ({
+                        questionId: questao.id,
+                        text: o.text,
+                        isCorrect: o.isCorrect,
+                        position: k + 1,
+                    })),
+                );
+            }
+            totalAulas++;
+            totalQuestoes += a.questions.length;
+        }
+    }
+    console.log("Seed concluido: " + MODULOS.length + " modulos, " + totalAulas + " aulas, " + totalQuestoes + " questoes.");
+}
+
+seed()
+    .then(() => process.exit(0))
+    .catch((e) => {
+        console.error("Falha no seed:", e);
+        process.exit(1);
+    });


### PR DESCRIPTION
Adiciona a trilha e o simulado do **ISC2 Certified in Cybersecurity (CC)**, o certificado de entrada em segurança da informação (vendor-neutral, sem pré-requisito). É a primeira trilha de cert de cyber neutra da plataforma (o SC-900 é preso à Microsoft), e fecha a jornada do iniciante em cyber junto com a trilha Fundamentos de Cibersegurança.

## Conteúdo
Trilha (nível iniciante), 7 módulos / 35 aulas / 175 questões de quiz:
1. Princípios de Segurança (tríade CIA, autenticação, MFA, privacidade)
2. Risco, Controles, Ética e Governança
3. Continuidade, Desastres e Resposta a Incidentes
4. Controle de Acesso (DAC/MAC/RBAC, menor privilégio)
5. Fundamentos de Redes (OSI, TCP/IP, portas)
6. Ameaças e Defesa de Rede (IDS/IPS, segmentação, nuvem)
7. Operações de Segurança (criptografia, hardening, políticas)

Simulado: 91 questões no formato da prova, distribuídas pelos pesos reais dos cinco domínios (90 min, corte 70%, 65 por tentativa).

## Alinhamento
Segue o novo outline do CC vigente a partir de set/2026: mantém os 5 domínios e integra os conceitos de IA (governança de IA, detecção de anomalias, SIEM com IA, model drift, vazamento em IA pública), ancorados nos subtópicos de cada domínio.

## Validação
Seeds idempotentes rodados em banco: trilha 7/35/175 (todas as aulas publicadas), simulado 91, tsc limpo. QC de conteúdo em questões difíceis (CIA, canal lateral, DAC/MAC/RBAC, hashing, NAT) confere.

## Pós-deploy (produção)
Depois do merge e do deploy, rodar em prod:
- `node scripts/seed-trilha-isc2-cc.ts` (a trilha)
- `node scripts/seed-isc2-cc.ts` (o simulado)
- `node scripts/seed-categorias-trilhas.ts` (categoriza a nova trilha como Cibersegurança; idempotente pro resto)
