### PR TITLE
feat: adiciona roadmaps de carreira

### DIFF
--- a/backend/app.ts
+++ b/backend/app.ts
@@ -7,6 +7,7 @@ import trailRoutes from "./src/routes/trail.routes.ts";
 import simuladoRoutes from "./src/routes/simulado.routes.ts";
 import desafioRoutes from "./src/routes/desafio.routes.ts";
 import adminRoutes from "./src/routes/admin.routes.ts";
+import roadmapRoutes from "./src/routes/roadmap.routes.ts";
 import { errorMiddleware } from "./src/middlewares/error.ts";
 import { apiLimiter } from "./src/middlewares/rateLimit.ts";
 import helmet from "helmet";
@@ -48,6 +49,7 @@ app.use(userRoutes);
 app.use(trailRoutes);
 app.use(simuladoRoutes);
 app.use(desafioRoutes);
+app.use(roadmapRoutes);
 app.use(adminRoutes);
 
 app.get("/health", (_req, res) => res.json({ status: "ok" }));

--- a/backend/drizzle/0029_nosy_nick_fury.sql
+++ b/backend/drizzle/0029_nosy_nick_fury.sql
@@ -1,0 +1,37 @@
+CREATE TYPE "public"."roadmap_phase" AS ENUM('fundamentos', 'core', 'avancado', 'deploy');--> statement-breakpoint
+CREATE TYPE "public"."roadmap_ref_type" AS ENUM('trail', 'module', 'lesson', 'simulado', 'challenge');--> statement-breakpoint
+CREATE TABLE "roadmap_stage_refs" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"stage_id" uuid NOT NULL,
+	"ref_type" "roadmap_ref_type" NOT NULL,
+	"ref_id" uuid NOT NULL,
+	"position" integer DEFAULT 0 NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "roadmap_stages" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"roadmap_id" uuid NOT NULL,
+	"phase" "roadmap_phase" NOT NULL,
+	"title" varchar(200) NOT NULL,
+	"description" text NOT NULL,
+	"tags" jsonb,
+	"position" integer NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "roadmaps" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"slug" varchar(80) NOT NULL,
+	"name" varchar(160) NOT NULL,
+	"description" text NOT NULL,
+	"level" "trail_level" NOT NULL,
+	"icon" varchar(40),
+	"position" integer DEFAULT 0 NOT NULL,
+	"premium" boolean DEFAULT false NOT NULL,
+	"published" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "roadmaps_slug_unique" UNIQUE("slug")
+);
+--> statement-breakpoint
+ALTER TABLE "roadmap_stage_refs" ADD CONSTRAINT "roadmap_stage_refs_stage_id_roadmap_stages_id_fk" FOREIGN KEY ("stage_id") REFERENCES "public"."roadmap_stages"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "roadmap_stages" ADD CONSTRAINT "roadmap_stages_roadmap_id_roadmaps_id_fk" FOREIGN KEY ("roadmap_id") REFERENCES "public"."roadmaps"("id") ON DELETE no action ON UPDATE no action;

--- a/backend/drizzle/meta/0029_snapshot.json
+++ b/backend/drizzle/meta/0029_snapshot.json
@@ -1,0 +1,2319 @@
+{
+  "id": "ffc5ca6d-e8e5-4206-80ee-454582fff349",
+  "prevId": "dad8b9bb-123f-4fce-a349-00147e4371e7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.achievements": {
+      "name": "achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "criteria_type": {
+          "name": "criteria_type",
+          "type": "achievement_criteria",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "achievements_name_unique": {
+          "name": "achievements_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge_submissions": {
+      "name": "challenge_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "challenge_language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "challenge_submission_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "passed_count": {
+          "name": "passed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_count": {
+          "name": "total_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xp_earned": {
+          "name": "xp_earned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "challenge_submissions_user_id_users_id_fk": {
+          "name": "challenge_submissions_user_id_users_id_fk",
+          "tableFrom": "challenge_submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "challenge_submissions_challenge_id_challenges_id_fk": {
+          "name": "challenge_submissions_challenge_id_challenges_id_fk",
+          "tableFrom": "challenge_submissions",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge_tests": {
+      "name": "challenge_tests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_output": {
+          "name": "expected_output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "challenge_tests_challenge_id_challenges_id_fk": {
+          "name": "challenge_tests_challenge_id_challenges_id_fk",
+          "tableFrom": "challenge_tests",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenges": {
+      "name": "challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "challenge_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stdin'"
+        },
+        "entry_point": {
+          "name": "entry_point",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_blocks": {
+          "name": "statement_blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "question_difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'facil'"
+        },
+        "starter_code": {
+          "name": "starter_code",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_date": {
+          "name": "active_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "challenges_number_unique": {
+          "name": "challenges_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "number"
+          ]
+        },
+        "challenges_active_date_unique": {
+          "name": "challenges_active_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "active_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.glossary": {
+      "name": "glossary",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "term": {
+          "name": "term",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "varchar(400)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "glossary_term_unique": {
+          "name": "glossary_term_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "term"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.languages": {
+      "name": "languages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "languages_name_unique": {
+          "name": "languages_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons_progress": {
+      "name": "lessons_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_progress_user_id_users_id_fk": {
+          "name": "lessons_progress_user_id_users_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_progress_lesson_id_lessons_id_fk": {
+          "name": "lessons_progress_lesson_id_lessons_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lessons_progress_user_id_lesson_id_unique": {
+          "name": "lessons_progress_user_id_lesson_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "lesson_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons": {
+      "name": "lessons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_blocks": {
+          "name": "content_blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_trail_id_trails_id_fk": {
+          "name": "lessons_trail_id_trails_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_module_id_modules_id_fk": {
+          "name": "lessons_module_id_modules_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "modules",
+          "columnsFrom": [
+            "module_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.modules": {
+      "name": "modules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "modules_trail_id_trails_id_fk": {
+          "name": "modules_trail_id_trails_id_fk",
+          "tableFrom": "modules",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_accounts": {
+      "name": "oauth_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_accounts_user_id_users_id_fk": {
+          "name": "oauth_accounts_user_id_users_id_fk",
+          "tableFrom": "oauth_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_accounts_provider_provider_id_unique": {
+          "name": "oauth_accounts_provider_provider_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "provider_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_answers": {
+      "name": "question_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_option_id": {
+          "name": "selected_option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_answers_user_id_users_id_fk": {
+          "name": "question_answers_user_id_users_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_question_id_questions_id_fk": {
+          "name": "question_answers_question_id_questions_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_selected_option_id_question_options_id_fk": {
+          "name": "question_answers_selected_option_id_question_options_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "question_options",
+          "columnsFrom": [
+            "selected_option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "question_answers_user_id_question_id_unique": {
+          "name": "question_answers_user_id_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_options": {
+      "name": "question_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_options_question_id_questions_id_fk": {
+          "name": "question_options_question_id_questions_id_fk",
+          "tableFrom": "question_options",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "question_difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'facil'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_lesson_id_lessons_id_fk": {
+          "name": "questions_lesson_id_lessons_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ranking_snapshots": {
+      "name": "ranking_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ranking_snapshots_user_id_users_id_fk": {
+          "name": "ranking_snapshots_user_id_users_id_fk",
+          "tableFrom": "ranking_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ranking_snapshots_user_id_snapshot_date_unique": {
+          "name": "ranking_snapshots_user_id_snapshot_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "snapshot_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmap_stage_refs": {
+      "name": "roadmap_stage_refs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_type": {
+          "name": "ref_type",
+          "type": "roadmap_ref_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "roadmap_stage_refs_stage_id_roadmap_stages_id_fk": {
+          "name": "roadmap_stage_refs_stage_id_roadmap_stages_id_fk",
+          "tableFrom": "roadmap_stage_refs",
+          "tableTo": "roadmap_stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmap_stages": {
+      "name": "roadmap_stages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "roadmap_id": {
+          "name": "roadmap_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "roadmap_phase",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "roadmap_stages_roadmap_id_roadmaps_id_fk": {
+          "name": "roadmap_stages_roadmap_id_roadmaps_id_fk",
+          "tableFrom": "roadmap_stages",
+          "tableTo": "roadmaps",
+          "columnsFrom": [
+            "roadmap_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmaps": {
+      "name": "roadmaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "trail_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "premium": {
+          "name": "premium",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roadmaps_slug_unique": {
+          "name": "roadmaps_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_attempt_answers": {
+      "name": "simulado_attempt_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_attempt_answers_attempt_id_simulado_attempts_id_fk": {
+          "name": "simulado_attempt_answers_attempt_id_simulado_attempts_id_fk",
+          "tableFrom": "simulado_attempt_answers",
+          "tableTo": "simulado_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempt_answers_question_id_simulado_questions_id_fk": {
+          "name": "simulado_attempt_answers_question_id_simulado_questions_id_fk",
+          "tableFrom": "simulado_attempt_answers",
+          "tableTo": "simulado_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempt_answers_option_id_simulado_options_id_fk": {
+          "name": "simulado_attempt_answers_option_id_simulado_options_id_fk",
+          "tableFrom": "simulado_attempt_answers",
+          "tableTo": "simulado_options",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulado_attempt_answers_attempt_id_question_id_option_id_unique": {
+          "name": "simulado_attempt_answers_attempt_id_question_id_option_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "attempt_id",
+            "question_id",
+            "option_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_attempt_questions": {
+      "name": "simulado_attempt_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_attempt_questions_attempt_id_simulado_attempts_id_fk": {
+          "name": "simulado_attempt_questions_attempt_id_simulado_attempts_id_fk",
+          "tableFrom": "simulado_attempt_questions",
+          "tableTo": "simulado_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempt_questions_question_id_simulado_questions_id_fk": {
+          "name": "simulado_attempt_questions_question_id_simulado_questions_id_fk",
+          "tableFrom": "simulado_attempt_questions",
+          "tableTo": "simulado_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulado_attempt_questions_attempt_id_question_id_unique": {
+          "name": "simulado_attempt_questions_attempt_id_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "attempt_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_attempts": {
+      "name": "simulado_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "simulado_id": {
+          "name": "simulado_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passed": {
+          "name": "passed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_attempts_user_id_users_id_fk": {
+          "name": "simulado_attempts_user_id_users_id_fk",
+          "tableFrom": "simulado_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempts_simulado_id_simulados_id_fk": {
+          "name": "simulado_attempts_simulado_id_simulados_id_fk",
+          "tableFrom": "simulado_attempts",
+          "tableTo": "simulados",
+          "columnsFrom": [
+            "simulado_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_options": {
+      "name": "simulado_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_options_question_id_simulado_questions_id_fk": {
+          "name": "simulado_options_question_id_simulado_questions_id_fk",
+          "tableFrom": "simulado_options",
+          "tableTo": "simulado_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_questions": {
+      "name": "simulado_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "simulado_id": {
+          "name": "simulado_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_questions_simulado_id_simulados_id_fk": {
+          "name": "simulado_questions_simulado_id_simulados_id_fk",
+          "tableFrom": "simulado_questions",
+          "tableTo": "simulados",
+          "columnsFrom": [
+            "simulado_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulados": {
+      "name": "simulados",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_count": {
+          "name": "question_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pass_percent": {
+          "name": "pass_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulados_slug_unique": {
+          "name": "simulados_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tokens": {
+      "name": "tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'refresh'"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tokens_user_id_users_id_fk": {
+          "name": "tokens_user_id_users_id_fk",
+          "tableFrom": "tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tokens_token_hash_unique": {
+          "name": "tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_tags": {
+      "name": "trail_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "trail_tags_trail_id_trails_id_fk": {
+          "name": "trail_tags_trail_id_trails_id_fk",
+          "tableFrom": "trail_tags",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trail_tags_tag_id_tags_id_fk": {
+          "name": "trail_tags_tag_id_tags_id_fk",
+          "tableFrom": "trail_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trail_tags_trail_id_tag_id_unique": {
+          "name": "trail_tags_trail_id_tag_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trail_id",
+            "tag_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trails": {
+      "name": "trails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "trail_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_achievements": {
+      "name": "user_achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "achievement_id": {
+          "name": "achievement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_achievements_user_id_users_id_fk": {
+          "name": "user_achievements_user_id_users_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_achievements_achievement_id_achievements_id_fk": {
+          "name": "user_achievements_achievement_id_achievements_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "achievements",
+          "columnsFrom": [
+            "achievement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_achievements_user_id_achievement_id_unique": {
+          "name": "user_achievements_user_id_achievement_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "achievement_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username_changed_at": {
+          "name": "username_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occupation": {
+          "name": "occupation",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github": {
+          "name": "github",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin": {
+          "name": "linkedin",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "failed_login_attempts": {
+          "name": "failed_login_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.achievement_criteria": {
+      "name": "achievement_criteria",
+      "schema": "public",
+      "values": [
+        "xp_total",
+        "lessons_completed",
+        "questions_correct",
+        "special"
+      ]
+    },
+    "public.challenge_kind": {
+      "name": "challenge_kind",
+      "schema": "public",
+      "values": [
+        "stdin",
+        "function"
+      ]
+    },
+    "public.challenge_language": {
+      "name": "challenge_language",
+      "schema": "public",
+      "values": [
+        "javascript",
+        "python",
+        "csharp",
+        "java"
+      ]
+    },
+    "public.challenge_submission_status": {
+      "name": "challenge_submission_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "passed",
+        "failed",
+        "error",
+        "timeout"
+      ]
+    },
+    "public.question_difficulty": {
+      "name": "question_difficulty",
+      "schema": "public",
+      "values": [
+        "facil",
+        "medio",
+        "dificil"
+      ]
+    },
+    "public.roadmap_phase": {
+      "name": "roadmap_phase",
+      "schema": "public",
+      "values": [
+        "fundamentos",
+        "core",
+        "avancado",
+        "deploy"
+      ]
+    },
+    "public.roadmap_ref_type": {
+      "name": "roadmap_ref_type",
+      "schema": "public",
+      "values": [
+        "trail",
+        "module",
+        "lesson",
+        "simulado",
+        "challenge"
+      ]
+    },
+    "public.trail_level": {
+      "name": "trail_level",
+      "schema": "public",
+      "values": [
+        "iniciante",
+        "intermediario",
+        "avancado"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin",
+        "moderator"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1783227653650,
       "tag": "0028_narrow_hammerhead",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1783695348882,
+      "tag": "0029_nosy_nick_fury",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/schema.ts
+++ b/backend/schema.ts
@@ -406,3 +406,50 @@ export const challengeSubmissions = pgTable("challenge_submissions", {
     xpEarned: integer("xp_earned").default(0).notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
 });
+
+// Roadmaps: orquestração sobre o conteúdo existente; progresso derivado dos sinais atuais.
+export const roadmapPhase = pgEnum("roadmap_phase", ["fundamentos", "core", "avancado", "deploy"]);
+export const roadmapRefType = pgEnum("roadmap_ref_type", [
+    "trail",
+    "module",
+    "lesson",
+    "simulado",
+    "challenge",
+]);
+
+export const roadmaps = pgTable("roadmaps", {
+    id: uuid("id").primaryKey().defaultRandom(),
+    slug: varchar("slug", { length: 80 }).notNull().unique(),
+    name: varchar("name", { length: 160 }).notNull(),
+    description: text("description").notNull(),
+    level: trailLevel("level").notNull(),
+    icon: varchar("icon", { length: 40 }),
+    position: integer("position").default(0).notNull(),
+    premium: boolean("premium").default(false).notNull(),
+    published: boolean("published").default(false).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+});
+
+export const roadmapStages = pgTable("roadmap_stages", {
+    id: uuid("id").primaryKey().defaultRandom(),
+    roadmapId: uuid("roadmap_id")
+        .references(() => roadmaps.id)
+        .notNull(),
+    phase: roadmapPhase("phase").notNull(),
+    title: varchar("title", { length: 200 }).notNull(),
+    description: text("description").notNull(),
+    tags: jsonb("tags").$type<string[]>(),
+    position: integer("position").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+});
+
+// refId polimórfico (sem FK): aponta pra trails/modules/lessons/simulados/challenges conforme refType.
+export const roadmapStageRefs = pgTable("roadmap_stage_refs", {
+    id: uuid("id").primaryKey().defaultRandom(),
+    stageId: uuid("stage_id")
+        .references(() => roadmapStages.id)
+        .notNull(),
+    refType: roadmapRefType("ref_type").notNull(),
+    refId: uuid("ref_id").notNull(),
+    position: integer("position").default(0).notNull(),
+});

--- a/backend/scripts/seed-roadmap-seguranca.ts
+++ b/backend/scripts/seed-roadmap-seguranca.ts
@@ -1,0 +1,143 @@
+// Seed do roadmap "Segurança": camada de orquestração sobre o conteúdo cyber que já
+// existe (Fundamentos, SC-900, ISC2 CC, AppSec), terminando no simulado do ISC2 CC.
+// Idempotente: se o roadmap já tiver estágios, não faz nada. Refs resolvidas por
+// nome (trilha) / slug (simulado); ref não encontrada é pulada com aviso.
+//
+// Rodar em prod: docker compose -f docker-compose.prod.yml exec -T backend node scripts/seed-roadmap-seguranca.ts
+import { db } from "../db.ts";
+import { roadmaps, roadmapStages, roadmapStageRefs, trails, simulados } from "../schema.ts";
+import { eq, count } from "drizzle-orm";
+
+const SLUG = "seguranca";
+
+const ROADMAP = {
+    slug: SLUG,
+    name: "Segurança",
+    description:
+        "Do zero à primeira certificação em segurança. Fundamentos, segurança na nuvem, aplicações web e a prova final, num caminho guiado e vendor-neutral.",
+    level: "iniciante" as const,
+    icon: "shield",
+    position: 1,
+};
+
+type RefType = "trail" | "simulado";
+interface Ref {
+    type: RefType;
+    ref: string; // nome da trilha ou slug do simulado
+}
+interface Stage {
+    phase: "fundamentos" | "core" | "avancado" | "deploy";
+    title: string;
+    description: string;
+    tags: string[];
+    refs: Ref[];
+}
+
+const STAGES: Stage[] = [
+    {
+        phase: "fundamentos",
+        title: "Fundamentos de Cibersegurança",
+        description:
+            "Comece pelo começo: a tríade CIA, o panorama de ameaças e atores, malware, engenharia social e os princípios de defesa.",
+        tags: ["Tríade CIA", "Ameaças", "Engenharia social"],
+        refs: [{ type: "trail", ref: "Fundamentos de Cibersegurança" }],
+    },
+    {
+        phase: "fundamentos",
+        title: "Identidade e conformidade na nuvem",
+        description:
+            "Identidade, conformidade e os fundamentos de segurança na nuvem, pelo currículo do Microsoft SC-900.",
+        tags: ["Identidade", "Compliance", "Azure"],
+        refs: [{ type: "trail", ref: "AZURE SC-900" }],
+    },
+    {
+        phase: "core",
+        title: "Certificação vendor-neutral: ISC2 CC",
+        description:
+            "A certificação de entrada em segurança da informação: os cinco domínios do exame Certified in Cybersecurity da ISC2.",
+        tags: ["ISC2", "5 domínios", "Vendor-neutral"],
+        refs: [{ type: "trail", ref: "ISC2 Certified in Cybersecurity (CC)" }],
+    },
+    {
+        phase: "core",
+        title: "Segurança de aplicações web (OWASP)",
+        description:
+            "Segurança de aplicações na prática, guiado pelo OWASP Top 10 2025: injeção, controle de acesso quebrado, configuração e mais.",
+        tags: ["OWASP", "AppSec", "Injeção"],
+        refs: [{ type: "trail", ref: "Segurança de Aplicações Web" }],
+    },
+    {
+        phase: "avancado",
+        title: "Prove-se: simulado do ISC2 CC",
+        description:
+            "Hora de provar: faça o simulado no formato da prova do ISC2 CC e valide se você está pronto para a certificação.",
+        tags: ["Simulado", "Certificação"],
+        refs: [{ type: "simulado", ref: "isc2-cc" }],
+    },
+];
+
+async function resolverRef(type: RefType, ref: string): Promise<string | null> {
+    if (type === "trail") {
+        const [t] = await db.select({ id: trails.id }).from(trails).where(eq(trails.name, ref));
+        return t?.id ?? null;
+    }
+    const [s] = await db.select({ id: simulados.id }).from(simulados).where(eq(simulados.slug, ref));
+    return s?.id ?? null;
+}
+
+async function seed() {
+    let [rm] = await db.select().from(roadmaps).where(eq(roadmaps.slug, SLUG));
+    if (rm) {
+        const [{ n }] = await db
+            .select({ n: count() })
+            .from(roadmapStages)
+            .where(eq(roadmapStages.roadmapId, rm.id));
+        if (Number(n) > 0) {
+            console.log("Roadmap " + SLUG + " já tem " + n + " estágios. Nada a fazer.");
+            return;
+        }
+    } else {
+        [rm] = await db.insert(roadmaps).values({ ...ROADMAP, premium: false, published: true }).returning();
+        console.log("Roadmap criado: " + rm.slug);
+    }
+
+    let pos = 1;
+    let refsCriados = 0;
+    let refsFaltando = 0;
+    for (const s of STAGES) {
+        const [stage] = await db
+            .insert(roadmapStages)
+            .values({
+                roadmapId: rm.id,
+                phase: s.phase,
+                title: s.title,
+                description: s.description,
+                tags: s.tags,
+                position: pos++,
+            })
+            .returning();
+        let rpos = 1;
+        for (const r of s.refs) {
+            const refId = await resolverRef(r.type, r.ref);
+            if (!refId) {
+                console.log("  ref não encontrada, pulando: " + r.type + " -> " + r.ref);
+                refsFaltando++;
+                continue;
+            }
+            await db
+                .insert(roadmapStageRefs)
+                .values({ stageId: stage.id, refType: r.type, refId, position: rpos++ });
+            refsCriados++;
+        }
+    }
+    console.log(
+        "Seed concluído: " + STAGES.length + " estágios, " + refsCriados + " refs (" + refsFaltando + " faltando).",
+    );
+}
+
+seed()
+    .then(() => process.exit(0))
+    .catch((e) => {
+        console.error("Falha no seed:", e);
+        process.exit(1);
+    });

--- a/backend/src/controllers/RoadmapController.ts
+++ b/backend/src/controllers/RoadmapController.ts
@@ -1,0 +1,21 @@
+import type { Request, Response, NextFunction } from "express";
+import { listarRoadmaps, obterRoadmap } from "../services/roadmap.service.ts";
+
+export const listRoadmaps = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        res.json(await listarRoadmaps(req.userId));
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const getRoadmap = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const slug = typeof req.params.slug === "string" ? req.params.slug : "";
+        const roadmap = await obterRoadmap(slug, req.userId);
+        if (!roadmap) return res.status(404).json({ erro: "Roadmap não encontrado" });
+        res.json(roadmap);
+    } catch (err) {
+        next(err);
+    }
+};

--- a/backend/src/routes/roadmap.routes.ts
+++ b/backend/src/routes/roadmap.routes.ts
@@ -1,0 +1,10 @@
+import { Router } from "express";
+import { autenticar } from "../middlewares/auth.ts";
+import { listRoadmaps, getRoadmap } from "../controllers/RoadmapController.ts";
+
+const router = Router();
+
+router.get("/roadmaps", autenticar, listRoadmaps);
+router.get("/roadmaps/:slug", autenticar, getRoadmap);
+
+export default router;

--- a/backend/src/services/roadmap.service.ts
+++ b/backend/src/services/roadmap.service.ts
@@ -1,0 +1,303 @@
+import { db } from "../../db.ts";
+import {
+    roadmaps,
+    roadmapStages,
+    roadmapStageRefs,
+    trails,
+    modules,
+    lessons,
+    lessonProgress,
+    simulados,
+    simuladoAttempts,
+    challenges,
+    challengeSubmissions,
+} from "../../schema.ts";
+import { eq, and, asc, inArray } from "drizzle-orm";
+
+type RefType = "trail" | "module" | "lesson" | "simulado" | "challenge";
+type StatusRoadmap = "nao_iniciado" | "em_progresso" | "concluido";
+
+interface Conclusao {
+    lessons: Set<string>;
+    simulados: Set<string>;
+    desafios: Set<string>;
+}
+
+const SEM_CONCLUSAO: Conclusao = {
+    lessons: new Set(),
+    simulados: new Set(),
+    desafios: new Set(),
+};
+
+// Sinais de conclusão do usuário, carregados uma vez. Desafio resolvido = submissão
+// com status "passed" (não xpEarned, que é específico do desafio do dia).
+async function carregarConclusao(userId: string): Promise<Conclusao> {
+    const [aulas, sims, des] = await Promise.all([
+        db.select({ id: lessonProgress.lessonId }).from(lessonProgress).where(eq(lessonProgress.userId, userId)),
+        db
+            .select({ id: simuladoAttempts.simuladoId })
+            .from(simuladoAttempts)
+            .where(and(eq(simuladoAttempts.userId, userId), eq(simuladoAttempts.passed, true))),
+        db
+            .select({ id: challengeSubmissions.challengeId })
+            .from(challengeSubmissions)
+            .where(and(eq(challengeSubmissions.userId, userId), eq(challengeSubmissions.status, "passed"))),
+    ]);
+    return {
+        lessons: new Set(aulas.map((r) => r.id)),
+        simulados: new Set(sims.map((r) => r.id)),
+        desafios: new Set(des.map((r) => r.id)),
+    };
+}
+
+// Aulas publicadas por trilha e por módulo referenciados (pra derivar conclusão de container).
+async function carregarAulasPorContainer(trailIds: string[], moduleIds: string[]) {
+    const porTrail = new Map<string, string[]>();
+    const porModule = new Map<string, string[]>();
+    if (trailIds.length) {
+        const rows = await db
+            .select({ trailId: lessons.trailId, id: lessons.id })
+            .from(lessons)
+            .where(and(inArray(lessons.trailId, trailIds), eq(lessons.published, true)));
+        for (const r of rows) {
+            const arr = porTrail.get(r.trailId) ?? [];
+            arr.push(r.id);
+            porTrail.set(r.trailId, arr);
+        }
+    }
+    if (moduleIds.length) {
+        const rows = await db
+            .select({ moduleId: lessons.moduleId, id: lessons.id })
+            .from(lessons)
+            .where(and(inArray(lessons.moduleId, moduleIds), eq(lessons.published, true)));
+        for (const r of rows) {
+            const arr = porModule.get(r.moduleId) ?? [];
+            arr.push(r.id);
+            porModule.set(r.moduleId, arr);
+        }
+    }
+    return { porTrail, porModule };
+}
+
+function refConcluido(
+    refType: RefType,
+    refId: string,
+    c: Conclusao,
+    aulas: { porTrail: Map<string, string[]>; porModule: Map<string, string[]> },
+): boolean {
+    switch (refType) {
+        case "lesson":
+            return c.lessons.has(refId);
+        case "simulado":
+            return c.simulados.has(refId);
+        case "challenge":
+            return c.desafios.has(refId);
+        case "trail": {
+            const ls = aulas.porTrail.get(refId) ?? [];
+            return ls.length > 0 && ls.every((id) => c.lessons.has(id));
+        }
+        case "module": {
+            const ls = aulas.porModule.get(refId) ?? [];
+            return ls.length > 0 && ls.every((id) => c.lessons.has(id));
+        }
+    }
+}
+
+function statusPorProgresso(feitos: number, total: number): StatusRoadmap {
+    if (total === 0 || feitos === 0) return "nao_iniciado";
+    if (feitos >= total) return "concluido";
+    return "em_progresso";
+}
+
+// Resolve cada ref para dados de exibição (título + o que o front precisa pra rotear).
+async function resolverRefs(refs: { refType: RefType; refId: string }[]) {
+    const idsDe = (t: RefType) => [...new Set(refs.filter((r) => r.refType === t).map((r) => r.refId))];
+    const [tr, md, ls, sm, ch] = await Promise.all([
+        idsDe("trail").length
+            ? db.select({ id: trails.id, name: trails.name }).from(trails).where(inArray(trails.id, idsDe("trail")))
+            : Promise.resolve([] as { id: string; name: string }[]),
+        idsDe("module").length
+            ? db
+                  .select({ id: modules.id, title: modules.title, trailId: modules.trailId })
+                  .from(modules)
+                  .where(inArray(modules.id, idsDe("module")))
+            : Promise.resolve([] as { id: string; title: string; trailId: string }[]),
+        idsDe("lesson").length
+            ? db
+                  .select({ id: lessons.id, title: lessons.title, trailId: lessons.trailId })
+                  .from(lessons)
+                  .where(inArray(lessons.id, idsDe("lesson")))
+            : Promise.resolve([] as { id: string; title: string; trailId: string }[]),
+        idsDe("simulado").length
+            ? db
+                  .select({ id: simulados.id, name: simulados.name, slug: simulados.slug })
+                  .from(simulados)
+                  .where(inArray(simulados.id, idsDe("simulado")))
+            : Promise.resolve([] as { id: string; name: string; slug: string }[]),
+        idsDe("challenge").length
+            ? db
+                  .select({ id: challenges.id, title: challenges.title, number: challenges.number })
+                  .from(challenges)
+                  .where(inArray(challenges.id, idsDe("challenge")))
+            : Promise.resolve([] as { id: string; title: string; number: number | null }[]),
+    ]);
+    const info = new Map<string, Record<string, unknown>>();
+    for (const r of tr) info.set("trail:" + r.id, { title: r.name, trailId: r.id });
+    for (const r of md) info.set("module:" + r.id, { title: r.title, trailId: r.trailId });
+    for (const r of ls) info.set("lesson:" + r.id, { title: r.title, trailId: r.trailId, lessonId: r.id });
+    for (const r of sm) info.set("simulado:" + r.id, { title: r.name, slug: r.slug });
+    for (const r of ch) info.set("challenge:" + r.id, { title: r.title, number: r.number });
+    return info;
+}
+
+export async function listarRoadmaps(userId?: string) {
+    const lista = await db
+        .select()
+        .from(roadmaps)
+        .where(eq(roadmaps.published, true))
+        .orderBy(asc(roadmaps.position));
+    if (lista.length === 0) return [];
+
+    const ids = lista.map((r) => r.id);
+    const etapas = await db
+        .select()
+        .from(roadmapStages)
+        .where(inArray(roadmapStages.roadmapId, ids))
+        .orderBy(asc(roadmapStages.position));
+    const etapaIds = etapas.map((e) => e.id);
+    const refs = etapaIds.length
+        ? await db.select().from(roadmapStageRefs).where(inArray(roadmapStageRefs.stageId, etapaIds))
+        : [];
+
+    let conclusao = SEM_CONCLUSAO;
+    let aulas = { porTrail: new Map<string, string[]>(), porModule: new Map<string, string[]>() };
+    if (userId) {
+        conclusao = await carregarConclusao(userId);
+        aulas = await carregarAulasPorContainer(
+            refs.filter((r) => r.refType === "trail").map((r) => r.refId),
+            refs.filter((r) => r.refType === "module").map((r) => r.refId),
+        );
+    }
+
+    const refsPorEtapa = new Map<string, typeof refs>();
+    for (const r of refs) {
+        const arr = refsPorEtapa.get(r.stageId) ?? [];
+        arr.push(r);
+        refsPorEtapa.set(r.stageId, arr);
+    }
+    const etapaConcluida = (stageId: string) => {
+        const rs = refsPorEtapa.get(stageId) ?? [];
+        return rs.length > 0 && rs.every((r) => refConcluido(r.refType as RefType, r.refId, conclusao, aulas));
+    };
+
+    return lista.map((r) => {
+        const suas = etapas.filter((e) => e.roadmapId === r.id);
+        const total = suas.length;
+        const feitos = userId ? suas.filter((e) => etapaConcluida(e.id)).length : 0;
+        const tags = [...new Set(suas.flatMap((e) => e.tags ?? []))].slice(0, 3);
+        return {
+            id: r.id,
+            slug: r.slug,
+            name: r.name,
+            description: r.description,
+            level: r.level,
+            icon: r.icon,
+            premium: r.premium,
+            tags,
+            stagesTotal: total,
+            stagesDone: feitos,
+            percent: total ? Math.round((feitos / total) * 100) : 0,
+            status: statusPorProgresso(feitos, total),
+        };
+    });
+}
+
+export async function obterRoadmap(slug: string, userId?: string) {
+    const [roadmap] = await db
+        .select()
+        .from(roadmaps)
+        .where(and(eq(roadmaps.slug, slug), eq(roadmaps.published, true)));
+    if (!roadmap) return null;
+
+    const etapas = await db
+        .select()
+        .from(roadmapStages)
+        .where(eq(roadmapStages.roadmapId, roadmap.id))
+        .orderBy(asc(roadmapStages.position));
+    const etapaIds = etapas.map((e) => e.id);
+    const refs = etapaIds.length
+        ? await db
+              .select()
+              .from(roadmapStageRefs)
+              .where(inArray(roadmapStageRefs.stageId, etapaIds))
+              .orderBy(asc(roadmapStageRefs.position))
+        : [];
+
+    let conclusao = SEM_CONCLUSAO;
+    let aulas = { porTrail: new Map<string, string[]>(), porModule: new Map<string, string[]>() };
+    if (userId) {
+        conclusao = await carregarConclusao(userId);
+        aulas = await carregarAulasPorContainer(
+            refs.filter((r) => r.refType === "trail").map((r) => r.refId),
+            refs.filter((r) => r.refType === "module").map((r) => r.refId),
+        );
+    }
+    const infoRef = await resolverRefs(refs.map((r) => ({ refType: r.refType as RefType, refId: r.refId })));
+
+    const refsPorEtapa = new Map<string, typeof refs>();
+    for (const r of refs) {
+        const arr = refsPorEtapa.get(r.stageId) ?? [];
+        arr.push(r);
+        refsPorEtapa.set(r.stageId, arr);
+    }
+
+    const etapasSaida = etapas.map((e) => {
+        const rs = refsPorEtapa.get(e.id) ?? [];
+        const completed =
+            userId && rs.length > 0 && rs.every((r) => refConcluido(r.refType as RefType, r.refId, conclusao, aulas));
+        return {
+            id: e.id,
+            phase: e.phase,
+            title: e.title,
+            description: e.description,
+            tags: e.tags ?? [],
+            position: e.position,
+            completed: !!completed,
+            refs: rs.map((r) => ({
+                refType: r.refType,
+                refId: r.refId,
+                ...(infoRef.get(r.refType + ":" + r.refId) ?? { title: null }),
+            })),
+        };
+    });
+
+    // Cadeado sequencial: a etapa fica bloqueada até a anterior ser concluída. A primeira nunca.
+    let anteriorConcluida = true;
+    const comCadeado = etapasSaida.map((e) => {
+        const locked = userId ? !anteriorConcluida : false;
+        anteriorConcluida = e.completed;
+        return { ...e, locked };
+    });
+
+    const feitos = comCadeado.filter((e) => e.completed).length;
+    const total = comCadeado.length;
+    const atual = comCadeado.find((e) => !e.completed && !e.locked);
+
+    return {
+        id: roadmap.id,
+        slug: roadmap.slug,
+        name: roadmap.name,
+        description: roadmap.description,
+        level: roadmap.level,
+        icon: roadmap.icon,
+        premium: roadmap.premium,
+        progress: {
+            stagesTotal: total,
+            stagesDone: feitos,
+            percent: total ? Math.round((feitos / total) * 100) : 0,
+            status: statusPorProgresso(feitos, total),
+        },
+        currentStageId: atual?.id ?? null,
+        stages: comCadeado,
+    };
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,8 @@ import { Login } from './pages/Login';
 import { Register } from './pages/Register';
 import { Home } from './pages/Home';
 import { Trilhas } from './pages/Trilhas';
+import { Roadmaps } from './pages/Roadmaps';
+import { RoadmapDetalhe } from './pages/Roadmaps/Detalhe';
 import { Aula } from './pages/Aula';
 import { Estudio } from './pages/Estudio';
 import { EstudioHome } from './pages/EstudioHome';
@@ -96,6 +98,22 @@ function AppRoutes() {
         element={
           <PrivateRoute>
             <Aula />
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/roadmaps"
+        element={
+          <PrivateRoute>
+            <Roadmaps />
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/roadmaps/:slug"
+        element={
+          <PrivateRoute>
+            <RoadmapDetalhe />
           </PrivateRoute>
         }
       />

--- a/frontend/src/data/nav.ts
+++ b/frontend/src/data/nav.ts
@@ -1,6 +1,7 @@
 // Itens da navegação principal, compartilhados por todas as abas para não divergirem.
 export const NAV_PRINCIPAL = [
   { label: 'Início', to: '/home' },
+  { label: 'Roadmaps', to: '/roadmaps' },
   { label: 'Trilhas', to: '/trilhas' },
   { label: 'Simulados', to: '/simulados' },
   { label: 'Desafios', to: '/desafios' },

--- a/frontend/src/pages/Roadmaps/Detalhe.tsx
+++ b/frontend/src/pages/Roadmaps/Detalhe.tsx
@@ -1,0 +1,211 @@
+import { useEffect, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { useAuth } from '../../contexts/AuthContext';
+import { Logo } from '../../components/Logo';
+import { MobileMenu } from '../../components/MobileMenu';
+import { UserMenu } from '../../components/UserMenu';
+import { ThemeToggle } from '../../components/ThemeToggle';
+import { Flame, Check, Lock, ChevronRight, ChevronLeft, Play } from '../../components/Icons';
+import { getInitials } from '../../utils/initials';
+import { user } from '../../data/home';
+import { NAV_PRINCIPAL as NAV } from '../../data/nav';
+import { obterRoadmap, type RoadmapDetalhe, type RoadmapStage, type RoadmapRef, type RoadmapPhase } from '../../services/roadmaps';
+import { obterTrilha } from '../../services/trails';
+
+const PHASE_LABEL: Record<RoadmapPhase, string> = {
+  fundamentos: 'Fundamentos',
+  core: 'Core',
+  avancado: 'Avançado',
+  deploy: 'Deploy',
+};
+
+function Ring({ percent }: { percent: number }) {
+  const r = 30;
+  const c = 2 * Math.PI * r;
+  const off = c - (percent / 100) * c;
+  return (
+    <svg width="76" height="76" viewBox="0 0 76 76" className="rmd-ring">
+      <circle cx="38" cy="38" r={r} fill="none" stroke="rgba(255,255,255,0.28)" strokeWidth="6" />
+      <circle
+        cx="38"
+        cy="38"
+        r={r}
+        fill="none"
+        stroke="#fff"
+        strokeWidth="6"
+        strokeLinecap="round"
+        strokeDasharray={c}
+        strokeDashoffset={off}
+        transform="rotate(-90 38 38)"
+      />
+      <text x="38" y="43" textAnchor="middle" fill="#fff" fontSize="17" fontWeight="700">
+        {percent}%
+      </text>
+    </svg>
+  );
+}
+
+export function RoadmapDetalhe() {
+  const { slug } = useParams();
+  const { user: authUser } = useAuth();
+  const navigate = useNavigate();
+
+  const displayName = authUser?.name ?? user.name;
+  const initials = getInitials(displayName);
+
+  const [rm, setRm] = useState<RoadmapDetalhe | null>(null);
+  const [carregando, setCarregando] = useState(true);
+  const [erro, setErro] = useState('');
+
+  useEffect(() => {
+    if (!slug) return;
+    obterRoadmap(slug)
+      .then(setRm)
+      .catch(() => setErro('Não foi possível carregar o roadmap.'))
+      .finally(() => setCarregando(false));
+  }, [slug]);
+
+  // Leva ao conteúdo do estágio conforme o tipo do ref.
+  async function irParaRef(ref?: RoadmapRef) {
+    if (!ref) return;
+    if (ref.refType === 'simulado' && ref.slug) return navigate(`/simulados/${ref.slug}`);
+    if (ref.refType === 'lesson' && ref.trailId && ref.lessonId) {
+      return navigate(`/trilhas/${ref.trailId}/aula/${ref.lessonId}`);
+    }
+    if (ref.refType === 'challenge') return navigate(`/desafios/${ref.refId}`);
+    if ((ref.refType === 'trail' || ref.refType === 'module') && ref.trailId) {
+      try {
+        const detalhe = await obterTrilha(ref.trailId);
+        const aulas = detalhe.modules.flatMap((m) => m.lessons);
+        const alvo =
+          aulas.find((l) => l.state === 'current') ?? aulas.find((l) => l.state !== 'locked') ?? aulas[0];
+        return navigate(alvo ? `/trilhas/${ref.trailId}/aula/${alvo.id}` : '/trilhas');
+      } catch {
+        return navigate('/trilhas');
+      }
+    }
+  }
+
+  function estadoDe(s: RoadmapStage): 'done' | 'current' | 'locked' | 'todo' {
+    if (s.completed) return 'done';
+    if (s.locked) return 'locked';
+    if (rm && s.id === rm.currentStageId) return 'current';
+    return 'todo';
+  }
+
+  return (
+    <div className="home-shell">
+      <div className="home">
+        <header className="topbar">
+          <MobileMenu />
+          <Logo variant="solid" size={20} />
+          <nav className="nav">
+            {NAV.map((item) => (
+              <Link
+                key={item.to}
+                to={item.to}
+                className={`nav__item${item.label === 'Roadmaps' ? ' nav__item--active' : ''}`}
+              >
+                {item.label}
+              </Link>
+            ))}
+          </nav>
+          <div className="topbar__spacer" />
+          <div className="streak-pill">
+            <Flame size={16} /> {authUser?.streak ?? 0}
+          </div>
+          <ThemeToggle inline />
+          <UserMenu
+            initials={initials}
+            level={authUser?.level ?? 1}
+            name={displayName}
+            email={authUser?.email}
+          />
+        </header>
+
+        <div className="rmd">
+          <Link to="/roadmaps" className="rmd-back">
+            <ChevronLeft size={16} /> Roadmaps
+          </Link>
+
+          {carregando && <p className="track__desc">Carregando roadmap...</p>}
+          {erro && <div className="auth__alert">{erro}</div>}
+          {!carregando && !erro && !rm && (
+            <p className="track__desc">Roadmap não encontrado.</p>
+          )}
+
+          {rm && (
+            <>
+              <div className="rmd-hero">
+                <div className="rmd-hero__body">
+                  <div className="rmd-hero__kicker">Roadmap de carreira</div>
+                  <h1 className="rmd-hero__title">{rm.name}</h1>
+                  <p className="rmd-hero__desc">{rm.description}</p>
+                </div>
+                <Ring percent={rm.progress.percent} />
+              </div>
+
+              <div className="rmd-stages">
+                {rm.stages.map((s, i) => {
+                  const estado = estadoDe(s);
+                  return (
+                    <div key={s.id} className={`rmd-stage rmd-stage--${estado}`}>
+                      <div className="rmd-stage__rail">
+                        <span className="rmd-stage__dot">
+                          {estado === 'done' ? (
+                            <Check size={16} />
+                          ) : estado === 'locked' ? (
+                            <Lock size={14} />
+                          ) : (
+                            i + 1
+                          )}
+                        </span>
+                      </div>
+                      <div className="rmd-stage__card">
+                        <div className="rmd-stage__top">
+                          <span className="rmd-phase">{PHASE_LABEL[s.phase]}</span>
+                          <span className="rmd-stage__title">{s.title}</span>
+                          <span className={`rmd-stage__badge rmd-stage__badge--${estado}`}>
+                            {estado === 'done'
+                              ? 'Concluído'
+                              : estado === 'locked'
+                                ? 'Bloqueado'
+                                : estado === 'current'
+                                  ? 'Em andamento'
+                                  : 'Disponível'}
+                          </span>
+                        </div>
+                        <p className="rmd-stage__desc">{s.description}</p>
+                        <div className="rmd-stage__tags">
+                          {s.tags.map((tag) => (
+                            <span key={tag} className="chip--outline">
+                              {tag}
+                            </span>
+                          ))}
+                        </div>
+                        {estado !== 'locked' && estado !== 'done' && (
+                          <button className="rmd-stage__btn" onClick={() => irParaRef(s.refs[0])}>
+                            <Play size={13} />{' '}
+                            {estado === 'current' ? 'Continuar estágio' : 'Começar estágio'}
+                          </button>
+                        )}
+                        {estado === 'done' && s.refs[0] && (
+                          <button
+                            className="rmd-stage__btn rmd-stage__btn--ghost"
+                            onClick={() => irParaRef(s.refs[0])}
+                          >
+                            Revisar <ChevronRight size={14} />
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Roadmaps/index.tsx
+++ b/frontend/src/pages/Roadmaps/index.tsx
@@ -1,0 +1,256 @@
+import { useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useAuth } from '../../contexts/AuthContext';
+import { Logo } from '../../components/Logo';
+import { MobileMenu } from '../../components/MobileMenu';
+import { UserMenu } from '../../components/UserMenu';
+import { ThemeToggle } from '../../components/ThemeToggle';
+import { Flame, Search, ChevronRight, Lock, Play } from '../../components/Icons';
+import { getInitials } from '../../utils/initials';
+import { user } from '../../data/home';
+import { NAV_PRINCIPAL as NAV } from '../../data/nav';
+import { listarRoadmaps, type RoadmapResumo, type Nivel } from '../../services/roadmaps';
+
+const NIVEL_LABEL: Record<Nivel, string> = {
+  iniciante: 'Iniciante',
+  intermediario: 'Intermediário',
+  avancado: 'Avançado',
+};
+
+const NIVEIS: { v: string; label: string }[] = [
+  { v: '', label: 'Todos' },
+  { v: 'iniciante', label: 'Iniciante' },
+  { v: 'intermediario', label: 'Intermediário' },
+  { v: 'avancado', label: 'Avançado' },
+];
+
+function glyph(name: string): string {
+  const partes = name
+    .replace(/[^A-Za-zÀ-ú ]/g, '')
+    .trim()
+    .split(/\s+/)
+    .slice(0, 2);
+  return partes.map((p) => p[0]?.toUpperCase() ?? '').join('') || 'RM';
+}
+
+const CTA: Record<RoadmapResumo['status'], string> = {
+  nao_iniciado: 'Começar roadmap',
+  em_progresso: 'Continuar',
+  concluido: 'Revisar',
+};
+
+export function Roadmaps() {
+  const { user: authUser } = useAuth();
+  const navigate = useNavigate();
+
+  const displayName = authUser?.name ?? user.name;
+  const initials = getInitials(displayName);
+
+  const [roadmaps, setRoadmaps] = useState<RoadmapResumo[]>([]);
+  const [carregando, setCarregando] = useState(true);
+  const [erro, setErro] = useState('');
+  const [nivel, setNivel] = useState('');
+
+  useEffect(() => {
+    listarRoadmaps()
+      .then(setRoadmaps)
+      .catch(() => setErro('Não foi possível carregar os roadmaps.'))
+      .finally(() => setCarregando(false));
+  }, []);
+
+  const filtrados = roadmaps.filter((r) => !nivel || r.level === nivel);
+  const continuar = roadmaps
+    .filter((r) => r.status === 'em_progresso')
+    .sort((a, b) => b.percent - a.percent)[0];
+  const emAndamento = roadmaps.filter((r) => r.status === 'em_progresso').length;
+  const concluidos = roadmaps.filter((r) => r.status === 'concluido').length;
+
+  return (
+    <div className="home-shell">
+      <div className="home">
+        <header className="topbar">
+          <MobileMenu />
+          <Logo variant="solid" size={20} />
+          <nav className="nav">
+            {NAV.map((item) => (
+              <Link
+                key={item.to}
+                to={item.to}
+                className={`nav__item${item.label === 'Roadmaps' ? ' nav__item--active' : ''}`}
+              >
+                {item.label}
+              </Link>
+            ))}
+          </nav>
+          <div className="topbar__spacer" />
+          <div className="searchbar">
+            <Search size={16} />
+            <span>Buscar roadmap…</span>
+          </div>
+          <div className="streak-pill">
+            <Flame size={16} /> {authUser?.streak ?? 0}
+          </div>
+          <ThemeToggle inline />
+          <UserMenu
+            initials={initials}
+            level={authUser?.level ?? 1}
+            name={displayName}
+            email={authUser?.email}
+          />
+        </header>
+
+        <div className="trilhas-page">
+          <div className="trilhas-page__head">
+            <div>
+              <h1 className="trilhas-page__title">Roadmaps de carreira</h1>
+              <p className="trilhas-page__sub">
+                Trilhas guiadas do zero à vaga. Escolha um caminho e siga estágio por estágio, no seu
+                ritmo.
+              </p>
+            </div>
+            <div className="trilhas-page__stats">
+              <Metric value={String(roadmaps.length)} label="roadmaps" />
+              <span className="trilhas-page__divider" />
+              <Metric value={String(emAndamento)} label="em progresso" accent />
+              {concluidos > 0 && (
+                <>
+                  <span className="trilhas-page__divider" />
+                  <Metric value={String(concluidos)} label="concluídos" />
+                </>
+              )}
+            </div>
+          </div>
+
+          {continuar && (
+            <div className="continue-card">
+              <span className="continue-card__glow" />
+              <div className="continue-card__body">
+                <div className="continue-card__kicker">Continuar de onde parou</div>
+                <h2 className="continue-card__title">{continuar.name}</h2>
+                <p className="continue-card__next">
+                  {continuar.stagesDone} de {continuar.stagesTotal} estágios concluídos
+                </p>
+                <div className="continue-card__progress">
+                  <div className="continue-card__track">
+                    <span style={{ width: `${continuar.percent}%` }} />
+                  </div>
+                  <span className="continue-card__pct">
+                    {continuar.percent}% · {continuar.stagesDone}/{continuar.stagesTotal}
+                  </span>
+                </div>
+              </div>
+              <button
+                className="continue-card__btn"
+                onClick={() => navigate(`/roadmaps/${continuar.slug}`)}
+              >
+                <Play size={13} /> Continuar
+              </button>
+            </div>
+          )}
+
+          <div className="filters">
+            <label className="select-filtro">
+              <span className="filters__label">Nível</span>
+              <select value={nivel} onChange={(e) => setNivel(e.target.value)}>
+                {NIVEIS.map((n) => (
+                  <option key={n.v} value={n.v}>
+                    {n.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <div className="topbar__spacer" />
+            <span className="filters__count">{filtrados.length} roadmaps</span>
+          </div>
+
+          {carregando && <p className="track__desc">Carregando roadmaps...</p>}
+          {erro && <div className="auth__alert">{erro}</div>}
+          {!carregando && !erro && filtrados.length === 0 && (
+            <p className="track__desc">
+              {nivel ? 'Nenhum roadmap com esse nível.' : 'Nenhum roadmap disponível ainda.'}
+            </p>
+          )}
+
+          <div className="track-grid">
+            {filtrados.map((r) => {
+              const started = r.status !== 'nao_iniciado';
+              return (
+                <div
+                  key={r.id}
+                  className={`track track--clickable${r.premium ? ' track--locked' : ''}`}
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => navigate(`/roadmaps/${r.slug}`)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') navigate(`/roadmaps/${r.slug}`);
+                  }}
+                >
+                  <div className="track__head">
+                    <span
+                      className="track__icon"
+                      style={{
+                        color: 'var(--accent)',
+                        background: 'color-mix(in srgb, var(--accent) 16%, transparent)',
+                      }}
+                    >
+                      {r.premium ? <Lock size={20} /> : glyph(r.name)}
+                    </span>
+                    <div className="track__meta">
+                      <div className="track__name">{r.name}</div>
+                      <div className="track__row">
+                        <span className="track__level" style={{ color: 'var(--accent)' }}>
+                          {NIVEL_LABEL[r.level]}
+                        </span>
+                        <span className="track__lessons">{r.stagesTotal} estágios</span>
+                      </div>
+                    </div>
+                  </div>
+                  <p className="track__desc track__desc--full">{r.description}</p>
+                  <div className="progress">
+                    <div className="progress__track">
+                      <span
+                        className="progress__fill"
+                        style={{
+                          width: `${r.percent}%`,
+                          background: started ? 'var(--accent)' : 'var(--surface-2)',
+                        }}
+                      />
+                    </div>
+                    <span className="progress__pct">{r.percent}%</span>
+                  </div>
+                  <hr className="rule" />
+                  <div className="track__foot">
+                    <div className="track__tags">
+                      {r.tags.map((tag) => (
+                        <span key={tag} className="chip--outline">
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                    <span
+                      className="track__cta"
+                      style={{ color: started ? 'var(--accent)' : 'var(--text)' }}
+                    >
+                      {r.premium ? 'Desbloquear' : CTA[r.status]} <ChevronRight size={15} />
+                    </span>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Metric({ value, label, accent }: { value: string; label: string; accent?: boolean }) {
+  return (
+    <div className="metric">
+      <div className="metric__value" style={accent ? { color: 'var(--accent)' } : undefined}>
+        {value}
+      </div>
+      <div className="metric__label">{label}</div>
+    </div>
+  );
+}

--- a/frontend/src/services/roadmaps.ts
+++ b/frontend/src/services/roadmaps.ts
@@ -1,0 +1,65 @@
+import api from './api';
+
+export type RoadmapStatus = 'nao_iniciado' | 'em_progresso' | 'concluido';
+export type RoadmapPhase = 'fundamentos' | 'core' | 'avancado' | 'deploy';
+export type Nivel = 'iniciante' | 'intermediario' | 'avancado';
+
+export interface RoadmapResumo {
+  id: string;
+  slug: string;
+  name: string;
+  description: string;
+  level: Nivel;
+  icon: string | null;
+  premium: boolean;
+  tags: string[];
+  stagesTotal: number;
+  stagesDone: number;
+  percent: number;
+  status: RoadmapStatus;
+}
+
+export interface RoadmapRef {
+  refType: 'trail' | 'module' | 'lesson' | 'simulado' | 'challenge';
+  refId: string;
+  title: string | null;
+  trailId?: string;
+  lessonId?: string;
+  slug?: string;
+  number?: number | null;
+}
+
+export interface RoadmapStage {
+  id: string;
+  phase: RoadmapPhase;
+  title: string;
+  description: string;
+  tags: string[];
+  position: number;
+  completed: boolean;
+  locked: boolean;
+  refs: RoadmapRef[];
+}
+
+export interface RoadmapDetalhe {
+  id: string;
+  slug: string;
+  name: string;
+  description: string;
+  level: Nivel;
+  icon: string | null;
+  premium: boolean;
+  progress: { stagesTotal: number; stagesDone: number; percent: number; status: RoadmapStatus };
+  currentStageId: string | null;
+  stages: RoadmapStage[];
+}
+
+export async function listarRoadmaps() {
+  const { data } = await api.get<RoadmapResumo[]>('/roadmaps');
+  return data;
+}
+
+export async function obterRoadmap(slug: string) {
+  const { data } = await api.get<RoadmapDetalhe>(`/roadmaps/${slug}`);
+  return data;
+}

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1454,6 +1454,200 @@
   border-color: var(--accent);
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 16%, transparent);
 }
+
+/* ===================== Roadmap (detalhe) ===================== */
+.rmd {
+  max-width: 860px;
+  margin: 0 auto;
+  padding: 22px 24px 60px;
+}
+.rmd-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--muted);
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 600;
+  margin-bottom: 16px;
+}
+.rmd-back:hover {
+  color: var(--text);
+}
+.rmd-hero {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  background: linear-gradient(120deg, #2d6bf5, #4b2fd6);
+  border-radius: var(--r-lg);
+  padding: 26px 28px;
+  color: #fff;
+  margin-bottom: 26px;
+}
+.rmd-hero__kicker {
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.85;
+}
+.rmd-hero__title {
+  font-size: 26px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  margin: 6px 0 8px;
+}
+.rmd-hero__desc {
+  font-size: 14.5px;
+  line-height: 1.55;
+  opacity: 0.92;
+  max-width: 560px;
+}
+.rmd-ring {
+  flex-shrink: 0;
+}
+.rmd-stages {
+  display: flex;
+  flex-direction: column;
+}
+.rmd-stage {
+  display: flex;
+  gap: 16px;
+}
+.rmd-stage__rail {
+  position: relative;
+  width: 34px;
+  flex-shrink: 0;
+  display: flex;
+  justify-content: center;
+}
+.rmd-stage:not(:last-child) .rmd-stage__rail::after {
+  content: '';
+  position: absolute;
+  top: 34px;
+  bottom: -14px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 2px;
+  background: var(--border);
+}
+.rmd-stage--done .rmd-stage__rail::after {
+  background: var(--success);
+}
+.rmd-stage__dot {
+  position: relative;
+  z-index: 1;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  font-size: 14px;
+  border: 2px solid var(--border-strong);
+  background: var(--surface);
+  color: var(--muted);
+}
+.rmd-stage__card {
+  flex: 1;
+  min-width: 0;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  padding: 16px 18px;
+  margin-bottom: 14px;
+}
+.rmd-stage__top {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.rmd-phase {
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+  background: var(--surface-2);
+  padding: 3px 8px;
+  border-radius: 6px;
+}
+.rmd-stage__title {
+  font-size: 16px;
+  font-weight: 700;
+}
+.rmd-stage__badge {
+  margin-left: auto;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--muted);
+}
+.rmd-stage__badge--done {
+  color: var(--success);
+}
+.rmd-stage__badge--current {
+  color: var(--accent);
+}
+.rmd-stage__desc {
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--muted);
+  margin: 8px 0 10px;
+}
+.rmd-stage__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.rmd-stage__btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  margin-top: 14px;
+  height: 38px;
+  padding: 0 18px;
+  border: none;
+  border-radius: 10px;
+  background: var(--accent);
+  color: #fff;
+  font-weight: 600;
+  font-size: 14px;
+  cursor: pointer;
+}
+.rmd-stage__btn--ghost {
+  background: transparent;
+  color: var(--accent);
+  padding: 0;
+  height: auto;
+  margin-top: 12px;
+}
+.rmd-stage--current .rmd-stage__dot {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+.rmd-stage--current .rmd-stage__card {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 12%, transparent);
+}
+.rmd-stage--done .rmd-stage__dot {
+  background: var(--success);
+  border-color: var(--success);
+  color: #fff;
+}
+.rmd-stage--locked .rmd-stage__card {
+  opacity: 0.65;
+}
+
+@media (max-width: 640px) {
+  .rmd-hero {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 16px;
+  }
+}
 .filter {
   height: 34px;
   padding: 0 15px;


### PR DESCRIPTION
Adiciona a feature de **Roadmaps de carreira**: caminhos guiados que dão direção ao aluno, agrupando trilhas, simulados e desafios em estágios ordenados, do zero à vaga.

## A ideia central
O roadmap é uma **camada de orquestração** sobre o conteúdo que já existe. Um estágio referencia conteúdo real (trilha, módulo, aula, simulado ou desafio) e a conclusão é **derivada** dos sinais de progresso que já temos (`lessons_progress`, `simulado_attempts`, `challenge_submissions`). Não duplica conteúdo nem inventa XP: quando o aluno conclui a trilha de um estágio, o estágio fecha e o próximo desbloqueia sozinho.

## Backend
- Migration `0029`: 3 tabelas (`roadmaps`, `roadmap_stages`, `roadmap_stage_refs`) e 2 enums. Progresso não tem tabela, é 100% derivado.
- Serviço que calcula progresso, percentual e os cadeados sequenciais; rotas `GET /roadmaps` e `GET /roadmaps/:slug` (ambas logadas).
- Seed do primeiro roadmap real, **Segurança** (5 estágios), lastreado em Fundamentos de Cibersegurança, SC-900, ISC2 CC e AppSec, terminando no simulado do ISC2 CC.

## Frontend
- Catálogo (`/roadmaps`): cards com progresso, filtro de nível e card "continuar de onde parou".
- Detalhe (`/roadmaps/:slug`): timeline vertical de estágios com estados (concluído, em andamento, bloqueado) e anel de progresso, reusando o design system.

## Validação (local)
tsc e lint limpos nos dois lados, frontend builda. Testado ponta a ponta com um usuário real: ao concluir a trilha do estágio 1, o roadmap foi de 0% para 20%, o estágio 1 virou concluído e o 2 desbloqueou.

## Pós-deploy (produção)
Depois do merge e do deploy (que aplica a migration), rodar em prod:
- `node scripts/seed-roadmap-seguranca.ts` (cria o roadmap Segurança; idempotente).

Por enquanto há só um roadmap real (Segurança), de propósito: a ideia é lançar um caminho completo antes de abrir os outros, conforme o conteúdo existir. Gate premium e CRUD no estúdio ficam para depois.
