### PR TITLE
feat: tela de detalhe da trilha

### DIFF
--- a/backend/drizzle/0030_tough_the_executioner.sql
+++ b/backend/drizzle/0030_tough_the_executioner.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "lessons" ADD COLUMN "duration_min" integer;--> statement-breakpoint
+ALTER TABLE "lessons" ADD COLUMN "preview" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "trails" ADD COLUMN "what_you_learn" jsonb;--> statement-breakpoint
+ALTER TABLE "trails" ADD COLUMN "prerequisites" jsonb;

--- a/backend/drizzle/meta/0030_snapshot.json
+++ b/backend/drizzle/meta/0030_snapshot.json
@@ -1,0 +1,2344 @@
+{
+  "id": "3dbd39a9-ea2e-4b9b-b97a-c777c6565ba1",
+  "prevId": "ffc5ca6d-e8e5-4206-80ee-454582fff349",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.achievements": {
+      "name": "achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "criteria_type": {
+          "name": "criteria_type",
+          "type": "achievement_criteria",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "achievements_name_unique": {
+          "name": "achievements_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge_submissions": {
+      "name": "challenge_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "challenge_language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "challenge_submission_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "passed_count": {
+          "name": "passed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_count": {
+          "name": "total_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xp_earned": {
+          "name": "xp_earned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "challenge_submissions_user_id_users_id_fk": {
+          "name": "challenge_submissions_user_id_users_id_fk",
+          "tableFrom": "challenge_submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "challenge_submissions_challenge_id_challenges_id_fk": {
+          "name": "challenge_submissions_challenge_id_challenges_id_fk",
+          "tableFrom": "challenge_submissions",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge_tests": {
+      "name": "challenge_tests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_output": {
+          "name": "expected_output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "challenge_tests_challenge_id_challenges_id_fk": {
+          "name": "challenge_tests_challenge_id_challenges_id_fk",
+          "tableFrom": "challenge_tests",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenges": {
+      "name": "challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "challenge_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stdin'"
+        },
+        "entry_point": {
+          "name": "entry_point",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_blocks": {
+          "name": "statement_blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "question_difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'facil'"
+        },
+        "starter_code": {
+          "name": "starter_code",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_date": {
+          "name": "active_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "challenges_number_unique": {
+          "name": "challenges_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "number"
+          ]
+        },
+        "challenges_active_date_unique": {
+          "name": "challenges_active_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "active_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.glossary": {
+      "name": "glossary",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "term": {
+          "name": "term",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "varchar(400)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "glossary_term_unique": {
+          "name": "glossary_term_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "term"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.languages": {
+      "name": "languages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "languages_name_unique": {
+          "name": "languages_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons_progress": {
+      "name": "lessons_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_progress_user_id_users_id_fk": {
+          "name": "lessons_progress_user_id_users_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_progress_lesson_id_lessons_id_fk": {
+          "name": "lessons_progress_lesson_id_lessons_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lessons_progress_user_id_lesson_id_unique": {
+          "name": "lessons_progress_user_id_lesson_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "lesson_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons": {
+      "name": "lessons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_blocks": {
+          "name": "content_blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "duration_min": {
+          "name": "duration_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview": {
+          "name": "preview",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_trail_id_trails_id_fk": {
+          "name": "lessons_trail_id_trails_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_module_id_modules_id_fk": {
+          "name": "lessons_module_id_modules_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "modules",
+          "columnsFrom": [
+            "module_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.modules": {
+      "name": "modules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "modules_trail_id_trails_id_fk": {
+          "name": "modules_trail_id_trails_id_fk",
+          "tableFrom": "modules",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_accounts": {
+      "name": "oauth_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_accounts_user_id_users_id_fk": {
+          "name": "oauth_accounts_user_id_users_id_fk",
+          "tableFrom": "oauth_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_accounts_provider_provider_id_unique": {
+          "name": "oauth_accounts_provider_provider_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "provider_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_answers": {
+      "name": "question_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_option_id": {
+          "name": "selected_option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_answers_user_id_users_id_fk": {
+          "name": "question_answers_user_id_users_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_question_id_questions_id_fk": {
+          "name": "question_answers_question_id_questions_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_selected_option_id_question_options_id_fk": {
+          "name": "question_answers_selected_option_id_question_options_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "question_options",
+          "columnsFrom": [
+            "selected_option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "question_answers_user_id_question_id_unique": {
+          "name": "question_answers_user_id_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_options": {
+      "name": "question_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_options_question_id_questions_id_fk": {
+          "name": "question_options_question_id_questions_id_fk",
+          "tableFrom": "question_options",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "question_difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'facil'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_lesson_id_lessons_id_fk": {
+          "name": "questions_lesson_id_lessons_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ranking_snapshots": {
+      "name": "ranking_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ranking_snapshots_user_id_users_id_fk": {
+          "name": "ranking_snapshots_user_id_users_id_fk",
+          "tableFrom": "ranking_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ranking_snapshots_user_id_snapshot_date_unique": {
+          "name": "ranking_snapshots_user_id_snapshot_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "snapshot_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmap_stage_refs": {
+      "name": "roadmap_stage_refs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_type": {
+          "name": "ref_type",
+          "type": "roadmap_ref_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "roadmap_stage_refs_stage_id_roadmap_stages_id_fk": {
+          "name": "roadmap_stage_refs_stage_id_roadmap_stages_id_fk",
+          "tableFrom": "roadmap_stage_refs",
+          "tableTo": "roadmap_stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmap_stages": {
+      "name": "roadmap_stages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "roadmap_id": {
+          "name": "roadmap_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "roadmap_phase",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "roadmap_stages_roadmap_id_roadmaps_id_fk": {
+          "name": "roadmap_stages_roadmap_id_roadmaps_id_fk",
+          "tableFrom": "roadmap_stages",
+          "tableTo": "roadmaps",
+          "columnsFrom": [
+            "roadmap_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmaps": {
+      "name": "roadmaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "trail_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "premium": {
+          "name": "premium",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roadmaps_slug_unique": {
+          "name": "roadmaps_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_attempt_answers": {
+      "name": "simulado_attempt_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_attempt_answers_attempt_id_simulado_attempts_id_fk": {
+          "name": "simulado_attempt_answers_attempt_id_simulado_attempts_id_fk",
+          "tableFrom": "simulado_attempt_answers",
+          "tableTo": "simulado_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempt_answers_question_id_simulado_questions_id_fk": {
+          "name": "simulado_attempt_answers_question_id_simulado_questions_id_fk",
+          "tableFrom": "simulado_attempt_answers",
+          "tableTo": "simulado_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempt_answers_option_id_simulado_options_id_fk": {
+          "name": "simulado_attempt_answers_option_id_simulado_options_id_fk",
+          "tableFrom": "simulado_attempt_answers",
+          "tableTo": "simulado_options",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulado_attempt_answers_attempt_id_question_id_option_id_unique": {
+          "name": "simulado_attempt_answers_attempt_id_question_id_option_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "attempt_id",
+            "question_id",
+            "option_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_attempt_questions": {
+      "name": "simulado_attempt_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_attempt_questions_attempt_id_simulado_attempts_id_fk": {
+          "name": "simulado_attempt_questions_attempt_id_simulado_attempts_id_fk",
+          "tableFrom": "simulado_attempt_questions",
+          "tableTo": "simulado_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempt_questions_question_id_simulado_questions_id_fk": {
+          "name": "simulado_attempt_questions_question_id_simulado_questions_id_fk",
+          "tableFrom": "simulado_attempt_questions",
+          "tableTo": "simulado_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulado_attempt_questions_attempt_id_question_id_unique": {
+          "name": "simulado_attempt_questions_attempt_id_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "attempt_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_attempts": {
+      "name": "simulado_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "simulado_id": {
+          "name": "simulado_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passed": {
+          "name": "passed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_attempts_user_id_users_id_fk": {
+          "name": "simulado_attempts_user_id_users_id_fk",
+          "tableFrom": "simulado_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempts_simulado_id_simulados_id_fk": {
+          "name": "simulado_attempts_simulado_id_simulados_id_fk",
+          "tableFrom": "simulado_attempts",
+          "tableTo": "simulados",
+          "columnsFrom": [
+            "simulado_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_options": {
+      "name": "simulado_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_options_question_id_simulado_questions_id_fk": {
+          "name": "simulado_options_question_id_simulado_questions_id_fk",
+          "tableFrom": "simulado_options",
+          "tableTo": "simulado_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_questions": {
+      "name": "simulado_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "simulado_id": {
+          "name": "simulado_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_questions_simulado_id_simulados_id_fk": {
+          "name": "simulado_questions_simulado_id_simulados_id_fk",
+          "tableFrom": "simulado_questions",
+          "tableTo": "simulados",
+          "columnsFrom": [
+            "simulado_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulados": {
+      "name": "simulados",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_count": {
+          "name": "question_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pass_percent": {
+          "name": "pass_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulados_slug_unique": {
+          "name": "simulados_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tokens": {
+      "name": "tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'refresh'"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tokens_user_id_users_id_fk": {
+          "name": "tokens_user_id_users_id_fk",
+          "tableFrom": "tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tokens_token_hash_unique": {
+          "name": "tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_tags": {
+      "name": "trail_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "trail_tags_trail_id_trails_id_fk": {
+          "name": "trail_tags_trail_id_trails_id_fk",
+          "tableFrom": "trail_tags",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trail_tags_tag_id_tags_id_fk": {
+          "name": "trail_tags_tag_id_tags_id_fk",
+          "tableFrom": "trail_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trail_tags_trail_id_tag_id_unique": {
+          "name": "trail_tags_trail_id_tag_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trail_id",
+            "tag_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trails": {
+      "name": "trails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "trail_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "what_you_learn": {
+          "name": "what_you_learn",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prerequisites": {
+          "name": "prerequisites",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_achievements": {
+      "name": "user_achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "achievement_id": {
+          "name": "achievement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_achievements_user_id_users_id_fk": {
+          "name": "user_achievements_user_id_users_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_achievements_achievement_id_achievements_id_fk": {
+          "name": "user_achievements_achievement_id_achievements_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "achievements",
+          "columnsFrom": [
+            "achievement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_achievements_user_id_achievement_id_unique": {
+          "name": "user_achievements_user_id_achievement_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "achievement_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username_changed_at": {
+          "name": "username_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occupation": {
+          "name": "occupation",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github": {
+          "name": "github",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin": {
+          "name": "linkedin",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "failed_login_attempts": {
+          "name": "failed_login_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.achievement_criteria": {
+      "name": "achievement_criteria",
+      "schema": "public",
+      "values": [
+        "xp_total",
+        "lessons_completed",
+        "questions_correct",
+        "special"
+      ]
+    },
+    "public.challenge_kind": {
+      "name": "challenge_kind",
+      "schema": "public",
+      "values": [
+        "stdin",
+        "function"
+      ]
+    },
+    "public.challenge_language": {
+      "name": "challenge_language",
+      "schema": "public",
+      "values": [
+        "javascript",
+        "python",
+        "csharp",
+        "java"
+      ]
+    },
+    "public.challenge_submission_status": {
+      "name": "challenge_submission_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "passed",
+        "failed",
+        "error",
+        "timeout"
+      ]
+    },
+    "public.question_difficulty": {
+      "name": "question_difficulty",
+      "schema": "public",
+      "values": [
+        "facil",
+        "medio",
+        "dificil"
+      ]
+    },
+    "public.roadmap_phase": {
+      "name": "roadmap_phase",
+      "schema": "public",
+      "values": [
+        "fundamentos",
+        "core",
+        "avancado",
+        "deploy"
+      ]
+    },
+    "public.roadmap_ref_type": {
+      "name": "roadmap_ref_type",
+      "schema": "public",
+      "values": [
+        "trail",
+        "module",
+        "lesson",
+        "simulado",
+        "challenge"
+      ]
+    },
+    "public.trail_level": {
+      "name": "trail_level",
+      "schema": "public",
+      "values": [
+        "iniciante",
+        "intermediario",
+        "avancado"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin",
+        "moderator"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -211,6 +211,13 @@
       "when": 1783695348882,
       "tag": "0029_nosy_nick_fury",
       "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1783951612904,
+      "tag": "0030_tough_the_executioner",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/schema.ts
+++ b/backend/schema.ts
@@ -95,6 +95,8 @@ export const trails = pgTable("trails", {
     name: varchar("name", { length: 255 }).notNull(),
     trailLevel: trailLevel("level").notNull(),
     description: text("description").notNull(),
+    whatYouLearn: jsonb("what_you_learn").$type<string[]>(),
+    prerequisites: jsonb("prerequisites").$type<string[]>(),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
 });
 
@@ -121,6 +123,8 @@ export const lessons = pgTable("lessons", {
     contentBlocks: jsonb("content_blocks").$type<{ type: string; value: string }[]>(),
     position: integer("position").notNull(),
     published: boolean("published").default(false).notNull(),
+    durationMin: integer("duration_min"),
+    preview: boolean("preview").default(false).notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
 });
 

--- a/backend/scripts/seed-detalhes-trilhas.ts
+++ b/backend/scripts/seed-detalhes-trilhas.ts
@@ -1,0 +1,349 @@
+// Preenche os campos da tela de detalhe da trilha:
+//  - what_you_learn e prerequisites (autorados por trilha, no mapa DETALHES);
+//  - duration_min de cada aula (estimativa de tempo de leitura dos blocos + quiz);
+//  - preview = true na primeira aula de cada trilha (deixa espiar sem estar inscrito).
+// Idempotente: sempre reescreve os valores. Trilha fora do mapa fica sem what/prereq
+// (a tela simplesmente nao mostra essas secoes), mas ainda recebe duracao e preview.
+//
+// Rodar em prod: docker compose -f docker-compose.prod.yml exec -T backend node scripts/seed-detalhes-trilhas.ts
+import { db } from "../db.ts";
+import { trails, modules, lessons, questions } from "../schema.ts";
+import { eq, asc, inArray, count } from "drizzle-orm";
+
+const DETALHES: Record<string, { whatYouLearn: string[]; prerequisites: string[] }> = {
+    "Lógica de Programação": {
+        whatYouLearn: [
+            "Pensar em algoritmos e resolver problemas passo a passo",
+            "Variáveis, tipos de dados e operadores",
+            "Condicionais, laços e repetição",
+            "Funções, coleções e um mini-projeto do zero",
+        ],
+        prerequisites: ["Nenhum: é o ponto de partida, só vontade de aprender"],
+    },
+    Python: {
+        whatYouLearn: [
+            "Escrever e rodar código Python do zero",
+            "Tipos, strings, controle de fluxo e estruturas de dados",
+            "Funções, módulos e a biblioteca padrão",
+            "Ler arquivos e CSV, tratar erros, e a ponte pra dados",
+        ],
+        prerequisites: ["Lógica de programação (algoritmos, laços, condicionais)"],
+    },
+    "Estatística e Probabilidade": {
+        whatYouLearn: [
+            "Estatística descritiva: média, mediana, desvio e distribuições",
+            "Probabilidade, amostragem e o Teorema Central do Limite",
+            "Inferência: intervalos de confiança e teste de hipótese",
+            "Correlação e por que ela não é causalidade",
+        ],
+        prerequisites: ["Python básico", "Matemática do ensino médio"],
+    },
+    "Análise de Dados": {
+        whatYouLearn: [
+            "Manipular dados com NumPy e pandas",
+            "Carregar, filtrar, ordenar e agrupar (groupby)",
+            "Limpar dados: faltantes, tipos, duplicatas e outliers",
+            "Juntar tabelas com merge e um fluxo de análise completo",
+        ],
+        prerequisites: ["Python (estruturas de dados, funções)", "Noções de estatística descritiva"],
+    },
+    "Protocolos da Web": {
+        whatYouLearn: [
+            "Como a web funciona: cliente-servidor e o ciclo de uma requisição",
+            "HTTP: métodos, cabeçalhos e códigos de status",
+            "REST e o design de APIs",
+            "URLs, cookies e o básico de HTTPS",
+        ],
+        prerequisites: ["Lógica de programação"],
+    },
+    "APIs e Frameworks": {
+        whatYouLearn: [
+            "Construir uma API REST com Node.js e Express",
+            "Rotas, middleware e validação de dados",
+            "Tratamento de erros e estrutura de projeto",
+            "Um CRUD completo de ponta a ponta",
+        ],
+        prerequisites: ["Lógica de programação", "Protocolos da web (HTTP, REST)"],
+    },
+    "Banco de Dados": {
+        whatYouLearn: [
+            "Modelo relacional e SQL do zero",
+            "Modelagem com relacionamentos e chaves",
+            "PostgreSQL na prática e conexão segura",
+            "O papel dos ORMs",
+        ],
+        prerequisites: ["Lógica de programação"],
+    },
+    Autenticação: {
+        whatYouLearn: [
+            "Hash de senha com bcrypt e por que nunca guardar senha em texto",
+            "Sessões, cookies e tokens JWT",
+            "Autorização por papéis (RBAC) e falhas comuns como IDOR",
+            "OAuth e login social",
+        ],
+        prerequisites: ["APIs e Frameworks (Express, rotas)", "Banco de dados"],
+    },
+    "Cache, Filas e Performance": {
+        whatYouLearn: [
+            "Medir e melhorar a performance do back-end",
+            "Cache com Redis e estratégias de invalidação",
+            "Filas e processamento assíncrono com workers",
+            "Como escalar sob carga",
+        ],
+        prerequisites: ["APIs e Frameworks", "Banco de dados"],
+    },
+    "Testes e Qualidade": {
+        whatYouLearn: [
+            "Testes unitários e de integração com Vitest",
+            "Mocks, TDD e cobertura de código",
+            "Testar uma API de ponta a ponta",
+            "Qualidade além dos testes: lint, tipos e review",
+        ],
+        prerequisites: ["APIs e Frameworks (uma app pra testar)"],
+    },
+    "Docker e Containers": {
+        whatYouLearn: [
+            "O que são containers e por que usá-los",
+            "Escrever um Dockerfile e construir imagens",
+            "Volumes e Docker Compose pra orquestrar serviços",
+            "Imagens enxutas e seguras a caminho do deploy",
+        ],
+        prerequisites: ["APIs e Frameworks", "Banco de dados"],
+    },
+    "CI/CD e Cloud": {
+        whatYouLearn: [
+            "Integração contínua rodando testes a cada push",
+            "GitHub Actions na prática",
+            "Build e publicação de imagens, e deploy contínuo",
+            "Onde a aplicação roda na nuvem, com HTTPS e observabilidade",
+        ],
+        prerequisites: ["Docker e containers", "Testes e qualidade"],
+    },
+    "Arquitetura e Escala": {
+        whatYouLearn: [
+            "Escala vertical e horizontal, e o monólito com réplicas stateless",
+            "Banco em escala: réplicas de leitura e cache",
+            "Comunicação assíncrona e mensageria",
+            "De monólito a serviços e padrões de resiliência",
+        ],
+        prerequisites: ["O caminho de back-end (APIs, banco, cache, deploy)"],
+    },
+    JavaScript: {
+        whatYouLearn: [
+            "A sintaxe e os tipos do JavaScript moderno",
+            "Funções, objetos, arrays e seus métodos",
+            "Assíncrono: callbacks, promises e async/await",
+            "Manipular o DOM e eventos no navegador",
+        ],
+        prerequisites: ["Lógica de programação"],
+    },
+    HTML: {
+        whatYouLearn: [
+            "Estruturar páginas com HTML semântico",
+            "Textos, links, imagens, listas e tabelas",
+            "Formulários e seus controles",
+            "Boas práticas de acessibilidade",
+        ],
+        prerequisites: ["Nenhum: um ótimo primeiro passo no front-end"],
+    },
+    CSS: {
+        whatYouLearn: [
+            "Estilizar páginas: cores, tipografia e o box model",
+            "Layout com Flexbox e Grid",
+            "Design responsivo com media queries",
+            "Transições e um toque de animação",
+        ],
+        prerequisites: ["HTML"],
+    },
+    "UI/UX Design": {
+        whatYouLearn: [
+            "Princípios de usabilidade e design de interface",
+            "Hierarquia visual, tipografia, cor e espaçamento",
+            "O processo de UX: pesquisa, wireframe e protótipo",
+            "Design systems e acessibilidade",
+        ],
+        prerequisites: ["Nenhum: uma porta de entrada para produto e front-end"],
+    },
+    "Fundamentos de Cibersegurança": {
+        whatYouLearn: [
+            "A tríade CIA e os princípios de defesa",
+            "O panorama de ameaças e atores",
+            "Malware, engenharia social e phishing",
+            "Criptografia e higiene de segurança no dia a dia",
+        ],
+        prerequisites: ["Nenhum: começa do zero em segurança"],
+    },
+    "Segurança de Aplicações Web": {
+        whatYouLearn: [
+            "O OWASP Top 10 na prática",
+            "Injeção (SQL, XSS) e controle de acesso quebrado",
+            "Configuração insegura e componentes vulneráveis",
+            "Pensar e testar como um atacante para defender",
+        ],
+        prerequisites: ["Noções de web (HTTP)", "Fundamentos de cibersegurança ajudam"],
+    },
+    "ISC2 Certified in Cybersecurity (CC)": {
+        whatYouLearn: [
+            "Os cinco domínios do exame ISC2 CC",
+            "Princípios de segurança e controle de acesso",
+            "Resposta a incidentes e continuidade de negócio",
+            "Segurança de redes e operações, vendor-neutral",
+        ],
+        prerequisites: ["Fundamentos de cibersegurança recomendado"],
+    },
+    "AZURE SC-900": {
+        whatYouLearn: [
+            "Conceitos de segurança, conformidade e identidade",
+            "Identidade e acesso com o Microsoft Entra",
+            "As soluções de segurança da Microsoft",
+            "Recursos de conformidade do Microsoft 365 e Azure",
+        ],
+        prerequisites: ["Noções básicas de nuvem ajudam"],
+    },
+    "AZURE AI-900": {
+        whatYouLearn: [
+            "Fundamentos de IA e IA responsável",
+            "Machine learning: conceitos e fluxo",
+            "Visão computacional e processamento de linguagem natural",
+            "IA generativa, mapeado para o exame AI-900",
+        ],
+        prerequisites: ["Nenhum: introdução conceitual à IA na Azure"],
+    },
+    "AZURE AI-901": {
+        whatYouLearn: [
+            "IA e IA responsável em profundidade",
+            "Modelos e o Microsoft Foundry",
+            "Visão, fala e análise de texto aplicadas",
+            "IA generativa, agentes e extração de informação",
+        ],
+        prerequisites: ["AI-900 ou noções de IA recomendado"],
+    },
+    "AZURE DP-900": {
+        whatYouLearn: [
+            "Conceitos centrais de dados",
+            "Dados relacionais e não relacionais no Azure",
+            "Cargas de trabalho analíticas",
+            "Os serviços de dados do Azure, para o exame DP-900",
+        ],
+        prerequisites: ["Nenhum: introdução a dados na nuvem"],
+    },
+    "AZURE AZ-900": {
+        whatYouLearn: [
+            "Conceitos de nuvem: modelos e benefícios",
+            "Os principais serviços do Azure",
+            "Segurança, identidade e governança",
+            "Preços e suporte, mapeado para o exame AZ-900",
+        ],
+        prerequisites: ["Nenhum: porta de entrada para a nuvem Azure"],
+    },
+    "AWS CLF-C02": {
+        whatYouLearn: [
+            "Conceitos de nuvem e a proposta da AWS",
+            "Segurança e o modelo de responsabilidade compartilhada",
+            "Os principais serviços da AWS (computação, storage, rede, banco)",
+            "Preços, suporte e faturamento, para o Cloud Practitioner",
+        ],
+        prerequisites: ["Nenhum: certificação de entrada na AWS"],
+    },
+    "AWS DVA-C02": {
+        whatYouLearn: [
+            "Desenvolver e implantar aplicações na AWS",
+            "Serviços-chave: Lambda, DynamoDB, S3 e API Gateway",
+            "Segurança, IAM e boas práticas para desenvolvedores",
+            "CI/CD e observabilidade, para o Developer Associate",
+        ],
+        prerequisites: ["Cloud Practitioner (CLF-C02) ou equivalente", "Saber programar"],
+    },
+};
+
+// Tempo estimado de leitura de uma aula: palavras dos blocos de texto a ~180 wpm,
+// mais um custo por bloco de codigo e por questao do quiz. Minimo de 3 min.
+function estimarMin(blocks: { type: string; value: string }[] | null, numQuestoes: number): number {
+    let palavras = 0;
+    let codeBlocks = 0;
+    for (const b of blocks ?? []) {
+        if (b.type === "text" || b.type === "quote") {
+            palavras += b.value.trim().split(/\s+/).filter(Boolean).length;
+        } else if (b.type === "code") {
+            codeBlocks += 1;
+        } else if (b.type === "table") {
+            palavras += 25;
+        }
+    }
+    const minutos = palavras / 180 + codeBlocks * 0.5 + numQuestoes * 1.2;
+    return Math.max(3, Math.round(minutos));
+}
+
+async function seed() {
+    const todas = await db.select().from(trails);
+    let metaAtualizadas = 0;
+    let aulasAtualizadas = 0;
+    let previews = 0;
+    const semDetalhe: string[] = [];
+
+    for (const t of todas) {
+        const d = DETALHES[t.name];
+        if (d) {
+            await db
+                .update(trails)
+                .set({ whatYouLearn: d.whatYouLearn, prerequisites: d.prerequisites })
+                .where(eq(trails.id, t.id));
+            metaAtualizadas++;
+        } else {
+            semDetalhe.push(t.name);
+        }
+
+        const mods = await db
+            .select()
+            .from(modules)
+            .where(eq(modules.trailId, t.id))
+            .orderBy(asc(modules.position));
+        const posDoModulo = new Map(mods.map((m) => [m.id, m.position]));
+
+        const aulas = await db.select().from(lessons).where(eq(lessons.trailId, t.id));
+        if (aulas.length === 0) continue;
+
+        const aulaIds = aulas.map((a) => a.id);
+        const contagens = await db
+            .select({ lessonId: questions.lessonId, n: count() })
+            .from(questions)
+            .where(inArray(questions.lessonId, aulaIds))
+            .groupBy(questions.lessonId);
+        const questoesPorAula = new Map(contagens.map((c) => [c.lessonId, Number(c.n)]));
+
+        const ordenadas = [...aulas].sort(
+            (a, b) =>
+                (posDoModulo.get(a.moduleId) ?? 0) - (posDoModulo.get(b.moduleId) ?? 0) ||
+                a.position - b.position,
+        );
+
+        for (let i = 0; i < ordenadas.length; i++) {
+            const a = ordenadas[i];
+            const min = estimarMin(a.contentBlocks, questoesPorAula.get(a.id) ?? 0);
+            const preview = i === 0;
+            await db.update(lessons).set({ durationMin: min, preview }).where(eq(lessons.id, a.id));
+            aulasAtualizadas++;
+            if (preview) previews++;
+        }
+    }
+
+    console.log(
+        "Detalhes seed: " +
+            metaAtualizadas +
+            " trilhas com what/prereq, " +
+            aulasAtualizadas +
+            " aulas com duracao, " +
+            previews +
+            " previews.",
+    );
+    if (semDetalhe.length) {
+        console.log("Sem what/prereq (nao estao no mapa DETALHES): " + semDetalhe.join(", "));
+    }
+}
+
+seed()
+    .then(() => process.exit(0))
+    .catch((e) => {
+        console.error("Falha no seed de detalhes:", e);
+        process.exit(1);
+    });

--- a/backend/src/services/trail.service.ts
+++ b/backend/src/services/trail.service.ts
@@ -9,8 +9,11 @@ import {
     questions,
     questionOptions,
     questionAnswers,
+    roadmaps,
+    roadmapStages,
+    roadmapStageRefs,
 } from "../../schema.ts";
-import { eq, asc, count, inArray, and } from "drizzle-orm";
+import { eq, asc, count, countDistinct, inArray, and } from "drizzle-orm";
 import type { z } from "zod";
 import type { createTrailSchema, updateTrailSchema } from "../schemas/trail.schemas.ts";
 import { AppError } from "../errors/AppError.ts";
@@ -260,9 +263,34 @@ export async function detalheDaTrilha(trailId: string, userId: string) {
                 title: a.title,
                 position: a.position,
                 published: a.published,
+                durationMin: a.durationMin,
+                preview: a.preview,
                 state: estadoPorAula.get(a.id) ?? "locked",
             })),
     }));
 
-    return { ...trilha, modules: modulosComAulas };
+    const lessonIds = todasAulas.map((a) => a.id);
+    const [studs] = lessonIds.length
+        ? await db
+              .select({ n: countDistinct(lessonProgress.userId) })
+              .from(lessonProgress)
+              .where(inArray(lessonProgress.lessonId, lessonIds))
+        : [{ n: 0 }];
+
+    // Area da trilha: o roadmap que a referencia (o principal, de menor posicao).
+    const [rm] = await db
+        .select({ name: roadmaps.name })
+        .from(roadmapStageRefs)
+        .innerJoin(roadmapStages, eq(roadmapStages.id, roadmapStageRefs.stageId))
+        .innerJoin(roadmaps, eq(roadmaps.id, roadmapStages.roadmapId))
+        .where(and(eq(roadmapStageRefs.refType, "trail"), eq(roadmapStageRefs.refId, trailId)))
+        .orderBy(asc(roadmaps.position))
+        .limit(1);
+
+    return {
+        ...trilha,
+        category: rm?.name ?? null,
+        studentsCount: Number(studs.n),
+        modules: modulosComAulas,
+    };
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { Trilhas } from './pages/Trilhas';
 import { Roadmaps } from './pages/Roadmaps';
 import { RoadmapDetalhe } from './pages/Roadmaps/Detalhe';
 import { Aula } from './pages/Aula';
+import { TrilhaDetalhe } from './pages/TrilhaDetalhe';
 import { Estudio } from './pages/Estudio';
 import { EstudioHome } from './pages/EstudioHome';
 import { Usuarios } from './pages/Usuarios';
@@ -92,6 +93,14 @@ function AppRoutes() {
         element={
           <PrivateRoute>
             <Trilhas />
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/trilhas/:trailId"
+        element={
+          <PrivateRoute>
+            <TrilhaDetalhe />
           </PrivateRoute>
         }
       />

--- a/frontend/src/components/Icons.tsx
+++ b/frontend/src/components/Icons.tsx
@@ -476,3 +476,41 @@ export const BookOpen = ({ size = 13 }: IconProps) => (
     <path d="M12 6.5C13.5 5 16 4.5 21 4.8V19c-5-.3-7.5.2-9 1.7z" />
   </svg>
 );
+
+export const Users = ({ size = 17 }: IconProps) => (
+  <svg {...base(size)} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <circle cx="9" cy="8" r="3.2" />
+    <path d="M2.5 20c0-3.4 3-5.2 6.5-5.2s6.5 1.8 6.5 5.2" />
+    <path d="M17 6a3 3 0 0 1 0 6M21 20c0-2.2-1.2-3.8-3.2-4.6" />
+  </svg>
+);
+
+export const Award = ({ size = 15 }: IconProps) => (
+  <svg {...base(size)} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <circle cx="12" cy="9" r="5" />
+    <path d="M8.5 13.5 7 22l5-3 5 3-1.5-8.5" />
+  </svg>
+);
+
+export const Globe = ({ size = 15 }: IconProps) => (
+  <svg {...base(size)} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <circle cx="12" cy="12" r="9" />
+    <path d="M3 12h18M12 3c2.5 2.5 2.5 15 0 18M12 3c-2.5 2.5-2.5 15 0 18" />
+  </svg>
+);
+
+export const DocLines = ({ size = 26 }: IconProps) => (
+  <svg {...base(size)} stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
+    <path d="M9 7h7M9 11h7" />
+  </svg>
+);
+
+export const Grid4 = ({ size = 17 }: IconProps) => (
+  <svg {...base(size)} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <rect x="3" y="3" width="7" height="7" rx="1" />
+    <rect x="14" y="3" width="7" height="7" rx="1" />
+    <rect x="3" y="14" width="7" height="7" rx="1" />
+    <rect x="14" y="14" width="7" height="7" rx="1" />
+  </svg>
+);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4,3 +4,4 @@
 @import './styles/simulado.css';
 @import './styles/conquistas.css';
 @import './styles/desafio.css';
+@import './styles/trilha-detalhe.css';

--- a/frontend/src/pages/TrilhaDetalhe/index.tsx
+++ b/frontend/src/pages/TrilhaDetalhe/index.tsx
@@ -1,0 +1,368 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { useAuth } from '../../contexts/AuthContext';
+import { Logo } from '../../components/Logo';
+import { MobileMenu } from '../../components/MobileMenu';
+import { UserMenu } from '../../components/UserMenu';
+import { ThemeToggle } from '../../components/ThemeToggle';
+import {
+  Flame,
+  Users,
+  BookOpen,
+  ClockExam,
+  Globe,
+  Check,
+  Play,
+  Eye,
+  Lock,
+  DocLines,
+  ChevronDown,
+  Grid4,
+} from '../../components/Icons';
+import { getInitials } from '../../utils/initials';
+import { user } from '../../data/home';
+import { NAV_PRINCIPAL as NAV } from '../../data/nav';
+import { obterTrilha, type TrailDetail, type LessonRef } from '../../services/trails';
+
+const NIVEL: Record<TrailDetail['trailLevel'], string> = {
+  iniciante: 'Iniciante',
+  intermediario: 'Intermediário',
+  avancado: 'Avançado',
+};
+
+function glyphDoNome(name: string): string {
+  const limpo = name.replace(/[^A-Za-zÀ-ú ]/g, '').trim();
+  const partes = limpo.split(/\s+/).slice(0, 2);
+  return partes.map((p) => p[0]?.toUpperCase() ?? '').join('') || '{}';
+}
+
+function formatDur(min: number): string {
+  if (min <= 0) return '';
+  if (min < 60) return `${min} min`;
+  const h = Math.floor(min / 60);
+  const m = min % 60;
+  return m ? `${h}h${String(m).padStart(2, '0')}` : `${h}h`;
+}
+
+type Disp = 'done' | 'current' | 'preview' | 'locked';
+function dispDe(l: LessonRef): Disp {
+  if (l.state === 'done') return 'done';
+  if (l.state === 'current') return 'current';
+  if (l.preview) return 'preview';
+  return 'locked';
+}
+
+export function TrilhaDetalhe() {
+  const { trailId } = useParams();
+  const { user: authUser } = useAuth();
+  const navigate = useNavigate();
+
+  const displayName = authUser?.name ?? user.name;
+  const initials = getInitials(displayName);
+
+  const [trilha, setTrilha] = useState<TrailDetail | null>(null);
+  const [carregando, setCarregando] = useState(true);
+  const [erro, setErro] = useState('');
+  const [abertos, setAbertos] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!trailId) return;
+    setCarregando(true);
+    obterTrilha(trailId)
+      .then((t) => {
+        setTrilha(t);
+        const atual = t.modules.find((m) => m.lessons.some((l) => l.state === 'current'));
+        setAbertos(new Set([(atual ?? t.modules[0])?.id].filter(Boolean) as string[]));
+      })
+      .catch(() => setErro('Não foi possível carregar a trilha.'))
+      .finally(() => setCarregando(false));
+  }, [trailId]);
+
+  const stats = useMemo(() => {
+    const aulas = trilha?.modules.flatMap((m) => m.lessons) ?? [];
+    const total = aulas.length;
+    const feitas = aulas.filter((l) => l.state === 'done').length;
+    const minutos = aulas.reduce((s, l) => s + (l.durationMin ?? 0), 0);
+    const alvo =
+      aulas.find((l) => l.state === 'current') ?? aulas.find((l) => l.state !== 'locked') ?? aulas[0];
+    const previa = aulas.find((l) => l.preview) ?? alvo;
+    return { total, feitas, minutos, alvo, previa, comecado: feitas > 0 };
+  }, [trilha]);
+
+  function irParaAula(l: LessonRef, disp: Disp) {
+    if (!trilha || disp === 'locked') return;
+    navigate(`/trilhas/${trilha.id}/aula/${l.id}`);
+  }
+  function irPara(l?: LessonRef) {
+    if (!trilha || !l) return;
+    navigate(`/trilhas/${trilha.id}/aula/${l.id}`);
+  }
+  function toggle(id: string) {
+    setAbertos((prev) => {
+      const n = new Set(prev);
+      n.has(id) ? n.delete(id) : n.add(id);
+      return n;
+    });
+  }
+
+  const alunos = trilha?.studentsCount ?? 0;
+  const inclui = trilha
+    ? [
+        { icon: <BookOpen size={15} />, label: `${stats.total} aulas em texto` },
+        { icon: <Check size={15} />, label: 'Quiz ao final de cada aula' },
+        { icon: <Grid4 size={15} />, label: 'Progresso salvo automaticamente' },
+      ]
+    : [];
+
+  return (
+    <div className="home-shell">
+      <div className="home">
+        <header className="topbar">
+          <MobileMenu />
+          <Logo variant="solid" size={20} />
+          <nav className="nav">
+            {NAV.map((item) => (
+              <Link
+                key={item.to}
+                to={item.to}
+                className={`nav__item${item.label === 'Trilhas' ? ' nav__item--active' : ''}`}
+              >
+                {item.label}
+              </Link>
+            ))}
+          </nav>
+          <div className="topbar__spacer" />
+          <div className="streak-pill">
+            <Flame size={16} /> {authUser?.streak ?? 0}
+          </div>
+          <ThemeToggle inline />
+          <UserMenu
+            initials={initials}
+            level={authUser?.level ?? 1}
+            name={displayName}
+            email={authUser?.email}
+          />
+        </header>
+
+        {carregando && <p className="track__desc" style={{ padding: 24 }}>Carregando trilha...</p>}
+        {erro && <div className="auth__alert" style={{ margin: 24 }}>{erro}</div>}
+        {!carregando && !erro && !trilha && (
+          <p className="track__desc" style={{ padding: 24 }}>Trilha não encontrada.</p>
+        )}
+
+        {trilha && (
+          <>
+            <div className="td-hero">
+              <span className="td-hero__glow" />
+              <div className="td-hero__inner">
+                <div className="td-hero__main">
+                  <div className="td-crumb">
+                    <Link to="/trilhas" className="td-back">
+                      Trilhas
+                    </Link>
+                    {trilha.category && (
+                      <>
+                        <span className="td-crumb__sep">/</span>
+                        <span>{trilha.category}</span>
+                      </>
+                    )}
+                    <span className="td-crumb__sep">/</span>
+                    <span className="td-crumb__cur">{trilha.name}</span>
+                  </div>
+                  <div className="td-hero__badgerow">
+                    <span className="td-hero__glyph">{glyphDoNome(trilha.name)}</span>
+                    <span className="td-hero__tag">
+                      {trilha.category
+                        ? `${trilha.category} · ${NIVEL[trilha.trailLevel]}`
+                        : NIVEL[trilha.trailLevel]}
+                    </span>
+                  </div>
+                  <h1 className="td-hero__title">{trilha.name}</h1>
+                  <p className="td-hero__desc">{trilha.description}</p>
+
+                  {alunos > 0 && (
+                    <div className="td-hero__rating">
+                      <div className="td-hero__students">
+                        <Users size={17} /> <b>{alunos.toLocaleString('pt-BR')}</b> alunos nesta trilha
+                      </div>
+                    </div>
+                  )}
+
+                  <div className="td-hero__meta">
+                    <span>
+                      <BookOpen size={15} /> {stats.total} aulas em texto
+                    </span>
+                    {stats.minutos > 0 && (
+                      <span>
+                        <ClockExam size={15} /> ~{formatDur(stats.minutos)} de leitura
+                      </span>
+                    )}
+                    <span>
+                      <Globe size={15} /> PT-BR
+                    </span>
+                  </div>
+                </div>
+
+                <div className="td-card">
+                  <button className="td-card__preview" onClick={() => irPara(stats.previa)}>
+                    <span className="td-card__preview-icon">
+                      <DocLines size={26} />
+                    </span>
+                  </button>
+                  <div className="td-card__body">
+                    <div className="td-card__price">
+                      <b>GRÁTIS</b>
+                    </div>
+                    <button className="td-card__cta" onClick={() => irPara(stats.alvo)} disabled={!stats.alvo}>
+                      {stats.comecado ? 'Continuar trilha' : 'Começar trilha'}
+                    </button>
+                    <hr className="rule" />
+                    <div className="td-card__inc-title">Esta trilha inclui</div>
+                    <div className="td-card__inc">
+                      {inclui.map((i) => (
+                        <div key={i.label} className="td-card__inc-item">
+                          <span className="td-card__inc-icon">{i.icon}</span>
+                          {i.label}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div className="td-body">
+              <div className="td-col">
+                {trilha.whatYouLearn && trilha.whatYouLearn.length > 0 && (
+                  <div className="card">
+                    <h3 className="td-h3">O que você vai aprender</h3>
+                    <div className="td-learn">
+                      {trilha.whatYouLearn.map((l) => (
+                        <div key={l} className="td-learn__item">
+                          <span className="td-learn__check">
+                            <Check size={16} />
+                          </span>
+                          <span>{l}</span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                <div>
+                  <div className="td-modules-head">
+                    <h3 className="td-h3" style={{ margin: 0 }}>
+                      Conteúdo da trilha
+                    </h3>
+                    <span className="td-modules-meta">
+                      {trilha.modules.length} módulos · {stats.total} aulas
+                      {stats.minutos > 0 ? ` · ~${formatDur(stats.minutos)} de leitura` : ''}
+                    </span>
+                  </div>
+                  <div className="td-modules">
+                    {trilha.modules.map((m) => {
+                      const aberto = abertos.has(m.id);
+                      const min = m.lessons.reduce((s, l) => s + (l.durationMin ?? 0), 0);
+                      return (
+                        <div key={m.id} className="td-mod">
+                          <button
+                            className={`td-mod__head${aberto ? ' td-mod__head--open' : ''}`}
+                            onClick={() => toggle(m.id)}
+                          >
+                            <span className={`td-mod__chev${aberto ? ' td-mod__chev--open' : ''}`}>
+                              <ChevronDown size={16} />
+                            </span>
+                            <span className="td-mod__title">{m.title}</span>
+                            <span className="td-mod__meta">
+                              {m.lessons.length} aulas{min > 0 ? ` · ~${formatDur(min)}` : ''}
+                            </span>
+                          </button>
+                          {aberto && m.lessons.length > 0 && (
+                            <div className="td-mod__lessons">
+                              {m.lessons.map((l) => {
+                                const disp = dispDe(l);
+                                const clicavel = disp !== 'locked';
+                                return (
+                                  <div
+                                    key={l.id}
+                                    className={`td-lesson${clicavel ? ' td-lesson--click' : ''}`}
+                                    onClick={() => irParaAula(l, disp)}
+                                  >
+                                    <span className={`td-lesson__icon td-lesson__icon--${disp}`}>
+                                      {disp === 'done' ? (
+                                        <Check size={15} />
+                                      ) : disp === 'current' ? (
+                                        <Play size={13} />
+                                      ) : disp === 'preview' ? (
+                                        <Eye size={15} />
+                                      ) : (
+                                        <Lock size={13} />
+                                      )}
+                                    </span>
+                                    <span
+                                      className={`td-lesson__name${disp === 'locked' ? ' td-lesson__name--locked' : ''}`}
+                                    >
+                                      {l.title}
+                                    </span>
+                                    {disp === 'preview' && <span className="td-lesson__preview">prévia</span>}
+                                    {l.durationMin ? (
+                                      <span className="td-lesson__dur">{l.durationMin} min</span>
+                                    ) : null}
+                                  </div>
+                                );
+                              })}
+                            </div>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+
+                {trilha.prerequisites && trilha.prerequisites.length > 0 && (
+                  <div className="card">
+                    <h3 className="td-h3">Pré-requisitos</h3>
+                    <div className="td-reqs">
+                      {trilha.prerequisites.map((r) => (
+                        <div key={r} className="td-req">
+                          <span className="td-req__dot" />
+                          {r}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              <div className="td-col">
+                <div className="card">
+                  <div className="td-students">
+                    <span className="td-students__icon">
+                      <Users size={19} />
+                    </span>
+                    <div>
+                      <div className="td-students__n">{alunos.toLocaleString('pt-BR')}</div>
+                      <div className="td-students__l">
+                        {alunos === 1 ? 'aluno nesta trilha' : 'alunos nesta trilha'}
+                      </div>
+                    </div>
+                  </div>
+                  {alunos === 0 && (
+                    <p className="td-empty">Seja o primeiro a fazer esta trilha.</p>
+                  )}
+                </div>
+
+                <div className="card">
+                  <h3 className="td-h3">Avaliações</h3>
+                  <p className="td-empty">
+                    Ainda não há avaliações nesta trilha. Conclua e seja o primeiro a avaliar.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Trilhas/index.tsx
+++ b/frontend/src/pages/Trilhas/index.tsx
@@ -259,9 +259,9 @@ export function Trilhas() {
                   className="track track--clickable"
                   role="button"
                   tabIndex={0}
-                  onClick={() => abrirTrilha(t.id)}
+                  onClick={() => navigate(`/trilhas/${t.id}`)}
                   onKeyDown={(e) => {
-                    if (e.key === 'Enter') abrirTrilha(t.id);
+                    if (e.key === 'Enter') navigate(`/trilhas/${t.id}`);
                   }}
                 >
                   <div className="track__head">

--- a/frontend/src/services/trails.ts
+++ b/frontend/src/services/trails.ts
@@ -67,6 +67,8 @@ export interface LessonRef {
   title: string;
   position: number;
   published?: boolean;
+  durationMin?: number | null;
+  preview?: boolean;
   state: LessonState;
 }
 
@@ -82,6 +84,10 @@ export interface TrailDetail {
   name: string;
   trailLevel: TrailApi['trailLevel'];
   description: string;
+  category?: string | null;
+  whatYouLearn?: string[] | null;
+  prerequisites?: string[] | null;
+  studentsCount?: number;
   modules: ModuleWithLessons[];
 }
 

--- a/frontend/src/styles/trilha-detalhe.css
+++ b/frontend/src/styles/trilha-detalhe.css
@@ -1,0 +1,109 @@
+.td-hero { position: relative; overflow: hidden; background: linear-gradient(160deg, #1B2433, #0F1620); color: #fff; padding: 30px 26px 34px; }
+.td-hero__glow { position: absolute; width: 360px; height: 360px; border-radius: 50%; top: -160px; right: -40px; background: radial-gradient(circle, color-mix(in srgb, var(--accent) 30%, transparent), transparent 70%); pointer-events: none; }
+.td-hero__inner { position: relative; display: grid; grid-template-columns: 1fr 360px; gap: 32px; align-items: start; }
+.td-hero__main { min-width: 0; }
+.td-crumb { display: flex; align-items: center; gap: 8px; font-size: 13px; color: rgba(255,255,255,.7); margin-bottom: 16px; }
+.td-crumb__sep { opacity: .5; margin: 0 8px; }
+.td-crumb__cur { color: #fff; }
+.td-hero__badgerow { display: flex; align-items: center; gap: 10px; margin-bottom: 14px; }
+.td-hero__glyph { width: 52px; height: 52px; border-radius: 14px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; font-family: var(--font-code); font-weight: 700; font-size: 18px; color: #fff; background: color-mix(in srgb, var(--accent) 60%, #0F1620); }
+.td-hero__tag { font-size: 12px; font-weight: 700; text-transform: uppercase; letter-spacing: .06em; color: #fff; background: color-mix(in srgb, var(--accent) 55%, transparent); padding: 5px 11px; border-radius: 8px; }
+.td-hero__title { margin: 0; font-size: 34px; font-weight: 700; letter-spacing: -.025em; line-height: 1.1; }
+.td-hero__desc { font-size: 16px; color: rgba(255,255,255,.82); margin: 12px 0 0; max-width: 560px; line-height: 1.55; }
+.td-hero__rating { display: flex; align-items: center; gap: 20px; margin-top: 20px; flex-wrap: wrap; }
+.td-stars { display: flex; gap: 2px; }
+.td-rating { display: flex; align-items: center; gap: 8px; }
+.td-rating__num { font-size: 18px; font-weight: 700; color: var(--gold); }
+.td-rating__count { font-size: 13.5px; color: rgba(255,255,255,.7); }
+.td-hero__students { display: flex; align-items: center; gap: 8px; font-size: 14px; color: rgba(255,255,255,.85); }
+.td-hero__students b { color: #fff; }
+.td-hero__meta { display: flex; gap: 18px; margin-top: 18px; flex-wrap: wrap; font-size: 13.5px; color: rgba(255,255,255,.8); }
+.td-hero__meta span { display: flex; align-items: center; gap: 7px; }
+.td-instructor { display: flex; align-items: center; gap: 11px; margin-top: 20px; font-size: 13.5px; color: rgba(255,255,255,.85); }
+.td-instructor b { color: #fff; }
+
+.td-card { background: var(--surface); color: var(--text); border: 1px solid var(--border); border-radius: 16px; padding: 8px; box-shadow: 0 18px 40px rgba(0,0,0,.28); }
+.td-card__preview { position: relative; height: 150px; border-radius: 12px; overflow: hidden; background: linear-gradient(150deg, var(--accent), color-mix(in srgb, var(--accent) 46%, #0A1430)); display: flex; align-items: center; justify-content: center; border: none; width: 100%; cursor: pointer; }
+.td-card__preview-icon { width: 56px; height: 56px; border-radius: 16px; background: rgba(255,255,255,.9); display: flex; align-items: center; justify-content: center; color: var(--accent); }
+.td-card__body { padding: 16px 14px 12px; }
+.td-card__price { display: flex; align-items: baseline; gap: 8px; }
+.td-card__price b { font-size: 24px; font-weight: 700; letter-spacing: -.02em; }
+.td-card__price span { font-size: 14px; color: var(--muted); }
+.td-card__cta { width: 100%; height: 50px; margin-top: 14px; border: none; border-radius: 12px; background: var(--accent); color: #fff; font-family: inherit; font-weight: 700; font-size: 15px; cursor: pointer; box-shadow: 0 8px 20px color-mix(in srgb, var(--accent) 32%, transparent); }
+.td-card__save { width: 100%; height: 46px; margin-top: 10px; border: 1px solid var(--border-strong); border-radius: 12px; background: transparent; color: var(--text); font-family: inherit; font-weight: 600; font-size: 14px; cursor: pointer; display: flex; align-items: center; justify-content: center; gap: 8px; }
+.td-card__inc-title { font-size: 13px; font-weight: 700; margin-bottom: 12px; }
+.td-card__inc { display: flex; flex-direction: column; gap: 11px; }
+.td-card__inc-item { display: flex; align-items: center; gap: 11px; font-size: 13.5px; }
+.td-card__inc-icon { color: var(--accent); display: flex; }
+
+.td-body { display: grid; grid-template-columns: 1fr 360px; gap: 32px; padding: 28px 26px 34px; align-items: start; color: var(--text); }
+.td-col { min-width: 0; display: flex; flex-direction: column; gap: 26px; }
+.td-h3 { font-size: 19px; font-weight: 700; letter-spacing: -.01em; margin: 0 0 16px; }
+.td-learn { display: grid; grid-template-columns: 1fr 1fr; gap: 13px 24px; }
+.td-learn__item { display: flex; gap: 11px; align-items: flex-start; }
+.td-learn__check { color: var(--success); display: flex; flex-shrink: 0; margin-top: 2px; }
+.td-learn__item span:last-child { font-size: 14px; line-height: 1.5; }
+
+.td-modules-head { display: flex; align-items: baseline; gap: 12px; margin-bottom: 14px; }
+.td-modules-meta { font-size: 13.5px; color: var(--muted); }
+.td-modules { display: flex; flex-direction: column; gap: 10px; }
+.td-mod { background: var(--surface); border: 1px solid var(--border); border-radius: 14px; overflow: hidden; }
+.td-mod__head { display: flex; align-items: center; gap: 12px; width: 100%; padding: 15px 18px; border: none; background: transparent; font-family: inherit; cursor: pointer; text-align: left; }
+.td-mod__head--open { background: var(--surface-2); }
+.td-mod__chev { color: var(--muted); display: flex; transform: rotate(-90deg); transition: transform .15s; }
+.td-mod__chev--open { transform: rotate(0deg); }
+.td-mod__title { flex: 1; min-width: 0; font-size: 14.5px; font-weight: 700; }
+.td-mod__meta { font-size: 12.5px; color: var(--muted); }
+.td-mod__lessons { border-top: 1px solid var(--border); }
+.td-lesson { display: flex; align-items: center; gap: 12px; padding: 11px 18px 11px 20px; border-bottom: 1px solid var(--border); }
+.td-lesson:last-child { border-bottom: none; }
+.td-lesson--click { cursor: pointer; }
+.td-lesson--click:hover { background: var(--surface-2); }
+.td-lesson__icon { display: flex; flex-shrink: 0; }
+.td-lesson__icon--done { color: var(--success); }
+.td-lesson__icon--current { color: var(--accent); }
+.td-lesson__icon--preview { color: var(--accent); }
+.td-lesson__icon--locked { color: var(--muted); }
+.td-lesson__name { flex: 1; min-width: 0; font-size: 13.5px; }
+.td-lesson__name--locked { color: var(--muted); }
+.td-lesson__preview { font-size: 11.5px; font-weight: 600; color: var(--accent); }
+.td-lesson__dur { font-size: 12px; color: var(--muted); font-family: var(--font-code); }
+
+.td-reqs { display: flex; flex-direction: column; gap: 10px; }
+.td-req { display: flex; gap: 11px; align-items: center; font-size: 14px; }
+.td-req__dot { width: 5px; height: 5px; border-radius: 50%; background: var(--muted); flex-shrink: 0; }
+
+.td-students { display: flex; align-items: center; gap: 11px; margin-bottom: 14px; }
+.td-students__icon { width: 38px; height: 38px; border-radius: 11px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; color: var(--accent); background: color-mix(in srgb, var(--accent) 13%, transparent); }
+.td-students__n { font-size: 18px; font-weight: 700; letter-spacing: -.01em; line-height: 1; }
+.td-students__l { font-size: 12.5px; color: var(--muted); }
+.td-students__avatars { display: flex; align-items: center; }
+.td-ava { width: 32px; height: 32px; border-radius: 50%; border: 2px solid var(--surface); display: flex; align-items: center; justify-content: center; font-size: 11px; font-weight: 700; }
+.td-students__more { font-size: 12.5px; color: var(--muted); margin-left: 10px; }
+
+.td-ratings { display: flex; align-items: center; gap: 14px; margin-bottom: 16px; }
+.td-ratings__big { text-align: center; }
+.td-ratings__num { font-size: 34px; font-weight: 700; letter-spacing: -.02em; line-height: 1; color: var(--gold); }
+.td-ratings__big .td-stars { justify-content: center; margin-top: 4px; }
+.td-ratings__count { font-size: 11.5px; color: var(--muted); margin-top: 4px; }
+.td-ratings__bars { flex: 1; display: flex; flex-direction: column; gap: 6px; }
+.td-rbar { display: flex; align-items: center; gap: 8px; }
+.td-rbar__star { font-size: 11.5px; color: var(--muted); width: 10px; }
+.td-rbar__track { flex: 1; height: 7px; border-radius: 99px; background: var(--surface-2); overflow: hidden; }
+.td-rbar__track span { display: block; height: 100%; border-radius: 99px; background: var(--gold); }
+.td-rbar__pct { font-size: 11px; color: var(--muted); width: 32px; text-align: right; }
+.td-reviews { display: flex; flex-direction: column; gap: 14px; }
+.td-review__head { display: flex; align-items: center; gap: 9px; margin-bottom: 6px; }
+.td-review__name { font-size: 13px; font-weight: 600; }
+.td-review__stars { margin-left: auto; }
+.td-review__text { font-size: 13px; line-height: 1.5; color: var(--muted); }
+
+.td-empty { font-size: 13.5px; color: var(--muted); line-height: 1.5; }
+.td-back { display: inline-flex; align-items: center; gap: 5px; color: rgba(255,255,255,.75); text-decoration: none; font-size: 13px; font-weight: 600; }
+.td-back:hover { color: #fff; }
+
+@media (max-width: 900px) {
+  .td-hero__inner { grid-template-columns: 1fr; }
+  .td-body { grid-template-columns: 1fr; }
+  .td-learn { grid-template-columns: 1fr; }
+}


### PR DESCRIPTION
## Tela de detalhe da trilha

Antes, clicar numa trilha no catálogo jogava o aluno direto na primeira aula, sem nenhum contexto sobre o que ele ia estudar. Agora existe uma tela de detalhe no caminho, no formato do design que combinamos.

### O que a tela mostra
- Hero com o breadcrumb (Trilhas / área / trilha), o nível, a quantidade de aulas, o tempo estimado de leitura e quantos alunos estão na trilha.
- Card de inscrição com o CTA Começar/Continuar e o "Esta trilha inclui".
- "O que você vai aprender" e "Pré-requisitos".
- O conteúdo da trilha em acordeão, com duração e prévia por aula e o estado (feito, atual, bloqueado).
- Uma sidebar com a contagem de alunos e o espaço das avaliações.

### Backend
- A trilha ganhou os campos `what_you_learn` e `prerequisites`, e a aula ganhou `duration_min` e `preview` (migração `0030`).
- O endpoint de detalhe (`GET /trails/:id`) passou a devolver esses campos, a categoria (o roadmap que lastreia a trilha) e a contagem de alunos distintos com progresso.
- Um seed novo (`seed-detalhes-trilhas.ts`) autora o "o que vai aprender" e os pré-requisitos por trilha, estima a duração de cada aula pelo tempo de leitura e marca a primeira aula como prévia. Idempotente.

### Frontend
- Página `TrilhaDetalhe` e rota `/trilhas/:trailId`, portadas do código do design (CSS e ícones incluídos).
- O clique no card do catálogo passa a abrir o detalhe; o card de "Continuar estudando" segue indo direto para a aula.

### Fora do escopo desta entrega
As avaliações e comentários ficam para um próximo passo, então a seção aparece com estado vazio. Alguns enfeites do design que dependem de features que ainda não temos (autor da trilha, salvar para depois) ficaram de fora por ora.

### Como testar local
```
docker compose exec -T backend npx drizzle-kit migrate
docker compose exec -T backend node scripts/seed-detalhes-trilhas.ts
```
Depois é só abrir o catálogo de Trilhas e clicar numa trilha. Confirmado em dev, nos temas claro e escuro.
