### PR TITLE
feat: trilha Docker e Containers (estágio 8 do roadmap backend)

### DIFF
--- a/backend/scripts/seed-roadmap-backend.ts
+++ b/backend/scripts/seed-roadmap-backend.ts
@@ -1,12 +1,12 @@
 // Seed do roadmap "Back-end": camada de orquestracao sobre as trilhas de fundacao
 // (Logica de Programacao, Protocolos da Web, APIs e Frameworks, Banco de Dados,
-// Autenticacao). Cobre os estagios 1 a 5 do desenho de 10 estagios; os estagios
-// 6 a 10 (cache, testes, docker, ci/cd, arquitetura) entram depois, conforme o
-// conteudo for autorado.
+// Autenticacao, Cache/Filas/Performance, Testes e Qualidade, Docker e Containers).
+// Cobre os estagios 1 a 8 do desenho de 10 estagios; os estagios 9 e 10 (ci/cd,
+// arquitetura) entram depois, conforme o conteudo for autorado.
 //
 // Idempotente POR ESTAGIO: cria o roadmap se faltar e insere apenas os estagios
 // que ainda nao existem (casados por titulo). Assim, para adicionar os estagios
-// 6 a 10 depois, basta acrescenta-los em STAGES e rodar de novo.
+// 9 e 10 depois, basta acrescenta-los em STAGES e rodar de novo.
 //
 // O Back-end e o roadmap principal do catalogo: na criacao, entra na posicao 1 e
 // empurra os roadmaps existentes uma posicao para baixo.
@@ -106,6 +106,15 @@ const STAGES: Stage[] = [
             "Garanta que o back-end continua correto quando o código muda: testes unitários e de integração, mocks, TDD, cobertura e a qualidade além dos testes (lint, tipos, review).",
         tags: ["Testes", "Vitest", "TDD"],
         refs: [{ type: "trail", ref: "Testes e Qualidade" }],
+    },
+    {
+        phase: "deploy",
+        position: 8,
+        title: "Docker & containers",
+        description:
+            "Empacote o back-end pra rodar igual em qualquer lugar: containers e imagens, Dockerfile, volumes, Docker Compose orquestrando app, banco e cache, e imagens enxutas e seguras a caminho do deploy.",
+        tags: ["Docker", "Compose", "Containers"],
+        refs: [{ type: "trail", ref: "Docker e Containers" }],
     },
 ];
 

--- a/backend/scripts/seed-roadmap-backend.ts
+++ b/backend/scripts/seed-roadmap-backend.ts
@@ -98,6 +98,15 @@ const STAGES: Stage[] = [
         tags: ["Redis", "Filas", "Performance"],
         refs: [{ type: "trail", ref: "Cache, Filas e Performance" }],
     },
+    {
+        phase: "avancado",
+        position: 7,
+        title: "Testes & qualidade",
+        description:
+            "Garanta que o back-end continua correto quando o código muda: testes unitários e de integração, mocks, TDD, cobertura e a qualidade além dos testes (lint, tipos, review).",
+        tags: ["Testes", "Vitest", "TDD"],
+        refs: [{ type: "trail", ref: "Testes e Qualidade" }],
+    },
 ];
 
 async function resolverRef(type: RefType, ref: string): Promise<string | null> {

--- a/backend/scripts/seed-trilha-docker-containers.ts
+++ b/backend/scripts/seed-trilha-docker-containers.ts
@@ -1,0 +1,5178 @@
+// Seed da trilha Docker e Containers (intermediario), estagio 8 do roadmap de Back-end.
+// Idempotente e nao destrutivo: se a trilha ja tiver aulas, nao faz nada.
+//
+// Rodar em prod: docker compose -f docker-compose.prod.yml exec -T backend node scripts/seed-trilha-docker-containers.ts
+import { db } from "../db.ts";
+import { trails, modules, lessons, questions, questionOptions } from "../schema.ts";
+import { eq } from "drizzle-orm";
+
+const NOME = "Docker e Containers";
+const LEVEL: "iniciante" | "intermediario" | "avancado" = "intermediario";
+const DESCRICAO =
+    "Empacote seu back-end pra rodar igual em qualquer lugar: o que são containers, Dockerfile e imagens, volumes, Docker Compose pra orquestrar app, banco e cache, imagens enxutas e seguras, e o caminho do container até o deploy. O fim do \"na minha máquina funciona\".";
+
+type Bloco = { type: "text" | "code" | "quote" | "table"; value: string };
+type Questao = {
+    statement: string;
+    difficulty: "facil" | "medio" | "dificil";
+    options: { text: string; isCorrect: boolean }[];
+};
+type Aula = { titulo: string; blocks: Bloco[]; questions: Questao[] };
+type Modulo = { titulo: string; aulas: Aula[] };
+
+const MODULOS: Modulo[] = [
+    {
+        "titulo": "Módulo 1 - Por que containers",
+        "aulas": [
+            {
+                "titulo": "O problema do \"na minha máquina funciona\"",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Por que containers existem\n\nVocê termina uma rota nova na sua API Express, os testes passam, o Postgres local responde rápido, o Redis guarda o cache certinho. Sobe pro servidor e alguma coisa quebra: um log de erro estranho, uma biblioteca que se comporta diferente, um npm install que não fecha do mesmo jeito que fechou na sua máquina.\n\nEsse é o problema clássico do \"na minha máquina funciona\". Não é frescura: é uma questão real de **ambiente**."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que costuma mudar de uma máquina pra outra\n\nAlgumas diferenças comuns entre o seu ambiente e o do servidor:\n\n- **Versão do Node**: você desenvolve com uma versão, o servidor tem outra instalada, e alguma sintaxe ou API do runtime se comporta diferente.\n- **Versão do sistema operacional**: seu Linux ou macOS tem um conjunto de bibliotecas; a distribuição do servidor tem outro.\n- **Pacotes instalados globalmente**: aquele pacote que você instalou uma vez com npm install -g e esqueceu que não está listado no package.json.\n- **Variáveis de ambiente**: sua API espera uma DATABASE_URL configurada de um jeito; o servidor tem outra, ou nenhuma.\n- **Versão dos serviços de apoio**: o Postgres da sua máquina está numa versão, o do servidor está em outra. O Redis local tem uma configuração padrão diferente da de produção."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# na sua máquina, durante o desenvolvimento\n$ node --version\nv20.11.0\n\n# no servidor, depois do deploy\n$ node --version\nv18.19.0\n\n# uma dependência que usa um recurso novo do runtime passa a falhar\n# so no servidor, mesmo com o codigo identico"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Não é só a versão do Node\n\nO mesmo tipo de divergência aparece em outras peças que você já conhece: o Postgres da trilha de banco pode estar numa versão na sua máquina e noutra no servidor; o Redis que você usa pro cache pode ter parâmetros de configuração padrão diferentes; até uma lib nativa do sistema operacional, usada por baixo dos panos por alguma dependência do Node, pode simplesmente não existir no servidor.\n\nCada uma dessas diferenças é pequena sozinha. Juntas, viram uma lista enorme de coisas pra conferir toda vez que a aplicação muda de máquina."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O jeito manual de resolver (e por que ele não escala)\n\nAntes de containers, preparar um ambiente novo era repetir um roteiro na mão: instalar o Node na versão certa, instalar o Postgres, instalar o Redis, configurar cada variável de ambiente, torcer pra nenhuma versão de dependência do sistema conflitar com outra aplicação que já rodava ali.\n\nO problema não é só saber o que instalar. É garantir que a combinação de versões seja a mesma na sua máquina, na do colega de time, no ambiente de teste e em produção. Um roteiro manual desatualiza rápido, e cada passo esquecido vira um motivo a mais pra travar o deploy."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "\"Na minha máquina funciona\" é sintoma de um problema real: o ambiente não é o mesmo. É exatamente esse problema que o container resolve."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "De forma geral, o que costuma causar o problema do \"na minha máquina funciona\"?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Diferenças de ambiente entre as máquinas, como a versão do Node instalada",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Falta de testes automatizados cobrindo as rotas principais da aplicação",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uso de um editor de código diferente do usado pelo resto do time",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Excesso de comentários explicando trechos simples do código",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual das opções abaixo é um exemplo real de diferença entre o ambiente de desenvolvimento e o servidor de produção?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "A versão do Postgres instalada pode divergir entre as máquinas",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O tamanho do monitor usado por quem desenvolveu a aplicação",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O nome escolhido para a branch onde o código foi desenvolvido",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A cor do tema escolhido no editor de código utilizado",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Sua API usa um recurso novo do Node que funciona no seu notebook. Depois do deploy, o mesmo código quebra no servidor com um erro de sintaxe não reconhecida. A causa mais provável é:",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O servidor tem uma versão do Node mais antiga, que ainda não suporta esse recurso",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O servidor está com o Postgres desatualizado em relação ao seu ambiente local",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Redis do servidor está configurado com uma porta diferente da esperada",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O arquivo de variáveis de ambiente do servidor não foi copiado no deploy",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de rodar npm install -g de um pacote pra testar algo rápido, sua aplicação passou a depender dele sem perceber. No servidor, o deploy quebra porque:",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O pacote não está listado no package.json nem foi instalado no servidor",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O npm install -g só funciona em ambientes de desenvolvimento, nunca em produção",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Pacotes globais são sempre removidos automaticamente durante qualquer deploy",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O servidor bloqueia por padrão qualquer pacote instalado depois do primeiro deploy",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um time consegue, quase sempre, manter dev, teste e produção com as mesmas versões de Node, Postgres e Redis usando só documentação e disciplina manual. O que torna essa abordagem frágil no longo prazo?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Cada atualização feita manualmente numa máquina precisa ser repetida, sem erro, nas outras",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A documentação escrita à mão nunca pode ser lida por mais de uma pessoa do time",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ferramentas de versionamento como o Git impedem esse tipo de sincronização entre máquinas",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Node, Postgres e Redis não permitem versões diferentes instaladas em máquinas diferentes",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "O que é um container",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## O que é, de fato, um container\n\nUm container é um **processo isolado** que roda no sistema operacional do host, carregando junto tudo que a aplicação precisa pra funcionar: o código, o runtime (o próprio Node, no caso de uma API Express), as bibliotecas do sistema e as dependências do projeto.\n\nNão é uma cópia inteira de um computador. É a sua aplicação, empacotada com tudo que ela usa, isolada do resto do sistema."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Isolado, mas no mesmo kernel\n\nPor baixo dos panos, no Linux, o Docker usa dois mecanismos do próprio sistema operacional:\n\n- **Namespaces**: isolam o que o processo enxerga, como rede, outros processos e sistema de arquivos.\n- **Cgroups**: limitam quanto de CPU e memória aquele processo pode consumir.\n\nO container usa esses dois recursos pra parecer uma \"caixinha\" isolada, mesmo rodando no mesmo kernel do host."
+                    },
+                    {
+                        "type": "code",
+                        "value": "$ docker run hello-world\n\nUnable to find image 'hello-world:latest' locally\nlatest: Pulling from library/hello-world\nStatus: Downloaded newer image for hello-world:latest\n\nHello from Docker!\nThis message shows that your installation appears to be working correctly.\n\n# o Docker nao achou a imagem hello-world na maquina local,\n# baixou do Docker Hub e rodou um container a partir dela"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Container é processo, não é sistema operacional\n\nUm jeito simples de pensar: o container é só mais um processo do Linux do host, só que isolado. Ele enxerga seu próprio sistema de arquivos, sua própria rede, seus próprios processos, mas na prática está usando o mesmo kernel que o host já tinha rodando.\n\nQuando o processo principal do container termina, o container termina junto."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## A mesma imagem, o mesmo comportamento, em qualquer lugar\n\nÉ isso que resolve o problema da aula anterior: se a sua API Express roda dentro de um container com o Node, as libs e as dependências dela empacotadas junto, não importa se o host tem Node instalado, ou qual versão. O container leva o que precisa.\n\nSua máquina, a máquina do colega de time, o ambiente de teste, o servidor de produção: todos rodando o mesmo container, com o mesmo resultado."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Um container é, no fundo, um processo isolado que carrega junto tudo que a aplicação precisa pra rodar, igual, em qualquer lugar."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "De forma simples, o que é um container?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Um processo isolado que roda com suas dependências empacotadas junto",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Uma cópia completa de um sistema operacional rodando ao lado do host",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um arquivo de configuração que descreve como instalar dependências",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um serviço externo que hospeda o código da aplicação na nuvem",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O que acontece ao rodar o comando docker run hello-world numa máquina que nunca usou essa imagem antes?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "O Docker baixa a imagem do Docker Hub e roda um container a partir dela",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O Docker instala o hello-world como programa permanente do sistema operacional",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Docker cria uma imagem nova a partir de um Dockerfile na pasta atual",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Docker pede confirmação antes de conectar a internet pela primeira vez",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Sua API rodou dentro de um container tanto na sua máquina quanto no notebook de um colega, mesmo com versões de Node diferentes instaladas nos dois hosts. Isso acontece porque:",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O container carrega consigo o próprio Node, empacotado dentro da imagem",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O Docker atualiza automaticamente o Node instalado em cada host",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O container usa a rede pra baixar a versão certa do Node em tempo real",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Docker Hub sincroniza a versão do Node entre as duas máquinas",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O que um container isola do sistema operacional host, usando namespaces e cgroups?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O que o processo enxerga (rede, arquivos, processos) e quanto de CPU e memória usa",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O hardware físico inteiro, dividido em partições exclusivas pra cada container",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O kernel do sistema, já que cada container roda um kernel Linux só seu",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A internet, já que containers não têm acesso à rede por padrão",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Você roda docker run alpine echo \"oi\". O comando imprime \"oi\" e, logo em seguida, o container para sozinho, sem nenhum comando extra. Por quê?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O container existe enquanto o processo principal roda; quando termina, ele para",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O Docker limita, por padrão, containers a poucos segundos de execução",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A imagem alpine é configurada pra parar containers depois de uma saída no terminal",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O comando echo sempre finaliza o container em que foi executado",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Container x máquina virtual",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Duas formas de isolar aplicações\n\nAntes de containers virarem populares, a forma comum de isolar aplicações num mesmo servidor físico já existia: a **máquina virtual**. Container e máquina virtual resolvem um problema parecido (isolar uma aplicação do resto) só que de jeitos bem diferentes."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Como a máquina virtual isola\n\nUma máquina virtual (VM) usa um **hypervisor** pra virtualizar o hardware e rodar, dentro dele, um sistema operacional completo, com o próprio kernel, independente do kernel do host.\n\nIsso quer dizer que cada VM carrega um sistema operacional inteiro: precisa dar boot, precisa de espaço em disco pra esse sistema todo, precisa de memória reservada pra ele funcionar, mesmo antes da aplicação em si começar a rodar."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Como o container isola\n\nO container não virtualiza um sistema operacional novo: ele compartilha o kernel do host e usa namespaces e cgroups (vistos na aula anterior) pra ficar isolado. Não existe boot de sistema operacional, porque o sistema operacional já está rodando, é o do host.\n\nO container só precisa iniciar o processo da aplicação. Por isso ele sobe muito mais rápido e ocupa muito menos espaço que uma VM."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Aspecto\",\"Container\",\"Máquina virtual\"],[\"Peso\",\"Poucos MB até algumas centenas de MB\",\"Geralmente vários GB, com o sistema operacional inteiro\"],[\"Boot\",\"Segundos, só inicia um processo\",\"Minutos, precisa dar boot num sistema operacional completo\"],[\"Isolamento\",\"Compartilha o kernel do host, isolado por namespaces e cgroups\",\"Isolamento completo, cada VM roda seu próprio kernel\"],[\"Quantas por host\",\"Dezenas ou centenas, com pouco overhead\",\"Poucas, cada uma reserva CPU, memória e disco pra si\"]]"
+                    },
+                    {
+                        "type": "code",
+                        "value": "$ time docker run --rm alpine echo \"container no ar\"\ncontainer no ar\n\nreal\t0m0.412s\n\n# o comando sobe o container, roda o echo, termina o processo\n# e remove o container (--rm), tudo em menos de meio segundo"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Quando usar cada um\n\nContainer é a escolha natural quando o objetivo é rodar várias instâncias de uma aplicação, escalar rápido e usar o hardware de forma eficiente, como a sua API Express, um worker, ou um serviço de fila.\n\nMáquina virtual continua fazendo sentido quando é preciso isolamento mais forte entre cargas de diferentes clientes, ou quando é necessário rodar um kernel diferente do host (Linux e Windows, por exemplo, no mesmo servidor físico).\n\nNa prática, é comum ver os dois combinados: provedores de nuvem rodam containers dentro de VMs, somando o isolamento mais forte da VM com a leveza do container."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Container e máquina virtual isolam de formas diferentes: uma reparte o hardware inteiro entre sistemas operacionais completos, o outro reparte um único kernel de um jeito leve."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual é a principal diferença entre um container e uma máquina virtual?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "O container compartilha o kernel do host; a VM virtualiza um sistema completo",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O container só roda aplicações web; a VM roda qualquer tipo de aplicação",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A VM sobe mais rápido, porque não depende do hardware físico do servidor",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O container guarda dados de forma permanente; a VM perde tudo ao reiniciar",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que um container costuma iniciar em segundos, enquanto uma máquina virtual pode levar minutos?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "O container não precisa dar boot em outro sistema, só inicia um processo",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O container sempre usa menos memória RAM do que qualquer máquina virtual",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Docker pré-instala o sistema operacional inteiro durante sua instalação",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A máquina virtual baixa uma imagem nova da internet toda vez que liga",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Sua equipe precisa rodar dezenas de instâncias da API no mesmo servidor físico, aproveitando ao máximo a CPU e a memória disponíveis. Containers tendem a se sair melhor que VMs nesse cenário porque:",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Compartilham o kernel do host e consomem pouco recurso extra por instância",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Cada container roda um kernel próprio, otimizado pro hardware disponível",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Containers recebem prioridade automática mais alta no agendamento de CPU",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Docker distribui sozinho os containers entre vários servidores físicos",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma empresa precisa rodar, no mesmo servidor físico, cargas de trabalho totalmente isoladas, com kernels de sistemas operacionais diferentes entre si. A opção mais adequada nesse caso é:",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Máquinas virtuais, porque cada uma leva seu próprio kernel completo",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Containers, porque o Docker roda kernels Linux e Windows num só container",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Containers, porque namespaces já garantem isolamento entre kernels diferentes",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Tanto faz, container e VM isolam o kernel exatamente do mesmo jeito",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Em provedores de nuvem, é comum containers rodarem dentro de máquinas virtuais, e não direto no hardware físico. Isso costuma acontecer porque:",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "A VM soma uma camada extra de isolamento entre clientes do provedor",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Containers não conseguem funcionar rodando direto sobre hardware físico",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "É a única forma de um container conseguir acesso à internet",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Docker exige um hypervisor instalado pra iniciar qualquer container",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Imagem x container",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## O molde e a instância\n\nPra quem já trabalha com back-end, tem uma analogia direta: pensa numa classe e num objeto instanciado a partir dela. A **imagem** é a classe, a definição de tudo que a aplicação precisa. O **container** é o objeto, a instância rodando, com estado e ciclo de vida próprios."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que tem dentro de uma imagem\n\nUma imagem é um pacote somente leitura: o código da aplicação, o runtime (Node, no caso de uma API Express), as bibliotecas do sistema, as dependências instaladas e o comando padrão pra iniciar tudo isso.\n\nUma vez construída, a imagem não muda. Pra alterar algo, o caminho é gerar uma imagem nova, não editar a que já existe."
+                    },
+                    {
+                        "type": "code",
+                        "value": "$ docker run -d --name web1 nginx\n$ docker run -d --name web2 nginx\n$ docker run -d --name web3 nginx\n$ docker ps\n\nCONTAINER ID   IMAGE   STATUS         NAMES\nc3f1a9e2b7d4   nginx   Up 4 seconds   web3\n9a8b7c6d5e4f   nginx   Up 7 seconds   web2\n1a2b3c4d5e6f   nginx   Up 11 seconds  web1"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Uma imagem, quantos containers forem precisos\n\nOs três comandos acima usam a mesma imagem (nginx) pra criar três containers diferentes, cada um com seu próprio nome, seu próprio processo, rodando ao mesmo tempo e de forma independente. Parar ou remover o web2 não afeta o web1, o web3, nem a imagem nginx que deu origem aos três.\n\nÉ a mesma lógica de instanciar várias vezes a partir de uma única definição."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Aspecto\",\"Imagem\",\"Container\"],[\"O que é\",\"Um molde somente leitura com tudo que a aplicação precisa\",\"Uma instância em execução (ou parada), criada a partir de uma imagem\"],[\"Muda depois de pronta\",\"Não, é imutável; pra mudar, gera-se uma nova imagem\",\"Sim, tem um estado próprio enquanto existe\"],[\"Quantas a partir de uma só\",\"Uma imagem serve de base pra quantos containers forem necessários\",\"Cada container vem de exatamente uma imagem\"],[\"Onde vive\",\"Guardada localmente ou num registry, como o Docker Hub\",\"Existe como processo, criado com docker run\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Remover um container não apaga a imagem\n\nRemover um container (docker rm) tira de circulação só aquela instância: a imagem que deu origem a ele continua guardada, pronta pra criar outro container quando for preciso. Da mesma forma, gerar uma imagem nova a partir de um código atualizado não muda os containers que já estavam rodando com a imagem antiga: eles continuam do jeito que estavam até serem recriados."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "A imagem é o molde, parado e imutável. O container é a instância viva, rodando a partir dele. Uma imagem, quantos containers forem precisos."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual opção descreve corretamente a diferença entre imagem e container?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Imagem é o molde imutável; container é uma instância rodando a partir dela",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Imagem e container são dois nomes diferentes pro mesmo conceito",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Container é o arquivo salvo em disco; imagem é o processo em execução",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Imagem só existe depois que algum container é criado a partir dela",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Rodar docker run nginx três vezes seguidas, com nomes diferentes pra cada container, resulta em:",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Três containers independentes, todos criados a partir da mesma imagem",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Três cópias separadas da imagem nginx, uma pra cada execução",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um erro, já que a mesma imagem não pode gerar mais de um container",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um único container, que reinicia sozinho a cada execução do comando",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Você removeu, com o comando docker rm, um container que rodava a partir da imagem node:20. A imagem node:20 continua disponível pra criar novos containers depois?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Sim, remover um container não afeta a imagem que deu origem a ele",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Não, remover o container também apaga a imagem usada por ele",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Só continua disponível se o container tiver sido parado antes de removido",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Só se a imagem for baixada de novo do Docker Hub logo em seguida",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de alterar o código da API e gerar uma imagem nova com docker build, os containers que já estavam rodando a partir da imagem antiga:",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Continuam rodando com o código antigo, sem nenhuma mudança automática",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "São atualizados sozinhos com o novo código na próxima requisição",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Param de funcionar até serem recriados manualmente por erro de versão",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Passam a usar a imagem nova assim que o build termina de rodar",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Dois containers diferentes rodam a partir da mesma imagem myapp:1.0. Um deles grava um arquivo temporário no seu próprio sistema de arquivos. O que acontece com a imagem original e com o outro container?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Nada muda nos dois: cada container tem seu próprio sistema de arquivos gravável",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O arquivo aparece também no outro container, já que os dois compartilham disco",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A imagem myapp:1.0 é alterada, afetando todo container futuro criado dela",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Docker bloqueia a escrita, porque a imagem já tem mais de um container",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Docker e por que containers mudaram o jogo",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## O Docker como ferramenta\n\n\"Container\" é um conceito do sistema operacional. **Docker** é a ferramenta que tornou esse conceito prático: um motor que constrói, roda e gerencia containers, uma linha de comando pra usar tudo isso no dia a dia, e um formato de imagem compartilhado com o Docker Hub.\n\nÉ por causa do Docker que empacotar uma aplicação em um container virou algo comum, e não um exercício acadêmico de sistemas operacionais."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Do \"na minha máquina funciona\" pro \"funciona em qualquer lugar\"\n\nVolta pro problema da primeira aula: versão de Node diferente, biblioteca de sistema diferente, variável de ambiente esquecida. Um container resolve isso porque empacota o ambiente inteiro junto com o código.\n\nA mesma imagem que roda no seu notebook roda no notebook do colega, no pipeline de teste e no servidor de produção. Não tem mais \"na minha máquina funciona\": tem uma imagem que funciona, e ponto."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Etapa\",\"Sem containers\",\"Com containers\"],[\"Preparar um servidor novo\",\"Instalar e configurar Node, Postgres, Redis e libs do sistema na mão\",\"Instalar o Docker e rodar a imagem já pronta\"],[\"Escalar a aplicação\",\"Provisionar e configurar cada máquina nova do zero\",\"Subir mais containers a partir da mesma imagem em segundos\"],[\"Onboarding de um dev novo\",\"Seguir um passo a passo manual, com risco de divergência\",\"Rodar a imagem já usada pelo resto do time\"],[\"Consistência dev/produção\",\"Os ambientes divergem aos poucos com o tempo\",\"A mesma imagem roda nos dois, sem surpresa de versão\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Escalar rápido é consequência do peso leve\n\nComo um container não precisa dar boot num sistema operacional novo (só inicia um processo, como visto na aula sobre container x VM), subir mais uma instância da API leva segundos. Precisou aguentar mais tráfego? Sobe mais um container a partir da mesma imagem, sem provisionar máquina nova do zero.\n\nEsse é o tipo de agilidade que muda o jeito de operar um back-end em produção."
+                    },
+                    {
+                        "type": "code",
+                        "value": "$ docker run node:20 node --version\nv20.11.0\n\n# nao importa a versao de Node instalada no host (ou se existe alguma):\n# o container leva a sua propria, empacotada dentro da imagem node:20"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que vem a seguir\n\nAté aqui, tudo ficou no conceito: o que é um container, como ele se compara a uma VM, a diferença entre imagem e container. No próximo módulo a mão entra na massa: escrever um Dockerfile de verdade pra empacotar uma aplicação Node, com **FROM**, **WORKDIR**, **COPY**, **RUN** e **CMD**, e construir a primeira imagem com **docker build**."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Container não resolve só o \"funciona na minha máquina\": muda o jeito de construir, escalar e entregar software."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual é o papel do Docker nesse cenário de containers?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "É a ferramenta que constrói, roda e compartilha containers na prática",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "É um sistema operacional novo que substitui o Linux nos servidores",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "É um serviço de nuvem que hospeda aplicações de forma automática",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "É uma linguagem de programação usada pra escrever APIs mais rápidas",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que containers ajudam a escalar uma aplicação com mais agilidade?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "São leves e iniciam em segundos, permitindo escalar mais rápido",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Aumentam sozinhos a capacidade de CPU disponível no servidor",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Reduzem automaticamente o número de requisições que a API recebe",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Eliminam de vez a necessidade de mais de um servidor físico",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um desenvolvedor novo entrou no time. Com a aplicação containerizada, configurar o ambiente dele fica mais simples porque:",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Ele só precisa instalar o Docker e usar as imagens do time",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Ele não precisa mais instalar nenhum programa na própria máquina",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Docker copia sozinho as configurações da máquina de outro colega",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A aplicação passa a rodar direto no navegador, sem ambiente local",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "A API que só funcionava na sua máquina agora roda dentro de um container e foi testada com sucesso no notebook de um colega, com sistema operacional diferente do seu. Isso é possível principalmente porque:",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O container leva consigo o runtime e as dependências exatas da aplicação",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O Docker converte sozinho o código da API pra linguagem nativa de cada SO",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O colega precisou instalar as mesmas versões de Node e Postgres que você",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Containers só funcionam de forma idêntica em hosts com o mesmo sistema",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Antes de containers, era comum times manterem documentos de \"passo a passo de instalação\" pra cada ambiente novo. Com containers, esse tipo de documento perde parte da função porque:",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "A imagem já contém, de forma executável, o que antes era descrito em texto",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Containers eliminam por completo a necessidade de documentar o projeto",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Docker gera esse documento sozinho a partir do código da aplicação",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Esse tipo de processo só existia antes das máquinas virtuais surgirem",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 2 - Sua primeira imagem: o Dockerfile",
+        "aulas": [
+            {
+                "titulo": "O Dockerfile e suas instruções (FROM, WORKDIR, COPY, RUN, CMD)",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# O Dockerfile e suas instruções\n\nNo módulo passado você entendeu o que é uma imagem e o que é um container. Agora chegou a hora de criar a sua primeira imagem, e isso começa com um arquivo chamado `Dockerfile`.\n\nO Dockerfile é a receita da imagem: um arquivo de texto simples, sem extensão, com uma instrução por linha. O Docker lê essas instruções de cima pra baixo e vai montando a imagem passo a passo, camada por camada (a gente volta nisso com calma na aula 5).\n\nCada linha começa com uma instrução, escrita em maiúsculas por convenção, seguida do argumento. As mais usadas no dia a dia de uma API Node são seis: `FROM`, `WORKDIR`, `COPY`, `RUN`, `EXPOSE` e `CMD`. Com essas seis você já empacota praticamente qualquer aplicação."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Instrução\", \"O que faz\"], [\"FROM\", \"Define a imagem base que a sua imagem vai usar, por exemplo node:22\"], [\"WORKDIR\", \"Define a pasta de trabalho dentro do container pras instruções seguintes\"], [\"COPY\", \"Copia arquivos do seu projeto pra dentro da imagem sendo construída\"], [\"RUN\", \"Executa um comando durante a construção da imagem, como o npm install\"], [\"EXPOSE\", \"Documenta em qual porta a aplicação escuta dentro do container\"], [\"CMD\", \"Define o comando padrão executado quando o container é iniciado\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## FROM: de onde você parte\n\nToda imagem Docker parte de outra imagem. `FROM node:22` diz pro Docker começar com uma imagem oficial que já vem com o Node.js 22, o sistema operacional e as ferramentas básicas instaladas. É sempre a primeira instrução do Dockerfile.\n\n## WORKDIR: a pasta de trabalho\n\n`WORKDIR /app` cria (se ainda não existir) e entra na pasta `/app` dentro do container. Todas as instruções seguintes, como `COPY`, `RUN` e `CMD`, passam a valer a partir dali. Sem isso, os arquivos se espalham pela raiz do container e o Dockerfile fica mais difícil de manter."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## COPY e RUN: trazendo arquivos e instalando\n\n`COPY` pega arquivos do seu projeto, a pasta onde você roda o `docker build`, e coloca dentro da imagem. `COPY package.json .` copia o `package.json` da pasta atual pro `WORKDIR` da imagem. Sem `COPY`, a imagem fica vazia, só com o sistema base do `FROM`.\n\nJá o `RUN` executa um comando enquanto a imagem está sendo construída, e o resultado fica gravado nela. `RUN npm install` instala as dependências do projeto uma vez, durante o build, e elas já ficam disponíveis na imagem pronta."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## EXPOSE e CMD: a porta e o comando final\n\n`EXPOSE 3000` não abre porta nenhuma sozinho: ele só documenta que a aplicação escuta na porta 3000 dentro do container. Quem realmente libera o acesso de fora é o `-p` do `docker run`, que você vê na aula 4.\n\nJá o `CMD` define o que roda quando o container é iniciado, não quando a imagem é construída. É a diferença mais importante da aula: `RUN` roda no build (uma vez, vira parte da imagem), `CMD` roda no `docker run` (toda vez que um container novo sobe a partir dela)."
+                    },
+                    {
+                        "type": "code",
+                        "value": "FROM node:22\nWORKDIR /app\nCOPY package.json .\nRUN npm install\nCOPY . .\nEXPOSE 3000\nCMD [\"node\", \"server.js\"]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Um Dockerfile é uma sequência de instruções lidas de cima pra baixo: cada linha molda uma parte da imagem final."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual instrução do Dockerfile define a imagem base da qual a sua imagem vai partir?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "FROM, que define a imagem base usada como ponto de partida.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "WORKDIR, que define a pasta de trabalho dentro do container.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "COPY, que copia arquivos do host pra dentro da imagem.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "CMD, que define o comando executado quando o container inicia.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O que a instrução WORKDIR faz num Dockerfile?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Copia os arquivos do projeto pra dentro da imagem sendo construída.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Cria e define a pasta de trabalho usada pelas instruções seguintes.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Executa um comando durante a construção da imagem, como o npm install.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Define o comando padrão executado quando o container é iniciado.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "No Dockerfile, RUN npm install e CMD [\"npm\", \"start\"] parecem parecidos, mas rodam em momentos diferentes. Qual a diferença?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "RUN executa uma vez durante o build; CMD executa toda vez que o container inicia.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "RUN roda toda vez que o container inicia; CMD roda uma vez durante o build da imagem.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "RUN e CMD fazem exatamente a mesma coisa, a diferença é só de estilo de escrita.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "RUN só funciona dentro do WORKDIR; CMD funciona em qualquer pasta do container.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Você colocou EXPOSE 3000 no Dockerfile, mas mesmo assim não conseguiu acessar a API pelo navegador depois de subir o container. Por quê?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque EXPOSE só documenta a porta, quem publica é o -p do docker run.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque EXPOSE precisa ser declarado antes da instrução FROM no Dockerfile.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque EXPOSE só funciona quando o Dockerfile também define um WORKDIR.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque EXPOSE exige que o npm install já tenha instalado o express antes.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que WORKDIR /app é preferível a usar RUN cd /app antes dos comandos seguintes num Dockerfile?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Porque cada RUN roda num processo novo e não guarda o cd pro próximo RUN.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o RUN cd /app não é um comando válido, o Dockerfile não reconhece o cd.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o WORKDIR precisa vir sempre antes do FROM pra definir a pasta certa.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o RUN cd /app só funciona em imagens Linux, não em imagens baseadas em Node.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Escrevendo o Dockerfile de uma API Node",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Empacotando a API Express\n\nLembra daquela API Express que você construiu nas trilhas de back-end, com rotas, alguma lógica de negócio e talvez até um banco por trás? Chegou a hora de empacotar ela numa imagem Docker, pra rodar igual no seu computador, no computador de um colega ou num servidor de produção.\n\nPra este exemplo, vamos usar uma API simples, só pra focar no Dockerfile: um `package.json` com o Express como dependência e um `server.js` que sobe um servidor na porta 3000."
+                    },
+                    {
+                        "type": "code",
+                        "value": "{\n  \"name\": \"minha-api\",\n  \"version\": \"1.0.0\",\n  \"main\": \"server.js\",\n  \"scripts\": {\n    \"start\": \"node server.js\"\n  },\n  \"dependencies\": {\n    \"express\": \"^4.19.2\"\n  }\n}"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Planejando as instruções\n\nAntes de escrever, vale pensar no que o Dockerfile precisa fazer, na ordem certa:\n\n- Partir de uma imagem com Node.js instalado\n- Definir uma pasta de trabalho dentro do container\n- Copiar o `package.json` e instalar as dependências\n- Copiar o resto do código da aplicação\n- Documentar a porta que a API usa\n- Definir o comando que sobe o servidor\n\nRepare que copiar o `package.json` vem antes de copiar o resto do código. Isso não é acaso, é o que garante o cache de build rápido que você vê na aula 5."
+                    },
+                    {
+                        "type": "code",
+                        "value": "FROM node:22\n\nWORKDIR /app\n\nCOPY package.json .\n\nRUN npm install\n\nCOPY . .\n\nEXPOSE 3000\n\nCMD [\"npm\", \"start\"]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Linha por linha\n\n`FROM node:22` parte da imagem oficial do Node.js na versão 22, já com o `node` e o `npm` prontos pra uso.\n\n`WORKDIR /app` define que, dali em diante, tudo acontece dentro da pasta `/app` do container.\n\n`COPY package.json .` copia só o `package.json` da sua máquina pro `WORKDIR` da imagem. O ponto (`.`) significa \"a pasta atual\", que é o `/app` definido no `WORKDIR`.\n\n`RUN npm install` lê aquele `package.json` recém copiado e instala o Express, e qualquer outra dependência, dentro da imagem."
+                    },
+                    {
+                        "type": "text",
+                        "value": "`COPY . .` agora copia todo o resto do projeto (o `server.js`, as rotas, tudo) da pasta atual do host pra pasta atual da imagem.\n\n`EXPOSE 3000` documenta que a API escuta na porta 3000 dentro do container.\n\n`CMD [\"npm\", \"start\"]` define o comando que sobe o servidor quando o container inicia. Essa é a forma \"exec\" do `CMD`, escrita como uma lista, e é a recomendada: ela roda o processo diretamente, sem passar por um shell no meio do caminho."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Um Dockerfile de API Node segue sempre o mesmo esqueleto: parte do Node, entra numa pasta, instala dependências, copia o código e define como rodar."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "No Dockerfile da API Node, qual instrução é responsável por instalar as dependências do projeto?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "RUN, que executa o npm install durante a construção da imagem.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "COPY, que instala as dependências junto quando copia o package.json.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "FROM, que já traz as dependências do projeto instaladas na imagem base.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "WORKDIR, que instala as dependências na pasta de trabalho definida.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois que o Dockerfile builda a imagem, qual instrução decide o comando executado toda vez que um container novo sobe dela?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "CMD, definida como npm start ao final do Dockerfile.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "RUN, definida como npm start ao final do Dockerfile.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "COPY, definida como npm start ao final do Dockerfile.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "EXPOSE, definida como npm start ao final do Dockerfile.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "No package.json do projeto, scripts.start está definido como node server.js. No Dockerfile, isso faz o CMD [\"npm\", \"start\"] funcionar como quê?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Como um atalho que, ao rodar, executa node server.js dentro do container.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Como um atalho que só funciona durante o docker build, nunca no docker run.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Como um atalho que precisa ser repetido também na instrução RUN do Dockerfile.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Como um atalho que substitui a necessidade de ter a instrução EXPOSE.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Se você esquecer a instrução WORKDIR no Dockerfile da API, o que tende a acontecer?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "COPY e RUN passam a atuar a partir da raiz do container, em vez de uma pasta própria.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O docker build falha de imediato, porque WORKDIR é obrigatório em todo Dockerfile.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O npm install para de funcionar, porque ele depende direto da instrução WORKDIR.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O CMD deixa de rodar quando o container inicia, mesmo estando no Dockerfile.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que o Dockerfile da aula copia package.json e roda npm install antes de copiar o resto do código com COPY . . , em vez de copiar tudo de uma vez só no início?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Separar a cópia do package.json evita refazer o npm install sempre que só o código muda.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o Docker não permite copiar mais de um arquivo numa única instrução COPY.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o npm install só funciona se rodar antes de qualquer instrução COPY existir.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque um COPY . . logo no início ultrapassa o limite de tamanho de camada do Docker.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "docker build: construindo a imagem",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Da receita pra imagem pronta\n\nCom o Dockerfile escrito, ele ainda é só um arquivo de texto, uma receita. Pra transformar essa receita numa imagem de verdade, que pode virar um container, você usa o comando `docker build`."
+                    },
+                    {
+                        "type": "code",
+                        "value": "docker build -t minha-api .\n\n[+] Building 12.4s (10/10) FINISHED\n => [1/5] FROM docker.io/library/node:22\n => [2/5] WORKDIR /app\n => [3/5] COPY package.json .\n => [4/5] RUN npm install\n => [5/5] COPY . .\n => exporting to image\n => => naming to docker.io/library/minha-api:latest"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O -t: nomeando e taggeando a imagem\n\nSem o `-t`, a imagem é construída, mas fica só com um ID gerado automaticamente, tipo `a3f9c8e2b1d4`, difícil de lembrar e de usar depois. O `-t` (de \"tag\") dá um nome legível pra imagem.\n\n`docker build -t minha-api .` cria a imagem com o nome `minha-api` e a tag `latest` por padrão. Se quiser controlar a versão, dá pra ser explícito: `docker build -t minha-api:1.0 .` gera a mesma imagem com a tag `1.0`, o que ajuda muito quando você tem várias versões da mesma aplicação."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O ponto final: o contexto de build\n\nAquele `.` no fim do comando não é decoração, ele é o contexto de build: o caminho da pasta que o Docker vai enviar pro daemon pra construir a imagem. É dentro dessa pasta que o Docker procura o `Dockerfile` (por padrão) e é de dentro dela que instruções como `COPY . .` copiam arquivos.\n\nPor isso o `docker build` precisa ser rodado a partir da raiz do seu projeto, a pasta que contém o `Dockerfile`, o `package.json` e o código. Rodar de outro lugar faz o Docker não encontrar os arquivos esperados."
+                    },
+                    {
+                        "type": "code",
+                        "value": "docker images\n\nREPOSITORY   TAG       IMAGE ID       CREATED          SIZE\nminha-api    latest    a3f9c8e2b1d4   30 seconds ago   1.12GB"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Parte do comando\", \"O que significa\"], [\"docker build\", \"Comando que constrói uma imagem a partir de um Dockerfile\"], [\"-t minha-api\", \"Dá um nome (tag) pra imagem gerada, aqui minha-api:latest\"], [\"-t minha-api:1.0\", \"Dá um nome e uma versão específica pra imagem, aqui a tag 1.0\"], [\".\", \"O contexto de build: a pasta onde o Docker procura o Dockerfile e os arquivos\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "docker build -t minha-api . lê o Dockerfile da pasta atual e gera uma imagem chamada minha-api, pronta pra virar container."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual comando constrói uma imagem Docker a partir de um Dockerfile?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "docker build, executado na pasta que contém o Dockerfile.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "docker run, executado na pasta que contém o Dockerfile.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "docker start, executado na pasta que contém o Dockerfile.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "docker pull, executado na pasta que contém o Dockerfile.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "No comando docker build -t minha-api . , pra que serve a flag -t?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Pra dar um nome (tag) à imagem que está sendo construída.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Pra apontar o caminho onde o Dockerfile foi salvo no projeto.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Pra listar as camadas que serão criadas durante o build.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Pra definir a porta que o container vai expor depois de pronto.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Você rodou docker build sem a flag -t. A imagem foi criada, mas o que aconteceu com o nome dela?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Ela ficou sem nome legível, identificada só por um ID gerado automaticamente.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Ela recebeu automaticamente o nome da pasta onde está o Dockerfile.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O build falhou, porque a flag -t é obrigatória em todo docker build.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ela recebeu automaticamente o nome latest, sem nenhum identificador extra.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Rodando docker build -t minha-api . de dentro de uma subpasta do projeto, sem o Dockerfile ali, o que acontece?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O Docker não encontra o Dockerfile esperado ali e o build falha.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O Docker sobe automaticamente até achar o Dockerfile na pasta certa.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Docker usa o último Dockerfile que foi construído com sucesso antes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Docker cria um Dockerfile vazio automaticamente pra completar o build.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de docker build -t minha-api:1.0 . e, mais tarde, docker build -t minha-api:2.0 . a partir do mesmo Dockerfile, o que acontece com a imagem minha-api:1.0?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Ela continua existindo normalmente, como uma tag separada de 2.0.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Ela é apagada automaticamente, porque só a tag mais nova pode existir.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ela é renomeada automaticamente de 1.0 pra 2.0, sem manter as duas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ela para de funcionar no docker run, só a mais nova pode rodar.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "docker run e o mapeamento de portas",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Tirando a imagem do papel\n\nUma imagem parada não faz nada por conta própria, ela é só o molde. Pra ela virar um processo rodando de verdade, um container, você usa o `docker run`. E como a API escuta numa porta lá dentro do container, esse é o momento de aprender a mapear portas."
+                    },
+                    {
+                        "type": "code",
+                        "value": "docker run -p 3000:3000 minha-api\n\n> minha-api@1.0.0 start\n> node server.js\n\nServidor rodando na porta 3000"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Por que mapear a porta\n\nCada container roda isolado, com sua própria rede. Mesmo que o `server.js` esteja escutando na porta 3000 dentro do container, essa porta não fica automaticamente acessível no seu computador (o host). Sem mapear, a API está rodando, mas inacessível de fora.\n\nÉ pra isso que serve o `-p` (de \"publish\"): ele conecta uma porta do host a uma porta do container, criando um caminho de fora pra dentro."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Host:container, a ordem importa\n\nA sintaxe é sempre `-p porta_do_host:porta_do_container`. Em `docker run -p 3000:3000 minha-api`, a porta 3000 da sua máquina passa a apontar pra porta 3000 do container.\n\nAs duas portas não precisam ser iguais. `docker run -p 8080:3000 minha-api` deixa a API acessível em `localhost:8080` no seu navegador, mesmo ela continuando a escutar na porta 3000 lá dentro do container. Quem define a porta interna é a aplicação (o `server.js` e o `EXPOSE` do Dockerfile); quem define por onde você acessa de fora é o número antes dos dois pontos."
+                    },
+                    {
+                        "type": "code",
+                        "value": "docker run -p 8080:3000 minha-api\n\ndocker ps\n\nCONTAINER ID   IMAGE       COMMAND                  PORTS                    NAMES\n7e2a9f1c4b8d   minha-api   \"docker-entrypoint.s…\"   0.0.0.0:8080->3000/tcp   sharp_turing"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Comando\", \"O que faz\"], [\"docker run minha-api\", \"Roda um container a partir da imagem, sem porta acessível de fora\"], [\"docker run -p 3000:3000 minha-api\", \"Mapeia a porta 3000 do host pra porta 3000 do container\"], [\"docker run -p 8080:3000 minha-api\", \"Mapeia a porta 8080 do host pra porta 3000 do container\"], [\"docker run -d -p 3000:3000 minha-api\", \"Roda o container em segundo plano (detached) com a porta mapeada\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "O -p conecta uma porta do host a uma porta do container: sem ele, a aplicação até roda, mas ninguém de fora consegue acessar."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "No comando docker run -p 3000:3000 minha-api, o que a flag -p faz?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Mapeia uma porta do host pra uma porta do container.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Define o nome que o container vai ter depois de criado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Define a imagem base que o container vai usar pra subir.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Roda o container em segundo plano, sem travar o terminal.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Na flag -p 8080:3000, qual das duas portas é a porta usada dentro do container, onde a aplicação realmente escuta?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "A 3000, porque em host:container ela é a segunda porta da flag.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A 8080, porque em host:container ela é a primeira porta da flag.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "As duas, porque host:container sempre precisa ser igual dos dois lados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Nenhuma das duas, a porta real é sempre definida pelo EXPOSE do Dockerfile.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Você rodou docker run minha-api, sem nenhuma flag -p, e a aplicação subiu certinho nos logs. Ainda assim, não consegue acessar em localhost:3000 no navegador. Por quê?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque sem o -p nenhuma porta do container fica acessível de fora do container.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o comando docker run sempre precisa da flag -d pra funcionar direito.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque a imagem minha-api foi construída sem a instrução FROM node correta.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o navegador só acessa containers que foram criados com docker compose.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Dois colegas rodam o mesmo docker run -p 3000:3000 minha-api ao mesmo tempo, cada um na própria máquina. Isso funciona sem conflito?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Sim, porque a porta 3000 de uma máquina não depende da porta da outra.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Não, porque a mesma porta não pode ser usada em duas máquinas diferentes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Sim, mas só se as duas máquinas estiverem na mesma rede local conectadas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não, porque a imagem minha-api só permite rodar num container por vez.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Dois containers diferentes, os dois criados a partir da imagem minha-api, tentam usar docker run -p 3000:3000 minha-api ao mesmo tempo na mesma máquina. O que acontece?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O segundo docker run falha, porque a porta 3000 do host já está em uso.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Os dois sobem normal, o Docker distribui as requisições entre eles.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O primeiro container é derrubado automaticamente pra abrir espaço pro segundo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os dois sobem normal, mas só o mais recente responde às requisições.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Camadas e cache de build (a ordem importa)",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Por que o build às vezes é rápido, às vezes não\n\nVocê já deve ter reparado: da primeira vez que você roda `docker build`, ele demora, baixa a imagem base, instala tudo. Mas se você rodar de novo logo em seguida, sem mudar nada, ele termina quase instantâneo. Isso não é sorte, é o sistema de camadas (layers) do Docker trabalhando a seu favor."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que é uma camada\n\nCada instrução do Dockerfile que mexe no sistema de arquivos (`FROM`, `COPY`, `RUN`) gera uma camada, uma espécie de \"fatia\" da imagem, empilhada sobre a anterior. O Docker guarda cada camada separadamente e calcula um hash a partir dela.\n\nNa hora de reconstruir a imagem, o Docker compara cada instrução com a camada que já existe em cache. Se a instrução e o que ela usa não mudaram, ele reaproveita a camada pronta em vez de executar tudo de novo. Isso é o cache de build."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# primeira vez: tudo executa\ndocker build -t minha-api .\n => [1/5] FROM node:22                        4.8s\n => [2/5] WORKDIR /app                        0.1s\n => [3/5] COPY package.json .                 0.1s\n => [4/5] RUN npm install                     6.2s\n => [5/5] COPY . .                             0.2s\n\n# só mudou o server.js, sem mexer no package.json\ndocker build -t minha-api .\n => [1/5] FROM node:22                        0.0s CACHED\n => [2/5] WORKDIR /app                        0.0s CACHED\n => [3/5] COPY package.json .                 0.0s CACHED\n => [4/5] RUN npm install                     0.0s CACHED\n => [5/5] COPY . .                             0.2s"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Por que copiar o package.json antes do código\n\nRepare na ordem do Dockerfile que você escreveu na aula 2: primeiro `COPY package.json .`, depois `RUN npm install`, só depois `COPY . .` com o resto do código.\n\nO Docker invalida uma camada, e todas as que vêm depois dela, sempre que o que ela usa muda. Como o `server.js` muda com muito mais frequência que as dependências do projeto, colocar `COPY . .` por último garante que só essa última camada precise ser refeita na maioria das vezes. O `RUN npm install`, que é a etapa mais lenta, só roda de novo quando o `package.json` muda de verdade."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# ordem que NÃO aproveita o cache direito\nFROM node:22\nWORKDIR /app\nCOPY . .\nRUN npm install\nEXPOSE 3000\nCMD [\"npm\", \"start\"]\n\n# qualquer alteração em qualquer arquivo, mesmo em server.js,\n# invalida o COPY . . e força o RUN npm install a rodar de novo"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Situação\", \"npm install reaproveita o cache?\"], [\"Só o server.js mudou, package.json igual (ordem correta)\", \"Sim, a camada do RUN npm install é reaproveitada\"], [\"O package.json mudou (nova dependência)\", \"Não, a camada é refeita porque a instrução anterior mudou\"], [\"COPY . . vem antes do RUN npm install (ordem ruim)\", \"Não, qualquer mudança no código já invalida o npm install\"], [\"Nada mudou no projeto desde o último build\", \"Sim, todas as camadas são reaproveitadas\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "A ordem das instruções no Dockerfile não é estética, ela decide quanto do cache o Docker consegue reaproveitar a cada build."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que é uma camada (layer) numa imagem Docker?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "O resultado gravado de uma instrução do Dockerfile, empilhado sobre a anterior.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um tipo de container que roda várias aplicações ao mesmo tempo isoladas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um arquivo de configuração que lista todas as portas expostas pela imagem.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma cópia completa e independente do sistema operacional usado no FROM.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Quando uma instrução do Dockerfile não muda entre dois builds, o que o Docker faz com a camada correspondente?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Reaproveita a camada do cache, sem rodar a instrução de novo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Executa a instrução de novo mesmo assim, só pra garantir que nada mudou.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Apaga a camada antiga e recria ela do zero em todo build seguinte.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ignora a instrução inteira e pula direto pra próxima do Dockerfile.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "No Dockerfile, COPY package.json . vem antes de RUN npm install, que vem antes de COPY . . com o resto do código. Mudando só um comentário no server.js e rodando o build de novo, o que tende a acontecer com a camada do RUN npm install?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Ela é reaproveitada do cache, porque nada que ela usa (o package.json) mudou.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Ela roda de novo do zero, porque qualquer mudança no projeto reinicia o cache inteiro.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ela é pulada completamente, porque o server.js não depende do npm install.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ela roda de novo só pela metade, reinstalando apenas os pacotes mais recentes.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um Dockerfile tem COPY . . logo depois do WORKDIR, e só depois vem RUN npm install. Um colega muda uma linha de comentário no server.js e o build refaz o npm install inteiro, do mesmo jeito de sempre. Por quê?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque o COPY . . antes do RUN invalida a camada do npm install a cada mudança.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o npm install sempre reinstala tudo, não importa a ordem das instruções.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque comentários no código contam como mudança de dependência pro Docker.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque esse Dockerfile não tem EXPOSE, o que desativa o cache de build.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um Dockerfile correto copia e instala o package.json antes do resto do código. Um arquivo .env, que muda de valor toda hora, só é copiado no COPY . . final. Isso afeta a camada do RUN npm install?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Não, porque o RUN npm install já rodou numa camada anterior ao COPY . . final.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Sim, porque qualquer arquivo do projeto, incluindo o .env, refaz o npm install.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não, porque arquivos .env são ignorados automaticamente pelo Docker no build.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Sim, mas só se o .env estiver listado dentro do package.json do projeto.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 3 - Trabalhando com containers e imagens",
+        "aulas": [
+            {
+                "titulo": "Comandos do dia a dia com containers (ps, logs, exec, stop, rm)",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Comandos do dia a dia com containers\n\nNo módulo anterior você escreveu um Dockerfile pra sua API Express, buildou a imagem com `docker build` e rodou o primeiro container com `docker run`. A partir de agora isso vira rotina: o container fica em segundo plano, e você precisa saber conversar com ele no dia a dia.\n\nNesta aula, os cinco comandos que mais aparecem no trabalho com Docker:\n\n- `docker ps`: o que está rodando agora\n- `docker logs`: o que o container está imprimindo\n- `docker exec`: entrar dentro do container\n- `docker stop`: parar um container\n- `docker rm`: remover um container de vez"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Observando o container: ps, logs e exec\n\n`docker ps` lista os containers em execução: ID, imagem usada, comando rodando, tempo de vida, status e portas. Container parado não aparece na lista padrão; pra ver todos, incluindo os parados, é `docker ps -a`.\n\n`docker logs` mostra a saída (stdout e stderr) do processo principal do container, o mesmo texto que apareceria no terminal se a aplicação rodasse direto na máquina. É o primeiro lugar pra olhar quando o container sobe e a aplicação não responde. Com `-f` (de \"follow\"), o log acompanha em tempo real.\n\nJá `docker exec -it container sh` abre um terminal interativo dentro de um container que já está rodando. `-i` mantém a entrada padrão aberta, `-t` aloca um terminal, juntas formam uma sessão interativa de verdade. `sh` costuma existir em qualquer imagem; se ela for baseada em Debian ou Ubuntu, `bash` também costuma funcionar."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# ver os containers rodando\ndocker ps\n\n# ver todos, incluindo os parados\ndocker ps -a\n\n# acompanhar a saida da aplicacao\ndocker logs minha-api\n\n# acompanhar em tempo real (Ctrl+C pra sair)\ndocker logs -f minha-api\n\n# entrar no container pra investigar por dentro\ndocker exec -it minha-api sh\n# dentro do container:\n#   ls\n#   cat package.json\n#   ps aux\n#   exit"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Parar x remover: stop e rm\n\nEssa é a diferença que mais confunde no começo. `docker stop` envia um sinal pedindo pro processo principal encerrar com calma (SIGTERM) e, depois de um tempo limite, força o encerramento se ele não responder. O container para, mas continua existindo: aparece em `docker ps -a`, guarda o filesystem que tinha e pode ser religado com `docker start`.\n\n`docker rm` é outra coisa: remove o container de vez, apagando esse filesystem junto. Um container em execução não pode ser removido direto, primeiro precisa estar parado (ou usar `docker rm -f`, que força a parada e a remoção num único comando).\n\nResumindo: parar é pausar, remover é apagar. Enquanto o container só está parado, o que foi gravado nele ainda existe."
+                    },
+                    {
+                        "type": "code",
+                        "value": "docker stop minha-api\ndocker ps -a\n# STATUS: Exited (0) 10 seconds ago -> ainda existe, so parado\n\ndocker start minha-api\ndocker ps\n# STATUS: Up 2 seconds -> religou o mesmo container\n\ndocker stop minha-api\ndocker rm minha-api\ndocker ps -a\n# o container sumiu da lista"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Comando\", \"O que faz\"], [\"docker ps\", \"Lista os containers em execução\"], [\"docker ps -a\", \"Lista todos os containers, incluindo os parados\"], [\"docker logs <nome>\", \"Mostra a saída do container\"], [\"docker logs -f <nome>\", \"Acompanha a saída em tempo real\"], [\"docker exec -it <nome> sh\", \"Abre um terminal dentro do container\"], [\"docker stop <nome>\", \"Para o container, mas mantém ele e os dados guardados\"], [\"docker rm <nome>\", \"Remove o container de vez\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "docker stop pausa o container, que continua existindo; docker rm apaga ele de vez, sem volta."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual comando mostra apenas os containers que estão rodando agora?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "docker ps, que lista os containers em execução.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "docker ps -a, que lista também os containers parados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "docker images, que lista as imagens da máquina.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "docker logs, que mostra a saída de um container.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Pra acompanhar a saída de um container em tempo real, sem repetir o comando a cada instante, qual opção usar?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "docker logs -f minha-api, que segue a saída em tempo real.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "docker logs -a minha-api, que mostra todo o histórico salvo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "docker ps -f minha-api, que filtra containers pelo nome.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "docker exec -f minha-api, que força a entrada no container.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de docker stop minha-api, o comando docker ps não mostra mais o container. Isso quer dizer que:",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O container está parado, mas ainda existe.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O container foi removido e não existe mais.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O comando falhou e o container segue rodando.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O container foi pausado com docker pause.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um colega roda docker exec -it minha-api bash e recebe um erro dizendo que o executável bash não foi encontrado. Qual a explicação mais provável?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "A imagem usa Alpine, que não vem com bash, só sh.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O container está parado e precisa ser iniciado antes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Falta a flag -i para abrir a entrada padrão.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O nome do container está escrito errado no comando.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Você quer remover um container que está rodando, sem parar ele antes num comando separado. Qual comando faz isso num passo só?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "docker rm -f, que força a parada e a remoção juntas.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "docker stop -r, que reinicia e já remove o container.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "docker rm --now, que ignora o tempo de espera do stop.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "docker kill -rm, que mata o processo e apaga tudo.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Imagens, tags e o registry",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Imagens guardadas na máquina\n\nToda vez que você roda `docker build` ou `docker pull`, uma imagem fica salva localmente. `docker images` lista as imagens que existem na sua máquina: repositório, tag, ID, data de criação e tamanho.\n\nBaixar uma imagem pronta é `docker pull`. Em vez de escrever um Dockerfile pra ter o Postgres da trilha de banco ou o Redis que você usou pra cache rodando aqui, você baixa a imagem que a comunidade já mantém, do jeito que ela foi publicada."
+                    },
+                    {
+                        "type": "code",
+                        "value": "docker images\n\ndocker pull node:22-alpine\ndocker pull postgres:16\ndocker pull redis:7\n\ndocker images\n# as tres imagens aparecem na lista agora"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Tags: a versão da imagem\n\nToda imagem tem um nome no formato `repositorio:tag`, como `node:22-alpine` ou `postgres:16`. A tag marca a versão (e às vezes a variante) daquela imagem. Quando você não escreve nenhuma tag, o Docker assume `latest`.\n\n`latest` não significa \"a versão mais nova e estável\", significa só \"a tag que esse projeto decidiu chamar de latest\" no momento. `docker pull node:latest` rodado hoje pode trazer uma versão diferente da que traria daqui a alguns meses, o que vai contra a ideia de \"roda igual em qualquer lugar\". Por isso é comum travar a versão, como `node:22-alpine`, em vez de depender do `latest`."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# as duas linhas abaixo baixam a mesma coisa\ndocker pull node\ndocker pull node:latest\n\n# essa trava numa versao especifica\ndocker pull node:22-alpine\n\n# variantes comuns da mesma imagem\ndocker pull node:22\ndocker pull node:22-alpine\ndocker pull node:22-slim"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Removendo imagens: docker rmi\n\n`docker rmi` remove uma imagem da máquina local (isso não afeta o registry, só o que está guardado no seu computador). Uma imagem usada por algum container, mesmo parado, não pode ser removida direto: o Docker recusa e pede pra remover o container primeiro."
+                    },
+                    {
+                        "type": "code",
+                        "value": "docker rmi node:22-slim\n# se algum container ainda usa essa imagem, o Docker recusa\n\ndocker rm meu-container-antigo\ndocker rmi node:22-slim\n# agora remove normalmente"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "A tag é a versão da imagem: sem tag, o Docker assume latest, e latest muda com o tempo."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual comando lista as imagens já baixadas na máquina local?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "docker images, que lista o que já foi baixado.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "docker ps -a, que lista os containers parados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "docker pull, que baixa uma imagem do registry.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "docker container ls, que lista containers ativos.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Em node:22-alpine, o que vem depois dos dois-pontos?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "A tag da imagem, que marca a versão.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O nome do container que vai ser criado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O ID gerado pra identificar a imagem.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O nome do registry onde ela foi publicada.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um Dockerfile começa com FROM node, sem nenhuma tag depois do nome. Qual o efeito disso?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Usa a tag latest, que pode mudar de versão com o tempo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O build falha, porque toda imagem exige uma tag explícita.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Usa a versão de Node instalada na máquina host.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Usa sempre a versão mais antiga disponível do Node.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "docker rmi minha-imagem retorna um erro dizendo que a imagem está em uso por um container. O que fazer pra remover mesmo assim?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Remover o container primeiro, ou usar docker rmi -f.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Rodar docker pull de novo pra atualizar a imagem.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Reiniciar o Docker e tentar o comando de novo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Usar docker stop no lugar do docker rmi, que remove.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que node:22-alpine costuma ser bem menor que node:22-slim, mesmo sendo a mesma versão do Node?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Alpine parte de uma base Linux mais enxuta que a slim.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Slim inclui ferramentas de debug que a alpine remove.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Alpine não inclui o gerenciador de pacotes npm.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A diferença é só cosmética, os dois pesam quase o mesmo.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Docker Hub e imagens oficiais",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## O registry: onde as imagens moram\n\nQuando você roda `docker pull postgres`, de onde vem essa imagem? De um registry, um servidor que guarda imagens publicadas, indexadas por nome e tag. O registry padrão do Docker é o Docker Hub (`hub.docker.com`), mas existem outros: o GitHub Container Registry, o registry de cada provedor de nuvem, ou até um registry privado dentro da empresa.\n\nSem indicar nenhum registry, o Docker sempre procura no Docker Hub. É por isso que `docker pull redis:7` simplesmente funciona: o nome \"redis\" é procurado lá."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Imagens oficiais x imagens da comunidade\n\nNo Docker Hub existem dois tipos de publicação. As **imagens oficiais** (Node, Postgres, Redis, Nginx, Python, entre outras) têm a curadoria do time do Docker em conjunto com o projeto original, documentação padronizada e atualização frequente contra falhas de segurança. Já as **imagens da comunidade** são publicadas por qualquer conta, sem essa curadoria central: podem estar desatualizadas, mal documentadas, ou serem exatamente o que você precisa, depende de quem mantém.\n\nConvenção prática: comece pela imagem oficial do que você precisa (`node`, `postgres`, `redis`), e só recorra a uma da comunidade se a oficial não cobrir o seu caso."
+                    },
+                    {
+                        "type": "code",
+                        "value": "docker search postgres\n# lista imagens no Docker Hub relacionadas a \"postgres\",\n# com nome, descricao e se e oficial\n\ndocker pull postgres:16\ndocker pull redis:7-alpine\ndocker pull node:22-alpine"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Baixar pronto em vez de construir\n\nNão faz sentido escrever um Dockerfile do zero pra ter um Postgres rodando, o mesmo Postgres que você já usou na trilha de banco de dados: o time do Postgres publica uma imagem oficial testada, configurável por variável de ambiente, atualizada quando sai uma correção de segurança. Escrever seu próprio Dockerfile faz sentido pra sua aplicação, que é única; pra peças de infraestrutura padrão como banco, cache ou proxy, baixar a imagem pronta é o caminho normal.\n\nÉ o mesmo raciocínio de instalar o Postgres com um gerenciador de pacotes: aqui, o \"pacote\" é a imagem, e o \"instalador\" é o `docker pull`."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"\", \"Imagem oficial\", \"Imagem da comunidade\"], [\"Mantida por\", \"Time do Docker + projeto original\", \"Qualquer conta pública\"], [\"Exemplos\", \"node, postgres, redis, nginx\", \"Variações e forks de terceiros\"], [\"Documentação\", \"Padronizada, na página da imagem\", \"Varia de projeto pra projeto\"], [\"Quando usar\", \"Primeira opção pra peças de infra padrão\", \"Quando a oficial não cobre o caso\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Antes de escrever um Dockerfile pra banco, cache ou fila, procure a imagem oficial primeiro: alguém já resolveu isso."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Quando você roda docker pull sem indicar nenhum outro endereço, de qual registry a imagem vem por padrão?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Docker Hub, que é o registry padrão do Docker.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "GitHub Container Registry, mantido pela Microsoft.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "npm, o registry de pacotes do JavaScript.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "ECR, o registry de containers da AWS.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O que diferencia uma imagem oficial de uma da comunidade no Docker Hub?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "A oficial tem curadoria do time do Docker e do projeto.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A oficial nunca recebe atualização, só a da comunidade.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A oficial roda mais rápido que qualquer outra imagem.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A oficial existe só pra bancos de dados relacionais.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Você precisa de um Redis pra cache na sua API. Qual é a abordagem mais direta?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Baixar a imagem oficial do Redis com docker pull redis.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Escrever um Dockerfile do zero instalando o Redis via apt.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Compilar o Redis a partir do código-fonte na imagem.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Instalar o Redis direto na máquina host, fora de containers.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual comando permite pesquisar, direto no terminal, imagens do Docker Hub relacionadas a um termo?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "docker search postgres, que pesquisa no Docker Hub.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "docker find postgres, que localiza imagens no disco.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "docker hub postgres, que abre o site do Docker Hub.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "docker pull --list postgres, que lista antes de baixar.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um time decide sempre usar a imagem oficial do Postgres, nunca uma variante da comunidade, mesmo quando a da comunidade tem uma funcionalidade a mais. Qual é o raciocínio mais forte pra essa escolha?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Atualização de segurança é mais previsível na oficial.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Imagens da comunidade nunca funcionam corretamente em produção.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Docker Hub bloqueia o uso comercial de imagens não oficiais.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Imagens oficiais são sempre menores em tamanho que as demais.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "O .dockerignore: o que não deve entrar na imagem",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## O problema: COPY . . copia tudo\n\nLembra do Dockerfile do módulo passado, com `COPY . .` copiando o projeto inteiro pra dentro da imagem? \"Tudo\" é literal: inclui a pasta `node_modules` (que vai ser reinstalada do zero com `npm install` dentro da imagem, então essa cópia é trabalho perdido), a pasta `.git` (todo o histórico de commits, sem nenhuma utilidade dentro de um container rodando) e o arquivo `.env` (que costuma guardar senha de banco, chave de API, segredo de sessão).\n\nTrês problemas aí: a imagem fica maior e mais lenta de transferir, o build fica mais lento (o Docker precisa ler e enviar tudo isso pro contexto de build antes mesmo de começar) e, o pior, segredo do `.env` vai parar dentro da imagem, acessível a qualquer um que tiver acesso a ela."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## .dockerignore: o mesmo princípio do .gitignore\n\nA solução é um arquivo `.dockerignore` na raiz do projeto, ao lado do Dockerfile. Antes de montar o contexto de build, o Docker lê esse arquivo e exclui tudo que casar com os padrões listados, do mesmo jeito que o Git faz com o `.gitignore`. Uma linha por padrão, `#` pra comentário, `*` como coringa, `!` pra abrir uma exceção dentro de algo já ignorado."
+                    },
+                    {
+                        "type": "code",
+                        "value": "node_modules\n.git\n.env\n.env.*\nnpm-debug.log\nDockerfile\n.dockerignore\n*.md\n.vscode\ncoverage"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Padrão\", \"Por que ignorar\"], [\"node_modules\", \"Reinstalado dentro da imagem com npm install\"], [\".git\", \"Histórico do repositório, inútil dentro do container\"], [\".env\", \"Segredos: senha, chave de API, token\"], [\"*.md\", \"Documentação não afeta a aplicação rodando\"], [\"coverage\", \"Relatório de teste, gerado localmente\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que você ganha com isso\n\nCom o `.dockerignore` no lugar, `COPY . .` continua copiando \"tudo\", só que \"tudo\" agora exclui exatamente o que não devia entrar. A imagem fica menor (sem `node_modules` duplicado), o build fica mais rápido (menos dado pra ler e enviar) e, principalmente, nenhum segredo do `.env` vai parar numa camada da imagem, onde qualquer pessoa com acesso a ela poderia extrair."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# sem .dockerignore, o contexto de build inclui tudo:\n# node_modules/ (poderia ter centenas de MB)\n# .git/ (todo o historico)\n# .env (senha do banco, chave de API)\n\n# com o .dockerignore no lugar:\ndocker build -t minha-api .\n# Sending build context to Docker daemon  4.2MB\n# (em vez de, por exemplo, 180MB sem o .dockerignore)"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "O .dockerignore não é opcional: sem ele, seu .env pode acabar dentro da imagem, e imagem se compartilha."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual é a função do arquivo .dockerignore?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Excluir arquivos do contexto enviado ao build.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Definir quais portas o container vai expor.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Listar as dependências que serão instaladas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Definir a imagem base usada no Dockerfile.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que copiar node_modules pra dentro da imagem é desperdício?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Porque ele é reinstalado do zero com npm install na imagem.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque ele nunca funciona corretamente dentro de containers.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o npm apaga essa pasta automaticamente no build.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o Dockerfile já bloqueia pastas com esse nome.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um dev sobe a imagem da API pra um registry público e, dias depois, percebe que a senha do banco estava dentro do .env copiado pro container. Qual prática teria evitado isso?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Ter um .dockerignore listando .env antes do build.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Ter trocado a senha do banco toda semana.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ter usado HTTPS para enviar a imagem ao registry.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ter compactado a imagem antes de publicar.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um projeto tem .gitignore configurado, ignorando node_modules e .env pro Git. Isso é suficiente pra manter esses arquivos fora da imagem Docker?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Não, o Docker usa um arquivo separado, o .dockerignore.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Sim, o Docker lê o .gitignore automaticamente também.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Sim, arquivos ignorados pelo Git nunca entram em imagens.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não, é preciso apagar esses arquivos manualmente antes.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O Dockerfile tem COPY package.json . seguido de RUN npm install e depois COPY . . . Com .dockerignore listando node_modules, o que acontece nesse segundo COPY?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Copia o resto do projeto, sem mexer no node_modules.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Reinstala o node_modules do zero, por cima do existente.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Falha o build, pois node_modules está no .dockerignore.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Copia o node_modules do host por cima da instalação.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Variáveis de ambiente e o problema dos dados que somem",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Configuração por fora da imagem\n\nUma imagem Docker deveria ser a mesma em qualquer ambiente: o que muda entre rodar sua API Express em desenvolvimento e em produção não é o código nem as dependências, é a configuração (endereço do banco, chave de API, nível de log). Se essas informações ficassem fixas dentro da imagem, seria preciso construir uma imagem por ambiente, o que vai contra a ideia de \"constrói uma vez, roda em qualquer lugar\".\n\nA solução é injetar configuração de fora, no momento de rodar o container, através de variáveis de ambiente. O código lê `process.env.DATABASE_URL` sem saber (nem precisar saber) se está em dev, staging ou produção; quem decide o valor é quem roda o container."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Passando variáveis: -e e --env-file\n\nPra uma variável avulsa, a flag `-e` no `docker run`. Pra várias de uma vez, um arquivo `.env` com a flag `--env-file`, que evita uma linha de comando gigante e mantém a configuração de cada ambiente guardada num arquivo (que, por sinal, deve estar no `.dockerignore` e no `.gitignore`, nunca commitado)."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# uma variavel por vez\ndocker run -e DATABASE_URL=postgres://user:senha@db:5432/app -p 3000:3000 minha-api\n\n# varias variaveis\ndocker run -e NODE_ENV=production -e PORT=3000 -e LOG_LEVEL=info minha-api\n\n# a partir de um arquivo\ndocker run --env-file .env -p 3000:3000 minha-api"
+                    },
+                    {
+                        "type": "code",
+                        "value": "# .env\nNODE_ENV=production\nPORT=3000\nDATABASE_URL=postgres://user:senha@db:5432/app\nREDIS_URL=redis://redis:6379\nLOG_LEVEL=info"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Forma\", \"Quando usar\"], [\"-e VAR=valor\", \"Uma ou duas variáveis, teste rápido\"], [\"--env-file .env\", \"Várias variáveis, configuração de um ambiente inteiro\"], [\"ENV no Dockerfile\", \"Valor padrão fixo, igual em toda imagem (raramente segredo)\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O problema: o que é gravado no container some\n\nSó que tem um limite pra isso. Tudo que a aplicação grava em disco dentro do container (um arquivo de upload, dados de um banco rodando ali dentro, um cache em arquivo) vive só enquanto aquele container existir. `docker stop` não apaga nada, mas `docker rm` remove o container e, junto, todo o filesystem que ele acumulou. Sobe um container novo da mesma imagem e ele começa do zero, sem histórico nenhum do anterior.\n\nPra configuração isso não é problema, ela vem de fora a cada `docker run`. Pra dados que precisam sobreviver ao container, como as tabelas de um Postgres, é um problema sério, e é exatamente o que o próximo módulo resolve com volumes."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Configuração entra por variável de ambiente e sobrevive porque vem de fora; dado gravado dentro do container não tem essa sorte."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "No comando docker run, qual flag define uma variável de ambiente pro container?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "-e, que define uma variável direto na linha de comando.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "-v, que monta um volume ou pasta dentro do container.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "-p, que publica uma porta do container pro host.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "-w, que define a pasta de trabalho dentro do container.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual comando roda um container passando várias variáveis de ambiente de uma vez, a partir de um arquivo?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "docker run --env-file .env, que carrega as variáveis do arquivo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "docker run --env .env, que carrega o arquivo indicado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "docker run -f .env, que aponta o arquivo de configuração.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "docker run --config .env, que aplica configurações do arquivo.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Você quer que a mesma imagem Docker rode em dev e em produção, mudando só o endereço do banco de dados. Qual é a abordagem correta?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Ler o endereço de uma variável de ambiente no docker run.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Buildar duas imagens, uma pra dev e outra pra produção.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Deixar o endereço fixo no código e trocar antes do deploy.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Guardar os dois endereços na imagem e escolher em runtime.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um time versiona um arquivo .env com a senha de produção direto no repositório Git, pra facilitar o uso do --env-file. Qual é o risco?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "A senha fica exposta pra quem tiver acesso ao repositório.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O Docker recusa rodar containers com esse tipo de arquivo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O build da imagem fica consideravelmente mais lento.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A variável de ambiente deixa de funcionar em produção.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma API grava arquivos de log num diretório dentro do container. O time roda docker rm nesse container pra liberar espaço e sobe outro da mesma imagem. Os logs antigos aparecem no novo container?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Não, porque docker rm apaga o filesystem do container junto.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Sim, porque containers da mesma imagem compartilham disco.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Sim, porque o Docker guarda um backup automático a cada rm.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não, mas só porque o novo container usa outra tag.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 4 - Volumes e dados que persistem",
+        "aulas": [
+            {
+                "titulo": "Por que o container é efêmero",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Por que o container é efêmero\n\nNo módulo passado você viu os comandos do dia a dia (docker ps, logs, exec, stop, rm) e esbarrou num detalhe importante: quando um container é removido, tudo que ele escreveu dentro de si mesmo desaparece junto. Essa aula explica por que isso acontece e por que isso é sério quando existe um banco de dados no meio."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O sistema de arquivos do container\n\nToda imagem Docker é formada por camadas somente leitura. Quando você roda docker run, o Docker adiciona por cima uma camada gravável, exclusiva daquele container. É nela que ficam os arquivos criados depois que o container está no ar: logs, arquivos temporários e, no caso de um banco, as próprias tabelas.\n\nEssa camada gravável vive junto com o container. Ela não é a imagem (a imagem continua intacta, só leitura) e não é compartilhada com outros containers da mesma imagem. Quando o container é removido com docker rm, essa camada some com ele."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# 1. Sobe um container e grava um arquivo dentro dele\ndocker run --name teste alpine sh -c \"echo 'dado importante' > /dados.txt && cat /dados.txt\"\n# dado importante\n\n# 2. Remove o container (a camada gravável vai junto)\ndocker rm teste\n\n# 3. Sobe um container NOVO, a partir da mesma imagem\ndocker run --rm alpine cat /dados.txt\n# cat: can't open '/dados.txt': No such file or directory"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O problema pro banco de dados\n\nIsso é inofensivo com um arquivo de teste, mas pense no Postgres da trilha de banco rodando dentro de um container. Ele grava cada tabela, cada índice e cada linha inserida em arquivos dentro de /var/lib/postgresql/data, o diretório padrão de dados do Postgres. Se esse container for removido (por engano, numa atualização de imagem, ou porque docker compose down recria os containers), o banco inteiro volta a zero.\n\nIsso inviabiliza rodar um banco assim em qualquer ambiente sério. Ninguém aceita perder os dados de produção porque um container foi recriado. Resolver exatamente esse problema é o papel dos volumes, assunto da próxima aula."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# Sobe um Postgres sem nenhum volume configurado\ndocker run --name meu-postgres -e POSTGRES_PASSWORD=senha123 -d postgres\n\n# Cria uma tabela e insere um registro\ndocker exec -it meu-postgres psql -U postgres -c \"CREATE TABLE alunos (id serial, nome text);\"\ndocker exec -it meu-postgres psql -U postgres -c \"INSERT INTO alunos (nome) VALUES ('Ana');\"\n\n# Remove o container\ndocker rm -f meu-postgres\n\n# Sobe um Postgres novo, com o mesmo comando\ndocker run --name meu-postgres -e POSTGRES_PASSWORD=senha123 -d postgres\ndocker exec -it meu-postgres psql -U postgres -c \"SELECT * FROM alunos;\"\n# ERROR:  relation \"alunos\" does not exist"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Comando\",\"O que acontece com o container\",\"Dados gravados nele sobrevivem?\"],[\"docker stop\",\"Para o processo, mas mantém o container e seu sistema de arquivos\",\"Sim\"],[\"docker start\",\"Retoma um container parado do jeito que ele estava\",\"Sim\"],[\"docker restart\",\"Reinicia o processo dentro do mesmo container\",\"Sim\"],[\"docker rm\",\"Remove o container e sua camada gravável\",\"Não\"],[\"docker compose down\",\"Para e remove os containers do compose\",\"Não, sem volume\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "O container guarda estado só enquanto ele existe. Remova o container e tudo que ele escreveu no próprio sistema de arquivos desaparece com ele."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que acontece com os arquivos que um container grava dentro de si mesmo quando ele é removido com docker rm?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Eles são apagados junto com o container removido",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Eles são movidos automaticamente para a imagem original",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Eles ficam guardados até o próximo docker run",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Eles são copiados para o host antes da remoção",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Onde fica a camada gravável de um container, aquela em que ele grava arquivos depois de iniciado?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Numa camada exclusiva do container, sobre as camadas da imagem",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Dentro da própria imagem, na última camada do docker build",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "No Docker Hub, junto com as camadas enviadas da imagem",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Num arquivo de configuração gerado a partir do Dockerfile",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um Postgres sem volume rodou por semanas num ambiente de teste. Depois de um docker compose down seguido de um docker compose up, os dados sumiram. Por quê?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O compose down remove os containers, e sem volume os dados iam junto",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O compose up sempre baixa uma imagem nova e zera os dados por padrão",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Postgres limpa as próprias tabelas quando o container reinicia",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O compose down só funciona quando existe algum volume configurado",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe roda docker stop no container do banco todo fim de expediente e docker start na manhã seguinte. O que acontece com os dados nesse ciclo?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Eles continuam lá, porque stop não remove o container nem seus arquivos",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Eles somem, porque o stop já apaga a camada gravável do container",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Eles só continuam se existir um volume nomeado criado antes do stop",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Eles são copiados pro host automaticamente durante o comando stop",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma aplicação grava um log dentro de um container. Depois que o container é removido com docker rm, o log não aparece em lugar nenhum, mesmo com a imagem original ainda no host. Por quê?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O log foi escrito na camada gravável do container, que some quando ele é removido",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O log foi escrito na imagem, mas o docker rm reverte a imagem pro estado do build",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O log ficou num cache temporário do Docker que expira sozinho depois de minutos",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O log foi enviado pro registry junto com a imagem, por isso não fica mais local",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Volumes nomeados (dados que sobrevivem)",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## O que é um volume nomeado\n\nUm volume é um espaço de armazenamento gerenciado pelo próprio Docker, fora do ciclo de vida de qualquer container específico. Ele existe independente de qual container está rodando: você monta ele dentro de um container, num caminho determinado, e o que for gravado ali passa a viver no volume, não na camada gravável efêmera do container.\n\nQuando o container é removido, o volume não vai junto. Ele continua existindo, guardando os dados, esperando ser montado de novo (pelo mesmo container recriado, ou por outro completamente diferente)."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# Cria um volume nomeado chamado dados-app\ndocker volume create dados-app\n\n# Lista todos os volumes existentes\ndocker volume ls\n\n# Mostra detalhes do volume, inclusive onde ele fica no host\ndocker volume inspect dados-app\n\n# Remove um volume que não está mais em uso\ndocker volume rm dados-app"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Montando um volume num container\n\nPra usar um volume, você monta ele num caminho dentro do container com a flag -v, no formato nome-do-volume:/caminho/no/container. Se o volume ainda não existir, o Docker cria ele automaticamente na hora do docker run, então nem sempre é preciso rodar o docker volume create antes."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# Sobe um container, monta o volume dados-app em /dados, e grava um arquivo\ndocker run --name c1 -v dados-app:/dados alpine sh -c \"echo 'sobrevivi' > /dados/arquivo.txt\"\n\n# Remove o container (o volume continua existindo)\ndocker rm c1\n\n# Sobe um container NOVO, monta o MESMO volume, e lê o arquivo\ndocker run --rm -v dados-app:/dados alpine cat /dados/arquivo.txt\n# sobrevivi"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Comando\",\"Pra que serve\"],[\"docker volume create <nome>\",\"Cria um volume nomeado vazio\"],[\"docker volume ls\",\"Lista os volumes existentes\"],[\"docker volume inspect <nome>\",\"Mostra detalhes do volume, como o caminho no host\"],[\"docker volume rm <nome>\",\"Remove um volume (precisa estar sem container usando)\"],[\"docker volume prune\",\"Remove todos os volumes que não estão em uso por nenhum container\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Um volume nomeado é gerenciado pelo Docker e vive fora do container: nasce antes, sobrevive depois e pode ser montado por qualquer container que precisar dele."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual comando cria um volume nomeado chamado dados-app, sem associar ele a nenhum container ainda?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "docker volume create dados-app",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "docker create volume dados-app",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "docker run volume dados-app",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "docker volume new dados-app",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual comando lista todos os volumes que já existem no Docker?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "docker volume ls",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "docker volume list",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "docker ps -a",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "docker inspect volume",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de rodar docker volume create dados-app e nunca montar esse volume em nenhum container, o que existe no sistema?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Um volume vazio chamado dados-app, pronto pra ser usado por um container",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Nada, o Docker só cria o volume de fato na primeira vez que for montado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um container parado chamado dados-app, esperando receber uma imagem",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um erro, porque todo volume precisa nascer junto com um docker run",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um container escreve um arquivo em /dados, caminho onde está montado o volume relatorios. O container é removido, e um novo container monta o mesmo volume relatorios em /saida. O arquivo aparece em /saida?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Sim, o conteúdo é do volume, não do caminho usado no container anterior",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Não, porque o caminho de montagem precisa ser idêntico ao usado antes",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não, porque cada caminho dentro do container tem seu próprio conteúdo",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Sim, mas o arquivo aparece vazio até o container ser reiniciado uma vez",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Dois containers diferentes, de imagens diferentes, montam o mesmo volume nomeado dados-compartilhados, cada um num caminho interno diferente. Um grava um arquivo, o outro consegue ler esse arquivo?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Sim, porque os dois apontam pro mesmo volume, não importa a imagem",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Não, porque volume só pode ser montado por containers da mesma imagem",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não, porque cada container enxerga uma cópia isolada desse volume",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Sim, mas só se as duas imagens usarem o mesmo sistema operacional base",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Persistindo o banco num volume",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Onde o Postgres guarda os dados\n\nA imagem oficial do postgres no Docker Hub grava todos os arquivos do banco (tabelas, índices, logs de transação) dentro de /var/lib/postgresql/data, o diretório padrão de dados do Postgres, o mesmo que você já viu rodando localmente na trilha de banco. Sem um volume montado nesse caminho, esses arquivos vivem na camada gravável do container e desaparecem se ele for removido, exatamente o problema da primeira aula."
+                    },
+                    {
+                        "type": "code",
+                        "value": "docker run --name meu-postgres \\\n  -e POSTGRES_PASSWORD=senha123 \\\n  -v dados-postgres:/var/lib/postgresql/data \\\n  -p 5432:5432 \\\n  -d postgres"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Testando a persistência\n\nCom o volume montado, o teste é o mesmo da aula anterior, só que agora com um banco de verdade: criar um dado, remover o container, subir outro e conferir se o dado continua lá."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# Cria uma tabela e insere um registro\ndocker exec -it meu-postgres psql -U postgres -c \"CREATE TABLE alunos (id serial, nome text);\"\ndocker exec -it meu-postgres psql -U postgres -c \"INSERT INTO alunos (nome) VALUES ('Ana');\"\n\n# Remove o container (o volume dados-postgres continua existindo)\ndocker rm -f meu-postgres\n\n# Sobe um Postgres NOVO, montando o MESMO volume\ndocker run --name meu-postgres \\\n  -e POSTGRES_PASSWORD=senha123 \\\n  -v dados-postgres:/var/lib/postgresql/data \\\n  -p 5432:5432 \\\n  -d postgres\n\ndocker exec -it meu-postgres psql -U postgres -c \"SELECT * FROM alunos;\"\n#  id | nome\n# ----+------\n#   1 | Ana"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O volume não sabe que o container mudou\n\nRepare que o segundo container nem é o mesmo container do primeiro, e nem precisa ser. O que garante a continuidade dos dados é o volume dados-postgres, montado no mesmo caminho pelos dois. Quando o Postgres inicia e encontra arquivos de dados já existentes em /var/lib/postgresql/data, ele simplesmente usa esses arquivos em vez de criar um banco vazio do zero."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Cenário\",\"Dados depois de recriar o container\"],[\"Postgres sem volume\",\"Banco vazio: dados anteriores perdidos\"],[\"Postgres com -v dados-postgres:/var/lib/postgresql/data\",\"Banco intacto: dados continuam\"],[\"Postgres com bind mount num caminho vazio do host\",\"Banco novo inicializado ali, e depois persiste enquanto a pasta existir\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "O container do Postgres pode ir e vir. Enquanto o volume dados-postgres continuar montado no mesmo caminho, o banco continua de onde parou."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Em qual caminho, dentro do container, a imagem oficial do Postgres grava os arquivos do banco?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "/var/lib/postgresql/data",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "/etc/postgresql/data",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "/usr/local/postgres/data",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "/data/postgresql",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual comando sobe um Postgres montando um volume nomeado dados-postgres no caminho de dados do Postgres?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "docker run -v dados-postgres:/var/lib/postgresql/data postgres",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "docker run -v /var/lib/postgresql/data:dados-postgres postgres",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "docker run -v dados-postgres /var/lib/postgresql/data postgres",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "docker run --volume dados-postgres=/var/lib/postgresql/data postgres",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de criar uma tabela num Postgres containerizado com volume montado, alguém roda docker restart no container, sem remover. O que acontece com a tabela?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Continua lá, porque restart não remove o container nem o volume montado",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Some, porque restart recria o container do zero a partir da imagem",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Continua lá, mas só porque o volume foi montado como somente leitura",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Some, porque o Postgres reseta o diretório de dados a cada reinício",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um time troca, no docker run, a tag da imagem de postgres:15 pra postgres:16, mantendo o mesmo volume dados-postgres montado no mesmo caminho. Do ponto de vista do volume, o que acontece com os arquivos que já estavam lá?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Continuam lá normalmente, porque pertencem ao volume, não à imagem",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "São apagados, porque toda nova tag baixa uma versão vazia do volume",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ficam inacessíveis até alguém recriar o volume do zero com a nova tag",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Somem, porque o volume fica preso à tag de imagem usada na criação",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um container Postgres é criado com -v dados-postgres:/var/lib/postgresql/data, mas o volume dados-postgres já existia, criado por um projeto anterior, com um banco diferente dentro. O que o novo container enxerga ao iniciar?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O banco antigo, porque o Postgres reaproveita os dados existentes ali",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um banco novo e vazio, porque cada docker run reformata o volume informado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um erro fatal, porque o Postgres exige um volume recém-criado e vazio",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os dois bancos ao mesmo tempo, o antigo e um novo, em esquemas separados",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Bind mounts e o hot reload em dev",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## O que é um bind mount\n\nUm bind mount também usa a flag -v, mas em vez de apontar pra um volume gerenciado pelo Docker, ele aponta direto pra uma pasta do seu computador, o host. O formato é -v /caminho/no/host:/caminho/no/container. Tudo que existir naquela pasta do host aparece dentro do container, no caminho indicado, e o inverso também vale: o que o container escrever ali aparece na pasta do host."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# Monta a pasta atual do host dentro de /app no container\ndocker run -v $PWD:/app -w /app node:20 ls\n\n# No Windows (PowerShell), o equivalente ao $PWD é:\ndocker run -v ${PWD}:/app -w /app node:20 ls"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Hot reload: o caso clássico de uso\n\nLembra do Dockerfile da sua API Express, lá do módulo 2? Ele faz COPY do código pra dentro da imagem. Isso é ótimo pra produção, mas péssimo pra desenvolvimento: qualquer alteração no código exigiria um docker build novo pra gerar outra imagem.\n\nO bind mount resolve isso em dev. Em vez de copiar o código pra dentro da imagem, você monta a pasta do projeto, do host, direto no container. O processo Node dentro do container passa a enxergar os mesmos arquivos que você está editando no seu editor, ao vivo. Com uma ferramenta de reload (nodemon, por exemplo) rodando dentro do container, cada alteração salva no host reinicia a aplicação lá dentro, sem rebuild de imagem nenhuma."
+                    },
+                    {
+                        "type": "code",
+                        "value": "docker run \\\n  --name api-dev \\\n  -v $PWD:/app \\\n  -w /app \\\n  -p 3000:3000 \\\n  node:20 \\\n  sh -c \"npm install && npx nodemon index.js\""
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Um detalhe importante: o node_modules\n\nSe a imagem já tiver um node_modules instalado (via RUN npm install no Dockerfile) e você montar a pasta do host por cima com um bind mount, o node_modules do host (que pode nem existir, ou ser de outro sistema operacional) sobrescreve o de dentro do container. Essa é uma das pegadinhas mais comuns de quem começa com bind mount em dev. Uma solução comum é somar um segundo -v, só pro node_modules, apontando pra um volume anônimo (sem nome definido) que fica por cima do bind mount naquele caminho específico."
+                    },
+                    {
+                        "type": "code",
+                        "value": "docker run \\\n  --name api-dev \\\n  -v $PWD:/app \\\n  -v /app/node_modules \\\n  -w /app \\\n  -p 3000:3000 \\\n  node:20 \\\n  sh -c \"npm install && npx nodemon index.js\""
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Bind mount é a ponte entre o código que você edita no host e o processo rodando dentro do container: edite aqui, o container vê na hora."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que um bind mount faz, na prática, quando você roda docker run -v $PWD:/app?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Monta a pasta atual do host dentro do caminho /app no container",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Copia a pasta atual do host pra dentro da imagem, de forma permanente",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Cria um volume novo chamado $PWD dentro do Docker, vazio",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Monta a pasta /app do container dentro da pasta atual do host",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual é o propósito clássico de usar bind mount em desenvolvimento, montando o código do host dentro do container?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Ver as mudanças do código refletidas no container na hora, sem rebuild",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Aumentar a performance de disco do container frente a um volume nomeado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Reduzir o tamanho final da imagem gerada durante o docker build",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Permitir que o container acesse a rede local do host diretamente",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de configurar um bind mount pro código com -v $PWD:/app, o desenvolvedor edita um arquivo no editor do host, mas a aplicação dentro do container, sem nenhuma ferramenta de reload, continua rodando com o código antigo. Por quê?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O bind mount atualiza os arquivos, mas o processo Node segue em memória",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O bind mount não propaga edições feitas depois que o container iniciou",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O código do host só chega ao container depois de um novo docker build",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "As edições só aparecem depois de um docker cp manual dos arquivos",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um projeto usa docker run -v $PWD:/app -v /app/node_modules imagem. Pra que serve esse segundo -v, montando um caminho do próprio container sem apontar pra lugar nenhum do host?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Cria um volume anônimo pro node_modules, protegendo o que já está instalado",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Cria um atalho pra abrir o node_modules direto no editor do host",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Impede que o container instale qualquer dependência nova depois de iniciado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Sincroniza o node_modules do host com o do container, nos dois sentidos",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um Dockerfile roda RUN npm install, instalando o node_modules dentro da imagem. Em dev, o time monta -v $PWD:/app, sem o volume extra pro node_modules, por cima. O que acontece com as dependências dentro do container em execução?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O node_modules da imagem fica encoberto pelo bind mount da raiz",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O node_modules da imagem continua intacto, o bind mount não sobrescreve",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os dois node_modules se combinam automaticamente, sem nenhum conflito",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O container ignora o bind mount ao encontrar um node_modules dentro",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Volume x bind mount, quando usar cada",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Dois jeitos de montar dados, dois objetivos diferentes\n\nVolume e bind mount usam a mesma flag (-v) e resolvem o mesmo problema geral, dados que sobrevivem ao container, mas servem a propósitos bem diferentes. Volume é armazenamento que o Docker gerencia pra você. Bind mount é uma pasta sua, do jeito que ela já é, aparecendo dentro do container."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Aspecto\",\"Volume nomeado\",\"Bind mount\"],[\"Quem gerencia\",\"O Docker\",\"Você, é uma pasta comum do host\"],[\"Onde fica\",\"Área interna do Docker no host\",\"Qualquer pasta que você escolher\"],[\"Uso típico\",\"Dados de banco em produção (Postgres, Redis)\",\"Código da aplicação em desenvolvimento\"],[\"Sintaxe no docker run\",\"-v nome-do-volume:/caminho\",\"-v /caminho/host:/caminho/container\"],[\"Sobrevive ao docker rm do container\",\"Sim\",\"Sim, é só uma pasta do host\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Quando usar cada um\n\nRegra prática: dado que o banco precisa manter (linhas de uma tabela, arquivos de um Redis com persistência) vai em volume nomeado. Código que você está escrevendo e quer ver refletido no container sem rebuild vai em bind mount. É por isso que, mais pra frente, o docker-compose.yml da sua aplicação vai ter as duas coisas ao mesmo tempo: um volume pro Postgres, um bind mount pra API em desenvolvimento."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# Volume nomeado: dados do Postgres, gerenciados pelo Docker\ndocker run --name db -v dados-postgres:/var/lib/postgresql/data -e POSTGRES_PASSWORD=senha123 -d postgres\n\n# Bind mount: código da API, controlado por você no host\ndocker run --name api -v $PWD:/app -w /app -p 3000:3000 node:20 sh -c \"npm install && npx nodemon index.js\""
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Cuidados\n\nAlguns pontos merecem atenção nos dois casos:\n\n- Onde o volume fica: o Docker guarda o conteúdo de um volume numa área própria do host, visível com docker volume inspect, mas não é pra você mexer direto ali. É acessado sempre através de um container.\n- Não versionar dados: nunca coloque a pasta de dados de um volume dentro do repositório Git. O que entra no controle de versão é o código; os dados do banco crescem e mudam a cada segundo, não fazem sentido num commit.\n- Permissões: num bind mount, os arquivos criados pelo container usam o usuário configurado dentro dele, o que às vezes gera arquivos no host pertencentes a um usuário diferente do seu. Vale atenção quando o processo dentro do container roda como root."
+                    },
+                    {
+                        "type": "code",
+                        "value": "docker volume inspect dados-postgres\n# [\n#   {\n#     \"Name\": \"dados-postgres\",\n#     \"Mountpoint\": \"/var/lib/docker/volumes/dados-postgres/_data\",\n#     \"Driver\": \"local\"\n#   }\n# ]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Volume pra dado que o Docker deve gerenciar, bind mount pra pasta que você quer enxergar e editar. Um não substitui o outro."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Pra persistir os dados de um Postgres em produção, qual das opções é a mais indicada?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Volume nomeado, porque é um armazenamento gerenciado pelo Docker",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Volume nomeado, porque sincroniza os dados direto com o repositório Git",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Bind mount, porque aponta direto pra uma pasta escolhida por você",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Bind mount, porque cria uma cópia dos dados dentro da própria imagem",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Pra montar o código de uma API Express no container em desenvolvimento, com hot reload, qual opção faz mais sentido?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Bind mount, porque reflete direto as edições feitas no host",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Bind mount, porque grava uma cópia do código dentro da imagem",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Volume nomeado, porque o Docker sincroniza com o editor sozinho",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Volume nomeado, porque cria automaticamente um túnel com o host",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um time monta um volume nomeado no lugar do código da API em dev, em vez de bind mount. Depois de horas editando arquivos no editor do host, nada muda dentro do container. Por quê?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O volume não é a pasta do host: editar lá não afeta o que está dentro dele",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O volume nomeado exige reiniciar o Docker Desktop a cada edição salva",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Falta instalar o nodemon dentro do container pra o volume detectar mudanças",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O volume nomeado só sincroniza edições feitas a partir de outro container",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um Dockerfile de produção não tem nenhum bind mount, só a imagem com o código copiado via COPY. Isso é um problema?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Não, a imagem de produção já traz o código pronto, sem depender do host",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Sim, toda imagem de produção também precisa de um bind mount do código",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não, mas só funciona se houver um volume nomeado apontando pro código",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Sim, sem bind mount o container não consegue iniciar o processo",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O docker-compose.yml de um projeto usa, ao mesmo tempo, um volume nomeado pro Postgres e um bind mount pro código da API. Por que essa combinação faz sentido, em vez de usar só um tipo pros dois casos?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Porque o banco precisa de armazenamento gerenciado, e o código, do host",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque bind mount é mais rápido, mas não funciona com bancos de dados",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque volume nomeado tem um limite de tamanho menor que bind mount",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque só é possível montar um volume por vez em cada docker-compose.yml",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 5 - Orquestrando com Docker Compose",
+        "aulas": [
+            {
+                "titulo": "O problema de subir vários containers na mão",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# O problema de subir vários containers na mão\n\nNos módulos anteriores você aprendeu a empacotar uma API Node num Dockerfile, construir a imagem e rodar o container com `docker run`. Também viu como usar volumes pra guardar dados que sobrevivem além do container. Isso resolve bem o caso de UM container.\n\nMas uma aplicação de verdade quase nunca é só isso. Pensa na sua API: ela precisa de um Postgres pra guardar dados e de um Redis pra cache e fila (aquele mesmo Postgres da trilha de banco, aquele mesmo Redis da trilha de cache). São três peças, três containers, cada um com sua imagem, suas portas, suas variáveis de ambiente e, no caso do banco, seu volume.\n\n## Subindo tudo na mão\n\nPra essas três peças conversarem, elas precisam estar na mesma rede Docker. O roteiro manual seria mais ou menos assim: criar uma rede, subir o Postgres nela com usuário, senha e um volume pro dado, subir o Redis, e só depois subir a API, garantindo que ela recebeu o endereço certo do banco e do cache."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# 1. criar uma rede pros containers se acharem\ndocker network create minha-app-net\n\n# 2. subir o Postgres, com volume pro dado e variaveis de acesso\ndocker run -d \\\n  --name db \\\n  --network minha-app-net \\\n  -e POSTGRES_USER=admin \\\n  -e POSTGRES_PASSWORD=senha123 \\\n  -e POSTGRES_DB=app \\\n  -v pgdata:/var/lib/postgresql/data \\\n  postgres:16\n\n# 3. subir o Redis\ndocker run -d \\\n  --name redis \\\n  --network minha-app-net \\\n  redis:7\n\n# 4. so agora subir a API, depois que o banco e o cache ja existem\ndocker run -d \\\n  --name api \\\n  --network minha-app-net \\\n  -p 3000:3000 \\\n  -e DATABASE_URL=postgresql://admin:senha123@db:5432/app \\\n  -e REDIS_URL=redis://redis:6379 \\\n  minha-api:1.0"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Por que isso dói\n\nEsse roteiro funciona, mas tem vários problemas:\n- **Ordem importa**: se você subir a API antes do banco existir, ela quebra na primeira query.\n- **Flags demais**: são quatro comandos, cada um com várias flags. Esquecer uma (tipo o `--network`) já quebra tudo.\n- **Nada fica documentado**: se outro dev do time precisar subir o ambiente, ele tem que adivinhar ou pedir esses comandos pra você.\n- **Refazer do zero é penoso**: se você quiser derrubar tudo e subir de novo, são quatro `docker stop`, quatro `docker rm`, e repetir os quatro `docker run`."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Aspecto\", \"Na mão (docker run)\", \"Docker Compose\"], [\"Onde fica o comando\", \"Decorado ou num script solto\", \"Um arquivo versionado (docker-compose.yml)\"], [\"Ordem de subida\", \"Você controla manualmente\", \"depends_on declara a ordem\"], [\"Rede entre containers\", \"Precisa criar e lembrar de usar em cada run\", \"O Compose cria e conecta tudo sozinho\"], [\"Subir tudo de novo\", \"Repetir vários comandos longos\", \"Um comando só\"], [\"Compartilhar com o time\", \"Copiar e colar comandos\", \"git pull e pronto\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que vem por aí\n\nEsse é exatamente o problema que o **Docker Compose** resolve. Em vez de uma sequência de comandos `docker run`, você descreve a stack inteira (API, Postgres, Redis, cada uma com sua configuração) em um único arquivo declarativo. Aí sobe tudo com um comando só, na ordem certa, na mesma rede. É isso que você vai escrever nas próximas aulas."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Cada container isolado até que precisa conversar com outro: é aí que o docker run na mão vira um roteiro frágil, e é aí que o Compose entra."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Por que uma aplicação real geralmente precisa de mais de um container?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Porque cada imagem Docker só roda por um tempo limitado antes de precisar ser trocada.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque ela depende de outras peças, como banco e cache, cada uma numa imagem própria.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o Docker cria, por padrão, um container extra só pra cuidar da rede da aplicação.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque um Dockerfile não pode ter mais de uma instrução RUN dentro do mesmo arquivo.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "No exemplo dos comandos na mão (docker run separados pra rede, banco, cache e API), o que acontece se a API subir antes do Postgres existir?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "A API quebra ao tentar rodar a primeira query, porque o banco que ela espera ainda não existe.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Nada acontece, porque o Docker adia toda conexão de rede até os containers ficarem prontos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A API sobe normalmente, mas fica sem acesso à internet até o Postgres ser criado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Docker cancela a criação da API e refaz a ordem dos containers sozinho.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual é o papel da rede criada manualmente com docker network create no roteiro de subir os containers na mão?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Ela limita quanto de memória cada container pode usar durante a execução.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ela substitui a necessidade de expor portas com a flag -p em qualquer container.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ela permite que os containers conectados a ela consigam se encontrar e conversar.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Ela impede que dois containers usem a mesma imagem ao mesmo tempo.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Além da ordem de subida, qual é outro problema prático de gerenciar vários docker run separados pra montar uma stack?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "São vários comandos longos e cheios de flags, fáceis de esquecer e difíceis de repassar.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O Docker cobra por cada comando docker run adicional executado no mesmo host.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Containers criados por comandos separados nunca conseguem compartilhar a mesma rede.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Cada docker run novo apaga silenciosamente os containers criados antes dele.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um dev do time recebeu só a lista de comandos docker run usados pra montar a stack e tentou reproduzir o ambiente do zero numa outra máquina. Qual é o risco mais provável?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O Docker recusa recriar containers com nomes usados antes, mesmo em outra máquina.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Esquecer ou trocar uma flag, como a rede ou uma variável, e a stack subir incompleta.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "As imagens usadas nos comandos somem do Docker Hub depois do primeiro uso.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os volumes criados na máquina original são copiados sozinhos pra máquina nova.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "O docker-compose.yml: services, ports, environment e volumes",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## O arquivo docker-compose.yml\n\nO Docker Compose usa um arquivo YAML, normalmente chamado `docker-compose.yml`, na raiz do projeto. Nele você descreve cada peça da sua stack como um **service**: a API, o Postgres, o Redis. O arquivo é declarativo, ou seja, você diz o que quer (essas três peças, com essas portas e variáveis) e o Compose cuida de criar, conectar e subir tudo."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Anatomia de um service\n\nDentro de `services`, cada chave é o nome de um service, e por baixo dele ficam as configurações daquele container:\n- **image**: qual imagem pronta usar (ex.: `postgres:16`, do Docker Hub).\n- **build**: em vez de uma imagem pronta, constrói a partir de um Dockerfile.\n- **ports**: quais portas do host mapeiam pra quais portas do container.\n- **environment**: variáveis de ambiente que o container recebe.\n- **volumes**: onde persistir dados ou montar código do host.\n- **depends_on**: em qual ordem os services devem subir.\n- **networks**: em quais redes o service participa (por padrão, o Compose já cria uma rede pra stack toda)."
+                    },
+                    {
+                        "type": "code",
+                        "value": "services:\n  redis:\n    image: redis:7\n    ports:\n      - \"6379:6379\""
+                    },
+                    {
+                        "type": "text",
+                        "value": "## image ou build\n\nPra peças prontas, como o banco ou o cache, você usa `image` e aponta pra uma imagem publicada no Docker Hub (é o mesmo Postgres e o mesmo Redis que você já conhece das trilhas de banco e cache). Já pra sua própria API, você não tem uma imagem pronta por aí: você usa `build`, apontando pro diretório que tem o Dockerfile (aquele que você escreveu no módulo 2). O Compose constrói a imagem local antes de subir o container."
+                    },
+                    {
+                        "type": "code",
+                        "value": "services:\n  api:\n    build: .\n    ports:\n      - \"3000:3000\"\n    environment:\n      - NODE_ENV=development\n      - PORT=3000\n    volumes:\n      - .:/app\n      - /app/node_modules"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Chave\", \"O que faz\", \"Exemplo\"], [\"image\", \"Usa uma imagem pronta de um registry\", \"image: postgres:16\"], [\"build\", \"Constrói a imagem a partir de um Dockerfile local\", \"build: .\"], [\"ports\", \"Mapeia porta do host pra porta do container\", \"ports: - \\\"3000:3000\\\"\"], [\"environment\", \"Define variáveis de ambiente do container\", \"environment: - PORT=3000\"], [\"volumes\", \"Persiste dados ou monta código do host\", \"volumes: - pgdata:/var/lib/postgresql/data\"], [\"depends_on\", \"Define a ordem de subida entre services\", \"depends_on: - db\"], [\"networks\", \"Liga o service a uma rede específica\", \"networks: - minha-rede\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "O docker-compose.yml é a planta baixa da sua stack: cada service, sua imagem, suas portas e suas variáveis, tudo num lugar só, versionado junto com o código."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "No docker-compose.yml, o que representa cada chave dentro de services?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Um container da stack, com sua própria imagem, portas e variáveis de ambiente.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Uma pasta do projeto que vai ser copiada pra dentro da imagem final.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um comando isolado que o Compose só executa uma única vez ao subir a stack.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um usuário do sistema que vai ter permissão de rodar aquele container.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual é a diferença entre usar image e usar build num service do compose?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "image baixa a imagem toda vez que sobe, build usa sempre uma imagem em cache.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "image usa uma imagem pronta de um registry, build constrói a partir de um Dockerfile.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "image só funciona pra bancos de dados, build só funciona pra aplicações próprias.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "image cria um container temporário, build cria sempre um container permanente.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Pra que serve a chave environment num service do docker-compose.yml?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Pra escolher em qual sistema operacional a imagem daquele service vai rodar.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Pra definir quantas réplicas daquele container o Compose deve manter no ar.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Pra definir variáveis de ambiente que o container recebe assim que é criado.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Pra listar quais outros services precisam subir antes daquele service.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "No service da api, o compose tem volumes com \".:/app\" e depois \"/app/node_modules\". Qual o efeito prático dessas duas linhas juntas?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O código do host fica montado no container, sem que o node_modules do host o sobrescreva.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O container ganha duas cópias do código, uma só de leitura e outra de escrita.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Compose ignora a pasta node_modules em qualquer ambiente, dentro ou fora do container.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A imagem é reconstruída sozinha sempre que algum arquivo do host muda de nome.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um service tem build: . e o Dockerfile dele muda depois que a imagem já existe localmente. O que precisa acontecer pra imagem refletir essa mudança no próximo up?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Nada: o Compose detecta sozinho qualquer alteração no Dockerfile a cada docker compose ps.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A imagem precisa ser reconstruída, já que o Compose não refaz o build sozinho a cada subida.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "As variáveis de environment precisam ser apagadas antes de qualquer novo build funcionar.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O service precisa trocar de build: . pra image: . pra aceitar a mudança.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Escrevendo um compose com API, Postgres e Redis",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Hora de juntar tudo\n\nVocê já viu a anatomia de um service e como usar image, build, ports, environment e volumes separadamente. Agora vamos escrever o docker-compose.yml completo pra uma stack de verdade: a API Node (construída a partir do Dockerfile do módulo 2), um Postgres e um Redis, exatamente as três peças que abriram esse módulo."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# Dockerfile da api, o mesmo do modulo 2\nFROM node:20-alpine\nWORKDIR /app\nCOPY package*.json ./\nRUN npm install\nCOPY . .\nEXPOSE 3000\nCMD [\"npm\", \"start\"]"
+                    },
+                    {
+                        "type": "code",
+                        "value": "services:\n  api:\n    build: .\n    ports:\n      - \"3000:3000\"\n    environment:\n      - NODE_ENV=development\n      - PORT=3000\n      - DATABASE_URL=postgresql://admin:senha123@db:5432/app\n      - REDIS_URL=redis://redis:6379\n    depends_on:\n      - db\n      - redis\n\n  db:\n    image: postgres:16\n    ports:\n      - \"5432:5432\"\n    environment:\n      - POSTGRES_USER=admin\n      - POSTGRES_PASSWORD=senha123\n      - POSTGRES_DB=app\n    volumes:\n      - pgdata:/var/lib/postgresql/data\n\n  redis:\n    image: redis:7\n    ports:\n      - \"6379:6379\"\n    volumes:\n      - redisdata:/data\n\nvolumes:\n  pgdata:\n  redisdata:"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Por trás de cada linha\n\n- O service `api` usa `build: .`: o Compose vai procurar um Dockerfile no diretório atual e construir a imagem antes de subir o container.\n- `DATABASE_URL` e `REDIS_URL` apontam pros hosts `db` e `redis`, que são exatamente os **nomes dos services** de Postgres e Redis, não `localhost`. Isso vai fazer mais sentido na aula sobre a rede do Compose.\n- `depends_on` garante que o Compose suba `db` e `redis` antes de `api`, o que evita (mas não elimina totalmente, como você vai ver no módulo 6) o erro de conexão recusada logo de cara.\n- No service `db`, as variáveis `POSTGRES_USER`, `POSTGRES_PASSWORD` e `POSTGRES_DB` são lidas pela própria imagem oficial do Postgres pra criar o banco inicial."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Os volumes nomeados\n\nNo fim do arquivo, a chave `volumes` (no nível raiz, não dentro de um service) declara os volumes nomeados usados pela stack: `pgdata` guarda os arquivos do Postgres, `redisdata` guarda o dump do Redis. Isso é o que você aprendeu no módulo 4: sem esse volume, os dados do banco sumiriam toda vez que o container `db` fosse removido. Com o Compose, esse volume sobrevive a um `docker compose down` (a não ser que você peça pra removê-lo também, como vai ver na próxima aula)."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Service\", \"Imagem ou build\", \"Porta\", \"Guarda\"], [\"api\", \"build a partir do Dockerfile local\", \"3000\", \"o código da aplicação\"], [\"db\", \"postgres:16\", \"5432\", \"os dados do banco, no volume pgdata\"], [\"redis\", \"redis:7\", \"6379\", \"cache e filas, no volume redisdata\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Um docker-compose.yml de verdade não é só sintaxe: cada porta, cada variável e cada volume ali é uma decisão sobre como as peças da aplicação vão se encontrar."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "No docker-compose.yml dessa aula, por que o service api usa build: . em vez de image?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Porque containers de API não podem usar imagens publicadas em nenhum registry.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque a API é uma aplicação própria, sem imagem pronta, então precisa ser construída ali.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque build: . deixa qualquer container rodar mais rápido do que usar uma image pronta.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque só é possível expor portas em services que usam build, nunca em image.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "No service db do exemplo, pra que servem POSTGRES_USER, POSTGRES_PASSWORD e POSTGRES_DB em environment?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "São lidas pela imagem do Postgres pra criar o usuário, a senha e o banco.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Configuram o nome do container que vai aparecer no docker compose ps.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Definem em qual porta do host o Postgres vai ficar disponível.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Escolhem qual versão da imagem do Postgres vai ser baixada do Docker Hub.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual é a função de depends_on no service api, apontando pra db e redis?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Garante que api só suba se db e redis já tiverem, no mínimo, uma hora no ar.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Garante que db e redis comecem a subir antes de api, na ordem declarada no arquivo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Impede que api seja removida enquanto db ou redis ainda existirem na máquina.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Faz api herdar automaticamente as variáveis de ambiente definidas em db e redis.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que o docker-compose.yml declara pgdata e redisdata na chave volumes do nível raiz, fora de qualquer service?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque assim eles ficam definidos como volumes nomeados, disponíveis pra qualquer service usar.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque volumes só funcionam se forem declarados fora dos services, por limitação do Compose.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque isso faz o Compose montar esses volumes automaticamente em todos os services.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque colocar volumes dentro de um service impediria aquele container de expor portas.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Rodando docker compose down (sem -v) depois de usar essa stack por um tempo, o que acontece com os dados gravados no Postgres via volume pgdata?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Somem junto com os containers, porque down remove containers e todos os volumes usados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ficam guardados dentro da imagem postgres:16, prontos pra qualquer novo container que a use.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Continuam existindo no volume nomeado, prontos pra serem montados de novo num próximo up.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "São movidos automaticamente pra dentro do Dockerfile da api, como um backup de segurança.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "up, down, logs: gerenciando a stack",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Subindo e derrubando a stack\n\nCom o docker-compose.yml pronto (o da aula anterior), gerenciar a API, o Postgres e o Redis vira questão de poucos comandos. Esquece aqueles vários `docker run` na mão: agora é o Compose que orquestra tudo.\n\nUm único comando, `docker compose up`, faz o trabalho que antes exigia vários `docker run` em sequência:\n- lê o `docker-compose.yml` da pasta atual;\n- constrói a imagem da `api` (usa o `build: .`), caso essa imagem ainda não exista localmente;\n- cria uma rede pra stack, se ainda não existir;\n- cria os volumes nomeados (`pgdata`, `redisdata`), se ainda não existirem;\n- sobe os containers respeitando o `depends_on`: primeiro `db` e `redis`, depois `api`;\n- junta os logs dos três containers no mesmo terminal.\n\nUm detalhe importante: se você mudar o Dockerfile depois que a imagem já existe, o `up` sozinho não percebe a mudança. Pra forçar a reconstrução, use `docker compose up --build` ou `docker compose build` antes."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# sobe tudo e fica preso ao terminal, mostrando os logs em tempo real\ndocker compose up\n\n# reconstroi as imagens antes de subir (necessario se o Dockerfile mudou)\ndocker compose up --build\n\n# Ctrl+C derruba a stack\n\n# sobe tudo em segundo plano (detached) e devolve o terminal\ndocker compose up -d"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Rodando em segundo plano\n\nNo dia a dia, o mais comum é usar `docker compose up -d`: a stack sobe em background e você continua usando o terminal pra outras coisas. Sem o `-d`, os logs de API, banco e cache ficam todos misturados na tela, o que só costuma ajudar quando você está depurando algo bem no início."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# lista os containers da stack, com status e portas\ndocker compose ps\n\n# mostra os logs de todos os services\ndocker compose logs\n\n# segue os logs em tempo real, so da api\ndocker compose logs -f api\n\n# para e remove os containers e a rede, mas mantem os volumes\ndocker compose down\n\n# para e remove containers, rede E volumes (apaga os dados do banco e do cache)\ndocker compose down -v"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Comando\", \"O que faz\"], [\"docker compose up\", \"Constrói se preciso, cria rede e volumes, sobe todos os services\"], [\"docker compose up -d\", \"A mesma coisa, mas em segundo plano\"], [\"docker compose ps\", \"Lista os containers da stack e o status de cada um\"], [\"docker compose logs\", \"Mostra os logs acumulados de todos os services\"], [\"docker compose logs -f api\", \"Segue em tempo real os logs de um service específico\"], [\"docker compose down\", \"Para e remove containers e rede, mantendo os volumes\"], [\"docker compose down -v\", \"Para e remove containers, rede e também os volumes\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "up sobe, down derruba, logs mostra o que está acontecendo: três comandos que substituem uma dezena de docker run decorados."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual é a diferença prática entre docker compose up e docker compose up -d?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "up ocupa o terminal mostrando logs ao vivo, up -d sobe a stack em segundo plano.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "up sobe só a api, up -d sobe api, db e redis juntos numa única vez.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "up cria os volumes da stack, up -d nunca cria volume nenhum em nenhuma hipótese.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "up serve só pra produção, up -d serve só pro ambiente local de desenvolvimento.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de subir a stack com docker compose up -d, qual comando mostra quais containers estão rodando e o status de cada um?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "docker compose build",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "docker compose logs",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "docker compose ps",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "docker compose down",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Você quer acompanhar, em tempo real, só os logs novos do container da api, sem misturar com os de db e redis. Qual comando faz isso?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "docker compose logs api",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "docker compose logs -f api",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "docker compose ps api",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "docker compose logs db redis",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de rodar docker compose down sem a flag -v, o que continua existindo?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Os volumes nomeados da stack, como pgdata, com os dados que já tinham sido gravados.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Os containers da stack, só que parados e prontos pra reiniciar com compose start.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A rede criada pelo Compose, ainda conectando os containers mesmo depois de removidos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "As portas mapeadas no host, que continuam reservadas até o próximo compose up.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um container da api está reiniciando sem parar logo depois do docker compose up -d. Qual comando ajuda a entender o motivo sem derrubar a stack inteira?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "docker compose stop api, que impede o container de tentar subir de novo em qualquer situação.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "docker compose logs api, pra ver a mensagem de erro que está levando ao restart.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "docker compose images, que mostra o conteúdo completo do Dockerfile usado pela imagem.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "docker compose build --no-cache, que sempre resolve qualquer problema de container reiniciando.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "A rede do Compose: um service acha o outro pelo nome",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Por que `db` e não `localhost`\n\nRepara de novo no `docker-compose.yml` da aula 3: a `api` se conecta ao banco usando `DATABASE_URL=postgresql://admin:senha123@db:5432/app` e ao Redis usando `REDIS_URL=redis://redis:6379`. Os hosts são `db` e `redis`, exatamente os nomes dos services no arquivo. Não é coincidência, e não seria `localhost`. Entender por quê é a peça que falta pra fechar o Compose.\n\nQuando você roda `docker compose up`, o Compose cria uma rede própria pra aquele projeto e conecta todos os services dela automaticamente. Você não precisou escrever nenhuma seção `networks` no seu `docker-compose.yml` pra isso funcionar: é o comportamento padrão. Isso já é uma diferença enorme em relação aos `docker run` na mão, onde você tinha que criar a rede manualmente e lembrar de usar `--network` em cada comando."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Resolvendo nomes por DNS\n\nDentro dessa rede, o Compose mantém um DNS interno que resolve o **nome do service** pro endereço IP do container certo. Quando o container da `api` tenta se conectar em `db`, o Docker resolve `db` pro IP atual do container do Postgres, sem você precisar descobrir ou fixar esse IP em lugar nenhum. Se o container do banco reiniciar e ganhar outro IP, a resolução por nome continua funcionando, então a API nem percebe a diferença."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Por que localhost não serve\n\nCada container tem seu próprio namespace de rede, com seu próprio `localhost` (o endereço de loopback `127.0.0.1`). Dentro do container da `api`, `localhost` aponta pro **próprio container da api**, não pro container do Postgres, nem pro computador que está rodando o Docker. Se você trocasse `DATABASE_URL` pra usar `localhost` em vez de `db`, a API tentaria abrir uma conexão Postgres dentro dela mesma, onde não existe Postgres nenhum rodando, e o resultado seria erro de conexão recusada."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# entra no container da api com um shell\ndocker compose exec api sh\n\n# de dentro do container, o nome \"db\" resolve pro Postgres\ngetent hosts db\n\n# e \"redis\" resolve pro Redis\ngetent hosts redis\n\n# mas \"localhost\" aqui dentro e o proprio container da api\ngetent hosts localhost"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## A própria plataforma funciona assim\n\nO ensina.dev roda em cima disso: o backend, o banco, o Redis e o frontend sobem via Docker Compose, e cada um acha o outro pelo nome do service, exatamente como no exemplo desse módulo. O backend fala com o Postgres pelo host `db` e com o Redis pelo host `redis`, nunca por `localhost`. É a mesma lógica que você acabou de aprender, rodando na plataforma que você usa pra estudar."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Dentro da rede do Compose, o nome do service é o endereço. localhost só serve pra falar com o próprio container."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "No docker-compose.yml da aula 3, por que a API se conecta ao banco usando o host db, e não localhost?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Porque db é o nome do service do Postgres, e é por esse nome que os containers se acham na rede.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque localhost é uma palavra reservada que o Docker bloqueia em qualquer variável de ambiente.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque só é possível usar localhost quando o service usa image, nunca quando usa build.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque db é o endereço IP fixo que o Postgres sempre recebe em qualquer instalação.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O que o Compose cria automaticamente pra conectar os services de um docker-compose.yml, mesmo sem você declarar nada em networks?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Um volume nomeado compartilhado entre todos os services da stack.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma rede própria da stack, que conecta todos os services automaticamente.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um túnel direto entre o host e cada container, ignorando a rede local.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um segundo Dockerfile, só pra configurar a parte de rede da aplicação.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Dentro do container da api, pra onde aponta o hostname localhost?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Aponta pro container do Postgres, já que ele é o primeiro a subir na ordem do depends_on.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Aponta pro computador que está rodando o Docker, fora de qualquer container.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Aponta pro próprio container da api, não pros outros containers nem pro host.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Aponta pra rede inteira do Compose, incluindo api, db e redis ao mesmo tempo.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "A api está configurada com DATABASE_URL usando localhost em vez de db, dentro de uma stack subida via Compose. O que deve acontecer ao tentar conectar no banco?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "A conexão funciona normalmente, porque o Compose traduz localhost pro nome do service.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A conexão falha, porque dentro do container da api não existe Postgres nenhum rodando ali.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A conexão funciona, mas só depois que o container da api for reiniciado de novo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A conexão falha só na primeira tentativa, e depois passa a funcionar sozinha.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Se o container do Postgres reiniciar e receber um novo endereço IP internamente, por que a api continua conseguindo se conectar em db sem nenhuma mudança de configuração?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Porque o Compose fixa o mesmo IP pro container do Postgres pra sempre, mesmo depois de reiniciar.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque a api guarda em cache o primeiro IP do Postgres e ignora qualquer mudança depois.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque a resolução acontece pelo nome do service, e o DNS interno aponta db pro IP atual.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque toda comunicação entre containers do Compose passa direto pelo host, sem depender de IP.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 6 - Juntando o back-end: app, Postgres e Redis",
+        "aulas": [
+            {
+                "titulo": "Conectando a API ao Postgres e Redis pelo nome do service",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Módulo 6: juntando o back-end com Postgres e Redis\n\nNos módulos anteriores você escreveu um Dockerfile, subiu containers, persistiu dados com volumes e orquestrou tudo com o Docker Compose. Chegou a hora de juntar as peças: a API que você já construiu (com **Express**, **pg** pro Postgres e **ioredis** pro Redis) rodando ao lado do banco e do cache, todos containerizados.\n\nA primeira pergunta que todo mundo faz é simples: como a API acha o Postgres e o Redis, se eles não estão mais em localhost?\n\n## O host não é mais localhost\n\nNo Módulo 5 você viu que, dentro da rede que o Compose cria, cada service enxerga os outros pelo **nome do service**, não por localhost e não por IP fixo. Isso vale pra qualquer conexão de rede, incluindo a conexão da sua API com o banco e com o cache.\n\nSe o seu docker-compose.yml declara um service chamado **db** pro Postgres e um **redis** pro Redis, é esse nome que entra na connection string da API:\n\n- Postgres: host db\n- Redis: host redis\n\nNada de localhost, 127.0.0.1 ou o IP que o container recebeu. Esses endereços só fariam sentido se a API estivesse rodando fora do compose, direto na sua máquina."
+                    },
+                    {
+                        "type": "code",
+                        "value": "services:\n  backend:\n    build: .\n    ports:\n      - \"3000:3000\"\n    environment:\n      DATABASE_URL: postgres://app:app123@db:5432/app\n      REDIS_URL: redis://redis:6379\n    depends_on:\n      - db\n      - redis\n\n  db:\n    image: postgres:16-alpine\n    environment:\n      POSTGRES_USER: app\n      POSTGRES_PASSWORD: app123\n      POSTGRES_DB: app\n    volumes:\n      - pgdata:/var/lib/postgresql/data\n\n  redis:\n    image: redis:7-alpine\n\nvolumes:\n  pgdata:"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## A DATABASE_URL passada por environment\n\nRepare que a DATABASE_URL usa **db** como host, a porta 5432 de sempre, e as credenciais que o service db recebeu em POSTGRES_USER e POSTGRES_PASSWORD. Ela chega até o container da API pelo bloco **environment**, do mesmo jeito que outras variáveis em módulos anteriores.\n\nÉ o mesmo formato de connection string que você já usava com o pg fora de container. Muda o host (de localhost pra db), o resto é igual."
+                    },
+                    {
+                        "type": "code",
+                        "value": "// db.js\nconst { Pool } = require('pg');\n\nconst pool = new Pool({\n  connectionString: process.env.DATABASE_URL,\n});\n\nmodule.exports = pool;\n\n// routes/usuarios.js\nconst pool = require('../db');\n\napp.get('/usuarios', async (req, res) => {\n  const { rows } = await pool.query('SELECT id, nome FROM usuarios');\n  res.json(rows);\n});"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O mesmo vale pro Redis\n\nO ioredis, que você já usa pra cache e filas, lê a REDIS_URL do mesmo jeito. Trocando o host de localhost pra **redis**, a API conecta no Redis do compose sem mudar mais nada no código."
+                    },
+                    {
+                        "type": "code",
+                        "value": "// cache.js\nconst Redis = require('ioredis');\n\nconst redis = new Redis(process.env.REDIS_URL);\n\nredis.on('connect', () => console.log('Conectado ao Redis'));\nredis.on('error', (err) => console.error('Erro no Redis:', err));\n\nmodule.exports = redis;"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "A regra é uma só: dentro do Compose, um service acha o outro pelo nome do service. O host da sua DATABASE_URL e da sua REDIS_URL é db e redis, não localhost."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "No docker-compose.yml, qual host a API deve usar pra conectar no Postgres do compose?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "O nome do service do Postgres no compose, por exemplo db",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "localhost, do jeito que a API acessava antes de usar Docker",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O IP interno do container, anotado à mão depois do build",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "127.0.0.1, já que os dois containers estão na mesma máquina",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Onde a API costuma receber a DATABASE_URL quando roda como service num docker-compose.yml?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "No bloco environment do service da API, no docker-compose.yml",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Direto no código-fonte, escrita fixa na linha de conexão",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Num arquivo dentro da imagem, copiado pelo Dockerfile",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "No comando docker build, como uma flag de build",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "A API já usava pg e ioredis antes de virar container. O que muda no código pra ela rodar dentro do compose?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Praticamente nada no código, só o host na connection string muda",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Trocar pg e ioredis por bibliotecas específicas pra Docker",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Reescrever as queries pra usar a sintaxe de rede do Compose",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Parar de usar variáveis de ambiente e fixar valores no código",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Num compose com os services backend, db (Postgres) e redis, qual string de conexão do Redis está correta pra API rodando dentro do compose?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "redis://redis:6379",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "redis://localhost:6379",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "redis://backend:6379",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "redis://127.0.0.1:6379",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "A API roda num container separado do Postgres. Por que ela não consegue usar localhost pra chegar no banco, mesmo os dois containers estando na mesma máquina host?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Cada container tem seu próprio localhost, que aponta pra ele mesmo, não pros outros",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O Docker bloqueia o acesso a localhost por padrão dentro de todo o container",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "localhost só funcionaria se o Postgres também expusesse essa porta 5432 pro host",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Compose remove a interface de loopback de dentro de cada container da rede",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "depends_on: ordem não é o mesmo que pronto",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## depends_on garante ordem, não prontidão\n\nNo Módulo 5 você usou depends_on pra fazer o Compose subir o banco antes da API. Existe uma pegadinha aí que derruba muita gente: depends_on, na forma simples (uma lista de nomes), garante só a **ordem de início dos containers**. Ele não espera o Postgres ficar pronto pra aceitar conexões, só espera o container do Postgres começar a rodar.\n\nSão coisas diferentes. O container pode aparecer como \"Up\" no docker ps enquanto o processo do Postgres lá dentro ainda está inicializando."
+                    },
+                    {
+                        "type": "code",
+                        "value": "services:\n  backend:\n    build: .\n    environment:\n      DATABASE_URL: postgres://app:app123@db:5432/app\n      REDIS_URL: redis://redis:6379\n    depends_on:\n      - db\n      - redis\n\n  db:\n    image: postgres:16-alpine\n    environment:\n      POSTGRES_USER: app\n      POSTGRES_PASSWORD: app123\n      POSTGRES_DB: app\n\n  redis:\n    image: redis:7-alpine"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Por que o Postgres demora pra ficar pronto\n\nQuando o container do db sobe pela primeira vez, o Postgres precisa inicializar o diretório de dados, criar o banco declarado em POSTGRES_DB e só então passar a aceitar conexões na porta 5432. Isso leva alguns segundos. Enquanto isso, o Docker já considera o container \"iniciado\", porque o processo principal (o postgres) começou a rodar.\n\nSe a API tentar conectar nesse intervalo, a conexão é recusada."
+                    },
+                    {
+                        "type": "code",
+                        "value": "$ docker compose up\n...\nbackend-1  | Iniciando servidor...\nbackend-1  | Error: connect ECONNREFUSED 172.19.0.3:5432\nbackend-1  |     at TCPConnectWrap.afterConnect [as oncomplete]\ndb-1       | 2026-07-12 10:15:03.100 UTC [1] LOG:  database system is ready to accept connections"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## A saída: a app lida com isso\n\nComo o depends_on simples não espera o banco ficar pronto, é a própria aplicação que precisa se defender. Duas saídas comuns:\n\n- **Retry na conexão**: a API tenta conectar, falha, espera um pouco e tenta de novo, até conseguir.\n- **Health check no Compose**: o Compose só considera o db pronto quando um comando de verificação passar, e a API só sobe depois disso (é o assunto da próxima aula).\n\nAs duas se complementam: mesmo com health check na subida, uma boa API resiste a uma reconexão eventual, tipo um restart do banco em produção."
+                    },
+                    {
+                        "type": "code",
+                        "value": "// db.js\nconst { Pool } = require('pg');\n\nconst pool = new Pool({ connectionString: process.env.DATABASE_URL });\n\nasync function conectarComRetry(tentativas = 10, esperaMs = 2000) {\n  for (let i = 1; i <= tentativas; i++) {\n    try {\n      await pool.query('SELECT 1');\n      console.log('Postgres pronto, conexão OK');\n      return;\n    } catch (err) {\n      console.log('Tentativa ' + i + '/' + tentativas + ' falhou, esperando ' + esperaMs + 'ms');\n      await new Promise((r) => setTimeout(r, esperaMs));\n    }\n  }\n  throw new Error('Não conectou no Postgres depois de várias tentativas');\n}\n\nmodule.exports = { pool, conectarComRetry };"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "depends_on decide a ordem em que os containers sobem. Não decide se o que está lá dentro já está pronto pra uso: isso é papel de um health check ou da própria aplicação."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "No compose, o service backend tem depends_on apontando pra db, na forma simples de lista. O que exatamente isso garante?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Que o container do db começa a subir antes do container do backend",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Que o Postgres do db já aceita conexões antes do backend subir",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que o backend só inicia depois que o db rodar todas as migrations",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que o backend reinicia sozinho se o container do db cair depois",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O compose só tem depends_on simples entre backend e db. Nos primeiros segundos de um docker compose up, a API loga connect ECONNREFUSED ao falar com o Postgres. Qual a explicação mais provável?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "O container do db subiu, mas o Postgres ainda estava inicializando",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O nome do service db está digitado errado na DATABASE_URL da API",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O volume de dados do Postgres foi apagado antes dessa subida",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A porta 5432 não foi publicada no bloco ports do service db",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "A API tenta conectar no Postgres, falha, espera um pouco e tenta de novo, até um número máximo de tentativas. Como esse padrão costuma ser chamado?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Retry na conexão",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Circuit breaker",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Debounce de requisição",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Pooling de conexões",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O compose só tem depends_on simples, sem healthcheck. O que reduz o risco da API cair por causa da demora do Postgres pra ficar pronto?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "A API tentar reconectar sozinha antes de aceitar requisições",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Aumentar o número de réplicas do service backend no compose",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Trocar a imagem do Postgres por uma versão mais recente",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Remover o depends_on do compose pra subir mais rápido",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "A API já tem retry na conexão, rodado uma única vez na inicialização. Por que isso sozinho não protege contra o Postgres cair e voltar durante a execução?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O retry só roda no início, não cobre uma queda depois que a app já está no ar",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O pg fecha e recria a pool de conexões automaticamente ao detectar uma queda",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Compose reinicia sozinho o container do backend sempre que o db cai",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O healthcheck do db passa a falhar pra sempre depois da primeira queda registrada",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Health check: esperando o banco ficar pronto",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## O que é um health check\n\nUm health check é um comando que o próprio Docker roda, de tempos em tempos, dentro do container, pra decidir se aquele service está \"saudável\" ou não. Pro Postgres, o comando clássico é o pg_isready, que já vem instalado na imagem oficial e responde se o servidor aceita conexões. Pro Redis, dá pra usar redis-cli ping, que responde PONG quando o servidor está no ar.\n\nDeclarado no compose, o health check vira parte do ciclo de vida do container: o Docker passa a saber a diferença entre \"container rodando\" e \"container pronto pra uso\"."
+                    },
+                    {
+                        "type": "code",
+                        "value": "services:\n  db:\n    image: postgres:16-alpine\n    environment:\n      POSTGRES_USER: app\n      POSTGRES_PASSWORD: app123\n      POSTGRES_DB: app\n    healthcheck:\n      test: [\"CMD-SHELL\", \"pg_isready -U app -d app\"]\n      interval: 5s\n      timeout: 5s\n      retries: 5\n\n  redis:\n    image: redis:7-alpine\n    healthcheck:\n      test: [\"CMD\", \"redis-cli\", \"ping\"]\n      interval: 5s\n      timeout: 3s\n      retries: 5"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Os parâmetros do healthcheck\n\n- **test**: o comando que o Docker executa dentro do container. Se sair com código 0, está saudável.\n- **interval**: de quanto em quanto tempo o Docker roda o teste.\n- **timeout**: quanto tempo esperar pela resposta antes de considerar falha.\n- **retries**: quantas falhas seguidas até marcar o service como \"unhealthy\".\n\nCom o healthcheck declarado, dá pra usar a forma longa do depends_on, com condition: service_healthy. Assim o Compose só libera a subida do backend depois que o db e o redis estiverem de fato saudáveis, não só \"iniciados\"."
+                    },
+                    {
+                        "type": "code",
+                        "value": "services:\n  backend:\n    build: .\n    environment:\n      DATABASE_URL: postgres://app:app123@db:5432/app\n      REDIS_URL: redis://redis:6379\n    depends_on:\n      db:\n        condition: service_healthy\n      redis:\n        condition: service_healthy"
+                    },
+                    {
+                        "type": "code",
+                        "value": "$ docker compose up -d\n$ docker ps\nCONTAINER ID   IMAGE                STATUS                    PORTS                    NAMES\na1b2c3d4e5f6   app-backend          Up 20 seconds             0.0.0.0:3000->3000/tcp   app-backend-1\nb2c3d4e5f6a1   postgres:16-alpine   Up 25 seconds (healthy)   0.0.0.0:5432->5432/tcp   app-db-1\nc3d4e5f6a1b2   redis:7-alpine       Up 25 seconds (healthy)   0.0.0.0:6379->6379/tcp   app-redis-1"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"depends_on\",\"O que garante\",\"Risco\"],[\"Forma simples (lista de services)\",\"Ordem de início dos containers\",\"App pode subir antes do banco aceitar conexão\"],[\"Forma longa (condition: service_healthy)\",\"Espera o service passar no healthcheck\",\"Depende de um healthcheck bem configurado\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Health check é o Docker perguntando pro service se ele está pronto de verdade antes de liberar quem depende dele. Sem isso, depends_on garante só a ordem de largada, não se o banco já está pronto pra uso."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O service db tem um healthcheck com o comando pg_isready. Pra que serve esse comando?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Pro Docker checar, de tempos em tempos, se o Postgres já aceita conexões",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Pro Postgres criar o banco declarado em POSTGRES_DB automaticamente",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Pra medir quanto tempo o container do db leva pra ser destruído",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Pra bloquear conexões externas até a API se autenticar",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Você quer que o Docker cheque, de tempos em tempos, se o Redis está respondendo. Qual comando faz sentido usar no test do healthcheck?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "redis-cli ping",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "redis-server status",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "redis check --alive",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "redis-cli healthcheck",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O service db tem healthcheck configurado, mas o backend ainda usa depends_on na forma simples de lista. O que falta pro Compose esperar o db ficar saudável antes de subir o backend?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Trocar o depends_on pela forma longa, com condition: service_healthy",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Nada, a forma de lista já espera o healthcheck passar sozinha antes",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Adicionar um sleep manual bem no início do comando do backend",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Diminuir bastante o interval do healthcheck pra ele rodar mais rápido",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de subir o compose, docker ps mostra o container do db com o status Up 10 seconds (unhealthy). O que esse status indica?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O comando do healthcheck falhou o número de vezes definido em retries",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O container travou e o Docker já está reiniciando ele automaticamente",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O healthcheck ainda não foi configurado pra esse service",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O volume de dados do Postgres está corrompido e precisa recriar",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O healthcheck do db está configurado com interval: 30s e retries: 5. No pior caso, quanto tempo o Compose pode levar pra marcar esse service como unhealthy depois dele parar de responder?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Perto de 5 intervalos de 30 segundos, algo em torno de 150 segundos",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Exatamente 30 segundos, o tempo de apenas um único intervalo de teste",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Instantâneo, o Docker detecta a falha assim que ela acontece",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "5 segundos, porque o retries sempre usa uma escala fixa em segundos",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Dev x produção: bind mount e hot reload x imagem pronta",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## O mesmo código, dois jeitos de rodar\n\nNo Módulo 4 você viu o bind mount: montar uma pasta do host dentro do container, editar o código fora e ver o efeito dentro, sem rebuildar a imagem. É essa técnica que sustenta o hot reload em desenvolvimento. Só que ela não faz sentido em produção: lá você quer a imagem com o código já dentro dela, testada e imutável, sem depender do que está (ou não) no disco do host.\n\nA prática comum, inclusive na própria ensina.dev, é manter dois arquivos de compose: um pro dia a dia de desenvolvimento, outro pra produção."
+                    },
+                    {
+                        "type": "code",
+                        "value": "FROM node:20-alpine\nWORKDIR /app\nCOPY package*.json ./\nRUN npm install\nCOPY . .\nEXPOSE 3000\nCMD [\"node\", \"src/index.js\"]"
+                    },
+                    {
+                        "type": "code",
+                        "value": "# docker-compose.yml (desenvolvimento)\nservices:\n  backend:\n    build: .\n    command: npm run dev\n    ports:\n      - \"3000:3000\"\n    volumes:\n      - ./:/app\n      - /app/node_modules\n    environment:\n      DATABASE_URL: postgres://app:app123@db:5432/app\n      REDIS_URL: redis://redis:6379\n    depends_on:\n      db:\n        condition: service_healthy\n      redis:\n        condition: service_healthy\n\n  db:\n    image: postgres:16-alpine\n    environment:\n      POSTGRES_USER: app\n      POSTGRES_PASSWORD: app123\n      POSTGRES_DB: app\n    healthcheck:\n      test: [\"CMD-SHELL\", \"pg_isready -U app -d app\"]\n      interval: 5s\n      timeout: 5s\n      retries: 5\n\n  redis:\n    image: redis:7-alpine\n    healthcheck:\n      test: [\"CMD\", \"redis-cli\", \"ping\"]\n      interval: 5s\n      timeout: 3s\n      retries: 5"
+                    },
+                    {
+                        "type": "code",
+                        "value": "# docker-compose.prod.yml (produção)\nservices:\n  backend:\n    build: .\n    ports:\n      - \"3000:3000\"\n    environment:\n      DATABASE_URL: postgres://app:app123@db:5432/app\n      REDIS_URL: redis://redis:6379\n    depends_on:\n      db:\n        condition: service_healthy\n      redis:\n        condition: service_healthy\n\n  db:\n    image: postgres:16-alpine\n    environment:\n      POSTGRES_USER: app\n      POSTGRES_PASSWORD: app123\n      POSTGRES_DB: app\n    volumes:\n      - pgdata:/var/lib/postgresql/data\n    healthcheck:\n      test: [\"CMD-SHELL\", \"pg_isready -U app -d app\"]\n      interval: 5s\n      timeout: 5s\n      retries: 5\n\n  redis:\n    image: redis:7-alpine\n    healthcheck:\n      test: [\"CMD\", \"redis-cli\", \"ping\"]\n      interval: 5s\n      timeout: 3s\n      retries: 5\n\nvolumes:\n  pgdata:"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que muda de um arquivo pro outro\n\nRepare nas diferenças:\n\n- O compose de dev tem volumes com ./:/app, o bind mount que joga o código do host pra dentro do container. Editou um arquivo, o container enxerga na hora.\n- O compose de dev também sobrescreve o CMD do Dockerfile com command: npm run dev, rodando um watcher tipo nodemon que reinicia o processo sozinho a cada mudança.\n- A entrada extra /app/node_modules impede que o bind mount apague o node_modules instalado dentro da imagem, trocando ele pelo (possivelmente vazio) da sua máquina.\n- O compose de produção não monta nada por cima do /app: o código que roda é o que o COPY colocou na imagem durante o docker build, e o comando é o CMD padrão do próprio Dockerfile, sem watcher.\n\nPra subir cada ambiente, o comando muda: docker compose up -d lê o docker-compose.yml de desenvolvimento por padrão; docker compose -f docker-compose.prod.yml up -d --build aponta pro arquivo de produção."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Aspecto\",\"Desenvolvimento\",\"Produção\"],[\"Código no container\",\"Bind mount (./:/app)\",\"Copiado na imagem (COPY)\"],[\"Mudou um arquivo\",\"Reflete na hora, com hot reload\",\"Precisa gerar uma imagem nova\"],[\"Comando de start\",\"npm run dev (nodemon)\",\"node src/index.js (CMD do Dockerfile)\"],[\"Objetivo\",\"Ciclo rápido de edição e teste\",\"Estabilidade e reprodutibilidade\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Em dev, o container roda o seu código editado ao vivo, montado por bind mount. Em produção, a imagem já é o código: mudou algo, a resposta é buildar de novo, não montar um volume por cima."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "No compose de desenvolvimento, o service backend tem volumes com a entrada ./:/app. Pra que serve esse bind mount?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Pra refletir o código editado no host dentro do container, sem rebuildar",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Pra fazer backup automático do código dentro de um volume nomeado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Pra impedir que o container acesse qualquer arquivo fora da pasta /app",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Pra compartilhar o mesmo código entre o backend e o service do Postgres",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "No compose de produção, o service backend não tem bind mount de código. De onde vem o código que roda dentro do container, então?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Do COPY feito durante o docker build, já dentro da imagem",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "De um volume nomeado, criado e populado na primeira execução",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "De um download automático feito pelo Compose ao subir o service",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Do host, copiado uma única vez no primeiro docker compose up",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Você editou um arquivo da API rodando com o compose de produção e quer ver o efeito da mudança. O que precisa fazer?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Gerar uma imagem nova com docker build e subir o container com ela",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Só salvar o arquivo, o container detecta a mudança sozinho",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Rodar docker compose restart, sem precisar buildar de novo",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Editar o arquivo direto de dentro do container, via docker exec",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "No compose de dev, além de ./:/app, tem uma segunda entrada: /app/node_modules. Qual problema essa segunda linha evita?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Que o bind mount do código sobrescreva o node_modules da imagem",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Que o node_modules do host seja enviado sem querer pro registry",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que duas versões diferentes do Node rodem ao mesmo tempo",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que o Postgres e o Redis compartilhem o mesmo node_modules",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "A mesma imagem, construída a partir do mesmo Dockerfile, é usada no compose de dev (com command: npm run dev) e no de produção (sem command, usando o CMD padrão). O que muda de um pro outro nesse caso?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O comando executado ao iniciar o container, não a imagem em si",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A versão do Node instalada, que muda conforme o command usado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Dockerfile usado, que é reescrito pelo compose em tempo real",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "As dependências instaladas, que variam de acordo com o command",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Depurando a stack",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Quando a stack não sobe direito\n\nMesmo com health check e retry, chega a hora de alguma coisa dar errado: a API não conecta no banco, o Redis parece fora do ar, uma porta não responde. Depurar uma stack em containers segue um roteiro parecido, service por service: olhar os logs, checar o status e, se precisar, entrar no container pra investigar por dentro."
+                    },
+                    {
+                        "type": "code",
+                        "value": "$ docker compose ps\nNAME              SERVICE   STATUS\napp-backend-1     backend   Up 2 minutes\napp-db-1          db        Up 2 minutes (healthy)\napp-redis-1       redis     Restarting (1) 5 seconds ago\n\n$ docker compose logs backend\n$ docker compose logs -f backend\n$ docker compose logs --tail=50 db"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Lendo os logs certo\n\ndocker compose logs seguido do nome do service mostra a saída daquele container desde que ele subiu. O -f (--follow) deixa acompanhando em tempo real, útil pra ver o exato momento em que a API tenta conectar e falha. O --tail=50 limita pras últimas linhas, bom quando o log já está enorme.\n\nSem o nome do service, docker compose logs mostra os logs de todos os services misturados, cada linha prefixada com o nome de quem gerou ela. Ajuda a ver a ordem dos eventos entre a API e o banco."
+                    },
+                    {
+                        "type": "code",
+                        "value": "$ docker compose exec backend sh\n/app # echo $DATABASE_URL\npostgres://app:app123@db:5432/app\n/app # node -e \"require('net').connect(5432,'db').on('connect',()=>{console.log('conectou');process.exit()}).on('error',e=>{console.error('erro:',e.message);process.exit(1)})\"\nconectou\n/app # exit"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## As causas mais comuns\n\nQuando a API não conecta, é quase sempre uma destas:\n\n- **Host errado na connection string**: colocou localhost em vez do nome do service (db ou redis).\n- **Service ainda não subiu, ou não passou no health check**: a API tentou conectar cedo demais, sem retry nem condition: service_healthy.\n- **Porta errada**: publicou ou apontou pra uma porta diferente da que o service realmente escuta.\n- **Credencial divergente**: a senha ou o nome do banco na DATABASE_URL da API não bate com o que o db recebeu em POSTGRES_PASSWORD ou POSTGRES_DB."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Mensagem no log\",\"Causa mais provável\"],[\"ECONNREFUSED\",\"Service certo, mas ainda não aceita conexão nessa porta\"],[\"ENOTFOUND / getaddrinfo\",\"Nome do host não existe: service errado ou fora da rede\"],[\"password authentication failed\",\"Usuário ou senha diferentes entre a API e o banco\"],[\"database app does not exist\",\"POSTGRES_DB e o banco da connection string não batem\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Container que não conecta em outro quase sempre é logs, host e porta, nessa ordem. docker compose logs mostra o sintoma, docker compose exec deixa confirmar a causa por dentro do próprio container."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Você quer acompanhar, em tempo real, o que o service backend está logando. Qual comando faz isso?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "docker compose logs -f backend",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "docker compose ps -f backend",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "docker compose exec -f backend",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "docker compose top backend",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "docker compose ps mostra o service redis com o status Restarting (1) 5 seconds ago. O que isso sugere?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "O container do redis está falhando ao iniciar e o Docker insiste de novo",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O Redis está processando um comando pesado e volta ao normal",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O healthcheck do redis está rodando, e esse é o comportamento esperado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O container do redis está saudável, só reiniciando por rotina",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Dentro do container do backend, echo $DATABASE_URL mostra postgres://app:app123@localhost:5432/app. Isso explica um erro de conexão. Qual é o problema?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O host deveria ser o nome do service do Postgres, não localhost",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A porta 5432 deveria estar entre aspas na variável de ambiente",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O usuário app não existe de verdade dentro do container backend",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Falta declarar essa variável também no Dockerfile, com ENV",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "A API loga password authentication failed for user app ao tentar falar com o Postgres. Onde faz mais sentido procurar o problema primeiro?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Comparar a senha da DATABASE_URL da API com o POSTGRES_PASSWORD do db",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Verificar se a porta 5432 foi realmente publicada no bloco ports do db",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Conferir se o service db está de fato na mesma network que o backend",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Checar se o volume de dados do Postgres foi montado do jeito certo",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Rodando docker compose exec backend sh e testando a conexão com o Postgres via Node, ela falha. Mas psql direto da sua máquina, apontando pra localhost:5432, funciona normalmente. O que essa diferença indica?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O problema é específico da rede interna do compose, não do Postgres",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O Postgres só aceita uma conexão simultânea, já usada pelo psql",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A imagem do backend não tem suporte a conexões TCP com containers",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O comando usado no Node sempre falha ao testar portas de rede",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 7 - Imagens enxutas, seguras e o caminho do deploy",
+        "aulas": [
+            {
+                "titulo": "Multi-stage build: a imagem final enxuta",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Módulo 7: imagens enxutas, seguras e o caminho do deploy\n\nVocê já sabe empacotar sua API Express, conectar no Postgres e no Redis via Compose e manter os dados vivos com volumes. Falta o último passo: pegar essa imagem e deixá-la pronta pra produção de verdade, pequena, segura e fácil de distribuir.\n\nO primeiro problema é o tamanho. Se você seguiu os módulos anteriores à risca, sua imagem hoje provavelmente carrega coisa que a produção nunca vai usar: o TypeScript, o eslint, as devDependencies inteiras, o cache do `npm`, até o código-fonte original antes de compilar."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O problema: uma imagem só, com tudo dentro\n\nUm Dockerfile de etapa única faz o build e a execução no mesmo lugar. Funciona, mas carrega pra imagem final tudo que só foi necessário durante o build:\n\n- As devDependencies (TypeScript, bundler, linter, framework de teste)\n- O código-fonte original, além do já compilado\n- Cache de instalação e arquivos temporários\n\nRepare como isso costuma ser escrito:"
+                    },
+                    {
+                        "type": "code",
+                        "value": "# Dockerfile de etapa única (o build e a execução no mesmo lugar)\nFROM node:22\nWORKDIR /app\nCOPY package*.json ./\nRUN npm install\nCOPY . .\nRUN npm run build\nEXPOSE 3000\nCMD [\"node\", \"dist/server.js\"]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Multi-stage build: uma etapa builda, outra roda\n\nUm Dockerfile pode ter mais de um `FROM`. Cada `FROM` começa uma etapa nova, e você pode nomear cada uma com `AS`. A etapa final é a que vira a imagem de verdade; as etapas anteriores existem só de apoio pro build e não sobram na imagem final, a não ser o que você copiar explicitamente com `COPY --from`."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# Etapa 1: build (tem TypeScript, devDependencies, código-fonte)\nFROM node:22 AS build\nWORKDIR /app\nCOPY package*.json ./\nRUN npm ci\nCOPY . .\nRUN npm run build\n\n# Etapa 2: imagem final (só o necessário pra rodar)\nFROM node:22-alpine\nWORKDIR /app\nENV NODE_ENV=production\nCOPY package*.json ./\nRUN npm ci --omit=dev\nCOPY --from=build /app/dist ./dist\nEXPOSE 3000\nCMD [\"node\", \"dist/server.js\"]"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"O que fica na imagem\", \"Dockerfile de etapa única\", \"Multi-stage build\"], [\"Código-fonte (.ts, .js originais)\", \"Sim\", \"Não\"], [\"devDependencies (TypeScript, eslint...)\", \"Sim\", \"Não\"], [\"Apenas o código já compilado (dist)\", \"Sim, junto com o resto\", \"Sim, só isso\"], [\"Tamanho final típico\", \"Bem maior\", \"Bem menor\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Multi-stage build não é sobre ter um Dockerfile mais comprido, é sobre a imagem final esquecer tudo que só serviu pra construí-la."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que caracteriza um multi-stage build no Dockerfile?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Um Dockerfile com mais de um FROM, copiando só o necessário entre as etapas.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um Dockerfile que builda a aplicação em vários containers ao mesmo tempo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Vários arquivos Dockerfile separados, um pra cada ambiente do projeto.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma flag do docker build que divide a imagem final em partes menores.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual instrução copia arquivos de uma etapa anterior pra etapa atual num multi-stage build?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "COPY --from=nome-da-etapa, referenciando a etapa pelo nome dado com AS.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "IMPORT --stage=nome-da-etapa, referenciando a etapa pelo nome dado com AS.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "FROM --copy=nome-da-etapa, referenciando a etapa pelo nome dado com AS.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "RUN --source=nome-da-etapa, referenciando a etapa pelo nome dado com AS.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que a imagem final de um multi-stage build não deve ter o TypeScript e as devDependencies instaladas?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque elas só servem pra etapa de build, o runtime não precisa delas.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o Node não consegue executar pacotes listados em devDependencies.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o Docker Hub rejeita imagens publicadas com devDependencies.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque a licença padrão de devDependencies proíbe o uso em produção.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Seu Dockerfile tem FROM node:22 (sem AS nenhum) e depois tenta COPY --from=build /app/dist ./dist. O que o Docker faz?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Tenta interpretar build como o nome de uma imagem externa e busca puxá-la.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Ignora o --from e copia da própria etapa atual, sem avisar o motivo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Usa a última etapa definida no arquivo, sem checar o nome pedido.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Falha o parse do Dockerfile antes mesmo de iniciar o build da imagem.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Seu Dockerfile é multi-stage, mas a imagem final ficou quase do mesmo tamanho de uma versão de etapa única. Causa mais provável?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "A etapa final copiou o node_modules inteiro vindo da etapa de build.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A etapa final usa node:22-alpine, que não reduz tamanho nesse caso.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O cache de build duplicou os arquivos entre as duas etapas do Dockerfile.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Docker manteve as camadas da etapa de build dentro da etapa final.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Imagens base pequenas: alpine e slim",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## A imagem final também tem uma imagem base\n\nMulti-stage já cortou o código-fonte e as devDependencies. O próximo corte é a própria imagem base da etapa final. `node:22` sozinho já carrega um sistema operacional completo (Debian), com bibliotecas e ferramentas que sua API nunca vai chamar em produção."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## As opções mais comuns\n\n- **node:22**: imagem completa, baseada em Debian, com bastante coisa pré-instalada\n- **node:22-slim**: o mesmo Debian, mas enxuto, sem bibliotecas de build nem documentação\n- **node:22-alpine**: baseada no Alpine Linux, que usa musl no lugar da glibc e parte de poucos megabytes de base\n\nOs números variam por versão do Node e por arquitetura, mas a diferença de grandeza entre elas se mantém:"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Imagem base\", \"Tamanho aproximado\", \"Sistema base\", \"Uso típico\"], [\"node:22\", \"~1.1 GB\", \"Debian completo\", \"Desenvolvimento, quando falta alguma lib do sistema\"], [\"node:22-slim\", \"~200 MB\", \"Debian enxuto\", \"Meio-termo, quando o alpine dá conflito\"], [\"node:22-alpine\", \"~150 MB\", \"Alpine Linux (musl)\", \"Imagem final de produção, na maioria dos casos\"]]"
+                    },
+                    {
+                        "type": "code",
+                        "value": "FROM node:22-alpine AS build\nWORKDIR /app\nRUN apk add --no-cache python3 make g++\nCOPY package*.json ./\nRUN npm ci\nCOPY . .\nRUN npm run build"
+                    },
+                    {
+                        "type": "text",
+                        "value": "O `apk add` ali é necessário só nessa etapa: o Alpine não vem com compilador C/C++ por padrão, e alguns pacotes nativos (`bcrypt`, `sharp`, entre outros) precisam compilar código durante o `npm ci`. Como isso roda na etapa de build, essas ferramentas nunca chegam na imagem final.\n\n## Menos coisa instalada, menos risco e menos espera\n\nCada pacote a mais na imagem base é um pacote a mais que pode ter uma vulnerabilidade conhecida (CVE) um dia. Imagens menores também sobem e descem mais rápido do registry, o que importa toda vez que um container reinicia ou escala.\n\nExiste ainda um passo além do alpine: imagens **distroless** (mantidas pelo Google, por exemplo), que trazem só o runtime do Node e a aplicação, sem shell, sem gerenciador de pacotes, nada além do estritamente necessário pra rodar. É uma opção mais avançada, vale saber que existe."
+                    },
+                    {
+                        "type": "code",
+                        "value": "docker images node\n\nREPOSITORY   TAG          IMAGE ID       CREATED         SIZE\nnode         22           3f8a1c9d2b41   3 weeks ago     1.09GB\nnode         22-slim      7e2b4f6a91c3   3 weeks ago     199MB\nnode         22-alpine    9a1d5e8f3b27   3 weeks ago     152MB"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "A imagem base que você escolhe pesa em cada pull, cada deploy e cada CVE que você não vai querer explicar depois. Alpine (ou algo ainda menor) deveria ser o padrão pra imagem final, não a exceção."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Entre as opções abaixo, qual costuma gerar a menor imagem final pra uma app Node?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "node:22-alpine, a imagem base mais enxuta entre as opções oficiais comuns.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "node:22, a imagem completa baseada em Debian com tudo pré-instalado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "node:latest, que aponta pra versão mais recente disponível do Node.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "node:22-slim, a versão enxuta do Debian, mas maior que a alpine.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O que caracteriza a imagem node:22-alpine?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "É baseada no Alpine Linux, que usa musl no lugar da glibc do Debian.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "É uma versão do Node compilada sem nenhum suporte ao gerenciador npm.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "É recomendada só pra ambiente de desenvolvimento, nunca pra produção.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "É uma imagem sem sistema de arquivos, só o binário do Node sozinho.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "No node:22-alpine, o npm ci falha ao instalar um pacote nativo (ex.: bcrypt), com erro de compilação. Causa mais provável?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Faltam ferramentas de build, como python3, make e g++, no alpine.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O pacote bcrypt não tem nenhuma versão compatível com o Node 22.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O alpine só aceita o npm install, nunca aceita o npm ci.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A imagem alpine bloqueia módulos nativos por padrão, por segurança.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Além de ocupar menos disco, qual a vantagem prática de usar uma imagem base menor?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Menos pacotes instalados, logo menos superfície pra uma vulnerabilidade.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O runtime do Node processa as requisições bem mais rápido dentro dela.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Imagens menores nunca mais vão precisar de atualização de segurança.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Docker Hub cobra uma taxa menor pra armazenar imagens menores.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O que é, de forma resumida, uma imagem distroless?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Uma imagem com só o runtime e a aplicação, sem shell nem pacotes extras.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Uma imagem sem camadas nenhuma, tudo achatado num único layer final.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma variante do Windows containers, sem nenhuma base Linux por trás.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma variante do alpine que remove todo o suporte a rede interna.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Segurança da imagem: nada de root, nada de segredo embutido",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Rodando como root sem perceber\n\nSem nenhuma instrução extra, o processo dentro do container roda como `root`. Isso passa despercebido porque tudo funciona normalmente, mas quer dizer que, se alguém explorar uma falha na sua aplicação (uma dependência vulnerável, um upload malicioso), o processo comprometido já nasce com privilégio total dentro do container."
+                    },
+                    {
+                        "type": "code",
+                        "value": "FROM node:22-alpine\nWORKDIR /app\nENV NODE_ENV=production\nCOPY package*.json ./\nRUN npm ci --omit=dev\nCOPY --from=build /app/dist ./dist\nRUN addgroup -S app && adduser -S app -G app\nUSER app\nEXPOSE 3000\nCMD [\"node\", \"dist/server.js\"]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "`addgroup -S` e `adduser -S` criam um grupo e um usuário de sistema, sem senha e sem privilégio extra. A partir do `USER app`, tudo que vem depois no Dockerfile (e o próprio `CMD`) roda com esse usuário, nunca mais como root.\n\n## Segredo dentro da imagem é segredo público\n\nToda instrução do Dockerfile vira uma camada, e camadas ficam guardadas na imagem, mesmo as que uma instrução posterior tenta apagar. Colocar uma senha de banco num `ENV` ou copiar um `.env` de verdade pra dentro da imagem significa que qualquer pessoa com acesso a ela (um colega, alguém que puxou do registry, um `docker history`) consegue ler esse segredo. Ele não desaparece só porque um comando depois deletou o arquivo. No Compose vale o mesmo princípio: `env_file` aponta pra um arquivo que fica de fora da imagem e do Git, nunca dentro do Dockerfile."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# Errado: segredo gravado na imagem\nFROM node:22-alpine\nWORKDIR /app\nENV DATABASE_PASSWORD=minhasenha123\nCOPY . .\nRUN npm ci --omit=dev\nCMD [\"node\", \"dist/server.js\"]\n\n# Certo: segredo entra só na hora de rodar, nunca no Dockerfile\ndocker run --env-file .env.production -p 3000:3000 minha-api:1.4.0"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Prática\", \"Risco\", \"Alternativa recomendada\"], [\"Rodar o processo como root (sem USER)\", \"Processo comprometido ganha privilégio total no container\", \"Criar um usuário próprio e usar USER\"], [\"Segredo em ENV ou COPY no Dockerfile\", \"Fica gravado na camada, legível por quem tiver a imagem\", \"Variável de ambiente ou secret injetado em runtime\"], [\"Nunca escanear a imagem final\", \"Vulnerabilidade conhecida passa despercebida\", \"Rodar um scanner antes de publicar\"]]"
+                    },
+                    {
+                        "type": "code",
+                        "value": "docker scout quickview minha-api:1.4.0\ndocker scout cves minha-api:1.4.0\n\n# alternativa com Trivy\ntrivy image minha-api:1.4.0"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Uma imagem segura não é a que nunca vai ser atacada, é a que roda sem privilégio de root e não entrega segredo de graça pra quem só queria baixar a aplicação."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Sem a instrução USER, com qual usuário o processo roda dentro do container, por padrão?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "root, o usuário padrão de qualquer processo sem USER definido.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "www-data, o usuário padrão criado pelas imagens baseadas em Debian.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "node, o usuário que a imagem oficial já deixa pronto pra uso direto.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "nobody, o usuário de baixo privilégio ativado por padrão no container.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual instrução do Dockerfile define com qual usuário os comandos seguintes vão rodar?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "USER, que muda o usuário usado pelas instruções seguintes e pelo CMD.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "RUN, que executa comandos durante a construção da imagem sendo criada.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "ENTRYPOINT, que define o processo principal executado no container.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "WORKDIR, que define a pasta de trabalho usada pelas instruções seguintes.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que colocar ENV DATABASE_PASSWORD=minhasenha123 direto no Dockerfile é uma má prática?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "A senha fica gravada na imagem, legível por qualquer um com acesso a ela.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A instrução ENV não aceita valores com números ou símbolos especiais.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Docker apaga variáveis ENV ao criar o container, quebrando a aplicação.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A instrução ENV só funciona durante o build, nunca chega ao container.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Você copiou um arquivo de segredo pra imagem e, numa instrução seguinte, rodou RUN rm arquivo-secreto, achando que assim ele some da imagem final. O que realmente acontece?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O arquivo continua recuperável, porque a camada anterior com ele permanece.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O arquivo é removido de todas as camadas, e a estratégia funciona bem.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Docker compacta as camadas no final, então o rm resolve o problema.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Isso só vira problema se a imagem for enviada a um registry público.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual é a forma correta de entregar um segredo (ex.: senha de banco) pro container em produção?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Como variável de ambiente injetada no run ou compose, fora da imagem.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Como ARG no Dockerfile, já que um ARG não persiste na imagem final.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Como arquivo dentro de /app, protegido por permissão 600 no build.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Direto no CMD do Dockerfile, como argumento de linha de comando.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Enviando a imagem pro registry: tag, push e pull",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Sua imagem pronta, agora ela precisa viajar\n\nLá no módulo 3, cada `docker pull postgres` ou `docker pull redis` baixava uma imagem pronta de um registry, o Docker Hub. Agora é a sua imagem que precisa ir pro mesmo lugar: construída e testada na sua máquina, publicada num registry, e puxada de onde a aplicação realmente vai rodar."
+                    },
+                    {
+                        "type": "code",
+                        "value": "docker build -t minha-api:1.4.0 .\n\n# cria uma referência apontando pro seu usuário/repositório no registry\ndocker tag minha-api:1.4.0 seunome/minha-api:1.4.0\ndocker tag minha-api:1.4.0 seunome/minha-api:latest"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Autenticando e publicando\n\nAntes do primeiro push, é preciso autenticar com o registry. Depois disso, cada `docker push` envia só as camadas que o registry ainda não tem, aproveitando o cache. Vale publicar sempre uma tag de versão (`1.4.0`) além da `latest`: em produção, depender só da `latest` significa nunca ter certeza de qual build está rodando, nem como voltar pra versão anterior se algo quebrar.\n\nO Docker Hub é o registry público mais comum, mas o mesmo fluxo vale pra um registry privado (GitHub Container Registry, um registry próprio da empresa, entre outros)."
+                    },
+                    {
+                        "type": "code",
+                        "value": "docker login\n\ndocker push seunome/minha-api:1.4.0\ndocker push seunome/minha-api:latest"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Comando\", \"O que faz\", \"Quando usar\"], [\"docker tag origem destino\", \"Cria uma nova referência pra mesma imagem\", \"Antes do push, apontando pro registry certo\"], [\"docker login\", \"Autentica com o registry\", \"Antes do primeiro push\"], [\"docker push nome:tag\", \"Envia a imagem (camadas que faltam) pro registry\", \"Depois de testar a imagem localmente\"], [\"docker pull nome:tag\", \"Baixa a imagem do registry pra máquina atual\", \"No servidor de produção, ou em máquina nova\"]]"
+                    },
+                    {
+                        "type": "code",
+                        "value": "# no servidor de producao, sem precisar do codigo-fonte\ndocker pull seunome/minha-api:1.4.0\ndocker run -d --name minha-api -p 3000:3000 --env-file .env.production seunome/minha-api:1.4.0"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Depois do push, a imagem não pertence mais só à sua máquina: ela vira um artefato versionado que qualquer servidor autorizado consegue puxar e rodar, sem precisar de mais nada além do Docker."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual comando cria uma nova referência (tag) pra uma imagem já construída, sem reconstruir nada?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "docker tag origem destino, criando uma nova referência pra mesma imagem.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "docker build --rename destino, criando uma nova referência pra mesma imagem.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "docker push --as destino, criando uma nova referência pra mesma imagem.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "docker commit --tag destino, criando uma nova referência pra mesma imagem.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O que fazer antes do primeiro docker push num registry privado ou no Docker Hub?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "docker login, autenticando com suas credenciais no registry de destino.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "docker init, criando localmente um registry novo antes do primeiro push.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "docker build --public, marcando a imagem construída como pública.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "docker pull do mesmo nome, reservando o repositório antes de publicar.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Você publicou só a tag latest e, num pull posterior, veio uma versão diferente da esperada. Por que depender só da latest é arriscado?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque a tag latest pode apontar pra builds diferentes ao longo do tempo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o docker pull sempre usa o cache local, ignorando o registry.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o Docker Hub demora até 24 horas pra propagar uma imagem nova.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque a imagem antiga fica presa até alguém rodar docker rmi antes.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual a vantagem de publicar uma tag de versão (ex.: 1.4.2) além da latest?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Dá pra saber qual build está rodando e voltar a uma versão anterior.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Tags de versão fazem a imagem ocupar menos espaço dentro do registry.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Sem tag de versão, o docker push falha com erro de permissão.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A tag latest fica bloqueada pro Docker depois da primeira publicação.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois do docker push, o que precisa existir no servidor de produção pra rodar a aplicação?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Só o Docker instalado e acesso ao registry pra rodar o docker pull.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O código-fonte completo, pro Docker reconstruir a imagem antes do run.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O mesmo Dockerfile usado no build, pra validar a origem da imagem.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "As devDependencies instaladas no host, caso precise recompilar algo.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Do container ao deploy: o próximo passo é CI/CD",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Onde os containers rodam de verdade\n\nExistem dois caminhos comuns pra colocar sua imagem rodando em produção. O primeiro é uma VPS com Docker instalado: você (ou um script) faz `docker pull` e `docker run` (ou `docker compose up -d`) direto nela, como já fizemos até aqui. O segundo é um serviço gerenciado de nuvem (Cloud Run, ECS, Azure Container Apps, entre outros): você entrega a imagem, e o provedor cuida do servidor, da rede e do restart por trás."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"\", \"VPS com Docker\", \"Serviço gerenciado de nuvem\"], [\"Quem administra o servidor\", \"Você\", \"O provedor de nuvem\"], [\"Como você entrega a app\", \"docker pull + docker run/compose\", \"Aponta pra imagem no registry\"], [\"Escala automática\", \"Só se você configurar na mão\", \"Geralmente já embutida\"], [\"Controle sobre o ambiente\", \"Total\", \"Limitado ao que o serviço expõe\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Quando uma máquina só não basta: orquestração\n\nCom uma aplicação só, uma VPS ou um serviço gerenciado resolve. Quando o cenário cresce (muitos containers, várias máquinas, precisa reiniciar sozinho se cair, escalar sozinho se o tráfego subir), entra em cena orquestração, e o nome mais conhecido é **Kubernetes**. Ele não substitui o Docker: ele gerencia containers Docker (ou compatíveis) rodando em escala, num cluster de máquinas. É assunto pra uma trilha inteira à parte, mas vale reconhecer a peça:"
+                    },
+                    {
+                        "type": "code",
+                        "value": "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: minha-api\nspec:\n  replicas: 3\n  selector:\n    matchLabels:\n      app: minha-api\n  template:\n    metadata:\n      labels:\n        app: minha-api\n    spec:\n      containers:\n        - name: minha-api\n          image: seunome/minha-api:1.4.0\n          ports:\n            - containerPort: 3000"
+                    },
+                    {
+                        "type": "text",
+                        "value": "Perceba o `image: seunome/minha-api:1.4.0`: é a mesma imagem publicada na aula passada, e `replicas: 3` pede três containers dela rodando ao mesmo tempo, o Kubernetes é quem garante isso.\n\n## Recapitulando a trilha inteira\n\n- **Módulo 1**: por que empacotar em containers, o fim do \"na minha máquina funciona\"\n- **Módulo 2**: escrever um Dockerfile e construir sua primeira imagem\n- **Módulo 3**: o dia a dia com containers, imagens e o registry\n- **Módulo 4**: volumes, pra dado sobreviver além do container\n- **Módulo 5**: Docker Compose, subindo vários serviços com um comando\n- **Módulo 6**: sua API de verdade conversando com Postgres e Redis containerizados\n- **Módulo 7**: imagem enxuta (multi-stage, base pequena), segura (sem root, sem segredo) e publicada num registry"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O próximo estágio: CI/CD & Cloud\n\nTudo que você fez na mão nesse módulo (build, tag, push) é exatamente o que um pipeline de CI/CD automatiza: a cada `git push`, ele builda a imagem, roda os testes (lembra da trilha de testes?) e publica no registry sozinho, sem depender de alguém lembrar de rodar os comandos certos na ordem certa. Esse é o próximo estágio do roadmap de Back-end: CI/CD & Cloud."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "De um Dockerfile de três linhas até uma imagem versionada, segura e publicada: o container virou a unidade que sai da sua máquina e chega igual em produção. O próximo passo é parar de fazer isso na mão."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Além de uma VPS com Docker instalado, onde mais uma imagem pode rodar em produção?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Num serviço gerenciado de nuvem, que cuida do servidor por trás pra você.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Só dentro do próprio Docker Hub, que também executa as imagens hospedadas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Direto no navegador do usuário final, sem nenhum servidor envolvido.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Em qualquer editor de código que tenha a extensão do Docker instalada.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O que é Kubernetes, de forma resumida?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Uma ferramenta que orquestra containers rodando em várias máquinas.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um substituto do Docker, usado pra construir imagens do zero.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um registry de imagens alternativo ao Docker Hub tradicional.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um comando do Compose usado pra subir vários containers de vez.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual a principal diferença entre rodar numa VPS própria e num serviço gerenciado de nuvem?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Na VPS você cuida do servidor; no gerenciado, o provedor cuida por você.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Na VPS a imagem precisa ser reconstruída localmente antes de cada deploy.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Serviços gerenciados não aceitam imagens vindas do Docker Hub público.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Numa VPS o container roda sem passar por nenhuma virtualização.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O time automatizou build, tag e push pra rodar sozinho a cada commit. Isso é o que a próxima etapa do roadmap, CI/CD, resolve?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Sim, um pipeline de CI/CD repete build, tag e push a cada mudança.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Não, CI/CD só roda os testes, o push da imagem continua manual.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não, isso exige migrar direto pro Kubernetes, CI/CD não participa.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Sim, mas só substitui o build, o push continua sendo manual.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que a trilha de Docker vem antes da trilha de CI/CD & Cloud no roadmap?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Porque CI/CD automatiza os passos manuais aprendidos aqui: build, tag, push.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque CI/CD só funciona com imagens publicadas há meses no registry.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o Kubernetes exige o Compose instalado antes de qualquer pipeline.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque ferramentas de CI/CD nunca conseguem instalar o Docker sozinhas.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+];
+
+async function seed() {
+    let [trilha] = await db.select().from(trails).where(eq(trails.name, NOME));
+    if (!trilha) {
+        [trilha] = await db
+            .insert(trails)
+            .values({ name: NOME, trailLevel: LEVEL, description: DESCRICAO })
+            .returning();
+        console.log("Trilha criada: " + trilha.name);
+    }
+
+    const existentes = await db.select().from(lessons).where(eq(lessons.trailId, trilha.id));
+    if (existentes.length > 0) {
+        console.log("Trilha " + NOME + " ja tem " + existentes.length + " aulas. Nada a fazer.");
+        return;
+    }
+
+    let totalAulas = 0;
+    let totalQuestoes = 0;
+    for (let mi = 0; mi < MODULOS.length; mi++) {
+        const m = MODULOS[mi];
+        const [mod] = await db
+            .insert(modules)
+            .values({ trailId: trilha.id, title: m.titulo, position: mi + 1 })
+            .returning();
+        for (let li = 0; li < m.aulas.length; li++) {
+            const a = m.aulas[li];
+            const [lesson] = await db
+                .insert(lessons)
+                .values({
+                    trailId: trilha.id,
+                    moduleId: mod.id,
+                    title: a.titulo,
+                    content: null,
+                    contentBlocks: a.blocks,
+                    position: li + 1,
+                    published: true,
+                })
+                .returning();
+            for (let qi = 0; qi < a.questions.length; qi++) {
+                const q = a.questions[qi];
+                const [questao] = await db
+                    .insert(questions)
+                    .values({
+                        lessonId: lesson.id,
+                        statement: q.statement,
+                        difficulty: q.difficulty,
+                        position: qi + 1,
+                    })
+                    .returning();
+                await db.insert(questionOptions).values(
+                    q.options.map((o, k) => ({
+                        questionId: questao.id,
+                        text: o.text,
+                        isCorrect: o.isCorrect,
+                        position: k + 1,
+                    })),
+                );
+            }
+            totalAulas++;
+            totalQuestoes += a.questions.length;
+        }
+    }
+    console.log("Seed concluido: " + MODULOS.length + " modulos, " + totalAulas + " aulas, " + totalQuestoes + " questoes.");
+}
+
+seed()
+    .then(() => process.exit(0))
+    .catch((e) => {
+        console.error("Falha no seed:", e);
+        process.exit(1);
+    });

--- a/backend/scripts/seed-trilha-testes-qualidade.ts
+++ b/backend/scripts/seed-trilha-testes-qualidade.ts
@@ -1,0 +1,5190 @@
+// Seed da trilha Testes e Qualidade (intermediario), estagio 7 do roadmap de Back-end.
+// Idempotente e nao destrutivo: se a trilha ja tiver aulas, nao faz nada.
+//
+// Rodar em prod: docker compose -f docker-compose.prod.yml exec -T backend node scripts/seed-trilha-testes-qualidade.ts
+import { db } from "../db.ts";
+import { trails, modules, lessons, questions, questionOptions } from "../schema.ts";
+import { eq } from "drizzle-orm";
+
+const NOME = "Testes e Qualidade";
+const LEVEL: "iniciante" | "intermediario" | "avancado" = "intermediario";
+const DESCRICAO =
+    "Garanta que seu back-end continua correto quando o código muda: testes unitários e de integração, mocks, TDD, cobertura, testes end-to-end, e a qualidade além dos testes (lint, formatação, tipos). A rede de segurança da sua aplicação.";
+
+type Bloco = { type: "text" | "code" | "quote" | "table"; value: string };
+type Questao = {
+    statement: string;
+    difficulty: "facil" | "medio" | "dificil";
+    options: { text: string; isCorrect: boolean }[];
+};
+type Aula = { titulo: string; blocks: Bloco[]; questions: Questao[] };
+type Modulo = { titulo: string; aulas: Aula[] };
+
+const MODULOS: Modulo[] = [
+    {
+        "titulo": "Módulo 1 - Por que testar e a pirâmide de testes",
+        "aulas": [
+            {
+                "titulo": "O que os testes te dão (e o custo de não testar)",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Por que testar (e o que custa não testar)\n\nVocê já construiu APIs com Express, modelou banco de dados, implementou autenticação com JWT e até cache com o padrão cache-aside. Seu código funciona. Mas ele vai continuar funcionando depois que alguém (você mesmo, daqui a três meses) mexer nele de novo?\n\nÉ essa pergunta que os testes automatizados respondem. Não são um extra burocrático: são a diferença entre mudar código com confiança e mudar código torcendo para não quebrar nada."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Confiança pra mudar sem medo\n\nTodo sistema em produção precisa mudar: corrigir bug, adicionar campo, trocar biblioteca, otimizar uma query lenta. Sem testes, cada mudança é um salto no escuro. Você mexe numa função do middleware de autenticação e fica se perguntando: será que ainda bloqueia token expirado? O cache-aside ainda invalida a chave certa depois da alteração?\n\nCom uma suíte de testes, essa pergunta tem resposta objetiva: roda o comando e em segundos sabe se algo quebrou. A confiança não vem de \"eu revisei com cuidado\", vem de \"o computador checou de novo, em todos os cenários que a gente já cobriu antes\"."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Pegar regressão: o que quebrou sem querer\n\nRegressão é quando uma mudança nova quebra algo que já funcionava. É o clássico consertar uma coisa e quebrar outras três sem perceber. Sem testes, regressão só aparece quando alguém, geralmente um usuário, esbarra nela em produção.\n\nUm teste automatizado funciona como uma trava: se o comportamento esperado muda sem intenção, o teste fica vermelho antes do código chegar em produção. É o que separa \"eu acho que não quebrei nada\" de \"eu sei que não quebrei nada\"."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Documentação viva\n\nTestes bem escritos também documentam como usar o código, e essa documentação não fica desatualizada: se o comportamento mudar e o teste não acompanhar, o teste quebra. Um README pode mentir depois de um tempo. Um teste que passa não mente.\n\nVeja um exemplo: uma função que valida se uma senha é forte o suficiente pro cadastro de usuário, e o teste que documenta exatamente essa regra."
+                    },
+                    {
+                        "type": "code",
+                        "value": "// src/utils/senha.js\nexport function senhaEhForte(senha) {\n  return senha.length >= 8 && /[0-9]/.test(senha) && /[A-Z]/.test(senha);\n}\n\n// src/utils/senha.test.js\nimport { describe, it, expect } from 'vitest';\nimport { senhaEhForte } from './senha.js';\n\ndescribe('senhaEhForte', () => {\n  it('aceita senha com 8+ caracteres, número e maiúscula', () => {\n    expect(senhaEhForte('Segredo123')).toBe(true);\n  });\n\n  it('rejeita senha com menos de 8 caracteres', () => {\n    expect(senhaEhForte('Ab1')).toBe(false);\n  });\n\n  it('rejeita senha sem número', () => {\n    expect(senhaEhForte('SenhaForte')).toBe(false);\n  });\n});"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O custo de não testar\n\nSem testes automatizados, três coisas acontecem, quase sempre nessa ordem:\n\n- **Medo de mexer**: o time evita refatorar ou melhorar código antigo porque ninguém tem certeza do que pode quebrar. O código \"funciona, não encosta\".\n- **Bug em produção**: o que não foi checado antes do deploy é checado depois, pelo usuário. Corrigir um bug que já afetou gente de verdade custa muito mais caro do que pegar ele antes.\n- **Testar tudo na mão, toda vez**: cada mudança pequena vira uma rodada de reteste manual em cada fluxo afetado (login, cadastro, checkout), repetindo à mão o roteiro que um script rodaria em segundos.\n\nNão testar não é economizar tempo. É empurrar o mesmo tempo pra frente, com juros."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Testes automatizados não existem pra provar que o código está perfeito. Existem pra avisar rápido quando ele deixa de fazer o que deveria."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual das opções abaixo é um benefício direto de ter uma suíte de testes automatizados?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Detectar rapidamente quando uma mudança quebrou um comportamento existente",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Eliminar por completo a necessidade de revisão de código antes do deploy",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Garantir que o código nunca vai ter nenhum tipo de bug em produção",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Substituir toda a documentação técnica escrita pela equipe do projeto",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "No contexto de testes automatizados, o que é uma regressão?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Algo que já funcionava e passou a falhar depois de uma mudança no código",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um teste que demora mais tempo que o esperado pra terminar de rodar",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma função do sistema que nunca foi coberta por nenhum teste automatizado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um erro de sintaxe que impede o projeto de ser iniciado ou compilado",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um colega diz que não precisa escrever testes porque o README já explica como cada função deve ser usada. Qual é o problema principal desse argumento?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O README pode desatualizar sem ninguém notar, mas o teste acusa a mudança",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "READMEs escritos em markdown perdem informação técnica importante do projeto",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Testes automatizados são sempre mais rápidos de escrever do que um README completo",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ferramentas de teste como o Vitest não conseguem ler arquivos README do projeto",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de meses sem escrever nenhum teste, o time passa a evitar mexer em partes antigas do sistema, mesmo havendo bugs claros pra corrigir. Isso ilustra diretamente qual custo de não testar?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O medo de mexer no código, porque ninguém tem certeza do que pode quebrar",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A obrigação de reescrever o sistema inteiro numa linguagem diferente",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A necessidade de contratar mais desenvolvedores pro mesmo projeto",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O aumento do tempo de resposta da API em produção",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Dizer que testes automatizados dão confiança pra mudar o código significa, com precisão, que:",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O time sabe rápido se um comportamento já coberto por teste deixou de funcionar",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O código testado nunca mais vai precisar de correção depois de ir pra produção",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Toda mudança futura no sistema passa a dispensar qualquer revisão humana",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A cobertura de testes garante que não existe bug em nenhuma parte do sistema",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Manual x automatizado",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Testar na mão: o que parece bastar no começo\n\nNo início de um projeto, testar na mão funciona bem: você sobe o servidor, chama o endpoint pelo Postman ou Insomnia, olha a resposta, confere se o status e o corpo vieram certos. Poucos endpoints, poucas regras, roteiro curto. É rápido de fazer e não parece exigir nenhum investimento extra."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Por que não escala\n\nO projeto cresce: mais endpoints, mais regras de negócio, mais combinações de entrada pra checar. Repetir o mesmo roteiro manual a cada mudança pequena começa a tomar um tempo desproporcional. E tempo apertado é exatamente quando passos começam a ser pulados: \"essa parte eu não mudei, deve estar ok\" é como bug conhecido vira bug em produção.\n\nTestar na mão não escala porque o esforço cresce junto com o sistema, enquanto a paciência (e o tempo disponível) do time não."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Aspecto\",\"Manual\",\"Automatizado\"],[\"Velocidade por execução\",\"Lenta, depende de alguém clicar ou chamar a API\",\"Rápida, roda em segundos\"],[\"Repetição\",\"Cansa e induz a pular passo\",\"Executa sempre o mesmo roteiro, sem pular nada\"],[\"Quando roda\",\"Só quando alguém lembra de rodar\",\"Pode rodar a cada commit, no CI\"],[\"Casos de borda\",\"Tende a cobrir só o caminho feliz\",\"Cobre os casos raros, se estiverem escritos\"],[\"Custo no início\",\"Baixo, não precisa escrever nada\",\"Mais alto, precisa escrever o teste\"],[\"Custo ao longo do tempo\",\"Cresce a cada nova mudança no sistema\",\"Se mantém baixo, o teste já existe\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que o automatizado resolve\n\nUm teste automatizado repete exatamente os mesmos passos, sempre, sem cansar e sem esquecer o caso estranho que só acontece \"às vezes\". Ele pode rodar a cada commit, integrado ao CI, sem depender de alguém lembrar de testar. O ganho não é só velocidade: é consistência. O teste não tem um dia ruim."
+                    },
+                    {
+                        "type": "code",
+                        "value": "// Isso é o que você faria na mão pra testar o endpoint de login:\ncurl -X POST http://localhost:3000/login -H \"Content-Type: application/json\" -d '{\"email\":\"ana@exemplo.com\",\"senha\":\"123456\"}'\n\n// E depois conferir a resposta na mão: status, token no corpo... de novo a cada mudança.\n\n// O mesmo teste, automatizado com supertest:\nimport { describe, it, expect } from 'vitest';\nimport request from 'supertest';\nimport { app } from '../app.js';\n\ndescribe('POST /login', () => {\n  it('retorna 200 e um token quando as credenciais são válidas', async () => {\n    const resposta = await request(app)\n      .post('/login')\n      .send({ email: 'ana@exemplo.com', senha: '123456' });\n\n    expect(resposta.status).toBe(200);\n    expect(resposta.body.token).toBeDefined();\n  });\n});"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Manual não desaparece, só muda de papel\n\nTeste manual continua tendo lugar, só que em outro tipo de trabalho: testes exploratórios (mexer no sistema sem roteiro fixo, tentando achar o que ninguém previu), avaliação de usabilidade, checagem de uma funcionalidade nova e ainda instável. O que muda é que o roteiro repetitivo e previsível (esse fluxo ainda retorna 200 depois do refactor?) deixa de fazer sentido ser feito à mão toda vez.\n\nA régua é simples: se o passo a passo é sempre o mesmo, automatiza. Se depende de julgamento humano sobre a experiência, continua manual."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Testar na mão prova que funcionou uma vez, num computador, num dia. Testar automatizado prova que continua funcionando, toda vez, em qualquer lugar."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Por que testar manualmente cada funcionalidade a cada mudança no código não escala num projeto que cresce?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Porque o tempo gasto testando na mão cresce junto com o número de funcionalidades",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque ferramentas como o Postman não conseguem testar rotas protegidas por JWT",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o Express não permite mais de uma rota sendo testada no mesmo dia",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque testes manuais só funcionam em ambientes de desenvolvimento local",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual é uma vantagem direta de um teste automatizado sobre um teste manual?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Ele repete exatamente os mesmos passos toda vez que é executado",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Ele nunca mais precisa ser atualizado depois de escrito uma vez",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ele substitui a necessidade de qualquer teste exploratório no projeto",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ele decide sozinho quais funcionalidades o time deveria construir",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Perto do prazo de entrega, o time decide pular a checagem manual de alguns fluxos secundários do sistema pra ganhar tempo. Que risco isso ilustra sobre o teste manual?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Sob pressão, passos do roteiro manual são pulados e casos deixam de ser checados",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O ambiente de testes manuais fica indisponível perto de prazos de entrega",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Fluxos secundários não podem ser testados de forma manual em nenhuma situação",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A equipe perde acesso ao código-fonte quando o prazo está próximo",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de automatizar os testes do fluxo de checkout, o time ainda acha útil, de vez em quando, alguém testar esse fluxo na mão. Em que situação isso faz mais sentido?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Pra avaliar a experiência de uso, algo que um teste automatizado não julga",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Pra substituir os testes automatizados que já existem pra esse mesmo fluxo",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Pra reduzir o número de vezes que o teste automatizado roda no CI",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Pra evitar ter que escrever testes automatizados em fluxos futuros",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um projeto tem uma suíte automatizada robusta, mas o time também mantém uma rotina de exploração manual sem roteiro fixo antes de todo lançamento grande. Por que isso não é contraditório?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Teste automatizado segue um roteiro fixo, testar sem roteiro acha problema que ninguém previu",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Teste automatizado só funciona em ambiente de desenvolvimento, nunca perto de um lançamento",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A rotina manual serve só pra confirmar que o CI executou os testes automatizados",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Testes automatizados perdem a validade sempre que uma versão nova é lançada",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "A pirâmide de testes",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Três níveis, um objetivo\n\nNem todo teste automatizado olha pro sistema do mesmo jeito. Um teste pode focar numa função isolada, numa rota inteira conversando com o banco, ou no fluxo completo que um usuário faria no navegador. Esses são os três níveis clássicos: **unitário**, **integração** e **end-to-end (e2e)**. Cada um pega um tipo diferente de problema, e entender a diferença evita escrever o teste errado no lugar errado."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Teste unitário: a base\n\nTesta uma unidade de código isolada, geralmente uma função ou um método, sem tocar banco de dados, rede ou sistema de arquivos. Dependências externas são trocadas por versões falsas (você vai ver isso em detalhe no módulo de mocks). Por rodar só em memória, um teste unitário roda em milissegundos, o que permite ter centenas ou milhares deles numa suíte sem o tempo de execução explodir."
+                    },
+                    {
+                        "type": "code",
+                        "value": "// src/utils/desconto.js\nexport function calcularTotalComDesconto(precoTotal, percentualDesconto) {\n  if (percentualDesconto < 0 || percentualDesconto > 100) {\n    throw new Error('Percentual de desconto inválido');\n  }\n  return precoTotal - (precoTotal * percentualDesconto) / 100;\n}\n\n// src/utils/desconto.test.js\nimport { describe, it, expect } from 'vitest';\nimport { calcularTotalComDesconto } from './desconto.js';\n\ndescribe('calcularTotalComDesconto', () => {\n  it('aplica o percentual de desconto sobre o preço total', () => {\n    expect(calcularTotalComDesconto(200, 10)).toBe(180);\n  });\n\n  it('lança erro quando o percentual é inválido', () => {\n    expect(() => calcularTotalComDesconto(200, 150)).toThrow();\n  });\n});"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Teste de integração: o meio\n\nTesta várias peças do sistema funcionando juntas: a rota do Express, o service com a lógica, o banco de dados (uma instância de teste, não a de produção). É o nível que pega problema que um teste unitário não vê, como uma query SQL errada ou um middleware de autenticação que não está sendo aplicado na rota certa. Como toca banco de verdade, é mais lento que o unitário, e a suíte tem bem menos testes desse tipo. O módulo 4 é inteiro sobre esse nível.\n\n## Teste end-to-end: o topo\n\nTesta o fluxo inteiro do jeito que o usuário viveria: cadastro, login, criar um recurso, ver ele aparecer na tela, tudo em sequência, muitas vezes passando pelo navegador de verdade. É o nível mais lento e mais caro de manter, então fica reservado pros fluxos mais críticos do sistema. O módulo 6 entra nesse nível com mais detalhe."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Nível\",\"O que testa\",\"Quantidade\",\"Velocidade\"],[\"Unitário\",\"Uma função ou unidade isolada, sem dependências reais\",\"Muitos\",\"Muito rápida (milissegundos)\"],[\"Integração\",\"Peças juntas, como rota, service e banco de teste\",\"Uma quantidade média\",\"Média (dezenas a centenas de ms)\"],[\"E2E\",\"O fluxo inteiro, do jeito que o usuário usa o sistema\",\"Poucos\",\"Lenta (segundos)\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Por que a base é larga\n\nA pirâmide tem essa forma, base larga e topo estreito, por causa do custo. Um teste unitário é barato: rápido de escrever, rápido de rodar, e quando falha aponta quase direto pra linha com o problema. Um teste e2e é caro: mais lento, mais frágil (depende de mais peças funcionando ao mesmo tempo, incluindo rede e às vezes navegador), e quando falha é mais difícil saber qual das muitas peças envolvidas causou o problema.\n\nPor isso a estratégia é: muitos testes unitários cobrindo a lógica de cada peça, uma quantidade média de integração confirmando que as peças se encaixam, e só um punhado de e2e confirmando que os fluxos mais importantes funcionam de ponta a ponta. Uma suíte com a pirâmide invertida (poucos unitários, muitos e2e) tende a ficar lenta e instável, e até ganhou apelido: casquinha de sorvete."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "A pirâmide não diz qual teste é melhor. Diz onde cada um vale o custo: rápido e barato na base, completo e caro no topo."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Na pirâmide de testes, qual nível fica na base, com a maior quantidade de testes?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "O nível unitário, que testa uma função ou unidade isolada",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O nível de integração, que testa rota, service e banco juntos",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O nível end-to-end, que testa o fluxo inteiro pelo usuário",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O nível de aceitação, que testa a documentação da API",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que um teste unitário roda tão mais rápido que um teste end-to-end?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Porque não toca banco, rede ou disco, só a unidade isolada em memória",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o Vitest executa testes unitários num servidor diferente do e2e",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque testes unitários não verificam o valor retornado pela função",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o navegador não participa da execução de nenhum teste automatizado",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um teste falha depois de uma alteração no service que calcula o frete. O teste unitário da função de cálculo continua verde, mas o teste de integração da rota /pedido fica vermelho. O que isso sugere primeiro?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O problema está mais na forma como a rota usa o service, não no cálculo",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O teste unitário está desatualizado e não reflete mais a regra de negócio",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O banco de dados de teste perdeu a conexão durante a execução da suíte",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Vitest não conseguiu carregar o arquivo de configuração do projeto",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um time decide escrever a suíte majoritariamente com testes end-to-end, com poucos unitários. Depois de alguns meses, a suíte demora 40 minutos pra rodar e falha de forma intermitente. Que problema clássico isso ilustra?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "A pirâmide invertida, poucos testes rápidos na base e muitos lentos no topo",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A falta de um banco de dados dedicado só para os testes de integração",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A ausência completa de testes manuais complementando a suíte automatizada",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um erro de configuração do Vitest que impede testes de rodar em paralelo",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que normalmente não faz sentido testar todas as variações de uma regra de negócio só no nível end-to-end, mesmo que isso também cubra a função por baixo?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Porque cada variação testada em e2e paga o custo total do fluxo, ficando lenta",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque testes e2e não têm acesso às mesmas regras de negócio que os unitários",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque ferramentas de e2e como Playwright não suportam múltiplos casos de teste",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o resultado de um teste end-to-end não pode ser verificado com expect",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "O que vale a pena testar",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Nem tudo merece o mesmo teste\n\nVocê não tem tempo infinito, e testar tudo com o mesmo cuidado não é o objetivo, é usar mal o tempo. A pergunta certa não é \"isso está testado?\", é \"o que acontece se isso quebrar, e vale a pena garantir que não quebre?\". Tem código que carrega uma regra de negócio importante e merece atenção grande. Tem código simples demais pra justificar o esforço."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que vale testar: lógica de negócio\n\nRegra de negócio é qualquer decisão que o sistema toma que, se estiver errada, causa dano real: calcular o valor de um pedido errado, deixar um usuário sem permissão acessar um recurso, aceitar um cadastro com dado inválido, autorizar um desconto que não deveria existir. É o tipo de código que muda com frequência (a regra muda porque o negócio muda) e que, se quebrar, ninguém percebe até o prejuízo aparecer. Isso inclui cálculo, validação, transição de estado (um pedido que vai de \"pendente\" pra \"pago\") e qualquer condicional que decide o que o sistema vai fazer."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Casos de borda: onde o bug mora\n\nCasos de borda são as entradas nos extremos ou fora do esperado: lista vazia, número zero ou negativo, string vazia, valor nulo, o limite exato de uma regra (desconto de exatamente 100%), muitos itens de uma vez. Ninguém escreve calcularTotalComDesconto(200, 10) errado. É calcularTotalComDesconto(200, -5) ou calcularTotalComDesconto(200, 100) que revelam se a função está preparada pra realidade, não só pro exemplo bonito do caminho feliz."
+                    },
+                    {
+                        "type": "code",
+                        "value": "// src/utils/desconto.test.js (continuando o exemplo da aula anterior)\nimport { describe, it, expect } from 'vitest';\nimport { calcularTotalComDesconto } from './desconto.js';\n\ndescribe('calcularTotalComDesconto: casos de borda', () => {\n  it('aceita desconto de 0%, o total não muda', () => {\n    expect(calcularTotalComDesconto(200, 0)).toBe(200);\n  });\n\n  it('aceita desconto de 100%, o total fica zero', () => {\n    expect(calcularTotalComDesconto(200, 100)).toBe(0);\n  });\n\n  it('rejeita desconto negativo', () => {\n    expect(() => calcularTotalComDesconto(200, -5)).toThrow();\n  });\n\n  it('rejeita desconto acima de 100%', () => {\n    expect(() => calcularTotalComDesconto(200, 150)).toThrow();\n  });\n});"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que geralmente não precisa de teste\n\nUm getter trivial, que só devolve uma propriedade de um objeto sem nenhuma lógica no meio, raramente vale o teste: se ele quebrar, é porque o próprio JavaScript quebrou. Vale o mesmo pra código de configuração estática (uma lista de constantes) e pra código de biblioteca que não é seu, como confirmar que o Express registra uma rota (isso já é responsabilidade de quem mantém o Express).\n\nIsso não é uma regra fixa pra sempre: uma função que hoje só devolve usuario.nome e amanhã passa a formatar o nome ou aplicar uma regra de capitalização deixou de ser trivial, e nesse momento passa a valer um teste."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"O que é\",\"Vale testar de perto?\",\"Por quê\"],[\"Cálculo de preço com desconto e imposto\",\"Sim\",\"Errar aqui custa dinheiro de verdade\"],[\"Validação de dado de entrada de um cadastro\",\"Sim\",\"Dado inválido que passa vira problema lá na frente\"],[\"Caso de borda de uma regra (zero, negativo, limite)\",\"Sim\",\"É onde a maioria dos bugs reais aparece\"],[\"Getter que só devolve uma propriedade do objeto\",\"Não\",\"Não existe lógica ali pra quebrar\"],[\"Lista de constantes ou configuração estática\",\"Não\",\"Não toma nenhuma decisão\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Teste o que decide, calcula ou valida. Não teste o que só repassa um valor sem pensar."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual das opções abaixo é um exemplo de lógica de negócio que vale a pena testar?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Uma função que calcula o valor final de um pedido aplicando desconto e imposto",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Uma função que só devolve o valor da propriedade email de um objeto usuário",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma lista fixa de constantes com os nomes de todos os estados brasileiros",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um arquivo de configuração que define a porta em que o servidor sobe",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que um getter trivial, que só retorna uma propriedade do objeto sem nenhuma lógica, geralmente não precisa de teste?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Porque não existe nenhuma decisão ou cálculo ali que possa estar errado",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o Vitest não testa bem funções que retornam um valor simples",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque getters não fazem parte da lógica de negócio de nenhum sistema",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque testar um getter sempre deixa a suíte de testes mais lenta",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Você revisa os testes de um CRUD de produtos e vê um teste extenso pra função getNomeProduto(produto), que só faz return produto.nome, mas nenhum teste pra função que calcula o preço com imposto. O que essa priorização tem de errado?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O tempo foi gasto testando algo sem lógica, deixando o cálculo sem cobertura",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Getters nunca deveriam existir em nenhum CRUD de produtos bem projetado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Funções de cálculo de imposto não podem ser testadas com Vitest da forma usual",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O problema é só de nomenclatura, a função deveria se chamar de outro jeito",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Numa função que calcula parcelas de um pagamento, um bug em produção só aconteceu quando o valor total era exatamente divisível pelo número de parcelas, sem sobrar centavo. Que tipo de caso esse bug representa?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Um caso de borda da regra de negócio que os testes não tinham coberto",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um erro de sintaxe que o Vitest deveria ter impedido de rodar",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma falha de configuração do banco de dados usado em produção",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um problema exclusivo de teste end-to-end, e não de lógica de negócio",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma função formatarStatusPedido(status) só faz um switch que traduz um código interno ('P', 'E', 'C') pro texto em português (Pendente, Enviado, Cancelado), sem nenhum outro cálculo. Ela merece teste automatizado?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Sim, um mapeamento código-texto errado também é uma regra que pode falhar",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Não, qualquer função com switch é considerada trivial e não precisa de teste",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Sim, mas só se a função também acessar o banco de dados em algum momento",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não, funções de formatação de texto não fazem parte da lógica de negócio",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Como um teste se parece e como rodar",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Antes de escrever, vamos olhar\n\nNos próximos módulos você vai escrever dezenas de testes: unitários, com mock, de integração com banco de verdade. Antes disso, vale conhecer a forma que um teste tem, por cima, e como ele roda no dia a dia. Isso tira o mistério antes de entrar no detalhe."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Anatomia por cima: describe, it, expect\n\nUm arquivo de teste com Vitest normalmente tem três peças:\n\n- **describe**: agrupa testes relacionados, geralmente todos os testes de uma mesma função ou módulo. É só organização, não é obrigatório.\n- **it** (ou test, são sinônimos no Vitest): descreve um comportamento específico, quase em português direto, tipo \"rejeita senha sem número\" ou \"retorna 404 quando o usuário não existe\".\n- **expect**: a afirmação em si. Pega o resultado que o código produziu e compara com o que era esperado, usando um matcher como toBe ou toEqual (a lista completa vem no módulo 2).\n\nO módulo 2 entra fundo em cada peça. Por agora, o que importa é reconhecer o formato quando você ver."
+                    },
+                    {
+                        "type": "code",
+                        "value": "import { describe, it, expect } from 'vitest';\nimport { senhaEhForte } from './senha.js';\n\n// describe agrupa: \"tudo isso aqui é sobre a função senhaEhForte\"\ndescribe('senhaEhForte', () => {\n\n  // cada it é um comportamento específico, com nome que se lê quase como frase\n  it('aceita senha com 8+ caracteres, número e maiúscula', () => {\n    const resultado = senhaEhForte('Segredo123');\n\n    // expect compara o resultado com o que era esperado\n    expect(resultado).toBe(true);\n  });\n\n  it('rejeita senha curta', () => {\n    expect(senhaEhForte('Ab1')).toBe(false);\n  });\n});"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Verde ou vermelho: o veredito\n\nQuando a suíte roda, cada it só termina de dois jeitos: passou (verde) ou falhou (vermelho). Não tem meio termo. Quando passa, o terminal mostra um resumo rápido. Quando falha, o Vitest mostra exatamente qual expect não bateu, o valor esperado e o valor que realmente veio, lado a lado. É esse veredito binário, com mensagem de erro clara, que faz o teste funcionar como alarme: não deixa dúvida sobre se algo quebrou."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Onde os testes ficam no projeto\n\nDuas convenções são comuns, e o Vitest reconhece as duas sem configuração extra:\n\n- **Ao lado do arquivo que testam**: senha.js e senha.test.js na mesma pasta. É a convenção mais comum em projeto Node hoje, porque fica fácil achar o teste de uma função.\n- **Numa pasta separada**: uma pasta tests/ ou __tests__/ espelhando a estrutura de src/.\n\nO que importa é o nome do arquivo: terminando em .test.js (ou .spec.js), o Vitest encontra e roda sozinho, sem precisar listar arquivo por arquivo."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# Roda a suíte inteira uma vez e encerra\nnpx vitest run\n\n# Modo watch: fica de olho nos arquivos e roda de novo a cada mudança salva\nnpx vitest\n\n# Roda só os testes de um arquivo ou pasta específica\nnpx vitest run src/utils/senha.test.js\n\n# Roda com relatório de cobertura (quanto do código os testes exercitam)\nnpx vitest run --coverage\n\n# Se o package.json tiver \"test\": \"vitest\" nos scripts, o mesmo comando fica:\nnpm test"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Um teste é uma frase: describe isso, it faz aquilo, expect que o resultado seja este. A forma se repete, só o conteúdo muda."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "No Vitest, qual é a função do describe num arquivo de teste?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Agrupar testes relacionados, geralmente da mesma função ou módulo",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Executar o código de produção antes de cada teste começar",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Definir qual matcher será usado dentro de cada bloco it do arquivo",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Substituir o expect quando o teste não precisa de nenhuma asserção",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de rodar a suíte, um teste aparece em vermelho no terminal. O que isso indica?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Que o valor recebido não bateu com o valor esperado no expect",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Que o arquivo de teste tem algum problema de formatação de código",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que o Vitest não encontrou teste nenhum pra executar naquele arquivo",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que a suíte inteira está rodando mais lenta do que o configurado",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Você cria o arquivo src/utils/frete.js com uma função nova e escreve os testes num arquivo chamado src/utils/frete.spec.js, na mesma pasta. Ao rodar npx vitest, o que acontece?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O Vitest encontra e roda o arquivo normalmente, porque reconhece o sufixo spec.js",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O Vitest ignora o arquivo, porque só reconhece nomes terminados em test.js",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Vitest lança um erro, porque teste e código não podem ficar na mesma pasta",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Vitest roda o arquivo, mas não mostra o resultado de cada it separado",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um novo integrante do time abre o projeto e não sabe qual comando roda os testes uma única vez, sem ficar em watch mode, e encerra sozinho. Qual comando resolve isso?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "npx vitest run",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "npx vitest watch",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "npx vitest --once",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "npx vitest init",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um desenvolvedor remove todos os blocos describe de um arquivo de teste, deixando só os blocos it soltos, direto no arquivo. O que acontece quando a suíte roda?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Os testes continuam rodando normalmente, describe é só organização, não obrigatório",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O Vitest lança erro de sintaxe, porque todo it precisa estar dentro de um describe",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os testes rodam, mas nenhum expect dentro deles é avaliado de verdade",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Vitest agrupa os it automaticamente num describe implícito, com nome vazio",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 2 - Seu primeiro teste unitário",
+        "aulas": [
+            {
+                "titulo": "O que é um teste unitário e subir o Vitest",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Módulo 2 - Seu primeiro teste unitário\n\nVocê já construiu APIs com Express, modelou tabelas, protegeu rotas com JWT e colocou cache na frente de consultas pesadas. Chegou a hora de garantir que esse código continua funcionando quando alguém (inclusive você, seis meses depois) mexer nele. Isso começa pelo nível mais simples da pirâmide de testes: o teste unitário.\n\nO runner que vamos usar é o **Vitest**. Se você já cruzou com **Jest** em algum projeto, pode ficar tranquilo: a API é praticamente idêntica (`describe`, `it`, `expect`, os mesmos matchers), então boa parte do que vem a seguir vale pros dois. O Vitest só troca o motor por baixo (usa Vite) pra rodar mais rápido e integrar melhor com projetos modernos."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que é testar uma unidade\n\nUm teste unitário testa **uma unidade de código isolada**, geralmente uma função, sem depender de banco de dados, chamada de rede, sistema de arquivos ou qualquer outra parte do sistema. Se você tem uma função `ehValidoEmail(email)` que recebe uma string e devolve um booleano, testar ela isoladamente não exige subir o Express nem conectar no Postgres: basta chamar a função e conferir o resultado.\n\nIsso é diferente de testar a rota `POST /usuarios` inteira, que passa pelo middleware de auth, valida o corpo da requisição, grava no banco e devolve uma resposta HTTP. Isso é teste de integração, assunto do Módulo 4. Aqui o foco é menor e mais direto: uma função, uma entrada, uma saída esperada."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Por que isolar traz confiança\n\nIsolar a unidade tem efeitos bem práticos no dia a dia:\n\n- **Roda rápido**: sem banco nem rede, um teste unitário costuma levar milissegundos, então dá pra ter centenas deles rodando em poucos segundos.\n- **É confiável**: não depende do banco estar de pé ou da rede estar funcionando, então quando ele falha, a causa é o código, não o ambiente.\n- **Aponta o problema exato**: se `ehValidoEmail` quebrar, só o teste dela falha, sem arrastar outras dez partes do sistema junto."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# instala o Vitest como dependencia de desenvolvimento\nnpm install -D vitest\n\n# roda os testes do projeto\nnpx vitest"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Onde o arquivo de teste fica\n\nO Vitest reconhece automaticamente qualquer arquivo terminado em `.test.ts` (ou `.spec.ts`) no projeto, exceto dentro de `node_modules`. A convenção mais comum é colocar o teste ao lado do arquivo que ele testa, com o mesmo nome:\n\n- `src/utils/validacao.ts`\n- `src/utils/validacao.test.ts`\n\nAlguns times preferem centralizar tudo numa pasta `__tests__/`, mas para testes unitários pequenos, deixar o teste ao lado do arquivo original costuma facilitar achar as duas pontas rápido."
+                    },
+                    {
+                        "type": "code",
+                        "value": "// src/utils/validacao.test.ts\nimport { describe, it, expect } from \"vitest\";\n\ndescribe(\"primeiro teste\", () => {\n  it(\"soma dois numeros corretamente\", () => {\n    expect(1 + 1).toBe(2);\n  });\n});\n\n// depois de \"npm install -D vitest\", rode \"npx vitest\"\n// esse arquivo ja aparece verde no terminal"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Teste unitário testa uma função sozinha, sem banco e sem rede: por isso roda rápido e, quando falha, você já sabe exatamente onde olhar."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que caracteriza um teste unitário, como os que você vai escrever no Vitest?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Testa uma função isolada, sem tocar banco de dados ou rede",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Testa a aplicação inteira aberta dentro de um navegador real",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Testa a rota HTTP completa junto com o banco de produção",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Testa a tela clicando manualmente em cada botão do sistema",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual comando instala o Vitest como dependência de desenvolvimento do projeto?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "npm install -D vitest",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "npm install --global vitest",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "npx create-vitest-app",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "npm publish vitest --dev",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Você roda `npx vitest` no terminal e ele não termina sozinho, fica ali esperando. O que está acontecendo?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O Vitest entrou em watch mode e reroda a cada mudança salva",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O pacote foi instalado errado e precisa ser reinstalado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Falta criar um arquivo de configuração antes de rodar",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O terminal perdeu a conexão com o processo do Node",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual nome de arquivo o Vitest reconhece automaticamente como um arquivo de teste?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "validacao.test.ts, seguindo o sufixo que o Vitest procura",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "validacaoTests.ts, com a palavra Tests em algum ponto",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "test_validacao.ts, com prefixo e underline separando",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "validacao.unit.ts, usando unit como marcador do tipo",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Seu time usa Jest em outros projetos e você está começando um serviço novo com Vitest. O que é verdade sobre os dois?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "A API de describe, it e expect é quase idêntica entre eles",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Os dois usam sintaxes completamente diferentes entre si",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Vitest só roda em projetos que nunca usaram Jest antes",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Jest parou de funcionar e todo projeto precisa migrar",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "describe, it, expect: anatomia",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## As três peças de todo teste\n\nPraticamente todo teste que você vai escrever com Vitest usa a mesma gramática básica: `describe` agrupa testes relacionados, `it` (ou `test`) descreve um caso específico, e `expect` verifica se o resultado bateu com o esperado. São só essas três peças, e dá pra escrever a maior parte dos testes unitários combinando elas."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que cada peça faz\n\n- **describe(nome, funcao)**: cria uma suíte, um agrupamento de testes que compartilham o mesmo contexto (por exemplo, todos os testes da função `ehValidoEmail`).\n- **it(nome, funcao)** ou **test(nome, funcao)**: representa um caso concreto, com um nome que descreve o comportamento esperado. `it` e `test` são sinônimos: fazem exatamente a mesma coisa, é só escolha de estilo do time.\n- **expect(valor)**: recebe o resultado que você quer verificar, encadeado com um matcher (como `.toBe(2)`) que decide se o teste passa ou falha."
+                    },
+                    {
+                        "type": "code",
+                        "value": "// src/utils/validacao.ts\nexport function ehValidoEmail(email: string): boolean {\n  const regex = /^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$/;\n  return regex.test(email);\n}"
+                    },
+                    {
+                        "type": "code",
+                        "value": "// src/utils/validacao.test.ts\nimport { describe, it, expect } from \"vitest\";\nimport { ehValidoEmail } from \"./validacao\";\n\ndescribe(\"ehValidoEmail\", () => {\n  it(\"retorna true para um email valido\", () => {\n    expect(ehValidoEmail(\"ana@exemplo.com\")).toBe(true);\n  });\n\n  it(\"retorna false para um email sem arroba\", () => {\n    expect(ehValidoEmail(\"ana.exemplo.com\")).toBe(false);\n  });\n});"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Agrupando cenários com describe aninhado\n\nQuando uma função tem vários grupos de cenário (por exemplo, \"quando o email é válido\" e \"quando falta alguma parte\"), dá pra aninhar `describe` dentro de `describe` pra organizar a leitura. O nome de cada `it` também importa: prefira frases que descrevem o comportamento, como \"retorna false para um email sem arroba\", em vez de nomes genéricos como \"teste 1\" ou \"caso 2\". É esse nome que aparece no terminal quando o teste falha, e é ele que vai te dizer o que quebrou sem precisar abrir o arquivo."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "describe agrupa, it descreve um caso, expect verifica o resultado: a gramática básica que sustenta praticamente qualquer teste que você vai escrever."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual função do Vitest agrupa vários testes relacionados sob um mesmo nome?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "describe",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "expect",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "beforeAll",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "require",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Dentro de um it, qual função afirma que um valor bateu com o esperado?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "expect",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "describe",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "import",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "module",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um colega trocou it por test no mesmo teste: test(\"soma dois numeros\", () => {...}). O que muda ao rodar?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Nada muda, porque test e it são sinônimos na mesma API",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O Vitest ignora o bloco, porque test não existe ali",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O teste passa a rodar de forma assíncrona forçada",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Vitest passa a exigir um describe extra por fora",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que agrupar testes relacionados dentro de um describe ajuda na leitura do resultado?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "A saída do terminal fica organizada por suíte de teste",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O describe faz os testes rodarem sempre em paralelo",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Sem describe o Vitest recusa rodar qualquer arquivo",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O describe substitui a necessidade de escrever expect",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Você quer testar ehValidoEmail tanto no caso de email válido quanto no caso de domínio ausente, mantendo a leitura organizada por cenário. Qual estrutura faz mais sentido?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Um describe para a função com um it por cenário testado",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um único it gigante cobrindo todos os cenários juntos",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um arquivo de teste separado pra cada linha de código",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um describe vazio, com os cenários soltos no arquivo",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Matchers (toBe x toEqual, toThrow)",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## O matcher decide o que \"passar\" significa\n\nDepois do `expect(valor)`, o matcher é quem decide como a comparação é feita. Usar o matcher errado é uma das formas mais comuns de escrever um teste que passa sem provar nada de fato, ou que falha por um motivo que não tem relação nenhuma com o bug real."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## A pegadinha do toBe com objetos\n\n`toBe` compara por **referência**, o mesmo que o `===` do JavaScript faz: funciona perfeito com número, string e booleano, porque esses valores já são comparados pelo conteúdo mesmo com `===`. O problema aparece com objetos e arrays: dois objetos com o mesmo conteúdo, criados separadamente, são referências diferentes na memória, então `toBe` falha entre eles mesmo parecendo iguais. Pra comparar o **conteúdo** de um objeto ou array, o matcher certo é `toEqual`, que compara campo a campo."
+                    },
+                    {
+                        "type": "code",
+                        "value": "import { describe, it, expect } from \"vitest\";\n\ndescribe(\"toBe x toEqual\", () => {\n  it(\"toBe funciona direto com primitivos\", () => {\n    expect(2 + 2).toBe(4);\n  });\n\n  it(\"toEqual compara o conteudo de dois objetos diferentes\", () => {\n    const usuarioA = { nome: \"Ana\" };\n    const usuarioB = { nome: \"Ana\" };\n\n    expect(usuarioA).toEqual(usuarioB);\n    // expect(usuarioA).toBe(usuarioB) falharia: sao referencias diferentes\n  });\n});"
+                    },
+                    {
+                        "type": "code",
+                        "value": "// src/utils/matematica.ts\nexport function dividir(a: number, b: number): number {\n  if (b === 0) {\n    throw new Error(\"Nao e possivel dividir por zero\");\n  }\n  return a / b;\n}\n\n// src/utils/matematica.test.ts\nimport { describe, it, expect } from \"vitest\";\nimport { dividir } from \"./matematica\";\n\ndescribe(\"dividir\", () => {\n  it(\"lanca erro ao dividir por zero\", () => {\n    expect(() => dividir(10, 0)).toThrow();\n  });\n\n  it(\"divide normalmente quando o divisor nao e zero\", () => {\n    expect(dividir(10, 2)).toBe(5);\n  });\n});"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Matcher\", \"O que verifica\"], [\"toBe\", \"Igualdade estrita (===), ideal para números, strings e booleanos\"], [\"toEqual\", \"Igualdade de conteúdo, campo a campo, ideal para objetos e arrays\"], [\"toBeTruthy\", \"Se o valor é truthy (qualquer coisa que não seja false, 0, string vazia, null ou undefined)\"], [\"toBeFalsy\", \"Se o valor é falsy (false, 0, string vazia, null ou undefined)\"], [\"toBeNull\", \"Se o valor é exatamente null\"], [\"toThrow\", \"Se a função, chamada dentro de uma arrow function, lança um erro ao executar\"], [\"toContain\", \"Se um array contém um item, ou se uma string contém um trecho\"]]"
+                    },
+                    {
+                        "type": "code",
+                        "value": "// src/auth/permissoes.ts\nexport function permissoesDoUsuario(tipo: \"comum\" | \"admin\"): string[] {\n  return tipo === \"admin\" ? [\"leitura\", \"escrita\", \"exclusao\"] : [\"leitura\"];\n}\n\n// src/auth/permissoes.test.ts\nimport { describe, it, expect } from \"vitest\";\nimport { permissoesDoUsuario } from \"./permissoes\";\n\ndescribe(\"permissoesDoUsuario\", () => {\n  it(\"usuario comum tem a permissao de leitura\", () => {\n    expect(permissoesDoUsuario(\"comum\")).toContain(\"leitura\");\n  });\n\n  it(\"usuario comum nao tem a permissao de exclusao\", () => {\n    // .not inverte qualquer matcher\n    expect(permissoesDoUsuario(\"comum\")).not.toContain(\"exclusao\");\n  });\n});"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "toBe compara valor exato, toEqual compara conteúdo: escolher o matcher certo evita um teste que mente sobre o que realmente verificou."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual matcher você usa pra comparar dois números primitivos?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "toBe",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "toEqual",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "toContain",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "toThrow",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual matcher verifica se uma função lança um erro ao ser executada?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "toThrow",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "toBe",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "toBeNull",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "toContain",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O teste expect({ nome: \"Ana\" }).toBe({ nome: \"Ana\" }) falha, mesmo os dois objetos parecendo iguais. Por quê?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "toBe compara referência, e são objetos diferentes na memória",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "toBe só aceita string, nunca compara objeto no Vitest",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O objeto da direita precisa vir de um import externo",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Faltou envolver os dois objetos com JSON.stringify antes",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual troca resolve o teste do item anterior, mantendo a intenção de comparar o conteúdo do objeto?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Trocar toBe por toEqual, que compara o conteúdo do objeto",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Trocar toBe por toBeTruthy, que aceita qualquer objeto",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Trocar o objeto esperado por uma string equivalente",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Remover o segundo objeto e comparar só o campo nome",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Você precisa garantir que dividir(10, 0) lança um erro. Qual chamada testa isso corretamente no Vitest?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "expect(() => dividir(10, 0)).toThrow()",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "expect(dividir(10, 0)).toThrow()",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "expect(dividir(10, 0)).toBe(Error)",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "expect(() => dividir).toThrow(10, 0)",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "O padrão AAA (Arrange, Act, Assert)",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Arrange, Act, Assert\n\nO padrão AAA organiza qualquer teste em três blocos: **Arrange** (preparar os dados e o estado necessários), **Act** (executar a ação ou função sendo testada) e **Assert** (verificar se o resultado bateu com o esperado). Você já faz isso de forma intuitiva ao escrever código: separa o que é dado de entrada do que é processamento. O AAA só torna essa separação explícita dentro do teste."
+                    },
+                    {
+                        "type": "code",
+                        "value": "// src/utils/validacao.ts\nexport function validarSenha(senha: string): boolean {\n  const temTamanhoMinimo = senha.length >= 8;\n  const temNumero = /\\d/.test(senha);\n  return temTamanhoMinimo && temNumero;\n}\n\n// src/utils/validacao.test.ts\nimport { describe, it, expect } from \"vitest\";\nimport { validarSenha } from \"./validacao\";\n\ndescribe(\"validarSenha\", () => {\n  it(\"aceita senha com 8 ou mais caracteres e pelo menos um numero\", () => {\n    // Arrange\n    const senha = \"senha1234\";\n\n    // Act\n    const resultado = validarSenha(senha);\n\n    // Assert\n    expect(resultado).toBe(true);\n  });\n});"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Por que a separação ajuda\n\nSem essa separação, é comum um teste crescer numa linha só, misturando preparo, execução e verificação, e ficar difícil de entender o que ele realmente testa. Com Arrange, Act e Assert bem marcados (por comentário ou só por uma linha em branco entre os blocos), qualquer pessoa lendo o teste seis meses depois reconhece de cara: aqui está o cenário, aqui está a ação, aqui está a checagem. Isso importa ainda mais em testes maiores, com vários dados de entrada."
+                    },
+                    {
+                        "type": "code",
+                        "value": "// src/utils/pedido.ts\ninterface ItemPedido {\n  preco: number;\n  quantidade: number;\n}\n\nexport function calcularTotalPedido(itens: ItemPedido[]): number {\n  return itens.reduce((total, item) => total + item.preco * item.quantidade, 0);\n}\n\n// src/utils/pedido.test.ts\nimport { describe, it, expect } from \"vitest\";\nimport { calcularTotalPedido } from \"./pedido\";\n\ndescribe(\"calcularTotalPedido\", () => {\n  it(\"soma o total de varios itens com quantidades diferentes\", () => {\n    // Arrange\n    const itens = [\n      { preco: 10, quantidade: 2 },\n      { preco: 5, quantidade: 3 },\n    ];\n\n    // Act\n    const total = calcularTotalPedido(itens);\n\n    // Assert\n    expect(total).toBe(35);\n  });\n});"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Um foco por teste\n\nO AAA funciona melhor quando cada `it` testa uma única coisa. Dá pra ter mais de um `expect` dentro do mesmo teste, desde que todos verifiquem o mesmo comportamento (por exemplo, checar dois campos do mesmo resultado). Quando você percebe que precisa testar dois comportamentos diferentes, o sinal é claro: são dois `it` separados, cada um com seu próprio Arrange, Act e Assert."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Arrange, Act, Assert: separar preparo, execução e verificação deixa qualquer teste fácil de ler meses depois de escrito."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "No padrão AAA, o que a etapa Arrange representa?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "A preparação dos dados e do estado antes da ação",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A execução da função que está sendo testada agora",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A verificação se o resultado bateu com o esperado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A limpeza do ambiente depois que o teste termina",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "No padrão AAA, qual etapa contém a chamada da função sendo testada?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Act",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Arrange",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Assert",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "After",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um teste mistura preparo, execução e verificação numa linha só, tipo expect(somar(dado1(), dado2())).toBe(esperado()). Qual é o problema principal?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Fica difícil separar entrada, ação e verificação depois",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O Vitest recusa expect com mais de uma função dentro",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O teste fica mais rápido, mas perde cobertura de código",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O JavaScript não permite chamar função dentro do expect",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que seguir Arrange, Act, Assert ajuda um teste a envelhecer bem, meses depois de escrito?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Quem lê reconhece de cara o dado, a ação e a checagem",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O AAA gera relatório de cobertura de forma automática",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O AAA elimina a necessidade de nomear os testes bem",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O AAA impede que o teste dependa de biblioteca externa",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Você está testando calcularTotalPedido com uma lista de itens. Qual ordem segue o padrão AAA da forma mais clara?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Montar a lista, chamar a função, comparar o total depois",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Chamar a função antes de montar a lista usada por ela",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Comparar o total esperado antes da função ser chamada",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Montar a lista dentro do próprio expect, junto do assert",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Rodando, lendo a falha e testando bordas",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Rodando de verdade\n\nRodar `npx vitest` sem mais nada entra em **watch mode**: o Vitest fica de pé, observando os arquivos, e reroda automaticamente os testes afetados a cada vez que você salva. É o jeito mais comum de trabalhar enquanto escreve código. Já `npx vitest run` executa a suíte inteira uma única vez e termina, o formato usado em pipelines de CI (assunto que volta com força no Módulo 6)."
+                    },
+                    {
+                        "type": "code",
+                        "value": "$ npx vitest\n\n PASS  src/utils/validacao.test.ts (3 tests) 4ms\n PASS  src/utils/matematica.test.ts (2 tests) 2ms\n\n Test Files  2 passed (2)\n      Tests  5 passed (5)\n   Duration  287ms\n\n# esse processo fica aberto, esperando o proximo save\n# \"npx vitest run\" roda uma vez e encerra sozinho"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Lendo a saída, do verde ao vermelho\n\nCada teste que passa aparece marcado como PASS, com o nome do arquivo e quantos testes rodaram. Quando um teste falha, o Vitest mostra o caminho completo até ele (o `describe` e o `it` envolvidos) junto com um bloco `Expected` (o que o `expect` esperava) contra `Received` (o que a função realmente devolveu). É esse contraste que aponta se o bug está na função ou no próprio teste."
+                    },
+                    {
+                        "type": "code",
+                        "value": "$ npx vitest\n\n FAIL  src/utils/validacao.test.ts > ehValidoEmail > retorna true para um email valido\n\nAssertionError: expected false to be true\n\n- Expected\n+ Received\n\n- true\n+ false\n\n Test Files  1 failed (1)\n      Tests  1 failed | 1 passed (2)"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Testando as bordas\n\nUm teste que só cobre o caminho feliz (o email certinho, o número redondo) prova bem pouco. É nos casos de borda que os bugs de verdade aparecem: **string vazia**, **valor negativo**, **zero**, e os **limites exatos** de uma regra (como o oitavo caractere de uma senha que exige mínimo de 8). Um cadastro que nunca testou email vazio, por exemplo, só descobre o problema quando alguém manda o formulário em branco em produção."
+                    },
+                    {
+                        "type": "code",
+                        "value": "// src/utils/validacao.test.ts\nimport { describe, it, expect } from \"vitest\";\nimport { ehValidoEmail, validarSenha } from \"./validacao\";\n\ndescribe(\"ehValidoEmail: casos de borda\", () => {\n  it(\"retorna false para string vazia\", () => {\n    expect(ehValidoEmail(\"\")).toBe(false);\n  });\n\n  it(\"retorna false quando falta algo depois do ultimo ponto\", () => {\n    expect(ehValidoEmail(\"ana@exemplo.\")).toBe(false);\n  });\n});\n\ndescribe(\"validarSenha: casos de borda\", () => {\n  it(\"rejeita senha com exatamente 7 caracteres\", () => {\n    expect(validarSenha(\"abc123z\")).toBe(false);\n  });\n\n  it(\"aceita senha com exatamente 8 caracteres\", () => {\n    expect(validarSenha(\"abc123zz\")).toBe(true);\n  });\n});"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Teste que só cobre o caminho feliz não prova nada: é na borda (vazio, negativo, limite) que o bug mora."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual comando roda os testes uma única vez, sem entrar em watch mode?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "npx vitest run",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "npx vitest watch",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "npx vitest init",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "npx vitest build",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O que significa um teste aparecer como FAIL na saída do Vitest?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Que algum expect do teste não bateu com o valor recebido",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Que o arquivo de teste tem erro de sintaxe e não compilou",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que o teste foi pulado de propósito com skip ou todo",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que o Vitest não achou nenhum arquivo de teste no projeto",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "A saída de um teste que falhou mostra Expected: true e Received: false. O que essas duas linhas indicam?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O valor esperado pelo expect contra o valor recebido",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O tempo esperado de execução contra o tempo real do teste",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A versão esperada do Vitest contra a versão instalada",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O número de testes esperados contra o número que rodou",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que testar casos de borda, como vazio, negativo e limite, além do caminho feliz?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque bugs comuns se escondem nesses valores fora do normal",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o Vitest exige três casos de borda por função",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque casos de borda deixam a suíte visivelmente mais rápida",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque sem eles o toBe e o toEqual param de funcionar",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Você testou ehValidoEmail só com um email válido comum, e o teste passou. Em produção, um cadastro com email vazio quebrou o sistema. O que faltou na suíte?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Um caso de borda cobrindo string vazia, fora do caminho feliz",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Trocar o matcher toBe por toEqual na verificação do email",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Envolver o teste existente com describe pra evitar o bug",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Rodar o mesmo teste duas vezes seguidas antes do deploy",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 3 - Mocks e dublês de teste",
+        "aulas": [
+            {
+                "titulo": "Por que isolar: o problema das dependências",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Módulo 3 - Mocks e dublês de teste\n\nNo Módulo 2 você testou funções que viviam sozinhas: recebiam um valor, devolviam outro, sem depender de mais nada. Mas boa parte do código de um back-end de verdade não é assim. Lembra daquele CRUD que você fez, com Express e banco? Ou o middleware de auth que decodifica um token, ou o cache-aside que decide se busca no Redis ou no banco? Essas peças tomam decisões, mas também conversam com coisas de fora: banco de dados, APIs externas, envio de email, o relógio. Testar isso unitariamente exige uma ferramenta nova: o dublê de teste."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O problema: sua função não vive sozinha\n\nPegue um exemplo comum: um `UsuarioService` que cadastra um novo usuário. Ele precisa checar se o email já existe (bate no banco), salvar o usuário novo (bate no banco de novo) e mandar um email de boas-vindas (bate numa API externa de envio de email). A lógica de decisão em si (\"se já existe, recusa; senão, cria e avisa\") é simples. O problema é que ela está emaranhada com três chamadas pra fora, e um teste unitário não quer saber se o Postgres está de pé ou se o provedor de email está respondendo."
+                    },
+                    {
+                        "type": "code",
+                        "value": "// src/usuarios/usuario.service.ts\nimport { emailClient } from \"../email/email.client\";\n\ninterface Usuario {\n  id: number;\n  nome: string;\n  email: string;\n  criadoEm: Date;\n}\n\ninterface UsuarioRepository {\n  buscarPorEmail(email: string): Promise<Usuario | null>;\n  criar(dados: Omit<Usuario, \"id\">): Promise<Usuario>;\n}\n\nexport class UsuarioService {\n  constructor(private repository: UsuarioRepository) {}\n\n  async cadastrar(nome: string, email: string): Promise<Usuario> {\n    const existente = await this.repository.buscarPorEmail(email);\n    if (existente) {\n      throw new Error(\"Email ja cadastrado\");\n    }\n\n    const usuario = await this.repository.criar({ nome, email, criadoEm: new Date() });\n    await emailClient.enviarBoasVindas(email);\n\n    return usuario;\n  }\n}"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que acontece se o teste usar as dependências de verdade\n\nSe o teste desse `cadastrar` gravar direto no banco de desenvolvimento, ele fica lento (uma consulta e uma escrita reais a cada teste) e sujo (o próximo teste encontra o usuário que o teste anterior deixou pra trás, e uma suíte que passa sozinha pode falhar quando roda junto com outras). Se ele chamar o `emailClient` de verdade, manda um email real toda vez que a suíte roda, sem nenhum controle sobre o resultado. E se a lógica usar `new Date()` sem nenhum controle, o valor de `criadoEm` muda a cada execução, o que complica até comparar o resultado num `expect`."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Dependência\", \"Por que atrapalha um teste unitário\"], [\"Banco de dados\", \"Lento pra subir, precisa de estado limpo entre execuções, os testes ficam acoplados uns aos outros\"], [\"API externa\", \"Depende de rede e de credenciais reais, pode falhar por um motivo alheio ao seu código\"], [\"Envio de email\", \"Manda email de verdade toda vez que a suíte roda, sem controle nenhum sobre o resultado\"], [\"Relógio (tempo)\", \"O valor muda a cada execução, o teste perde a previsibilidade\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## A saída: substituir a dependência por um dublê\n\nNo teste unitário, a solução não é evitar essas dependências, é trocá-las por uma versão controlada só durante o teste: um dublê de teste (do inglês *test double*, o mesmo termo usado no cinema pra quem substitui o ator numa cena arriscada). Com o dublê no lugar do banco, do email e do relógio, o teste passa a verificar só o que interessa: será que `cadastrar` toma a decisão certa? Na próxima aula, os quatro tipos de dublê que dá pra montar com o Vitest."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Testar uma função que depende de banco, API externa e relógio direto contra essas dependências reais deixa o teste lento e imprevisível: o dublê existe pra devolver o controle pra quem escreve o teste."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "No Módulo 3, qual é o problema central que motiva o uso de dublês de teste?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "A unidade testada depende de coisas externas, como banco e email",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O Vitest não consegue reconhecer mais de um arquivo de teste",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "As funções puras do Módulo 2 pararam de funcionar no projeto",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O JavaScript não permite declarar duas funções no mesmo arquivo",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual das dependências abaixo costuma exigir um dublê de teste, por ser externa à própria lógica?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Uma chamada de rede para uma API externa de terceiros",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Uma função pura que soma dois números recebidos",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma constante numérica declarada no topo do arquivo",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um objeto literal criado dentro do próprio teste",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O teste do UsuarioService.cadastrar está gravando no banco de desenvolvimento de verdade e mandando email real toda vez que roda. Qual é o problema disso?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Fica lento, deixa estado sujo e depende de serviços externos reais",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Fica mais confiável, porque usa exatamente os dados de produção",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Vitest recusa terminar a suíte quando detecta uma chamada de rede",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Fica mais rápido, porque reaproveita a conexão aberta do banco real",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que new Date() dentro da lógica testada é considerado uma dependência arriscada num teste unitário?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O valor muda a cada execução, tirando a previsibilidade do teste",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "new Date() lança erro sempre que chamado dentro de um arquivo .test",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "new Date() exige uma conexão de rede ativa pra funcionar direito",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "new Date() só pode ser usado dentro de funções assíncronas no Node",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "UsuarioService.cadastrar depende do repository, do emailClient e do relógio. Num teste unitário desse método, o que faz mais sentido isolar com dublês?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "As três dependências externas, mantendo real a lógica do próprio service",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Só o repository, deixando emailClient e relógio rodarem de verdade",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Nenhuma dependência, já que mockar qualquer uma delas falsifica o teste",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A lógica de decisão do service, mantendo as três dependências reais",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Os dublês de teste: mock, stub, spy e fake",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Dublê de teste: o nome e a ideia\n\nO termo *test double* (dublê de teste) é do Martin Fowler, emprestado direto do cinema: assim como um dublê substitui o ator numa cena arriscada, um dublê de teste substitui uma dependência real numa situação em que você não quer (ou não pode) usar a coisa de verdade. Só que \"dublê\" não é uma coisa só: existem quatro variações comuns, cada uma respondendo uma pergunta diferente sobre o teste."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## As quatro variações, de forma simples\n\n- **Stub**: devolve uma resposta fixa e pronta quando chamado, sem lógica nenhuma por trás. Serve pra fazer a dependência \"responder alguma coisa\" e deixar o fluxo seguir.\n- **Mock**: parece um stub (também devolve algo controlado), mas o foco dele é a interação: depois você verifica se foi chamado, quantas vezes e com quais argumentos.\n- **Spy**: observa uma função real sem trocar o comportamento dela. A função original continua rodando, o spy só fica registrando as chamadas por cima.\n- **Fake**: uma implementação alternativa e simplificada da dependência real, funcional mas mais simples (o exemplo clássico é um repositório em memória no lugar do banco)."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Dublê\", \"O que faz\"], [\"Stub\", \"Devolve uma resposta fixa e pronta, sem lógica real por trás\"], [\"Mock\", \"Devolve uma resposta controlada e registra as chamadas, pra depois verificar a interação\"], [\"Spy\", \"Observa uma função real sem trocar o comportamento dela, só registra as chamadas\"], [\"Fake\", \"Substitui a dependência por uma implementação simplificada, porém funcional (ex.: repositório em memória)\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Quando cada um se encaixa\n\nNa prática, ninguém para pra classificar cada dublê no meio do trabalho, e é comum ouvir \"mock\" sendo usado pra qualquer um dos quatro. Mas a distinção ajuda a escolher a ferramenta certa: use **stub** quando só precisa que a dependência devolva algo pra função seguir; use **mock** quando o próprio teste é sobre a interação (\"o service chamou o email certo?\"); use **spy** quando quer manter o comportamento real de algo e só confirmar que foi chamado (por exemplo, espiar um log de erro dentro do middleware de auth sem mudar o jeito como ele decide bloquear a requisição); use **fake** quando a dependência tem lógica de verdade que vale a pena simular, como um repositório que precisa buscar, salvar e checar duplicidade."
+                    },
+                    {
+                        "type": "code",
+                        "value": "// um fake: implementacao simplificada porem funcional, no lugar do banco\ninterface Usuario {\n  id: number;\n  nome: string;\n  email: string;\n}\n\nclass UsuarioRepositoryFake {\n  private usuarios: Usuario[] = [];\n\n  async buscarPorEmail(email: string): Promise<Usuario | null> {\n    return this.usuarios.find((u) => u.email === email) ?? null;\n  }\n\n  async criar(dados: Omit<Usuario, \"id\">): Promise<Usuario> {\n    const usuario = { id: this.usuarios.length + 1, ...dados };\n    this.usuarios.push(usuario);\n    return usuario;\n  }\n}"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Conectando com o UsuarioService\n\nNo `cadastrar` do Módulo 3, dá pra ver os quatro tipos disputando espaço: `buscarPorEmail` pode virar um **stub** (só precisa devolver `null` ou um usuário existente), `emailClient.enviarBoasVindas` vira um **mock** (o teste quer confirmar que foi chamado com o email certo) e o repository inteiro poderia virar um **fake** em memória, se valer a pena simular o comportamento de busca e criação juntos. Nas próximas duas aulas, isso sai do papel e vira código de verdade com `vi.fn()` e `vi.mock()`."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Stub devolve resposta pronta, mock verifica a interação, spy observa sem trocar nada, fake reimplementa de um jeito simples: dublês diferentes pra perguntas diferentes sobre o mesmo teste."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual dublê devolve uma resposta pronta e fixa pra quem chama, sem nenhuma lógica real por trás?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Stub",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Mock",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Spy",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Fake",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual dublê observa as chamadas de uma função real sem substituir o comportamento dela?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Spy",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Stub",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Mock",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Fake",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Você precisa que o repositório de usuários se comporte de verdade durante o teste (buscar, salvar, checar duplicidade), sem tocar o banco real. Qual dublê encaixa melhor?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Fake, uma implementação simplificada porém funcional, tipo em memória",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Stub, que devolve sempre a mesma resposta fixa pra qualquer chamada",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Spy, que só observa chamadas numa função que já existe de verdade",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Mock, que só registra quantas vezes uma função foi chamada",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual é a diferença principal entre mock e stub, dois dublês que costumam se confundir?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Mock verifica a interação depois, stub só devolve uma resposta fixa",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Mock só funciona em teste de integração, stub só em teste unitário",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Mock sempre precisa de um banco real, stub nunca depende de nada",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Mock deixa o teste mais lento, porque grava tudo num disco real",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O teste do UsuarioService.cadastrar precisa garantir que emailClient.enviarBoasVindas foi chamado com o email certo. Qual dublê responde melhor essa pergunta?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Mock, porque o teste verifica a interação, não só um retorno",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Stub, porque o teste só depende do valor que a função devolve",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Fake, porque o teste precisa de uma implementação real de email",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Spy, porque o teste não pode alterar o envio real do email",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "vi.fn e vi.mock na prática",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## vi.fn: criando uma função dublê do zero\n\n`vi.fn()` cria uma função mock: uma função de verdade, que pode ser passada pra qualquer lugar que espera uma função, mas que o Vitest instrumenta por dentro pra lembrar de cada chamada. Sozinha, sem nenhuma configuração, ela devolve `undefined` quando chamada. Encadeando `.mockReturnValue(valor)` você define o que ela devolve numa chamada síncrona; encadeando `.mockResolvedValue(valor)` você define o que ela devolve dentro de uma `Promise`, pro caso de dublar uma função assíncrona (o caso mais comum ao mockar um repositório ou um cliente de API)."
+                    },
+                    {
+                        "type": "code",
+                        "value": "import { vi, describe, it, expect } from \"vitest\";\n\ndescribe(\"vi.fn basico\", () => {\n  it(\"cria uma funcao mock com retorno controlado\", () => {\n    const buscarPorEmail = vi.fn();\n    buscarPorEmail.mockReturnValue(null);\n\n    expect(buscarPorEmail(\"ana@exemplo.com\")).toBe(null);\n  });\n\n  it(\"controla o retorno de uma funcao assincrona\", async () => {\n    const buscarPorEmail = vi.fn();\n    buscarPorEmail.mockResolvedValue({ id: 1, nome: \"Ana\" });\n\n    const resultado = await buscarPorEmail(\"ana@exemplo.com\");\n    expect(resultado).toEqual({ id: 1, nome: \"Ana\" });\n  });\n});"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Trocando a dependência real por um objeto de vi.fn\n\nComo o `UsuarioService` recebe o `repository` pelo construtor, dublar essa dependência é só montar um objeto literal com um `vi.fn()` em cada método que a interface espera, e passar esse objeto no lugar do repositório real. Não precisa de nenhuma ferramenta especial do Vitest pra isso, é injeção de dependência de qualquer jeito: o service não sabe (nem precisa saber) se está recebendo o repositório real ou um dublê."
+                    },
+                    {
+                        "type": "code",
+                        "value": "// src/usuarios/usuario.service.test.ts\nimport { vi, describe, it, expect } from \"vitest\";\nimport { UsuarioService } from \"./usuario.service\";\n\ndescribe(\"UsuarioService.cadastrar\", () => {\n  it(\"cadastra um usuario novo quando o email ainda nao existe\", async () => {\n    const repositoryFalso = {\n      buscarPorEmail: vi.fn().mockResolvedValue(null),\n      criar: vi.fn().mockResolvedValue({ id: 1, nome: \"Ana\", email: \"ana@exemplo.com\" }),\n    };\n    const service = new UsuarioService(repositoryFalso);\n\n    const usuario = await service.cadastrar(\"Ana\", \"ana@exemplo.com\");\n\n    expect(usuario.id).toBe(1);\n  });\n});"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## vi.mock: quando a dependência não é injetada\n\nO `emailClient` é diferente: ele é importado direto dentro de `usuario.service.ts`, não chega pelo construtor. Pra substituir um módulo inteiro assim, o Vitest tem o `vi.mock(caminho, factory)`: você aponta o caminho do módulo (igual ao do `import`) e devolve, na `factory`, a versão mockada de tudo que esse módulo exporta. (Quando você quer manter o comportamento real de uma função e só espiar as chamadas por cima, sem recriar o módulo inteiro, a ferramenta certa é o `vi.spyOn`, que volta com força lá na frente.)"
+                    },
+                    {
+                        "type": "code",
+                        "value": "// src/usuarios/usuario.service.test.ts\nimport { vi, describe, it, expect } from \"vitest\";\nimport { UsuarioService } from \"./usuario.service\";\nimport { emailClient } from \"../email/email.client\";\n\nvi.mock(\"../email/email.client\", () => ({\n  emailClient: {\n    enviarBoasVindas: vi.fn().mockResolvedValue(undefined),\n  },\n}));\n\ndescribe(\"UsuarioService.cadastrar: envio de email\", () => {\n  it(\"chama o emailClient depois de cadastrar\", async () => {\n    const repositoryFalso = {\n      buscarPorEmail: vi.fn().mockResolvedValue(null),\n      criar: vi.fn().mockResolvedValue({ id: 1, nome: \"Ana\", email: \"ana@exemplo.com\" }),\n    };\n    const service = new UsuarioService(repositoryFalso);\n\n    await service.cadastrar(\"Ana\", \"ana@exemplo.com\");\n\n    expect(emailClient.enviarBoasVindas).toHaveBeenCalled();\n  });\n});"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "vi.fn cria a função dublê, mockReturnValue e mockResolvedValue controlam o que ela devolve, vi.mock troca o módulo inteiro quando a dependência é importada direto: três ferramentas, cada uma resolvendo um jeito diferente de dependência."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que vi.fn() cria, sozinho, sem nenhuma configuração extra?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Uma função mock que, por padrão, devolve undefined quando chamada",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Uma conexão real com o banco de dados configurado no projeto",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um servidor HTTP de teste escutando numa porta local livre",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um arquivo de configuração novo do Vitest dentro do projeto",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "repository.buscarPorEmail é assíncrono e devolve uma Promise. Qual método controla o retorno dele num vi.fn()?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "mockResolvedValue, feito pra funções que devolvem uma Promise",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "mockReturnValue, que funciona igual pra funções síncronas e assíncronas",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "mockAsyncValue, o método padrão do Vitest pra qualquer Promise",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "mockImplementationSync, usado quando a função não é assíncrona",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O construtor do UsuarioService espera um objeto repository com buscarPorEmail e criar. Como montar um dublê desse repository direto no teste, sem usar vi.mock?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Um objeto literal com métodos criados por vi.fn(), passado no construtor",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um vi.mock(\"./usuario.repository\") declarado dentro do próprio it",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma importação direta do repository real, o mesmo usado em produção",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma classe nova que estende UsuarioService e sobrescreve o construtor",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O emailClient é importado direto no arquivo do service, não recebido por parâmetro. Qual ferramenta troca esse módulo inteiro por uma versão mockada?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "vi.mock, apontando pro caminho do módulo importado",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "vi.fn, chamado direto dentro do próprio arquivo de produção",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "vi.spyOn, aplicado sobre a classe UsuarioService inteira",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "expect, configurado no topo do arquivo de teste",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de vi.mock(\"../email/email.client\", factory), o teste importa emailClient normalmente e chama service.cadastrar. O que essa combinação garante?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Que emailClient.enviarBoasVindas ali é a versão mockada pelo factory",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Que o service passa a ignorar completamente a chamada ao emailClient",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que o Vitest apaga o arquivo email.client.ts durante a execução",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que qualquer import de email em outro arquivo também é bloqueado",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Verificando chamadas com toHaveBeenCalledWith",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Não basta rodar sem quebrar: verificar a interação\n\nAté aqui, os dublês serviram pra controlar o que uma dependência devolve. Mas uma função criada com `vi.fn()` também lembra de cada chamada que recebeu: com quais argumentos, quantas vezes. Verificar essa interação é o que diferencia um mock de um simples stub, como visto na Aula 2, e é essencial quando o próprio comportamento que você quer garantir é \"o service chamou tal dependência do jeito certo\", não só \"o service devolveu tal valor\"."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Matcher\", \"O que verifica\"], [\"toHaveBeenCalled\", \"Se a função foi chamada ao menos uma vez, sem checar argumento nem quantidade\"], [\"toHaveBeenCalledWith\", \"Se a função foi chamada com exatamente aqueles argumentos\"], [\"toHaveBeenCalledTimes\", \"Se a função foi chamada exatamente um número N de vezes\"], [\"toHaveBeenCalledOnce\", \"Atalho para toHaveBeenCalledTimes(1), confirma exatamente uma chamada\"]]"
+                    },
+                    {
+                        "type": "code",
+                        "value": "import { vi, describe, it, expect } from \"vitest\";\n\ndescribe(\"verificando chamadas\", () => {\n  it(\"confirma que a funcao foi chamada\", () => {\n    const enviarBoasVindas = vi.fn();\n\n    enviarBoasVindas(\"ana@exemplo.com\");\n\n    expect(enviarBoasVindas).toHaveBeenCalled();\n  });\n\n  it(\"confirma com quais argumentos a funcao foi chamada\", () => {\n    const enviarBoasVindas = vi.fn();\n\n    enviarBoasVindas(\"ana@exemplo.com\");\n\n    expect(enviarBoasVindas).toHaveBeenCalledWith(\"ana@exemplo.com\");\n  });\n});"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Voltando pro UsuarioService: quem foi chamado, e como\n\nNo `cadastrar`, faz sentido confirmar que `repository.criar` foi chamado com o nome e o email recebidos, e que `emailClient.enviarBoasVindas` foi chamado com o email certo. Só que o objeto que `criar` recebe também carrega `criadoEm: new Date()`, que muda a cada execução, então comparar com um objeto fixo e completo em `toHaveBeenCalledWith` vai falhar por um motivo bobo. Pra isso, o Vitest aceita `expect.objectContaining({...})` dentro do próprio `toHaveBeenCalledWith`, checando só os campos que importam pro teste."
+                    },
+                    {
+                        "type": "code",
+                        "value": "// src/usuarios/usuario.service.test.ts\nit(\"chama o repository.criar com o nome e o email recebidos\", async () => {\n  const repositoryFalso = {\n    buscarPorEmail: vi.fn().mockResolvedValue(null),\n    criar: vi.fn().mockResolvedValue({ id: 1, nome: \"Ana\", email: \"ana@exemplo.com\" }),\n  };\n  const service = new UsuarioService(repositoryFalso);\n\n  await service.cadastrar(\"Ana\", \"ana@exemplo.com\");\n\n  expect(repositoryFalso.criar).toHaveBeenCalledWith(\n    expect.objectContaining({ nome: \"Ana\", email: \"ana@exemplo.com\" })\n  );\n  expect(repositoryFalso.buscarPorEmail).toHaveBeenCalledTimes(1);\n});"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Quando toHaveBeenCalledTimes pega um bug de verdade\n\nImagine que uma alteração no `cadastrar` introduziu um bug bobo: por causa de uma condição mal colocada, `emailClient.enviarBoasVindas` passa a ser chamado duas vezes por cadastro. Um teste que só confere `toHaveBeenCalledWith(email)` continua verde, porque o email certo foi chamado, só que duas vezes. É o `toHaveBeenCalledTimes(1)` que pega esse tipo de bug, o que reforça por que checar a quantidade de chamadas importa tanto quanto checar os argumentos."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "toHaveBeenCalled confirma que rolou, toHaveBeenCalledWith confirma com o quê, toHaveBeenCalledTimes confirma quantas vezes: sem as três, um mock só prova metade da história."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que expect(fn).toHaveBeenCalled() verifica sobre uma função mock?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Se a função foi chamada pelo menos uma vez durante o teste",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Se a função devolveu exatamente o valor esperado pelo teste",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Se a função foi declarada com a palavra reservada async",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Se a função existe dentro do arquivo de produção testado",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual matcher confirma não só que a função foi chamada, mas com quais argumentos exatos?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "toHaveBeenCalledWith",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "toHaveBeenCalled",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "toHaveBeenCalledTimes",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "toHaveReturnedWith",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "expect(repositoryFalso.criar).toHaveBeenCalledWith({ nome: \"Ana\", email: \"ana@exemplo.com\" }) falha, mesmo o cadastro funcionando certinho. Por quê?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O objeto real também tem criadoEm, e a comparação exata não bate",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "toHaveBeenCalledWith não aceita objetos como argumento de busca",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O repositoryFalso precisa ser declarado fora do describe pra contar",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O método criar não pode ser assíncrono dentro de um dublê",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual troca resolve o teste do item anterior, aceitando um objeto parcial na comparação?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "toHaveBeenCalledWith(expect.objectContaining({ nome, email }))",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "toHaveBeenCalledWith(expect.anything())",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "toHaveBeenCalledWith(JSON.stringify({ nome, email }))",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "toHaveBeenCalledTimes(expect.objectContaining({ nome, email }))",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de uma mudança no código, o teste com toHaveBeenCalledWith continua verde, mas em produção o email de boas vindas está sendo enviado duas vezes. Qual asserção pegaria esse bug?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "expect(emailClient.enviarBoasVindas).toHaveBeenCalledTimes(1)",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "expect(emailClient.enviarBoasVindas).toHaveBeenCalledWith(email)",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "expect(emailClient.enviarBoasVindas).toHaveBeenCalled()",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "expect(emailClient.enviarBoasVindas).toBeInstanceOf(Function)",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "O perigo de mockar demais",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Quando o teste só testa o mock\n\nSe você mocka literalmente tudo, incluindo a própria lógica que deveria estar sob teste, o teste vira uma verificação circular: você configura o mock pra devolver X, e depois confere que devolveu X. Ele passa sempre, inclusive quando a lógica real está quebrada, porque a lógica real nunca chegou a rodar. Isso é o perigo de mockar demais, e é mais comum do que parece quando a pressão é só \"deixar o teste verde\"."
+                    },
+                    {
+                        "type": "code",
+                        "value": "// exemplo do que NAO fazer: mockar o proprio metodo que deveria ser testado\nimport { vi, describe, it, expect } from \"vitest\";\nimport { UsuarioService } from \"./usuario.service\";\n\ndescribe(\"cadastrar (mockado demais)\", () => {\n  it(\"nao prova que a logica de cadastro funciona\", async () => {\n    const service = new UsuarioService({} as any);\n    vi.spyOn(service, \"cadastrar\").mockResolvedValue({\n      id: 1,\n      nome: \"Ana\",\n      email: \"ana@exemplo.com\",\n      criadoEm: new Date(),\n    });\n\n    const usuario = await service.cadastrar(\"Ana\", \"ana@exemplo.com\");\n\n    expect(usuario.id).toBe(1);\n    // passa mesmo se a logica real de \"cadastrar\" estiver quebrada:\n    // \"cadastrar\" nunca rodou de verdade, foi ele mesmo que foi substituido\n  });\n});"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## A régua: o que mockar e o que deixar real\n\nUma régua prática: mocka o que é **lento, externo ou não-determinístico** (banco de dados, API externa, envio de email, relógio). Deixa real o que é **a própria lógica que você quer provar**: as decisões, os cálculos, as validações, o \"miolo\" da unidade sob teste. Se você mocka justamente essa parte, sobra pouca coisa pra testar, porque o teste deixou de exercitar qualquer coisa que você escreveu."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Situação\", \"Mockar ou manter real\"], [\"Chamada ao banco de dados (repository)\", \"Mockar: é lenta e externa ao que você quer testar\"], [\"Chamada a uma API de terceiros\", \"Mockar: depende de rede e de fatores fora do seu controle\"], [\"O relógio (new Date, Date.now)\", \"Mockar: sem isso o resultado muda a cada execução\"], [\"A lógica de decisão dentro do próprio service\", \"Manter real: é exatamente isso que o teste precisa provar\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Mockando o tempo por cima\n\nO relógio é um caso à parte: não é uma dependência externa como um banco ou uma API, é uma função nativa da linguagem, mas ainda assim vale mockar, porque `new Date()` devolve um valor diferente a cada execução. O Vitest resolve isso com `vi.useFakeTimers()` e `vi.setSystemTime(data)`: você congela o \"agora\" no valor que quiser, testa o comportamento (por exemplo, se um convite expirou) e depois volta com `vi.useRealTimers()`, sem precisar esperar o tempo passar de verdade."
+                    },
+                    {
+                        "type": "code",
+                        "value": "// src/usuarios/convite.ts\nexport function conviteExpirado(criadoEm: Date, validadeEmDias: number): boolean {\n  const limite = new Date(criadoEm);\n  limite.setDate(limite.getDate() + validadeEmDias);\n  return new Date() > limite;\n}\n\n// src/usuarios/convite.test.ts\nimport { vi, describe, it, expect, beforeEach, afterEach } from \"vitest\";\nimport { conviteExpirado } from \"./convite\";\n\ndescribe(\"conviteExpirado\", () => {\n  beforeEach(() => {\n    vi.useFakeTimers();\n  });\n\n  afterEach(() => {\n    vi.useRealTimers();\n  });\n\n  it(\"considera expirado um convite de 7 dias apos 8 dias\", () => {\n    const criadoEm = new Date(\"2026-01-01T10:00:00\");\n    vi.setSystemTime(new Date(\"2026-01-09T10:00:00\"));\n\n    expect(conviteExpirado(criadoEm, 7)).toBe(true);\n  });\n\n  it(\"considera valido um convite de 7 dias apos apenas 2 dias\", () => {\n    const criadoEm = new Date(\"2026-01-01T10:00:00\");\n    vi.setSystemTime(new Date(\"2026-01-03T10:00:00\"));\n\n    expect(conviteExpirado(criadoEm, 7)).toBe(false);\n  });\n});"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Mockar o banco, a API externa e o relógio dá controle sobre o teste; mockar a própria lógica que você quer provar só finge que testou."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual é o risco principal de mockar praticamente tudo dentro de um teste unitário?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "O teste passa a verificar o próprio mock, não o comportamento real",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O teste fica mais lento, porque o Vitest recria cada mock do zero",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Vitest recusa rodar arquivos com mais de um vi.mock declarado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O teste deixa de aparecer no relatório de cobertura de código",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual das opções abaixo é a candidata mais clara pra virar um dublê num teste unitário?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Uma chamada de rede pra uma API externa de terceiros",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Uma função que soma dois números recebidos por parâmetro",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um objeto de configuração criado dentro do próprio teste",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A lógica de validação que o teste deveria estar provando",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um teste mocka o próprio método que está testando, com vi.spyOn(service, \"cadastrar\").mockResolvedValue(...), e confere só o retorno. O cadastrar real tem um bug. O teste pega esse bug?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Não, porque a lógica real de cadastrar nunca chega a rodar",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Sim, porque mockResolvedValue reexecuta a lógica original por baixo",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Sim, porque o Vitest compara o mock com o código fonte sozinho",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não, mas só quando o bug está no repository, nunca no service",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que o relógio (new Date, Date.now) costuma virar um dublê, mesmo sendo nativo da linguagem e não uma API de terceiros?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque o valor muda a cada execução, tirando o determinismo do teste",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o Vitest bloqueia por padrão qualquer uso direto de Date",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque new Date lança exceção quando chamada dentro de um it",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o Node não permite importar Date dentro de um arquivo de teste",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Dois testes cobrem UsuarioService.cadastrar: um mocka só repository e emailClient, mantendo a lógica de decisão real; outro mocka o próprio método cadastrar inteiro. Os dois estão verdes. Qual prova de fato que o cadastro funciona?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Só o primeiro, porque nele a lógica real de cadastrar chega a rodar",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Os dois, porque ambos usam vi.fn e por isso são igualmente válidos",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Só o segundo, porque ele isola completamente qualquer dependência",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Nenhum dos dois, teste com mock nunca prova comportamento real",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 4 - Testes de integração",
+        "aulas": [
+            {
+                "titulo": "O que integração testa (e o unitário não)",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Módulo 4 - Testes de integração\n\nNos módulos anteriores você testou funções isoladas: um cálculo, uma validação, um service inteiro com o banco trocado por um mock. Esses testes são rápidos e focados, mas têm um ponto cego. Eles garantem que a peça funciona sozinha, do jeito que quem escreveu o mock imaginou. Não garantem que as peças encaixam quando o pedido chega de verdade, passando pela rota, pelo middleware e pelo banco.\n\nÉ aí que entra o teste de integração: testar várias partes do sistema juntas, do jeito que elas realmente rodam em produção."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que é um teste de integração\n\nUm teste de integração exercita mais de uma camada ao mesmo tempo, sem trocar as peças por dublês. No CRUD de tarefas que você já construiu, por exemplo, isso quer dizer:\n\n- a rota Express de verdade, registrada com `app.post`\n- o middleware que roda antes dela (auth, validação, parsing de JSON)\n- o service com a regra de negócio\n- o banco de dados de verdade (um banco de teste, não mockado)\n\nNenhuma dessas peças é substituída. O teste faz uma requisição HTTP real contra a aplicação inteira e confere o que volta."
+                    },
+                    {
+                        "type": "code",
+                        "value": "// tarefas.service.test.js (teste unitário, do Módulo 3)\nimport { describe, it, expect, vi } from 'vitest'\nimport { pool } from '../db/pool.js'\nimport { criarTarefa } from '../services/tarefas.service.js'\n\nvi.mock('../db/pool.js', () => ({\n  pool: { query: vi.fn() }\n}))\n\ndescribe('criarTarefa (unitário)', () => {\n  it('retorna a tarefa criada', async () => {\n    pool.query.mockResolvedValue({\n      rows: [{ id: 1, titulo: 'Estudar SQL', concluida: false }]\n    })\n\n    const tarefa = await criarTarefa({ titulo: 'Estudar SQL' })\n\n    expect(tarefa).toEqual({ id: 1, titulo: 'Estudar SQL', concluida: false })\n  })\n})"
+                    },
+                    {
+                        "type": "code",
+                        "value": "// services/tarefas.service.js (com um bug real no SQL)\nexport async function criarTarefa({ titulo }) {\n  const { rows } = await pool.query(\n    `INSERT INTO tarefas (titulo, feita)\n     VALUES ($1, false)\n     RETURNING id, titulo, concluida`,\n    [titulo]\n  )\n  return rows[0]\n}\n\n// a coluna certa, na migration, é concluida (não feita)\n// o teste unitário acima passa do mesmo jeito: pool.query está mockado,\n// ninguém nunca manda esse SQL pro Postgres de verdade"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que o unitário não pega\n\nO teste unitário passou porque `pool.query` nunca tocou um banco real. Um teste de integração, rodando contra um banco de teste de verdade, chamaria esse service e o Postgres devolveria um erro parecido com `column feita of relation tarefas does not exist`.\n\nÉ esse tipo de problema que a integração pega e o unitário não:\n\n- **SQL errado**: coluna, tabela ou tipo que não bate com o schema real.\n- **Serialização**: o JSON de resposta transforma datas, `null`, `undefined` de um jeito que o teste unitário, olhando o objeto JS puro, não percebe.\n- **Middleware fora de ordem**: o auth registrado depois da rota, o parser de JSON faltando.\n- **Integração entre camadas**: o controller espera `tarefa.concluida`, mas o service devolve `tarefa.done`.\n\nNenhum desses bugs aparece testando o service com um mock. Eles só aparecem quando a requisição passa pelo caminho inteiro."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Aspecto\",\"Teste unitário\",\"Teste de integração\"],[\"Isola o quê\",\"Uma função ou módulo só\",\"Rota, middleware, service e banco juntos\"],[\"Dependências\",\"Trocadas por mock (vi.mock, vi.fn)\",\"Reais: app Express de verdade e banco de teste\"],[\"Velocidade\",\"Milissegundos\",\"Mais lento (I/O de banco real)\"],[\"O que pega\",\"Lógica de negócio, cálculo, condição\",\"SQL errado, serialização, ordem de middleware\"],[\"Posição na pirâmide\",\"Base (muitos testes)\",\"Meio (menos testes que unitário)\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Teste unitário garante que a peça funciona sozinha. Teste de integração garante que as peças, juntas, ainda funcionam."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que diferencia um teste de integração de um teste unitário?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Ele testa várias peças reais juntas, como rota, middleware e banco",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Ele testa uma função isolada, com as dependências trocadas por mocks",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ele testa só o HTML e o CSS da tela, sem passar pelo backend",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ele testa apenas se a API responde dentro de um tempo limite",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "No teste de integração do CRUD de tarefas, o que continua sendo real, sem virar mock?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "A rota Express, o middleware e o banco de dados",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Apenas a rota Express, o resto continua mockado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Apenas o banco de dados, a rota é simulada à parte",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Nada: todas as camadas continuam trocadas por dublês",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um teste unitário do service `criarTarefa` (com `pool.query` mockado) passa, mas em produção o endpoint quebra com erro de coluna inexistente no Postgres. Por que o teste unitário não pegou isso?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque o mock nunca envia o SQL de verdade pro banco de dados",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o Vitest ignora erros de SQL por padrão nos testes unitários",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o Postgres só valida colunas quando roda em produção",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque testes unitários não conseguem usar `expect` para checar erros",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um teste unitário compara o objeto retornado pelo service e passa. Só que o JSON que a API realmente devolve no `res.body` está diferente do esperado. Que tipo de problema é esse?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "É um problema de serialização, resolvido só quando o teste confere o body HTTP real",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "É um problema de performance, resolvido só quando o teste mede o tempo de resposta",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "É um bug do Vitest, resolvido rodando os testes com a flag `--no-cache` ativada",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "É um problema de tipagem, resolvido automaticamente pelo compilador do TypeScript",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O controller da rota `GET /tarefas/:id` lê `tarefa.concluida`, mas o service, depois de um refactor, passou a devolver o campo `tarefa.feita`. Os testes unitários do service continuam passando. Qual teste vai expor essa quebra de contrato entre as camadas?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Um teste de integração, fazendo a requisição HTTP e conferindo o corpo",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um teste unitário adicional, testando o service com um mock diferente",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um teste de cobertura, rodando `vitest run --coverage` no service",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Nenhum teste pega isso, só um code review manual identificaria",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "O banco de teste efêmero",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Por que não testar contra o banco de dev\n\nTodo teste de integração de verdade precisa de um banco de dados. A tentação é apontar o teste pro banco que você já tem rodando, o de desenvolvimento. Não faça isso.\n\nUm teste de integração de CRUD precisa deixar o banco num estado conhecido antes de cada teste, o que normalmente significa limpar as tabelas entre um teste e outro. Se esse `TRUNCATE` roda contra o banco de dev por engano, ele apaga os dados de dev de verdade. Não é uma hipótese: é exatamente o tipo de acidente que acontece quando a `DATABASE_URL` do teste aponta pro lugar errado."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## A solução: um banco efêmero só para os testes\n\nA prática é ter um banco descartável, que existe só durante a rodada de testes:\n\n1. Sobe um Postgres novo (geralmente num container Docker), numa porta separada da do banco de dev.\n2. Aplica as migrations nele, do zero, com a ferramenta que você já usa (Knex, Prisma, Drizzle...).\n3. Roda os testes, limpando as tabelas entre cada um.\n4. Derruba o container no final. Na próxima rodada, tudo começa limpo de novo.\n\nIsso também resolve outro problema: o banco de teste tem exatamente o schema das migrations atuais, sem nenhum dado estranho que alguém deixou lá manualmente."
+                    },
+                    {
+                        "type": "code",
+                        "value": "#!/usr/bin/env bash\n# tests/run-integration.sh\nset -euo pipefail\n\nexport DATABASE_URL=postgres://test:test@localhost:55433/testdb\n\ndocker run -d --rm --name pg_test -e POSTGRES_USER=test -e POSTGRES_PASSWORD=test -e POSTGRES_DB=testdb -p 55433:5432 postgres:16-alpine\n\necho Aguardando o banco aceitar conexoes...\nuntil docker exec pg_test pg_isready -U test -d testdb; do sleep 1; done\n\nnpm run migrate\n\nnpx vitest run tests/integration\n\ndocker rm -f pg_test"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## É assim que a própria plataforma faz\n\nO backend da plataforma tem um script só pra isso, separado do `npm test` do dia a dia. Ele sobe um Postgres efêmero em Docker, espera o banco aceitar conexão, aplica as migrations e só então roda os testes de integração. No final, derruba o container.\n\nRodar os testes de integração é um comando à parte (algo como `bash tests/run-integration.sh`), nunca o `npm test` comum. A separação existe justamente pra que a `DATABASE_URL` de teste nunca seja, por acidente, a de desenvolvimento."
+                    },
+                    {
+                        "type": "code",
+                        "value": "// tests/tarefas.integration.test.js\nimport { describe, it, expect, beforeAll, afterEach, afterAll } from 'vitest'\nimport { pool } from '../db/pool.js'\nimport { rodarMigrations } from '../db/migrate.js'\n\nbeforeAll(async () => {\n  await rodarMigrations()\n})\n\nafterEach(async () => {\n  await pool.query('TRUNCATE TABLE tarefas RESTART IDENTITY CASCADE')\n})\n\nafterAll(async () => {\n  await pool.end()\n})\n\ndescribe('POST /tarefas', () => {\n  // os testes de integração vêm aqui (próxima aula)\n})"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Hook\",\"Quando roda\",\"Uso no teste de integração\"],[\"beforeAll\",\"Uma vez, antes de todos os testes do arquivo\",\"Subir e migrar o banco de teste\"],[\"afterEach\",\"Depois de cada teste\",\"Limpar (truncar) as tabelas usadas\"],[\"afterAll\",\"Uma vez, depois de todos os testes\",\"Fechar a conexão com o banco (pool.end())\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "O banco de teste existe pra morrer. Se ele sobreviver ao teste sem ser derrubado, alguma coisa saiu do script."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Por que os testes de integração não devem rodar contra o banco de desenvolvimento?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Porque a limpeza das tabelas entre testes apagaria dados de dev",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o driver do Postgres bloqueia conexões vindas do Vitest",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o comando `TRUNCATE` não existe na versão de dev do Postgres",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque os testes deixariam o banco de dev sem espaço em disco",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "No fluxo com banco efêmero, o que acontece com o container do banco de teste depois que a suíte termina?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Ele é derrubado, e a próxima rodada sobe um banco novo",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Ele continua rodando, guardando dados pra próxima rodada",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ele passa a ser usado como banco de desenvolvimento",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ele fica pausado até o Vitest retomar automaticamente",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um dev configura o script de teste de integração apontando `DATABASE_URL` para o banco de desenvolvimento por engano. O que tende a acontecer quando a suíte roda?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O `afterEach` limpa as tabelas e apaga dados reais do banco de dev",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O Vitest detecta o erro e recusa a rodar os testes de integração",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "As migrations falham, porque o banco de dev já está migrado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os testes ficam mais rápidos, pois o banco de dev já está aquecido",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Numa suíte de teste de integração, em qual hook faz mais sentido aplicar as migrations no banco de teste?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "No `beforeAll`, que roda uma única vez pro arquivo inteiro",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "No `afterEach`, para garantir que roda de novo a cada teste",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "No `afterAll`, depois que os testes já leram os dados",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Dentro de cada `it`, pra isolar a migration por teste",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de rodar sozinho, um teste de integração passa. Rodado junto com o resto da suíte, ele falha porque encontra uma tarefa que outro teste criou e não devia estar lá. Qual é a causa mais provável?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Falta limpar (truncar) as tabelas entre um teste e outro",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O supertest reaproveita a mesma instância do app nos testes",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Vitest está rodando os arquivos de teste fora de ordem",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O banco de teste efêmero não aceita mais de uma conexão",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Testando HTTP com supertest",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Testar HTTP sem subir servidor\n\nVocê já viu `app.listen(3000)` ligar o Express numa porta. Pra testar, você não precisa disso: o supertest recebe o próprio objeto `app` e conversa com ele diretamente, em memória, sem abrir porta nenhuma.\n\nIsso resolve um problema chato de teste de integração: se cada teste subisse um servidor numa porta, você teria testes disputando porta entre si, ou precisando escolher uma porta livre toda vez. Com supertest, isso não existe."
+                    },
+                    {
+                        "type": "code",
+                        "value": "// tests/tarefas.integration.test.js\nimport { describe, it, expect } from 'vitest'\nimport request from 'supertest'\nimport { app } from '../app.js' // o mesmo app do Express, sem app.listen()\n\ndescribe('GET /tarefas', () => {\n  it('responde 200 com a lista de tarefas', async () => {\n    const res = await request(app).get('/tarefas')\n\n    expect(res.status).toBe(200)\n    expect(Array.isArray(res.body)).toBe(true)\n  })\n})"
+                    },
+                    {
+                        "type": "code",
+                        "value": "describe('POST /tarefas', () => {\n  it('cria a tarefa e responde 201 com o corpo certo', async () => {\n    const res = await request(app)\n      .post('/tarefas')\n      .send({ titulo: 'Estudar supertest' })\n\n    expect(res.status).toBe(201)\n    expect(res.body).toMatchObject({ titulo: 'Estudar supertest', concluida: false })\n    expect(res.body.id).toBeDefined()\n  })\n})"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Supertest\",\"O que faz\"],[\"request(app)\",\"Aponta as próximas chamadas pro app Express, sem subir porta\"],[\".get(path) / .post(path) / .put(path) / .delete(path)\",\"Monta a requisição HTTP pro path informado\"],[\".send(objeto)\",\"Manda o objeto como corpo da requisição (JSON)\"],[\".set(header, valor)\",\"Adiciona um header, como Authorization\"],[\"res.status\",\"Código HTTP da resposta (200, 201, 404...)\"],[\"res.body\",\"Corpo da resposta já parseado como JSON\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Headers e o atalho .expect()\n\nPra testar uma rota atrás do middleware de auth que você já construiu, basta anexar o token com `.set('Authorization', ...)`, igual um cliente HTTP de verdade faria.\n\nO supertest também tem um atalho: `.expect(codigo)` encadeado na própria chamada já falha o teste se o status não bater. Os exemplos aqui usam `expect(res.status).toBe(...)` do Vitest, que dá uma mensagem melhor quando quebra, mas as duas formas fazem a mesma checagem."
+                    },
+                    {
+                        "type": "code",
+                        "value": "describe('DELETE /tarefas/:id (rota protegida pelo middleware de auth)', () => {\n  it('sem token, responde 401', async () => {\n    const res = await request(app).delete('/tarefas/1')\n\n    expect(res.status).toBe(401)\n  })\n\n  it('com token válido, remove e responde 204', async () => {\n    const res = await request(app)\n      .delete('/tarefas/1')\n      .set('Authorization', `Bearer ${tokenDeTeste}`)\n\n    expect(res.status).toBe(204)\n  })\n})"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "supertest não é um navegador simulado. É o seu app Express de verdade, só que sem a porta."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que o supertest recebe pra testar uma rota Express?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "O próprio objeto `app`, sem precisar chamar `app.listen()`",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A URL pública onde a API já está publicada em produção",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um arquivo de configuração com as rotas escritas em YAML",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O nome do arquivo de rotas, que ele importa sozinho",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de `const res = await request(app).get('/tarefas')`, onde fica o JSON de resposta já parseado?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Em `res.body`, já como objeto ou array",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Em `res.text`, como uma string crua",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Em `res.data`, do mesmo jeito que no Axios",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Em `res.json`, como uma função a chamar",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um teste faz `request(app).post('/tarefas').send({ titulo: 'Ler' })` e a rota responde 400, mesmo com os dados certos. O controller lê `req.body.titulo` e recebe `undefined`. Qual configuração no `app.js` provavelmente está faltando?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O middleware `express.json()`, que faz o parsing do corpo",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O `cors()`, que libera a origem de onde o teste chama a API",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O `.set('Authorization', ...)` dentro do próprio teste",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O `express.static()`, que serve os arquivos da pasta public",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um teste de integração quer conferir que a tarefa criada tem `titulo: 'Estudar supertest'` e `concluida: false`, sem se importar com o valor exato do `id` gerado pelo banco. Qual matcher do Vitest encaixa melhor?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "`toMatchObject`, que confere só as propriedades informadas",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "`toBe`, que compara o objeto inteiro por igualdade estrita",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "`toHaveBeenCalledWith`, que confere os argumentos de uma chamada",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "`toBeInstanceOf`, que confere a classe do objeto retornado",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma suíte de testes de integração com supertest termina de rodar, mas o processo do Vitest não sai sozinho, ficando pendurado no terminal. O app é importado de `app.js`, que não chama `listen()`. O que mais provavelmente está prendendo o processo?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Uma conexão aberta com o banco, sem `pool.end()` no `afterAll`",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O próprio supertest, que mantém a porta aberta entre os testes",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O `app.listen()`, que o supertest chama por baixo dos panos",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O `express.json()`, que fica esperando corpo de requisição",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Um teste de endpoint de ponta a ponta",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Juntando as peças\n\nVocê já viu o banco de teste efêmero (aula 2) e como fazer requisições com supertest (aula 3). Agora é hora de juntar tudo num teste de integração completo, do jeito que ele existe de verdade: cria alguma coisa com um POST, confere a resposta, e confirma que aquilo realmente ficou salvo com um GET depois."
+                    },
+                    {
+                        "type": "code",
+                        "value": "// tests/tarefas.integration.test.js\nimport { describe, it, expect, beforeAll, afterEach, afterAll } from 'vitest'\nimport request from 'supertest'\nimport { app } from '../app.js'\nimport { pool } from '../db/pool.js'\nimport { rodarMigrations } from '../db/migrate.js'\n\nbeforeAll(async () => {\n  await rodarMigrations()\n})\n\nafterEach(async () => {\n  await pool.query('TRUNCATE TABLE tarefas RESTART IDENTITY CASCADE')\n})\n\nafterAll(async () => {\n  await pool.end()\n})\n\ndescribe('POST /tarefas', () => {\n  it('cria a tarefa e responde 201 com o corpo certo', async () => {\n    const res = await request(app)\n      .post('/tarefas')\n      .send({ titulo: 'Estudar testes de integração' })\n\n    expect(res.status).toBe(201)\n    expect(res.body).toMatchObject({\n      titulo: 'Estudar testes de integração',\n      concluida: false\n    })\n    expect(res.body.id).toBeDefined()\n  })\n})"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que esse teste já prova\n\nRodando contra o banco de teste de verdade, esse teste passa só se: a rota existe, o `express.json()` está lá pra ler o corpo, o service monta o INSERT certo, as colunas batem com a migration, e o controller devolve o JSON no formato esperado. É bem mais do que o teste unitário do service, sozinho, garante.\n\nMas ele só confere a resposta do POST. Ainda não prova que a tarefa ficou salva de um jeito que um outro pedido consegue encontrar."
+                    },
+                    {
+                        "type": "code",
+                        "value": "describe('fluxo criar e depois buscar', () => {\n  it('a tarefa criada aparece num GET /tarefas/:id depois', async () => {\n    const criada = await request(app)\n      .post('/tarefas')\n      .send({ titulo: 'Revisar PR' })\n\n    const id = criada.body.id\n\n    const busca = await request(app).get(`/tarefas/${id}`)\n\n    expect(busca.status).toBe(200)\n    expect(busca.body).toMatchObject({\n      id,\n      titulo: 'Revisar PR',\n      concluida: false\n    })\n  })\n})"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Por que o segundo request importa\n\nO primeiro teste prova que o POST responde certo. O segundo prova outra coisa: que o dado persistiu no banco de teste, e que uma requisição totalmente separada (um novo `GET`) consegue ler exatamente o que foi escrito. Isso pega bugs que nenhum dos dois sozinho pegaria, como uma tabela errada no `SELECT`, uma condição de busca que não bate com a coluna usada no `INSERT`, ou uma serialização diferente entre o que o `POST` devolve e o que o `GET` devolve pro mesmo registro.\n\nÉ o tipo de teste que teria pego o bug de coluna trocada (`feita` x `concluida`) que apareceu na aula 1."
+                    },
+                    {
+                        "type": "code",
+                        "value": "describe('GET /tarefas/:id inexistente', () => {\n  it('responde 404 quando o id não existe', async () => {\n    const res = await request(app).get('/tarefas/999999')\n\n    expect(res.status).toBe(404)\n    expect(res.body.erro).toBeDefined()\n  })\n})"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Um teste de integração bom não pergunta só o que a rota respondeu. Pergunta também o que ficou depois que a resposta voltou."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Num teste de integração de `POST /tarefas`, o que confirma que o endpoint respondeu do jeito esperado?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Conferir `res.status` e `res.body` na resposta do POST",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Conferir se o `console.log` do controller imprimiu a tarefa",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Conferir o tempo, em milissegundos, que a requisição levou",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Conferir se o arquivo de rotas foi importado sem erro",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "No teste que cria uma tarefa com POST e depois busca com GET, de onde vem o `id` usado na segunda chamada?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Do `res.body.id` devolvido pela resposta do POST",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "De um valor fixo, escrito direto no código do teste",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "De uma consulta separada direto no banco de produção",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Do header `Location` que o Express adiciona sozinho",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um teste confere só o `res.body` do POST /tarefas e passa. Seria possível esse teste passar mesmo se o SELECT usado no GET /tarefas/:id estivesse buscando na tabela errada?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Sim, porque o teste do POST não chega a exercitar o GET",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Não, porque o supertest roda GET e POST sempre juntos",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não, porque o Vitest recusa rodar o arquivo se o schema mudou",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Sim, mas só se o banco de teste não tiver sido migrado",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "No teste de criação, `expect(res.body).toMatchObject({ titulo: 'Revisar PR', concluida: false })` passa, mas trocar para `toEqual({ titulo: 'Revisar PR', concluida: false })` faz o mesmo teste falhar. Por quê?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque `toEqual` exige igualdade completa, e sobra o `id` gerado",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque `toEqual` só roda em testes unitários, nunca com supertest",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque `toMatchObject` ignora o campo `status` da resposta HTTP",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque `toEqual`, diferente de `toMatchObject`, não existe no Vitest",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma suíte de integração só tem testes do caminho feliz (POST cria, GET encontra). Um colega sugere adicionar um teste pra GET /tarefas/:id com um id que não existe. Qual é o principal ganho disso?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Confere se a rota trata o caso de não encontrar, sem quebrar com 500",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Deixa a suíte mais rápida, porque reduz consultas no banco de teste",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Substitui a necessidade de testar o caminho feliz separadamente",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Garante que o middleware de auth bloqueia usuários não autenticados",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Isolamento, velocidade e dados de teste",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Por que a integração fica no meio da pirâmide\n\nLembra da pirâmide, lá do Módulo 1? Unitário na base, muitos e rápidos. Integração no meio, menos e mais lentos. Um teste unitário roda em milissegundos, sem tocar disco nem rede. Um teste de integração abre conexão com um banco real e faz uma query de verdade, e isso custa tempo: um teste que levava 2ms como unitário pode levar 50ms ou mais como integração.\n\nIsso não é motivo pra abandonar a integração, mas é motivo pra não testar tudo nesse nível. Regra de negócio complexa, caso de borda de validação, cálculo: isso continua mais barato, e mais rápido de rodar centenas de vezes, como teste unitário. A integração entra pra garantir que as peças se encaixam, não pra repetir cada combinação de entrada que o unitário já cobre."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Nível\",\"Quantidade típica\",\"Velocidade\",\"Papel\"],[\"Unitário\",\"Muitos (centenas)\",\"Milissegundos\",\"Regra de negócio, cálculo, validação\"],[\"Integração\",\"Um bloco por endpoint ou fluxo\",\"Dezenas a centenas de ms\",\"Rota, banco e middleware juntos\"],[\"E2e\",\"Poucos, os fluxos críticos\",\"Segundos\",\"O sistema inteiro, como o usuário usa\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Isolamento: um teste não pode depender do outro\n\nUm teste de integração pode passar sozinho e falhar quando roda junto com a suíte inteira, se ele depender de dado deixado por outro teste (ou deixar dado pra trás). Os sintomas clássicos: um teste que espera a tabela vazia e encontra registros de sobra; um teste que conta com um `id` fixo que já foi usado por outro teste antes.\n\nA defesa é o que você já viu na aula 2: limpar o banco entre cada teste com `afterEach`, e nunca depender da ordem em que os testes rodam. Cada teste cria os dados que precisa e não assume nada que outro teste tenha deixado."
+                    },
+                    {
+                        "type": "code",
+                        "value": "// RUIM: o segundo teste depende do id criado pelo primeiro\nlet idCriado\n\nit('cria a tarefa', async () => {\n  const res = await request(app).post('/tarefas').send({ titulo: 'A' })\n  idCriado = res.body.id\n})\n\nit('busca a tarefa', async () => {\n  const res = await request(app).get(`/tarefas/${idCriado}`)\n  expect(res.status).toBe(200)\n  // se o primeiro teste for pulado ou rodar depois, este quebra\n})\n\n// BOM: cada teste cria o que precisa, sem depender de outro\nit('busca a tarefa criada', async () => {\n  const criada = await request(app).post('/tarefas').send({ titulo: 'A' })\n  const res = await request(app).get(`/tarefas/${criada.body.id}`)\n\n  expect(res.status).toBe(200)\n})"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Dados de teste: seeds e factories\n\nPreencher os dados de cada teste na mão funciona, mas repete muito código e fica frágil, com todo teste reescrevendo o mesmo objeto de tarefa. Duas saídas comuns:\n\n- **Seed**: uma função que insere um conjunto conhecido de dados antes de um teste ou grupo de testes, como um usuário já cadastrado pra testar login.\n- **Factory**: uma função que monta um objeto de teste com valores padrão, permitindo sobrescrever só o que importa pro teste atual.\n\nIsso reduz repetição e deixa claro, no teste, só o que é relevante pra aquele caso."
+                    },
+                    {
+                        "type": "code",
+                        "value": "// tests/factories/tarefa.js\nlet contador = 0\n\nexport function novaTarefa(overrides = {}) {\n  contador++\n  return {\n    titulo: `Tarefa de teste ${contador}`,\n    concluida: false,\n    ...overrides\n  }\n}\n\n// no teste:\nit('marca uma tarefa como concluída', async () => {\n  const criada = await request(app).post('/tarefas').send(novaTarefa())\n\n  const res = await request(app)\n    .patch(`/tarefas/${criada.body.id}`)\n    .send({ concluida: true })\n\n  expect(res.body.concluida).toBe(true)\n})"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Teste de integração rápido de escrever e lento de rodar é normal. Teste de integração que só passa numa ordem específica é um bug esperando pra acontecer."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Por que testes de integração costumam ser mais lentos que testes unitários?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Porque eles fazem I/O real, como consultas a um banco de dados",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o Vitest roda testes de integração em modo debug por padrão",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque eles precisam ser escritos em TypeScript, não em JavaScript",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o supertest sempre espera 1 segundo entre cada requisição",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O que caracteriza um teste isolado dos outros testes na mesma suíte?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Ele não depende de dado de outro teste, nem deixa dado pra trás",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Ele roda numa thread separada, sem compartilhar memória com os outros",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ele usa um `describe` próprio, diferente dos demais testes do arquivo",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ele importa o `app` de um arquivo diferente dos outros testes",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Dois testes: o primeiro cria uma tarefa e guarda o `id` numa variável fora do `it`; o segundo usa essa variável pra buscar a tarefa. Juntos, passam. Rodando só o segundo, ele falha. Qual é o problema?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O segundo teste depende do estado deixado pelo primeiro",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O Vitest não suporta rodar um teste específico com a flag `-t`",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O supertest perde a conexão quando só um teste roda por vez",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O banco de teste efêmero exige que todos os testes rodem juntos",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual é a vantagem de usar uma factory, como `novaTarefa()`, pra montar os dados de um teste de integração, em vez de escrever o objeto na mão em cada teste?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Reduz repetição e deixa claro só o que importa pro teste",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Faz o teste rodar em paralelo com os outros automaticamente",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Substitui a necessidade de limpar o banco entre os testes",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Torna o teste unitário, já que não usa mais o banco real",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um endpoint de cálculo de desconto tem 15 regras de negócio diferentes (cupom, quantidade, cliente antigo...). Testar as 15 regras como teste de integração, batendo no banco a cada uma, deixaria a suíte bem mais lenta. Qual é a saída mais alinhada com a pirâmide de testes?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Testar as 15 regras como unitário, e só o fluxo geral como integração",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Testar as 15 regras só como integração, é o nível mais confiável",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Remover os testes de integração desse endpoint, por serem lentos",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Testar as 15 regras como e2e, abrindo navegador pra cada uma",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 5 - TDD e código testável",
+        "aulas": [
+            {
+                "titulo": "O ciclo do TDD (red, green, refactor)",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# O ciclo do TDD: red, green, refactor\n\nTDD (test-driven development) inverte a ordem que você provavelmente está acostumado a escrever código. Em vez de implementar a função e só depois criar um teste pra conferir se ela funciona, você escreve o teste primeiro, descrevendo um comportamento que ainda não existe. A implementação vem depois.\n\nEsse processo se repete em ciclos curtos, com três fases bem definidas: **red**, **green** e **refactor**. É esse ciclo que dá nome à técnica."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## As três fases\n\n- **Red**: escreve um teste para um comportamento que ainda não existe no código. Ele falha ao rodar (às vezes nem compila, porque a função referenciada ainda não existe). Essa falha prova que o teste realmente testa alguma coisa.\n- **Green**: escreve o código mínimo necessário para o teste passar. Nessa fase não interessa se o código está bonito, só que fique verde.\n- **Refactor**: com o teste passando como rede de segurança, melhora a estrutura do código (nomes, duplicação, organização) sem mudar o comportamento observável. Roda os testes de novo pra confirmar que continuam verdes."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Fase\", \"O que você faz\", \"Como sabe que terminou\"], [\"Red\", \"Escreve um teste para um comportamento que ainda não existe\", \"O teste falha ao rodar\"], [\"Green\", \"Escreve o código mais simples possível para passar no teste\", \"O teste fica verde\"], [\"Refactor\", \"Melhora nomes, remove duplicação, reorganiza o código\", \"Os testes continuam verdes\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Por que escrever o teste antes muda o design\n\nQuando o teste vem primeiro, você é forçado a pensar em como a função vai ser chamada antes de pensar em como ela vai ser implementada por dentro. Isso muda a perspectiva: você projeta a partir de quem vai usar a função (o teste), não a partir da conveniência de quem está implementando.\n\nNa prática, isso tende a produzir funções menores, com dependências explícitas e fáceis de isolar, porque um teste difícil de escrever costuma ser sintoma de um design ruim. Se pra testar uma função pequena você precisa configurar meio sistema, o problema não é do teste, é do design."
+                    },
+                    {
+                        "type": "code",
+                        "value": "// FASE RED: o teste existe, a funcao ainda nao\nimport { describe, it, expect } from 'vitest'\nimport { formatarNomeExibicao } from './usuario'\n\ndescribe('formatarNomeExibicao', () => {\n  it('deixa a primeira letra maiuscula quando nao ha sobrenome', () => {\n    expect(formatarNomeExibicao('joao')).toBe('Joao')\n  })\n})\n\n// npx vitest --run\n// FAIL: 'formatarNomeExibicao' is not defined\n\n// FASE GREEN: implementacao minima pra ficar verde\nexport function formatarNomeExibicao(nome) {\n  return nome.charAt(0).toUpperCase() + nome.slice(1)\n}\n\n// npx vitest --run\n// PASS  1 passed (1)\n\n// FASE REFACTOR: o teste continua passando, entao da pra limpar\nexport function formatarNomeExibicao(nome) {\n  const [primeiraLetra, ...resto] = nome\n  return primeiraLetra.toUpperCase() + resto.join('')\n}\n\n// npx vitest --run\n// PASS  1 passed (1) -> comportamento igual, estrutura melhor"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "TDD não é sobre escrever mais testes, é sobre deixar o teste guiar o design: primeiro você decide como a função deveria ser usada, só depois se preocupa em como ela vai funcionar por dentro."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "No ciclo do TDD, o que caracteriza a fase red?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "O teste é escrito antes do código e falha ao rodar",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O código é escrito antes do teste e passa de primeira",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O teste é reescrito depois que o código já está pronto",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O código antigo é apagado para começar tudo de novo",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois que o teste fica verde, qual é o objetivo da fase refactor?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Melhorar o código mantendo os testes passando",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Escrever testes novos para aumentar a cobertura total",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Trocar o teste por uma versão mais simples de validar",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Remover os comentários deixados durante a fase green",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Você escreve um teste para uma função que ainda não existe e roda a suíte. O terminal mostra um erro dizendo que a função não está definida, e não uma falha de asserção comum. O que isso significa dentro do ciclo TDD?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Ainda é a fase red, esse erro também conta como o teste falhando",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O teste foi escrito errado e precisa ser reescrito do zero",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Já é hora de partir para a fase refactor, pois o erro apareceu",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Existe um problema de configuração do runner de testes",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual é a principal vantagem de escrever o teste antes da implementação, segundo a proposta do TDD?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O design nasce pensado em como a função será usada",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O código fica automaticamente mais rápido em produção",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Deixa de ser necessário revisar o código depois",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A cobertura de testes chega a 100% sem esforço",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Durante a fase refactor, depois de renomear uma variável interna da função, o teste que antes passava começa a falhar. O que isso indica?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O comportamento da função mudou, não só a estrutura interna",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O teste estava malformado desde a fase red e precisa mudar",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "É esperado, pois todo refactor deve falhar o teste uma vez",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O runner de testes perdeu o cache e precisa reiniciar",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "TDD na prática, passo a passo",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Partindo de um requisito pequeno\n\nVamos aplicar o ciclo na prática com um requisito bem pequeno, do tipo que aparece o tempo todo num sistema de cursos: **um cupom de desconto**. A regra inicial é simples: quando o cupom for `ALUNO10`, aplica 10% de desconto sobre o valor original.\n\nEm vez de sair implementando tudo de uma vez, o TDD pede pra começar pelo menor caso possível e ir andando em passos curtos."
+                    },
+                    {
+                        "type": "code",
+                        "value": "// RED: o primeiro teste, para o caso mais simples\nimport { describe, it, expect } from 'vitest'\nimport { aplicarDesconto } from './cupom'\n\ndescribe('aplicarDesconto', () => {\n  it('aplica 10% de desconto quando o cupom e ALUNO10', () => {\n    expect(aplicarDesconto('ALUNO10', 100)).toBe(90)\n  })\n})\n\n// npx vitest --run\n// FAIL: Cannot find module './cupom' (o arquivo nem existe ainda)"
+                    },
+                    {
+                        "type": "code",
+                        "value": "// GREEN: o minimo possivel para o teste passar\nexport function aplicarDesconto(cupom, valorOriginal) {\n  return 90\n}\n\n// npx vitest --run\n// PASS  1 passed (1)\n// verde, mas so porque existe um unico teste: essa implementacao\n// obviamente nao serve pra qualquer cupom ou valor"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Um teste força a generalização\n\nDevolver `90` direto é, de propósito, uma trapaça: o único teste que existe até aqui não é suficiente pra provar que a função realmente calcula desconto. É exatamente pra isso que serve o próximo requisito: **um cupom inválido não aplica desconto nenhum**.\n\nEsse segundo teste é quem vai forçar a implementação a virar código de verdade."
+                    },
+                    {
+                        "type": "code",
+                        "value": "// RED: um segundo teste, dentro do mesmo describe('aplicarDesconto', ...)\nit('nao aplica desconto quando o cupom e invalido', () => {\n  expect(aplicarDesconto('QUALQUERCOISA', 100)).toBe(100)\n})\n\n// npx vitest --run\n// FAIL: expected 100, recebido 90 (o retorno fixo nao serve mais)\n\n// GREEN: agora precisa de logica de verdade pra passar as duas\nexport function aplicarDesconto(cupom, valorOriginal) {\n  if (cupom === 'ALUNO10') {\n    return valorOriginal * 0.9\n  }\n  return valorOriginal\n}\n\n// npx vitest --run\n// PASS  2 passed (2)"
+                    },
+                    {
+                        "type": "code",
+                        "value": "// REFACTOR: os dois testes continuam verdes, entao da pra melhorar\n// a estrutura sem medo (aqui, preparando pra outros cupons no futuro)\nexport const CUPONS = {\n  ALUNO10: 0.1,\n}\n\nexport function aplicarDesconto(cupom, valorOriginal) {\n  const percentual = CUPONS[cupom] ?? 0\n  return valorOriginal * (1 - percentual)\n}\n\n// npx vitest --run\n// PASS  2 passed (2) -> comportamento igual, mais facil de estender"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Cada teste novo empurra a implementação um passo além do que ela sabia fazer antes: o primeiro tira do zero, o segundo tira da trapaça. É assim, em passos pequenos, que o design vai se formando."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "No passo a passo do TDD, qual é a atitude recomendada diante de um requisito novo?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Escrever um teste do comportamento esperado e ver ele falhar",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Escrever a implementação inteira e só depois criar os testes",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Criar a documentação da função antes de qualquer código",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Rodar a suíte inteira pra conferir o que já existe no projeto",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "No exemplo da função aplicarDesconto, por que devolver sempre 90 era aceitável na primeira fase green?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Porque só existia um teste, e o objetivo era ficar verde",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque 90 é o valor correto para qualquer cupom recebido",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque a fase green não exige rodar os testes de verdade",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o refactor sempre vem antes do segundo teste",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de adicionar o teste do cupom inválido, a suíte mostrou uma falha: esperado 100, recebido 90. O que essa falha revela sobre a implementação anterior?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Ela era simples demais e não cobria o novo caso",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O teste novo foi escrito com o valor errado por engano",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O ambiente de testes não foi reiniciado entre as execuções",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A função aplicarDesconto tinha um efeito colateral escondido",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois dos dois testes ficarem verdes, o código passou a usar um objeto CUPONS pra guardar os percentuais. Por que essa mudança conta como refactor, e não como um novo ciclo red-green?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque nenhum teste mudou ou foi criado, só a estrutura interna",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque os testes antigos foram apagados e reescritos do zero",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque a cobertura de testes aumentou depois da mudança",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o comportamento mudou para os cupons já existentes",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Num ciclo onde a primeira implementação devolve um valor fixo só pra passar no primeiro teste, o que garante que essa simplificação não fique escondida na versão final do código?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Adicionar novos testes que forcem a generalização da regra",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Marcar a função com um comentário TODO e seguir em frente",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Aumentar o tempo de timeout do teste até ele passar com folga",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Rodar o mesmo teste várias vezes pra confirmar que é estável",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Código testável (injeção de dependência, funções puras)",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Por que código acoplado é difícil de testar\n\nUma função fica difícil de testar quando ela decide sozinha, por dentro, de onde vêm os dados que usa: abre a própria conexão com o banco, chama `fetch` direto, lê `Date.now()`, ou importa um módulo concreto e usa sem nenhuma indireção. Isso é acoplamento.\n\nLembra do cache-aside que você implementou lá atrás? Se a função que decide \"veio do cache ou do banco\" estiver misturada com o código que fala direto com Redis e Postgres, fica impossível testar só a decisão sem subir os dois serviços de verdade."
+                    },
+                    {
+                        "type": "code",
+                        "value": "// ANTES: a regra de negocio e o acesso ao banco vivem juntos\nexport async function podeEmitirCertificado(usuarioId) {\n  const resultado = await db.query(\n    'SELECT aulas_concluidas, aulas_total FROM progresso WHERE usuario_id = $1',\n    [usuarioId]\n  )\n  const { aulas_concluidas, aulas_total } = resultado.rows[0]\n  return aulas_concluidas / aulas_total >= 0.8\n}\n\n// pra testar isso, ou sobe um banco de verdade, ou faz mock\n// do modulo inteiro de banco: nao da pra testar so a regra dos 80%"
+                    },
+                    {
+                        "type": "code",
+                        "value": "import { describe, it, expect, vi } from 'vitest'\n\n// DEPOIS: a regra pura separada do acesso a dado\nexport function calcularElegibilidadeCertificado(aulasConcluidas, aulasTotal) {\n  return aulasConcluidas / aulasTotal >= 0.8\n}\n\n// o I/O fica isolado, e a dependencia entra por fora (injecao)\nexport async function podeEmitirCertificado(usuarioId, buscarProgresso = db.buscarProgresso) {\n  const { aulasConcluidas, aulasTotal } = await buscarProgresso(usuarioId)\n  return calcularElegibilidadeCertificado(aulasConcluidas, aulasTotal)\n}\n\n// teste da regra pura: nenhum banco envolvido\ndescribe('calcularElegibilidadeCertificado', () => {\n  it('libera com 80% ou mais de conclusao', () => {\n    expect(calcularElegibilidadeCertificado(8, 10)).toBe(true)\n  })\n\n  it('nao libera com menos de 80%', () => {\n    expect(calcularElegibilidadeCertificado(7, 10)).toBe(false)\n  })\n})\n\n// teste da parte com I/O, usando um dublê no lugar do banco\nit('busca o progresso usando a dependencia informada', async () => {\n  const buscarProgressoFalso = vi.fn().mockResolvedValue({ aulasConcluidas: 9, aulasTotal: 10 })\n  const resultado = await podeEmitirCertificado('user-1', buscarProgressoFalso)\n  expect(resultado).toBe(true)\n  expect(buscarProgressoFalso).toHaveBeenCalledWith('user-1')\n})"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Funções puras: as mais fáceis de testar\n\n`calcularElegibilidadeCertificado` do exemplo acima é uma **função pura**: pra mesma entrada, sempre devolve a mesma saída, e não toca em nada fora dela (não grava, não loga, não chama rede). Isso faz dela a coisa mais barata de testar que existe: você só passa valores e confere o retorno.\n\nO oposto seria uma função que usa `Math.random()`, `new Date()` ou mexe num parâmetro recebido por referência. Nesses casos, rodar a função duas vezes com a mesma entrada pode dar respostas diferentes, e o teste vira uma aposta."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Separar lógica de I/O\n\nA estratégia por trás dos dois exemplos acima tem nome: empurrar banco, rede, relógio e arquivo pra borda do código, e manter o miolo (as decisões) como funções puras. Isso vale pro middleware de auth também: a parte que decide se um token é válido pode ser uma função pura que recebe o token e a chave secreta, separada da parte que lê o header da requisição e chama `next()`.\n\nQuanto mais regra de negócio estiver em funções puras, menos você precisa de banco, servidor ou rede rodando só pra escrever um teste."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Característica\", \"Código difícil de testar\", \"Código fácil de testar\"], [\"Dependências\", \"Cria a própria conexão com banco ou API dentro da função\", \"Recebe as dependências de fora, por parâmetro\"], [\"Efeitos colaterais\", \"Lê relógio, gera valor aleatório ou grava arquivo no meio da lógica\", \"Só calcula e devolve um valor, sem tocar no mundo externo\"], [\"Acoplamento\", \"Importa um módulo concreto e usa direto, sem indireção\", \"Depende de uma função passada como parâmetro\"], [\"Determinismo\", \"A mesma entrada pode gerar saídas diferentes entre execuções\", \"A mesma entrada sempre gera a mesma saída\"], [\"Responsabilidade\", \"Mistura decisão de negócio com acesso a banco no mesmo bloco\", \"Separa o que decide do que busca ou salva dado\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Função pura é o jeito mais barato de testar alguma coisa. Injeção de dependência é o que sobra pra quando o código realmente precisa tocar o mundo de fora: banco, rede, relógio."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que caracteriza uma função pura?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Mesma entrada sempre produz a mesma saída, sem efeito colateral",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Sempre devolve um valor booleano, verdadeiro ou falso",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Nunca recebe nenhum parâmetro na sua assinatura de chamada",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Sempre acessa o banco de dados pra gerar o resultado final",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que uma função que abre a própria conexão com o banco dentro do corpo é difícil de testar isoladamente?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Porque testá-la exige um banco real ou mock do módulo inteiro",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque funções que usam banco nunca podem ter teste automatizado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o runner de testes não permite importar módulo de banco",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque toda função com banco é considerada lenta demais pra testar",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma função calcula se um usuário pode emitir certificado e, no mesmo corpo, consulta o progresso direto no banco. O time quer testar só a regra dos 80% sem subir banco nenhum. Qual mudança resolve isso?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Extrair a regra para uma função pura, sem acesso a banco",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Aumentar o timeout do teste pra esperar a resposta do banco",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Trocar o banco de dados de teste por um banco mais rápido",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Envolver a consulta ao banco num bloco try/catch",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "No exemplo com podeEmitirCertificado(usuarioId, buscarProgresso = db.buscarProgresso), qual é o papel do segundo parâmetro?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Permitir trocar a busca real por um dublê durante o teste",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Definir o número mínimo de aulas concluídas exigido",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Guardar o resultado da função em cache entre chamadas",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Validar se o usuarioId tem o formato esperado",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma função de validação de cupom usa new Date() internamente pra checar se ele ainda está no prazo de validade. Por que isso torna a função mais difícil de testar do que uma função pura equivalente?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Porque o resultado muda de acordo com o momento em que o teste roda",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o runner de testes não consegue importar a classe Date",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque toda validação de data precisa necessariamente de banco",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque funções com Date sempre lançam exceção em ambiente de teste",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Anatomia de um bom teste",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## O que faz um teste ser bom\n\nUma suíte de testes só vale alguma coisa se você confia nela. Um teste mal escrito pode passar ou falhar pelo motivo errado, ou ser tão confuso que, quando quebra, ninguém entende o que realmente aconteceu. Quatro características separam um bom teste de um teste qualquer:\n\n- Tem um **nome que descreve o comportamento**\n- Tem **um foco só**\n- É **independente** dos outros testes\n- Testa **comportamento**, não detalhe de implementação"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Nomes que descrevem comportamento\n\nO nome do teste deveria contar a história sozinho: se ele falhar no CI às três da manhã, quem ler o nome no relatório precisa entender o que quebrou sem abrir o arquivo. Compare `'teste 1'` com `'devolve 401 quando o token e invalido'`, lembra do middleware de auth do módulo anterior.\n\nUma convenção simples que funciona bem: descrever o cenário e o resultado esperado, tipo \"faz X quando Y\" ou \"devolve Z quando W\"."
+                    },
+                    {
+                        "type": "code",
+                        "value": "import { describe, it } from 'vitest'\n\n// nomes que nao dizem nada quando alguem le o relatorio de falha\ndescribe('auth', () => {\n  it('teste 1', () => { /* ... */ })\n  it('funciona', () => { /* ... */ })\n  it('caso invalido', () => { /* ... */ })\n})\n\n// nomes que descrevem o comportamento esperado\ndescribe('middleware de autenticacao', () => {\n  it('devolve 401 quando o token nao vem no header', () => { /* ... */ })\n  it('devolve 401 quando o token esta expirado', () => { /* ... */ })\n  it('chama next() quando o token e valido', () => { /* ... */ })\n})"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Um foco por teste, testes independentes\n\nCada teste deveria verificar um comportamento só. Não significa ter um `expect` por `it` (várias asserções sobre o mesmo comportamento tudo bem), mas sim não misturar coisas sem relação, tipo validar formato de e-mail e checar se o registro foi salvo no banco dentro do mesmo teste. Quando um teste assim falha, o relatório não diz qual das duas coisas quebrou.\n\nAlém disso, um teste não deveria depender do que outro deixou pra trás, tipo uma variável global com token salvo, ou uma linha inserida por outro teste e nunca limpa. Lembra do `beforeEach`/`afterEach` que zera o banco de teste entre execuções (módulo anterior): é exatamente pra garantir essa independência."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Testar comportamento, não implementação\n\nUm bom teste verifica o que a função promete pra fora: dado tal entrada, tal saída; dada tal requisição, tal status e tal corpo de resposta. Ele não deveria se importar com detalhe de como isso é feito por dentro, tipo se o código usa `for` ou `reduce`, ou quantas vezes uma função auxiliar interna foi chamada.\n\nA prova dos nove: se você refatorar o miolo de uma função sem mudar o que ela promete, os testes deveriam continuar passando sem precisar tocar neles. Se quebram, é sinal de que estavam presos a implementação, não a comportamento."
+                    },
+                    {
+                        "type": "code",
+                        "value": "import { it, expect, vi } from 'vitest'\n\n// ruim: preso a um detalhe interno que pode mudar sem afetar o resultado\nit('usa um for loop pra somar os itens', () => {\n  const espiao = vi.spyOn(internals, 'somarComForLoop')\n  calcularTotal([{ preco: 10 }, { preco: 20 }])\n  expect(espiao).toHaveBeenCalled()\n})\n\n// bom: verifica o resultado que a funcao promete pra fora\nit('soma o preco de todos os itens do carrinho', () => {\n  const total = calcularTotal([{ preco: 10 }, { preco: 20 }])\n  expect(total).toBe(30)\n})\n// se calcularTotal trocar o for por reduce amanha, esse teste nem percebe"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Um teste bom se lê como uma frase e se comporta como uma caixa preta: você olha o nome e entende o comportamento, olha o corpo e só vê entrada e saída, nunca o miolo de como ela chegou lá."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que torna um nome de teste bom, dentro da ideia de nome que descreve comportamento?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Dá pra entender o que quebrou só de ler o nome",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Segue a mesma numeração usada nos arquivos do projeto",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "É curto o bastante pra caber numa linha do terminal",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Usa exatamente o mesmo verbo em todos os testes",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que testes independentes, em que a ordem não importa, são importantes?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Porque um teste não deveria depender do estado deixado por outro",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o runner exige que os arquivos sigam ordem alfabética",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque testes independentes sempre rodam mais rápido que os outros",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque cada arquivo de teste só pode ter um describe",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um teste de criação de curso só passa quando roda depois do teste de login, porque reaproveita um token salvo numa variável global do arquivo. O que esse cenário indica?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Os testes estão acoplados por ordem, o que quebra a independência",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O teste de criação de curso está testando o comportamento errado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O token JWT foi gerado com uma chave secreta inválida",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O runner está rodando os testes em paralelo por engano",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um teste verifica quantas vezes uma função interna privada foi chamada durante o cálculo do total do carrinho, em vez de verificar o valor total devolvido. Qual problema isso traz?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O teste quebra mesmo sem mudança no resultado da função",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O teste fica mais rápido porque não precisa calcular o total",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O teste passa a cobrir mais linhas de código do arquivo",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O teste deixa de precisar do describe pra funcionar",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um único it() reúne vários expect checando validação de e-mail, validação de senha e criação do registro no banco, tudo em sequência. Quando ele falha, o relatório aponta só a primeira asserção quebrada. Qual é a desvantagem principal dessa estrutura?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Fica difícil saber, só pelo relatório, o que realmente quebrou",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O runner não permite mais de um expect dentro do mesmo it",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O teste passa a rodar numa ordem diferente a cada execução",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O tempo de execução do teste cresce de forma exponencial",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Os princípios FIRST",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Os princípios FIRST\n\nExiste um pequeno checklist, resumido no acrônimo **FIRST**, que ajuda a avaliar se um teste está saudável ou se vai virar dor de cabeça com o tempo: **F**ast, **I**solated (ou Independent), **R**epeatable, **S**elf-validating, **T**imely. Ele resume boa parte do que já apareceu nas aulas anteriores, agora com nome pra cada ideia."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Princípio\", \"O que significa\", \"Na prática\"], [\"Fast\", \"A suíte roda em segundos, não minutos\", \"Testes unitários sem banco ou rede real, dublês no lugar de I/O lento\"], [\"Isolated / Independent\", \"Um teste não depende de outro nem da ordem de execução\", \"Cada teste cria seus próprios dados, sem reaproveitar estado global\"], [\"Repeatable\", \"O mesmo teste dá o mesmo resultado sempre, em qualquer máquina\", \"Sem depender de hora do dia, rede externa ou dado de produção\"], [\"Self-validating\", \"O teste decide sozinho se passou ou falhou, sem checagem manual\", \"Usa expect, não imprime algo no terminal pra alguém ler\"], [\"Timely\", \"O teste é escrito perto da hora de escrever o código\", \"No TDD, antes do código; no mínimo, junto, nunca meses depois\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Fast e Repeatable\n\nSe a suíte demora minutos pra rodar, o time para de rodar ela a toda hora, e o feedback rápido que é a maior vantagem de testar automatizado se perde. Isso costuma acontecer quando teste unitário depende de banco, rede ou de outro serviço de verdade em vez de um dublê.\n\nRepeatable anda junto: um teste que depende do relógio da máquina, da ordem de execução ou de um serviço externo instável pode passar hoje e falhar amanhã sem que o código tenha mudado nada. Isso é o começo do que o módulo seguinte chama de teste flaky."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Isolated, Self-validating e Timely\n\nIsolated retoma a independência entre testes vista na aula anterior: nenhum teste deveria precisar que outro rode antes. Self-validating quer dizer que o próprio `expect` decide o resultado, sem alguém lendo `console.log` pra julgar se passou. E Timely é sobre o momento: escrever o teste junto com o código (ou antes dele, como no TDD) é o que mantém o design guiado pelo teste; escrever semanas depois, quando o código já está fixado em produção, perde boa parte desse benefício."
+                    },
+                    {
+                        "type": "code",
+                        "value": "import { describe, it, expect } from 'vitest'\nimport { calcularElegibilidadeCertificado } from './certificado'\n\ndescribe('calcularElegibilidadeCertificado', () => {\n  // Fast: nao acessa banco nem rede, roda em milissegundos\n  // Isolated: nao depende de nenhum outro teste do arquivo\n  // Repeatable: mesma entrada, mesma saida, sempre\n  it('libera certificado com 80% ou mais de conclusao', () => {\n    expect(calcularElegibilidadeCertificado(8, 10)).toBe(true)\n  })\n\n  // Self-validating: o proprio expect decide, ninguem le nada no console\n  it('nao libera certificado com menos de 80%', () => {\n    expect(calcularElegibilidadeCertificado(7, 10)).toBe(false)\n  })\n})\n\n// Timely: estes testes foram escritos junto com a funcao, nao depois"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Fechando o módulo\n\nO ciclo red-green-refactor, código testável (função pura e injeção de dependência) e os princípios FIRST são três jeitos de olhar pro mesmo problema: como escrever teste que continua útil daqui a um ano, em vez de virar peso morto que o time ignora ou apaga. No próximo módulo entra cobertura, testes end-to-end e o problema dos testes flaky, incluindo como isso tudo roda dentro do CI."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "FIRST não é regra pra decorar, é um diagnóstico: toda vez que um teste vira dor de cabeça, dá pra apontar qual dessas cinco letras ele está quebrando."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que o F de FIRST representa?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Fast, a suíte de testes deve rodar rápido",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Fixed, os testes não podem ser alterados depois",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Final, os testes devem ser os últimos arquivos do projeto",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Full, os testes devem cobrir cem por cento do código",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O que significa um teste ser self-validating?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Ele mesmo decide se passou ou falhou, sem checagem manual",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Ele valida sozinho os dados enviados pelo usuário",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ele se corrige automaticamente quando encontra um erro",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ele gera sozinho sua própria massa de dados de teste",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma suíte de testes unitários leva 12 minutos pra rodar porque cada teste abre uma conexão real com o banco de dados. Qual princípio do FIRST está sendo violado?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Fast, já que testes unitários deveriam rodar em segundos",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Timely, já que os testes deveriam ter sido escritos antes",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Self-validating, já que o banco real invalida o resultado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Isolated, já que conexões de banco não podem ser paralelas",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Dois testes só falham quando rodam num pipeline com fuso horário diferente do notebook do desenvolvedor, porque a função usa new Date() sem nenhum controle. Isso quebra qual princípio do FIRST?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Repeatable, o mesmo teste deveria dar o mesmo resultado sempre",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Fast, testes que usam data costumam ser mais lentos",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Timely, testes que envolvem data precisam ser escritos por último",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Isolated, cada fuso horário deveria ter sua própria suíte",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um time só escreve os testes de uma funcionalidade semanas depois dela estar em produção, quando já apareceram bugs. Além do risco óbvio de regressão não pega antes do deploy, por que isso também enfraquece o valor do design que o TDD promete?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Porque o teste deixa de influenciar o design, já que o código já está fixado",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque testes escritos depois do deploy não podem usar o runner normalmente",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque a cobertura de código passa a ser contada de forma incorreta",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque testes tardios são sempre mais lentos que testes escritos antes",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 6 - Cobertura, e2e e flaky tests",
+        "aulas": [
+            {
+                "titulo": "Cobertura de código e a armadilha do 100%",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Cobertura de código e a armadilha do 100%\n\nNo módulo passado você viu TDD e o que torna um código testável: injeção de dependência, funções puras, lógica separada de I/O. Só que escrever testes bons não responde sozinho a uma pergunta que cedo ou tarde aparece: quanto do meu código está, de fato, sendo testado? É pra responder isso que existe a cobertura de código (code coverage), um relatório que mostra exatamente quais linhas, ramos e funções os seus testes chegam a executar, e quais ficam de fora.\n\nCobertura é uma ferramenta poderosa para achar buracos na sua suíte. Só que, usada do jeito errado (como meta cega, perseguindo 100%), ela pode te dar uma falsa sensação de segurança. Esse é o assunto desta aula."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que a cobertura mede\n\nQuando você roda a suíte com cobertura ativada, a ferramenta instrumenta o código (acrescenta um contador invisível em cada trecho) e observa o que realmente é executado enquanto os testes rodam. No fim, ela cruza isso com o código-fonte e calcula quatro métricas:\n\n- **Statements (instruções)**: quantas instruções do código (uma atribuição, uma chamada de função, um return) chegaram a rodar pelo menos uma vez.\n- **Branches (ramos)**: quantos caminhos de decisão (o if e o else, cada case de um switch, os dois lados de um ternário) foram exercitados. Rodar só o if e nunca o else conta como metade da cobertura de branch daquele trecho.\n- **Functions (funções)**: quantas funções do arquivo foram chamadas ao menos uma vez pelos testes.\n- **Lines (linhas)**: quantas linhas de código foram executadas, parecido com statements, mas contado por linha do arquivo em vez de por instrução.\n\nNenhuma dessas métricas diz se o teste checou o resultado certo. Elas só dizem se aquele trecho rodou durante os testes. Guarda essa distinção, porque ela é o centro da armadilha que vem mais adiante."
+                    },
+                    {
+                        "type": "code",
+                        "value": "// instalar o provider de cobertura do Vitest (uma vez só no projeto)\nnpm install -D @vitest/coverage-v8\n\n// o Jest (equivalente classico do Vitest) tambem tem um --coverage embutido,\n// a ideia de instrumentar o codigo e ler um relatorio depois e a mesma\n\n// rodar a suite inteira com relatorio de cobertura\nnpx vitest run --coverage\n\n// vitest.config.ts: configurando o relatorio\nimport { defineConfig } from 'vitest/config';\n\nexport default defineConfig({\n  test: {\n    coverage: {\n      provider: 'v8',\n      reporter: ['text', 'html'],\n      exclude: ['**/*.config.js', 'src/db.js'],\n    },\n  },\n});\n\n// saida no terminal depois de rodar\n// -----------------|---------|----------|---------|---------|-------------------\n// File              | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s\n// -----------------|---------|----------|---------|---------|-------------------\n// All files         |   84.61 |    66.66 |     100 |   84.61 |\n//  frete.js         |   84.61 |    66.66 |     100 |   84.61 | 7\n// -----------------|---------|----------|---------|---------|-------------------"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Como ler o relatório\n\nA tabela que aparece no terminal (o reporter `text`) resume, por arquivo e para o projeto inteiro, as quatro métricas que você acabou de ver. A coluna `Uncovered Line #s` é a mais prática no dia a dia: ela aponta exatamente quais números de linha nenhum teste chegou a executar, então é o primeiro lugar a olhar quando a cobertura de um arquivo está baixa.\n\nO reporter `html` gera uma pasta `coverage/` com um relatório navegável: abra `coverage/index.html` no navegador e clique em qualquer arquivo para ver o código-fonte pintado linha a linha (verde para o que os testes exercitaram, vermelho para o que ficou de fora, amarelo para um branch parcialmente coberto). É bem mais rápido de vasculhar do que ler número no terminal, principalmente num arquivo grande."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## A armadilha do 100%\n\nAqui mora o perigo: cobertura mede execução, não verificação. Um teste pode passar pela linha inteira, entrar em todos os branches, chamar todas as funções, e mesmo assim não checar se o resultado é o certo. Nesse caso a ferramenta de cobertura mostra 100%, tudo tranquilo, só que se alguém quebrar a lógica amanhã, o teste continua passando, porque ele nunca conferiu o valor de verdade.\n\nPerseguir 100% como meta, sozinho, incentiva exatamente esse tipo de teste: escrito só para 'passar pela linha', sem pensar no comportamento esperado. O número sobe, a confiança real na suíte não."
+                    },
+                    {
+                        "type": "code",
+                        "value": "// desconto.js\nexport function calcularDesconto(valor, cupom) {\n  if (cupom === 'PROMO10') {\n    return valor * 0.9;\n  }\n  return valor;\n}\n\n// desconto.test.js (ANTES: bate 100% de cobertura, mas nao garante nada)\nimport { describe, it, expect } from 'vitest';\nimport { calcularDesconto } from './desconto';\n\ndescribe('calcularDesconto', () => {\n  it('funciona com cupom', () => {\n    const resultado = calcularDesconto(100, 'PROMO10');\n    expect(resultado).toBeDefined(); // passa mesmo se o calculo estiver errado\n  });\n\n  it('funciona sem cupom', () => {\n    const resultado = calcularDesconto(100, 'OUTRO');\n    expect(resultado).toBeDefined();\n  });\n});\n\n// desconto.test.js (DEPOIS: mesma cobertura, agora testando o valor certo)\ndescribe('calcularDesconto', () => {\n  it('aplica 10% de desconto quando o cupom e PROMO10', () => {\n    expect(calcularDesconto(100, 'PROMO10')).toBe(90);\n  });\n\n  it('nao aplica desconto quando o cupom nao e reconhecido', () => {\n    expect(calcularDesconto(100, 'OUTRO')).toBe(100);\n  });\n});\n\n// se alguem trocar 0.9 por 0.5 sem querer, a versao ANTES continua verde,\n// a versao DEPOIS quebra na hora, que e o que se espera de um teste de verdade"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Cobertura alta é dado sobre execução, não sobre confiança nos testes. Use o relatório para achar linha esquecida, nunca como troféu para caçar até 100%."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que a métrica de cobertura de branches mede?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Quantos caminhos de decisão, como um if e seu else, os testes exercitaram",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Quantas funções distintas do arquivo os testes chegaram a chamar uma vez",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Quantas linhas do arquivo os testes chegaram a executar em algum momento",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Quanto tempo, em média, os testes levam para rodar cada arquivo do projeto",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual comando roda a suíte do Vitest já com o relatório de cobertura?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "npx vitest coverage --run-once",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "npx vitest run --coverage",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "npx vitest --report=coverage",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "npx vitest run --check-lines",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um arquivo mostra 100% em todas as colunas do relatório de cobertura, mas um bug no cálculo de desconto passou para produção sem nenhum teste acusar o problema. O que provavelmente aconteceu?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O bug foi introduzido depois da última vez que a suíte rodou com a cobertura ativada",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "100% de cobertura é matematicamente impossível, então o relatório mostrado estava errado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os testes exercitaram o código, mas usaram uma asserção fraca que não conferia o valor certo",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O relatório de cobertura do Vitest está com um erro de cálculo e não deveria ser confiável",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Ao abrir o relatório HTML de cobertura, uma linha aparece destacada em amarelo. O que isso costuma indicar?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Aquela linha tem uma vulnerabilidade de segurança identificada automaticamente",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Aquela linha foi modificada recentemente e ainda não foi revisada por ninguém",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Vitest não conseguiu instrumentar aquela linha específica para medir cobertura",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um branch, como um if com else, foi só parcialmente exercitado pelos testes",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um time define uma meta: nenhum PR pode ser aceito se a cobertura cair abaixo de 100%. Depois de alguns meses, a suíte tem 100% de cobertura, mas bugs continuam chegando em produção com a mesma frequência de antes. Qual explicação é mais consistente com a armadilha do 100% vista nesta aula?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "A meta incentivou testes que exercitam o código sem checar o comportamento certo",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "100% de cobertura é impossível de sustentar por mais de um mês em qualquer projeto",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A meta de cobertura não tem nenhuma relação com a frequência de bugs em produção",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O time provavelmente parou de rodar a suíte de testes antes de cada deploy",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Testes end-to-end",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Testes end-to-end\n\nAté aqui a pirâmide te levou do unitário (uma função isolada) até a integração (rota, service e banco trabalhando juntos, testados com supertest direto pela API). Falta o topo: o teste end-to-end (e2e), que não entra pela API, entra pela porta da frente. Ele abre a aplicação do jeito que um usuário abriria, clica onde um usuário clicaria, e confere se o que aparece na tela, e o que fica gravado no banco, é o esperado.\n\nÉ o teste mais parecido com a experiência real. E, como você vai ver, é justamente por isso que ele custa mais caro."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O fluxo inteiro, de ponta a ponta\n\nUm teste e2e não chama uma função nem faz uma requisição HTTP direto contra o Express: ele controla um navegador de verdade (ou uma simulação bem próxima disso), aberto contra a aplicação rodando de verdade, front e back juntos. Um cenário típico: abrir a tela de login, digitar e-mail e senha, clicar em 'Entrar', esperar a navegação para a tela de tarefas, clicar em 'Nova tarefa', preencher o formulário, confirmar, e checar que a tarefa aparece na lista, inclusive depois de recarregar a página (prova de que ela foi realmente gravada no banco, não só numa variável em memória no navegador).\n\nRepare a diferença de camada: o teste de integração do módulo anterior falava HTTP diretamente com as rotas do Express. O e2e vai uma camada acima, fala com a interface, e deixa a própria aplicação decidir como transformar aquele clique numa chamada HTTP."
+                    },
+                    {
+                        "type": "code",
+                        "value": "// exemplo com Playwright: cadastro de tarefa, do login ate a lista\nimport { test, expect } from '@playwright/test';\n\ntest('usuario loga e cadastra uma nova tarefa', async ({ page }) => {\n  await page.goto('http://localhost:3000/login');\n\n  await page.getByLabel('E-mail').fill('aluno@ensina.dev');\n  await page.getByLabel('Senha').fill('senha123');\n  await page.getByRole('button', { name: 'Entrar' }).click();\n\n  await expect(page).toHaveURL('http://localhost:3000/tarefas');\n\n  await page.getByRole('button', { name: 'Nova tarefa' }).click();\n  await page.getByLabel('Titulo').fill('Estudar testes e2e');\n  await page.getByRole('button', { name: 'Salvar' }).click();\n\n  await expect(page.getByText('Estudar testes e2e')).toBeVisible();\n\n  await page.reload();\n  await expect(page.getByText('Estudar testes e2e')).toBeVisible(); // confirma que gravou no banco\n});\n\n// o Cypress resolve o mesmo problema com uma API propria (cy.visit, cy.get, cy.click),\n// mas a ideia por tras e a mesma: controlar um navegador de verdade contra a aplicacao de verdade"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"\",\"Teste de integração (supertest)\",\"Teste e2e (Playwright/Cypress)\"],[\"O que ele fala com\",\"As rotas do Express, direto por HTTP\",\"A interface, como um usuário faria\"],[\"O que ele exercita\",\"Rota, service e banco\",\"Front, rota, service, banco e a navegação inteira\"],[\"Velocidade\",\"Rápido, roda em memória ou contra um banco de teste local\",\"Lento, sobe navegador, front e back de verdade\"],[\"Fragilidade\",\"Quebra só se a API mudar\",\"Quebra também se um botão ou texto da tela mudar\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Por que existem poucos testes e2e\n\nTrês motivos empurram o e2e para o topo da pirâmide, com poucos testes:\n\n- **Lentos**: cada teste precisa subir o front, o back e o banco de verdade, abrir um navegador, esperar a página carregar, esperar animações e requisições terminarem. Um teste que levaria milissegundos como unitário pode levar vários segundos como e2e.\n- **Frágeis**: o teste depende de detalhes da interface (o texto de um botão, a estrutura de um formulário, o tempo que uma tela leva para carregar). Um redesenho que não muda nenhuma regra de negócio pode quebrar dezenas de testes e2e.\n- **Caros**: além do tempo de execução, alguém precisa escrever, manter e depurar esses testes, e a infraestrutura para rodar navegador em CI custa mais do que só rodar um processo Node.\n\nPor isso a pirâmide pede poucos e2e: só onde o custo compensa."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Onde o e2e compensa\n\nA resposta não é 'nunca fazer e2e', é 'fazer pouco e onde mais importa'. Os candidatos naturais são os fluxos críticos do negócio, aqueles que, se quebrarem, derrubam a aplicação inteira do ponto de vista do usuário: login, cadastro, checkout de um pedido, o fluxo de pagamento. Não vale a pena escrever um e2e para cada variação de validação de formulário (isso já está coberto, e mais barato, pelos testes unitários e de integração). Vale a pena para o caminho principal que, se parar de funcionar, ninguém mais consegue usar o sistema."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "e2e testa a promessa que você faz para o usuário: que o botão realmente faz o que ele diz que faz. Vale ouro nos fluxos certos, e custa caro demais para testar tudo."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que diferencia um teste e2e de um teste de integração feito com supertest?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "O e2e só verifica o backend; o de integração verifica o backend e o frontend juntos",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O e2e passa pela interface como um usuário faria; o de integração fala direto com a rota",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O e2e não usa nenhum framework de teste; o de integração sempre depende do Vitest",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O e2e roda mais rápido, porque não precisa esperar resposta nenhuma do banco de dados",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que os testes e2e ficam no topo da pirâmide, em menor quantidade?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Porque testes e2e não conseguem checar se um dado foi realmente gravado no banco",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque escrever um e2e exige uma linguagem de programação diferente do resto",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque são lentos, frágeis a mudanças de interface e caros de escrever e manter",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque a maioria das ferramentas de e2e, como o Playwright, ainda é instável",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um time redesenha a tela de login, trocando o texto do botão de 'Entrar' para 'Acessar', sem mudar nenhuma regra de negócio. Vários testes e2e passam a falhar, enquanto os unitários e de integração continuam passando. O que isso ilustra?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Um bug real introduzido no redesenho, que os outros níveis de teste não pegaram",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que os testes de integração desse projeto estão desatualizados e devem ser reescritos",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que o Playwright não é compatível com mudanças de texto em botões de formulário",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A fragilidade do e2e: ele depende de detalhes de interface que mudam sem alterar a lógica",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe decide escrever um teste e2e para cada uma das 40 validações de campo do formulário de cadastro de tarefa. Por que essa não costuma ser uma boa estratégia?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque validações de campo são mais baratas e rápidas de cobrir com testes unitários",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o Playwright tem um limite técnico de dez testes por arquivo de teste",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque testes e2e não são capazes de preencher formulários com múltiplos campos",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque validações de campo não devem ser testadas em nenhum nível da pirâmide",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um teste e2e cadastra uma tarefa, recarrega a página e confere que ela continua na lista. Que garantia adicional esse teste dá, que um teste de integração com supertest (que também confere o POST e o retorno 201) não dá sozinho?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Confirma que o banco usado em produção está configurado com backup automático",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Confirma que a interface dispara a chamada certa e reflete o dado persistido na tela",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Confirma que a query SQL usada para inserir a tarefa está livre de vulnerabilidades",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Confirma que a rota aceita o mesmo payload em qualquer ordem dos campos enviados",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Testes flaky: causas e como evitar",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Testes flaky: causas e como evitar\n\nTem um tipo de teste que é pior do que um teste que falha: é o teste que falha às vezes. Você roda a suíte, vermelho. Roda de novo, sem mudar uma linha de código, verde. Roda de novo, vermelho outra vez. Esse comportamento tem nome: teste flaky (instável), e ele é um dos problemas mais corrosivos que uma suíte de testes pode ter.\n\nNesta aula você vai ver as causas mais comuns de flakiness e, mais importante, como escrever testes que não caem nessa armadilha."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## As causas mais comuns\n\nQuase todo teste flaky cai em uma dessas categorias:\n\n- **Dependência de tempo**: o teste espera um `setTimeout`, compara `Date.now()`, ou assume que uma operação assíncrona termina dentro de um prazo fixo. Numa máquina mais lenta (como o runner do CI, sob carga), o prazo estoura e o teste falha.\n- **Ordem dos testes**: um teste depende do que outro deixou para trás (uma variável, uma linha no banco, um contador global). Ele passa quando roda depois do teste certo, e falha quando roda sozinho ou em outra ordem.\n- **Estado compartilhado não limpo**: dois testes usam o mesmo dado (o mesmo e-mail de usuário, a mesma linha no banco de teste) e um interfere no outro, sem que o código de nenhum dos dois tenha um bug de verdade.\n- **Chamada de rede real**: o teste bate numa API externa de verdade. Se a rede cai, a API está fora do ar ou responde mais devagar naquele instante, o teste falha por um motivo que não tem nada a ver com o código sendo testado.\n- **Aleatoriedade**: o teste usa `Math.random()`, um identificador gerado na hora, ou depende da ordem em que o banco devolve linhas sem um `ORDER BY` explícito. Às vezes o valor sorteado cai num caso que o teste não previu."
+                    },
+                    {
+                        "type": "code",
+                        "value": "// flaky: depende de tempo real e de uma janela de espera apertada demais\nimport { describe, it, expect } from 'vitest';\nimport { debounce } from './debounce';\n\ndescribe('debounce', () => {\n  it('so chama a funcao uma vez apos 100ms de silencio', async () => {\n    let chamadas = 0;\n    const fn = debounce(() => chamadas++, 100);\n\n    fn();\n    fn();\n    fn();\n\n    await new Promise((resolve) => setTimeout(resolve, 105)); // margem apertada\n\n    expect(chamadas).toBe(1);\n    // no CI, sob carga, esses 5ms de folga somem e o teste falha do nada\n  });\n});"
+                    },
+                    {
+                        "type": "code",
+                        "value": "// corrigido: controla o tempo em vez de esperar o tempo real passar\nimport { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';\nimport { debounce } from './debounce';\n\ndescribe('debounce', () => {\n  beforeEach(() => {\n    vi.useFakeTimers();\n  });\n\n  afterEach(() => {\n    vi.useRealTimers();\n  });\n\n  it('so chama a funcao uma vez apos 100ms de silencio', () => {\n    let chamadas = 0;\n    const fn = debounce(() => chamadas++, 100);\n\n    fn();\n    fn();\n    fn();\n\n    vi.advanceTimersByTime(100); // avanca o relogio na hora, sem esperar de verdade\n\n    expect(chamadas).toBe(1);\n    // deterministico: sempre os mesmos 100ms, nao importa a velocidade da maquina\n  });\n});"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Causa\",\"Como evitar\"],[\"Dependência de tempo real\",\"Controlar o tempo com timers falsos (vi.useFakeTimers, vi.advanceTimersByTime) em vez de esperar de verdade\"],[\"Ordem dos testes\",\"Cada teste cria os próprios dados e não depende do que outro teste deixou para trás\"],[\"Estado compartilhado não limpo\",\"Isolar com beforeEach/afterEach: recriar ou truncar o estado antes ou depois de cada teste\"],[\"Chamada de rede real\",\"Mockar a chamada externa (vi.mock, vi.fn) em vez de bater numa API de verdade\"],[\"Aleatoriedade\",\"Fixar a semente do gerador ou injetar um gerador determinístico no teste\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Por que flaky é mais perigoso do que parece\n\nUm teste que falha sempre é fácil de lidar com: ele aponta um problema, alguém corrige, ele volta a passar. O teste flaky corrói de um jeito diferente: na primeira vez que ele falha sem motivo aparente, alguém roda de novo e ele passa. Na segunda vez, mais alguém faz o mesmo. Depois de algumas semanas, o reflexo do time inteiro vira 'roda de novo que deve ser só flakiness', inclusive quando a falha é real.\n\nEsse é o efeito mais caro: o time para de confiar na suíte. E o valor inteiro de ter testes automatizados (o sinal claro de que algo quebrou) desaparece justamente na hora em que mais precisava dele. Um teste flaky não corrigido tende a esconder, cedo ou tarde, uma regressão de verdade."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Um teste que falha sempre te dá informação. Um teste flaky te ensina a ignorar a informação. É por isso que ele é pior do que não ter teste nenhum."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que caracteriza um teste flaky?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Ele demora muito mais tempo que os demais testes da suíte para terminar de rodar",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ele aponta, na mensagem de erro, o número exato da linha onde está o problema",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ele passa em algumas execuções e falha em outras, sem nenhuma mudança no código",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Ele sempre falha, mesmo depois de o bug que ele apontava já ter sido corrigido",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual das opções abaixo é uma causa comum de teste flaky?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "O teste usa describe e it para organizar os casos dentro do mesmo arquivo",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O teste importa a função sendo testada de um arquivo separado do teste",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O teste usa expect para comparar o resultado retornado com o valor esperado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O teste espera um tempo fixo, como 100ms, para uma operação assíncrona terminar",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "A suíte tem 50 testes. Isolados, todos passam. Rodados juntos, dois deles falham, mas só quando um roda logo depois do outro. O que provavelmente está acontecendo?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Um teste está deixando estado (dado no banco, variável) que interfere no seguinte",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O Vitest tem um limite de testes simultâneos e descarta alguns deles ao acaso",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os dois testes estão testando exatamente a mesma função, o que nunca é permitido",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A suíte está usando Math.random() dentro do próprio runner de testes do Vitest",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um teste de integração bate direto numa API de pagamentos de terceiro de verdade (não mockada) para conferir se o pedido é aprovado. Esse teste falha de vez em quando, mesmo sem mudança no código. Qual é o ajuste mais direto para resolver isso?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Rodar esse teste sozinho, fora da suíte principal, sempre antes de todos os outros",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Mockar a chamada à API externa, controlando a resposta que o teste espera",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Trocar o Vitest por outro test runner mais tolerante a chamadas de rede reais",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Aumentar o tempo de timeout do teste até a API de pagamentos nunca mais falhar",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Dois testes independentes usam o mesmo e-mail fixo para criar um usuário de teste ('teste@exemplo.com'). Rodados em sequência no CI, o segundo falha com erro de e-mail duplicado; rodados sozinhos, cada um passa. Qual mudança resolve a causa raiz, e não só o sintoma?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Marcar os dois testes com it.skip sempre que forem rodados na mesma suíte de CI",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Trocar a ordem de execução dos arquivos de teste no arquivo de configuração",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Gerar um e-mail único por teste e limpar os dados criados entre um teste e outro",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Aumentar o timeout do segundo teste para dar tempo do primeiro liberar o e-mail",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Testes no CI",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Testes no CI\n\nUma suíte de testes que só roda quando alguém lembra de rodar localmente vale bem menos do que parece. Cedo ou tarde alguém esquece, ou roda só parte dela, ou ignora um teste vermelho porque 'já é tarde, deve ser só flaky' (viu na aula passada como isso é perigoso). A solução é tirar essa decisão da mão de qualquer pessoa: rodar a suíte inteira, automaticamente, toda vez que alguém sobe código. Isso é integração contínua, ou CI (continuous integration), e é o assunto desta aula."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Rodar a cada push e a cada pull request\n\nNum pipeline de CI configurado, a suíte de testes roda sozinha em dois momentos: a cada push (cada vez que alguém envia commits para o repositório remoto) e a cada pull request (antes de qualquer mudança ser aceita na branch principal). O servidor de CI sobe um ambiente limpo do zero, do jeito que você viu no Módulo 4 para o banco de teste efêmero (sobe, migra, roda os testes), só que dessa vez sem depender da máquina de ninguém.\n\nO ganho principal é o bloqueio de merge: a maioria das plataformas (GitHub incluído) permite marcar a execução dos testes como uma verificação obrigatória (required status check) numa pull request. Se a suíte falhar, o botão de mesclar fica bloqueado, e ninguém precisa lembrar de rodar nada manualmente antes de aprovar o código."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# .github/workflows/testes.yml\nname: Testes\n\non:\n  push:\n  pull_request:\n\njobs:\n  testes:\n    runs-on: ubuntu-latest\n\n    services:\n      postgres:\n        image: postgres:16\n        env:\n          POSTGRES_PASSWORD: teste\n          POSTGRES_DB: app_teste\n        ports:\n          - 5432:5432\n\n    steps:\n      - uses: actions/checkout@v4\n\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n\n      - run: npm ci\n\n      - run: npm run migrate\n        env:\n          DATABASE_URL: postgres://postgres:teste@localhost:5432/app_teste\n\n      - run: npx vitest run --coverage\n        env:\n          DATABASE_URL: postgres://postgres:teste@localhost:5432/app_teste"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Cuidado com o modo watch, e por que rapidez importa\n\nRepare que o workflow roda `vitest run`, com o `run` explícito, e não só `vitest`. Sem isso, o Vitest entra no modo watch por padrão (o mesmo modo interativo que você usa no dia a dia, reobservando arquivos e esperando você digitar algo no terminal), e ele nunca termina sozinho. Num pipeline de CI isso trava o job para sempre, até estourar o tempo limite.\n\nVelocidade também importa pelo motivo oposto: cada minuto que a suíte leva para rodar é um minuto que a pull request fica esperando, e um minuto de máquina de CI custando. É aqui que a pirâmide de testes paga a conta: uma suíte com muitos unitários rápidos, alguns de integração e pouquíssimos e2e roda em segundos ou poucos minutos. Uma suíte pesada em e2e pode levar dezenas de minutos só para dar o primeiro sinal verde."
+                    },
+                    {
+                        "type": "code",
+                        "value": "// package.json (trecho)\n{\n  \"scripts\": {\n    \"test\": \"vitest run\",\n    \"test:watch\": \"vitest\",\n    \"test:coverage\": \"vitest run --coverage\"\n  }\n}\n\n// localmente, no dia a dia: npm run test:watch (fica observando e re-rodando)\n// no CI: npm test (roda uma vez, mostra o resultado e encerra sozinho)"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que vem depois: CI/CD\n\nRodar os testes automaticamente é só a primeira metade de um pipeline de CI/CD completo. A outra metade (build da aplicação, empacotar, publicar uma imagem, fazer o deploy em produção) é assunto para mais adiante, quando você vir Docker e containers. Por enquanto, o que importa fixar é o papel dos testes dentro desse pipeline: eles são o portão de qualidade que decide se o código está bom o suficiente para seguir adiante. Sem uma suíte confiável (sem flaky, rápida, cobrindo o que importa), esse portão não vale nada, é só uma etapa que todo mundo aprende a ignorar."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "CI não substitui escrever bons testes, só garante que ninguém esqueça de rodá-los a cada mudança."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que significa, na prática, 'rodar os testes no CI'?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Cada desenvolvedor precisa rodar a suíte manualmente antes de cada commit local",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os testes passam a rodar apenas uma vez por semana, num horário fixo agendado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os testes de integração são substituídos por testes e2e no ambiente de CI",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A suíte roda automaticamente a cada push ou pull request, sem depender de ninguém",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que marcar a execução dos testes como 'required status check' numa pull request é importante?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Porque bloqueia o botão de merge automaticamente enquanto a suíte não passar",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque faz os testes rodarem com uma cobertura de código maior que localmente",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque transforma automaticamente cada teste falho em uma issue no repositório",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque reduz o tempo total que a suíte de testes leva para terminar de rodar",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um workflow de CI roda apenas `vitest`, sem o `run`, no job de testes. O job nunca termina, até o runner estourar o tempo limite e falhar. Qual é a causa mais provável?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "A suíte tem testes flaky demais, e o Vitest entra num laço tentando repeti-los",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Sem run, o Vitest sobe no modo watch, que espera mudanças e nunca encerra sozinho",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O banco de dados de teste não foi migrado antes da suíte começar a rodar",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O workflow tentou rodar testes e2e sem ter instalado o navegador necessário",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que uma suíte pesada em testes e2e tende a atrasar mais o pipeline de CI do que uma suíte com muitos unitários e poucos e2e, testando a mesma aplicação?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque testes e2e só podem rodar em runners com placa de vídeo dedicada",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque testes unitários não podem ser paralelizados dentro do mesmo pipeline",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque cada e2e sobe navegador, front e back de verdade, o que leva bem mais tempo",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o CI cobra por teste executado, e testes e2e custam mais caro por padrão",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe nota que sua pull request demora, em média, 25 minutos para receber o sinal verde do CI, o que está atrasando os merges do time. A suíte tem 400 testes unitários, 30 de integração e 45 testes e2e. Qual mudança tende a atacar melhor a causa raiz do atraso?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Reescrever os 400 testes unitários usando um framework diferente do Vitest",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Remover a etapa de instalação de dependências do workflow para ganhar segundos",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Aumentar o tempo limite do job de CI para dar mais folga para a suíte inteira",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Revisar os 45 e2e, mantendo só os fluxos críticos, e mover o resto para outro nível",
+                                "isCorrect": true
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Quando usar cada nível de teste",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Quando usar cada nível de teste\n\nLá no Módulo 1 você conheceu a pirâmide de testes: unitário na base, integração no meio, e2e no topo. Agora, depois de ver como cada nível funciona na prática (incluindo o que os torna caros, lentos ou frágeis), dá para responder a pergunta que fecha esta trilha: diante de uma funcionalidade nova, qual nível de teste vale a pena escrever, e quanto de cada?\n\nA resposta curta é a proporção da própria pirâmide: muitos testes unitários, alguns de integração, poucos e2e. A resposta longa explica o porquê de cada 'quanto'."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Muitos testes unitários: a base barata\n\nTestes unitários testam uma função ou uma unidade pequena isolada (com mocks no lugar das dependências, como você viu no Módulo 3), sem subir banco, sem rede, sem navegador. Isso os torna baratos em três frentes: rápidos de rodar (uma suíte inteira de unitários roda em segundos), fáceis de escrever, e fáceis de manter (um teste isolado quebra por um motivo só: a unidade que ele testa mudou de comportamento).\n\nSão o lugar certo para cobrir regras de negócio, cálculos, validações e casos de borda: toda vez que existe uma lógica com mais de um caminho possível (um desconto que muda por faixa, uma validação com várias regras), vale a pena um teste unitário para cada caminho relevante. É aqui que a proporção da pirâmide pesa mais: a maioria dos testes da sua suíte deveria ser deste tipo."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Alguns testes de integração: as junções que importam\n\nTestes de integração (Módulo 4) custam mais que unitários (sobem um banco de teste, esperam I/O de verdade), então não faz sentido testar toda combinação possível nesse nível. O critério é outro: testar as junções importantes, os pontos onde as peças se encaixam e onde um teste unitário, sozinho, não seria capaz de pegar o problema.\n\nExemplos de junção que vale a pena testar com integração: uma rota que depende de uma query específica no banco (o teste unitário mockaria o banco e nunca pegaria uma query errada), um middleware de autenticação protegendo de fato uma rota (o teste unitário da função que valida o token não prova que o middleware está registrado na rota certa), um fluxo que grava em mais de uma tabela dentro da mesma transação. A régua é: se o unitário já prova isso com mock, não precisa de integração; se só prova rodando as peças juntas, precisa."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Poucos testes e2e: só os fluxos críticos\n\ne2e é o nível mais caro dos três, como você viu na aula sobre testes end-to-end deste módulo, então ele fica reservado para os fluxos que, se pararem de funcionar, tiram a aplicação do ar do ponto de vista de quem usa: login, cadastro, o checkout de um pedido, o fluxo de pagamento. Não é preciso (nem desejável) um e2e para cada tela ou cada variação de formulário, isso já está coberto, mais barato e mais rápido, pelos níveis de baixo.\n\nUma forma prática de decidir se um fluxo merece um e2e: pergunte o que acontece se ele quebrar em produção sem ninguém perceber. Se a resposta é 'a empresa para de vender' ou 'ninguém mais consegue entrar no sistema', é candidato a e2e. Se a resposta é 'um campo de formulário aceita um valor que não devia', isso é trabalho para um teste unitário."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"\",\"Unitário\",\"Integração\",\"e2e\"],[\"Quantidade na suíte\",\"Muitos\",\"Alguns\",\"Poucos\"],[\"O que testa\",\"Uma função ou unidade isolada, com mocks\",\"Rota, service e banco trabalhando juntos\",\"O fluxo inteiro, pela interface\"],[\"Velocidade\",\"Muito rápido (segundos para a suíte inteira)\",\"Médio (sobe banco de teste)\",\"Lento (sobe front, back e navegador)\"],[\"Quando escrever\",\"Regras de negócio, cálculos, validações, casos de borda\",\"Junções importantes: rota + banco, middleware protegendo rota\",\"Fluxos críticos: login, cadastro, checkout, pagamento\"],[\"Custo de manutenção\",\"Baixo\",\"Médio\",\"Alto\"]]"
+                    },
+                    {
+                        "type": "code",
+                        "value": "// como a mesma funcionalidade (cadastro de tarefa) aparece nos tres niveis\n\n// 1) unitario: valida a regra, isolado, sem banco\n// tarefas.service.test.js\nit('rejeita tarefa sem titulo', () => {\n  expect(() => validarTarefa({ titulo: '' })).toThrow('titulo e obrigatorio');\n});\n\n// 2) integracao: sobe a rota de verdade contra um banco de teste\n// tarefas.routes.integration.test.js\nit('POST /tarefas grava no banco e devolve 201', async () => {\n  const resposta = await request(app)\n    .post('/tarefas')\n    .set('Authorization', `Bearer ${token}`)\n    .send({ titulo: 'Estudar piramide de testes' });\n\n  expect(resposta.status).toBe(201);\n\n  const linha = await db.query('SELECT * FROM tarefas WHERE id = $1', [resposta.body.id]);\n  expect(linha.rows[0].titulo).toBe('Estudar piramide de testes');\n});\n\n// 3) e2e: so existe para o fluxo critico (aqui, o cadastro completo), nao para cada regra\n// cadastro-tarefa.e2e.test.js\ntest('usuario loga e cadastra uma tarefa pela tela', async ({ page }) => {\n  // mesma ideia do exemplo de e2e visto antes neste modulo\n});"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Pirâmide de testes é economia: muitos unitários porque são baratos, alguns de integração nas junções que importam, poucos e2e só nos fluxos críticos demais para confiar em outra coisa."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Segundo a pirâmide de testes, qual é a proporção esperada entre os três níveis?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Muitos testes unitários, alguns de integração, poucos e2e",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A mesma quantidade de testes unitários, de integração e e2e",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Muitos testes e2e, alguns de integração, poucos unitários",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Só testes de integração, já que cobrem unitário e e2e juntos",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual critério ajuda a decidir se um fluxo merece um teste e2e?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Perguntar se o fluxo usa alguma biblioteca externa instalada via npm",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Perguntar se a aplicação fica inutilizável para o usuário caso o fluxo quebre",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Perguntar se aquele fluxo já tem algum teste unitário cobrindo a mesma regra",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Perguntar quantas linhas de código a funcionalidade ocupa no projeto inteiro",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um middleware de autenticação tem um teste unitário que confere se a função de validar o token rejeita um token inválido. Mesmo assim, uma rota que deveria estar protegida continua respondendo normalmente sem token nenhum. O que esse cenário sugere sobre os níveis de teste usados?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Faltava um teste e2e, já que só ele seria capaz de pegar esse tipo de problema",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Vitest não suporta testar middlewares de autenticação em nenhum nível da pirâmide",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Faltou um teste de integração para confirmar que o middleware está registrado na rota",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O teste unitário da função de validar token está incorreto e precisa ser reescrito",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que testar cada uma das variações de validação de um formulário (campo vazio, campo muito longo, formato inválido) costuma ser trabalho para testes unitários, e não para e2e?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque testes e2e não conseguem preencher campos de formulário de forma alguma",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque validações de campo, por padrão, não entram no escopo de nenhum teste",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o Playwright e o Cypress não são compatíveis com formulários HTML",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "São muitos casos de borda, e o unitário cobre cada um rápido e sem depender de UI",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma aplicação tem 300 testes unitários, 20 de integração e 2 e2e (login e checkout). Um novo desenvolvedor sugere adicionar testes e2e para cada uma das 15 páginas do sistema, argumentando que isso 'garante que tudo funciona'. Qual é o risco principal dessa proposta, considerando o que a pirâmide de testes ensina?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "A suíte ficaria lenta e frágil, sem necessariamente cobrir melhor os casos de borda",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Testes e2e não são capazes de detectar nenhum tipo de regressão numa aplicação real",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O número de e2e nunca pode ultrapassar o número de testes de integração existentes",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A cobertura de código do projeto cairia, já que e2e não entra no relatório de cobertura",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 7 - Qualidade além dos testes",
+        "aulas": [
+            {
+                "titulo": "Linter (ESLint)",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Qualidade além dos testes\n\nVocê chegou ao último módulo da trilha. Nos módulos anteriores você aprendeu a testar: unitário, mocks, integração, TDD, cobertura, e2e. Testes automatizados garantem uma coisa específica, que o comportamento do código está correto pros casos que alguém pensou em escrever. Mas existe uma classe inteira de problema que teste nenhum pega, porque o código \"funciona\" mesmo estando malfeito: uma variável que sobrou de uma refatoração e nunca mais é usada, um == onde devia ser ===, um detalhe de estilo que muda de arquivo pra arquivo.\n\nEsse módulo fecha a trilha com as ferramentas que cuidam da qualidade antes mesmo do teste rodar: linter, formatador, tipos e revisão humana. No fim, tudo isso se junta num fluxo só, rodando local, no pre-commit e no CI."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que o ESLint pega\n\nESLint é um analisador estático: lê o código sem executar nada, procurando padrões que o motor JavaScript aceita de boa, mas que quase sempre são bug ou descuido. Algumas regras \"core\" (sem plugin nenhum) já pegam:\n\n- Variável declarada e nunca usada (`no-unused-vars`), sobra de refatoração.\n- Comparação solta com `==` em vez de `===` (`eqeqeq`), que compara tipos diferentes com coerção implícita.\n- `switch` com `case` sem `break`, caindo pro próximo por acidente (`no-fallthrough`).\n- Usar `var` onde devia ser `const` ou `let` (`no-var`, `prefer-const`).\n\nTem também aquele clássico do `await` esquecido numa chamada assíncrona: a função segue em frente antes da Promise resolver, e o erro só aparece bem depois, com dado incompleto salvo no banco. Pegar isso de verdade exige informação de tipo, é a regra `@typescript-eslint/no-floating-promises`, que só existe quando o projeto usa TypeScript. Você vai entender por quê daqui a duas aulas, quando o assunto for tipo como forma de teste."
+                    },
+                    {
+                        "type": "code",
+                        "value": "// pedidos.js\nfunction calcularTotal(pedido) {\n    const taxa = 0.1\n    let desconto = 0\n    let logPrefixo = \"[pedidos]\"\n\n    if (pedido.cupom == \"PROMO10\") {\n        desconto = pedido.subtotal * 0.1\n    }\n\n    return pedido.subtotal + pedido.subtotal * taxa - desconto\n}\n\nmodule.exports = { calcularTotal }\n\n// rodando o linter nesse arquivo:\n\n$ npx eslint pedidos.js\n\npedidos.js\n  5:9   warning  'logPrefixo' is assigned a value but never used  no-unused-vars\n  7:18  error    Expected '===' and instead saw '=='              eqeqeq\n\n1 error, 1 warning"
+                    },
+                    {
+                        "type": "code",
+                        "value": "// eslint.config.js\nimport js from \"@eslint/js\";\n\nexport default [\n  js.configs.recommended,\n  {\n    languageOptions: {\n      ecmaVersion: \"latest\",\n      sourceType: \"module\",\n    },\n    rules: {\n      eqeqeq: \"error\",\n      \"no-unused-vars\": \"warn\",\n      \"no-var\": \"error\",\n      \"prefer-const\": \"error\",\n    },\n  },\n];"
+                    },
+                    {
+                        "type": "code",
+                        "value": "# rodar o linter no projeto inteiro\nnpx eslint .\n\n# rodar só numa pasta\nnpx eslint src/\n\n# aplicar as correções automáticas (o que dá pra corrigir sozinho, tipo trocar var por const)\nnpx eslint . --fix\n\n# script no package.json\n# \"scripts\": { \"lint\": \"eslint .\" }\nnpm run lint"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Direto no editor, direto no time\n\nRodar `npx eslint .` manualmente funciona, mas o ganho de verdade é ver o erro sublinhado enquanto você digita. A extensão ESLint do VS Code (ou equivalente noutro editor) lê o mesmo `eslint.config.js` do projeto e marca o problema na hora, antes até de salvar o arquivo.\n\nNum time, o `eslint.config.js` fica versionado no repositório: todo mundo roda exatamente as mesmas regras, então \"código bagunçado\" deixa de ser opinião de quem está revisando e vira erro objetivo, com linha e coluna. Isso tira uma fonte inteira de atrito do code review (assunto da aula 4) e barra, cedo, bugs que só apareceriam em produção, tipo aquele == que compara tipos diferentes sem avisar."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "O linter não sabe se o seu código faz a coisa certa. Ele sabe que um monte de jeito de fazer errado deixa pista no próprio código, antes de qualquer teste rodar."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Rodando `npx eslint .` no projeto, o terminal aponta um erro na regra `eqeqeq`. O que essa regra está cobrando?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Trocar uma comparação `==` por `===`, evitando coerção de tipo implícita.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Trocar uma variável `var` por `let` ou `const` no trecho apontado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Adicionar um `await` que ficou faltando antes de uma chamada assíncrona.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Remover uma variável que foi declarada e nunca foi usada no arquivo.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual é o objetivo principal de um linter como o ESLint?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Analisar o código sem executar ele, apontando padrões arriscados ou problemáticos.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Executar os testes automatizados do projeto e informar quais passaram ou falharam.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Compilar o código TypeScript e checar se os tipos declarados batem entre si.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Formatar o código automaticamente, ajustando aspas, espaços e indentação.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um time decide versionar o arquivo `eslint.config.js` no repositório em vez de deixar cada dev configurar o próprio editor sozinho. Qual é a principal razão prática?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Garante que todo mundo do time roda exatamente as mesmas regras sobre o mesmo código.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Garante que o código vai rodar mais rápido em produção, sem quase nenhuma diferença.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Garante que os testes de integração vão poder rodar sem precisar de banco de dados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Garante que o TypeScript vai aceitar qualquer tipo `any` sem apontar erro nenhum.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de rodar `npx eslint . --fix`, ainda sobra um erro de `no-unused-vars` num dos arquivos. Por que o `--fix` não resolveu esse caso sozinho?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Corrigir sozinho exigiria decidir se a variável deve ser removida ou usada de verdade.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O `--fix` só se aplica a regras de formatação, nunca a regras sobre variáveis.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Esse erro só desaparece depois que os testes do arquivo passarem a rodar verdes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "É preciso adicionar a flag `--force` junto de `--fix` pra aplicar em variáveis não usadas.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um projeto Node.js (sem TypeScript) usa só ESLint com as regras recomendadas. Um dev esquece um `await` antes de chamar `salvarNoBanco()`, uma função assíncrona. Por que essa falha específica tende a passar batido pelo ESLint puro?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Sem informação de tipo, o ESLint não consegue saber se aquela chamada devolve uma Promise.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A regra `eqeqeq` cobre chamadas assíncronas, mas só quando o projeto usa `async/await` puro.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O ESLint ignora por padrão qualquer código dentro de uma função declarada como `async`.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Faltou instalar o plugin `eslint-plugin-vitest` pra habilitar checagem de código assíncrono.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Formatador (Prettier) e a diferença pro linter",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Prettier: fim da discussão de estilo\n\nNa aula passada, o ESLint separou os problemas de comportamento (o == que compara tipos diferentes, a variável esquecida) do resto. Mas sobrou uma categoria inteira que o ESLint nem tenta resolver sozinho: aspas simples ou duplas? Vírgula depois do último item de um array? Quantos espaços de indentação? Onde quebrar uma linha grande?\n\nNenhuma dessas escolhas muda o comportamento do código. E é exatamente por isso que elas rendem as discussões mais longas (e mais inúteis) de code review. O Prettier existe pra acabar com essa conversa: ele formata o código automaticamente, sempre do mesmo jeito, sem perguntar sua opinião."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"\",\"ESLint (linter)\",\"Prettier (formatter)\"],[\"O que resolve\",\"Problema real: bug potencial, código morto, padrão perigoso\",\"Estilo visual: aspas, espaçamento, quebra de linha\"],[\"Exemplo de regra\",\"eqeqeq, no-unused-vars, no-fallthrough\",\"aspas duplas, 2 espaços, vírgula final\"],[\"Corrige sozinho\",\"Só o que é seguro corrigir (--fix)\",\"Sempre, é o trabalho inteiro dele\"],[\"Se ignorar o aviso\",\"Pode virar bug em produção\",\"Só fica inconsistente com o resto do time\"],[\"Roda em\",\"Editor, terminal, pre-commit, CI\",\"Editor, terminal, pre-commit, CI\"]]"
+                    },
+                    {
+                        "type": "code",
+                        "value": "// antes do prettier\nconst usuario = {nome:'Ana',   idade: 30,\n    ativo:true}\n\nfunction saudacao(nome) {\nreturn \"Olá, \" + nome + '!'\n}\n\n// depois de: npx prettier --write arquivo.js\n\nconst usuario = { nome: \"Ana\", idade: 30, ativo: true };\n\nfunction saudacao(nome) {\n  return \"Olá, \" + nome + \"!\";\n}"
+                    },
+                    {
+                        "type": "code",
+                        "value": "// .prettierrc\n{\n  \"semi\": true,\n  \"singleQuote\": false,\n  \"trailingComma\": \"all\",\n  \"tabWidth\": 2,\n  \"printWidth\": 100\n}"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## ESLint e Prettier na mesma casa\n\nRodar os dois juntos pode gerar conflito: uma regra de estilo do ESLint (tipo `quotes` ou `indent`) discordando do que o Prettier decide. A solução não é fazer os dois brigarem, é tirar do ESLint a responsabilidade de estilo e deixar isso só com o Prettier. O pacote `eslint-config-prettier` desliga, no ESLint, todas as regras que tratam de formatação, sobrando só as regras que pegam problema de verdade.\n\nNo code review, isso muda a conversa. Ninguém mais comenta \"troca essa aspa\" ou \"falta vírgula aqui\", porque o Prettier já rodou antes do PR existir. Sobra tempo pra revisar o que importa: a lógica está certa, o teste cobre o caso de borda, o nome da função diz o que ela faz (assunto da aula 4)."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# formata tudo e sobrescreve os arquivos\nnpx prettier --write .\n\n# só verifica, sem alterar (usado no CI: falha se algo não está formatado)\nnpx prettier --check .\n\n# scripts no package.json\n# \"scripts\": {\n#   \"format\": \"prettier --write .\",\n#   \"format:check\": \"prettier --check .\"\n# }\nnpm run format:check"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Estilo de código não é sobre gosto pessoal, é sobre não gastar energia de time discutindo o que uma ferramenta resolve em menos de um segundo."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual é a diferença principal entre o que o ESLint faz e o que o Prettier faz?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "ESLint aponta problema no código, Prettier só ajusta a formatação visual dele.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "ESLint ajusta a formatação visual, Prettier aponta problema de comportamento.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "ESLint roda no CI, Prettier só funciona rodando manualmente dentro do editor.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "ESLint testa o comportamento do código, Prettier testa se os tipos estão certos.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O que o comando `npx prettier --check .` faz, diferente de `npx prettier --write .`?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Só informa se algum arquivo está fora do padrão, sem alterar nada.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Corrige os arquivos fora do padrão, mas sem sobrescrever o original.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Roda apenas nos arquivos que foram alterados no último commit.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Verifica se os testes continuam passando depois da formatação.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de configurar o Prettier, o time começa a brigar porque uma regra do ESLint (`quotes`) diverge da formatação que o Prettier aplica. Qual é a solução recomendada?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Usar o `eslint-config-prettier` pra desligar, no ESLint, as regras de estilo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Desinstalar o Prettier e deixar toda a formatação só por conta do ESLint.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Configurar o `.prettierrc` pra copiar exatamente as regras do ESLint.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Rodar o ESLint antes do Prettier sempre, nunca o contrário, pra evitar conflito.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um PR abre com o comentário de review \"troca aspa simples por aspa dupla nessa linha\". Com Prettier e `--check` já rodando no CI, o que deveria ter acontecido antes desse comentário existir?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O CI já deveria ter barrado o PR por formatação, antes de qualquer humano revisar.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O revisor deveria ter aberto uma exceção, já que aspas não afetam o comportamento.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O time deveria ter configurado o ESLint pra ignorar esse tipo de comentário.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O autor do PR deveria ter pedido pro Prettier ignorar esse arquivo específico.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um projeto tem `prettier --check .` passando no CI, mas dois devs ainda reclamam de diffs enormes de formatação toda vez que um mexe no código do outro. O que mais provavelmente está errado?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Os dois usam versões diferentes do Prettier (ou config diferente), gerando saída distinta.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O `--check` do CI não é suficiente, era preciso trocar para o comando `--write` no pipeline.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Prettier não deveria rodar em conjunto com o ESLint dentro do mesmo repositório.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Falta configurar o `tsconfig.json` do projeto pra alinhar a formatação entre os dois.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "O TypeScript como teste",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Tipos são uma forma de teste\n\nUm teste unitário prova que, pra uma entrada específica, a função devolve o resultado certo. Um sistema de tipos prova outra coisa: que pra toda entrada daquele formato, uma classe inteira de erro não acontece. Passar uma string onde a função espera um number. Acessar pedido.desconto num objeto que nunca teve esse campo. Chamar uma função com um argumento a menos.\n\nSão exatamente os erros mais bobos e mais comuns em JavaScript puro, porque nada barra eles até o código rodar (e às vezes nem quando roda, se o caminho específico não for exercitado por nenhum teste). O TypeScript pega isso antes da primeira linha ser executada, com o compilador lendo o código estaticamente, do jeito que o ESLint lê, só que entendendo a forma dos dados."
+                    },
+                    {
+                        "type": "code",
+                        "value": "// pedido.ts\ninterface Pedido {\n  id: string;\n  subtotal: number;\n  cupom?: string;\n}\n\nfunction calcularTotal(pedido: Pedido): number {\n  const taxa = 0.1;\n  return pedido.subtotal + pedido.subtotal * taxa;\n}\n\ncalcularTotal({ id: \"1\", subtotal: \"150\" });\n// error TS2322: Type 'string' is not assignable to type 'number'.\n\ncalcularTotal({ id: \"1\", subtotal: 150, desconto: 20 });\n// error TS2353: Object literal may only specify known properties,\n// and 'desconto' does not exist in type 'Pedido'."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## tsc --noEmit como teste no pipeline\n\nO comando tsc normalmente compila TypeScript pra JavaScript. Com a flag --noEmit, ele faz só a parte que interessa aqui: verifica os tipos do projeto inteiro e não gera nenhum arquivo de saída. O resultado é binário, exit code 0 se não achou erro de tipo, diferente de 0 se achou, do mesmo jeito que npx vitest run volta verde ou vermelho.\n\nQuem liga isso tudo é a opção strict no tsconfig.json. Ela ativa, entre outras, noImplicitAny (proíbe uma variável sem tipo definido nem inferido, que hoje vira só any e o compilador para de checar) e strictNullChecks (null e undefined passam a ser erro de tipo quando não esperados, em vez de estourar em produção). Sem strict, o TypeScript deixa passar boa parte dos erros que ele existe pra pegar."
+                    },
+                    {
+                        "type": "code",
+                        "value": "// tsconfig.json\n{\n  \"compilerOptions\": {\n    \"strict\": true,\n    \"target\": \"ES2022\",\n    \"module\": \"NodeNext\",\n    \"noEmit\": true\n  },\n  \"include\": [\"src/**/*.ts\"]\n}\n\n$ npx tsc --noEmit\n\nsrc/pedido.ts:12:24 - error TS2322: Type 'string' is not assignable to type 'number'.\n\nFound 1 error."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Situação\",\"Teste unitário pega?\",\"Tipo (TypeScript) pega?\"],[\"Passar string onde é number\",\"Só se existir um teste pra esse caso\",\"Sempre, em todo lugar que chamar a função\"],[\"Campo que não existe no objeto\",\"Só se o teste checar esse campo\",\"Sempre, na hora de escrever o código\"],[\"Cálculo de desconto errado\",\"Sim, se o teste cobrir esse cenário\",\"Não, o tipo number está correto do mesmo jeito\"],[\"Esquecer um caso de borda da regra\",\"Sim, se alguém pensou nesse caso ao escrever o teste\",\"Não, isso é comportamento, não formato de dado\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Tipo não substitui teste\n\nOs tipos são fortes exatamente onde os testes são fracos: cobrem todo lugar que usa aquele dado, de uma vez, sem precisar que alguém escreva um caso pra cada chamada. Mas eles não sabem nada sobre a regra de negócio. Uma função calcularTotal(pedido: Pedido): number que devolve o total errado continua compilando sem erro nenhum, porque devolveu um number, só que o number errado.\n\nPor isso os dois ficam no pipeline, não um no lugar do outro: o tipo prova que a forma dos dados está certa em todo o código, o teste prova que o comportamento está certo nos casos que importam."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Um teste prova que uma entrada específica funciona. Um tipo prova que uma classe inteira de erro nunca vai acontecer, em nenhuma chamada, em lugar nenhum do código."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual erro o TypeScript pega antes mesmo do código rodar?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Passar um valor do tipo errado pra uma função que espera outro tipo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Uma função que devolve o cálculo de desconto errado pro cliente final.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um teste que ficou passando mesmo cobrindo pouco do comportamento real.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma query no banco que demora mais do que o esperado pra responder.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O que o comando `tsc --noEmit` faz?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Verifica os tipos do projeto inteiro e não gera nenhum arquivo JavaScript de saída.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Compila o projeto TypeScript inteiro e gera os arquivos JavaScript de produção.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Roda os testes automatizados do projeto sem gerar relatório de cobertura.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Formata os arquivos `.ts` do projeto de acordo com as regras do `tsconfig.json`.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma interface `Pedido` tem só os campos `id` e `subtotal`. Ao criar um objeto literal `{ id: '1', subtotal: 10, desconto: 5 }` passado direto pra uma função que espera `Pedido`, o TypeScript acusa erro. Por quê?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Objeto literal passado direto é checado contra propriedades que a interface não declara.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O campo `desconto` deveria ter sido declarado como `string`, não como `number`, na chamada.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Interfaces do TypeScript aceitam no máximo dois campos por padrão, sem configuração extra.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A função só aceita objetos criados com `new Pedido()`, nunca um objeto literal direto.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um projeto ativa `strict: true` no `tsconfig.json`. Uma variável que antes não tinha tipo nenhum declarado passa a dar erro de compilação. Qual opção dentro do `strict` provavelmente causou isso?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "`noImplicitAny`, que proíbe uma variável ficar sem tipo definido nem inferido.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "`strictNullChecks`, que proíbe uma variável aceitar `null` ou `undefined`.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "`noEmit`, que impede o compilador de gerar arquivo de saída no projeto.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "`esModuleInterop`, que ajusta como os `imports` de módulos são resolvidos.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "A função `calcularTotal(pedido: Pedido): number` está com o tipo certinho e o `tsc --noEmit` passa sem erro. Mesmo assim, ela devolve o total errado pra pedidos com cupom aplicado. Por que o TypeScript não pegou esse problema?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Tipo garante a forma do dado, não garante que a lógica de cálculo implementada está certa.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O `strict` mode provavelmente estava desligado quando esse trecho foi escrito e testado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Faltou declarar o campo `cupom` como obrigatório na interface `Pedido` do projeto.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O erro só existe porque a função não foi escrita como `async`, mesmo lidando com desconto.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Revisão de código",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## O que a máquina não vê\n\nLinter, formatter e checagem de tipo rodam em segundos e pegam uma quantidade enorme de problema, sem cansar, sem ficar de mau humor, sem deixar passar por estar com pressa. Mas nenhuma dessas ferramentas sabe se o código faz a coisa certa. Elas não sabem se a regra de negócio implementada é a regra combinada, se o nome da função engana quem lê, se falta tratar o caso em que o carrinho está vazio, ou se aquele endpoint novo esqueceu de passar pelo mesmo middleware de autenticação que protege os outros.\n\nIsso quem pega é outra pessoa lendo o código antes dele entrar na branch principal. É a última camada de qualidade da trilha, e é a única que não roda com npx."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"O que olhar\",\"Pergunta pra fazer\"],[\"Corretude\",\"O código faz o que o PR diz que faz, no caminho feliz e nos outros?\"],[\"Testes\",\"Os testes cobrem o comportamento novo, ou só passam porque testam pouco?\"],[\"Legibilidade\",\"Alguém sem contexto nenhum entende essa função só de ler?\"],[\"Casos de borda\",\"Lista vazia, campo nulo, erro de rede: o que acontece?\"],[\"Segurança\",\"Esse endpoint novo passa pelo mesmo middleware de auth dos outros?\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Como dar um feedback que ajuda\n\nComentário de review vira ruído quando é vago (\"não gostei\") ou quando soa como ordem sem explicação. Um comentário bom diz o quê, por quê, e dá espaço pra quem escreveu discordar com argumento:\n\n- Separe bloqueante de sugestão. \"Isso quebra se pedido.itens vier vazio, precisa tratar\" é diferente de \"nit: eu tiraria essa variável intermediária, mas não é bloqueante\".\n- Pergunte em vez de mandar. \"Por que validar o CPF aqui em vez de no middleware?\" abre conversa, \"muda isso pra cá\" fecha.\n- Comente o código, não a pessoa. \"Essa função ficou fazendo duas coisas\" em vez de \"você não separou as responsabilidades\".\n- Aprove com comentários quando nada for bloqueante. Travar um PR bom por causa de nomenclatura atrasa o time sem ganho real."
+                    },
+                    {
+                        "type": "code",
+                        "value": "// PR #482: adiciona rota de cancelamento de pedido\n\n  router.post('/pedidos/:id/cancelar', async (req, res) => {\n+   const pedido = await db.pedidos.findById(req.params.id);\n+   pedido.status = 'cancelado';\n+   await db.pedidos.save(pedido);\n+   res.json(pedido);\n  });\n\n// comentários da revisão:\n\n// [bloqueante] Falta o authMiddleware nessa rota, todas as outras\n// de /pedidos passam por ele antes do handler.\n\n// [bloqueante] E se pedido vier undefined (id que não existe)?\n// Hoje isso derruba o processo com um erro não tratado.\n\n// [sugestão, não bloqueante] dá pra extrair a troca de status\n// pra um método pedido.cancelar() e reaproveitar isso em outro lugar depois."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## PR pequeno revisa melhor\n\nA qualidade de uma revisão despenca depois de poucas centenas de linhas de diff. Ninguém segura atenção em oitocentas linhas mudadas: o revisor cansa, começa a passar o olho, e o \"aprovado\" vira formalidade em vez de revisão de verdade. PRs pequenos (uma rota, uma função, uma migration) mantêm o revisor de fato lendo, e ainda trazem outros ganhos: revisão sai mais rápido, o merge não fica represado, e se algo quebrar em produção, reverter um PR pequeno é trivial, reverter um PR gigante que mexeu em dez arquivos é um problema à parte.\n\nLint, formatação e tipo já garantiram que o PR pequeno não tem erro bobo. Sobra pro revisor humano o que só humano pega: era essa mesmo a solução certa pro problema?"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "O linter pega o erro de sintaxe, o tipo pega o erro de forma, o teste pega o erro de comportamento. O review pega a pergunta que nenhuma ferramenta sabe fazer: era isso mesmo que devia ser construído?"
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Segundo a aula, qual dessas é uma preocupação tipicamente do code review, e não do lint, formatter ou type-check?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Se o nome da função comunica direito o que ela realmente faz.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Se existe alguma variável declarada no arquivo e nunca usada.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Se a indentação do arquivo segue o padrão combinado pelo time.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Se um valor do tipo errado foi passado pra dentro de uma função.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um review comenta apenas \"não gostei dessa parte\", sem mais detalhes. Qual é o principal problema desse comentário?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Não diz o quê está errado nem por quê, então quem escreveu não sabe o que mudar.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Comentário de review deveria vir sempre por mensagem direta, nunca dentro do PR.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Esse tipo de comentário só é válido quando vem de quem é dono do repositório.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Falta rodar o linter antes de comentar qualquer coisa sobre o código do PR.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Durante um review, o revisor escreve: \"[bloqueante] essa rota não passa pelo authMiddleware que as outras de /pedidos usam.\" Que tipo de problema esse comentário está pegando?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Um problema de segurança que ferramenta automática nenhuma detectaria sozinha.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um problema de formatação que o Prettier deveria ter corrigido antes do PR abrir.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um problema de tipo que o `tsc --noEmit` deveria ter apontado durante o CI.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um problema de cobertura de teste que o relatório do Vitest já deveria mostrar.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que PRs pequenos tendem a receber revisão de melhor qualidade do que PRs enormes?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "A atenção do revisor cai depois de muitas linhas, e o \"aprovado\" vira formalidade.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "PRs pequenos são os únicos que conseguem passar pelo pipeline de CI configurado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ferramentas como ESLint e Prettier só analisam PRs abaixo de um certo tamanho.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "PRs grandes não podem ser revertidos caso algum problema apareça em produção.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Dois PRs chegam pro mesmo revisor: um de 15 linhas mudando a regra de desconto, outro de 900 linhas misturando refatoração, rota nova e ajuste de dependência. Só dá tempo de revisar um com atenção hoje. Qual é o argumento mais forte pra revisar o pequeno primeiro?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Diff pequeno e focado permite revisão de verdade, o grande tende a virar aprovação rasa.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "PR pequeno nunca precisa de teste novo, então a revisão é sempre mais rápida de concluir.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "PR grande automaticamente reprova no CI por ultrapassar o limite de linhas do pipeline.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Revisor só pode aprovar um PR por dia, então o menor libera o merge mais cedo sempre.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "O fluxo de qualidade completo e o próximo passo (Docker)",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Tudo junto: o fluxo de qualidade\n\nCada peça desse módulo resolve um problema diferente: o ESLint pega código arriscado, o Prettier resolve estilo, o TypeScript prova a forma dos dados, o teste prova o comportamento, e o code review pega o que sobra pra um humano decidir. Sozinha, cada camada segura uma fatia do problema. Juntas, formam um fluxo com quatro momentos:\n\n- No editor: lint e formatação rodando ao salvar, feedback imediato.\n- No pre-commit: um gate rápido, local, antes do código sair da sua máquina.\n- No CI: a mesma bateria (lint, formatação, tipo, teste) rodando de novo, sem depender de ninguém ter lembrado de rodar local.\n- No code review: a camada humana, depois que a máquina já aprovou o básico.\n\nNenhuma camada substitui a outra. O pre-commit não roda a suíte de integração inteira (seria lento demais pra cada commit), o CI não lê se o nome da função faz sentido, e o review não vai reler as duzentas asserções de teste que já rodaram verde."
+                    },
+                    {
+                        "type": "code",
+                        "value": "// package.json\n{\n  \"scripts\": {\n    \"lint\": \"eslint .\",\n    \"format:check\": \"prettier --check .\",\n    \"typecheck\": \"tsc --noEmit\",\n    \"test\": \"vitest run\",\n    \"test:coverage\": \"vitest run --coverage\",\n    \"verify\": \"npm run lint && npm run format:check && npm run typecheck && npm run test\"\n  }\n}\n\n$ npm run verify\n\n> lint\nsem problemas\n\n> format:check\ntodos os arquivos formatados\n\n> typecheck\nsem erro de tipo\n\n> test\n47 passed (47)"
+                    },
+                    {
+                        "type": "code",
+                        "value": "// package.json (trecho)\n{\n  \"lint-staged\": {\n    \"*.{js,ts}\": [\"eslint --fix\", \"prettier --write\"]\n  }\n}\n\n// .husky/pre-commit\nnpx lint-staged\n\n$ git commit -m \"feat: cancelamento de pedido\"\nRodando lint-staged...\neslint --fix em 3 arquivo(s)\nprettier --write em 3 arquivo(s)\n[feature/cancelar-pedido a1b2c3d] feat: cancelamento de pedido"
+                    },
+                    {
+                        "type": "code",
+                        "value": "# .github/workflows/ci.yml\nname: CI\n\non:\n  pull_request:\n    branches: [main]\n\njobs:\n  verify:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n      - run: npm ci\n      - run: npm run lint\n      - run: npm run format:check\n      - run: npm run typecheck\n      - run: npm run test:coverage"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Fechando a trilha\n\nSete módulos atrás, a pergunta era simples: como ter confiança pra mudar código que já funciona? A resposta virou uma trilha inteira:\n\n- Por que testar: teste automatizado é confiança pra mudar e documentação viva, não burocracia.\n- Primeiro teste unitário: describe, it, expect, o padrão AAA, rodando com Vitest.\n- Mocks e dublês: isolar a unidade do banco, da API externa, do tempo, sem exagerar e mockar até a própria lógica que devia estar sendo testada.\n- Testes de integração: rota, service e banco juntos, testados de verdade com supertest e um banco efêmero.\n- TDD e código testável: red, green, refactor, e por que injeção de dependência e função pura tornam tudo mais fácil de testar.\n- Cobertura, e2e e flaky tests: número de cobertura como bússola (não meta), o topo da pirâmide, e como não deixar o CI instável.\n- Qualidade além do teste: lint, formatação, tipo e review, a rede de segurança que cuida do que o teste não cobre.\n\nCada módulo resolveu uma lacuna que o anterior deixava aberta. Não existe uma ferramenta única que garante qualidade, existe esse conjunto todo rodando junto."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O próximo estágio: Docker & containers\n\nSeu código agora está testado, coberto, tipado, formatado e revisado. Mas ele ainda depende de rodar numa máquina com a versão certa do Node, as variáveis de ambiente certas, o Postgres certo na porta certa. \"Na minha máquina funciona\" é o problema que sobra depois que todo o resto desse módulo já foi resolvido.\n\nO próximo estágio do roadmap de Back-end é Docker & containers: empacotar a aplicação (código, dependências, runtime) numa imagem que roda exatamente igual na sua máquina, na do colega, no CI que acabou de rodar npm run verify, e no servidor de produção. É o passo que fecha o ciclo entre \"código testado e aprovado\" e \"código rodando de verdade\", em qualquer lugar."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Teste prova que o código funciona. Lint, tipo e review provam que ele é confiável de mexer de novo amanhã. Container garante que, funcionando aqui, funciona em qualquer lugar. É pra lá que essa trilha te leva agora."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "No fluxo de qualidade da aula, o que roda tipicamente no pre-commit, antes do código sair da máquina do dev?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Um gate rápido e local, tipo lint e formatação nos arquivos alterados.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A suíte inteira de testes de integração, incluindo o banco de dados efêmero.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O deploy automático da aplicação pro ambiente de produção da empresa.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A revisão de código feita por outro humano do time antes do merge.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual ferramenta, das citadas na trilha, é usada pra empacotar a aplicação e fazer ela rodar do mesmo jeito em qualquer máquina, sendo o próximo passo depois dessa trilha?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Docker",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Vitest",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "ESLint",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Prettier",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O CI do projeto roda, nessa ordem: `npm run lint`, `npm run format:check`, `npm run typecheck`, `npm run test:coverage`. Um PR falha no segundo passo. O que precisa ser corrigido?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Existe arquivo fora do padrão, é só rodar `prettier --write` e commitar de novo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Existe erro de tipo que o `tsc` encontrou num arquivo alterado nesse PR específico.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Existe algum teste que quebrou depois da última mudança feita nesse pull request.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Existe uma variável declarada e nunca usada em algum arquivo alterado no PR.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de configurar husky + lint-staged, um `git commit` roda automaticamente `eslint --fix` e `prettier --write`, mas só nos arquivos staged, não no projeto inteiro. Qual é a vantagem prática disso, comparado a rodar em tudo?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O commit continua rápido, porque só o que realmente vai ser commitado é processado.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O ESLint só sabe corrigir arquivos que já foram commitados alguma vez antes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Prettier não consegue formatar arquivos que ainda não existem no repositório remoto.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Git bloqueia qualquer hook que tente alterar arquivos fora da área de stage.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "A trilha termina dizendo que o próximo estágio do roadmap é Docker & containers. Qual problema específico, que sobra mesmo depois de lint, formatação, tipo, teste e review, o Docker resolve?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "A aplicação depender da versão certa de linguagem e dependências de cada máquina.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A falta de testes automatizados cobrindo os principais fluxos de negócio da aplicação.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A ausência de um linter configurado corretamente no ambiente de produção da empresa.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A dificuldade de revisar código quando o time inteiro trabalha de forma remota.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+];
+
+async function seed() {
+    let [trilha] = await db.select().from(trails).where(eq(trails.name, NOME));
+    if (!trilha) {
+        [trilha] = await db
+            .insert(trails)
+            .values({ name: NOME, trailLevel: LEVEL, description: DESCRICAO })
+            .returning();
+        console.log("Trilha criada: " + trilha.name);
+    }
+
+    const existentes = await db.select().from(lessons).where(eq(lessons.trailId, trilha.id));
+    if (existentes.length > 0) {
+        console.log("Trilha " + NOME + " ja tem " + existentes.length + " aulas. Nada a fazer.");
+        return;
+    }
+
+    let totalAulas = 0;
+    let totalQuestoes = 0;
+    for (let mi = 0; mi < MODULOS.length; mi++) {
+        const m = MODULOS[mi];
+        const [mod] = await db
+            .insert(modules)
+            .values({ trailId: trilha.id, title: m.titulo, position: mi + 1 })
+            .returning();
+        for (let li = 0; li < m.aulas.length; li++) {
+            const a = m.aulas[li];
+            const [lesson] = await db
+                .insert(lessons)
+                .values({
+                    trailId: trilha.id,
+                    moduleId: mod.id,
+                    title: a.titulo,
+                    content: null,
+                    contentBlocks: a.blocks,
+                    position: li + 1,
+                    published: true,
+                })
+                .returning();
+            for (let qi = 0; qi < a.questions.length; qi++) {
+                const q = a.questions[qi];
+                const [questao] = await db
+                    .insert(questions)
+                    .values({
+                        lessonId: lesson.id,
+                        statement: q.statement,
+                        difficulty: q.difficulty,
+                        position: qi + 1,
+                    })
+                    .returning();
+                await db.insert(questionOptions).values(
+                    q.options.map((o, k) => ({
+                        questionId: questao.id,
+                        text: o.text,
+                        isCorrect: o.isCorrect,
+                        position: k + 1,
+                    })),
+                );
+            }
+            totalAulas++;
+            totalQuestoes += a.questions.length;
+        }
+    }
+    console.log("Seed concluido: " + MODULOS.length + " modulos, " + totalAulas + " aulas, " + totalQuestoes + " questoes.");
+}
+
+seed()
+    .then(() => process.exit(0))
+    .catch((e) => {
+        console.error("Falha no seed:", e);
+        process.exit(1);
+    });


### PR DESCRIPTION
## Trilha Docker e Containers (estágio 8 do roadmap de Back-end)

Oitava trilha do roadmap de back-end, fase **deploy**, nível intermediário. Fecha o "na minha máquina funciona": o aluno aprende a empacotar o back-end que construiu (API, banco, cache) em containers e a orquestrar tudo com Compose.

### Conteúdo (7 módulos, 35 aulas, 175 questões)
1. **Por que containers** (o problema de ambiente, container x VM, imagem x container)
2. **Sua primeira imagem: o Dockerfile** (FROM, WORKDIR, COPY, RUN, CMD, docker build/run, camadas e cache)
3. **Trabalhando com containers e imagens** (ps, logs, exec, stop, rm, registry, tags, .dockerignore, variáveis de ambiente)
4. **Volumes e dados que persistem** (container efêmero, volumes nomeados, bind mounts e hot reload)
5. **Orquestrando com Docker Compose** (docker-compose.yml, up/down/logs, a rede do compose por nome de service)
6. **Juntando o back-end: app, Postgres e Redis** (conexão pelo nome do service, depends_on, health check, dev x produção)
7. **Imagens enxutas, seguras e o caminho do deploy** (multi-stage build, imagens base pequenas, não rodar como root, push pro registry, ponte pro próximo estágio de CI/CD)

Cada aula fecha com um resumo e traz exemplos rodáveis (Dockerfile, docker-compose.yml, comandos docker). Conecta com as trilhas de API, banco e cache.

### Roadmap
Adiciona o **estágio 8 (Docker & containers)** ao seed do roadmap de back-end, na fase deploy, apontando para a nova trilha. Seed idempotente por estágio.

### Qualidade das questões
Aplicada a regra de opções equilibradas desde a autoria: a alternativa correta não se destaca pela forma. Medição automática nas 175 questões:
- Vício forte (correta é a mais longa E pelo menos 1.4x a média das erradas): **0%**
- Correta pelo menos 1.4x a média das erradas: **0%**
- Zero travessão, zero emoji, zero "todas as anteriores"

A posição da correta é irrelevante: o backend embaralha questões e alternativas ao servir.

### Empilhado no #165
Esta branch parte da branch do #165 (Testes e Qualidade), porque o estágio 8 do seed do roadmap depende do estágio 7. Enquanto o #165 não entrar na develop, o diff aqui inclui também a trilha de Testes. Assim que o #165 for mergeado, sobra só a trilha Docker. Ordem de merge: primeiro o #165, depois este.

### Como validar local
```
docker compose exec -T backend node scripts/seed-trilha-docker-containers.ts
docker compose exec -T backend node scripts/seed-roadmap-backend.ts
```
Confirmado em dev: 35 aulas publicadas, 175 questões (4 opções, 1 correta cada), roadmap com 8 estágios e 0 refs faltando.
