### PR TITLE
feat: CRUD de roadmap (backend + gestão no estúdio)

### DIFF
--- a/backend/src/controllers/RoadmapController.ts
+++ b/backend/src/controllers/RoadmapController.ts
@@ -1,6 +1,27 @@
 import type { Request, Response, NextFunction } from "express";
-import { listarRoadmaps, obterRoadmap } from "../services/roadmap.service.ts";
+import {
+    listarRoadmaps,
+    obterRoadmap,
+    listarRoadmapsAdmin,
+    obterRoadmapStudio,
+    criarRoadmap,
+    atualizarRoadmap,
+    excluirRoadmap,
+    criarEstagio,
+    atualizarEstagio,
+    excluirEstagio,
+    adicionarRef,
+    removerRef,
+} from "../services/roadmap.service.ts";
+import {
+    createRoadmapSchema,
+    updateRoadmapSchema,
+    createStageSchema,
+    updateStageSchema,
+    createRefSchema,
+} from "../schemas/roadmap.schema.ts";
 
+// ===================== Leitura (aluno) =====================
 export const listRoadmaps = async (req: Request, res: Response, next: NextFunction) => {
     try {
         res.json(await listarRoadmaps(req.userId));
@@ -15,6 +36,97 @@ export const getRoadmap = async (req: Request, res: Response, next: NextFunction
         const roadmap = await obterRoadmap(slug, req.userId);
         if (!roadmap) return res.status(404).json({ erro: "Roadmap não encontrado" });
         res.json(roadmap);
+    } catch (err) {
+        next(err);
+    }
+};
+
+// ===================== Admin: roadmaps =====================
+export const listRoadmapsStudio = async (_req: Request, res: Response, next: NextFunction) => {
+    try {
+        res.json(await listarRoadmapsAdmin());
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const getRoadmapStudio = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        res.json(await obterRoadmapStudio(String(req.params.id)));
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const createRoadmap = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const dados = createRoadmapSchema.parse(req.body);
+        res.status(201).json(await criarRoadmap(dados));
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const updateRoadmap = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const dados = updateRoadmapSchema.parse(req.body);
+        res.json(await atualizarRoadmap(String(req.params.id), dados));
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const deleteRoadmap = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        await excluirRoadmap(String(req.params.id));
+        res.json({ ok: true });
+    } catch (err) {
+        next(err);
+    }
+};
+
+// ===================== Admin: estágios =====================
+export const createStage = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const dados = createStageSchema.parse(req.body);
+        res.status(201).json(await criarEstagio(String(req.params.id), dados));
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const updateStage = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const dados = updateStageSchema.parse(req.body);
+        res.json(await atualizarEstagio(String(req.params.id), dados));
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const deleteStage = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        await excluirEstagio(String(req.params.id));
+        res.json({ ok: true });
+    } catch (err) {
+        next(err);
+    }
+};
+
+// ===================== Admin: referências de conteúdo =====================
+export const createStageRef = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const dados = createRefSchema.parse(req.body);
+        res.status(201).json(await adicionarRef(String(req.params.id), dados));
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const deleteStageRef = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        await removerRef(String(req.params.id));
+        res.json({ ok: true });
     } catch (err) {
         next(err);
     }

--- a/backend/src/routes/roadmap.routes.ts
+++ b/backend/src/routes/roadmap.routes.ts
@@ -1,10 +1,39 @@
 import { Router } from "express";
-import { autenticar } from "../middlewares/auth.ts";
-import { listRoadmaps, getRoadmap } from "../controllers/RoadmapController.ts";
+import { autenticar, exigirAdmin } from "../middlewares/auth.ts";
+import {
+    listRoadmaps,
+    getRoadmap,
+    listRoadmapsStudio,
+    getRoadmapStudio,
+    createRoadmap,
+    updateRoadmap,
+    deleteRoadmap,
+    createStage,
+    updateStage,
+    deleteStage,
+    createStageRef,
+    deleteStageRef,
+} from "../controllers/RoadmapController.ts";
 
 const router = Router();
 
+// Leitura (qualquer logado)
 router.get("/roadmaps", autenticar, listRoadmaps);
+
+// Gestão pelo estúdio (admin). Vem antes de "/roadmaps/:slug" e usa o prefixo
+// "/studio" para não colidir com a rota de detalhe do aluno.
+router.get("/studio/roadmaps", autenticar, exigirAdmin, listRoadmapsStudio);
+router.get("/studio/roadmaps/:id", autenticar, exigirAdmin, getRoadmapStudio);
+router.post("/roadmaps", autenticar, exigirAdmin, createRoadmap);
+router.patch("/roadmaps/:id", autenticar, exigirAdmin, updateRoadmap);
+router.delete("/roadmaps/:id", autenticar, exigirAdmin, deleteRoadmap);
+router.post("/roadmaps/:id/stages", autenticar, exigirAdmin, createStage);
+router.patch("/roadmap-stages/:id", autenticar, exigirAdmin, updateStage);
+router.delete("/roadmap-stages/:id", autenticar, exigirAdmin, deleteStage);
+router.post("/roadmap-stages/:id/refs", autenticar, exigirAdmin, createStageRef);
+router.delete("/roadmap-stage-refs/:id", autenticar, exigirAdmin, deleteStageRef);
+
+// Detalhe do aluno por slug (por último, para não capturar as rotas acima).
 router.get("/roadmaps/:slug", autenticar, getRoadmap);
 
 export default router;

--- a/backend/src/schemas/roadmap.schema.ts
+++ b/backend/src/schemas/roadmap.schema.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+
+const nivel = z.enum(["iniciante", "intermediario", "avancado"]);
+const fase = z.enum(["fundamentos", "core", "avancado", "deploy"]);
+const tipoRef = z.enum(["trail", "module", "lesson", "simulado", "challenge"]);
+const slug = z
+    .string()
+    .trim()
+    .min(2, "Slug muito curto")
+    .max(80, "Slug muito longo")
+    .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, "Use apenas letras minúsculas, números e hífens");
+
+export const createRoadmapSchema = z.object({
+    slug: slug.optional(),
+    name: z.string().trim().min(2, "Nome deve ter ao menos 2 caracteres").max(160, "Nome muito longo"),
+    description: z.string().trim().min(10, "A descrição deve ter ao menos 10 caracteres"),
+    level: nivel,
+    icon: z.string().trim().max(40, "Ícone muito longo").optional(),
+    position: z.int().min(0, "A posição não pode ser negativa").optional(),
+    premium: z.boolean().optional(),
+    published: z.boolean().optional(),
+});
+
+export const updateRoadmapSchema = z.object({
+    slug: slug.optional(),
+    name: z.string().trim().min(2, "Nome deve ter ao menos 2 caracteres").max(160, "Nome muito longo").optional(),
+    description: z.string().trim().min(10, "A descrição deve ter ao menos 10 caracteres").optional(),
+    level: nivel.optional(),
+    icon: z.string().trim().max(40, "Ícone muito longo").nullable().optional(),
+    position: z.int().min(0, "A posição não pode ser negativa").optional(),
+    premium: z.boolean().optional(),
+    published: z.boolean().optional(),
+});
+
+export const createStageSchema = z.object({
+    phase: fase,
+    title: z.string().trim().min(2, "Título deve ter ao menos 2 caracteres").max(200, "Título muito longo"),
+    description: z.string().trim().min(2, "Descrição obrigatória"),
+    tags: z.array(z.string().trim().min(1).max(40)).max(10, "No máximo 10 tags").optional(),
+    position: z.int().positive("A posição deve ser um número positivo").optional(),
+});
+
+export const updateStageSchema = z.object({
+    phase: fase.optional(),
+    title: z.string().trim().min(2, "Título deve ter ao menos 2 caracteres").max(200, "Título muito longo").optional(),
+    description: z.string().trim().min(2, "Descrição obrigatória").optional(),
+    tags: z.array(z.string().trim().min(1).max(40)).max(10, "No máximo 10 tags").optional(),
+    position: z.int().positive("A posição deve ser um número positivo").optional(),
+});
+
+export const createRefSchema = z.object({
+    refType: tipoRef,
+    refId: z.uuid("Conteúdo inválido"),
+    position: z.int().min(0, "A posição não pode ser negativa").optional(),
+});

--- a/backend/src/services/roadmap.service.ts
+++ b/backend/src/services/roadmap.service.ts
@@ -12,7 +12,16 @@ import {
     challenges,
     challengeSubmissions,
 } from "../../schema.ts";
-import { eq, and, asc, inArray } from "drizzle-orm";
+import { eq, and, asc, desc, inArray, count } from "drizzle-orm";
+import type { z } from "zod";
+import type {
+    createRoadmapSchema,
+    updateRoadmapSchema,
+    createStageSchema,
+    updateStageSchema,
+    createRefSchema,
+} from "../schemas/roadmap.schema.ts";
+import { AppError } from "../errors/AppError.ts";
 
 type RefType = "trail" | "module" | "lesson" | "simulado" | "challenge";
 type StatusRoadmap = "nao_iniciado" | "em_progresso" | "concluido";
@@ -300,4 +309,234 @@ export async function obterRoadmap(slug: string, userId?: string) {
         currentStageId: atual?.id ?? null,
         stages: comCadeado,
     };
+}
+
+// ============================ CRUD (admin) ============================
+
+type DadosCriarRoadmap = z.infer<typeof createRoadmapSchema>;
+type DadosAtualizarRoadmap = z.infer<typeof updateRoadmapSchema>;
+type DadosCriarEstagio = z.infer<typeof createStageSchema>;
+type DadosAtualizarEstagio = z.infer<typeof updateStageSchema>;
+type DadosCriarRef = z.infer<typeof createRefSchema>;
+
+function gerarSlug(nome: string): string {
+    return nome
+        .normalize("NFD")
+        .replace(/[̀-ͯ]/g, "")
+        .toLowerCase()
+        .trim()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "");
+}
+
+// Lista para o admin: todos os roadmaps (inclusive rascunhos), com contagem de estágios.
+export async function listarRoadmapsAdmin() {
+    const lista = await db.select().from(roadmaps).orderBy(asc(roadmaps.position));
+    const contagens = await db
+        .select({ roadmapId: roadmapStages.roadmapId, n: count() })
+        .from(roadmapStages)
+        .groupBy(roadmapStages.roadmapId);
+    const porId = new Map(contagens.map((c) => [c.roadmapId, Number(c.n)]));
+    return lista.map((r) => ({ ...r, stagesTotal: porId.get(r.id) ?? 0 }));
+}
+
+// Estrutura crua de um roadmap para edição no estúdio (por id, sem progresso de aluno).
+export async function obterRoadmapStudio(id: string) {
+    const [roadmap] = await db.select().from(roadmaps).where(eq(roadmaps.id, id));
+    if (!roadmap) throw new AppError(404, "Roadmap não encontrado");
+
+    const etapas = await db
+        .select()
+        .from(roadmapStages)
+        .where(eq(roadmapStages.roadmapId, id))
+        .orderBy(asc(roadmapStages.position));
+    const etapaIds = etapas.map((e) => e.id);
+    const refs = etapaIds.length
+        ? await db
+              .select()
+              .from(roadmapStageRefs)
+              .where(inArray(roadmapStageRefs.stageId, etapaIds))
+              .orderBy(asc(roadmapStageRefs.position))
+        : [];
+    const info = await resolverRefs(refs.map((r) => ({ refType: r.refType as RefType, refId: r.refId })));
+
+    const refsPorEtapa = new Map<string, typeof refs>();
+    for (const r of refs) {
+        const arr = refsPorEtapa.get(r.stageId) ?? [];
+        arr.push(r);
+        refsPorEtapa.set(r.stageId, arr);
+    }
+
+    return {
+        ...roadmap,
+        stages: etapas.map((e) => ({
+            id: e.id,
+            phase: e.phase,
+            title: e.title,
+            description: e.description,
+            tags: e.tags ?? [],
+            position: e.position,
+            refs: (refsPorEtapa.get(e.id) ?? []).map((r) => ({
+                id: r.id,
+                refType: r.refType,
+                refId: r.refId,
+                position: r.position,
+                ...(info.get(r.refType + ":" + r.refId) ?? { title: null }),
+            })),
+        })),
+    };
+}
+
+export async function criarRoadmap(dados: DadosCriarRoadmap) {
+    const slug = (dados.slug?.trim() || gerarSlug(dados.name)).slice(0, 80);
+    if (!slug) throw new AppError(400, "Não foi possível gerar um slug a partir do nome");
+    const [existe] = await db.select({ id: roadmaps.id }).from(roadmaps).where(eq(roadmaps.slug, slug));
+    if (existe) throw new AppError(409, "Já existe um roadmap com esse slug");
+
+    let position = dados.position;
+    if (position === undefined) {
+        const [ult] = await db.select({ p: roadmaps.position }).from(roadmaps).orderBy(desc(roadmaps.position)).limit(1);
+        position = ult ? ult.p + 1 : 1;
+    }
+    const [rm] = await db
+        .insert(roadmaps)
+        .values({
+            slug,
+            name: dados.name,
+            description: dados.description,
+            level: dados.level,
+            icon: dados.icon ?? null,
+            position,
+            premium: dados.premium ?? false,
+            published: dados.published ?? false,
+        })
+        .returning();
+    return rm;
+}
+
+export async function atualizarRoadmap(id: string, dados: DadosAtualizarRoadmap) {
+    const [rm] = await db.select({ id: roadmaps.id }).from(roadmaps).where(eq(roadmaps.id, id));
+    if (!rm) throw new AppError(404, "Roadmap não encontrado");
+
+    const sets: Partial<typeof roadmaps.$inferInsert> = {};
+    if (dados.slug !== undefined) {
+        const s = dados.slug.trim();
+        const [outro] = await db.select({ id: roadmaps.id }).from(roadmaps).where(eq(roadmaps.slug, s));
+        if (outro && outro.id !== id) throw new AppError(409, "Já existe um roadmap com esse slug");
+        sets.slug = s;
+    }
+    if (dados.name !== undefined) sets.name = dados.name;
+    if (dados.description !== undefined) sets.description = dados.description;
+    if (dados.level !== undefined) sets.level = dados.level;
+    if (dados.icon !== undefined) sets.icon = dados.icon;
+    if (dados.position !== undefined) sets.position = dados.position;
+    if (dados.premium !== undefined) sets.premium = dados.premium;
+    if (dados.published !== undefined) sets.published = dados.published;
+    if (Object.keys(sets).length === 0) throw new AppError(400, "Nada para atualizar");
+
+    const [atualizado] = await db.update(roadmaps).set(sets).where(eq(roadmaps.id, id)).returning();
+    return atualizado;
+}
+
+export async function excluirRoadmap(id: string) {
+    const [rm] = await db.select({ id: roadmaps.id }).from(roadmaps).where(eq(roadmaps.id, id));
+    if (!rm) throw new AppError(404, "Roadmap não encontrado");
+    await db.transaction(async (tx) => {
+        const etapas = await tx
+            .select({ id: roadmapStages.id })
+            .from(roadmapStages)
+            .where(eq(roadmapStages.roadmapId, id));
+        const ids = etapas.map((e) => e.id);
+        if (ids.length) {
+            await tx.delete(roadmapStageRefs).where(inArray(roadmapStageRefs.stageId, ids));
+            await tx.delete(roadmapStages).where(inArray(roadmapStages.id, ids));
+        }
+        await tx.delete(roadmaps).where(eq(roadmaps.id, id));
+    });
+}
+
+export async function criarEstagio(roadmapId: string, dados: DadosCriarEstagio) {
+    const [rm] = await db.select({ id: roadmaps.id }).from(roadmaps).where(eq(roadmaps.id, roadmapId));
+    if (!rm) throw new AppError(404, "Roadmap não encontrado");
+
+    let position = dados.position;
+    if (position === undefined) {
+        const [ult] = await db
+            .select({ p: roadmapStages.position })
+            .from(roadmapStages)
+            .where(eq(roadmapStages.roadmapId, roadmapId))
+            .orderBy(desc(roadmapStages.position))
+            .limit(1);
+        position = ult ? ult.p + 1 : 1;
+    }
+    const [stage] = await db
+        .insert(roadmapStages)
+        .values({
+            roadmapId,
+            phase: dados.phase,
+            title: dados.title,
+            description: dados.description,
+            tags: dados.tags ?? [],
+            position,
+        })
+        .returning();
+    return stage;
+}
+
+export async function atualizarEstagio(id: string, dados: DadosAtualizarEstagio) {
+    const [st] = await db.select({ id: roadmapStages.id }).from(roadmapStages).where(eq(roadmapStages.id, id));
+    if (!st) throw new AppError(404, "Estágio não encontrado");
+
+    const sets: Partial<typeof roadmapStages.$inferInsert> = {};
+    if (dados.phase !== undefined) sets.phase = dados.phase;
+    if (dados.title !== undefined) sets.title = dados.title;
+    if (dados.description !== undefined) sets.description = dados.description;
+    if (dados.tags !== undefined) sets.tags = dados.tags;
+    if (dados.position !== undefined) sets.position = dados.position;
+    if (Object.keys(sets).length === 0) throw new AppError(400, "Nada para atualizar");
+
+    const [atualizado] = await db.update(roadmapStages).set(sets).where(eq(roadmapStages.id, id)).returning();
+    return atualizado;
+}
+
+export async function excluirEstagio(id: string) {
+    const [st] = await db.select({ id: roadmapStages.id }).from(roadmapStages).where(eq(roadmapStages.id, id));
+    if (!st) throw new AppError(404, "Estágio não encontrado");
+    await db.transaction(async (tx) => {
+        await tx.delete(roadmapStageRefs).where(eq(roadmapStageRefs.stageId, id));
+        await tx.delete(roadmapStages).where(eq(roadmapStages.id, id));
+    });
+}
+
+export async function adicionarRef(stageId: string, dados: DadosCriarRef) {
+    const [st] = await db.select({ id: roadmapStages.id }).from(roadmapStages).where(eq(roadmapStages.id, stageId));
+    if (!st) throw new AppError(404, "Estágio não encontrado");
+
+    // Valida que o conteúdo referenciado existe, para nunca criar um ref pendurado.
+    const info = await resolverRefs([{ refType: dados.refType, refId: dados.refId }]);
+    if (!info.has(dados.refType + ":" + dados.refId)) {
+        throw new AppError(400, "O conteúdo referenciado não existe");
+    }
+
+    let position = dados.position;
+    if (position === undefined) {
+        const [ult] = await db
+            .select({ p: roadmapStageRefs.position })
+            .from(roadmapStageRefs)
+            .where(eq(roadmapStageRefs.stageId, stageId))
+            .orderBy(desc(roadmapStageRefs.position))
+            .limit(1);
+        position = ult ? ult.p + 1 : 1;
+    }
+    const [ref] = await db
+        .insert(roadmapStageRefs)
+        .values({ stageId, refType: dados.refType, refId: dados.refId, position })
+        .returning();
+    return { ...ref, ...(info.get(dados.refType + ":" + dados.refId) ?? {}) };
+}
+
+export async function removerRef(id: string) {
+    const [ref] = await db.select({ id: roadmapStageRefs.id }).from(roadmapStageRefs).where(eq(roadmapStageRefs.id, id));
+    if (!ref) throw new AppError(404, "Referência não encontrada");
+    await db.delete(roadmapStageRefs).where(eq(roadmapStageRefs.id, id));
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,8 @@ import { SimuladoBriefing } from './pages/Simulados/Briefing';
 import { TentativaSimulado } from './pages/Simulados/Tentativa';
 import { SimuladosAdmin } from './pages/SimuladosAdmin';
 import { SimuladoEditor } from './pages/SimuladosAdmin/Editor';
+import { RoadmapsAdmin } from './pages/RoadmapsAdmin';
+import { RoadmapEditor } from './pages/RoadmapsAdmin/Editor';
 import { Desafios } from './pages/Desafios';
 import { Desafio } from './pages/Desafios/Desafio';
 import { DesafiosAdmin } from './pages/DesafiosAdmin';
@@ -130,6 +132,22 @@ function AppRoutes() {
         element={
           <AdminRoute>
             <Usuarios />
+          </AdminRoute>
+        }
+      />
+      <Route
+        path="/estudio/roadmaps"
+        element={
+          <AdminRoute>
+            <RoadmapsAdmin />
+          </AdminRoute>
+        }
+      />
+      <Route
+        path="/estudio/roadmaps/:id"
+        element={
+          <AdminRoute>
+            <RoadmapEditor />
           </AdminRoute>
         }
       />

--- a/frontend/src/data/nav.ts
+++ b/frontend/src/data/nav.ts
@@ -12,6 +12,7 @@ export const NAV_PRINCIPAL = [
 
 export const NAV_ESTUDIO = [
   { label: 'Trilhas', to: '/estudio' },
+  { label: 'Roadmaps', to: '/estudio/roadmaps' },
   { label: 'Usuários', to: '/estudio/usuarios' },
   { label: 'Simulados', to: '/estudio/simulados' },
   { label: 'Desafios', to: '/estudio/desafios' },

--- a/frontend/src/pages/RoadmapsAdmin/Editor.tsx
+++ b/frontend/src/pages/RoadmapsAdmin/Editor.tsx
@@ -1,0 +1,380 @@
+import { useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { EstudioTopbar } from '../../components/EstudioTopbar';
+import { Plus, Pencil, Trash, ChevronLeft, Minus } from '../../components/Icons';
+import { useRequisicao } from '../../hooks/useRequisicao';
+import { mensagemErro } from '../../utils/erro';
+import { useToast } from '../../contexts/ToastContext';
+import { listarTrilhas } from '../../services/trails';
+import {
+  obterRoadmapStudio,
+  criarEstagio,
+  atualizarEstagio,
+  excluirEstagio,
+  adicionarRef,
+  removerRef,
+  type RoadmapPhase,
+  type RoadmapStudioStage,
+} from '../../services/roadmaps';
+
+const FASES: { v: RoadmapPhase; label: string }[] = [
+  { v: 'fundamentos', label: 'Fundamentos' },
+  { v: 'core', label: 'Core' },
+  { v: 'avancado', label: 'Avançado' },
+  { v: 'deploy', label: 'Deploy' },
+];
+const FASE_LABEL: Record<RoadmapPhase, string> = {
+  fundamentos: 'Fundamentos',
+  core: 'Core',
+  avancado: 'Avançado',
+  deploy: 'Deploy',
+};
+
+interface StageForm {
+  phase: RoadmapPhase;
+  title: string;
+  description: string;
+  tags: string;
+  position: string;
+}
+const NOVO_ESTAGIO: StageForm = { phase: 'fundamentos', title: '', description: '', tags: '', position: '' };
+
+function parseTags(s: string): string[] {
+  return s
+    .split(',')
+    .map((t) => t.trim())
+    .filter(Boolean);
+}
+
+export function RoadmapEditor() {
+  const { id = '' } = useParams();
+  const navigate = useNavigate();
+  const { mostrar } = useToast();
+  const { dados, carregando, erro: falhaCarga, recarregar } = useRequisicao(
+    () => obterRoadmapStudio(id),
+    [id],
+  );
+  const { dados: trilhasData } = useRequisicao(() => listarTrilhas(), []);
+  const trilhas = trilhasData ?? [];
+
+  const [novo, setNovo] = useState<StageForm | null>(null);
+  const [editando, setEditando] = useState<(StageForm & { id: string }) | null>(null);
+  const [refTrail, setRefTrail] = useState<Record<string, string>>({});
+  const [erro, setErro] = useState('');
+  const [salvando, setSalvando] = useState(false);
+
+  async function comErro(fn: () => Promise<void>, msgOk: string, msgErro: string) {
+    if (salvando) return;
+    setSalvando(true);
+    setErro('');
+    try {
+      await fn();
+      mostrar(msgOk);
+      recarregar();
+    } catch (e: unknown) {
+      setErro(mensagemErro(e, msgErro));
+    } finally {
+      setSalvando(false);
+    }
+  }
+
+  function payloadDe(f: StageForm) {
+    return {
+      phase: f.phase,
+      title: f.title,
+      description: f.description,
+      tags: parseTags(f.tags),
+      ...(f.position.trim() !== '' ? { position: Number(f.position) } : {}),
+    };
+  }
+
+  async function criar() {
+    if (!novo) return;
+    await comErro(
+      async () => {
+        await criarEstagio(id, payloadDe(novo));
+        setNovo(null);
+      },
+      'Estágio adicionado.',
+      'Não foi possível adicionar o estágio.',
+    );
+  }
+
+  async function salvarEdicao() {
+    if (!editando) return;
+    const { id: stageId, ...f } = editando;
+    await comErro(
+      async () => {
+        await atualizarEstagio(stageId, payloadDe(f));
+        setEditando(null);
+      },
+      'Estágio atualizado.',
+      'Não foi possível salvar o estágio.',
+    );
+  }
+
+  async function excluirEtapa(s: RoadmapStudioStage) {
+    if (!window.confirm(`Excluir o estágio "${s.title}" e suas referências?`)) return;
+    await comErro(() => excluirEstagio(s.id), 'Estágio excluído.', 'Não foi possível excluir o estágio.');
+  }
+
+  async function addRef(stageId: string) {
+    const trailId = refTrail[stageId];
+    if (!trailId) return;
+    await comErro(
+      async () => {
+        await adicionarRef(stageId, { refType: 'trail', refId: trailId });
+        setRefTrail((m) => ({ ...m, [stageId]: '' }));
+      },
+      'Trilha vinculada ao estágio.',
+      'Não foi possível vincular a trilha.',
+    );
+  }
+
+  async function delRef(refId: string) {
+    await comErro(() => removerRef(refId), 'Referência removida.', 'Não foi possível remover a referência.');
+  }
+
+  function iniciarEdicao(s: RoadmapStudioStage) {
+    setNovo(null);
+    setEditando({
+      id: s.id,
+      phase: s.phase,
+      title: s.title,
+      description: s.description,
+      tags: s.tags.join(', '),
+      position: String(s.position),
+    });
+  }
+
+  const stages = dados?.stages ?? [];
+
+  return (
+    <div className="home">
+      <EstudioTopbar
+        crumb={
+          <button className="studio__crumblink" onClick={() => navigate('/estudio/roadmaps')}>
+            <ChevronLeft size={14} /> Roadmaps
+          </button>
+        }
+      />
+
+      <div className="estudio-home">
+        {carregando && <p className="track__desc">Carregando...</p>}
+        {falhaCarga && <div className="auth__alert">Não foi possível carregar o roadmap.</div>}
+
+        {dados && (
+          <>
+            <div className="estudio-home__head">
+              <div>
+                <h1 className="estudio-home__title">{dados.name}</h1>
+                <p className="estudio-home__sub">
+                  {dados.published ? 'Publicado' : 'Rascunho'} · {stages.length}{' '}
+                  {stages.length === 1 ? 'estágio' : 'estágios'} · /{dados.slug}
+                </p>
+              </div>
+              {!novo && !editando && (
+                <button className="btn btn--accent" onClick={() => setNovo({ ...NOVO_ESTAGIO })}>
+                  <Plus size={14} /> Novo estágio
+                </button>
+              )}
+            </div>
+
+            {erro && <div className="auth__alert">{erro}</div>}
+
+            {novo && (
+              <StageFields
+                titulo="Novo estágio"
+                form={novo}
+                setForm={(f) => setNovo(f)}
+                onCancel={() => {
+                  setNovo(null);
+                  setErro('');
+                }}
+                onSave={criar}
+                salvando={salvando}
+                salvarLabel="Adicionar estágio"
+              />
+            )}
+
+            <div className="rmadm-stages">
+              {stages.map((s) =>
+                editando?.id === s.id ? (
+                  <StageFields
+                    key={s.id}
+                    titulo="Editar estágio"
+                    form={editando}
+                    setForm={(f) => setEditando({ ...f, id: s.id })}
+                    onCancel={() => {
+                      setEditando(null);
+                      setErro('');
+                    }}
+                    onSave={salvarEdicao}
+                    salvando={salvando}
+                    salvarLabel="Salvar"
+                  />
+                ) : (
+                  <div key={s.id} className="rmadm-stage">
+                    <div className="rmadm-stage__head">
+                      <div className="rmadm-stage__titlewrap">
+                        <span className="chip--outline rmadm-stage__phase">{FASE_LABEL[s.phase]}</span>
+                        <span className="rmadm-stage__pos">#{s.position}</span>
+                        <span className="rmadm-stage__title">{s.title}</span>
+                      </div>
+                      <div className="estudio-home__actions">
+                        <button
+                          className="estudio-home__act"
+                          onClick={() => iniciarEdicao(s)}
+                          aria-label="Editar estágio"
+                        >
+                          <Pencil size={14} />
+                        </button>
+                        <button
+                          className="estudio-home__act estudio-home__act--danger"
+                          onClick={() => excluirEtapa(s)}
+                          aria-label="Excluir estágio"
+                        >
+                          <Trash size={14} />
+                        </button>
+                      </div>
+                    </div>
+                    {s.description && <p className="rmadm-stage__desc">{s.description}</p>}
+                    {s.tags.length > 0 && (
+                      <div className="track__tags">
+                        {s.tags.map((t) => (
+                          <span key={t} className="chip--outline">
+                            {t}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+
+                    <div className="rmadm-refs">
+                      <div className="rmadm-refs__label">Conteúdo do estágio</div>
+                      {s.refs.length === 0 && (
+                        <p className="rmadm-refs__empty">Nenhuma trilha vinculada ainda.</p>
+                      )}
+                      {s.refs.map((r) => (
+                        <div key={r.id} className="rmadm-ref">
+                          <span className="chip--outline rmadm-ref__type">{r.refType}</span>
+                          <span className="rmadm-ref__title">{r.title ?? '(conteúdo removido)'}</span>
+                          <button
+                            className="estudio-home__act estudio-home__act--danger"
+                            onClick={() => delRef(r.id)}
+                            aria-label="Remover referência"
+                          >
+                            <Minus size={14} />
+                          </button>
+                        </div>
+                      ))}
+                      <div className="rmadm-refadd">
+                        <select
+                          className="estudio-form__input"
+                          value={refTrail[s.id] ?? ''}
+                          onChange={(e) => setRefTrail((m) => ({ ...m, [s.id]: e.target.value }))}
+                        >
+                          <option value="">Vincular uma trilha...</option>
+                          {trilhas.map((t) => (
+                            <option key={t.id} value={t.id}>
+                              {t.name}
+                            </option>
+                          ))}
+                        </select>
+                        <button
+                          className="btn btn--ghost"
+                          disabled={!refTrail[s.id] || salvando}
+                          onClick={() => addRef(s.id)}
+                        >
+                          <Plus size={13} /> Vincular
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                ),
+              )}
+            </div>
+
+            {stages.length === 0 && !novo && (
+              <p className="track__desc">
+                Nenhum estágio ainda. Clique em "Novo estágio" para começar a montar o caminho.
+              </p>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface StageFieldsProps {
+  titulo: string;
+  form: StageForm;
+  setForm: (f: StageForm) => void;
+  onCancel: () => void;
+  onSave: () => void;
+  salvando: boolean;
+  salvarLabel: string;
+}
+
+function StageFields({ titulo, form, setForm, onCancel, onSave, salvando, salvarLabel }: StageFieldsProps) {
+  return (
+    <div className="estudio-form">
+      <div className="estudio-form__title">{titulo}</div>
+      <div className="sim-adm__row">
+        <div>
+          <label className="studio__label">Fase</label>
+          <select
+            className="estudio-form__input"
+            value={form.phase}
+            onChange={(e) => setForm({ ...form, phase: e.target.value as RoadmapPhase })}
+          >
+            {FASES.map((f) => (
+              <option key={f.v} value={f.v}>
+                {f.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="studio__label">Posição (ordem)</label>
+          <input
+            className="estudio-form__input"
+            type="number"
+            value={form.position}
+            placeholder="auto"
+            onChange={(e) => setForm({ ...form, position: e.target.value })}
+          />
+        </div>
+      </div>
+      <label className="studio__label">Título</label>
+      <input
+        className="estudio-form__input"
+        value={form.title}
+        placeholder="Ex.: Banco de dados"
+        onChange={(e) => setForm({ ...form, title: e.target.value })}
+      />
+      <label className="studio__label">Descrição</label>
+      <textarea
+        className="estudio-form__input estudio-form__textarea"
+        value={form.description}
+        placeholder="O que este estágio ensina."
+        onChange={(e) => setForm({ ...form, description: e.target.value })}
+      />
+      <label className="studio__label">Tags (separadas por vírgula)</label>
+      <input
+        className="estudio-form__input"
+        value={form.tags}
+        placeholder="Ex.: SQL, PostgreSQL, Modelagem"
+        onChange={(e) => setForm({ ...form, tags: e.target.value })}
+      />
+      <div className="estudio-form__actions">
+        <button className="btn btn--ghost" onClick={onCancel}>
+          Cancelar
+        </button>
+        <button className="btn btn--accent" disabled={salvando} onClick={onSave}>
+          {salvando ? 'Salvando...' : salvarLabel}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/RoadmapsAdmin/index.tsx
+++ b/frontend/src/pages/RoadmapsAdmin/index.tsx
@@ -1,0 +1,280 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { EstudioTopbar } from '../../components/EstudioTopbar';
+import { Plus, Pencil, Trash, ChevronRight, Target } from '../../components/Icons';
+import { useRequisicao } from '../../hooks/useRequisicao';
+import { mensagemErro } from '../../utils/erro';
+import { useToast } from '../../contexts/ToastContext';
+import {
+  listarRoadmapsAdmin,
+  criarRoadmap,
+  atualizarRoadmap,
+  excluirRoadmap,
+  type RoadmapAdminItem,
+  type Nivel,
+} from '../../services/roadmaps';
+
+const NIVEIS: { v: Nivel; label: string }[] = [
+  { v: 'iniciante', label: 'Iniciante' },
+  { v: 'intermediario', label: 'Intermediário' },
+  { v: 'avancado', label: 'Avançado' },
+];
+
+interface FormState {
+  id: string;
+  slug: string;
+  name: string;
+  description: string;
+  level: Nivel;
+  icon: string;
+  position: string;
+  premium: boolean;
+  published: boolean;
+  editando: boolean;
+}
+
+const NOVO: FormState = {
+  id: '',
+  slug: '',
+  name: '',
+  description: '',
+  level: 'iniciante',
+  icon: '',
+  position: '',
+  premium: false,
+  published: false,
+  editando: false,
+};
+
+export function RoadmapsAdmin() {
+  const navigate = useNavigate();
+  const { mostrar } = useToast();
+  const { dados, carregando, erro: falhaCarga, recarregar } = useRequisicao(listarRoadmapsAdmin, []);
+  const roadmaps = dados ?? [];
+  const [form, setForm] = useState<FormState | null>(null);
+  const [erro, setErro] = useState('');
+  const [salvando, setSalvando] = useState(false);
+
+  function editar(r: RoadmapAdminItem) {
+    setErro('');
+    setForm({
+      id: r.id,
+      slug: r.slug,
+      name: r.name,
+      description: r.description,
+      level: r.level,
+      icon: r.icon ?? '',
+      position: String(r.position),
+      premium: r.premium,
+      published: r.published,
+      editando: true,
+    });
+  }
+
+  async function salvar() {
+    if (!form || salvando) return;
+    setSalvando(true);
+    setErro('');
+    const comuns = {
+      name: form.name,
+      description: form.description,
+      level: form.level,
+      icon: form.icon.trim() || undefined,
+      premium: form.premium,
+      published: form.published,
+      ...(form.position.trim() !== '' ? { position: Number(form.position) } : {}),
+    };
+    try {
+      if (form.editando) {
+        await atualizarRoadmap(form.id, comuns);
+      } else {
+        await criarRoadmap({ slug: form.slug.trim() || undefined, ...comuns });
+      }
+      mostrar(form.editando ? 'Roadmap atualizado.' : 'Roadmap criado.');
+      setForm(null);
+      recarregar();
+    } catch (e: unknown) {
+      setErro(mensagemErro(e, 'Não foi possível salvar o roadmap.'));
+    } finally {
+      setSalvando(false);
+    }
+  }
+
+  async function excluir(r: RoadmapAdminItem) {
+    if (!window.confirm(`Excluir o roadmap "${r.name}" e todos os seus estágios?`)) return;
+    setErro('');
+    try {
+      await excluirRoadmap(r.id);
+      mostrar('Roadmap excluído.');
+      recarregar();
+    } catch (e: unknown) {
+      setErro(mensagemErro(e, 'Não foi possível excluir o roadmap.'));
+    }
+  }
+
+  return (
+    <div className="home">
+      <EstudioTopbar crumb={<b>Roadmaps</b>} />
+
+      <div className="estudio-home">
+        <div className="estudio-home__head">
+          <div>
+            <h1 className="estudio-home__title">Roadmaps</h1>
+            <p className="estudio-home__sub">
+              Crie caminhos de carreira e organize seus estágios sobre as trilhas existentes.
+            </p>
+          </div>
+          {!form && (
+            <button className="btn btn--accent" onClick={() => setForm({ ...NOVO })}>
+              <Plus size={14} /> Novo roadmap
+            </button>
+          )}
+        </div>
+
+        {form && (
+          <div className="estudio-form">
+            <div className="estudio-form__title">{form.editando ? 'Editar roadmap' : 'Novo roadmap'}</div>
+            <label className="studio__label">Nome</label>
+            <input
+              className="estudio-form__input"
+              value={form.name}
+              placeholder="Ex.: Back-end"
+              onChange={(e) => setForm({ ...form, name: e.target.value })}
+            />
+            <label className="studio__label">Slug (identificador na URL)</label>
+            <input
+              className="estudio-form__input"
+              value={form.slug}
+              disabled={form.editando}
+              placeholder={form.editando ? '' : 'gerado do nome se vazio (ex.: back-end)'}
+              onChange={(e) => setForm({ ...form, slug: e.target.value })}
+            />
+            <label className="studio__label">Descrição</label>
+            <textarea
+              className="estudio-form__input estudio-form__textarea"
+              value={form.description}
+              placeholder="Do zero à vaga: o que este caminho ensina."
+              onChange={(e) => setForm({ ...form, description: e.target.value })}
+            />
+            <div className="sim-adm__row">
+              <div>
+                <label className="studio__label">Nível</label>
+                <select
+                  className="estudio-form__input"
+                  value={form.level}
+                  onChange={(e) => setForm({ ...form, level: e.target.value as Nivel })}
+                >
+                  {NIVEIS.map((n) => (
+                    <option key={n.v} value={n.v}>
+                      {n.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="studio__label">Posição (ordem)</label>
+                <input
+                  className="estudio-form__input"
+                  type="number"
+                  value={form.position}
+                  placeholder="auto"
+                  onChange={(e) => setForm({ ...form, position: e.target.value })}
+                />
+              </div>
+              <div>
+                <label className="studio__label">Ícone (opcional)</label>
+                <input
+                  className="estudio-form__input"
+                  value={form.icon}
+                  placeholder="ex.: server"
+                  onChange={(e) => setForm({ ...form, icon: e.target.value })}
+                />
+              </div>
+            </div>
+            <label className="sim-adm__check">
+              <input
+                type="checkbox"
+                checked={form.premium}
+                onChange={(e) => setForm({ ...form, premium: e.target.checked })}
+              />
+              Premium (bloqueado por assinatura)
+            </label>
+            <label className="sim-adm__check">
+              <input
+                type="checkbox"
+                checked={form.published}
+                onChange={(e) => setForm({ ...form, published: e.target.checked })}
+              />
+              Publicado (visível para os alunos)
+            </label>
+            {erro && <div className="auth__alert">{erro}</div>}
+            <div className="estudio-form__actions">
+              <button
+                className="btn btn--ghost"
+                onClick={() => {
+                  setForm(null);
+                  setErro('');
+                }}
+              >
+                Cancelar
+              </button>
+              <button className="btn btn--accent" disabled={salvando} onClick={salvar}>
+                {salvando ? 'Salvando...' : form.editando ? 'Salvar' : 'Criar roadmap'}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {carregando && <p className="track__desc">Carregando...</p>}
+        {!form && (erro || falhaCarga) && (
+          <div className="auth__alert">{erro || 'Não foi possível carregar os roadmaps.'}</div>
+        )}
+        {!carregando && roadmaps.length === 0 && !form && (
+          <p className="track__desc">Nenhum roadmap cadastrado ainda.</p>
+        )}
+
+        <div className="estudio-home__list">
+          {roadmaps.map((r) => (
+            <div key={r.id} className="estudio-home__card">
+              <button
+                className="estudio-home__open"
+                onClick={() => navigate(`/estudio/roadmaps/${r.id}`)}
+              >
+                <span className="estudio-home__glyph">
+                  <Target size={18} />
+                </span>
+                <div className="estudio-home__meta">
+                  <div className="estudio-home__name">{r.name}</div>
+                  <div className="estudio-home__info">
+                    {r.stagesTotal} {r.stagesTotal === 1 ? 'estágio' : 'estágios'} ·{' '}
+                    {r.published ? 'Publicado' : 'Rascunho'}
+                    {r.premium ? ' · Premium' : ''}
+                  </div>
+                </div>
+              </button>
+              <div className="estudio-home__actions">
+                <button className="estudio-home__act" onClick={() => editar(r)} aria-label="Editar roadmap">
+                  <Pencil size={15} />
+                </button>
+                <button
+                  className="estudio-home__act estudio-home__act--danger"
+                  onClick={() => excluir(r)}
+                  aria-label="Excluir roadmap"
+                >
+                  <Trash size={15} />
+                </button>
+                <button
+                  className="estudio-home__act"
+                  onClick={() => navigate(`/estudio/roadmaps/${r.id}`)}
+                  aria-label="Gerenciar estágios"
+                >
+                  <ChevronRight size={16} />
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/services/roadmaps.ts
+++ b/frontend/src/services/roadmaps.ts
@@ -63,3 +63,127 @@ export async function obterRoadmap(slug: string) {
   const { data } = await api.get<RoadmapDetalhe>(`/roadmaps/${slug}`);
   return data;
 }
+
+// ===================== ADMIN (estúdio) =====================
+
+export type RefType = RoadmapRef['refType'];
+
+export interface RoadmapAdminItem {
+  id: string;
+  slug: string;
+  name: string;
+  description: string;
+  level: Nivel;
+  icon: string | null;
+  position: number;
+  premium: boolean;
+  published: boolean;
+  stagesTotal: number;
+}
+
+export interface RoadmapStudioRef {
+  id: string;
+  refType: RefType;
+  refId: string;
+  position: number;
+  title: string | null;
+  trailId?: string;
+  slug?: string;
+}
+
+export interface RoadmapStudioStage {
+  id: string;
+  phase: RoadmapPhase;
+  title: string;
+  description: string;
+  tags: string[];
+  position: number;
+  refs: RoadmapStudioRef[];
+}
+
+export interface RoadmapStudio {
+  id: string;
+  slug: string;
+  name: string;
+  description: string;
+  level: Nivel;
+  icon: string | null;
+  position: number;
+  premium: boolean;
+  published: boolean;
+  stages: RoadmapStudioStage[];
+}
+
+export interface PayloadRoadmap {
+  slug?: string;
+  name: string;
+  description: string;
+  level: Nivel;
+  icon?: string;
+  position?: number;
+  premium?: boolean;
+  published?: boolean;
+}
+export type PayloadRoadmapUpdate = Partial<PayloadRoadmap>;
+
+export interface PayloadStage {
+  phase: RoadmapPhase;
+  title: string;
+  description: string;
+  tags?: string[];
+  position?: number;
+}
+export type PayloadStageUpdate = Partial<PayloadStage>;
+
+export interface PayloadRef {
+  refType: RefType;
+  refId: string;
+  position?: number;
+}
+
+export async function listarRoadmapsAdmin() {
+  const { data } = await api.get<RoadmapAdminItem[]>('/studio/roadmaps');
+  return data;
+}
+
+export async function obterRoadmapStudio(id: string) {
+  const { data } = await api.get<RoadmapStudio>(`/studio/roadmaps/${id}`);
+  return data;
+}
+
+export async function criarRoadmap(payload: PayloadRoadmap) {
+  const { data } = await api.post<RoadmapAdminItem>('/roadmaps', payload);
+  return data;
+}
+
+export async function atualizarRoadmap(id: string, payload: PayloadRoadmapUpdate) {
+  const { data } = await api.patch(`/roadmaps/${id}`, payload);
+  return data;
+}
+
+export async function excluirRoadmap(id: string) {
+  await api.delete(`/roadmaps/${id}`);
+}
+
+export async function criarEstagio(roadmapId: string, payload: PayloadStage) {
+  const { data } = await api.post<RoadmapStudioStage>(`/roadmaps/${roadmapId}/stages`, payload);
+  return data;
+}
+
+export async function atualizarEstagio(id: string, payload: PayloadStageUpdate) {
+  const { data } = await api.patch(`/roadmap-stages/${id}`, payload);
+  return data;
+}
+
+export async function excluirEstagio(id: string) {
+  await api.delete(`/roadmap-stages/${id}`);
+}
+
+export async function adicionarRef(stageId: string, payload: PayloadRef) {
+  const { data } = await api.post<RoadmapStudioRef>(`/roadmap-stages/${stageId}/refs`, payload);
+  return data;
+}
+
+export async function removerRef(id: string) {
+  await api.delete(`/roadmap-stage-refs/${id}`);
+}

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -4711,3 +4711,107 @@
   opacity: 1;
   visibility: visible;
 }
+
+/* Estúdio: editor de roadmap (estágios e referências) */
+.studio__crumblink {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--muted);
+  font-size: 14px;
+  font-weight: 600;
+  padding: 0;
+}
+.studio__crumblink:hover {
+  color: var(--text);
+}
+.rmadm-stages {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 8px;
+}
+.rmadm-stage {
+  border: 1px solid var(--border);
+  background: var(--surface);
+  border-radius: 14px;
+  padding: 16px 18px;
+}
+.rmadm-stage__head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+.rmadm-stage__titlewrap {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.rmadm-stage__phase {
+  text-transform: capitalize;
+}
+.rmadm-stage__pos {
+  font-size: 12.5px;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+.rmadm-stage__title {
+  font-weight: 600;
+  font-size: 15.5px;
+  color: var(--text);
+}
+.rmadm-stage__desc {
+  color: var(--muted);
+  font-size: 14px;
+  margin: 10px 0 0;
+  line-height: 1.5;
+}
+.rmadm-stage .track__tags {
+  margin-top: 10px;
+}
+.rmadm-refs {
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 1px dashed var(--border);
+}
+.rmadm-refs__label {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+.rmadm-refs__empty {
+  color: var(--muted);
+  font-size: 13.5px;
+  margin: 0 0 8px;
+}
+.rmadm-ref {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 0;
+}
+.rmadm-ref__type {
+  text-transform: capitalize;
+  font-size: 11.5px;
+}
+.rmadm-ref__title {
+  flex: 1;
+  font-size: 14px;
+  color: var(--text);
+}
+.rmadm-refadd {
+  display: flex;
+  gap: 8px;
+  margin-top: 10px;
+}
+.rmadm-refadd select {
+  flex: 1;
+}


### PR DESCRIPTION
## O que faz

Ate agora os roadmaps so podiam ser criados por seed. Este PR adiciona a **gestao completa pelo backend (admin)**, nos tres niveis do roadmap: o roadmap em si, seus estagios e as referencias de conteudo de cada estagio. Segue o padrao das trilhas (rotas admin com autenticar + exigirAdmin, controller fino, logica no service, validacao Zod).

## Endpoints (todos admin, exceto os dois de leitura de aluno que ja existiam)

| Metodo | Rota | Acao |
|---|---|---|
| GET | /studio/roadmaps | Lista todos os roadmaps (inclui rascunhos) com contagem de estagios |
| GET | /studio/roadmaps/:id | Estrutura crua para edicao (estagios + refs com titulo resolvido, sem progresso) |
| POST | /roadmaps | Cria roadmap |
| PATCH | /roadmaps/:id | Atualiza roadmap |
| DELETE | /roadmaps/:id | Exclui roadmap (cascata nos estagios e refs) |
| POST | /roadmaps/:id/stages | Adiciona estagio |
| PATCH | /roadmap-stages/:id | Atualiza estagio |
| DELETE | /roadmap-stages/:id | Exclui estagio (cascata nos refs) |
| POST | /roadmap-stages/:id/refs | Adiciona referencia de conteudo ao estagio |
| DELETE | /roadmap-stage-refs/:id | Remove referencia |

## Decisoes

- **Refs validados na criacao:** ao adicionar uma referencia, o service confere que o conteudo (trilha/modulo/aula/simulado/desafio) existe de verdade, retornando 400 se nao. Isso evita o ref pendurado (estagio apontando para conteudo inexistente).
- **Slug** gerado a partir do nome quando ausente, com unicidade garantida (409 se repetido).
- **Posicao** auto-incrementada quando ausente (roadmap, estagio e ref).
- **Exclusao em cascata** em transacao (roadmap -> estagios -> refs; estagio -> refs).
- Leituras de gestao sob /studio/roadmaps para nao colidir com o GET /roadmaps/:slug do aluno.
- **Sem migration:** as tabelas (roadmaps, roadmap_stages, roadmap_stage_refs) ja existem desde a 0029.

## Validacao (dev)

- Typecheck (tsc) limpo.
- Teste funcional do service: criar (slug/posicao automaticos), estagio com tags, ref valido (resolve titulo), ref invalido barrado, visao de estudio, slug duplicado barrado, update e exclusao em cascata (todos ok).
- Rotas confirmadas no ar e protegidas: chamadas sem token retornam 401 (nao 404).

## Estúdio (frontend, incluído neste PR)

Telas admin de gestão de roadmap em `frontend/src/pages/RoadmapsAdmin` (lista + editor de estágios e referências), item **Roadmaps** na navegação do estúdio e rotas admin no `App.tsx`. Consomem os endpoints acima. Detalhes e validação (build, lint e teste logado como admin) no comentário do PR.
