### PR TITLE
style: alarga o conteúdo do catálogo de trilhas e roadmaps

### DIFF
--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1258,8 +1258,8 @@
 
 /* ===================== TRILHAS ===================== */
 .trilhas-page {
-  padding: 32px 48px;
-  max-width: 1180px;
+  padding: 32px 32px;
+  max-width: 1440px;
   margin: 0 auto;
 }
 .trilhas-page__head {


### PR DESCRIPTION
As telas de Trilhas e Roadmaps compartilham o container .trilhas-page, então um ajuste só vale pras duas em paralelo. Aumentei o max-width de 1180 para 1440px e reduzi o padding lateral de 48 para 32px, pra diminuir a margem vazia nas laterais em telas grandes. Validado local nos dois temas.