### PR TITLE
feat: adiciona o roadmap de Back-end

### DIFF
--- a/backend/scripts/seed-roadmap-backend.ts
+++ b/backend/scripts/seed-roadmap-backend.ts
@@ -1,0 +1,174 @@
+// Seed do roadmap "Back-end": camada de orquestracao sobre as trilhas de fundacao
+// (Logica de Programacao, Protocolos da Web, APIs e Frameworks, Banco de Dados,
+// Autenticacao). Cobre os estagios 1 a 5 do desenho de 10 estagios; os estagios
+// 6 a 10 (cache, testes, docker, ci/cd, arquitetura) entram depois, conforme o
+// conteudo for autorado.
+//
+// Idempotente POR ESTAGIO: cria o roadmap se faltar e insere apenas os estagios
+// que ainda nao existem (casados por titulo). Assim, para adicionar os estagios
+// 6 a 10 depois, basta acrescenta-los em STAGES e rodar de novo.
+//
+// O Back-end e o roadmap principal do catalogo: na criacao, entra na posicao 1 e
+// empurra os roadmaps existentes uma posicao para baixo.
+//
+// Refs de trilha resolvidas por nome; ref nao encontrada e pulada com aviso.
+//
+// Rodar em prod: docker compose -f docker-compose.prod.yml exec -T backend node scripts/seed-roadmap-backend.ts
+import { db } from "../db.ts";
+import { roadmaps, roadmapStages, roadmapStageRefs, trails, simulados } from "../schema.ts";
+import { eq, and, sql } from "drizzle-orm";
+
+const SLUG = "backend";
+
+const ROADMAP = {
+    slug: SLUG,
+    name: "Back-end",
+    description:
+        "Do zero a vaga de back-end: logica e uma linguagem, os protocolos da web, APIs, banco de dados e seguranca. Um caminho guiado, da base ao deploy.",
+    level: "iniciante" as const,
+    icon: "server",
+};
+
+type RefType = "trail" | "simulado";
+interface Ref {
+    type: RefType;
+    ref: string; // nome da trilha ou slug do simulado
+}
+interface Stage {
+    phase: "fundamentos" | "core" | "avancado" | "deploy";
+    position: number;
+    title: string;
+    description: string;
+    tags: string[];
+    refs: Ref[];
+}
+
+const STAGES: Stage[] = [
+    {
+        phase: "fundamentos",
+        position: 1,
+        title: "Lógica & uma linguagem",
+        description:
+            "A base de tudo: pensar em algoritmos e dominar a lógica de programação, o alicerce de qualquer linguagem que você for usar no back-end.",
+        tags: ["Lógica", "Algoritmos", "Programação"],
+        refs: [{ type: "trail", ref: "Lógica de Programação" }],
+    },
+    {
+        phase: "fundamentos",
+        position: 2,
+        title: "Protocolos da Web",
+        description:
+            "Como a web conversa: HTTP e seus métodos, códigos de status, REST e o modelo cliente-servidor que sustenta toda API.",
+        tags: ["HTTP", "REST", "Cliente-servidor"],
+        refs: [{ type: "trail", ref: "Protocolos da Web" }],
+    },
+    {
+        phase: "core",
+        position: 3,
+        title: "APIs & Frameworks",
+        description:
+            "Construa sua primeira API REST com Node.js e Express: rotas, middleware, validação, tratamento de erros e a estrutura de um projeto de verdade.",
+        tags: ["Node.js", "Express", "API REST"],
+        refs: [{ type: "trail", ref: "APIs e Frameworks" }],
+    },
+    {
+        phase: "core",
+        position: 4,
+        title: "Banco de dados",
+        description:
+            "Dê persistência à sua API: modelo relacional, SQL, modelagem com relacionamentos, PostgreSQL na prática e o papel dos ORMs.",
+        tags: ["SQL", "PostgreSQL", "Modelagem"],
+        refs: [{ type: "trail", ref: "Banco de Dados" }],
+    },
+    {
+        phase: "core",
+        position: 5,
+        title: "Autenticação & Segurança",
+        description:
+            "Saiba quem é o usuário e o que ele pode fazer: hash de senha com bcrypt, sessões, tokens JWT, autorização por papéis e OAuth com login social.",
+        tags: ["JWT", "bcrypt", "OAuth"],
+        refs: [{ type: "trail", ref: "Autenticação" }],
+    },
+];
+
+async function resolverRef(type: RefType, ref: string): Promise<string | null> {
+    if (type === "trail") {
+        const [t] = await db.select({ id: trails.id }).from(trails).where(eq(trails.name, ref));
+        return t?.id ?? null;
+    }
+    const [s] = await db.select({ id: simulados.id }).from(simulados).where(eq(simulados.slug, ref));
+    return s?.id ?? null;
+}
+
+async function seed() {
+    let [rm] = await db.select().from(roadmaps).where(eq(roadmaps.slug, SLUG));
+    if (!rm) {
+        // Back-end e o roadmap principal: empurra os existentes para baixo e entra em 1o.
+        await db.update(roadmaps).set({ position: sql`${roadmaps.position} + 1` });
+        [rm] = await db
+            .insert(roadmaps)
+            .values({ ...ROADMAP, position: 1, premium: false, published: true })
+            .returning();
+        console.log("Roadmap criado: " + rm.slug + " (posicao 1)");
+    } else {
+        console.log("Roadmap " + SLUG + " ja existe. Adicionando estagios que faltam.");
+    }
+
+    let estagiosNovos = 0;
+    let estagiosExistentes = 0;
+    let refsCriados = 0;
+    let refsFaltando = 0;
+    for (const s of STAGES) {
+        const [existente] = await db
+            .select({ id: roadmapStages.id })
+            .from(roadmapStages)
+            .where(and(eq(roadmapStages.roadmapId, rm.id), eq(roadmapStages.title, s.title)));
+        if (existente) {
+            estagiosExistentes++;
+            continue;
+        }
+        const [stage] = await db
+            .insert(roadmapStages)
+            .values({
+                roadmapId: rm.id,
+                phase: s.phase,
+                title: s.title,
+                description: s.description,
+                tags: s.tags,
+                position: s.position,
+            })
+            .returning();
+        estagiosNovos++;
+        let rpos = 1;
+        for (const r of s.refs) {
+            const refId = await resolverRef(r.type, r.ref);
+            if (!refId) {
+                console.log("  ref nao encontrada, pulando: " + r.type + " -> " + r.ref);
+                refsFaltando++;
+                continue;
+            }
+            await db
+                .insert(roadmapStageRefs)
+                .values({ stageId: stage.id, refType: r.type, refId, position: rpos++ });
+            refsCriados++;
+        }
+    }
+    console.log(
+        "Seed concluido: " +
+            estagiosNovos +
+            " estagios novos, " +
+            estagiosExistentes +
+            " ja existiam, " +
+            refsCriados +
+            " refs criados (" +
+            refsFaltando +
+            " faltando).",
+    );
+}
+
+seed()
+    .then(() => process.exit(0))
+    .catch((e) => {
+        console.error("Falha no seed:", e);
+        process.exit(1);
+    });


### PR DESCRIPTION
## O que faz

Cria o **roadmap de Back-end**, o caminho principal do catalogo, com os **5 estagios de fundacao** que ja tem conteudo. Segue o padrao do seed do roadmap de Seguranca (camada de orquestracao: cada estagio referencia uma trilha existente, progresso derivado dos sinais de conclusao).

| # | Estagio | Fase | Trilha |
|---|---|---|---|
| 1 | Logica & uma linguagem | fundamentos | Logica de Programacao |
| 2 | Protocolos da Web | fundamentos | Protocolos da Web |
| 3 | APIs & Frameworks | core | APIs e Frameworks |
| 4 | Banco de dados | core | Banco de Dados |
| 5 | Autenticacao & Seguranca | core | Autenticacao |

Os estagios 6 a 10 do desenho original (cache e filas, testes, docker, ci/cd, arquitetura) serao adicionados depois, conforme as trilhas forem autoradas.

## Decisoes

- **Idempotente por estagio** (diferente do seed de Seguranca, que e tudo-ou-nada): cria o roadmap se faltar e insere apenas os estagios ausentes, casados por titulo. Assim, para adicionar os estagios 6 a 10 depois, basta acrescenta-los no array e rodar de novo.
- **Back-end e o roadmap principal:** na criacao, entra na posicao 1 e empurra os roadmaps existentes uma posicao para baixo (Seguranca vai para 2). So acontece na primeira execucao.
- Refs de trilha resolvidas por nome; ref nao encontrada e pulada com aviso.

## Validacao (dev)

- tsc limpo; seed criou o roadmap na posicao 1 com os 5 estagios e os 5 refs resolvidos (0 faltando).
- Re-execucao idempotente: 0 estagios novos, posicoes estaveis.
- Endpoint `GET /roadmaps/backend` para um aluno sem progresso: 0%, `nao_iniciado`, estagio 1 aberto e estagios 2 a 5 travados (cadeado sequencial correto).

## Como testar

    docker compose exec -T backend node scripts/seed-roadmap-backend.ts