### PR TITLE
fix: loga erros de validação e limita o telefone no cadastro

### DIFF
--- a/backend/src/middlewares/error.ts
+++ b/backend/src/middlewares/error.ts
@@ -10,6 +10,10 @@ export function errorMiddleware(err: Error, _req: Request, res: Response, _next:
 
     // Se for erro do Zod
     if (err instanceof ZodError) {
+        console.warn(
+            "Validação rejeitada:",
+            err.issues.map((i) => `${i.path.join(".")} (${i.message})`).join("; "),
+        );
         if (env.NODE_ENV !== "development") {
             return res.status(400).json({
                 erro: "Dados inválidos",

--- a/backend/src/schemas/auth.schema.ts
+++ b/backend/src/schemas/auth.schema.ts
@@ -22,7 +22,7 @@ export const registerSchema = z.object({
     password: senhaForte,
     birthDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Data deve ser AAAA-MM-DD"),
     gender: z.string(),
-    phone: z.string(),
+    phone: z.string().trim().max(20, "Telefone muito longo"),
 });
 
 export const forgotPasswordSchema = z.object({
@@ -71,5 +71,5 @@ export const completarPerfilSchema = z.object({
         .regex(/^[a-zA-Z0-9_]+$/, "Use apenas letras, números e underscore"),
     birthDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Data deve ser AAAA-MM-DD"),
     gender: z.string().min(1, "Selecione o gênero"),
-    phone: z.string().min(1, "Informe o telefone"),
+    phone: z.string().trim().min(1, "Informe o telefone").max(20, "Telefone muito longo"),
 });


### PR DESCRIPTION
Um cadastro que falhava com erro genérico ("Erro ao criar conta") não deixava rastro pra diagnosticar. Investigando, apareceram dois pontos cegos, que este PR corrige.

## O que muda
1. **Observabilidade:** o `errorMiddleware` não logava os erros de validação (`ZodError`), só os 500. Uma falha de validação no cadastro ficava invisível nos logs de produção (que devolvem só "Dados inválidos", sem detalhe). Agora ele loga o campo e a regra que falharam (`Validação rejeitada: phone (Telefone muito longo)`), sem expor nada na resposta.
2. **Bug do telefone:** o campo `phone` era `z.string()` sem limite, mas a coluna é `varchar(20)`. Telefone acima de 20 caracteres estourava no insert e virava **500**. Agora os schemas de cadastro e de perfil limitam em 20, virando um **400** claro (e logado). A máscara do front já segura em 15, então isso é defesa em profundidade.

## Validação (local)
tsc limpo, os 18 testes do schema de auth passam, e o telefone longo agora retorna 400 (antes 500) com o log `Validação rejeitada: phone (Telefone muito longo)`.

Contexto: veio do diagnóstico de um cadastro real que falhou. O cadastro em si funciona (o número da usuária, com máscara, cabe em 20); o valor deste PR é parar de ficar cego quando algo falha.
