### PR TITLE
feat: trilha Machine Learning na Prática (estágio 8 do roadmap de Ciência de Dados)

### DIFF
--- a/backend/scripts/seed-roadmap-ciencia-dados.ts
+++ b/backend/scripts/seed-roadmap-ciencia-dados.ts
@@ -96,6 +96,15 @@ const STAGES: Stage[] = [
         tags: ["matplotlib", "seaborn", "EDA"],
         refs: [{ type: "trail", ref: "Visualização de Dados" }],
     },
+    {
+        phase: "avancado",
+        position: 7,
+        title: "Machine learning",
+        description:
+            "O coração da ciência de dados: o fluxo de um projeto de ML, regressão e classificação com scikit-learn, como avaliar modelos e fugir do overfitting, preparar dados e o aprendizado não-supervisionado.",
+        tags: ["scikit-learn", "Regressão", "Classificação"],
+        refs: [{ type: "trail", ref: "Machine Learning" }],
+    },
 ];
 
 async function resolverRef(type: RefType, ref: string): Promise<string | null> {

--- a/backend/scripts/seed-roadmap-ciencia-dados.ts
+++ b/backend/scripts/seed-roadmap-ciencia-dados.ts
@@ -105,6 +105,15 @@ const STAGES: Stage[] = [
         tags: ["scikit-learn", "Regressão", "Classificação"],
         refs: [{ type: "trail", ref: "Machine Learning" }],
     },
+    {
+        phase: "avancado",
+        position: 8,
+        title: "Machine learning na prática",
+        description:
+            "ML além do básico: feature engineering, ajuste de hiperparâmetros, ensembles (random forest e boosting), pipelines robustos, lidar com desbalanceamento e overfitting, e uma introdução a deep learning.",
+        tags: ["Ensembles", "Boosting", "Tuning"],
+        refs: [{ type: "trail", ref: "Machine Learning na Prática" }],
+    },
 ];
 
 async function resolverRef(type: RefType, ref: string): Promise<string | null> {

--- a/backend/scripts/seed-trilha-machine-learning.ts
+++ b/backend/scripts/seed-trilha-machine-learning.ts
@@ -1,0 +1,5186 @@
+// Seed da trilha Machine Learning (avancado), estagio 7 do roadmap de Ciencia de Dados.
+// Idempotente e nao destrutivo: se a trilha ja tiver aulas, nao faz nada.
+//
+// Rodar em prod: docker compose -f docker-compose.prod.yml exec -T backend node scripts/seed-trilha-machine-learning.ts
+import { db } from "../db.ts";
+import { trails, modules, lessons, questions, questionOptions } from "../schema.ts";
+import { eq } from "drizzle-orm";
+
+const NOME = "Machine Learning";
+const LEVEL: "iniciante" | "intermediario" | "avancado" = "avancado";
+const DESCRICAO =
+    "O coração da ciência de dados: o que é machine learning, o fluxo de um projeto (treino, teste, avaliação), regressão e classificação com scikit-learn, como avaliar modelos de verdade e fugir do overfitting, preparar dados e uma introdução ao aprendizado não-supervisionado. Onde os dados viram previsão.";
+
+type Bloco = { type: "text" | "code" | "quote" | "table"; value: string };
+type Questao = {
+    statement: string;
+    difficulty: "facil" | "medio" | "dificil";
+    options: { text: string; isCorrect: boolean }[];
+};
+type Aula = { titulo: string; blocks: Bloco[]; questions: Questao[] };
+type Modulo = { titulo: string; aulas: Aula[] };
+
+const MODULOS: Modulo[] = [
+    {
+        "titulo": "Módulo 1 - O que é machine learning",
+        "aulas": [
+            {
+                "titulo": "Aprender dos dados x programar regras",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# O que é machine learning\n\nVocê já passou por Python, Estatística, pandas, SQL e Visualização. Em algum momento entre um `GROUP BY` e uma regressão linear, talvez tenha se perguntado: onde entra, de fato, o \"aprendizado de máquina\" do nome? A resposta começa com uma mudança de mentalidade bem simples: em vez de escrever regra por regra o que o programa deve fazer, você dá exemplos pro programa e deixa que ele descubra o padrão sozinho.\n\nEsse é o coração de machine learning (ML): **aprender padrões a partir de dados, em vez de programar as regras na mão**. Parece sutil, mas muda completamente como se resolve um problema."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O exemplo clássico: filtrar spam\n\nImagine que você precisa construir um filtro de spam. A abordagem tradicional (programar regras na mão) seria assim: se o e-mail contém \"clique aqui\", é spam; se contém \"ganhe dinheiro\", é spam; se o remetente não está nos contatos e tem mais de três links, é spam. Você, como programador, senta e escreve cada critério, um por um.\n\nO problema aparece rápido. Quem manda spam também percebe o padrão e adapta a mensagem: troca \"ganhe dinheiro\" por \"gnhe dinheir0\", usa imagens em vez de texto, varia o remetente. Cada truque novo exige uma regra nova. A lista de exceções cresce mais rápido do que sua capacidade de mantê-la, e ainda assim e-mails legítimos continuam sendo bloqueados por engano."
+                    },
+                    {
+                        "type": "code",
+                        "value": "def eh_spam_regra(texto):\n    palavras_suspeitas = [\"clique aqui\", \"ganhe dinheiro\", \"promoção imperdível\"]\n    texto = texto.lower()\n    return any(p in texto for p in palavras_suspeitas)\n\nprint(eh_spam_regra(\"Ganhe dinheiro fácil sem sair de casa\"))\n# True: pegou a regra certinho\n\nprint(eh_spam_regra(\"Gnhe dinheir0 fácil sem sair de casa\"))\n# False: um pequeno truque de digitação já escapa da regra\n\nprint(eh_spam_regra(\"Pauta da reunião de amanhã: clique aqui para confirmar presença\"))\n# True: e-mail legítimo do trabalho, bloqueado por engano (falso positivo)"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## A alternativa: aprender com exemplos\n\nA abordagem de machine learning inverte o processo. Em vez de escrever as regras, você reúne milhares de e-mails já classificados por humanos como spam ou não spam e entrega esses exemplos para um algoritmo. O algoritmo não recebe nenhuma regra pronta: ele analisa os exemplos, encontra os padrões que separam um grupo do outro (frequência de certas palavras, características do remetente, estrutura do texto) e constrói, sozinho, um critério de decisão.\n\nNa prática, isso não é tão diferente do que você já fez na trilha de Estatística. Quando ajustou uma regressão linear, você não escreveu \"se x for tal coisa, y é tal outra\": deixou que o próprio cálculo encontrasse os coeficientes da reta que melhor se ajustava aos dados. Aquilo já era, no fundo, uma forma simples de aprendizado a partir de dados. Machine learning generaliza essa ideia para problemas bem mais variados que uma reta."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Aspecto\", \"Regras programadas na mão\", \"Aprendizado de máquina\"], [\"Quem define o comportamento\", \"A pessoa que programa, regra por regra\", \"O modelo, a partir de exemplos rotulados\"], [\"Lida bem com exceções e variações?\", \"Mal: cada exceção vira uma nova regra\", \"Bem: aprende um padrão geral dos dados\"], [\"O que fazer quando o cenário muda\", \"Reescrever as regras manualmente\", \"Retreinar o modelo com dados novos\"], [\"O que a solução exige\", \"Conhecimento explícito do domínio\", \"Dados de qualidade e em quantidade\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Por que isso importa\n\nEntender essa diferença é o primeiro passo da trilha inteira. Todo algoritmo de machine learning que você vai ver daqui pra frente (regressão, árvore de decisão, k-means) segue essa mesma lógica básica: aprender um padrão a partir de exemplos, e não seguir instruções escritas à mão. Nas próximas aulas você vai ver os diferentes jeitos de aprender (com ou sem rótulos), o vocabulário que aparece em todo lugar no scikit-learn, e onde exatamente esse aprendizado se encaixa no fluxo de um projeto de dados."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Machine learning não é sobre escrever o comportamento certo: é sobre dar exemplos bons o suficiente para que o padrão certo seja aprendido."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que caracteriza a abordagem de aprendizado de máquina em comparação com a programação tradicional baseada em regras?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "O modelo aprende padrões a partir de exemplos de dados, em vez de seguir regras escritas à mão.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O programador escreve regras cada vez mais detalhadas até cobrir todos os casos imagináveis.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O sistema segue uma sequência de passos fixos, definida antes de qualquer contato com dados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O comportamento do programa é fixado no código e nunca muda depois de publicado em produção.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "No filtro de spam construído só com regras de palavras proibidas, por que ele erra tanto em deixar passar spam disfarçado quanto em bloquear e-mails legítimos?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque as regras comparam o texto de forma literal e não entendem contexto ou variações reais.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o servidor de e-mail limita quantas regras podem valer para cada mensagem recebida.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o modelo de linguagem das regras não foi treinado com exemplos suficientes de spam.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque as regras são avaliadas em ordem aleatória, o que muda o resultado a cada execução.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "A trilha de Estatística mostrou a regressão linear ajustando uma reta que minimiza o erro sobre os dados. Por que esse processo já pode ser entendido como uma forma simples de aprendizado de máquina?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque os coeficientes da reta são ajustados a partir dos dados, sem regras fixas escolhidas manualmente.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque a regressão linear usa o mesmo algoritmo interno das redes neurais profundas mais avançadas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque toda reta ajustada por regressão vira automaticamente um modelo de classificação de categorias.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o cálculo do erro da reta exige rótulos de teste que só existem em deep learning.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe precisa decidir entre um sistema de regras e um modelo de machine learning para aprovar ou reprovar transações financeiras. Em qual cenário as regras programadas na mão ainda são a escolha mais sensata?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Quando há poucas exceções conhecidas e o critério de decisão é simples e precisa ser auditável.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Quando há milhões de exemplos rotulados disponíveis e os padrões de fraude mudam com frequência.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Quando o volume de transações é tão grande que nenhuma pessoa consegue revisar as regras manualmente.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Quando os padrões de comportamento fraudulento variam de cliente para cliente de forma imprevisível.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um programa guarda numa tabela todos os e-mails já vistos e a classificação (spam ou não) de cada um. Para um e-mail novo, que nunca apareceu na tabela, ele não sabe o que responder. Por que isso NÃO é considerado aprendizado de máquina?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Porque o programa memorizou casos específicos, sem extrair um padrão capaz de lidar com exemplos novos.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque tabelas de consulta são proibidas por definição em qualquer sistema com dados rotulados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque aprendizado de máquina exige o uso obrigatório de redes neurais para qualquer problema.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o programa usa muito pouca memória do computador para armazenar as informações necessárias.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Supervisionado, não-supervisionado e reforço",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Nem todo aprendizado é igual\n\nA aula passada mostrou a ideia central: aprender padrões a partir de exemplos. Mas \"exemplos\" pode significar coisas bem diferentes dependendo do problema. Às vezes você sabe exatamente a resposta certa de cada exemplo (esse e-mail é spam, aquele não é). Às vezes você só tem os dados, sem nenhuma resposta anotada, e quer descobrir uma estrutura escondida neles. E às vezes não existem exemplos prontos: existe um agente que aprende agindo, por tentativa e erro.\n\nEssas três situações correspondem aos três grandes tipos de aprendizado de máquina: supervisionado, não-supervisionado e por reforço."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Aprendizado supervisionado: aprender a prever\n\nNo aprendizado supervisionado, cada exemplo do conjunto de dados vem com uma resposta certa conhecida, chamada de rótulo (ou alvo, ou target). O modelo aprende a relação entre as características de entrada e esse rótulo, para depois prever o rótulo de exemplos novos, que ele nunca viu.\n\nÉ o caso do filtro de spam da aula passada (cada e-mail rotulado como spam ou não spam) e também da regressão linear da trilha de Estatística (cada imóvel com seu preço de venda já conhecido). Sempre que o objetivo é **prever** algo que já foi observado no passado para casos parecidos, o problema é supervisionado."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Aprendizado não-supervisionado: aprender a descrever\n\nNo aprendizado não-supervisionado não existe rótulo nenhum. Você tem só os dados, sem saber de antemão a resposta certa, e o objetivo passa a ser descobrir uma estrutura que já existe ali, mas está escondida: grupos de exemplos parecidos entre si, ou uma forma mais simples de representar os mesmos dados.\n\nO exemplo mais comum é agrupar clientes por perfil de compra sem saber previamente quais perfis existem (isso se chama clustering, e você vai ver o algoritmo k-means no Módulo 7). Aqui o verbo não é \"prever\": é **agrupar** ou **descobrir**."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Aprendizado por reforço: aprender agindo\n\nO terceiro tipo funciona de um jeito diferente dos outros dois: não existe uma base de dados pronta com exemplos rotulados de antemão. Em vez disso, existe um agente que interage com um ambiente, toma decisões e recebe recompensas ou punições de acordo com o resultado delas. Aos poucos, por tentativa e erro, o agente aprende a agir de um jeito que maximiza a recompensa recebida.\n\nÉ assim que agentes aprendem a jogar jogos complexos (como xadrez ou Go) ou a controlar um robô. O scikit-learn, ferramenta principal desta trilha, não é feito para esse tipo de problema (existem bibliotecas próprias para isso). Por enquanto, vale conhecer o nome e a ideia: aprender é possível mesmo sem nenhum exemplo pronto de resposta certa."
+                    },
+                    {
+                        "type": "code",
+                        "value": "import pandas as pd\n\n# Dados de clientes de um e-commerce\nclientes = pd.DataFrame({\n    \"idade\": [25, 41, 33, 52, 29],\n    \"gasto_mensal\": [120, 340, 210, 480, 90],\n    \"comprou_categoria_x\": [0, 1, 1, 1, 0]  # rótulo: 1 = comprou, 0 = não comprou\n})\n\nprint(clientes)\n#    idade  gasto_mensal  comprou_categoria_x\n# 0     25           120                     0\n# 1     41           340                     1\n# 2     33           210                     1\n# 3     52           480                     1\n# 4     29            90                     0\n\n# Com a coluna \"comprou_categoria_x\" como alvo, isso é supervisionado:\n# o modelo aprenderia a prever esse rótulo para clientes novos.\n# Sem essa coluna, os mesmos dados serviriam para não-supervisionado:\n# por exemplo, agrupar clientes parecidos sem saber os grupos de antemão."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Tipo de aprendizado\", \"Tem rótulos?\", \"O que o modelo faz\", \"Exemplo\"], [\"Supervisionado\", \"Sim\", \"Aprende a prever o rótulo de exemplos novos\", \"Prever se um e-mail é spam\"], [\"Não-supervisionado\", \"Não\", \"Descobre estrutura ou agrupamentos nos dados\", \"Agrupar clientes por perfil de compra\"], [\"Por reforço\", \"Não, usa recompensas\", \"Aprende por tentativa e erro, maximizando recompensa\", \"Agente que aprende a jogar um jogo\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Antes de treinar qualquer modelo, a primeira pergunta é sempre a mesma: existe um rótulo para aprender a prever, ou o objetivo é descobrir uma estrutura que ainda não conhecemos?"
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual característica define o aprendizado supervisionado?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Os dados de treino vêm acompanhados de um rótulo conhecido, que o modelo aprende a prever.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Os dados de treino não têm nenhuma informação além dos valores das próprias features.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O modelo interage com um ambiente e recebe recompensas a cada decisão tomada.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O modelo agrupa os exemplos em categorias que ele mesmo descobre durante o treino.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe de marketing tem uma base com histórico de compras de clientes, mas nenhuma informação sobre a qual \"perfil\" cada cliente pertence. Eles querem descobrir grupos naturais de clientes parecidos. Que tipo de aprendizado se encaixa nesse problema?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Não supervisionado, porque não há rótulo prévio e o objetivo é descobrir estrutura nos dados.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Supervisionado, porque o histórico de compras já funciona como rótulo direto de cada cliente.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Por reforço, porque a equipe vai testar recompensas para cada grupo de clientes formado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Supervisionado, porque o objetivo final é prever exatamente o comportamento futuro de cada cliente.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um agente de software aprende a jogar um jogo eletrônico disputando milhares de partidas, ganhando pontos quando vence uma fase e perdendo pontos quando é derrotado, sem que ninguém diga a jogada certa em cada momento. Que tipo de aprendizado descreve melhor esse cenário?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Por reforço, porque o agente aprende por tentativa e erro a partir de recompensas e punições.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Aprendizado supervisionado, porque cada partida jogada funciona como um exemplo rotulado de jogada certa.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Aprendizado não supervisionado, porque o jogo não fornece nenhum tipo de retorno para o agente.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Aprendizado supervisionado, porque a pontuação de cada fase é usada diretamente como rótulo de treino.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma imobiliária tem uma planilha com características de imóveis já vendidos (área, bairro, número de quartos) e o preço final de venda de cada um. Ela quer estimar o preço de um imóvel novo, ainda não vendido. Isso é um problema de que tipo?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Supervisionado, porque o preço de venda de imóveis anteriores funciona como o rótulo a ser aprendido.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Não supervisionado, porque características como área e bairro não têm relação direta com o preço.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Por reforço, porque o preço final só é conhecido depois de uma sequência de negociações.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não supervisionado, porque o objetivo é agrupar imóveis parecidos em faixas de preço.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual das situações abaixo é um exemplo de aprendizado supervisionado, e não de aprendizado não supervisionado, apesar de também envolver \"encontrar padrões\" nos dados?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Prever, com base em exames já diagnosticados, se um novo paciente tem ou não uma doença específica.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Agrupar produtos de um catálogo em categorias parecidas sem nenhuma informação sobre a categoria real.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Reduzir o número de variáveis de um conjunto de dados para visualizar os clientes em duas dimensões.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Separar textos de notícias em grupos temáticos parecidos sem qualquer rótulo de assunto informado.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "O vocabulário: features, alvo, modelo",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Falando a mesma língua\n\nA partir daqui, alguns termos vão aparecer o tempo todo: na documentação do scikit-learn, em mensagens de erro, em artigos e em conversas com outras pessoas da área. Vale a pena parar uma aula inteira só para fixar esse vocabulário, porque confundir esses termos é uma das maiores fontes de confusão de quem está começando em machine learning.\n\nA boa notícia é que você já conhece a peça principal: o DataFrame do pandas. Quase todo o vocabulário de ML mapeia direto para conceitos que você já usa."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## As peças do quebra-cabeça\n\n**Feature** (ou atributo, ou variável): cada característica usada como entrada do modelo. Numa tabela de imóveis, são colunas como área, número de quartos e distância do centro.\n\n**Alvo** (ou target, ou rótulo): o que o modelo tenta prever. No mesmo exemplo, seria o preço de venda.\n\n**Amostra** (ou exemplo, ou observação): cada caso individual do conjunto de dados. Em termos de DataFrame, cada linha é uma amostra: um imóvel específico, um cliente específico, um e-mail específico.\n\n**Modelo**: a estrutura matemática (no scikit-learn, o objeto estimador) que aprende o padrão a partir dos dados e depois faz previsões.\n\n**Treino**: o processo de ajustar o modelo usando os dados disponíveis, chamando o método `.fit()`.\n\n**Previsão**: o valor que o modelo retorna para um exemplo novo, chamando o método `.predict()`."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Termo\", \"Sinônimos comuns\", \"O que significa\", \"Exemplo (dataset de imóveis)\"], [\"Feature\", \"Atributo, variável, coluna de entrada\", \"Cada característica usada para prever\", \"area_m2, quartos, distancia_centro_km\"], [\"Alvo\", \"Target, rótulo, variável dependente\", \"O que o modelo tenta prever\", \"preco_mil\"], [\"Amostra\", \"Exemplo, observação, instância, linha\", \"Cada caso individual do dataset\", \"Um imóvel específico (uma linha)\"], [\"Modelo\", \"Estimador, no vocabulário do scikit-learn\", \"A estrutura que aprende o padrão e prevê\", \"Um objeto LinearRegression já treinado\"]]"
+                    },
+                    {
+                        "type": "code",
+                        "value": "import pandas as pd\n\nimoveis = pd.DataFrame({\n    \"area_m2\": [55, 78, 120, 42, 95],\n    \"quartos\": [2, 3, 4, 1, 3],\n    \"distancia_centro_km\": [8.2, 3.5, 12.0, 1.1, 6.4],\n    \"preco_mil\": [210, 340, 480, 190, 350]\n})\n\n# X: as features, tudo que o modelo usa para prever, menos o alvo\nX = imoveis.drop(columns=\"preco_mil\")\n\n# y: o alvo, a coluna que queremos prever\ny = imoveis[\"preco_mil\"]\n\nprint(X.shape)\n# (5, 3) -> 5 amostras, 3 features\n\nprint(y.shape)\n# (5,) -> 5 valores de alvo, um por amostra"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"\", \"X (features)\", \"y (alvo)\"], [\"Formato\", \"Tabela: linhas (amostras) por colunas (features)\", \"Lista: um valor por amostra\"], [\"Contém\", \"As variáveis usadas para prever\", \"O que o modelo deve aprender a prever\"], [\"No pandas\", \"DataFrame\", \"Series\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Por que decorar isso vale a pena\n\nEsses seis termos (feature, alvo, amostra, modelo, treino, previsão) e a notação X/y vão aparecer em praticamente todo código de scikit-learn que você escrever daqui pra frente. Quando uma mensagem de erro falar em \"shape de X incompatível com y\", ou a documentação disser \"o estimador precisa ser ajustado (fit) antes de prever (predict)\", você já vai saber exatamente do que se trata."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Feature é o que você sabe sobre cada exemplo. Alvo é o que você quer descobrir. Todo problema de machine learning supervisionado nasce dessa divisão."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que é uma \"feature\" em um problema de machine learning?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Uma característica ou variável usada como entrada para o modelo fazer a previsão.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O valor final que o modelo tenta prever para cada amostra do conjunto de dados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O algoritmo específico escolhido para treinar o modelo, como regressão ou árvore.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A métrica usada para avaliar se o modelo acertou ou errou uma previsão.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Em um dataset de clientes de banco com as colunas idade, renda_mensal, tempo_de_conta e inadimplente (0 ou 1, indicando se deixou de pagar), qual conjunto de colunas forma corretamente o X (features) se o objetivo é prever inadimplência?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "idade, renda_mensal e tempo_de_conta, deixando inadimplente de fora por ser o alvo a prever.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Apenas a coluna inadimplente, porque é ela que representa todas as features do cliente.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "idade, renda_mensal, tempo_de_conta e inadimplente juntas, já que todas as colunas viram features.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Apenas idade e renda_mensal, porque tempo_de_conta não pode ser usado como entrada do modelo.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Num DataFrame de exames laboratoriais em que cada linha representa um paciente e cada coluna representa um exame diferente, o que corresponde a uma \"amostra\" (ou exemplo, ou observação) nesse conjunto de dados?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Uma linha inteira, com todos os resultados de exames de um único paciente.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Uma coluna inteira, com o resultado de um exame específico para todos os pacientes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O nome de cada exame, usado como cabeçalho das colunas do DataFrame.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O valor médio de todos os exames de todos os pacientes juntos.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois que um modelo já foi treinado, ele é usado para prever o preço de imóveis novos, que ainda não foram vendidos. Nesse momento de previsão sobre dados novos, o que se pode afirmar sobre X e y?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Existe X, com as features dos imóveis novos, mas ainda não existe um y real para comparar.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Existem X e y completos, porque todo imóvel já tem preço de mercado conhecido de antemão.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não existe X nem y, porque o modelo já aprendeu tudo durante a fase de treino.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Existe apenas y, já que o modelo agora só precisa gerar o preço final do imóvel.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Antes de chamar `.fit(X, y)`, um objeto `LinearRegression()` recém-criado no scikit-learn já pode ser chamado de \"modelo treinado\", pronto para prever valores confiáveis?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Não, porque antes do fit ele só define o algoritmo escolhido, sem ter aprendido nada ainda.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Sim, porque todo objeto do scikit-learn já nasce com os coeficientes calculados por padrão.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Sim, porque o método predict funciona normalmente mesmo sem nunca ter passado por fit.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não, porque o scikit-learn exige rótulos de teste antes mesmo de o objeto ser criado.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Onde ML entra no fluxo de dados",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## O fluxo que você já percorreu\n\nOlhando para trás, dá pra ver um fluxo se formando ao longo da trilha de Ciência de Dados: primeiro você aprendeu a buscar dados com SQL, depois a limpar e organizar esses dados com pandas, depois a entender suas variáveis com estatística descritiva e correlação, e por fim a enxergar padrões visualmente com gráficos. Cada etapa depende da anterior: não dá para explorar dados que ainda não foram limpos, nem limpar dados que ainda não foram coletados.\n\nMachine learning entra como a etapa seguinte dessa cadeia: depois que os dados já foram coletados, limpos e explorados, o modelo é o que transforma esses dados prontos em previsão."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## ML depende de tudo que veio antes\n\nUm erro comum de quem está começando é achar que o algoritmo de machine learning \"resolve\" problemas de qualidade dos dados sozinho. Não resolve. Se a base tem valores faltantes mal tratados, outliers não investigados ou colunas com significado confuso, o modelo aprende exatamente esses problemas junto com o padrão real, porque para o algoritmo não existe diferença entre \"dado real\" e \"dado com erro\": existe só o dado que foi entregue a ele.\n\nPor isso, boa parte do trabalho de um projeto de machine learning nem é sobre o modelo em si: é sobre garantir que os dados que chegam até ele fazem sentido. Você já treinou esse olhar nas trilhas anteriores."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Machine learning, estatística e inteligência artificial\n\nOs três termos se confundem bastante, e vale desfazer a confusão. Inteligência artificial (IA) é o campo mais amplo: qualquer técnica que faça um sistema se comportar de forma inteligente, incluindo regras escritas à mão, algoritmos de busca e também machine learning. Machine learning é uma parte da IA: a parte específica que aprende com dados em vez de seguir instruções fixas.\n\nEstatística, por sua vez, tem uma relação de parentesco muito próxima com machine learning (a regressão linear, por exemplo, é estudada nas duas áreas). A diferença costuma estar no foco: a estatística tradicionalmente se preocupa em explicar e testar relações com rigor (essa correlação é real ou é coincidência da amostra?), enquanto machine learning se preocupa mais em prever bem casos novos, mesmo que o modelo por dentro seja menos fácil de interpretar. Não é uma fronteira rígida: é uma questão de ênfase. E deep learning, que você vai ouvir falar bastante, é uma subárea de machine learning baseada em redes neurais com muitas camadas: o próximo nível depois do que esta trilha cobre."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Área\", \"Foco principal\", \"Exemplo de técnica\"], [\"Inteligência artificial\", \"Fazer sistemas agirem de forma inteligente, por qualquer meio\", \"Regras, busca, machine learning, robótica\"], [\"Machine learning\", \"Aprender padrões dos dados para prever ou agrupar\", \"Regressão, árvore de decisão, k-means\"], [\"Estatística\", \"Entender e testar relações nos dados com rigor\", \"Teste de hipótese, intervalo de confiança, regressão\"]]"
+                    },
+                    {
+                        "type": "code",
+                        "value": "import pandas as pd\n\n# Etapas 1 e 2 do fluxo, já conhecidas: os dados chegaram (SQL) e foram limpos (pandas)\nvendas = pd.DataFrame({\n    \"preco\": [29.9, 49.9, 15.0, 89.9, 120.0],\n    \"desconto_pct\": [10, 0, 20, 5, 0],\n    \"categoria\": [\"A\", \"B\", \"A\", \"C\", \"B\"],\n    \"vendido_em_1_dia\": [1, 0, 1, 0, 1]\n})\n\n# Etapa 3, também já conhecida: explorar os dados\nprint(vendas.describe())\n# count, mean, std, min, quartis e max de cada coluna numérica: o resumo de sempre\n\n# Etapa 4: é aqui que o machine learning entra.\n# Os dados limpos e explorados viram X (features) e y (alvo)...\nX = vendas.drop(columns=\"vendido_em_1_dia\")\ny = vendas[\"vendido_em_1_dia\"]\n\n# ...prontos para um modelo aprender. Treinar de fato (fit/predict)\n# é o assunto do próximo módulo: por aqui, o que importa é o lugar do ML no fluxo."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que vem a seguir\n\nSaber onde o machine learning se encaixa evita duas armadilhas comuns: tratar o modelo como se ele fosse a parte mais importante do projeto (raramente é) e esperar que ele compense, sozinho, dados mal preparados (nunca compensa). No Módulo 2 você vai ver esse fluxo com mais detalhe, incluindo por que os dados usados para treinar o modelo precisam ser separados dos dados usados para avaliar se ele realmente aprendeu alguma coisa."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Machine learning não substitui as etapas anteriores da ciência de dados: ele depende inteiramente delas para ter algo de bom para aprender."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual alternativa descreve corretamente a relação entre inteligência artificial e machine learning?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Machine learning é uma parte da inteligência artificial, focada especificamente em aprender com dados.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Inteligência artificial é uma técnica específica dentro do machine learning, usada só em robótica.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Machine learning e inteligência artificial são exatamente a mesma coisa, apenas com nomes diferentes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Inteligência artificial só existe quando o sistema usa redes neurais profundas para funcionar.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma pessoa recebe uma base de dados cheia de valores faltantes e duplicados e decide treinar um modelo de machine learning imediatamente, sem tratar esses problemas antes. Qual é a consequência mais provável dessa decisão?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O modelo provavelmente aprende padrões distorcidos, porque a previsão depende da qualidade dos dados de entrada.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Nenhuma, porque algoritmos de machine learning corrigem automaticamente valores faltantes e duplicados durante o treino.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O modelo vai treinar mais rápido, já que dados sujos exigem menos capacidade de processamento do computador.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O modelo vai ignorar sozinho as linhas problemáticas e treinar apenas com os dados perfeitamente limpos.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma pesquisadora quer saber, com rigor estatístico, se existe mesmo uma relação significativa entre horas de estudo e nota da prova, ou se essa relação observada pode ser só coincidência da amostra. Esse objetivo está mais alinhado com qual área?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Estatística, porque o foco está em testar e explicar a relação entre as variáveis com rigor.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Machine learning, porque qualquer relação entre variáveis só pode ser medida com algoritmos de predição.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Machine learning, porque o objetivo principal de qualquer modelo é sempre maximizar a acurácia da previsão.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Estatística, porque essa área nunca lida com dados de amostras, apenas com populações completas.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Durante a análise exploratória com pandas e estatística, percebeu-se uma forte correlação entre duas variáveis do dataset e vários outliers extremos numa terceira variável. Como essa etapa anterior deveria influenciar a etapa de machine learning que vem a seguir?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Deveria influenciar as decisões sobre quais variáveis usar e como tratar os outliers antes de treinar o modelo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Não deveria influenciar em nada, já que o algoritmo de machine learning refaz essa análise sozinho, do zero.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Deveria ser ignorada, porque correlação e outliers só importam na etapa de visualização dos dados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Deveria apenas ser registrada num relatório separado, sem qualquer conexão com a etapa de modelagem.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um artigo descreve deep learning como \"a próxima fronteira depois do machine learning tradicional\". Do ponto de vista técnico mais preciso, qual é a relação entre deep learning e machine learning?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Deep learning é uma subárea do machine learning que usa redes neurais com muitas camadas.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Deep learning é um campo totalmente separado de machine learning, sem nenhuma relação técnica entre os dois.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Deep learning substitui por completo o machine learning tradicional em qualquer tipo de problema.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Deep learning é sinônimo exato de inteligência artificial, enquanto machine learning é algo bem diferente.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "ML não é mágica: limites e vieses",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Desfazendo a mágica\n\nDe fora, um modelo de machine learning pode parecer mágica: você entrega dados novos e ele \"adivinha\" a resposta certa. Não é mágica. É matemática e estatística encontrando padrões nos dados que foram mostrados a ele, e nada além disso. Essa última aula do módulo é sobre ser honesto quanto ao que machine learning consegue e ao que não consegue fazer, antes de começar a treinar modelos de verdade nos próximos módulos."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O modelo só conhece o que os dados mostraram\n\nUm modelo não tem acesso ao mundo real: ele tem acesso apenas ao conjunto de dados que recebeu no treino. Se esses dados não representam bem a situação em que o modelo vai ser usado, o desempenho cai, mesmo que o algoritmo esteja implementado corretamente. Um modelo de reconhecimento de imagem treinado quase só com fotos bem iluminadas, por exemplo, tende a errar mais em fotos escuras, simplesmente porque viu poucos exemplos desse tipo durante o treino.\n\nEsse é o motivo pelo qual dados bons e representativos importam mais do que a escolha do algoritmo. Um algoritmo sofisticado treinado com dados ruins costuma perder para um algoritmo simples treinado com dados bons."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O modelo também aprende os vieses dos dados\n\nAqui mora um risco mais sério. Se os dados históricos usados no treino refletem algum tipo de desigualdade (um processo de contratação que historicamente favoreceu um perfil específico de candidato, por exemplo), o modelo aprende esse padrão como se fosse um padrão legítimo a ser reproduzido. E o problema piora porque a decisão passa a parecer neutra: \"foi o algoritmo que decidiu\", quando na verdade o algoritmo só reproduziu, em escala, um viés que já existia nos dados.\n\nPor isso, tratar as previsões de um modelo como automaticamente objetivas é um erro. A pergunta \"que dados foram usados para treinar isso, e quem eles representam de verdade\" deveria vir sempre antes de confiar cegamente numa previsão."
+                    },
+                    {
+                        "type": "code",
+                        "value": "import pandas as pd\n\n# Base de clientes para prever inadimplência, com poucas amostras da classe minoritária\nclientes = pd.DataFrame({\n    \"renda\": [3200, 5400, 2100, 7800, 3900, 4600, 2900, 6100, 3300, 5000],\n    \"inadimplente\": [0, 0, 0, 0, 0, 0, 0, 0, 0, 1]  # só 1 em 10 é inadimplente\n})\n\nprint(clientes[\"inadimplente\"].value_counts())\n# 0    9\n# 1    1\n# Name: inadimplente, dtype: int64\n\n# Um modelo \"preguiçoso\", que sempre prevê 0 (não inadimplente), já acerta 90% das vezes\n# sem ter aprendido nada de útil sobre quem realmente é inadimplente.\n# Dados representativos (e a métrica de avaliação certa, tema do Módulo 5) importam\n# muito mais do que só treinar um modelo qualquer e olhar a acurácia isolada."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Mito comum sobre machine learning\", \"Realidade\"], [\"O modelo é neutro e objetivo, porque é matemática\", \"O modelo reflete os padrões, inclusive os vieses, dos dados usados no treino\"], [\"Mais dados sempre resolvem qualquer problema\", \"Dados de má qualidade ou não representativos atrapalham mesmo em grande volume\"], [\"Um modelo com nota alta no treino já está pronto para produção\", \"O que importa de verdade é o desempenho em dados novos, nunca vistos no treino\"], [\"O algoritmo mais avançado sempre dá o melhor resultado\", \"Dados bons e um problema bem definido pesam mais que a sofisticação do algoritmo\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Honesto, não inútil\n\nNada disso quer dizer que machine learning não sirva para nada: quer dizer que ele precisa ser usado com responsabilidade, questionamento e avaliação criteriosa, em vez de confiança automática. É exatamente isso que o restante da trilha ensina: como dividir dados em treino e teste, como escolher a métrica certa para cada problema, como perceber quando um modelo decorou o treino em vez de aprender de verdade. Machine learning é uma ferramenta poderosa, desde que se conheçam os limites dela."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Machine learning não adivinha o futuro: ele projeta, para casos parecidos, o padrão que aprendeu no passado. Fora desse território conhecido, reconhecer os limites vale mais do que confiar cegamente no modelo."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual afirmação descreve corretamente uma limitação real do machine learning?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Um modelo só consegue aprender os padrões que estão presentes nos dados usados para treiná-lo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um modelo bem treinado nunca comete erros de previsão em nenhuma situação nova.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um modelo de machine learning é sempre neutro, porque se baseia apenas em matemática.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um modelo treinado com poucos dados funciona exatamente tão bem quanto um treinado com muitos.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma empresa treina um modelo para triagem de currículos usando dez anos de decisões de contratação passadas. Se essas decisões passadas favoreceram sistematicamente um determinado perfil de candidato, o que é mais provável acontecer com o modelo?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O modelo tende a reproduzir esse mesmo favorecimento, porque aprende exatamente os padrões dos dados históricos.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O modelo automaticamente corrige esse favorecimento, já que algoritmos matemáticos eliminam qualquer viés humano.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O modelo ignora completamente as decisões passadas e avalia cada currículo novo de forma totalmente isolada.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O modelo detecta sozinho que houve favorecimento e alerta a empresa sobre o problema encontrado.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um modelo de reconhecimento de imagens foi treinado quase inteiramente com fotos tiradas durante o dia, com boa iluminação. Colocado em produção, ele passa a receber fotos noturnas com frequência. O que é mais provável observar?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Desempenho pior nas fotos noturnas, porque esse cenário está pouco representado nos dados de treino.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O mesmo desempenho de sempre, já que a iluminação da foto nunca influencia modelos de imagem.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Desempenho melhor nas fotos noturnas, porque menos detalhes visíveis facilitam o trabalho do modelo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Erro imediato de execução, já que modelos de imagem não conseguem processar fotos escuras.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um modelo encontra forte relação estatística entre o número de sorvetes vendidos e o número de afogamentos registrados numa cidade, usando essa relação para prever afogamentos. O que essa situação melhor ilustra sobre os limites do machine learning?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O modelo capta uma correlação útil para prever, o que não significa que sorvete cause afogamento.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O modelo está claramente errado, porque relações estatísticas fortes sempre indicam uma causa real.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O modelo deveria ser descartado, já que nenhuma correlação encontrada por machine learning tem valor prático.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O modelo provou, de forma definitiva, que existe um mecanismo causal direto entre as duas variáveis.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um modelo atinge 99% de acerto nos dados usados para treiná-lo, mas quando testado com dados novos, nunca vistos antes, o acerto cai para 60%. Como interpretar essa diferença à luz dos limites do machine learning?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O modelo provavelmente decorou particularidades do treino, sem aprender um padrão que generalize.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Essa diferença é normal e esperada, e não exige nenhuma investigação adicional da equipe responsável.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O resultado de 99% no treino não é, sozinho, suficiente para decidir se o modelo é bom.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A queda de desempenho mostra que os dados novos foram medidos com uma escala numérica diferente.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 2 - O fluxo de um projeto de ML",
+        "aulas": [
+            {
+                "titulo": "O pipeline de ML (visão geral)",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# O fluxo de um projeto de machine learning\n\nNos módulos anteriores você entendeu o que é machine learning: aprender padrões a partir de dados, em vez de programar regras na mão. Mas da ideia até um modelo funcionando existe um caminho com etapas bem definidas, um fluxo que se repete (com variações) em praticamente todo projeto de ML, do mais simples ao mais sofisticado.\n\nEsse fluxo é o mapa deste módulo. Vamos ver a visão geral agora e detalhar cada etapa nas próximas quatro aulas."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## As etapas do pipeline\n\nUm projeto de machine learning passa, tipicamente, por sete etapas:\n\n1. **Definir o problema**: o que exatamente queremos prever? Que decisão esse modelo vai apoiar?\n2. **Obter os dados**: reunir exemplos relevantes, geralmente organizados em um DataFrame do pandas.\n3. **Preparar os dados**: limpar, tratar valores faltantes, lidar com ruído (o módulo 6 aprofunda essa etapa).\n4. **Dividir em treino e teste**: separar uma parte dos dados para treinar e outra para avaliar depois (aula 2).\n5. **Treinar o modelo**: apresentar os dados de treino ao algoritmo escolhido (aula 3).\n6. **Avaliar o modelo**: medir o quanto ele acerta em dados que nunca viu (aula 3 e módulo 5).\n7. **Usar o modelo**: aplicar as previsões no problema real que motivou tudo isso.\n\nRepare que boa parte do trabalho (etapas 2 e 3) acontece antes de qualquer algoritmo de ML entrar em cena. É o DataFrame limpo que você já sabe construir com pandas, mais os outliers e correlações que você aprendeu a enxergar na visualização de dados."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Etapa\",\"Pergunta que ela responde\",\"Onde você já viu (ou vai ver)\"],[\"1. Definir o problema\",\"O que eu quero prever, e por quê?\",\"Módulo 1: vocabulário de ML\"],[\"2. Obter os dados\",\"De onde vêm os exemplos?\",\"SQL e pandas, nas trilhas anteriores\"],[\"3. Preparar os dados\",\"Os dados estão limpos e prontos?\",\"Módulo 6 desta trilha\"],[\"4. Dividir treino/teste\",\"Como avaliar sem trapacear?\",\"Aula 2 deste módulo\"],[\"5. Treinar\",\"Como o modelo aprende o padrão?\",\"Aula 3 deste módulo\"],[\"6. Avaliar\",\"O modelo generaliza bem?\",\"Aula 3 e módulo 5\"],[\"7. Usar\",\"Como aplicar a previsão no mundo real?\",\"Aula 4 deste módulo\"]]"
+                    },
+                    {
+                        "type": "code",
+                        "value": "# Visao geral do pipeline em codigo (cada peca e detalhada nas proximas aulas)\n\n# 1-3. Definir o problema, obter e preparar os dados\n# df = pd.read_csv(\"clientes.csv\")           # o DataFrame que voce ja conhece do pandas\n\n# 4. Dividir em treino e teste\nfrom sklearn.model_selection import train_test_split\nX_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)\n\n# 5. Treinar\nfrom sklearn.neighbors import KNeighborsClassifier\nmodelo = KNeighborsClassifier()\nmodelo.fit(X_train, y_train)\n\n# 6. Avaliar\nmodelo.score(X_test, y_test)\n# 0.93                                        -> 93% de acerto no conjunto de teste\n\n# 7. Usar\nmodelo.predict(dados_novos)                   # previsao para casos ainda nao vistos"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Um mapa, não uma esteira\n\nVale um alerta antes de seguir: na prática, esse fluxo raramente é percorrido em linha reta uma única vez. Você treina um modelo, avalia, percebe que os dados precisavam de mais limpeza, volta à etapa 3, tenta de novo. É normal (e esperado) ir e voltar entre as etapas.\n\nE como já vimos no módulo 1: nenhuma etapa desse pipeline compensa dados ruins. Um modelo treinado sobre dados enviesados ou mal coletados aprende exatamente esse viés, por mais caprichado que seja o resto do fluxo."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "O pipeline de ML não é burocracia: é a diferença entre um modelo que parece funcionar e um modelo em que você pode confiar para prever dados que ainda não existem."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Segundo o pipeline apresentado, qual etapa vem logo antes de treinar o modelo?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Dividir os dados em conjuntos de treino e teste.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Avaliar o modelo com dados que ele ainda não viu.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Usar o modelo para prever dados novos do mundo real.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Definir qual será a métrica de sucesso do projeto.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe começou a testar vários algoritmos de ML até um deles dar uma acurácia alta, sem antes definir claramente qual problema o modelo deveria resolver. Qual é o principal risco dessa abordagem?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O modelo pode acertar métricas no papel sem responder a nenhuma pergunta de negócio útil.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O treinamento vai demorar muito mais tempo do que se o problema tivesse sido definido antes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O scikit-learn recusa o treinamento quando o problema do projeto não foi definido antes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A acurácia obtida será sempre mais baixa do que se o problema tivesse sido definido antes.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de avaliar seu primeiro modelo e ver um desempenho ruim, um cientista de dados decide voltar para revisar como os dados foram limpos, antes de treinar de novo. Como isso se encaixa no pipeline de ML?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "É esperado: o pipeline costuma ser percorrido várias vezes, não numa única passada linear.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "É um erro grave: o pipeline deve ser seguido uma única vez, do início ao fim, sem repetições.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Só é válido se o motivo for um bug no código, nunca por causa da qualidade dos dados usados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Indica que o algoritmo escolhido foi o errado e deveria ser trocado antes de mexer nos dados.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma loja quer prever quais clientes vão cancelar a assinatura no próximo mês. Antes de sair coletando dados, qual pergunta pertence à etapa de definir o problema?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Que evento conta como cancelamento e qual histórico de dados será usado para prever isso.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Qual valor de test_size deve ser passado para a função train_test_split do scikit-learn.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Qual algoritmo de classificação vai gerar a maior acurácia possível para esse problema.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Qual biblioteca de machine learning em Python tem a documentação mais fácil de usar.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual alternativa descreve corretamente a relação entre o pipeline de ML e o que você já estudou nas trilhas anteriores?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Etapas como obter e preparar os dados reaproveitam diretamente SQL e pandas vistos antes.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O pipeline de ML substitui o uso de SQL e pandas, que só servem para relatórios simples.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Estatística deixa de ser útil a partir do momento em que o scikit-learn entra no fluxo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Visualização de dados só volta a ser necessária depois que o modelo já está em produção.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Treino x teste e o train_test_split",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Por que nunca avaliar no mesmo dado que treinou\n\nImagine uma prova em que o aluno estuda exatamente as perguntas que vão cair, com as respostas incluídas. Ele pode até decorar tudo e tirar nota máxima, mas isso não prova que aprendeu a matéria, só que decorou aquele gabarito específico.\n\nCom modelos de ML acontece algo parecido. Se você treina um modelo e mede o desempenho dele nos mesmos dados usados no treino, corre o risco de medir o quanto ele decorou aqueles exemplos, não o quanto ele aprendeu o padrão de verdade. Lembra da regressão linear na trilha de estatística? Se o erro dela fosse calculado só nos pontos usados para ajustar a reta, esse erro pareceria ótimo, mas não diria nada sobre como a reta se sairia com um ponto novo."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## A solução: separar treino e teste\n\nA prática padrão é separar uma parte dos dados antes de treinar qualquer coisa. O modelo só enxerga o conjunto de treino durante o `fit`. O conjunto de teste fica de lado, intocado, e só entra em cena na hora de avaliar, como uma prova com perguntas que o aluno nunca viu antes.\n\nO scikit-learn tem uma função pronta para isso: `train_test_split`, do módulo `sklearn.model_selection`."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.model_selection import train_test_split\n\n# supondo X e y ja carregados, com 150 linhas ao todo\nX_train, X_test, y_train, y_test = train_test_split(\n    X, y, test_size=0.2, random_state=42\n)\n\nX_train.shape, X_test.shape\n# ((120, 4), (30, 4))                -> 80% para treino (120), 20% para teste (30)"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Os dois parâmetros que mais importam\n\n`test_size` define a fração dos dados reservada para o teste: `0.2` significa 20%. Não existe um valor universal certo, mas é comum ver algo entre 20% e 30% para teste, deixando o restante para o treino.\n\n`random_state` fixa a semente aleatória usada para embaralhar os dados antes de dividir. Sem ele, cada execução do código gera uma divisão diferente, o que dificulta comparar dois experimentos de forma justa: a diferença de resultado pode ser só sorte da divisão, não mérito do modelo."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"\",\"Avaliar no treino\",\"Avaliar no teste\"],[\"O que mede\",\"Quanto o modelo decorou os exemplos\",\"Quanto o modelo generaliza para o novo\"],[\"Resultado típico\",\"Tende a ser otimista demais\",\"Mais realista sobre o uso real\"],[\"Uso correto\",\"Acompanhar o ajuste durante o treino\",\"Veredito final de desempenho\"]]"
+                    },
+                    {
+                        "type": "code",
+                        "value": "# NAO faca isso: usar o mesmo dado para treinar e para avaliar\n# (supondo um modelo qualquer, ja instanciado)\nmodelo.fit(X_train, y_train)\nmodelo.score(X_train, y_train)\n# 0.98                                -> parece otimo, mas o modelo ja viu essas respostas\n\n# Avaliacao correta: dados que o modelo nunca viu no treino\nmodelo.score(X_test, y_test)\n# 0.91                                -> mais baixo, e essa e a estimativa que importa"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Um modelo só prova que aprendeu quando acerta dados que nunca viu. Acertar o que já foi decorado não conta."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que a função train_test_split do scikit-learn faz?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Divide os dados em um conjunto para treinar o modelo e outro para avaliá-lo depois.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Treina o modelo e já calcula a acurácia final em uma única chamada de função.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Remove valores faltantes e outliers antes de qualquer etapa de treino do modelo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Escolhe automaticamente, entre vários algoritmos, qual é o mais adequado para os dados.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "No trecho train_test_split(X, y, test_size=0.2, random_state=42), o que representa o parâmetro test_size=0.2?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Que 20% dos exemplos vão para o conjunto de teste, e o restante para o treino.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Que o modelo vai rodar 20 vezes antes de calcular a métrica final de avaliação.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que apenas 20% das colunas do conjunto de dados serão usadas para treinar o modelo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que a semente aleatória usada para embaralhar e dividir os dados será fixada no valor vinte.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um modelo apresentou 99% de acerto quando avaliado com model.score(X_train, y_train), mas apenas 62% com model.score(X_test, y_test). O que esse resultado sugere?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O modelo decorou particularidades do treino e generaliza mal para dados novos.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O conjunto de teste foi montado com uma proporção de test_size incorreta demais.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O valor de random_state usado na divisão dos dados provavelmente estava incorreto.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O modelo está com desempenho ótimo, pois pelo menos uma das métricas foi alta.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Dois cientistas de dados rodaram o mesmo código de train_test_split, mas sem passar random_state, e por isso obtiveram divisões diferentes dos dados em cada execução. Qual é a consequência prática disso?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Fica mais difícil comparar experimentos, pois cada divisão de dados muda os resultados.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O modelo treinado vai automaticamente ter uma acurácia mais baixa em qualquer teste.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O scikit-learn recusa a execução até que um valor de random_state seja informado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os dados de treino e teste vão se sobrepor parcialmente entre uma execução e outra.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que dizemos que o objetivo do treino é o modelo generalizar para dados novos, e não apenas acertar os dados de treino?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque, na prática, o modelo vai prever exemplos que nunca apareceram durante o treino.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o scikit-learn calcula a generalização automaticamente ao final de cada chamada de fit.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque acertar todos os dados de treino é sempre impossível, mesmo com bons algoritmos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque a generalização é uma métrica obrigatória, exigida por toda avaliação de classificação.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "A API do scikit-learn (fit/predict/score)",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Um padrão que se repete em todo modelo\n\nDepois de entender por que dividimos os dados, vamos falar sobre a parte que mais surpreende quem começa em ML: não importa qual algoritmo você escolher, a forma de usá-lo no scikit-learn é sempre a mesma. Regressão linear, árvore de decisão, k-NN, todos seguem a mesma receita de três passos.\n\nEssa consistência não é acaso: é uma escolha de design da biblioteca, que permite trocar de algoritmo sem reescrever o resto do código."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Os três métodos essenciais\n\n- `fit(X_train, y_train)`: aprende os padrões a partir dos dados de treino. Ajusta os parâmetros internos do modelo, sem devolver nenhuma previsão.\n- `predict(X_novo)`: usa o que foi aprendido para gerar previsões em dados novos, sejam eles o `X_test` ou qualquer dado com o mesmo formato.\n- `score(X_test, y_test)`: calcula rapidamente uma métrica padrão de desempenho (acurácia para classificação, R² para regressão) comparando a previsão com o valor real.\n\nRepare na ordem: primeiro se aprende (`fit`), depois se aplica (`predict`), depois se resume o resultado (`score`)."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# O mesmo padrao, independente do algoritmo escolhido\nfrom sklearn.linear_model import LogisticRegression\nfrom sklearn.tree import DecisionTreeClassifier\n\nmodelo_a = LogisticRegression()\nmodelo_a.fit(X_train, y_train)\nprevisoes_a = modelo_a.predict(X_test)\nmodelo_a.score(X_test, y_test)\n# 0.93\n\nmodelo_b = DecisionTreeClassifier()\nmodelo_b.fit(X_train, y_train)\nprevisoes_b = modelo_b.predict(X_test)\nmodelo_b.score(X_test, y_test)\n# 0.89\n\n# fit, predict e score: os mesmos tres passos, dois algoritmos diferentes"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que cada método devolve\n\n`predict` devolve um array com uma previsão para cada linha de entrada: se `X_test` tem 30 linhas, `predict(X_test)` devolve 30 valores. Já `score` devolve um único número, resumindo o desempenho geral no conjunto informado.\n\nO que exatamente esse número representa depende do tipo de modelo: para um classificador, por padrão é a proporção de acertos; para um regressor, é o R², que a trilha de regressão (módulo 3) explica em detalhe. Por enquanto, pense em `score` como um jeito rápido de perguntar ao modelo: \"no geral, quão bem você está indo?\""
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Método\",\"O que você passa\",\"O que ele devolve\",\"O que faz\"],[\"fit(X, y)\",\"dados de treino e respostas certas\",\"o próprio modelo, já ajustado\",\"aprende os padrões\"],[\"predict(X)\",\"dados novos, sem as respostas\",\"um array com uma previsão por linha\",\"aplica o que aprendeu\"],[\"score(X, y)\",\"dados e as respostas verdadeiras\",\"um número único, geralmente entre 0 e 1\",\"resume o desempenho\"]]"
+                    },
+                    {
+                        "type": "code",
+                        "value": "previsoes = modelo_a.predict(X_test[:5])\nprevisoes\n# array([0, 0, 1, 0, 1])\n\ny_test[:5].values\n# array([0, 0, 1, 0, 1])              -> nesse trecho, todas as previsoes bateram com o real"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "fit aprende, predict aplica, score resume. Troque o algoritmo à vontade: essas três palavras continuam valendo."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "No scikit-learn, qual método é usado para treinar um modelo com os dados de treino?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "model.fit(X_train, y_train)",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "model.predict(X_train, y_train)",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "model.score(X_train, y_train)",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "model.train(X_train, y_train)",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de rodar modelo.fit(X_train, y_train), o que modelo.predict(X_test) devolve?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Um array com uma previsão para cada linha de X_test.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um único número resumindo o desempenho do modelo no teste.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O próprio conjunto X_test, sem nenhuma alteração aplicada.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um novo modelo já reajustado com os dados de teste.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um colega escreveu modelo.score(X_train, y_train) achando que estava medindo o desempenho real do modelo, mas está avaliando o mesmo conjunto usado no fit. Qual é o problema, especificamente com o número que esse score devolve?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Ele reflete o quanto o modelo decorou o treino, não sua capacidade de generalizar.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Ele não pode ser calculado, pois score não aceita os mesmos dados usados no fit.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ele sempre retorna, nesse caso, um valor exatamente igual a 1.0, sem exceção.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ele na verdade recalcula o fit do modelo, em vez de avaliar seu desempenho.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual é a principal vantagem prática de todos os modelos do scikit-learn seguirem a mesma interface fit/predict/score?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Trocar de algoritmo no meio de um projeto exige poucas mudanças no restante do código.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Todos os modelos passam a ter exatamente a mesma acurácia nos mesmos dados de teste.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O tempo de treinamento fica idêntico entre algoritmos diferentes que usam essa interface comum.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os hiperparâmetros de todos os algoritmos passam a ter exatamente os mesmos nomes e valores.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O que o método score calcula, por padrão, em um modelo de classificação do scikit-learn?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "A proporção de previsões corretas do modelo sobre o conjunto de dados informado.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A diferença média entre os valores previstos e os valores reais em cada linha.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O tempo total, em segundos, que o modelo levou para treinar e ser avaliado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A quantidade de exemplos de treino que foram usados para ajustar os parâmetros.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Um modelo de ponta a ponta",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Um modelo, do início ao fim\n\nChegou a hora de juntar tudo (pipeline, split e a API fit/predict/score) em um único exemplo, completo, rodando de ponta a ponta. Vamos usar o `iris`, um dos datasets de exemplo que já vêm junto com o scikit-learn: medidas de flores (comprimento e largura de sépala e pétala) e a tarefa de prever a espécie.\n\nO foco aqui não é o algoritmo (isso o módulo 4 aprofunda), é o fluxo: esse esqueleto de código se repete, com pequenas variações, em praticamente todo projeto supervisionado simples."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.datasets import load_iris\nimport pandas as pd\n\niris = load_iris()\nX = pd.DataFrame(iris.data, columns=iris.feature_names)   # atributos (features)\ny = pd.Series(iris.target, name=\"especie\")                # alvo (target)\n\nX.shape, y.shape\n# ((150, 4), (150,))          -> 150 flores, 4 medidas cada, 1 especie por linha\n\ny.unique()\n# array([0, 1, 2])            -> 3 especies possiveis, codificadas como numeros"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Separar X e y: atributos e alvo\n\nEssa separação retoma o vocabulário do módulo 1: `X` reúne os atributos (as medidas de cada flor), e `y` guarda o alvo, a espécie que queremos prever. Cada linha de `X` corresponde à mesma posição em `y`: a flor na linha 0 de `X` tem sua espécie no valor da posição 0 de `y`.\n\nVale uma honestidade: o `iris` é um dataset pequeno (150 linhas) e bem separável, quase um \"hello world\" de ML. Dados reais costumam ser maiores, mais barulhentos, e resultam em métricas menos perfeitas. Isso não é falha do fluxo, é o mundo real sendo mais bagunçado que um dataset didático."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.model_selection import train_test_split\nfrom sklearn.neighbors import KNeighborsClassifier\n\nX_train, X_test, y_train, y_test = train_test_split(\n    X, y, test_size=0.2, random_state=42\n)\n\nmodelo = KNeighborsClassifier(n_neighbors=3)\nmodelo.fit(X_train, y_train)\n# KNeighborsClassifier(n_neighbors=3)   -> o modelo agora guarda o que aprendeu do treino"
+                    },
+                    {
+                        "type": "code",
+                        "value": "previsoes = modelo.predict(X_test)\nprevisoes[:8]\n# array([1, 0, 2, 1, 1, 0, 1, 2])\n\ny_test[:8].values\n# array([1, 0, 2, 1, 1, 0, 1, 2])        -> nesse trecho, previsao bateu com o valor real\n\nmodelo.score(X_test, y_test)\n# 1.0          -> 100% de acerto no teste (dataset pequeno e bem separavel, como comentamos)"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Código\",\"Etapa do pipeline\"],[\"load_iris(), pd.DataFrame(...)\",\"Obter os dados\"],[\"X = ...  /  y = ...\",\"Separar atributos e alvo\"],[\"train_test_split(X, y, ...)\",\"Dividir treino e teste\"],[\"modelo.fit(X_train, y_train)\",\"Treinar\"],[\"modelo.score(X_test, y_test)\",\"Avaliar\"],[\"modelo.predict(dado_novo)\",\"Usar\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Carregar os dados, separar X e y, dividir treino e teste, treinar, prever, avaliar: esse esqueleto muda pouco de projeto para projeto. Domine esse fluxo e você já sabe o caminho, mesmo antes de conhecer o próximo algoritmo."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "No exemplo com o dataset iris, o que a variável X representa?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "As medidas das flores, usadas como atributos de entrada do modelo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A espécie de cada flor, usada como alvo a ser previsto pelo modelo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O número total de flores presentes em todo o conjunto de dados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A acurácia final obtida pelo modelo já treinado no conjunto de teste.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de modelo.fit(X_train, y_train) e modelo.predict(X_test), o que se compara para saber se a previsão foi boa?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O resultado de predict(X_test) com os valores reais guardados em y_test.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O resultado de predict(X_test) com os valores usados dentro de X_train.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O valor de score(X_train, y_train) com o valor de score(X_test, y_test).",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O tempo de execução do fit com o tempo de execução do predict.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Se, no lugar do KNeighborsClassifier, o exemplo usasse um DecisionTreeClassifier, o que precisaria mudar no restante do código (split, fit, predict, score)?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Praticamente nada: a chamada de fit, predict e score continua igual, só muda o import.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O train_test_split precisaria usar um test_size diferente para árvores de decisão.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O X e o y precisariam ser recriados em um formato numérico específico para árvores.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O predict precisaria ser chamado antes do fit, já que o algoritmo é uma árvore.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "No exemplo, modelo.score(X_test, y_test) retornou 1.0 (100% de acerto). O que é mais razoável concluir disso, considerando as características do dataset iris?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O resultado reflete um dataset pequeno e bem separável, não uma garantia para dados reais maiores.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O resultado prova que o k-NN é o melhor algoritmo possível para qualquer problema de classificação.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O resultado indica um erro no código, já que nenhum modelo real atinge 100% de acerto.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O resultado só é confiável porque a divisão de treino e teste usou exatamente random_state=42.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual é a ordem correta das etapas no esqueleto de um projeto supervisionado simples, como o do exemplo com iris?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Carregar os dados, separar X e y, dividir treino/teste, treinar, prever e avaliar.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Separar X e y, treinar o modelo, carregar os dados, dividir treino/teste, avaliar.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Dividir treino/teste, carregar os dados, separar X e y, avaliar, treinar o modelo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Carregar os dados, treinar o modelo, dividir treino/teste, separar X e y, prever.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Validação e não vazar o teste",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Depois do primeiro modelo, vêm os ajustes\n\nCom o esqueleto da aula anterior funcionando, é natural querer melhorar: trocar o algoritmo, testar outro valor de `n_neighbors`, comparar configurações diferentes. A pergunta é: em cima de qual conjunto de dados você toma essas decisões?\n\nA resposta não pode ser \"o conjunto de teste\". Se você espia o teste toda vez que testa uma configuração nova e escolhe a que deu melhor nota ali, o teste deixa de medir generalização e passa a medir o quanto você ajustou suas escolhas a ele. É a mesma armadilha da aula 2 (avaliar no que já foi visto), só que um nível acima: agora é a sua decisão que está sendo ajustada ao teste, não o modelo."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Um terceiro conjunto: a validação\n\nA prática comum é dividir os dados em três partes, não duas:\n\n- **Treino**: usado no `fit`, para o modelo aprender os padrões.\n- **Validação**: usada para comparar configurações e decidir qual usar.\n- **Teste**: guardado de lado, consultado uma única vez, no final, para a avaliação honesta.\n\nEssa é a introdução da ideia. O módulo 5 aprofunda com validação cruzada (`cross-validation`), uma forma mais robusta de usar os dados de validação quando o conjunto é pequeno."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.model_selection import train_test_split\n\n# 1o split: separa o teste, que so sera usado no final\nX_treino_val, X_test, y_treino_val, y_test = train_test_split(\n    X, y, test_size=0.2, random_state=42\n)\n\n# 2o split: do que sobrou, separa treino e validacao\nX_train, X_val, y_train, y_val = train_test_split(\n    X_treino_val, y_treino_val, test_size=0.25, random_state=42\n)\n\nlen(X_train), len(X_val), len(X_test)\n# (90, 30, 30)          -> de 150 exemplos: 60% treino, 20% validacao, 20% teste"
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.neighbors import KNeighborsClassifier\n\nfor k in [1, 3, 5, 7]:\n    modelo = KNeighborsClassifier(n_neighbors=k)\n    modelo.fit(X_train, y_train)\n    print(k, modelo.score(X_val, y_val))\n# 1 0.90\n# 3 0.97\n# 5 0.97\n# 7 0.93          -> k=3 parece a melhor escolha, olhando so a validacao\n\n# So depois de decidir k, uma unica vez, olhamos o teste:\nmodelo_final = KNeighborsClassifier(n_neighbors=3)\nmodelo_final.fit(X_train, y_train)\nmodelo_final.score(X_test, y_test)\n# 0.93          -> avaliacao final, feita uma unica vez"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Conjunto\",\"Usado para\",\"Quantas vezes é consultado\"],[\"Treino\",\"Ajustar os parâmetros do modelo (fit)\",\"Várias vezes, a cada tentativa\"],[\"Validação\",\"Comparar configurações e escolher a melhor\",\"Várias vezes, a cada tentativa\"],[\"Teste\",\"Estimativa final e honesta de desempenho\",\"Idealmente, uma única vez\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que vem a seguir\n\nEssa separação em três partes é só o começo. No módulo 5, a validação cruzada mostra como aproveitar melhor os dados de validação sem depender de uma única divisão da sorte. No módulo 6, o cuidado se estende à preparação dos dados: escalar variáveis e codificar categorias também precisam respeitar o split, calculados a partir do treino e só depois aplicados à validação e ao teste, para não vazar informação de um conjunto para o outro."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Teste é o exame final: você faz uma vez, e ele vale menos se você já tiver espiado as respostas durante as rodadas de validação."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual é o papel do conjunto de validação em um projeto de ML?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Comparar diferentes configurações do modelo antes de decidir qual usar no fim.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Treinar o modelo, no lugar do conjunto de treino considerado tradicional.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Substituir de vez o conjunto de teste na avaliação final do modelo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Armazenar os dados brutos antes de qualquer etapa de preparação deles.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que não é uma boa prática usar o conjunto de teste repetidas vezes para decidir qual configuração de modelo é a melhor?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque as decisões passam a se ajustar ao teste, tornando a avaliação final menos honesta.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o scikit-learn bloqueia chamadas repetidas de score sobre o mesmo conjunto de teste.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o conjunto de teste perde os dados originais a cada nova chamada de score.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque cada chamada de score no teste altera os valores salvos dentro de y_test.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um cientista de dados testou cinco algoritmos diferentes, sempre avaliando com score(X_test, y_test), escolheu o de maior nota no teste e reportou essa nota como o desempenho esperado do modelo. Qual é o problema dessa prática?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "A nota reportada tende a ser otimista, pois o teste virou parte da escolha do algoritmo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A nota reportada está incorreta porque score não deveria ser chamado mais de uma vez.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A nota reportada seria mais confiável se os cinco algoritmos tivessem sido testados no treino.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A nota reportada só seria válida se todos os cinco algoritmos usassem o mesmo random_state.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "No código que faz dois train_test_split em sequência (um para separar o teste, outro para separar treino e validação), por que o teste é separado primeiro, logo no primeiro split?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Para que decisões tomadas depois, como a escolha feita na validação, não afetem o teste.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque a função train_test_split só aceita ser chamada uma vez por conjunto de dados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o scikit-learn exige que o parâmetro test_size venha antes do random_state.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque calcular a validação antes do teste sempre gera uma divisão de dados errada.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Em uma divisão de 150 exemplos em 60% treino, 20% validação e 20% teste, quantos exemplos aproximadamente vão para cada conjunto?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "90 para treino, 30 para validação e 30 para teste.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "75 para treino, 45 para validação e 30 para teste.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "100 para treino, 25 para validação e 25 para teste.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "90 para treino, 45 para validação e 15 para teste.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 3 - Regressão: prever números",
+        "aulas": [
+            {
+                "titulo": "O problema de regressão",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# O problema de regressão\n\nAté aqui você aprendeu o vocabulário de machine learning e o fluxo de um projeto: dividir em treino e teste, treinar com `fit`, prever com `predict`, avaliar com `score`. Chegou a hora de colocar esse fluxo pra trabalhar no primeiro tipo de problema da trilha: a **regressão**.\n\nRegressão é a tarefa de prever um número. Não uma categoria, não uma classe: um valor contínuo, que pode assumir (em teoria) qualquer ponto numa escala. Preço de um imóvel, temperatura de amanhã, salário de um cargo, tempo de entrega de um pedido, faturamento do mês que vem. Se a pergunta é \"quanto?\" ou \"qual valor?\", você está diante de um problema de regressão."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que caracteriza um alvo contínuo\n\nO jeito mais rápido de reconhecer um problema de regressão é olhar pro alvo (a coluna que você quer prever, o target que você já viu no Módulo 1). Se esse alvo é numérico e pode variar de forma contínua (R$ 180 mil, R$ 180,50 mil, R$ 312,90 mil), é regressão. Se o alvo é uma categoria (spam ou não spam, aprovado ou reprovado, tipo de flor), isso é classificação, o assunto do próximo módulo.\n\nA distinção importa porque muda tudo: o algoritmo usado, a métrica de avaliação, até a forma de interpretar o resultado. Errar \"R$ 312 mil\" por R$ 5 mil é um tipo de erro bem diferente de prever a classe errada quando a resposta era outra classe."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Aspecto\",\"Regressão\",\"Classificação\"],[\"O que prevê\",\"Um número contínuo\",\"Uma categoria (classe)\"],[\"Exemplo de alvo\",\"Preço, temperatura, salário\",\"Spam ou não, aprovado ou não\"],[\"Pergunta típica\",\"Quanto? Qual valor?\",\"Qual grupo? Qual tipo?\"],[\"Métricas usadas\",\"MAE, MSE, RMSE, R2\",\"Acurácia, precisão, recall, F1\"],[\"Onde entra na trilha\",\"Módulo 3 (este)\",\"Módulo 4\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Onde a regressão entra no fluxo que você já conhece\n\nNada muda na engrenagem que você viu no Módulo 2. Você ainda vai separar os dados em treino e teste com `train_test_split`, treinar o modelo com `.fit(X_train, y_train)`, prever com `.predict(X_test)` e avaliar comparando a previsão com o valor real do teste.\n\nA diferença é só o tipo de modelo (agora, um modelo de regressão) e o tipo de métrica usada na avaliação, que você vai ver na Aula 5. O padrão fit/predict/score se repete em praticamente todo modelo do scikit-learn, e isso não é acidente: é a API pensada pra você trocar de algoritmo sem reescrever o fluxo inteiro."
+                    },
+                    {
+                        "type": "code",
+                        "value": "import pandas as pd\n\nimoveis = pd.DataFrame({\n    \"area_m2\": [30, 45, 60, 75, 90, 120],\n    \"quartos\": [1, 2, 2, 3, 3, 4],\n    \"preco_mil\": [175.0, 240.0, 316.0, 379.0, 425.0, 588.0],\n})\n\nprint(imoveis[\"preco_mil\"].dtype)\n# float64\n\nprint(float(imoveis[\"preco_mil\"].min()), float(imoveis[\"preco_mil\"].max()))\n# 175.0 588.0\nprint(round(float(imoveis[\"preco_mil\"].mean()), 2))\n# 353.83"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Regressão não é mágica\n\nUm modelo de regressão sempre encontra uma reta (ou uma superfície, quando há várias variáveis) que minimiza o erro nos dados que você deu a ele. Isso vale mesmo quando a relação real é fraca ou inexistente: o algoritmo não recusa o ajuste, ele só faz o melhor que consegue com o que tem.\n\nPrever bem depende de existir, de fato, uma relação entre as variáveis de entrada e o alvo, e de ter dados que capturem essa relação. Sem isso, o `fit()` roda sem erro nenhum e as previsões saem ruins mesmo assim."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Regressão é prever um número, não uma categoria. Antes de escolher qualquer algoritmo, vale perguntar: o alvo que eu quero prever é mesmo contínuo, ou é uma categoria disfarçada de número?"
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual das alternativas descreve corretamente um problema de regressão?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Prever um valor numérico contínuo, como o preço de um imóvel ou a temperatura.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Prever a categoria correta entre duas ou mais classes possíveis, como spam ou não.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Agrupar exemplos parecidos sem usar nenhum rótulo definido previamente.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Reduzir o número de variáveis mantendo o máximo de informação possível.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma imobiliária quer prever se um imóvel vai vender em até 30 dias (sim ou não) e, separadamente, por quanto ele vai vender (em reais). Como classificar essas duas tarefas?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "A primeira é classificação e a segunda é regressão: os alvos têm naturezas diferentes.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "As duas são regressão, porque ambas usam os mesmos dados de entrada sobre o imóvel.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "As duas são classificação, porque o resultado final sempre vira uma decisão de negócio.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A primeira é regressão e a segunda é classificação, já que preço tem poucas categorias.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "No fluxo de ML que você já viu (fit, predict, score), o que muda quando o problema passa a ser de regressão?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O tipo de modelo e a métrica de avaliação mudam, mas fit e predict continuam iguais.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O método fit deixa de existir, porque modelos de regressão não passam por treino.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A divisão em treino e teste deixa de ser necessária, já que o alvo é numérico.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O predict passa a devolver sempre uma probabilidade em vez de um valor direto.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma escola quer prever a nota (0 a 10, com casas decimais) que cada aluno vai tirar na prova final a partir das horas de estudo. Por que isso é um problema de regressão, e não de classificação?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Porque a nota é um valor contínuo numa escala, não uma categoria fixa entre poucas opções.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o número de alunos analisados é grande demais para caber numa classificação.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque horas de estudo é uma variável numérica, e só se pode prever números com números.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque a escola já usa notas para decidir aprovação, o que torna o problema numérico.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um analista tenta prever o preço de imóveis usando só a cor da porta de entrada como variável. O modelo treina sem erro no código, mas as previsões são ruins. O que isso ilustra?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Que o algoritmo encontra uma reta mesmo sem existir relação real entre a variável e o alvo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Que a regressão linear só funciona quando existe uma única variável de entrada disponível.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que o scikit-learn bloqueia o treino quando detecta uma variável irrelevante no conjunto.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que esse tipo de erro só aparece quando faltam dados suficientes para treinar o modelo.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Regressão linear simples: a reta",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Regressão linear simples: a reta\n\nNa trilha de Estatística você já viu a reta de regressão: aquela reta que resume a relação entre duas variáveis numéricas. Machine learning não reinventa essa ideia, ele a usa como o primeiro e mais simples modelo de regressão. A regressão linear simples prevê um alvo `y` a partir de uma única variável `x`, pela equação que você já conhece:\n\ny = a * x + b\n\nO trabalho do modelo é encontrar os melhores valores de `a` e `b` para os dados que você tem. É só isso: uma reta, dois números."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Os coeficientes: inclinação e intercepto\n\nCada letra da equação tem um papel:\n\n- **a (inclinação, ou coeficiente angular):** quanto y muda, em média, para cada unidade a mais de x. Se a = 4,27 numa regressão que prevê preço de imóvel (em R$ mil) a partir da área (em m2), cada metro quadrado a mais soma, em média, R$ 4,27 mil ao preço previsto.\n- **b (intercepto):** o valor previsto de y quando x = 0. Nem sempre tem uma leitura prática (um imóvel de área zero não existe), mas é o ponto onde a reta cruza o eixo vertical, e o modelo precisa dele pra se ajustar direito aos dados.\n\nSaber ler esses dois números já é interpretar o modelo. Não tem caixa-preta aqui: a regressão linear simples é, literalmente, os dois coeficientes de uma reta."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Ajustando a reta aos dados: mínimos quadrados\n\nDado um conjunto de pontos (x, y), existem infinitas retas passando perto deles. Qual é \"a\" reta certa? A resposta padrão é o método dos mínimos quadrados (ordinary least squares, ou OLS): entre todas as retas possíveis, escolha a que minimiza a soma dos quadrados dos resíduos.\n\nResíduo é a diferença entre o valor real e o valor previsto pela reta, ponto a ponto: residuo = y_real - y_previsto. Alguns pontos ficam acima da reta (resíduo positivo), outros abaixo (resíduo negativo). Elevar ao quadrado antes de somar tem dois efeitos: elimina o sinal, pra erros positivos não cancelarem negativos por acaso, e penaliza mais os erros grandes do que os pequenos.\n\nSe você imaginar um gráfico de pontos espalhados com uma reta passando no meio, os resíduos são as distâncias verticais entre cada ponto e a reta: mínimos quadrados é a reta que deixa a soma dessas distâncias, ao quadrado, a menor possível."
+                    },
+                    {
+                        "type": "code",
+                        "value": "area = [30, 45, 60, 75, 90]          # m2\npreco = [150, 220, 280, 340, 410]    # R$ mil\n\nmedia_x = sum(area) / len(area)\nmedia_y = sum(preco) / len(preco)\n\nnumerador = sum((x - media_x) * (y - media_y) for x, y in zip(area, preco))\ndenominador = sum((x - media_x) ** 2 for x in area)\n\na = numerador / denominador\nb = media_y - a * media_x\n\nprint(round(a, 4), round(b, 4))\n# 4.2667 24.0"
+                    },
+                    {
+                        "type": "code",
+                        "value": "previstos = [round(a * x + b, 1) for x in area]\nresiduos = [round(y - p, 1) for y, p in zip(preco, previstos)]\n\nprint(previstos)\n# [152.0, 216.0, 280.0, 344.0, 408.0]\nprint(residuos)\n# [-2.0, 4.0, 0.0, -4.0, 2.0]\nprint(sum(residuos))\n# 0.0"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Área (m2)\",\"Preço real (R$ mil)\",\"Preço previsto (R$ mil)\",\"Resíduo\"],[\"30\",\"150\",\"152,0\",\"-2,0\"],[\"45\",\"220\",\"216,0\",\"4,0\"],[\"60\",\"280\",\"280,0\",\"0,0\"],[\"75\",\"340\",\"344,0\",\"-4,0\"],[\"90\",\"410\",\"408,0\",\"2,0\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Regressão linear simples é só isso: duas constantes escolhidas pra deixar a soma dos erros ao quadrado a menor possível. Todo modelo mais sofisticado da trilha parte dessa mesma lógica de ajustar parâmetros aos dados."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Na equação da reta de regressão y = a*x + b, o que o coeficiente a representa?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "A inclinação da reta: quanto y muda, em média, a cada unidade a mais de x.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O valor de y previsto quando x é igual a zero, independente da inclinação.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A distância média entre os pontos reais e a reta ajustada aos dados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A proporção de pontos que caem exatamente sobre a reta ajustada.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O método dos mínimos quadrados escolhe a reta que minimiza o quê?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "A soma dos quadrados das diferenças entre os valores reais e os valores previstos pela reta.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A soma das diferenças absolutas entre os valores reais e os valores previstos pela reta.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O número total de pontos que ficam acima da reta em relação aos que ficam abaixo dela.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A distância entre o primeiro e o último ponto do conjunto de dados usado no ajuste.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Você já viu correlação na trilha de Estatística. Qual é a relação entre correlação e a inclinação a da reta de regressão?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Uma correlação mais forte entre x e y tende a deixar os pontos mais próximos da reta.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A inclinação a é sempre igual ao coeficiente de correlação entre as duas variáveis.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Correlação e inclinação medem exatamente a mesma coisa, só em escalas numéricas diferentes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Quando a correlação é zero, a reta de regressão sempre tem inclinação negativa.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de ajustar uma reta de regressão por mínimos quadrados, um analista soma todos os resíduos (real menos previsto) dos dados de treino. O resultado esperado dessa soma é:",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Igual a zero, porque mínimos quadrados equilibra os desvios positivos e negativos.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Sempre um número positivo, já que os erros de previsão se acumulam na mesma direção.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Igual à soma dos valores reais de y, porque a reta passa exatamente pela origem.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Igual ao coeficiente a, já que os dois vêm do mesmo cálculo de mínimos quadrados.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um conjunto de dados tem quatro pontos bem alinhados e um quinto ponto bem distante da tendência dos outros. Por que esse quinto ponto pode puxar bastante a reta de mínimos quadrados na direção dele?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Porque o método eleva os resíduos ao quadrado, e o erro grande pesa muito mais na soma.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o scikit-learn remove automaticamente os quatro pontos alinhados ao detectar o padrão.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque a reta de regressão sempre passa exatamente pelo ponto mais distante da média.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque mínimos quadrados considera apenas os dois pontos mais extremos do conjunto de dados.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "LinearRegression no scikit-learn",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# LinearRegression no scikit-learn\n\nVocê já sabe calcular a e b na mão. Na prática, ninguém faz isso linha por linha: o scikit-learn resolve o ajuste por mínimos quadrados pra você, de forma rápida e testada, através da classe `LinearRegression`. O valor de ter aprendido o cálculo manual não foi perdido: agora você sabe exatamente o que a biblioteca está fazendo por baixo do capô."
+                    },
+                    {
+                        "type": "code",
+                        "value": "import numpy as np\nfrom sklearn.linear_model import LinearRegression\n\n# mesmos dados da Aula 2, agora como arrays do numpy\nX = np.array([[30], [45], [60], [75], [90]])   # 2D: (n_amostras, 1)\ny = np.array([150, 220, 280, 340, 410])         # 1D: (n_amostras,)\n\nmodelo = LinearRegression()\nmodelo.fit(X, y)\n\nprint(round(float(modelo.coef_[0]), 4))\n# 4.2667\nprint(round(float(modelo.intercept_), 4))\n# 24.0"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Interpretando coef_ e intercept_\n\nRepare: são os mesmos números da Aula 2, calculados a mão. `modelo.coef_` é um array (porque em regressão múltipla existe um coeficiente por variável, você vê já na próxima aula) com o valor de a. `modelo.intercept_` é um número único com o valor de b. O scikit-learn não inventa uma lógica nova: ele resolve o mesmo mínimos quadrados que você já entende, só que de forma otimizada para conjuntos de dados bem maiores do que seria razoável calcular à mão.\n\nUm detalhe de implementação importa aqui: X precisa ser bidimensional, mesmo com uma variável só (por isso `[[30], [45], ...]`, e não `[30, 45, ...]`). O scikit-learn sempre espera uma matriz de amostras por variáveis, mesmo quando \"por variáveis\" é só uma coluna."
+                    },
+                    {
+                        "type": "code",
+                        "value": "novos_imoveis = np.array([[50], [100], [150]])\nprevisoes = modelo.predict(novos_imoveis)\n\nprint([round(float(p), 2) for p in previsoes])\n# [237.33, 450.67, 664.0]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Retomando train_test_split, e o que você já sabe ler\n\nNo exemplo acima, treinamos e previmos em cima de dados diferentes (os 5 imóveis de treino, depois 3 imóveis novos), o que é bom. Mas com um conjunto de dados só, sem imóveis \"novos\" de verdade, como avaliar o modelo de forma justa? A resposta é a mesma do Módulo 2: usar `train_test_split` pra separar uma fatia que o modelo nunca vê durante o treino, e usar essa fatia só na hora de avaliar.\n\nAntes de seguir pra regressão múltipla, um resumo rápido do que você já sabe ler numa LinearRegression treinada:\n\n- `fit(X, y)`: ajusta o modelo aos dados de treino.\n- `predict(X)`: devolve as previsões para os dados passados.\n- `coef_`: os coeficientes (a) aprendidos, um por variável de entrada.\n- `intercept_`: o intercepto (b) aprendido pelo modelo.\n- `score(X, y)`: devolve o R2 do modelo, que você vai destrinchar na Aula 5."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.model_selection import train_test_split\n\n# um conjunto maior, 10 imóveis\nareas = np.array([[28], [35], [42], [50], [58], [65], [72], [80], [95], [110]])\nprecos = np.array([145, 175, 205, 235, 270, 300, 325, 355, 410, 465])\n\nX_train, X_test, y_train, y_test = train_test_split(\n    areas, precos, test_size=0.2, random_state=42\n)\n\nprint(X_train.shape, X_test.shape)\n# (8, 1) (2, 1)\n\nmodelo_2 = LinearRegression()\nmodelo_2.fit(X_train, y_train)\n# a partir daqui, o fluxo é o de sempre: modelo_2.predict(X_test) e comparar com y_test"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "fit encontra os coeficientes, predict aplica a reta aprendida a dados novos. Debaixo da API simples do scikit-learn está a mesma conta de mínimos quadrados que você acabou de fazer à mão."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "No scikit-learn, qual é a ordem correta para treinar e usar um modelo de regressão linear?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Criar o modelo, chamar fit com os dados de treino e depois predict com dados novos.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Chamar predict para gerar os dados e depois fit para ajustar o modelo a eles.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Criar o modelo e chamar score diretamente, sem precisar treinar com fit antes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Chamar fit com os dados de teste e predict com os dados de treino, nessa ordem.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de modelo.fit(X, y) em uma regressão linear simples, o que os atributos coef_ e intercept_ representam?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Os valores de a e b da reta que o modelo aprendeu a partir dos dados de treino.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A previsão do modelo para o primeiro e o último exemplo do conjunto de treino.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O erro médio e o erro máximo cometidos pelo modelo nos dados de treino.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A quantidade de exemplos e de variáveis usadas para treinar o modelo.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Ao treinar uma regressão linear simples com uma única variável de entrada no scikit-learn, qual é o formato esperado para X?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Uma matriz de duas dimensões, tipo (n_amostras, 1), mesmo havendo só uma variável.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um vetor de uma dimensão, tipo (n_amostras,), igual ao formato esperado para y.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um número único, já que existe apenas uma variável de entrada no modelo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma lista de textos com o nome da variável repetido para cada amostra.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um colega treina uma regressão linear com modelo.fit(X, y) usando o conjunto de dados inteiro e depois avalia o modelo prevendo sobre esse mesmo X. Qual é o problema dessa prática?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "A avaliação fica otimista, pois o modelo é testado nos mesmos dados que usou no treino.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O método predict não funciona quando recebe o mesmo X que foi usado no fit.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O coef_ calculado fica incorreto sempre que treino e avaliação usam os mesmos dados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O scikit-learn gera um erro de execução ao detectar que X se repete entre fit e predict.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Ao chamar modelo.predict(X_novo) passando um array com três novos imóveis, o que o retorno desse método traz?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Um array com três valores, cada um sendo o preço previsto para o imóvel correspondente.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um único valor numérico, que é a média das previsões para os três imóveis informados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um array com os coeficientes coef_ recalculados para esses três imóveis específicos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um valor booleano indicando se as previsões estão dentro da faixa observada no treino.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Regressão múltipla",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Regressão múltipla\n\nPreço de imóvel não depende só da área. Depende também do número de quartos, da idade da construção, da localização, e de mais uma dúzia de fatores. A regressão múltipla é exatamente a regressão linear que você já conhece, só que com mais de uma variável de entrada:\n\ny = b + a1*x1 + a2*x2 + ... + an*xn\n\nCada xi é uma feature (área, quartos, idade), cada ai é o coeficiente daquela feature, e b continua sendo o intercepto. No scikit-learn, a mudança no código é mínima: você passa uma matriz X com várias colunas em vez de uma só."
+                    },
+                    {
+                        "type": "code",
+                        "value": "import pandas as pd\nfrom sklearn.linear_model import LinearRegression\n\nimoveis = pd.DataFrame({\n    \"area_m2\":    [30, 45, 60, 75, 90, 120],\n    \"quartos\":    [1, 2, 2, 3, 3, 4],\n    \"idade_anos\": [5, 10, 2, 8, 15, 1],\n    \"preco_mil\":  [175, 240, 316, 379, 425, 588],\n})\n\nX = imoveis[[\"area_m2\", \"quartos\", \"idade_anos\"]]\ny = imoveis[\"preco_mil\"]\n\nmodelo = LinearRegression()\nmodelo.fit(X, y)\n\nprint([round(float(c), 2) for c in modelo.coef_])\n# [4.0, 15.0, -2.0]\nprint(round(float(modelo.intercept_), 2))\n# 50.0\n\nfor nome, coeficiente in zip(X.columns, modelo.coef_):\n    print(f\"{nome}: {float(coeficiente):.2f}\")\n# area_m2: 4.00\n# quartos: 15.00\n# idade_anos: -2.00"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## A interpretação fica mais delicada\n\nCom uma variável só, a era simplesmente \"quanto y sobe por unidade de x\". Com várias variáveis, cada coeficiente passa a significar \"quanto y sobe por unidade daquela variável, mantendo as outras constantes\". No exemplo: mantendo quartos e idade fixos, cada m2 a mais soma, em média, R$ 4 mil ao preço.\n\nEssa leitura assume que dá pra variar uma feature \"segurando\" as outras, o que nem sempre é realista: área e número de quartos, por exemplo, costumam andar juntos na vida real, já que imóveis maiores tendem a ter mais quartos. Quando as features de entrada estão correlacionadas entre si, os coeficientes individuais ficam menos confiáveis como explicação isolada, mesmo que o modelo, como um todo, continue prevendo bem."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Feature\",\"Coeficiente\",\"O que significa (mantendo as outras fixas)\"],[\"area_m2\",\"4,0\",\"Cada m2 a mais soma, em média, R$ 4 mil ao preço previsto\"],[\"quartos\",\"15,0\",\"Cada quarto a mais soma, em média, R$ 15 mil ao preço previsto\"],[\"idade_anos\",\"-2,0\",\"Cada ano a mais de idade tira, em média, R$ 2 mil do preço previsto\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Por que a escala das variáveis importa\n\nRepare que o coeficiente de quartos (15) é maior que o de area_m2 (4). Isso não quer dizer que quartos \"importa mais\": quer dizer que uma unidade de quartos (um quarto inteiro) tem um impacto diferente de uma unidade de área (um metro quadrado, uma fração pequena do imóvel). Se a área estivesse em centímetros quadrados em vez de metros, o coeficiente ficaria bem menor sem o modelo mudar em nada de essência. O código abaixo mostra exatamente isso.\n\nColocar as variáveis todas na mesma escala antes de treinar (com `StandardScaler`, por exemplo) é assunto do Módulo 6. Por enquanto já vale guardar a lição: coeficiente grande não é sinônimo de variável importante."
+                    },
+                    {
+                        "type": "code",
+                        "value": "imoveis[\"area_cm2\"] = imoveis[\"area_m2\"] * 10000\n\nX2 = imoveis[[\"area_cm2\", \"quartos\", \"idade_anos\"]]\nmodelo_cm = LinearRegression()\nmodelo_cm.fit(X2, y)\n\nfor nome, coeficiente in zip(X2.columns, modelo_cm.coef_):\n    print(f\"{nome}: {float(coeficiente):.6f}\")\n# area_cm2: 0.000400\n# quartos: 15.000000\n# idade_anos: -2.000000\n\nprint(round(float(modelo_cm.intercept_), 2))\n# 50.0\n\n# só o coeficiente da variável reescalada mudou (proporcionalmente à mudança de unidade);\n# quartos, idade_anos e o intercepto continuam idênticos, e as previsões também não mudam"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Mais variáveis não é só mais poder preditivo, é também mais cuidado ao ler o que cada coeficiente está dizendo. Coeficiente grande não é sinônimo de variável importante, principalmente quando as escalas são diferentes."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que diferencia a regressão múltipla da regressão linear simples?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "A múltipla usa duas ou mais variáveis de entrada para prever o alvo, em vez de apenas uma.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A múltipla prevê duas ou mais variáveis de saída ao mesmo tempo, em vez de apenas uma.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A múltipla não usa mínimos quadrados, e sim um algoritmo de classificação por trás.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A múltipla só funciona quando todas as variáveis de entrada são categóricas.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Em um modelo que prevê preço a partir de área, número de quartos e idade do imóvel, o coeficiente da área indica o quê?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O quanto o preço tende a mudar por m2 a mais, mantendo quartos e idade constantes.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O quanto o preço tende a mudar por m2 a mais, somado ao efeito de quartos e idade juntos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A porcentagem do preço final que é explicada exclusivamente pela área do imóvel.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A importância da área em relação às outras variáveis, independente da escala usada.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que interpretar os coeficientes fica mais delicado na regressão múltipla do que na simples?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque as variáveis de entrada podem estar correlacionadas entre si, misturando os efeitos.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o scikit-learn não permite mais de uma variável ao calcular o método fit.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque a regressão múltipla deixa de usar mínimos quadrados no ajuste dos coeficientes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque cada coeficiente passa a representar uma probabilidade em vez de uma taxa de variação.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um modelo usa área em metros quadrados e recebe coeficiente 4,0. Um colega refaz o mesmo modelo com a área em centímetros quadrados e o coeficiente vira 0,0004. O que está acontecendo?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "A escala da variável mudou, então o coeficiente muda de magnitude sem o modelo piorar.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O segundo modelo está errado, porque coeficientes não podem ter casas decimais tão pequenas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A mudança de unidade indica que a variável deixou de ter relação linear com o preço.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O segundo modelo é mais preciso, já que coeficientes menores indicam menos overfitting.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um modelo de preço de imóveis tem coeficiente 30 para quartos e 4 para área em m2. É correto concluir que o número de quartos é a variável mais importante do modelo?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Não necessariamente: os coeficientes estão em escalas diferentes e não dá pra comparar direto.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Sim, porque em qualquer modelo o coeficiente maior sempre indica a variável mais importante.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não, porque coeficientes negativos são sempre mais importantes do que os positivos no modelo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Sim, mas só quando as duas variáveis têm a mesma unidade de medida entre si.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Métricas: MAE, RMSE e R2",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Métricas de regressão: MAE, RMSE e R2\n\nDesde o Módulo 2 você usa modelo.score(X_test, y_test) pra ter uma nota rápida do modelo. Para um regressor como o LinearRegression, esse número já é o R2. Mas avaliar um modelo de regressão direito costuma pedir mais de uma métrica: cada uma conta uma parte diferente da história de quão perto as previsões chegam dos valores reais."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Métrica\",\"O que mede\",\"Quando olhar com mais atenção\"],[\"MAE\",\"Erro médio absoluto, na mesma unidade do alvo\",\"Quando todo erro deve pesar igual, independente do tamanho\"],[\"MSE\",\"Erro médio ao quadrado, em unidade ao quadrado\",\"Mais como etapa intermediária pro RMSE do que pra leitura direta\"],[\"RMSE\",\"Raiz do MSE, de volta à unidade original do alvo\",\"Quando erros grandes devem pesar mais do que vários erros pequenos\"],[\"R2\",\"Proporção da variação do alvo explicada pelo modelo\",\"Pra comparar modelos entre si e ver o quadro geral\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Comparando previsão com o valor real\n\nRetomando o modelo de preço de imóveis: depois do train_test_split, o modelo nunca viu os dados de teste durante o treino. Chega a hora da verdade, comparar predict(X_test) com o y_test de verdade:"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Preço real (R$ mil)\",\"Preço previsto (R$ mil)\",\"Erro (real - previsto)\"],[\"180\",\"185\",\"-5\"],[\"250\",\"235\",\"15\"],[\"300\",\"303\",\"-3\"],[\"220\",\"212\",\"8\"],[\"340\",\"360\",\"-20\"]]"
+                    },
+                    {
+                        "type": "code",
+                        "value": "import numpy as np\nfrom sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score\n\ny_test = np.array([180, 250, 300, 220, 340])   # preço real, R$ mil\ny_pred = np.array([185, 235, 303, 212, 360])   # preço previsto pelo modelo\n\nmae = mean_absolute_error(y_test, y_pred)\nmse = mean_squared_error(y_test, y_pred)\nrmse = np.sqrt(mse)\nr2 = r2_score(y_test, y_pred)\n\nprint(f\"MAE:  {mae:.2f}\")\n# MAE:  10.20\nprint(f\"MSE:  {mse:.2f}\")\n# MSE:  144.60\nprint(f\"RMSE: {rmse:.2f}\")\n# RMSE: 12.02\nprint(f\"R2:   {r2:.4f}\")\n# R2:   0.9550"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Lendo os quatro números juntos\n\nOlhando a tabela de erros, quatro imóveis erraram por pouco (5, 15, 3 e 8 mil) e um errou por bastante (20 mil, no imóvel mais caro do grupo). O MAE trata todo erro do mesmo jeito e dá 10,2. O RMSE eleva cada erro ao quadrado antes de tirar a média e a raiz, o que faz o erro de 20 mil pesar muito mais que os outros, puxando o resultado pra 12,02: quando o RMSE se destaca bem acima do MAE, é sinal de que uns poucos erros grandes estão puxando a média.\n\nO R2 de 0,955 diz que o modelo explica cerca de 95,5% da variação dos preços reais, um número bom. Mas olhando só pra ele, você perderia o detalhe de que um imóvel específico errou por R$ 20 mil, quase 6% do valor dele. Machine learning não é mágica: R2 alto não garante que toda previsão individual vai ser boa, e olhar a tabela de previsão x real, não só o resumo estatístico, continua valendo a pena."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Nenhuma métrica sozinha conta a história inteira. MAE, RMSE e R2 respondem perguntas diferentes sobre o mesmo conjunto de erros: um bom hábito é olhar mais de uma antes de confiar no modelo."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que o MAE (erro absoluto médio) mede?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "A média das diferenças absolutas entre os valores previstos e os valores reais.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A proporção de previsões que ficaram exatamente iguais aos valores reais observados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A maior diferença encontrada entre um valor previsto e o valor real correspondente.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A média dos valores reais menos a média dos valores previstos pelo modelo inteiro.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que o RMSE costuma ser maior ou igual ao MAE para o mesmo conjunto de previsões?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque elevar os erros ao quadrado penaliza mais os erros grandes do que os pequenos.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o RMSE é calculado sobre o dobro dos dados usados no cálculo do MAE.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o MAE ignora previsões erradas, enquanto o RMSE considera todas elas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o RMSE é sempre calculado nos dados de treino, e o MAE nos dados de teste.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O que significa um R2 de 0,80 para um modelo de regressão?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O modelo explica cerca de 80% da variação do alvo observada nos dados.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O modelo acerta exatamente o valor real em 80% das previsões realizadas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O modelo erra, em média, 80% do valor real em cada previsão que faz.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O modelo usa 80% das variáveis disponíveis para gerar cada previsão feita.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma seguradora está prevendo o valor de indenizações e quer penalizar bastante previsões muito abaixo do valor real, que geram prejuízo maior. Qual métrica combina melhor com essa prioridade?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "RMSE, porque eleva os erros ao quadrado e dá mais peso justamente aos erros grandes.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "MAE, porque trata todo erro da mesma forma, sem depender do tamanho de cada um.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "R2, porque mede diretamente o prejuízo em reais causado por cada erro de previsão.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "MAE, porque é a métrica padrão do scikit-learn para qualquer problema de seguros.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um modelo apresenta R2 de 0,95, mas o MAE mostra um erro médio de R$ 40 mil em imóveis que custam, em média, R$ 90 mil. O que essa combinação de números indica?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Que apesar do R2 alto, o erro médio ainda é grande perto do valor típico do alvo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Que os dois números estão contraditórios, e um dos cálculos com certeza está errado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que o modelo está com overfitting, já que R2 alto sempre indica esse problema.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que o MAE nesse caso não é uma métrica válida quando o R2 já está calculado.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 4 - Classificação: prever categorias",
+        "aulas": [
+            {
+                "titulo": "O problema de classificação",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Classificação: prever categorias\n\nNo módulo anterior você usou regressão pra prever um número: o preço de um imóvel, a nota de uma prova, o consumo de energia de uma casa. Mas nem toda pergunta que a ciência de dados tenta responder tem uma resposta numérica contínua. Às vezes a pergunta é outra: esse e-mail é spam ou não é? Esse paciente tem a doença ou não tem? Esse cliente vai cancelar a assinatura ou vai continuar?\n\nEsse é o problema de **classificação**: em vez de prever um valor que pode ser qualquer número, o modelo prevê uma **classe**, escolhida entre um conjunto fixo e conhecido de possibilidades. É o outro grande pilar do aprendizado supervisionado, ao lado da regressão, e é o assunto deste módulo."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Classe, rótulo, categoria: o mesmo vocabulário\n\nAssim como na regressão a coluna que você quer prever se chama alvo (`target`), na classificação essa coluna guarda uma **classe** (também chamada de **rótulo** ou **categoria**). Alguns exemplos de alvo em problemas de classificação:\n\n- spam ou não spam\n- aprovado ou reprovado\n- doente ou saudável\n- risco baixo, risco médio ou risco alto\n\nCada linha dos dados, cada exemplo, já vem com uma dessas classes marcada (é assim que o aprendizado é supervisionado: alguém rotulou os exemplos de treino antes). O trabalho do modelo é aprender, a partir desses exemplos já rotulados, a prever a classe de um exemplo novo, que ele nunca viu."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Binária x multiclasse\n\nQuando o alvo tem só duas classes possíveis, como spam ou não spam, o problema é de **classificação binária**. É o caso mais comum, e o que este módulo usa na maioria dos exemplos.\n\nQuando o alvo tem três ou mais classes possíveis, como classificar uma notícia em \"esporte\", \"política\" ou \"economia\", o problema é de **classificação multiclasse**. A ideia central não muda (ainda é prever uma categoria entre opções conhecidas), mas alguns algoritmos e métricas precisam de ajustes pra lidar com mais de duas opções, algo que essa trilha só toca de leve."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Aspecto\",\"Regressão\",\"Classificação\"],[\"O que prevê\",\"Um valor numérico contínuo\",\"Uma classe (categoria) entre um conjunto conhecido\"],[\"Exemplo de alvo\",\"Preço de um imóvel, nota de uma prova\",\"Spam ou não spam, aprovado ou reprovado\"],[\"Saída do modelo\",\"Um número (ex.: R$ 350.000)\",\"Um rótulo (ex.: \\\"spam\\\") ou uma probabilidade\"],[\"Métrica comum\",\"MAE, MSE, RMSE, R2 (módulo 3)\",\"Acurácia, precisão, recall (módulo 5)\"]]"
+                    },
+                    {
+                        "type": "code",
+                        "value": "import pandas as pd\n\nemails = pd.DataFrame({\n    \"tamanho_kb\": [12, 340, 8, 220, 15],\n    \"tem_link\": [1, 1, 0, 1, 0],\n    \"classe\": [\"spam\", \"não spam\", \"não spam\", \"spam\", \"não spam\"],\n})\n\nprint(emails[\"classe\"].value_counts())\n# não spam    3\n# spam        2\n# Name: classe, dtype: int64"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Nem tudo é rótulo confiável\n\nUm classificador só é tão bom quanto os rótulos que aprendeu a imitar. Se os exemplos de treino têm rótulos errados, inconsistentes ou enviesados (um sistema de aprovação de crédito treinado em decisões humanas enviesadas, por exemplo), o modelo aprende exatamente esse padrão, erros e vieses incluídos. Machine learning não separa o certo do errado sozinho: ele encontra o padrão que está nos dados, seja ele qual for.\n\nOutro ponto de atenção, que o módulo 5 aprofunda: nem sempre as classes aparecem em quantidades parecidas. Um sistema de detecção de fraude pode ter 99% de transações normais e 1% de fraudes. Um modelo \"preguiçoso\", que sempre prevê \"normal\", já acerta 99% das vezes, e ainda assim é inútil. Definir bem o que é \"um bom modelo\" fica pra frente."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Regressão prevê um número. Classificação prevê uma categoria, escolhida entre um conjunto conhecido de classes."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que um modelo de classificação prevê, diferente de um modelo de regressão?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Uma classe (categoria), escolhida entre um conjunto conhecido de rótulos.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um valor numérico que pode assumir qualquer número real possível.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A quantidade exata de linhas presentes nos dados de treino usados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma nova coluna de dados que ainda não existia no conjunto original.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um banco quer prever se um cliente vai pagar ou não um empréstimo (duas respostas possíveis). Esse é um problema de classificação:",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "binária, porque existem exatamente duas classes possíveis.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "multiclasse, porque a previsão envolve mais de uma variável.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "de regressão, porque o resultado final é uma probabilidade.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "não supervisionada, porque o banco não tem rótulos históricos.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um sistema classifica fotos de animais em \"gato\", \"cachorro\", \"pássaro\" ou \"outro\". Esse é um problema de classificação:",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "multiclasse, porque existem mais de duas classes possíveis.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "binária, porque cada foto pertence a apenas uma classe por vez.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "de regressão, porque a saída é uma pontuação de confiança.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "não supervisionada, porque as fotos não têm rótulo definido.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma coluna chamada \"nivel_risco\" guarda os valores 1, 2 e 3, representando risco baixo, médio e alto. Prever essa coluna é um problema de:",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "classificação, pois os números representam categorias, não quantidades.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "regressão, porque a coluna contém apenas valores numéricos inteiros.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "classificação, mas só funciona se os valores forem sempre positivos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "regressão, já que o scikit-learn não classifica valores numéricos.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma empresa treina um classificador de currículos usando decisões de contratação de anos anteriores, que favoreciam um perfil específico de candidato. O modelo tende a repetir esse padrão. Isso mostra que:",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "o modelo aprende os padrões dos dados de treino, inclusive os enviesados.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "classificação é imune a viés, porque usa só cálculo matemático puro.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "o problema deixa de ser classificação assim que envolve pessoas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "algoritmos de classificação corrigem sozinhos dados desbalanceados.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Regressão logística",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Regressão logística: um nome que engana\n\nApesar do nome, regressão logística não resolve problemas de regressão: é um dos algoritmos mais usados para **classificação**, principalmente binária. O nome vem da função matemática que ela usa por baixo dos panos, a função logística (também chamada de sigmoide), não do tipo de problema que ela resolve. É uma pegadinha de nome clássica, e vale gravar: regressão logística classifica."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## A intuição: espremendo a reta entre 0 e 1\n\nLembra da reta da regressão linear (módulo 3), que combina as features multiplicando cada uma por um coeficiente e somando tudo? A regressão logística parte da mesma ideia, mas dá um passo a mais: pega o resultado dessa combinação linear e passa por uma função em formato de S (a sigmoide), que espreme qualquer número, por maior ou menor que seja, pra um valor entre 0 e 1.\n\nEsse valor entre 0 e 1 é interpretado como uma **probabilidade**: a chance estimada de o exemplo pertencer à classe positiva. Quanto mais a combinação linear das features empurra esse valor pra perto de 1, mais o modelo \"acredita\" naquela classe."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Da probabilidade à classe: o limiar\n\nUma probabilidade sozinha não é uma decisão. Pra transformar os 0,82 ou 0,15 que saem da sigmoide numa classe (\"sim\" ou \"não\"), o scikit-learn aplica um **limiar** (`threshold`): por padrão, 0,5. Probabilidade maior ou igual a 0,5 vira a classe positiva; menor que isso vira a classe negativa.\n\nEsse limiar não é uma lei da física, é só um padrão razoável. O módulo 5 mostra situações (como exames médicos, em que deixar passar um doente é pior do que assustar um saudável à toa) em que faz sentido mover esse limiar pra 0,2 ou 0,3, tornando o modelo mais \"desconfiado\"."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.linear_model import LogisticRegression\nimport pandas as pd\n\ndados = pd.DataFrame({\n    \"horas_estudo\": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],\n    \"aprovado\":     [0, 0, 0, 0, 0, 1, 1, 1, 1, 1],\n})\n\nX = dados[[\"horas_estudo\"]]\ny = dados[\"aprovado\"]\n\nmodelo = LogisticRegression()\nmodelo.fit(X, y)\n\nnovos_alunos = pd.DataFrame({\"horas_estudo\": [2, 5.5, 9]})\n\nprint(modelo.predict(novos_alunos))\n# [0 1 1]\n\nprint(modelo.predict_proba(novos_alunos))\n# [[0.9  0.1 ]\n#  [0.42 0.58]\n#  [0.04 0.96]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## A fronteira de decisão da regressão logística\n\nImagine um gráfico com os exemplos espalhados, coloridos por classe. A **fronteira de decisão** é a linha (ou, com mais de duas features, o plano) que separa a região onde o modelo prevê uma classe da região onde ele prevê a outra: exatamente onde a probabilidade prevista cruza o limiar de 0,5.\n\nComo a regressão logística é, no fundo, uma combinação linear das features, essa fronteira é sempre uma **reta** (ou um plano, em mais dimensões). Isso é uma limitação real: se as classes só puderem ser separadas por uma curva, uma reta nunca vai fazer um trabalho perfeito, por mais dados que você use."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Regressão logística é regressão só no nome: o que ela devolve é uma probabilidade, e um limiar transforma essa probabilidade em classe."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Apesar do nome, a regressão logística é usada para resolver problemas de:",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "classificação: estima a probabilidade de pertencer a cada classe.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "regressão, estimando diretamente um valor numérico contínuo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "agrupamento, juntando exemplos parecidos sem usar rótulos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "redução de dimensionalidade, diminuindo o número de features.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O que o método `predict_proba()` de um `LogisticRegression` devolve para cada exemplo?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "A probabilidade estimada de o exemplo pertencer a cada classe.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A classe final já escolhida, depois de aplicar o limiar padrão.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O erro do modelo, medido nos dados de teste separados antes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os coeficientes que o modelo ajustou durante o treino com `fit()`.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por padrão, o scikit-learn classifica um exemplo na classe positiva quando a probabilidade prevista é:",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "maior ou igual a 0,5, o limiar padrão de decisão.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "igual a 1,0, ou seja, quando o modelo tem certeza total.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "menor que 0,5, priorizando a classe negativa por padrão.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "igual à proporção de positivos observada nos dados de treino.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Em um exame para detectar uma doença grave, a equipe passa a classificar como positivo qualquer paciente com probabilidade prevista acima de 0,2, em vez de 0,5. O objetivo dessa mudança é:",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "reduzir os casos de pacientes doentes classificados como saudáveis.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "aumentar a acurácia geral do modelo em todos os pacientes testados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "tornar o treino do modelo mais rápido em bases de dados grandes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "transformar o problema, que deixa de ser binário e vira multiclasse.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "A fronteira de decisão de uma regressão logística, no espaço das features, tem o formato de:",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "uma reta (ou plano), já que o modelo combina as features linearmente.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "uma curva em S, o mesmo formato da função sigmoide usada por dentro.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "um conjunto de degraus retos, um para cada pergunta feita ao modelo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "um círculo ao redor da média de cada classe presente no treino.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "k-vizinhos mais próximos (k-NN)",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## A intuição: classificar pela vizinhança\n\nO k-NN (`k-nearest neighbors`, k-vizinhos mais próximos) usa talvez a ideia mais simples de todo o machine learning: para classificar um exemplo novo, olhe para os exemplos de treino mais parecidos com ele e copie a classe da maioria. É a versão matemática do ditado \"diz-me com quem andas e te direi quem és\".\n\nNão existe fórmula nem curva ajustada aos dados. O k-NN guarda os exemplos de treino e, na hora de prever, mede a distância do exemplo novo até todos eles, escolhe os `k` mais próximos e deixa esses vizinhos votarem na classe."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Um algoritmo que quase não treina\n\nIsso torna o k-NN um caso curioso: o `fit()` dele é rápido e simples, basicamente guarda os dados de treino na memória. Todo o trabalho pesado acontece depois, em cada chamada de `predict()`, quando o modelo precisa calcular a distância até cada exemplo guardado. Por isso ele é chamado de aprendiz preguiçoso (`lazy learner`): adia o esforço pra hora de prever, em vez de resumir os dados numa fórmula durante o treino.\n\nA distância mais comum entre dois exemplos é a distância euclidiana, a mesma da régua: a raiz quadrada da soma dos quadrados das diferenças em cada feature."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O efeito do k na fronteira de decisão\n\nO valor de `k` muda bastante o comportamento do modelo. Com `k` pequeno (como `k=1`), a previsão depende de pouquíssimos vizinhos, então um exemplo ruidoso ou um outlier no treino pode virar a decisão sozinho: a fronteira de decisão fica irregular, cheia de dobras, acompanhando de perto cada ponto do treino (um sinal de possível overfitting).\n\nCom `k` grande, cada previsão passa pelo voto de muitos vizinhos, o que suaviza a fronteira de decisão, mas também pode borrar a separação entre classes que ficam próximas uma da outra (um sinal de possível underfitting). Não existe um `k` universalmente certo: ele costuma ser escolhido testando alguns valores, algo que o módulo 5 retoma com a validação cruzada."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Por que k-NN precisa de features na mesma escala\n\nComo o k-NN decide tudo por distância, a escala de cada feature importa demais. Imagine comparar clientes usando \"idade\" (varia de 20 a 60) e \"renda anual em reais\" (varia de 20.000 a 200.000). Uma diferença de 5 anos é pequena em números absolutos perto de uma diferença de 5.000 reais, mesmo que as duas sejam, proporcionalmente, igual de relevantes pro problema.\n\nSem escalar as features antes de treinar, a renda praticamente decide sozinha a distância entre exemplos, e a idade vira ruído de fundo, quase ignorado. Por isso o k-NN quase sempre é usado depois de um `StandardScaler` (o módulo 6 mostra como). Regressão logística e árvore de decisão sentem bem menos esse problema."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.neighbors import KNeighborsClassifier\nimport pandas as pd\n\ndados = pd.DataFrame({\n    \"idade\": [22, 25, 47, 52, 46, 56, 23, 60],\n    \"salario_mil\": [2.5, 3.0, 8.0, 9.5, 7.8, 10.2, 2.8, 11.0],\n    \"comprou_plano_premium\": [0, 0, 1, 1, 1, 1, 0, 1],\n})\n\nX = dados[[\"idade\", \"salario_mil\"]]\ny = dados[\"comprou_plano_premium\"]\n\nmodelo = KNeighborsClassifier(n_neighbors=3)\nmodelo.fit(X, y)\n\nnovo_cliente = pd.DataFrame({\"idade\": [48], \"salario_mil\": [8.5]})\n\nprint(modelo.predict(novo_cliente))\n# [1]\n\nprint(modelo.predict_proba(novo_cliente))\n# [[0. 1.]]"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Aspecto\",\"k pequeno (ex.: k=1)\",\"k grande (ex.: k=25)\"],[\"Sensibilidade a ruído\",\"Alta: um vizinho estranho muda a previsão\",\"Baixa: o voto de um outlier pesa pouco\"],[\"Fronteira de decisão\",\"Irregular, acompanha de perto cada exemplo\",\"Mais suave, pode borrar classes próximas\"],[\"Risco principal\",\"Overfitting: decorar o treino\",\"Underfitting: ignorar padrões locais\"],[\"Custo computacional\",\"Baixo por previsão\",\"Mais alto (compara com mais vizinhos)\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "k-NN não aprende uma fórmula: aprende a comparar. A classe de um exemplo novo é a classe da vizinhança que ele mais se parece."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Como o k-NN decide a classe de um exemplo novo?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Olha os k exemplos mais próximos e vota pela classe mais comum.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Ajusta uma equação linear que combina todas as features de entrada.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Faz perguntas de sim ou não em sequência até chegar numa classe.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Agrupa todos os exemplos em clusters antes de calcular a previsão.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um modelo k-NN é treinado com `k=1`. Esse valor tende a deixar o modelo:",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "muito sensível a ruído, já que um único vizinho decide a classe.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "muito lento para treinar, mesmo com poucos exemplos de entrada.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "incapaz de lidar com problemas que têm mais de duas classes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "imune a overfitting, já que usa só um vizinho por previsão.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que o k-NN exige que as features estejam numa escala parecida?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "porque ele decide a classe com base na distância entre exemplos.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "porque ele só aceita valores decimais entre 0 e 1 como entrada.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "porque o `fit()` retorna erro ao receber escalas diferentes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "porque o scikit-learn exige escala igual para qualquer modelo.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um conjunto de dados tem \"idade\" (0 a 100) e \"renda mensal\" (0 a 50.000), sem nenhum escalonamento. Ao treinar um k-NN nesses dados, o efeito mais provável é:",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "a renda dominar a distância calculada, deixando a idade quase irrelevante.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "o modelo ignorar automaticamente a coluna com a maior variação.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "o k-NN normalizar as duas colunas sozinho, antes de calcular distâncias.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "o treino falhar com erro, já que as escalas precisam ser sempre iguais.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Aumentar bastante o valor de `k` em um k-NN tende a deixar a fronteira de decisão:",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "mais suave, podendo borrar a separação entre classes próximas.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "mais irregular, seguindo de perto cada exemplo do treino.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "idêntica à de uma árvore de decisão, não importa os dados usados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "impossível de calcular quando existe mais de uma feature.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Árvore de decisão",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## A intuição: uma sequência de perguntas\n\nUma árvore de decisão classifica de um jeito bem parecido com o de um médico fazendo perguntas de triagem: \"tem febre?\", se sim, \"tem tosse também?\", e assim por diante, até chegar numa conclusão. Cada pergunta olha para uma feature e divide os exemplos em dois grupos, criando um fluxograma de perguntas encadeadas.\n\nEssa estrutura de perguntas se/então é o que torna a árvore de decisão um dos algoritmos mais fáceis de interpretar: dá pra desenhá-la, segui-la manualmente e explicar exatamente por que o modelo chegou naquela previsão, sem depender de fórmula nenhuma."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Como a árvore escolhe as perguntas\n\nDurante o treino, para cada divisão (cada nó da árvore), o algoritmo testa várias combinações de feature e limite (\"idade menor que 30?\", \"salário maior que 5000?\") e escolhe a que melhor separa as classes, deixando cada galho resultante o mais \"puro\" possível: com exemplos concentrados numa única classe, e não misturados.\n\nO scikit-learn mede essa pureza com um critério chamado impureza de Gini (o padrão do `DecisionTreeClassifier`), mas o nome importa menos que a ideia: a árvore sempre busca a pergunta que mais separa as classes naquele ponto, de forma gulosa, uma divisão de cada vez."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Da pergunta à decisão, e o formato da fronteira\n\nO processo se repete em cada galho novo, criando divisões sucessivas, até bater num critério de parada (uma folha ficar pura, ou a árvore atingir a profundidade máxima permitida). Cada **folha** guarda a classe mais comum entre os exemplos de treino que caíram ali, e é essa classe que a árvore prevê para qualquer exemplo novo que termine naquela folha.\n\nComo cada pergunta testa uma única feature contra um limite (\"maior que\" ou \"menor que\"), a fronteira de decisão de uma árvore é sempre formada por linhas retas perpendiculares aos eixos, um formato de degraus, bem diferente da reta única da regressão logística."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.tree import DecisionTreeClassifier\nimport pandas as pd\n\ndados = pd.DataFrame({\n    \"febre\": [1, 0, 1, 0, 1, 0, 1, 0],\n    \"tosse\": [1, 1, 0, 0, 1, 0, 1, 1],\n    \"diagnostico\": [\"gripe\", \"saudavel\", \"alergia\", \"saudavel\", \"gripe\", \"saudavel\", \"gripe\", \"alergia\"],\n})\n\nX = dados[[\"febre\", \"tosse\"]]\ny = dados[\"diagnostico\"]\n\nmodelo = DecisionTreeClassifier(max_depth=3, random_state=42)\nmodelo.fit(X, y)\n\nnovo_paciente = pd.DataFrame({\"febre\": [1], \"tosse\": [1]})\n\nprint(modelo.predict(novo_paciente))\n# ['gripe']\n\nprint(modelo.predict_proba(novo_paciente))\n# [[0. 1. 0.]]\n# colunas em ordem alfabética de classes_: alergia, gripe, saudavel"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O risco de deixar a árvore crescer demais\n\nSe nada limitar o crescimento, uma árvore de decisão pode continuar fazendo perguntas até cada folha conter um único exemplo de treino, decorado. O resultado é uma árvore gigante, cheia de galhos hiperespecíficos, que acerta 100% dos dados de treino e generaliza mal para dados novos: um caso claro de **overfitting**, o modelo aprendeu o ruído dos dados de treino, não só o padrão.\n\nPor isso o `DecisionTreeClassifier` aceita parâmetros como `max_depth` (profundidade máxima) para conter esse crescimento. O quanto limitar, e como perceber que a árvore decorou em vez de aprender, é assunto para o módulo 5, quando o overfitting ganha uma definição mais formal."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Algoritmo\",\"Intuição\",\"Precisa escalar features?\",\"Fácil de interpretar?\"],[\"Regressão logística\",\"Ajusta uma curva em S e devolve uma probabilidade\",\"Ajuda o treino, mas não é obrigatório\",\"Média: dá pra olhar os coeficientes\"],[\"k-NN (k-vizinhos)\",\"Vota pela classe dos k exemplos mais parecidos\",\"Sim, essencial: o algoritmo usa distância\",\"Baixa: não explica o motivo da previsão\"],[\"Árvore de decisão\",\"Faz perguntas sequenciais do tipo se/então\",\"Não precisa: não usa distância entre pontos\",\"Alta: dá pra desenhar e ler a árvore\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Uma árvore de decisão não esconde o motivo da resposta: o motivo é o caminho de perguntas que ela percorreu até a folha."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Uma árvore de decisão classifica um exemplo novo por meio de:",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "uma sequência de perguntas do tipo se/então sobre as features.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "uma equação linear que soma o peso de cada feature de entrada.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "o cálculo da distância até os exemplos mais próximos do treino.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "uma média entre as previsões de vários modelos diferentes.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O que a árvore de decisão busca em cada divisão (nó) durante o treino?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "uma pergunta que separe as classes, deixando os galhos mais puros.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "uma pergunta escolhida ao acaso entre as features disponíveis.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "a feature cujo nome vem primeiro em ordem alfabética nos dados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "a divisão que deixa a árvore com o menor número de galhos.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que árvores de decisão costumam ser consideradas fáceis de interpretar?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "porque as regras de decisão dão pra ler e desenhar como um fluxograma.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "porque elas sempre alcançam acurácia maior do que outros modelos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "porque não precisam de nenhum dado de treino rotulado pra funcionar.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "porque o scikit-learn explica em texto cada previsão feita por elas.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma árvore de decisão treinada sem limite de profundidade acerta 100% dos exemplos de treino, mas erra bastante em dados novos. Isso é sinal de:",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "overfitting: a árvore decorou particularidades do treino, sem generalizar.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "underfitting: a árvore é simples demais pra captar os padrões dos dados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "vazamento de dados: o alvo foi usado sem querer como feature de entrada.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "um bug no scikit-learn, já que árvores nunca deveriam acertar tudo.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Comparada à fronteira de decisão de uma regressão logística, a fronteira de uma árvore de decisão tende a ser:",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "formada por linhas retas perpendiculares aos eixos, tipo um degrau.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "sempre uma única reta diagonal, igual à da regressão logística.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "uma curva suave em formato de S, ajustada aos dados de treino.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "sempre igual, já que toda fronteira de decisão tem o mesmo formato.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "O fluxo scikit-learn e predict_proba",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## O mesmo fluxo, um resultado diferente\n\nO padrão que você viu na regressão (módulo 3) se repete aqui, exatamente igual: escolher o algoritmo, instanciar o modelo, chamar `fit(X_treino, y_treino)` para treinar, e `predict(X_novo)` para prever. Isso vale para `LogisticRegression`, `KNeighborsClassifier`, `DecisionTreeClassifier` e praticamente qualquer outro modelo do scikit-learn: a API é sempre a mesma, só muda o que a saída representa.\n\nNuma regressão, `predict()` devolve um número. Numa classificação, `predict()` devolve uma classe. E o método `score(X_teste, y_teste)`, que na regressão devolvia R2, aqui devolve **acurácia**: a fração de exemplos que o modelo classificou corretamente. Mas acurácia sozinha engana em vários casos comuns, como classes desbalanceadas, isso é assunto do módulo 5, o próximo desta trilha."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## predict() decide, predict_proba() mostra a confiança\n\nAlém de `predict()`, os modelos de classificação do scikit-learn (regressão logística, k-NN, árvore de decisão, entre outros) também têm o método `predict_proba()`. A diferença:\n\n- `predict(X)` devolve a classe final, já decidida (aplicando o limiar por trás dos panos).\n- `predict_proba(X)` devolve a probabilidade estimada para cada classe, sem decidir nada, deixando essa decisão pra você.\n\nIsso importa porque duas previsões \"positivas\" podem ter confiança bem diferente: uma com probabilidade 0,51 e outra com 0,98 viram a mesma classe em `predict()`, mas contam histórias bem diferentes. Quando a decisão tem consequência (aprovar um empréstimo, sinalizar uma fraude), vale olhar `predict_proba()` antes de confiar cegamente na classe final."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.linear_model import LogisticRegression\nfrom sklearn.model_selection import train_test_split\nimport pandas as pd\n\ndados = pd.DataFrame({\n    \"horas_estudo\": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1.5, 8.5],\n    \"aprovado\":     [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 1],\n})\n\nX = dados[[\"horas_estudo\"]]\ny = dados[\"aprovado\"]\n\nX_treino, X_teste, y_treino, y_teste = train_test_split(\n    X, y, test_size=0.25, random_state=42\n)\n\nmodelo = LogisticRegression()\nmodelo.fit(X_treino, y_treino)\n\nprint(modelo.score(X_teste, y_teste))\n# 1.0\n\nprint(modelo.classes_)\n# [0 1]\n\nnovos_alunos = pd.DataFrame({\"horas_estudo\": [3, 5.5, 8]})\nprint(modelo.predict(novos_alunos))\n# [0 1 1]\n\nprint(modelo.predict_proba(novos_alunos))\n# [[0.85 0.15]\n#  [0.45 0.55]\n#  [0.06 0.94]]"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Aspecto\",\"predict()\",\"predict_proba()\"],[\"O que devolve\",\"A classe final escolhida pelo modelo\",\"A probabilidade estimada de cada classe\"],[\"Formato da saída\",\"Um rótulo por exemplo (ex.: \\\"gripe\\\")\",\"Uma lista de probabilidades por exemplo\"],[\"Quando usar\",\"Quando basta a decisão automática\",\"Quando quer ver a confiança ou ajustar o limiar\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Três algoritmos, três formatos de fronteira\n\nVale juntar num só lugar o que ficou espalhado pelo módulo. A **fronteira de decisão** é a linha (ou superfície) imaginária que separa, no espaço das features, a região onde o modelo prevê uma classe da região onde ele prevê outra. Os três algoritmos deste módulo desenham essa linha de formas bem diferentes:\n\n- Regressão logística: uma reta (ou plano), porque a decisão vem de uma combinação linear das features.\n- k-NN: um contorno irregular, que muda com a densidade dos pontos ao redor e com o valor de `k`.\n- Árvore de decisão: um conjunto de retas perpendiculares aos eixos, em formato de degraus.\n\nNenhum formato é \"o melhor\" em todo problema: depende de como as classes de verdade se separam nos dados."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Não existe algoritmo vencedor universal\n\nVale terminar com uma honestidade importante: não existe um algoritmo de classificação que seja sempre o melhor, para qualquer conjunto de dados. Regressão logística é rápida e interpretável, mas só desenha fronteiras retas. k-NN se adapta a formatos complexos, mas depende de escala e fica lento com muitos dados. Árvore de decisão é fácil de explicar, mas sozinha tende a decorar o treino. A escolha depende do problema, do volume de dados e do quanto a interpretação importa, não existe atalho que substitua testar e comparar.\n\nE nenhum dos três é mágico: todos aprendem só o que os dados de treino mostram a eles. Com dados ruins, rótulos errados ou não representativos, mesmo o algoritmo certo produz um modelo ruim. O módulo 6 desta trilha volta a esse ponto, mostrando como preparar dados de verdade para um modelo."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "predict() decide por você. predict_proba() mostra o quão confiante o modelo estava antes de decidir."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "No scikit-learn, qual método devolve diretamente a classe final prevista por um modelo de classificação?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "O método `predict()`, que devolve o rótulo já decidido pelo modelo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O método `fit()`, que devolve o rótulo previsto logo após o treino.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O método `score()`, que devolve a acurácia do modelo nos dados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O atributo `classes_`, que devolve a lista de classes conhecidas.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual a diferença central entre `predict()` e `predict_proba()` num modelo de classificação?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "`predict()` devolve a classe escolhida; `predict_proba()`, a probabilidade por classe.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "`predict()` funciona só em regressão; `predict_proba()`, só em classificação binária.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "`predict()` usa dados de treino; `predict_proba()` usa sempre dados de teste.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "`predict()` devolve texto; `predict_proba()` devolve somente números inteiros.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Em qual situação faz mais sentido consultar `predict_proba()` em vez de só `predict()`?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "quando é preciso ajustar o limiar de decisão para a situação em questão.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "quando o modelo usado é uma árvore de decisão, e nunca outro tipo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "quando os dados de treino e teste têm exatamente o mesmo tamanho.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "quando o problema deixa de ser classificação e passa a ser regressão.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um modelo tem `classes_` igual a `[0, 1]` e `predict_proba()` devolve `[[0.3, 0.7]]` para um exemplo. O que esse resultado indica?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "70% de probabilidade estimada de o exemplo pertencer à classe 1.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "70% de acurácia geral do modelo, medida nos dados de teste inteiros.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "certeza total de que o exemplo pertence à classe 1, sem nenhuma dúvida.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "30% dos exemplos de treino inteiros pertencem à classe 0, no total.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Diante de um novo problema de classificação, qual afirmação é mais correta sobre escolher entre regressão logística, k-NN e árvore de decisão?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "não existe vencedor universal: a escolha depende dos dados e do problema.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "a árvore de decisão deve ser sempre a primeira escolha, por ser mais simples.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "o k-NN deve ser evitado sempre, porque nunca funciona bem na prática.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "a regressão logística só funciona quando existem mais de duas classes.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 5 - Avaliar modelos de verdade",
+        "aulas": [
+            {
+                "titulo": "Por que a acurácia engana",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## O número que parece bom demais\n\nLá no Módulo 4 você treinou seus primeiros classificadores e usou `modelo.score(X_teste, y_teste)` pra saber se estavam bons. Esse número é a **acurácia**: a proporção de previsões certas sobre o total. Simples, direto e, em muitos casos, enganoso.\n\nImagine que alguém te diz: \"meu modelo detecta fraude em cartão de crédito com 99% de acurácia\". Parece ótimo, certo? Só que essa frase, sozinha, não diz quase nada sobre se o modelo é útil. Nesta aula você vai entender por quê."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Classes desbalanceadas\n\nMuitos problemas reais de classificação têm uma classe bem mais rara que a outra. Isso se chama **desbalanceamento de classes**:\n\n- Fraude em cartão de crédito: a esmagadora maioria das transações é legítima.\n- Diagnóstico de uma doença rara: quase todo mundo que faz o exame não tem a doença.\n- Detecção de spam em certos contextos: a maior parte do tráfego é email legítimo.\n\nNesses casos, a classe que a gente quer identificar (a fraude, a doença, o spam) é minoria nos dados. E é exatamente aí que a acurácia trai a gente."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.datasets import make_classification\nfrom sklearn.model_selection import train_test_split\nfrom sklearn.dummy import DummyClassifier\nfrom sklearn.linear_model import LogisticRegression\nfrom sklearn.metrics import accuracy_score\n\n# dataset desbalanceado: 99% classe 0 (\"não é fraude\"), 1% classe 1 (\"é fraude\")\nX, y = make_classification(\n    n_samples=5000,\n    n_features=10,\n    weights=[0.99, 0.01],\n    random_state=42,\n)\n\nX_treino, X_teste, y_treino, y_teste = train_test_split(\n    X, y, test_size=0.3, stratify=y, random_state=42\n)\n\n# modelo bobo: sempre prevê a classe mais frequente\nbobo = DummyClassifier(strategy=\"most_frequent\")\nbobo.fit(X_treino, y_treino)\npred_bobo = bobo.predict(X_teste)\n\nprint(\"Acurácia do modelo bobo:\", accuracy_score(y_teste, pred_bobo))\n# Acurácia do modelo bobo: 0.99\n\nprint(\"Casos da classe rara encontrados pelo bobo:\", pred_bobo.sum())\n# Casos da classe rara encontrados pelo bobo: 0\n\n# agora um modelo de verdade\nmodelo = LogisticRegression()\nmodelo.fit(X_treino, y_treino)\npred = modelo.predict(X_teste)\n\nprint(\"Acurácia do modelo real:\", accuracy_score(y_teste, pred))\n# Acurácia do modelo real: 0.985\n\nprint(\"Casos da classe rara encontrados pelo modelo real:\", pred.sum())\n# Casos da classe rara encontrados pelo modelo real: 7"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Modelo\", \"Acurácia\", \"Encontrou algum caso da classe rara?\"], [\"Bobo (sempre prevê a maioria)\", \"0.99\", \"Não, nenhum\"], [\"Regressão logística real\", \"0.985\", \"Sim, várias vezes\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Por que isso acontece\n\nA acurácia trata todo acerto e todo erro do mesmo jeito: um ponto pra cada previsão certa, nada além disso. Ela não pergunta ERROU EM QUÊ. Quando 99% dos exemplos são de uma classe, um modelo que ignora completamente a outra classe ainda acerta quase tudo, porque a maioria dos exemplos são fáceis (são todos da classe majoritária).\n\nO problema não é a conta da acurácia estar errada. O problema é que ela esconde justamente os casos que mais importam: os raros, que geralmente são o motivo de você estar construindo o modelo."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## A acurácia não é vilã\n\nIsso não quer dizer que acurácia é uma métrica ruim. Em problemas com classes equilibradas (tipo 50/50 ou 60/40), ela continua sendo uma medida razoável e fácil de explicar. O erro é usá-la sozinha, sem olhar a distribuição das classes e sem perguntar que TIPO de erro o modelo está cometendo. É exatamente isso que a matriz de confusão, na próxima aula, vai destrinchar."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Um modelo com 99% de acurácia pode ser genial ou pode ser um modelo que nunca aprendeu nada e só repete a resposta mais comum. A acurácia sozinha não distingue os dois casos."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que significa dizer que um problema de classificação tem classes desbalanceadas?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Uma classe aparece com frequência bem maior que a outra nos dados",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O modelo usa mais atributos pra prever uma classe do que a outra",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O conjunto de treino tem mais linhas do que o conjunto de teste",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "As métricas de avaliação retornam valores bem diferentes entre si",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um modelo de detecção de fraude tem 99,5% de acurácia, sabendo que só 0,5% das transações são fraudulentas. O que esse número, sozinho, sugere?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Que o modelo provavelmente prevê sempre a classe majoritária, sem pegar fraude",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Que o modelo aprendeu a distinguir muito bem fraude de transação legítima",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que a acurácia é, nesse caso, a métrica mais confiável pra comparar modelos",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que o conjunto de dados usado no treino provavelmente estava balanceado",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que comparar um modelo real com um DummyClassifier(strategy='most_frequent') é uma prática útil?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque ele serve de piso de comparação: um modelo só é bom se superar essa base",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque ele treina mais rápido e por isso deve substituir o modelo real em produção",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque ele ajusta automaticamente o desbalanceamento das classes antes do treino",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque ele calcula a matriz de confusão sem precisar dividir treino e teste",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Em um dataset com 98% de exemplos da classe A e 2% da classe B, um modelo real teve 96% de acurácia, menor que os 98% de um modelo bobo. Isso prova que o modelo real é pior?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Não necessariamente: o modelo real pode estar acertando exemplos da classe B",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Sim, porque acurácia menor sempre indica um modelo com pior capacidade preditiva",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Sim, porque nesse cenário a acurácia é a única métrica capaz de medir qualidade",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não, porque a acurácia do modelo bobo não pode ser calculada nesse cenário",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Em qual cenário a acurácia sozinha já é uma métrica razoável pra avaliar um classificador?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Quando as classes têm proporções parecidas e o custo dos erros é semelhante",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Quando uma das classes é rara, mas acertá-la importa mais que o restante",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Quando o objetivo principal é nunca deixar passar um caso da classe rara",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Quando o conjunto de dados tem muitas variáveis categóricas com categorias",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Matriz de confusão",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Abrindo o acerto e o erro em quatro partes\n\nA acurácia responde só uma pergunta: quantas previsões o modelo acertou? A **matriz de confusão** responde uma pergunta bem mais útil: acertou e errou COMO? Ela cruza o que o modelo previu com o que realmente aconteceu, e separa o resultado em quatro grupos."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Os quatro grupos\n\nPense num exame de uma doença, em que a classe positiva é \"tem a doença\":\n\n- **Verdadeiro Positivo (VP):** o modelo disse \"tem a doença\" e a pessoa realmente tem.\n- **Verdadeiro Negativo (VN):** o modelo disse \"não tem\" e a pessoa realmente não tem.\n- **Falso Positivo (FP):** o modelo disse \"tem a doença\" mas a pessoa não tem (um alarme falso).\n- **Falso Negativo (FN):** o modelo disse \"não tem\" mas a pessoa tem (a doença passa batida).\n\nVP e VN são acertos. FP e FN são os dois jeitos diferentes de errar, e raramente têm o mesmo custo."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"\", \"Previsto: Negativo\", \"Previsto: Positivo\"], [\"Real: Negativo\", \"Verdadeiro Negativo (VN)\", \"Falso Positivo (FP)\"], [\"Real: Positivo\", \"Falso Negativo (FN)\", \"Verdadeiro Positivo (VP)\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O custo de cada erro depende do problema\n\nNum exame de uma doença grave, o falso negativo costuma ser o pior erro: a pessoa sai achando que está saudável e não trata a doença a tempo. O falso positivo também tem custo (exames extras, ansiedade), mas geralmente é menor.\n\nJá num filtro de spam, a conta pode inverter: um falso positivo (um email importante indo pro spam sem o usuário ver) às vezes pesa mais do que um falso negativo (um spam que passa e vai pra caixa de entrada, chato mas inofensivo).\n\nNão existe uma regra universal. Antes de escolher qual erro evitar mais, você precisa entender o problema que está resolvendo."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.metrics import confusion_matrix\n\n# y_teste: o que realmente aconteceu (1 = tem a doença, 0 = não tem)\ny_teste = [1, 0, 1, 1, 0, 0, 1, 0, 0, 0]\ny_pred  = [1, 0, 0, 1, 0, 1, 1, 0, 0, 0]\n\nmatriz = confusion_matrix(y_teste, y_pred)\nprint(matriz)\n# [[5 1]\n#  [1 3]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Lendo a saída do scikit-learn\n\nPor padrão, `confusion_matrix(y_teste, y_pred)` organiza as classes em ordem crescente e coloca as classes REAIS nas linhas e as classes PREVISTAS nas colunas. No exemplo acima, a primeira linha é sobre quem realmente é da classe 0 (5 acertos como VN, 1 erro como FP) e a segunda linha é sobre quem realmente é da classe 1 (1 erro como FN, 3 acertos como VP).\n\nVale reforçar: a matriz sozinha não dá uma nota única pro modelo. Ela é a base pra calcular as métricas que resumem tudo isso em números comparáveis, o assunto da próxima aula."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "A matriz de confusão não julga o modelo, ela só mostra os fatos: o que era o quê e o que o modelo disse que era. Julgar se isso é bom ou ruim depende do preço que cada erro tem no seu problema."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Na matriz de confusão, o que caracteriza um falso positivo?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "O modelo previu a classe positiva, mas o valor real era negativo",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O modelo previu a classe negativa, mas o valor real era positivo",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O modelo acertou a previsão da classe positiva corretamente",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O modelo errou a previsão das duas classes, positiva e negativa",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Num exame de uma doença grave, por que o falso negativo costuma ser considerado o erro mais perigoso?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque a pessoa doente sai achando que está saudável e não é tratada a tempo",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque a pessoa saudável precisa repetir o exame sem nenhuma necessidade real",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque esse tipo de erro sempre torna o exame mais caro para o laboratório",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque esse erro é sempre mais raro estatisticamente do que o falso positivo",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um filtro de spam analisa 1000 emails: marca 40 legítimos como spam (o usuário nunca vê) e deixa passar 5 spams reais na caixa de entrada. Qual erro pesa mais nesse cenário?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O falso positivo, porque emails legítimos ficam escondidos sem aviso",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O falso negativo, porque os spams que passaram trazem mais risco",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O verdadeiro positivo, porque identificar spam corretamente já é ruim",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os dois pesam igual, porque o que importa é só o total de 45 erros",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Na convenção padrão do confusion_matrix do scikit-learn, o que representam as linhas e as colunas da matriz retornada?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Linhas são as classes reais e colunas são as classes previstas pelo modelo",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Linhas são as classes previstas e colunas são as classes reais dos dados",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Linhas representam o treino e colunas representam o teste dos dados",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Linhas e colunas são intercambiáveis porque a matriz é sempre simétrica",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Dada a matriz de confusão [[5, 1], [1, 3]], em que a linha e a coluna 0 são a classe negativa e a linha e a coluna 1 são a classe positiva, quantos falsos negativos o modelo cometeu?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "1 falso negativo",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "3 falsos negativos",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "5 falsos negativos",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "4 falsos negativos",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Precisão, recall e F1",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Resumindo a matriz de confusão em números\n\nA matriz de confusão é rica, mas incômoda de comparar entre modelos: ninguém quer decidir \"qual modelo é melhor\" olhando quatro números de cada vez. Precisão, recall e F1 pegam a mesma informação da matriz e resumem em números únicos, cada um respondendo uma pergunta diferente."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Precisão: quando o modelo diz \"sim\", dá pra confiar?\n\n**Precisão** = VP / (VP + FP). Ela responde: das vezes que o modelo previu a classe positiva, quantas realmente eram? Precisão alta significa poucos alarmes falsos.\n\nPriorize precisão quando um falso positivo é caro: por exemplo, marcar um conteúdo como impróprio e removê-lo sem necessidade, ou recomendar um investimento ruim como se fosse seguro."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Recall: quantos casos reais o modelo encontrou?\n\n**Recall** (também chamado de sensibilidade) = VP / (VP + FN). Ela responde: dos casos positivos que realmente existiam, quantos o modelo encontrou? Recall alto significa poucos casos deixados passar.\n\nPriorize recall quando um falso negativo é caro: diagnóstico de doença grave, detecção de fraude, qualquer situação em que deixar passar um caso real é pior do que investigar um caso que não era nada.\n\nOs dois costumam competir: um modelo mais \"generoso\" pra prever positivo tende a aumentar o recall e derrubar a precisão, e vice-versa. O F1-score existe pra resumir esse equilíbrio num único número."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Métrica\", \"Pergunta que responde\", \"Quando priorizar\"], [\"Precisão\", \"Das vezes que previu positivo, quantas acertou?\", \"Quando um alarme falso custa caro\"], [\"Recall\", \"Dos positivos reais, quantos foram encontrados?\", \"Quando deixar passar um caso custa caro\"], [\"F1-score\", \"Qual o equilíbrio entre precisão e recall?\", \"Quando as duas coisas importam parecido\"]]"
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.datasets import make_classification\nfrom sklearn.model_selection import train_test_split\nfrom sklearn.linear_model import LogisticRegression\nfrom sklearn.metrics import classification_report\n\nX, y = make_classification(\n    n_samples=2000, n_features=10, weights=[0.9, 0.1], random_state=42\n)\nX_treino, X_teste, y_treino, y_teste = train_test_split(\n    X, y, test_size=0.3, stratify=y, random_state=42\n)\n\nmodelo = LogisticRegression()\nmodelo.fit(X_treino, y_treino)\ny_pred = modelo.predict(X_teste)\n\nprint(classification_report(y_teste, y_pred, target_names=[\"classe 0\", \"classe 1\"]))\n#               precision    recall  f1-score   support\n#\n#     classe 0       0.94      0.98      0.96       540\n#     classe 1       0.78      0.55      0.65        60\n#\n#     accuracy                           0.94       600\n#    macro avg       0.86      0.77      0.81       600\n# weighted avg       0.92      0.94      0.93       600"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## ROC e AUC, por cima\n\nExiste outra forma de olhar esse trade-off: a curva ROC. Ela mostra como o recall e a taxa de falsos positivos mudam conforme você varia o limiar de decisão do modelo (lembra do `predict_proba` do Módulo 4? é ele que permite variar esse limiar, em vez de usar direto o `predict`). Como a plataforma não desenha gráficos, imagine uma linha que sobe da esquerda pra direita: quanto mais perto do canto superior esquerdo ela passa, melhor o modelo separa as classes em qualquer limiar escolhido.\n\nA **AUC** (area under the curve) resume essa curva inteira num número entre 0 e 1: 0,5 é o desempenho de um sorteio de moeda, 1,0 é separação perfeita. Na prática, calcula-se com `roc_auc_score(y_teste, probabilidades)`, usando a probabilidade da classe positiva, não a classe prevista."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Precisão sem recall esconde o que ficou de fora. Recall sem precisão esconde o alarme falso que você criou. Nenhuma métrica sozinha conta a história inteira."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que o recall mede num problema de classificação?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "De todos os positivos reais, quantos o modelo conseguiu identificar",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "De todas as previsões positivas, quantas realmente eram positivas",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A proporção geral de acertos do modelo, somando as duas classes",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A média harmônica entre a precisão e a taxa de erro do modelo",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um exame de triagem de câncer precisa evitar ao máximo deixar passar um caso real, mesmo gerando mais exames desnecessários depois. Qual métrica deve ser priorizada?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Recall alto, mesmo que isso derrube um pouco a precisão do modelo",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Precisão alta, mesmo que isso derrube um pouco o recall do modelo",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Acurácia geral, porque ela já equilibra os dois tipos de erro",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Somente o F1-score, deixando de lado a precisão e o recall",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que o F1-score usa a média harmônica entre precisão e recall, em vez de uma média simples?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque ela pune com mais força quando um dos dois valores é muito baixo",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque ela sempre resulta num valor maior do que a média simples",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque a média simples não existe quando as classes são desbalanceadas",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque ela ignora a classe minoritária no cálculo do resultado final",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um modelo tem precisão de 0,95 e recall de 0,20 na classe positiva. O que isso sugere sobre o comportamento dele?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Ele raramente prevê a classe positiva, mas acerta quando o faz",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Ele prevê a classe positiva com frequência e quase sempre erra",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ele tem desempenho parecido e equilibrado entre as duas classes",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ele está sofrendo overfitting grave no conjunto de treino usado",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Sobre a curva ROC e a AUC de um classificador, qual afirmação está correta?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Uma AUC de 0,5 equivale ao desempenho de uma escolha aleatória",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Uma AUC de 0,5 indica que o modelo classifica tudo corretamente",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A curva ROC substitui o cálculo separado de precisão e recall",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A AUC só existe quando o modelo usa acurácia como métrica base",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Overfitting x underfitting: o trade-off viés-variância",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## O aluno que decorou a prova\n\nImagine um aluno que decorou palavra por palavra as respostas de uma lista de exercícios, sem entender o raciocínio por trás. Na prova com as mesmas questões, ele vai bem. Numa prova com questões parecidas, mas diferentes, ele vai mal, porque não aprendeu o padrão, só decorou o exemplo.\n\nModelos de machine learning podem cometer o mesmo erro. E o oposto também é possível: um aluno que nem estudou o suficiente pra ir bem nem na prova que ele já tinha visto."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Overfitting: foi bem no treino, mal no teste\n\n**Overfitting** é quando o modelo se ajusta demais aos dados de treino, inclusive ao ruído e às particularidades daquele conjunto específico, em vez de aprender o padrão geral. O sinal clássico: desempenho ótimo no treino e desempenho bem pior no teste, uma diferença grande entre os dois.\n\nCostuma acontecer com modelos complexos demais pro tamanho ou pra complexidade real dos dados: uma árvore de decisão sem limite de profundidade, por exemplo, pode crescer até isolar cada exemplo de treino individualmente."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Underfitting: foi mal nos dois\n\n**Underfitting** é o oposto: o modelo é simples demais (ou os dados e as features não são suficientes) pra captar nem o padrão básico dos dados de treino. O sinal: desempenho baixo tanto no treino quanto no teste, geralmente parecido entre os dois.\n\nAqui o problema não é falta de generalização, é falta de aprendizado mesmo. O modelo não capturou nem o que já viu."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O trade-off viés-variância\n\nEsses dois problemas têm nome técnico: **viés** (bias) é o erro que vem de suposições simples demais do modelo, o sintoma do underfitting. **Variância** é o erro que vem de o modelo ser sensível demais aos dados específicos de treino, o sintoma do overfitting: se você trocasse o conjunto de treino por outro parecido, o modelo mudaria bastante.\n\nO objetivo é equilibrar os dois: um modelo simples o suficiente pra generalizar, mas complexo o suficiente pra captar o padrão real. Não existe fórmula fixa pra esse ponto ideal, ele depende dos dados e é encontrado testando."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.tree import DecisionTreeClassifier\nfrom sklearn.model_selection import train_test_split\nfrom sklearn.datasets import make_classification\n\nX, y = make_classification(n_samples=1000, n_features=10, random_state=42)\nX_treino, X_teste, y_treino, y_teste = train_test_split(\n    X, y, test_size=0.3, random_state=42\n)\n\nfor profundidade in [1, 3, 5, None]:\n    arvore = DecisionTreeClassifier(max_depth=profundidade, random_state=42)\n    arvore.fit(X_treino, y_treino)\n    score_treino = arvore.score(X_treino, y_treino)\n    score_teste = arvore.score(X_teste, y_teste)\n    print(f\"profundidade={profundidade} | treino={score_treino:.2f} | teste={score_teste:.2f}\")\n\n# profundidade=1    | treino=0.78 | teste=0.76\n# profundidade=3    | treino=0.89 | teste=0.85\n# profundidade=5    | treino=0.94 | teste=0.86\n# profundidade=None | treino=1.00 | teste=0.81"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"\", \"Overfitting\", \"Underfitting\"], [\"Desempenho no treino\", \"Alto, às vezes quase perfeito\", \"Baixo\"], [\"Desempenho no teste\", \"Bem abaixo do treino\", \"Baixo, parecido com o treino\"], [\"Causa comum\", \"Modelo complexo demais pro problema\", \"Modelo simples demais pro problema\"], [\"Relação com viés-variância\", \"Variância alta\", \"Viés alto\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Um modelo com 100% de acerto no treino não é motivo de comemoração, é motivo de desconfiança. O que importa é como ele se sai no que nunca viu."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que caracteriza o overfitting num modelo de machine learning?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Desempenho muito bom no treino e bem pior no teste",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Desempenho ruim tanto no treino quanto no teste",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Desempenho parecido e bom nos dois conjuntos de dados",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um tempo de treinamento muito longo no scikit-learn",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um modelo atinge 60% de acurácia no treino e 58% no teste. O que esse resultado sugere?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Underfitting: o modelo não aprendeu nem o treino direito",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Overfitting: o modelo decorou o treino e não consegue generalizar",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Vazamento de dados: informação do teste vazou para o treino",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Nenhum problema, já que a diferença entre os dois é pequena",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "No trade-off viés-variância, o que representa uma variância alta?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O modelo é muito sensível aos dados de treino e muda bastante com eles",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O modelo ignora os dados de treino e prevê de forma praticamente aleatória",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O modelo usa poucas variáveis (features) pra tentar prever o resultado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O modelo aplica suposições simples demais que não captam o padrão real",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma árvore sem limite de profundidade atinge 100% no treino e 81% no teste. Uma árvore com profundidade limitada atinge 94% no treino e 86% no teste. Qual generaliza melhor?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "A limitada, porque o teste é o que importa pra avaliar generalização",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A sem limite, porque 100% no treino comprova que ela aprendeu bem",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "As duas generalizam igual, já que a diferença está só no treino",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A sem limite, porque quanto mais profunda, melhor ela capta os dados",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Reduzir a complexidade de um modelo que está com overfitting tende a que efeito?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Diminuir a variância, deixando o treino e o teste mais parecidos",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Aumentar a variância, afastando ainda mais o treino e o teste",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Eliminar de vez a necessidade de separar treino e teste em dados",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Garantir 100% de acurácia no teste em praticamente qualquer caso",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Validação cruzada",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## O problema de confiar em um único split\n\nDesde o Módulo 2 você separa os dados em treino e teste antes de avaliar um modelo, e por um bom motivo: avaliar no mesmo dado que treinou infla o resultado. Mas um único split também tem um problema: o score que você vê depende de QUAIS exemplos, por acaso, caíram no teste.\n\nCom pouco dado, isso pesa ainda mais: um split pode isolar por acaso os exemplos mais fáceis (score bonito, mas enganoso) ou os mais difíceis (score ruim, também enganoso) no conjunto de teste."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## A ideia da validação cruzada\n\nA **validação cruzada** (cross-validation) resolve isso repetindo a divisão várias vezes. A versão mais comum é o **k-fold**: divide o conjunto de dados em k partes (folds) de tamanho parecido, e repete k vezes o processo de treinar com k-1 partes e testar na parte restante, trocando qual parte é o teste a cada rodada.\n\nNo final, em vez de um único score, você tem k scores. A média deles é uma estimativa mais confiável do desempenho do modelo, e o desvio entre eles mostra o quanto essa estimativa pode variar."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.model_selection import cross_val_score\nfrom sklearn.linear_model import LogisticRegression\nfrom sklearn.datasets import make_classification\n\nX, y = make_classification(n_samples=1000, n_features=10, random_state=42)\n\nmodelo = LogisticRegression()\nscores = cross_val_score(modelo, X, y, cv=5)\n\nprint(scores)\n# [0.85 0.82 0.87 0.84 0.86]\n\nprint(f\"Média: {scores.mean():.2f} | Desvio padrão: {scores.std():.2f}\")\n# Média: 0.85 | Desvio padrão: 0.02"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"\", \"Um único split\", \"Validação cruzada (k-fold)\"], [\"Quantas vezes treina\", \"1\", \"k vezes (comum: 5 ou 10)\"], [\"Estimativa\", \"Um número só, pode ser sorte ou azar\", \"Média de k números, mais estável\"], [\"Custo computacional\", \"Baixo\", \"k vezes maior\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que a validação cruzada não resolve\n\nCross-validation dá uma estimativa melhor, mas não é mágica. Ela custa k vezes mais processamento, porque treina o modelo do zero em cada fold. E se você usa a validação cruzada repetidamente pra ESCOLHER entre modelos ou ajustar parâmetros, e depois reporta esse mesmo resultado como o desempenho final, a estimativa tende a ficar otimista: os dados de validação acabaram influenciando a escolha, mesmo sem serem usados diretamente no treino. Por isso, em projetos mais rigorosos, ainda se reserva um conjunto de teste final, que só é usado uma vez, no fim de tudo."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Fechando o Módulo 5\n\nVocê agora sabe desconfiar de um número de acurácia isolado, ler uma matriz de confusão, calcular e interpretar precisão, recall e F1, reconhecer os sinais de overfitting e underfitting, e avaliar um modelo de um jeito mais confiável com validação cruzada. É a caixa de ferramentas que separa quem só chama `.fit()` de quem sabe se o modelo realmente presta.\n\nNo próximo módulo, o foco muda pros dados que alimentam o modelo: escalar variáveis, codificar categorias, tratar valores faltantes e, principalmente, evitar que informação do teste vaze pro treino, usando os Pipelines do scikit-learn."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Confiar em um único split é julgar um aluno por uma prova só. A validação cruzada aplica várias provas parecidas e olha a média: o que sobra depois disso conta muito mais sobre o que o modelo realmente aprendeu."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que a validação cruzada (k-fold) faz, na prática?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Treina e avalia o modelo várias vezes, trocando qual parte é o teste",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Treina o modelo uma única vez, usando todos os dados disponíveis",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Escolhe automaticamente o melhor algoritmo entre vários candidatos",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Elimina de vez a necessidade de separar treino e teste nos dados",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que uma estimativa de validação cruzada costuma ser mais confiável que a de um único split?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque reduz o efeito de um split ter caído fácil ou difícil demais",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque ela sempre aumenta a acurácia final do modelo testado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque ela treina o modelo com mais dados do que qualquer split",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque ela elimina de vez a variância entre as partes dos dados",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Ao rodar cross_val_score com cv=5, os 5 scores voltam bem diferentes entre si, de 0,60 a 0,95. O que isso sugere?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Que o desempenho do modelo é instável entre partes diferentes dos dados",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Que o modelo tem desempenho excelente e consistente em qualquer parte",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que houve um erro de sintaxe na chamada da função cross_val_score",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que o parâmetro cv=5 deveria virar cv=1 pra corrigir o problema",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual é uma limitação real da validação cruzada, na prática?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Custa k vezes mais processamento: treina o modelo do zero em cada fold",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Não pode ser usada em problemas de classificação, apenas de regressão",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Substitui por completo a necessidade de um conjunto de teste reservado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Só entrega resultado correto quando o conjunto de dados está balanceado",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um cientista de dados usa validação cruzada só pra escolher entre modelos e ajustar parâmetros, e depois relata essa mesma média como o desempenho final esperado, sem testar em nenhum dado à parte. Qual o risco dessa prática?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "A estimativa pode ficar otimista, pois os mesmos dados guiaram a escolha",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Nenhum risco, pois a validação cruzada já equivale a um teste reservado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O risco só existe quando o cv usado é maior que 10 partes dos dados",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A validação cruzada torna a divisão treino/teste desnecessária ali",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 6 - Preparar dados para o modelo",
+        "aulas": [
+            {
+                "titulo": "Features boas: garbage in, garbage out",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Features boas: garbage in, garbage out\n\nAté aqui você aprendeu a treinar modelos de regressão e de classificação, avaliar com as métricas certas e reconhecer overfitting. Lá no módulo 2 apareceu uma regra que não sai mais da cabeça: o teste só serve como avaliação honesta se continuar sendo um dado que o modelo nunca viu. Este módulo pega esse mesmo cuidado e estende pra uma etapa que vem antes do treino: preparar os dados.\n\nA primeira parada é uma verdade que separa projeto de ML que funciona do que não funciona: o algoritmo importa menos do que a qualidade das variáveis, as features, que você entrega pra ele. Um Random Forest sofisticado treinado com features ruins costuma perder pra uma regressão linear simples treinada com features boas.\n\nEssa ideia tem um nome conhecido na área: **garbage in, garbage out** (lixo entra, lixo sai). Se as variáveis que descrevem seus exemplos não carregam informação relacionada ao que você quer prever, nenhum algoritmo cria essa informação do nada. Não existe truque de modelagem que compense dado sem sinal."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que é feature engineering\n\nFeature engineering é o processo de criar, transformar e selecionar as variáveis que entram no modelo. Não é sobre escolher o algoritmo, é sobre preparar a matéria-prima que o algoritmo recebe. Alguns exemplos comuns: extrair mês, dia da semana ou se é fim de semana a partir de uma data completa; calcular IMC a partir de altura e peso; reduzir um endereço completo só ao bairro ou à cidade; contar palavras ou detectar termos específicos dentro de um texto livre.\n\nLembra do DataFrame que você limpou e manipulou na trilha de Análise de Dados? Feature engineering usa esse mesmo tipo de manipulação com `pandas`, mas com um objetivo específico: criar colunas que ajudem o modelo a enxergar um padrão que você já sabe, ou suspeita, que existe nos dados."
+                    },
+                    {
+                        "type": "code",
+                        "value": "import pandas as pd\n\ndf = pd.DataFrame({\n    'data_venda': ['2024-01-06', '2024-06-20', '2024-12-24'],\n    'preco': [250000, 310000, 480000],\n    'area_m2': [65, 80, 120]\n})\n\ndf['data_venda'] = pd.to_datetime(df['data_venda'])\ndf['mes_venda'] = df['data_venda'].dt.month\ndf['fim_de_semana'] = df['data_venda'].dt.dayofweek >= 5\ndf['preco_por_m2'] = df['preco'] / df['area_m2']\n\nprint(df[['mes_venda', 'fim_de_semana', 'preco_por_m2']])\n#    mes_venda  fim_de_semana  preco_por_m2\n# 0          1           True   3846.153846\n# 1          6          False   3875.000000\n# 2         12          False   4000.000000"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Dado bruto\", \"Feature criada\", \"Por que ajuda o modelo\"], [\"Data completa (2024-01-06)\", \"Mês da venda e se é fim de semana\", \"O modelo não interpreta texto de data, mas aprende padrões sazonais representados em números\"], [\"Altura e peso em colunas separadas\", \"IMC (peso dividido pela altura ao quadrado)\", \"Junta duas variáveis numa métrica já validada, mais direta do que as duas isoladas\"], [\"Endereço completo por extenso\", \"Bairro ou cidade\", \"Reduz uma variável quase única por linha a categorias que se repetem e formam padrão\"], [\"Total gasto e tempo de casa separados\", \"Gasto médio mensal (total dividido pelo tempo)\", \"Revela diferenças de padrão de consumo que as duas colunas isoladas escondiam\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Os limites: feature engineering não é mágica\n\nMesmo a melhor feature engineering não compensa dados coletados errado, com viés, ou que simplesmente não têm relação nenhuma com o que você quer prever. Se o objetivo é prever se um cliente vai cancelar a assinatura, mas o único dado disponível é o nome dele, nenhuma transformação vai conjurar esse sinal do nada. Feature engineering reorganiza e destaca informação que já existe nos dados, ela não cria informação que nunca foi coletada.\n\nEssa ideia conecta direto com o resto do módulo: antes de sair trocando de algoritmo atrás de mais desempenho, vale investir tempo entendendo e preparando bem as variáveis que você já tem."
+                    },
+                    {
+                        "type": "code",
+                        "value": "df_clientes = pd.DataFrame({\n    'meses_como_cliente': [2, 24, 6, 48],\n    'total_gasto': [150, 4800, 900, 9600]\n})\n\ndf_clientes['gasto_medio_mensal'] = (\n    df_clientes['total_gasto'] / df_clientes['meses_como_cliente']\n)\n\nprint(df_clientes)\n#    meses_como_cliente  total_gasto  gasto_medio_mensal\n# 0                    2          150                75.0\n# 1                   24         4800               200.0\n# 2                    6          900               150.0\n# 3                   48         9600               200.0\n# duas empresas com total gasto e tempo de casa bem diferentes\n# podem ter o mesmo gasto médio mensal: a nova feature revela\n# uma semelhança que as colunas originais, isoladas, escondiam"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Um algoritmo sofisticado não conserta features ruins, mas features boas fazem até um modelo simples brilhar. Antes de trocar de algoritmo, pergunte se você já tirou o máximo de sinal dos seus dados."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que significa a expressão \"garbage in, garbage out\" aplicada a machine learning?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Dados sem informação relevante sobre o alvo não geram boas previsões, não importa o algoritmo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um modelo salvo com o disco corrompido nunca mais consegue ser carregado pelo scikit-learn.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Todo dataset precisa ser limpo com pandas antes de ser lido pela linguagem Python.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Quanto mais colunas um dataset tiver, pior o desempenho de qualquer modelo treinado.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O que é feature engineering, no contexto de um projeto de machine learning?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O processo de criar e transformar variáveis pra que carreguem mais sinal útil sobre o alvo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O processo de escolher entre regressão e classificação, de acordo com o tipo da variável alvo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O processo de ajustar os hiperparâmetros do algoritmo depois que o modelo já foi treinado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O processo de dividir o dataset em treino e teste antes de qualquer outra etapa do projeto.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que extrair \"mês da venda\" e \"dia da semana\" a partir de uma data completa costuma ajudar um modelo?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque o modelo não interpreta texto de data, mas aprende padrões sazonais representados em números.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque colunas de data sempre atrapalham o cálculo de correlação entre as variáveis do dataset.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o scikit-learn exige que toda variável de entrada tenha o mesmo formato de número inteiro.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque datas completas ocupam muito mais espaço em memória do que qualquer outra variável.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma empresa quer prever se um cliente vai cancelar a assinatura, mas o único dado disponível é o nome do cliente. Feature engineering bem feita resolve esse problema?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Não, porque feature engineering reorganiza informação que já existe nos dados, sem criar sinal novo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Sim, combinando várias transformações do nome é possível chegar a um sinal forte de cancelamento.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Sim, mas só se o nome for convertido antes pra letras maiúsculas e sem nenhuma acentuação.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não, porque feature engineering só se aplica a problemas de regressão, nunca de classificação.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Duas empresas clientes têm o mesmo total gasto e o mesmo tempo de casa em meses, mas perfis de consumo bem diferentes. Criar a feature \"gasto médio mensal\" ajuda nesse caso porque...",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Junta duas variáveis brutas numa métrica que pode revelar diferenças que cada uma escondia sozinha.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Substitui a necessidade de escalar as variáveis antes de treinar qualquer modelo de classificação.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Elimina automaticamente qualquer outlier presente nas colunas originais de gasto e de tempo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Garante que o modelo vai atingir uma acurácia mais alta do que usando as duas colunas separadas.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Escalar e padronizar variáveis",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Por que a escala das variáveis importa\n\nImagine um dataset de clientes com duas colunas: idade (variando de 18 a 90) e renda mensal (variando de 0 a 50000). Se você usar k-NN pra encontrar os clientes mais parecidos, o algoritmo calcula a distância entre pontos considerando todas as colunas ao mesmo tempo. Só que renda varia na casa dos milhares e idade varia na casa das dezenas: a distância acaba sendo dominada quase inteiramente pela renda. Pro k-NN, um cliente de 20 anos e um de 80 anos podem parecer \"vizinhos\" só porque a diferença de renda entre eles é pequena, mesmo com 60 anos de diferença de idade.\n\nIsso não é exclusividade do k-NN. Regressão logística com regularização (aquela que penaliza coeficientes grandes pra evitar overfitting) também sofre: se uma variável tem escala muito maior que as outras, a penalização trata ela de um jeito desproporcional. Já algoritmos baseados em árvore (decision tree, Random Forest) não têm esse problema, porque decidem cada corte olhando uma variável de cada vez, sem calcular distância entre pontos."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## StandardScaler: média 0 e desvio padrão 1\n\nA padronização (standardization) transforma cada variável pra que ela passe a ter média 0 e desvio padrão 1. A fórmula por trás é simples: z = (x menos a média) dividido pelo desvio padrão. Se isso lembra o z-score que apareceu na trilha de Estatística, é exatamente a mesma ideia: cada valor passa a representar quantos desvios padrão ele está distante da média.\n\nSe você plotasse um histograma da variável antes e depois do StandardScaler, o formato da distribuição continuaria o mesmo, só o eixo mudaria: em vez de valores em reais ou em anos, os valores passam a representar desvios padrão em torno de zero.\n\n**A regra vale pra qualquer scaler: ajuste (fit) só com os dados de treino, e aplique (transform) essa mesma transformação no treino e no teste.** Nunca chame `fit` ou `fit_transform` usando o conjunto de teste, nem o dataset inteiro antes de dividir. A aula 5 deste módulo explica em detalhe por que isso é tão importante."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.preprocessing import StandardScaler\nfrom sklearn.model_selection import train_test_split\nimport pandas as pd\n\ndf = pd.DataFrame({\n    'idade': [22, 35, 45, 60, 28, 51],\n    'renda_mensal': [2200, 5400, 8900, 12000, 3100, 9500]\n})\n\nX_treino, X_teste = train_test_split(df, test_size=0.33, random_state=42)\n\nscaler = StandardScaler()\nscaler.fit(X_treino)  # calcula média e desvio padrão só com o treino\n\nX_treino_escalado = scaler.transform(X_treino)\nX_teste_escalado = scaler.transform(X_teste)\n\nprint(X_treino_escalado.mean(axis=0))\n# [0. 0.]\nprint(X_treino_escalado.std(axis=0))\n# [1. 1.]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## MinMaxScaler: comprimindo pra um intervalo fixo\n\nOutra forma comum de escalar é o MinMaxScaler, que comprime os valores pra um intervalo fixo, geralmente entre 0 e 1. A fórmula: cada valor menos o mínimo, dividido pela diferença entre o máximo e o mínimo da variável. O menor valor vira 0, o maior vira 1, e todo o resto fica proporcional entre eles.\n\nA diferença prática entre os dois: o StandardScaler é a escolha mais comum por padrão, e lida razoavelmente bem com a maioria dos casos. Já o MinMaxScaler é mais sensível a outliers, porque um único valor extremo define o mínimo ou o máximo, e comprime todos os outros valores pra perto do outro extremo. Ele costuma ser preferido quando você precisa mesmo de valores dentro de um intervalo limitado, como em algumas redes neurais."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.preprocessing import MinMaxScaler\n\nscaler_mm = MinMaxScaler()\nscaler_mm.fit(X_treino)  # calcula mínimo e máximo só com o treino\n\nX_treino_normalizado = scaler_mm.transform(X_treino)\nX_teste_normalizado = scaler_mm.transform(X_teste)\n\nprint(X_treino_normalizado.min(axis=0))\n# [0. 0.]\nprint(X_treino_normalizado.max(axis=0))\n# [1. 1.]\n\nprint(X_teste_normalizado.min(axis=0))\n# valores do teste podem ficar abaixo de 0 ou acima de 1 se algum\n# cliente do teste tiver idade ou renda fora do intervalo visto no\n# treino, e isso é esperado: o intervalo [0, 1] só vale pro treino"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Situação\", \"Sensível à escala?\", \"O que fazer\"], [\"k-NN (distância entre pontos)\", \"Sim, bastante\", \"Escalar sempre, com StandardScaler ou MinMaxScaler\"], [\"Regressão logística com regularização\", \"Sim\", \"Escalar antes de treinar, senão a penalização pesa errado\"], [\"Regressão linear simples, sem regularização\", \"Pouco\", \"Escalar ajuda a interpretar coeficientes, mas não é obrigatório\"], [\"Árvore de decisão e Random Forest\", \"Não\", \"Escalar não muda o resultado, os cortes são por variável isolada\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Escalar uma variável não muda a informação que ela carrega, só a régua usada pra medir. Mas pra algoritmos que calculam distância, essa régua faz toda a diferença."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Por que o k-NN é sensível à escala das variáveis?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Porque ele calcula distância entre pontos, e valores maiores acabam dominando essa distância.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque ele só aceita valores entre 0 e 1 como entrada, do mesmo jeito que uma probabilidade.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque ele treina visivelmente mais devagar quando as variáveis estão em escalas diferentes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque ele exige que todas as variáveis sigam uma distribuição normal pra funcionar direito.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual a diferença principal entre StandardScaler e MinMaxScaler?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "StandardScaler centra os dados em média 0 e desvio 1; MinMaxScaler comprime pra um intervalo fixo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "StandardScaler funciona só com variáveis categóricas; MinMaxScaler só com variáveis numéricas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "StandardScaler remove outliers automaticamente; MinMaxScaler mantém todos os valores originais.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "StandardScaler precisa do dataset dividido antes; MinMaxScaler pode ser usado no dataset inteiro.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Você ajustou o StandardScaler usando o dataset inteiro, antes de dividir em treino e teste. Qual o problema mais direto disso?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "A média e o desvio usados pra escalar já enxergaram o teste, e a avaliação deixa de ser isenta.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O modelo treinado passa a demorar visivelmente mais tempo pra convergir durante o treinamento.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O StandardScaler lança um erro de execução quando é ajustado antes do train_test_split.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os dados de treino e de teste ficam com um número diferente de colunas depois da transformação.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um dataset de salários tem um outlier grande, um diretor ganhando muito mais que o resto do time. Qual scaler tende a ser mais afetado por esse outlier?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "MinMaxScaler, porque o outlier vira o máximo e comprime o resto pra perto de zero.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "StandardScaler, porque a média sobe tanto que todos os outros valores somem da escala.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Nenhum dos dois, porque scalers lineares não são sensíveis a outliers de forma nenhuma.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ambos são afetados de forma idêntica, já que os dois usam exatamente a mesma fórmula.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um cientista de dados não escala as variáveis antes de treinar um Random Forest, mas escala antes de treinar uma regressão logística regularizada. Essa escolha faz sentido?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Sim, árvores dividem por variável isolada e não usam distância, e a regularização é sensível à escala.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Não, todo algoritmo de machine learning exige as variáveis na mesma escala pra funcionar direito.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não, escalar sempre muda o resultado final de qualquer modelo, então a escolha deveria ser igual.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Sim, mas só porque Random Forest treina mais rápido, sem relação nenhuma com escala.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Codificar categóricas: one-hot encoding",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Modelos só entendem números\n\nOs exemplos até aqui usaram variáveis numéricas: idade, renda, área. Mas boa parte dos dados do mundo real vem em categorias: cidade, cor do produto, tipo de plano, nível de escolaridade. Nenhum algoritmo do scikit-learn sabe calcular distância ou multiplicar coeficiente pela palavra \"São Paulo\". Antes de treinar, toda variável categórica precisa virar número.\n\nA tentação mais simples é trocar cada categoria por um número sequencial: São Paulo = 0, Rio de Janeiro = 1, Belo Horizonte = 2. O problema é que isso cria uma relação de ordem e de distância que não existe de verdade: o modelo pode aprender que \"Belo Horizonte é o dobro de São Paulo\", o que não faz sentido nenhum pra uma variável sem ordem natural entre as categorias.\n\n## Categorias nominais e ordinais pedem tratamento diferente\n\nCategorias nominais não têm ordem entre si: cidade, cor, forma de pagamento. Pra essas, a codificação correta é o one-hot encoding: cada categoria vira uma coluna binária própria (0 ou 1), sem sugerir ordem nenhuma entre elas. Já categorias ordinais têm uma ordem natural: nível de escolaridade, nota de satisfação, tamanho de roupa (P, M, G). Pra essas, um mapeamento numérico que preserve a ordem costuma fazer mais sentido do que criar uma coluna pra cada valor."
+                    },
+                    {
+                        "type": "code",
+                        "value": "import pandas as pd\n\ndf = pd.DataFrame({\n    'escolaridade': ['Médio', 'Fundamental', 'Superior', 'Médio']\n})\n\nmapa_ordem = {'Fundamental': 0, 'Médio': 1, 'Superior': 2}\ndf['escolaridade_num'] = df['escolaridade'].map(mapa_ordem)\n\nprint(df)\n#   escolaridade  escolaridade_num\n# 0        Médio                 1\n# 1  Fundamental                 0\n# 2     Superior                 2\n# 3        Médio                 1"
+                    },
+                    {
+                        "type": "code",
+                        "value": "df_cidade = pd.DataFrame({\n    'cidade': ['São Paulo', 'Rio de Janeiro', 'São Paulo', 'Belo Horizonte']\n})\n\ndf_codificado = pd.get_dummies(df_cidade, columns=['cidade'])\nprint(df_codificado)\n#    cidade_Belo Horizonte  cidade_Rio de Janeiro  cidade_São Paulo\n# 0                   False                  False               True\n# 1                   False                   True              False\n# 2                   False                  False               True\n# 3                    True                  False              False"
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.preprocessing import OneHotEncoder\n\ncidade_treino = pd.DataFrame({'cidade': ['São Paulo', 'Rio de Janeiro', 'São Paulo']})\ncidade_teste = pd.DataFrame({'cidade': ['Belo Horizonte', 'São Paulo']})\n\nencoder = OneHotEncoder(handle_unknown='ignore', sparse_output=False)\nencoder.fit(cidade_treino)  # só aprende as categorias do treino\n\nprint(encoder.get_feature_names_out())\n# ['cidade_Rio de Janeiro' 'cidade_São Paulo']\n\nprint(encoder.transform(cidade_teste))\n# [[0. 0.]\n#  [0. 1.]]\n# \"Belo Horizonte\" não existia no treino: com handle_unknown='ignore',\n# a linha fica zerada nessa categoria, em vez de gerar erro"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Tipo de variável\", \"Exemplo\", \"Como codificar\"], [\"Nominal, sem ordem entre categorias\", \"Cidade, cor, forma de pagamento\", \"One-hot encoding, com get_dummies ou OneHotEncoder\"], [\"Ordinal, com ordem natural\", \"Escolaridade, satisfação, tamanho P/M/G\", \"Mapeamento numérico que preserva a ordem entre as categorias\"], [\"Alta cardinalidade, muitas categorias únicas\", \"CEP, ID de produto, nome de usuário\", \"Agrupar categorias raras antes, ou repensar se a coluna deve entrar assim\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Cuidado com a explosão de colunas\n\nQuando uma variável categórica tem muitos valores únicos (CEP, ID de produto, nome de usuário), o one-hot encoding cria uma coluna pra cada categoria, e o dataset pode ganhar milhares de colunas esparsas (quase todas com zero). Isso encarece o treinamento e pode até prejudicar o desempenho do modelo, em vez de ajudar. Antes de aplicar one-hot direto numa variável assim, vale considerar agrupar as categorias raras numa classe \"outros\" ou repensar se aquela coluna, do jeito que está, deveria mesmo entrar no modelo.\n\nUma variação comum é usar `get_dummies(df, columns=[...], drop_first=True)`, que descarta a primeira coluna de cada variável codificada. Como as colunas restantes já deixam essa categoria implícita (todas as outras zeradas), isso evita redundância sem perder informação."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Categoria sem ordem vira coluna binária, categoria com ordem vira número que respeita essa ordem. Confundir os dois ensina ao modelo uma matemática que não existe nos dados."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Por que é preciso codificar variáveis categóricas antes de treinar a maioria dos modelos do scikit-learn?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Porque os algoritmos fazem operações matemáticas com os dados e não processam texto diretamente.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o Python não permite guardar texto dentro de um array do numpy em nenhuma hipótese.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque codificar categorias deixa o treinamento do modelo mais rápido em qualquer situação.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque só modelos de classificação aceitam variáveis numéricas, os de regressão aceitam texto.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual o problema de simplesmente trocar cada cidade por um número sequencial (São Paulo=0, Rio=1, Salvador=2) numa variável nominal?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O modelo passa a enxergar ordem e distância entre categorias que não existe de verdade.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Nenhum, contanto que o número máximo seja menor que a quantidade de linhas do dataset.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O modelo demora mais pra treinar porque precisa converter os números de volta pra texto.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O scikit-learn recusa treinar o modelo quando encontra números atribuídos a categorias.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Quando faz mais sentido usar um mapeamento numérico simples (Fundamental=0, Médio=1, Superior=2) em vez de one-hot encoding?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Quando a categoria é ordinal, ou seja, quando existe uma ordem natural entre os valores.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Quando a variável tem muitas categorias diferentes e o dataset é relativamente pequeno.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Quando o modelo escolhido é uma árvore de decisão, porque árvores não aceitam one-hot.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Quando o objetivo do projeto é regressão, porque classificação não aceita mapeamento numérico.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Você usa OneHotEncoder, ajusta com o treino e transforma treino e teste. No teste aparece uma categoria de cidade que não existia no treino. O que acontece com handle_unknown='ignore'?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "As colunas dessa categoria nova ficam todas com zero, sem gerar erro no processamento.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O encoder cria automaticamente uma nova coluna pra representar essa categoria inédita.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O scikit-learn lança um erro e interrompe a execução, porque a categoria não existia no treino.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A linha inteira é removida do conjunto de teste antes de calcular qualquer métrica do modelo.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma variável de CEP tem 8000 valores únicos num dataset de 10000 linhas. Qual a consequência mais provável de aplicar one-hot direto nela, sem tratamento?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O dataset ganha milhares de colunas esparsas, o que aumenta muito a dimensionalidade do problema.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Nenhuma, one-hot encoding sempre gera o mesmo número de colunas, independente da cardinalidade.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O modelo passa a tratar o CEP automaticamente como uma variável ordinal, com ordem geográfica.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O pandas converte a coluna de CEP direto pra tipo numérico, sem criar nenhuma coluna nova.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Dados faltantes e imputação",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Dados faltantes não desaparecem sozinhos\n\nNa trilha de Análise de Dados você aprendeu a identificar valores faltantes com `isna()` e a lidar com eles usando `dropna()` ou `fillna()`. Agora, no contexto de treinar um modelo, essa decisão fica ainda mais importante: a maioria dos algoritmos do scikit-learn simplesmente não aceita `NaN` como entrada e lança um erro na hora do `fit`. Ignorar o problema não é opção, ele trava o treinamento antes mesmo de começar."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Duas saídas possíveis: remover ou imputar\n\nA primeira saída é remover: descartar linhas (ou colunas) que têm valores faltantes, com `dropna()`. É simples, mas tem custo: se os valores faltantes forem comuns, você perde muitos dados, e se a falta não for aleatória (por exemplo, clientes com renda mais baixa tendem a não informar a renda), remover introduz um viés no dataset que sobra.\n\nA segunda saída é imputar: preencher o valor faltante com uma estimativa calculada a partir dos dados que você tem (média, mediana, valor mais frequente, ou um valor fixo). Isso preserva a linha inteira, mas troca um buraco por uma suposição: o valor imputado não é o valor real que faltou, é a melhor estimativa possível dado o resto dos dados."
+                    },
+                    {
+                        "type": "code",
+                        "value": "import numpy as np\nimport pandas as pd\nfrom sklearn.impute import SimpleImputer\n\nX_treino = pd.DataFrame({\n    'idade': [25, np.nan, 40, 35],\n    'renda': [3000, 4500, np.nan, 5200]\n})\nX_teste = pd.DataFrame({\n    'idade': [np.nan, 50],\n    'renda': [2800, 6100]\n})\n\nimputer = SimpleImputer(strategy='median')\nimputer.fit(X_treino)  # calcula a mediana só com o treino\n\nX_treino_imputado = imputer.transform(X_treino)\nX_teste_imputado = imputer.transform(X_teste)\n\nprint(X_treino_imputado)\n# idade: mediana do treino (ignorando o NaN) é 35.0\n# renda: mediana do treino (ignorando o NaN) é 4500.0\n# [[  25.  3000.]\n#  [  35.  4500.]\n#  [  40.  4500.]\n#  [  35.  5200.]]\n\nprint(X_teste_imputado)\n# [[  35.  2800.]\n#  [  50.  6100.]]\n# o 35.0 usado aqui é a mediana calculada no treino, não uma\n# mediana recalculada com os dados de teste"
+                    },
+                    {
+                        "type": "code",
+                        "value": "categorias = pd.DataFrame({\n    'plano': ['básico', np.nan, 'premium', 'básico', np.nan]\n})\n\nimputer_cat = SimpleImputer(strategy='most_frequent')\ncategorias_imputadas = imputer_cat.fit_transform(categorias)\n\nprint(categorias_imputadas)\n# [['básico']\n#  ['básico']\n#  ['premium']\n#  ['básico']\n#  ['básico']]\n# a categoria mais frequente ('básico') preencheu os NaN\n# (aqui fit_transform foi usado só pra ilustrar a mecânica num\n# dataset único; no fluxo real, o fit é sempre feito com o treino)"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Estratégia\", \"Quando usar\", \"Risco\"], [\"Remover a linha (dropna)\", \"Poucos valores faltantes, e de forma aleatória\", \"Perde dados, e pode enviesar se a falta não for aleatória\"], [\"Imputar com a média\", \"Variável numérica sem outliers fortes\", \"Outliers puxam a média pra longe do valor típico da variável\"], [\"Imputar com a mediana\", \"Variável numérica com outliers ou assimetria\", \"Ainda é uma estimativa, não recupera o valor real perdido\"], [\"Imputar com o mais frequente\", \"Variável categórica\", \"Pode reforçar demais a categoria que já era dominante\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O efeito no modelo e o cuidado de sempre\n\nImputar não é uma operação neutra. Preencher todos os valores faltantes de idade com a mesma média reduz a variância real da variável, e se muitos valores faltarem, o modelo passa a enxergar uma quantidade artificial de gente exatamente \"na média\". Em datasets onde a própria ausência do dado carrega informação (como no exemplo da renda), imputar sem pensar nisso pode até esconder um padrão que seria útil pro modelo aprender.\n\nE, como já apareceu nas aulas anteriores: o imputer também segue a regra de ajustar só com o treino. Calcular a média ou a mediana olhando também o conjunto de teste faz essa estatística \"vazar\" informação que o modelo não deveria ter na hora de ser avaliado."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Preencher um valor faltante é fazer uma aposta educada, não recuperar o dado verdadeiro. Escolha a estratégia sabendo o que ela assume, e calcule sempre a partir do treino."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que geralmente acontece se você tenta treinar um modelo do scikit-learn com uma coluna que tem valores NaN?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "A maioria dos algoritmos lança um erro e não consegue completar o treinamento do modelo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O modelo ignora automaticamente as linhas com NaN e treina normalmente com o restante.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O scikit-learn substitui o NaN pela média da coluna de forma automática, sem avisar.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O modelo trata o NaN como se fosse zero, sem gerar nenhum tipo de erro no processo.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que imputar com a mediana costuma ser mais seguro que imputar com a média quando a variável tem outliers fortes?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "A mediana não é puxada pelos valores extremos, enquanto a média é bem sensível a eles.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A mediana sempre resulta num número inteiro, o que facilita o treinamento do modelo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A média só pode ser calculada em variáveis categóricas, nunca em variáveis numéricas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A mediana recalcula sozinha o valor certo, ignorando qualquer forma de outlier presente.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual o principal risco de simplesmente remover, com dropna, todas as linhas que têm algum valor faltante?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Se a falta não for aleatória, remover pode enviesar o dataset que sobra pra treinar o modelo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Nenhum, remover linhas com NaN nunca afeta a distribuição das variáveis que restaram.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O modelo passa a exigir mais poder computacional pra treinar com um número menor de linhas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O scikit-learn passa a rejeitar o dataset por ele ficar com um número ímpar de linhas.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um dataset de crédito tem a coluna renda com 40% de valores faltantes, e quem não informa a renda tende a ganhar menos. Qual abordagem de imputação tende a distorcer mais o modelo?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Preencher com a média, porque ela ignora que a ausência está ligada ao próprio valor da renda.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Preencher com a mediana, porque ela é sempre igual ao valor mais alto de toda a distribuição.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Remover a coluna inteira, porque isso preserva perfeitamente o padrão original dos dados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Preencher com zero, porque zero está sempre dentro do intervalo esperado pra renda mensal.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O SimpleImputer foi ajustado usando o dataset inteiro, antes da divisão entre treino e teste. Qual o problema mais direto dessa escolha?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "A média ou mediana usada pra imputar já incorpora o teste, o que compromete a avaliação honesta.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Nenhum, imputação é uma etapa neutra que não interfere na avaliação do modelo depois do treino.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O SimpleImputer não funciona se for ajustado antes do train_test_split, e o código quebra.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O modelo passa a treinar mais rápido, já que os dados chegam completos antes da divisão.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Vazamento de dados e Pipeline",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## O que é vazamento de dados (data leakage)\n\nAo longo deste módulo, uma regra apareceu em toda aula: escale, codifique e impute usando só o conjunto de treino, depois aplique essa mesma transformação no teste. Chegou a hora de nomear por que essa regra existe, e ela não é surpresa nova: é uma extensão direta daquele cuidado do módulo 2 de nunca avaliar o modelo com um dado que ele, ou qualquer etapa antes dele, já viu de alguma forma. Quando alguma informação do conjunto de teste (ou do futuro, em dados organizados no tempo) influencia o treinamento, isso se chama vazamento de dados, ou data leakage.\n\nÉ um dos erros mais comuns e mais silenciosos em projetos de ML: o código roda sem nenhum erro, as métricas costumam sair ótimas, e o modelo parece muito bom. Só que essa avaliação está mentindo. Na prática, com dados novos que o modelo nunca viu, o desempenho real costuma despencar.\n\n## Como o vazamento acontece na prática\n\nO caso mais comum é exatamente o que as aulas anteriores vinham evitando: calcular média, desvio padrão, mínimo, máximo ou categoria mais frequente usando o dataset inteiro, antes de separar treino e teste. Quando isso acontece, a estatística usada pra transformar os dados já \"viu\" uma amostra do conjunto de teste, e o teste deixa de simular dados realmente novos."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# X (features) e y (alvo) já preparados, como nos módulos anteriores\n\n# ERRADO: ajusta o scaler com o dataset inteiro, antes do split\nfrom sklearn.preprocessing import StandardScaler\nfrom sklearn.model_selection import train_test_split\nfrom sklearn.linear_model import LogisticRegression\n\nscaler = StandardScaler()\nX_escalado = scaler.fit_transform(X)  # viu treino E teste juntos aqui\n\nX_treino, X_teste, y_treino, y_teste = train_test_split(\n    X_escalado, y, test_size=0.2, random_state=42\n)\n\nmodelo = LogisticRegression()\nmodelo.fit(X_treino, y_treino)\nprint(modelo.score(X_teste, y_teste))\n# a métrica aqui pode parecer ótima, mas está inflada: o scaler\n# usou estatísticas calculadas com o próprio conjunto de teste"
+                    },
+                    {
+                        "type": "code",
+                        "value": "# CERTO: divide primeiro, ajusta o scaler só com o treino\nfrom sklearn.preprocessing import StandardScaler\nfrom sklearn.model_selection import train_test_split\nfrom sklearn.linear_model import LogisticRegression\n\nX_treino, X_teste, y_treino, y_teste = train_test_split(\n    X, y, test_size=0.2, random_state=42\n)\n\nscaler = StandardScaler()\nscaler.fit(X_treino)  # fit só com o treino\n\nX_treino_escalado = scaler.transform(X_treino)\nX_teste_escalado = scaler.transform(X_teste)  # só transform, nunca fit\n\nmodelo = LogisticRegression()\nmodelo.fit(X_treino_escalado, y_treino)\nprint(modelo.score(X_teste_escalado, y_teste))\n# agora a métrica reflete o desempenho num dado que o preparo\n# nunca tinha visto antes, do jeito que a avaliação deveria ser"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Pipeline: encadeando preparo e modelo sem vazar\n\nSeguir a ordem certa manualmente funciona, mas cria espaço pra erro: é fácil esquecer, num projeto grande, o que o scaler já viu ou não. O scikit-learn resolve isso com o `Pipeline`: um objeto que encadeia etapas de preparo (scaler, imputer, encoder) e o modelo final numa sequência única. Quando você chama `fit` no pipeline inteiro, cada etapa de preparo ajusta e transforma só com os dados que chegam até ela naquele momento; como o pipeline inteiro só recebe o treino durante o fit, não tem como vazar.\n\nO Pipeline também é essencial quando você usa validação cruzada, aquela técnica vista em detalhe no módulo 5: sem pipeline, é fácil escalar os dados uma vez só e rodar a validação cruzada em cima do resultado já escalado, o que vaza dado de cada fold de teste pros folds de treino vizinhos. Com o Pipeline dentro do `cross_val_score`, cada fold refaz o fit do zero, só com os dados de treino daquele fold."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.pipeline import Pipeline\nfrom sklearn.preprocessing import StandardScaler\nfrom sklearn.linear_model import LogisticRegression\nfrom sklearn.model_selection import train_test_split, cross_val_score\n\nX_treino, X_teste, y_treino, y_teste = train_test_split(\n    X, y, test_size=0.2, random_state=42\n)\n\npipeline = Pipeline([\n    ('scaler', StandardScaler()),\n    ('modelo', LogisticRegression())\n])\n\npipeline.fit(X_treino, y_treino)\nprint(pipeline.score(X_teste, y_teste))\n# 0.91\n\n# validação cruzada usando o pipeline inteiro: cada fold ajusta\n# o scaler do zero, só com os dados de treino daquele fold\nscores = cross_val_score(pipeline, X_treino, y_treino, cv=5)\nprint(scores)\n# [0.89 0.92 0.9  0.88 0.91]"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Etapa\", \"Certo\", \"Errado\"], [\"Escalar variáveis\", \"scaler.fit(X_treino), depois transform no treino e no teste\", \"scaler.fit_transform(X) no dataset inteiro, antes do split\"], [\"Imputar faltantes\", \"imputer.fit(X_treino), depois transform nos dois conjuntos\", \"imputer.fit(X) usando todas as linhas, incluindo o teste\"], [\"Codificar categorias\", \"encoder.fit(X_treino), depois transform no treino e no teste\", \"get_dummies aplicado no dataset inteiro, antes de dividir\"], [\"Validação cruzada com preparo\", \"Pipeline inteiro dentro do cross_val_score\", \"Escalar uma vez só e rodar cross_val_score em cima do resultado escalado\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Uma métrica calculada com dado que vazou do teste não mede o modelo, mede a mentira que você contou pra si mesmo. O Pipeline existe pra essa mentira não acontecer por descuido."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que é vazamento de dados (data leakage) num projeto de machine learning?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Quando informação do teste, ou de dados futuros, acaba influenciando o treino e infla a avaliação.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Quando o modelo perde acurácia porque foi treinado com poucos exemplos no conjunto de treino.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Quando uma coluna do dataset tem muitos valores faltantes e o modelo não consegue processá-la.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Quando o conjunto de treino e o conjunto de teste têm exatamente o mesmo número de linhas.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual é o problema de rodar scaler.fit_transform() no dataset inteiro, antes de fazer o train_test_split?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "A média e o desvio usados pra escalar já incorporam o teste, e a avaliação deixa de ser isenta.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O StandardScaler não aceita ser usado antes do train_test_split e gera um erro de execução.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os dados de treino ficam com uma escala diferente dos dados de teste depois da divisão.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O modelo demora muito mais tempo pra treinar quando o scaler é ajustado antes da divisão.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual a principal vantagem de usar Pipeline em vez de aplicar scaler, encoder e modelo em etapas manuais separadas?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Reduz o risco de esquecer a ordem certa e de vazar dado de teste, sobretudo na validação cruzada.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O Pipeline sempre entrega uma acurácia mais alta do que fazer os mesmos passos manualmente.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Pipeline permite treinar o modelo sem precisar dividir os dados em treino e em teste.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Pipeline escolhe sozinho qual algoritmo de machine learning é o mais adequado pro problema.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma cientista de dados escalou o dataset inteiro uma única vez, e só depois rodou cross_val_score com 5 folds em cima dos dados já escalados. O que está errado nisso?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Cada fold de teste foi indiretamente usado pra calcular a escala aplicada nos folds de treino.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Nada está errado, escalar antes da validação cruzada é a forma recomendada de usar cross_val_score.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O cross_val_score não aceita dados que já foram escalados antes, e vai lançar um erro na execução.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os 5 folds vão treinar modelos idênticos entre si, tornando a validação cruzada inútil nesse caso.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um modelo teve acurácia de 98% no teste durante o desenvolvimento, mas caiu pra 70% em produção. O pipeline de preparo tinha sido ajustado no dataset inteiro, antes do split. Qual a explicação mais provável?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Houve vazamento de dados: a avaliação no teste já estava inflada pelo preparo ajustado com ele.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O modelo em produção está recebendo dados de uma distribuição bem diferente da usada no treino.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O algoritmo escolhido não é adequado pra esse tipo de problema e precisa ser trocado por outro.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A infraestrutura de produção está rodando uma versão do scikit-learn diferente da usada em dev.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 7 - Aprendizado não-supervisionado e o próximo passo",
+        "aulas": [
+            {
+                "titulo": "Aprender sem rótulos",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Módulo 7 - Aprendizado não-supervisionado e o próximo passo\n\nDos módulos 3 a 6 desta trilha, todo modelo que você treinou tinha uma coluna alvo: o preço do imóvel, se o cliente cancelou o plano, se o e-mail era spam. Você sempre teve, de antemão, a resposta certa de cada exemplo do treino, e o modelo aprendia a imitar essa resposta em dados novos.\n\nMas nem todo problema com dados vem com uma coluna de resposta pronta. Às vezes você só tem a tabela: idade, renda, histórico de compra, sem nenhuma pista de qual é a \"resposta certa\" pra cada linha. Esse é o território deste último módulo da trilha: o aprendizado não-supervisionado."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Supervisionado x não-supervisionado, agora com mais profundidade\n\nRelembrando o Módulo 1: no aprendizado **supervisionado**, cada exemplo de treino vem com um rótulo (o alvo, ou `y`), e o objetivo é aprender uma função que prevê esse rótulo em exemplos novos. Foi o que você fez em regressão (prever um número) e em classificação (prever uma categoria).\n\nNo aprendizado **não-supervisionado**, os dados de treino não têm rótulo nenhum: só existem as features (o `X`), sem nenhum `y` correspondente. O objetivo muda por completo. Em vez de prever um valor já conhecido, o algoritmo busca descobrir uma estrutura escondida nos dados, como grupos de exemplos parecidos entre si ou combinações de variáveis que resumem a informação da base inteira."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Aspecto\", \"Supervisionado\", \"Não-supervisionado\"], [\"Tem rótulo (y) no treino?\", \"Sim, cada exemplo já vem com a resposta certa\", \"Não, só existem as features (X)\"], [\"Objetivo do modelo\", \"Prever um valor ou uma categoria conhecidos\", \"Descobrir estrutura, como grupos ou padrões\"], [\"Exemplos de algoritmo\", \"Regressão linear, regressão logística, k-NN, árvore\", \"K-means, PCA\"], [\"Como o resultado é avaliado\", \"Compara a previsão com o rótulo real (MAE, F1...)\", \"Não há rótulo pra comparar; a avaliação é indireta\"], [\"Pergunta típica\", \"Esse cliente vai cancelar o plano?\", \"Existem grupos naturais de clientes nesta base?\"]]"
+                    },
+                    {
+                        "type": "code",
+                        "value": "import pandas as pd\n\n# a mesma ideia de tabela de clientes de uma classificação,\n# só que sem a coluna alvo (\"cancelou\") que existiria lá\nclientes = pd.DataFrame({\n    \"idade\": [23, 45, 31, 52, 28, 40],\n    \"renda_mensal\": [2000, 9200, 4100, 11000, 3000, 8700],\n    \"tempo_de_casa_meses\": [3, 40, 12, 55, 6, 38],\n})\n\nprint(clientes.head(3))\n#    idade  renda_mensal  tempo_de_casa_meses\n# 0     23          2000                     3\n# 1     45          9200                    40\n# 2     31          4100                    12\n\n# repare: não existe coluna \"cancelou\" nem \"categoria\" aqui\n# o objetivo não é prever algo que já existe, é descobrir uma estrutura nova"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Por que isso importa\n\nEsse tipo de pergunta aparece o tempo todo fora da sala de aula. Um time de marketing quer saber se existem \"tipos\" de cliente na base, sem que ninguém tenha definido esses tipos antes. Um time de operações quer saber se alguma transação foge muito do padrão das demais. Um cientista de dados, ao receber uma base nova, quer entender rapidamente se ela tem estrutura antes mesmo de decidir o que fazer com ela.\n\nEm nenhum desses casos existe uma coluna pronta com a resposta certa. É aí que o não-supervisionado entra, e é o assunto das próximas aulas: primeiro agrupando exemplos parecidos (clustering), depois simplificando muitas colunas em poucas (redução de dimensionalidade)."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Aprendizado não-supervisionado não prevê uma resposta que já existe em algum lugar: ele procura uma estrutura que ninguém tinha nomeado ainda."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que diferencia um problema de aprendizado supervisionado de um não-supervisionado?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Se os exemplos de treino têm ou não um rótulo (y) conhecido",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O número mínimo de linhas exigido na base de dados usada",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O tipo de linguagem de programação usada no projeto",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A quantidade de colunas numéricas presentes na tabela",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe tem uma tabela de clientes com idade, renda e histórico de compra, sem nenhuma coluna que diga o que fazer com cada cliente. A equipe quer descobrir se existem grupos naturais parecidos entre si. Que tipo de problema é esse?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Não-supervisionado, já que não existe rótulo pra guiar o aprendizado",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Supervisionado, porque a base tem mais de uma coluna numérica",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "De regressão, já que renda e idade são variáveis contínuas",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Impossível de resolver sem antes rotular manualmente cada cliente",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que a ideia de \"acertar\" ou \"errar\" muda no aprendizado não-supervisionado, comparado ao supervisionado?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque não existe rótulo verdadeiro pra comparar com o resultado do modelo",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o não-supervisionado nunca erra, já que não faz previsão nenhuma",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque nele não se usa nenhum dado numérico, só colunas de texto",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o scikit-learn não calcula métrica nenhuma pra esses algoritmos",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma loja quer prever se um cliente vai cancelar a assinatura no próximo mês, usando o histórico de quem já cancelou ou não no passado. Esse é um problema de que tipo?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Supervisionado, pois existe rótulo passado (cancelou ou não) pra treinar o modelo",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Não-supervisionado, pois o objetivo é descobrir um grupo de clientes parecidos",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não-supervisionado, pois a loja ainda não sabe o resultado do próximo mês",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Supervisionado, mas só pode ser resolvido com k-means e nenhum outro algoritmo",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual afirmação sobre aprendizado não-supervisionado é verdadeira?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Ele pode revelar estruturas inesperadas, mas cabe a alguém interpretar o achado",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Ele sempre encontra o mesmo número de grupos, independente dos dados usados",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ele dispensa qualquer decisão humana depois que o algoritmo termina de rodar",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ele supera modelos supervisionados em previsão sempre que aplicado ao mesmo problema",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Clustering com k-means",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Agrupar por parecença\n\nClustering é a tarefa de separar um conjunto de dados em grupos (os *clusters*), de forma que exemplos dentro do mesmo grupo sejam parecidos entre si, e exemplos de grupos diferentes sejam bem diferentes. Ninguém diz ao algoritmo, de antemão, quais são os grupos certos: ele descobre isso sozinho, olhando só pra semelhança entre os exemplos.\n\nO **k-means** é o algoritmo de clustering mais usado como porta de entrada. O nome já entrega a ideia: `k` é o número de grupos que você quer encontrar, e `means` (médias) é como cada grupo é representado."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Como o k-means funciona\n\nO algoritmo segue um processo simples e repetitivo:\n\n1. Você escolhe `k`, o número de clusters que quer encontrar.\n2. O algoritmo espalha `k` pontos iniciais pelos dados, chamados **centroides** (um por cluster).\n3. Cada exemplo da base é atribuído ao centroide mais próximo dele (por distância).\n4. Cada centroide se move pra posição média de todos os exemplos que foram atribuídos a ele.\n5. Os passos 3 e 4 se repetem até os centroides pararem de se mover de forma relevante (o algoritmo convergiu).\n\nUm centroide não é, necessariamente, um exemplo real da base: ele é um ponto matemático, a média das posições do grupo."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Escolher k: o método do cotovelo\n\nO k-means não decide sozinho quantos grupos existem: você informa `k` antes de rodar. Escolher um `k` ruim gera grupos artificiais (muito pequenos ou sem sentido) ou grupos grandes demais, que misturam exemplos diferentes.\n\nUma forma comum de escolher `k` é o **método do cotovelo**. A ideia: rodar o k-means várias vezes, com `k` = 1, 2, 3, 4 e assim por diante, e medir a **inércia** de cada rodada (a soma das distâncias ao quadrado de cada ponto até o centroide do seu cluster; quanto menor, mais compactos os grupos). Se você desenhasse um gráfico com `k` no eixo horizontal e a inércia no eixo vertical, veria uma curva caindo: ela cai rápido no início e depois desacelera, quase achatando numa linha reta. O ponto onde a queda desacelera bruscamente é o \"cotovelo\", e costuma ser um bom candidato pra `k`. Não é uma resposta matematicamente exata, é uma pista visual, e o conhecimento do problema (\"faz sentido ter 3 segmentos de cliente ou 8?\") ajuda a decidir junto."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.cluster import KMeans\nfrom sklearn.preprocessing import StandardScaler\nimport pandas as pd\n\nclientes = pd.DataFrame({\n    \"renda_mensal\": [2000, 2200, 15000, 16500, 3000, 14000],\n    \"gasto_mensal\": [1800, 2000, 3000, 3200, 2600, 3100],\n})\n\n# k-means usa distância, então escalar antes é tão importante quanto foi para o k-NN\nX_escalado = StandardScaler().fit_transform(clientes)\n\nkmeans = KMeans(n_clusters=2, random_state=42, n_init=10)\nkmeans.fit(X_escalado)\n\nprint(kmeans.labels_)\n# algo como array([0, 0, 1, 1, 0, 1])\n# um grupo reúne quem tem renda e gasto mais baixos, o outro quem tem renda e gasto mais altos\n# (o número do grupo, 0 ou 1, é só um rótulo arbitrário, não indica ordem ou qualidade)\n\nprint(kmeans.cluster_centers_)\n# as coordenadas dos 2 centroides, no espaço já escalado"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Cuidados com o k-means\n\nAlguns pontos valem atenção antes de usar o k-means no dia a dia:\n\n- **Escala importa**: como ele usa distância entre pontos, uma variável em escala muito maior domina o cálculo se você não padronizar antes (o mesmo problema do k-NN, visto no Módulo 6).\n- **`k` é escolhido por você**: o algoritmo não decide o número de grupos sozinho, é um hiperparâmetro que você define.\n- **Inicialização importa**: os centroides iniciais são posicionados de forma aleatória, e uma inicialização ruim pode levar a um resultado pior. O parâmetro `n_init` roda o algoritmo várias vezes, com inícios diferentes, e fica com o melhor resultado.\n- **Grupos tendem a ficar arredondados**: o k-means funciona melhor quando os clusters têm formato mais ou menos esférico e tamanho parecido; formatos muito irregulares confundem o algoritmo."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "O k-means não sabe o que é um cliente bom ou uma transação suspeita: ele só sabe medir distância. O sentido de cada grupo quem dá é você."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "No k-means, o que é o centroide de um cluster?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "O ponto que representa a média das posições dos exemplos daquele grupo",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O primeiro exemplo da base que foi atribuído àquele grupo específico",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O exemplo mais distante de todos os outros grupos formados",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um dos exemplos originais escolhido como representante fixo do grupo",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "A cada iteração do k-means, como um exemplo é atribuído a um cluster?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "É atribuído ao cluster cujo centroide está mais próximo dele, por distância",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "É atribuído de forma aleatória, sorteado a cada nova iteração do algoritmo",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "É atribuído ao cluster que, até então, tem o menor número de exemplos",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "É atribuído por votação dos exemplos vizinhos mais próximos dele",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Assim como o k-NN, o k-means também exige atenção à escala das variáveis. Por quê?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque a distância usada para formar os grupos é dominada pela variável de maior magnitude",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o scikit-learn recusa a rodar o `fit` se as colunas tiverem escalas diferentes",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque, sem escalonar, o número de clusters `k` muda sozinho durante o treino",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque colunas em escalas diferentes não podem ficar juntas num mesmo DataFrame",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "No método do cotovelo, o que se espera observar na curva de inércia à medida que `k` aumenta?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "A inércia cai continuamente, mas a queda desacelera a partir de um certo ponto",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A inércia sobe de forma constante à medida que mais clusters são adicionados",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A inércia permanece igual, não importa quantos clusters sejam testados",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A inércia cai até `k` igual a 2 e depois volta a subir sempre daí em diante",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um analista roda o k-means com `k` igual a 3, já com os dados escalados, e os grupos formados ficam muito desiguais e sem sentido de negócio. O que essa observação sugere?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O valor de `k` escolhido pode não refletir a estrutura dos dados, vale testar outros",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O k-means nunca erra o número de grupos, o problema só pode estar nos dados brutos",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "É o comportamento esperado: o k-means sempre gera grupos de tamanhos bem diferentes",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O algoritmo deveria ser trocado direto por uma regressão linear nesse tipo de caso",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Redução de dimensionalidade com PCA",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Muitas colunas, um problema real\n\nAté aqui, os exemplos desta trilha usaram poucas features de propósito, pra facilitar a explicação. Mas uma base de dados real de ciência de dados costuma ter dezenas, às vezes centenas de colunas: dados de clientes, de sensores, de transações, de imagens.\n\nIsso traz três dores de cabeça. Primeiro, é impossível visualizar mais de 2 ou 3 dimensões num gráfico. Segundo, muitas dessas colunas costumam ser redundantes entre si (lembra da correlação, lá da trilha de Estatística?): renda e faixa de consumo, por exemplo, costumam andar juntas. Terceiro, muitas colunas deixam o treino mais lento e, em alguns modelos, mais barulhento. A pergunta natural é: dá pra comprimir várias colunas em poucas, sem perder o essencial da informação?"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## A intuição do PCA\n\nO **PCA** (Análise de Componentes Principais) responde exatamente essa pergunta. Ele cria um novo conjunto de eixos, chamados **componentes principais**, que são combinações das colunas originais. O primeiro componente é escolhido pra capturar a maior variação possível dos dados; o segundo captura a maior parte do que sobrou (sem repetir o que o primeiro já capturou); e assim por diante.\n\nUma boa analogia: imagine tentar fotografar um objeto em 3D com uma única foto 2D. Existe um ângulo que mostra bem a forma do objeto, e outro que mostra quase só um risco sem informação nenhuma. O PCA procura, matematicamente, o \"melhor ângulo\" pra representar os dados com menos dimensões, sem você precisar da matemática pesada por trás pra usar."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Pra que serve, na prática\n\nDois usos aparecem o tempo todo. O primeiro é **visualização**: reduzir uma base de muitas colunas pra 2 componentes, só pra poder plotar num gráfico e enxergar se existe alguma estrutura, algum agrupamento, algum ponto fora da curva. É comum, inclusive, usar PCA junto com k-means: rodar o clustering nas colunas originais (ou escaladas), e usar o PCA só depois, pra desenhar os clusters encontrados num gráfico 2D.\n\nO segundo uso é **simplificação**: reduzir o número de colunas antes de treinar um modelo, economizando tempo de treino e removendo parte do ruído. Vale um alerta: os componentes gerados são combinações das colunas originais, então perdem o significado direto de cada variável. Depois do PCA, fica mais difícil dizer \"esse componente é a renda do cliente\", porque ele geralmente é um pouco de várias colunas ao mesmo tempo."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.decomposition import PCA\nfrom sklearn.preprocessing import StandardScaler\nimport pandas as pd\n\ndados = pd.DataFrame({\n    \"idade\": [23, 45, 31, 52, 28, 40],\n    \"renda_mensal\": [2500, 9000, 4200, 11000, 3100, 8500],\n    \"anos_estudo\": [12, 18, 15, 20, 13, 17],\n    \"gasto_mensal\": [1900, 5200, 2800, 6100, 2200, 4900],\n})\n\nX_escalado = StandardScaler().fit_transform(dados)\n\npca = PCA(n_components=2)\nX_reduzido = pca.fit_transform(X_escalado)\n\nprint(X_reduzido.shape)\n# (6, 2) -> as 4 colunas originais viraram 2 componentes principais\n\nprint(pca.explained_variance_ratio_)\n# algo como [0.83, 0.11]\n# o 1º componente sozinho já explica cerca de 83% da variância dos dados originais\n# os 2 componentes juntos preservam perto de 94% da informação"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O preço da compressão\n\nO atributo `explained_variance_ratio_` mostra, pra cada componente, quanto da variância (informação) original ele preserva. Somando os valores dos componentes que você manteve, dá pra saber quanto da informação total sobrou depois da compressão.\n\nAqui vale a mesma honestidade de sempre: reduzir dimensões tem preço. Uma parte da variância sempre fica pra trás (a não ser que você mantenha todos os componentes originais, e aí não há compressão nenhuma). Antes de confiar num gráfico 2D gerado por PCA pra tirar conclusões, vale conferir quanto da variância original aqueles 2 componentes realmente preservam: 94% é uma boa representação, 40% já é bem mais arriscado de interpretar."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "PCA não escolhe as colunas mais importantes e descarta o resto: ele cria eixos novos, misturando as colunas originais, pra guardar o máximo de informação no menor número de dimensões possível."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual é o objetivo principal do PCA (Análise de Componentes Principais)?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Reduzir variáveis, combinando-as em componentes que preservam o máximo de informação",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Aumentar o número de variáveis disponíveis pra deixar o modelo ainda mais preciso",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Substituir os valores faltantes de uma coluna pela média dos demais valores válidos",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Escolher de forma totalmente automática qual algoritmo de classificação usar",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O que representa o primeiro componente principal gerado pelo PCA?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "A combinação das variáveis originais que captura a maior variância dos dados",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A variável original que tem a maior correlação com o alvo do problema",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A média simples de todas as variáveis originais, calculada linha a linha",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A variável original que tem o menor número de valores faltantes na base",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de padronizar os dados e aplicar PCA com 2 componentes numa base de 10 colunas, `explained_variance_ratio_` retorna algo como [0.55, 0.20]. O que isso indica?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Os 2 componentes preservam juntos cerca de 75% da variância dos dados originais",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O modelo treinado nessa base tem 75% de acurácia na tarefa de classificação",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "55% e 20% das linhas da base foram descartadas durante a redução de dimensões",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "As duas primeiras colunas originais, sozinhas, já explicam 75% dos dados",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de reduzir uma base de 20 para 2 dimensões com PCA e plotar os pontos, dá pra afirmar que dois pontos próximos no gráfico são parecidos em todas as 20 variáveis originais?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Não necessariamente: o PCA preserva a maior parte da variância, mas parte da informação se perde",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Sim, o PCA garante fidelidade total às variáveis originais sempre que os dados são padronizados",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Sim, porque o PCA apenas remove colunas redundantes e mantém as demais intactas",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não, porque o PCA embaralha de forma aleatória a ordem das linhas da base original",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma dupla de cientistas de dados quer visualizar, num gráfico 2D, se os clusters encontrados por um k-means com 15 variáveis fazem sentido. Qual caminho é mais adequado?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Rodar o k-means nas 15 variáveis escaladas e usar o PCA só depois, para plotar em 2 dimensões",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Aplicar o PCA primeiro pra reduzir a 1 variável e rodar o k-means só com essa variável",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Selecionar apenas duas das 15 colunas originais, escolhidas ao acaso, e ignorar as demais",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Desistir da visualização, já que não é possível representar mais de 2 variáveis num gráfico",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Quando usar não-supervisionado",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Três usos clássicos\n\nCom clustering e redução de dimensionalidade na caixa de ferramentas, vale mapear onde o aprendizado não-supervisionado costuma aparecer no trabalho real com dados:\n\n- **Segmentação**: dividir clientes, usuários ou produtos em grupos de comportamento parecido, sem que ninguém tenha definido esses grupos antes. É o uso mais comum de k-means no mercado.\n- **Detecção de anomalia**: encontrar exemplos muito diferentes do padrão geral, como uma transação fora do comum ou uma leitura de sensor fora da curva.\n- **Exploração**: quando você recebe uma base nova e ainda não sabe bem o que fazer com ela, técnicas não-supervisionadas ajudam a enxergar estrutura antes mesmo de decidir se um projeto supervisionado faz sentido."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Caso de uso\", \"O que se busca\", \"Técnica comum\"], [\"Segmentação de clientes\", \"Grupos com comportamento parecido\", \"K-means\"], [\"Detecção de anomalia\", \"Pontos muito distantes de qualquer grupo\", \"Clustering (distância ao centroide)\"], [\"Exploração de uma base nova\", \"Estrutura e redundância entre colunas\", \"PCA\"], [\"Visualizar dados com muitas colunas\", \"Enxergar em 2D uma base de alta dimensão\", \"PCA\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Detecção de anomalia com o que você já sabe\n\nDetectar anomalia com clustering não exige um algoritmo novo: a ideia é olhar pra distância entre cada ponto e o centroide do cluster mais próximo dele. Pontos muito distantes de qualquer centroide, ou que formam sozinhos um cluster minúsculo, são candidatos a anomalia: uma transação de cartão fora do padrão de gastos do cliente, uma leitura de sensor de máquina fora da faixa normal.\n\nRepare na palavra **candidatos**. O algoritmo aponta o que foge do padrão estatístico, não o que é, de fato, fraude ou defeito. Cabe a uma pessoa (ou a uma regra de negócio) investigar cada ponto sinalizado antes de agir sobre ele."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Os cuidados: avaliar é mais difícil sem rótulo\n\nNo Módulo 5, você viu métricas como precisão, recall e F1, todas comparando a previsão do modelo com um rótulo verdadeiro. Sem rótulo, essas métricas simplesmente não existem: não há um \"gabarito\" pra confrontar com os grupos encontrados.\n\nIsso não quer dizer que não dá pra avaliar nada. Existem métricas internas, calculadas só a partir da estrutura dos próprios clusters, sem precisar de rótulo (a inércia do k-means é uma delas, o coeficiente de silhueta é outra). Mas nenhuma delas substitui a pergunta mais importante: os grupos encontrados fazem sentido pro problema de negócio? É fácil forçar qualquer `k` num k-means e obter *uma* resposta; garantir que essa resposta é *boa* exige olhar além do número."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.metrics import silhouette_score\n\n# X_escalado e kmeans.labels_ são os mesmos da aula sobre k-means\nscore = silhouette_score(X_escalado, kmeans.labels_)\n\nprint(score)\n# um número entre -1 e 1\n# perto de 1: clusters bem separados e coesos\n# perto de 0: clusters que se sobrepõem, mal definidos\n# negativo: muitos pontos parecem estar no cluster errado"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Um fluxo comum na prática\n\nNo dia a dia, não-supervisionado e supervisionado costumam trabalhar juntos, não como escolhas concorrentes. Um fluxo bem comum: usar PCA e k-means pra explorar uma base nova e entender se existe estrutura; dar nome de negócio aos grupos encontrados (\"clientes de alto valor\", \"clientes em risco de cancelamento\"); e, só depois, se fizer sentido, treinar um modelo supervisionado pra prever a qual grupo um cliente novo provavelmente pertence.\n\nO não-supervisionado, nesse fluxo, funciona como uma lupa: ajuda a enxergar o problema antes de decidir qual pergunta supervisionada vale a pena fazer."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Sem rótulo, o algoritmo não erra nem acerta sozinho: quem decide se um grupo faz sentido é sempre uma pessoa olhando pro resultado com espírito crítico."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual das opções é um uso típico de aprendizado não-supervisionado?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Segmentar clientes em grupos parecidos sem que ninguém tenha rotulado os grupos antes",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Prever o preço de um imóvel a partir de um histórico de vendas com preço conhecido",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Classificar e-mails como spam ou não spam usando exemplos já rotulados antes",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Calcular a acurácia de um modelo já treinado numa tarefa de classificação",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que sinalizar uma anomalia com clustering costuma exigir revisão humana depois?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque o algoritmo aponta o que foge do padrão estatístico, sem dizer se é fraude ou erro",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o k-means erra a maior parte dos cálculos de distância em bases muito grandes",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque toda anomalia sinalizada por um algoritmo é, por definição, um erro de digitação",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o scikit-learn bloqueia a execução de detecção de anomalia sem revisão prévia",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Sem uma coluna de rótulo, como normalmente se avalia se os grupos de um k-means fazem sentido?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Combinando métricas internas, como inércia ou silhueta, com a leitura humana dos grupos",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Calculando a acurácia dos grupos formados em relação a um alvo verdadeiro conhecido",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Comparando a matriz de confusão entre os diferentes clusters encontrados no treino todo",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Usando o R² entre os centroides encontrados e a média geral de todos os dados originais",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe de marketing pede: \"rode o k-means na base de clientes e nos diga o nome de cada grupo encontrado\". O que o algoritmo entrega sozinho, e o que depende da equipe?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O algoritmo entrega os grupos numerados; dar nome de negócio a cada um é interpretação humana",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O algoritmo entrega tanto os grupos quanto o nome de negócio de cada um, de forma automática",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O algoritmo não consegue formar grupo nenhum sem que a equipe defina os nomes antes",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O algoritmo entrega os nomes dos grupos, mas nunca informa quantos clientes há em cada um",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de um k-means com `k` igual a 4 numa base de clientes, um cluster ficou com apenas 3 clientes, bem distantes dos demais pontos. O que essa observação sugere?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Esses 3 clientes podem ser um grupo atípico, que vale investigar antes de generalizar",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O valor de `k` está definitivamente errado e precisa, obrigatoriamente, cair para 3",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O k-means deve ser abandonado nesse caso, em favor direto de uma árvore de decisão",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Esses 3 clientes certamente têm erro de digitação nos dados e devem ser excluídos",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Recap e o próximo passo: Machine Learning na Prática",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Você chegou ao fim da trilha de Machine Learning\n\nQuando você começou esta trilha, machine learning talvez fosse só um termo repetido em notícia de tecnologia. Sete módulos depois, você sabe o que o termo realmente significa: aprender padrões a partir de dados em vez de programar regra por regra, sabe treinar e avaliar um modelo de verdade, sabe evitar as armadilhas mais comuns (overfitting, vazamento de dados, acurácia enganosa), e agora sabe até encontrar estrutura em dados sem rótulo nenhum.\n\nAntes de seguir pro próximo estágio do roadmap de Ciência de Dados, vale olhar pra trás e ver o caminho inteiro."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Módulo\", \"O que você levou dele\"], [\"1\", \"O que é ML, tipos de aprendizado e o vocabulário essencial (features, alvo, modelo)\"], [\"2\", \"O pipeline de um projeto e o padrão fit/predict/score do scikit-learn\"], [\"3\", \"Regressão: prever números com LinearRegression e métricas como MAE, RMSE e R2\"], [\"4\", \"Classificação: prever categorias com regressão logística, k-NN e árvore de decisão\"], [\"5\", \"Avaliar de verdade: matriz de confusão, precisão, recall, F1 e validação cruzada\"], [\"6\", \"Preparar dados sem vazamento: escalonamento, one-hot encoding e Pipeline\"], [\"7\", \"Aprendizado não-supervisionado: agrupar com k-means e simplificar com PCA\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O fio condutor\n\nRepare no caminho que essa sequência percorre. Você começou entendendo que ML é aprender padrões em vez de escrever regra fixa. Aprendeu o pipeline que qualquer projeto segue, treinar sem nunca avaliar no mesmo dado usado no treino. Usou esse pipeline pra prever números (regressão) e depois categorias (classificação). Descobriu que treinar um modelo é fácil, e que avaliar esse modelo com honestidade é que separa um projeto sério de um projeto ingênuo. Aprendeu que dado malpreparado, ou vazado entre treino e teste, derruba até o melhor algoritmo. E, por fim, viu que nem todo problema chega com um rótulo pronto, e que dá pra extrair valor dos dados mesmo assim.\n\nO fio condutor é esse: da pergunta \"o que significa aprender com dados\" até a prática de construir e, com as devidas ressalvas, confiar num modelo."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Honestidade final sobre limites\n\nVale fechar como o Módulo 1 começou: machine learning não é mágica. Um modelo só é tão bom quanto os dados que ele viu no treino; dados enviesados ou pouco representativos geram modelos enviesados ou pouco úteis. Nenhum modelo desta trilha, nem os do próximo estágio, elimina a necessidade de entender o problema de negócio por trás dos números. Todo modelo erra parte do tempo, e a métrica certa pra medir esse erro depende do que está em jogo em cada aplicação.\n\nEssa desconfiança treinada (perguntar como o modelo foi avaliado, com quais dados, e o que ele erra) vale tanto pra um projeto seu quanto pra qualquer resultado de ML que você ler por aí."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Próximo passo: Machine Learning na Prática\n\nO próximo estágio do roadmap de Ciência de Dados pega exatamente de onde esta trilha parou, e aprofunda quatro frentes:\n\n- **Feature engineering avançado**: ir além do escalonamento e do one-hot encoding, criando variáveis novas e mais poderosas a partir das que já existem.\n- **Seleção e ajuste de hiperparâmetros**: em vez de escolher `n_neighbors` ou a profundidade de uma árvore no chute, testar várias combinações de forma sistemática, com GridSearch, apoiado na validação cruzada que você viu no Módulo 5.\n- **Ensembles**: combinar várias árvores de decisão numa \"equipe\" de modelos, como random forest e boosting, que juntas costumam errar menos do que qualquer árvore sozinha.\n- **Uma introdução a deep learning**: o próximo salto de complexidade, com redes neurais e ferramentas como TensorFlow e PyTorch, pra problemas onde os modelos desta trilha já não bastam."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.model_selection import GridSearchCV\nfrom sklearn.ensemble import RandomForestClassifier\n\n# uma prévia do próximo estágio: testar hiperparâmetros de forma sistemática,\n# em vez de ajustar um valor de cada vez no chute\nparametros = {\"n_estimators\": [50, 100, 200], \"max_depth\": [3, 5, None]}\n\nbusca = GridSearchCV(RandomForestClassifier(random_state=42), parametros, cv=5)\n# busca.fit(X_treino, y_treino)\n# busca.best_params_ traria a melhor combinação de hiperparâmetros encontrada,\n# testada com validação cruzada de 5 dobras em cada combinação"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Você não sai desta trilha sabendo todos os algoritmos que existem. Sai sabendo o funil que qualquer um deles segue: preparar dado direito, treinar sem trapacear, avaliar com honestidade e desconfiar de todo resultado bom demais."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual foi o fluxo geral de um projeto de machine learning apresentado a partir do Módulo 2 desta trilha?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Preparar os dados, dividir em treino e teste, treinar, avaliar e só então usar o modelo",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Treinar o modelo direto, coletar dados depois, e publicar sem dividir treino e teste",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Avaliar o modelo antes de treiná-lo, e só depois preparar os dados restantes",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Escolher o algoritmo mais complexo disponível e aplicá-lo direto nos dados brutos",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual é o próximo passo sugerido no roadmap de Ciência de Dados depois desta trilha de Machine Learning?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Machine Learning na Prática, com feature engineering avançado, GridSearch e ensembles",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Voltar para a trilha de Estatística e Probabilidade, agora em nível avançado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A trilha de Machine Learning encerra por completo o roadmap de Ciência de Dados",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A trilha de Visualização de Dados, ainda não estudada em nenhum estágio anterior",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual par conecta corretamente um módulo desta trilha à sua ideia central?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Módulo 6: preparar os dados depois de dividir treino e teste, evitando vazamento",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Módulo 3: escolher entre precisão e recall dependendo do custo de cada erro",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Módulo 5: prever um número contínuo usando uma reta de regressão linear",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Módulo 4: treinar o modelo sem nunca avaliar num conjunto de teste separado",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma árvore de decisão do Módulo 4 vai bem no treino, mas sua profundidade máxima foi escolhida no chute, testando um valor de cada vez. Qual recurso do próximo estágio resolve isso de forma sistemática?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O GridSearch, que testa várias combinações de hiperparâmetros, apoiado em validação cruzada",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O StandardScaler, aplicado agora sobre os hiperparâmetros do modelo em vez das variáveis",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O PCA, reduzindo diretamente o número de hiperparâmetros disponíveis pra testar",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Repetir a divisão treino e teste várias vezes até o resultado no teste melhorar",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Random forest e boosting, citados como o próximo passo do roadmap, têm em comum o fato de ambos serem",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Ensembles: combinam várias árvores de decisão pra chegar numa previsão mais robusta",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Técnicas de redução de dimensionalidade, do mesmo grupo do PCA visto neste módulo",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Técnicas de clustering, do mesmo grupo do k-means visto neste módulo",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Métricas de avaliação, do mesmo grupo de precisão, recall e F1 vistas no Módulo 5",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+];
+
+async function seed() {
+    let [trilha] = await db.select().from(trails).where(eq(trails.name, NOME));
+    if (!trilha) {
+        [trilha] = await db
+            .insert(trails)
+            .values({ name: NOME, trailLevel: LEVEL, description: DESCRICAO })
+            .returning();
+        console.log("Trilha criada: " + trilha.name);
+    }
+
+    const existentes = await db.select().from(lessons).where(eq(lessons.trailId, trilha.id));
+    if (existentes.length > 0) {
+        console.log("Trilha " + NOME + " ja tem " + existentes.length + " aulas. Nada a fazer.");
+        return;
+    }
+
+    let totalAulas = 0;
+    let totalQuestoes = 0;
+    for (let mi = 0; mi < MODULOS.length; mi++) {
+        const m = MODULOS[mi];
+        const [mod] = await db
+            .insert(modules)
+            .values({ trailId: trilha.id, title: m.titulo, position: mi + 1 })
+            .returning();
+        for (let li = 0; li < m.aulas.length; li++) {
+            const a = m.aulas[li];
+            const [lesson] = await db
+                .insert(lessons)
+                .values({
+                    trailId: trilha.id,
+                    moduleId: mod.id,
+                    title: a.titulo,
+                    content: null,
+                    contentBlocks: a.blocks,
+                    position: li + 1,
+                    published: true,
+                })
+                .returning();
+            for (let qi = 0; qi < a.questions.length; qi++) {
+                const q = a.questions[qi];
+                const [questao] = await db
+                    .insert(questions)
+                    .values({
+                        lessonId: lesson.id,
+                        statement: q.statement,
+                        difficulty: q.difficulty,
+                        position: qi + 1,
+                    })
+                    .returning();
+                await db.insert(questionOptions).values(
+                    q.options.map((o, k) => ({
+                        questionId: questao.id,
+                        text: o.text,
+                        isCorrect: o.isCorrect,
+                        position: k + 1,
+                    })),
+                );
+            }
+            totalAulas++;
+            totalQuestoes += a.questions.length;
+        }
+    }
+    console.log("Seed concluido: " + MODULOS.length + " modulos, " + totalAulas + " aulas, " + totalQuestoes + " questoes.");
+}
+
+seed()
+    .then(() => process.exit(0))
+    .catch((e) => {
+        console.error("Falha no seed:", e);
+        process.exit(1);
+    });

--- a/backend/scripts/seed-trilha-ml-na-pratica.ts
+++ b/backend/scripts/seed-trilha-ml-na-pratica.ts
@@ -1,0 +1,5174 @@
+// Seed da trilha Machine Learning na Pratica (avancado), estagio 8 do roadmap de Ciencia de Dados.
+// Idempotente e nao destrutivo: se a trilha ja tiver aulas, nao faz nada.
+//
+// Rodar em prod: docker compose -f docker-compose.prod.yml exec -T backend node scripts/seed-trilha-ml-na-pratica.ts
+import { db } from "../db.ts";
+import { trails, modules, lessons, questions, questionOptions } from "../schema.ts";
+import { eq } from "drizzle-orm";
+
+const NOME = "Machine Learning na Prática";
+const LEVEL: "iniciante" | "intermediario" | "avancado" = "avancado";
+const DESCRICAO =
+    "Machine learning além do básico: feature engineering, ajuste de hiperparâmetros, ensembles (random forest e boosting), pipelines robustos, lidar com classes desbalanceadas e overfitting, e uma introdução a deep learning. Do modelo que funciona ao modelo que ganha.";
+
+type Bloco = { type: "text" | "code" | "quote" | "table"; value: string };
+type Questao = {
+    statement: string;
+    difficulty: "facil" | "medio" | "dificil";
+    options: { text: string; isCorrect: boolean }[];
+};
+type Aula = { titulo: string; blocks: Bloco[]; questions: Questao[] };
+type Modulo = { titulo: string; aulas: Aula[] };
+
+const MODULOS: Modulo[] = [
+    {
+        "titulo": "Módulo 1 - Feature engineering na prática",
+        "aulas": [
+            {
+                "titulo": "Features valem mais que o algoritmo",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Features valem mais que o algoritmo\n\nNa trilha de Machine Learning você comparou modelos, ajustou hiperparâmetros básicos e olhou pra métricas de avaliação. Provavelmente reparou que trocar de algoritmo (uma árvore por uma regressão logística, por exemplo) muda o resultado, mas raramente muda demais. O que costuma mover o ponteiro de verdade, na prática, é outra coisa: as colunas que você entrega pro modelo treinar."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O modelo só é tão bom quanto as features\n\nUm algoritmo de machine learning só encontra padrões que estão, de alguma forma, representados nos dados de entrada. Se uma informação decisiva pro problema não vira feature, nenhum modelo, por mais sofisticado que seja, vai descobrir essa informação sozinho. É a versão de machine learning do velho **garbage in, garbage out**: dado ruim ou incompleto na entrada, previsão ruim na saída, não importa o quanto você capriche no algoritmo."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que é feature engineering\n\n**Feature engineering** é o processo de criar, transformar e selecionar as variáveis que o modelo recebe, usando o que você sabe sobre o problema pra representar melhor esse problema em forma de número. Não é só \"adicionar mais dado\": muitas vezes é pegar o dado que você já tem e reorganizar ele de um jeito que o algoritmo consiga enxergar o padrão com menos esforço."
+                    },
+                    {
+                        "type": "code",
+                        "value": "import pandas as pd\n\ndf = pd.DataFrame({\n    'area_m2': [120, 45, 80, 200],\n    'quartos': [3, 1, 2, 4],\n    'ano_construcao': [2005, 2018, 2010, 1995]\n})\n\nano_atual = 2026\n\n# feature derivada: idade do imóvel em anos\ndf['idade_imovel'] = ano_atual - df['ano_construcao']\n\n# feature derivada: área média por cômodo\ndf['area_por_quarto'] = df['area_m2'] / df['quartos']\n\nprint(df[['area_m2', 'quartos', 'idade_imovel', 'area_por_quarto']])\n#    area_m2  quartos  idade_imovel  area_por_quarto\n# 0      120        3            21             40.0\n# 1       45        1             8             45.0\n# 2       80        2            16             40.0\n# 3      200        4            31             50.0"
+                    },
+                    {
+                        "type": "text",
+                        "value": "Repare que `idade_imovel` e `area_por_quarto` provavelmente têm uma relação mais direta com o preço do imóvel do que `ano_construcao` sozinho. Uma árvore de decisão até consegue aproximar essa mesma informação fazendo vários splits em `ano_construcao`, parecido com o jeito que ela lidava com o overfitting quando ficava funda demais na trilha de ML, mas entregar a feature já pronta poupa esse trabalho e ajuda o modelo a generalizar com menos dado de treino."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Feature crua\", \"Feature derivada\", \"Por que ajuda\"], [\"ano_construcao\", \"idade_imovel\", \"Idade tem relação mais direta com o preço do que o ano em si\"], [\"data_da_venda\", \"dia_da_semana, mes, eh_feriado\", \"Deixa a sazonalidade explícita em vez de escondida num timestamp\"], [\"renda e numero_de_dependentes\", \"renda_per_capita\", \"Uma única razão capta a interação que duas colunas separadas escondem\"], [\"latitude e longitude\", \"distancia_ao_centro\", \"Coordenadas cruas quase não têm relação linear com preço, a distância tem\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "O algoritmo é o motor, mas a feature é o combustível: motor bom com combustível ruim não anda longe."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual das alternativas melhor descreve o que é feature engineering?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Criar, transformar e selecionar variáveis pra representar melhor o problema.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Escolher qual algoritmo de machine learning treinar em cada problema novo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ajustar os hiperparâmetros do modelo depois que o treino inicial já terminou.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Dividir os dados em conjuntos de treino e de teste antes de treinar o modelo.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um cientista de dados trocou uma regressão logística por um gradient boosting nas mesmas features e a métrica de validação subiu 1%. Depois, ele criou uma feature de idade a partir da data de nascimento e a métrica subiu 8%. O que esse resultado ilustra melhor?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Que a qualidade das features costuma pesar mais no resultado do que a escolha entre algoritmos.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Que gradient boosting é sempre superior a regressão logística em qualquer conjunto de dados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que criar features novas é sempre mais importante do que ajustar hiperparâmetros do modelo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que o modelo mais simples deve ser preferido sempre que os dados têm poucas colunas.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que se diz que feature engineering depende de conhecimento sobre o domínio do problema?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque saber o que é relevante no problema real ajuda a decidir quais variáveis criar ou combinar.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque só especialistas em estatística conseguem programar transformações de dados em Python.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o scikit-learn exige declarar manualmente o domínio de cada variável do conjunto.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque todo projeto de machine learning precisa de uma equipe multidisciplinar grande.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um time comparou duas random forests idênticas em hiperparâmetros: uma recebeu o timestamp bruto da data de nascimento (dias desde 1970) e outra recebeu a idade em anos já calculada. A segunda teve desempenho de validação melhor, mesmo os dois números vindo da mesma informação. Qual é a explicação mais provável?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "A árvore precisa de muitos splits pra aproximar a idade a partir do timestamp bruto sozinha.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O timestamp bruto tem uma escala numérica inválida, então o scikit-learn rejeita essa coluna sozinho.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Random forest, ao contrário de uma árvore isolada, exige que todas as features usem a mesma unidade.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O timestamp bruto tem uma correlação negativa com o alvo, o que atrapalha qualquer modelo de árvore.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma cientista de dados tem duas opções antes do prazo acabar: testar mais três algoritmos diferentes com as features atuais, ou investir o tempo criando cinco features novas a partir do conhecimento do negócio. Qual tende a trazer mais ganho?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Investir nas features novas, já que a representação dos dados costuma pesar mais que o algoritmo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Testar mais algoritmos, porque cada família de modelo capta um padrão que as features não expõem.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "As duas opções tendem a trazer o mesmo ganho, já que algoritmo e feature sempre pesam de forma igual.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Nenhuma das duas, porque sem ajustar hiperparâmetros nenhuma mudança altera a métrica final do modelo.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Criar features: interações, datas e binning",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Interações: multiplicar e combinar colunas\n\nÀs vezes o efeito de uma variável depende do valor de outra. Preço por metro quadrado importa mais quando cruzado com o bairro; tempo no site importa mais quando cruzado com o número de páginas visitadas. Quando você multiplica, divide ou combina duas colunas, cria uma **feature de interação** que expõe esse efeito conjunto sem que o modelo precise descobrir a combinação sozinho.\n\nIsso lembra a comparação que você fez na trilha de Machine Learning entre um modelo linear e uma árvore: a árvore aproxima interações fazendo splits sucessivos, mas um modelo linear, como a regressão logística, não capta interação nenhuma a menos que você entregue ela pronta como feature."
+                    },
+                    {
+                        "type": "code",
+                        "value": "import pandas as pd\n\ndf = pd.DataFrame({\n    'preco_unitario': [50, 120, 30, 80],\n    'quantidade': [10, 2, 25, 5],\n    'desconto_percentual': [0.1, 0.0, 0.2, 0.05]\n})\n\n# interação: receita bruta (multiplicação de duas colunas)\ndf['receita'] = df['preco_unitario'] * df['quantidade']\n\n# interação: receita líquida, já considerando o desconto\ndf['receita_liquida'] = df['receita'] * (1 - df['desconto_percentual'])\n\nprint(df[['receita', 'receita_liquida']])\n#    receita  receita_liquida\n# 0      500            450.0\n# 1      240            240.0\n# 2      750            600.0\n# 3      400            380.0"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Extraindo sinal de datas\n\nUma coluna de data pura, tipo `2026-07-13`, quase não ajuda o modelo do jeito que está: pra ele é só um número gigante. O sinal útil mora em como você quebra essa data em pedaços que fazem sentido pro problema.\n\n- **Dia da semana**: vendas de restaurante mudam de sexta pra terça.\n- **Mês**: sazonalidade (época de provas, black friday, período de chuva).\n- **É fim de semana**: comportamento de compra muda.\n- **É feriado**: quedas ou picos que não têm a ver com tendência nenhuma, só com o calendário."
+                    },
+                    {
+                        "type": "code",
+                        "value": "import pandas as pd\n\ndf = pd.DataFrame({\n    'data_pedido': pd.to_datetime([\n        '2026-01-05', '2026-07-04', '2026-12-25', '2026-03-17'\n    ])\n})\n\ndf['dia_semana'] = df['data_pedido'].dt.dayofweek  # 0 = segunda, 6 = domingo\ndf['mes'] = df['data_pedido'].dt.month\ndf['eh_fim_de_semana'] = df['dia_semana'].isin([5, 6]).astype(int)\n\nferiados_2026 = pd.to_datetime(['2026-01-01', '2026-12-25', '2026-04-21'])\ndf['eh_feriado'] = df['data_pedido'].isin(feriados_2026).astype(int)\n\nprint(df[['dia_semana', 'mes', 'eh_fim_de_semana', 'eh_feriado']])\n#    dia_semana  mes  eh_fim_de_semana  eh_feriado\n# 0           0    1                 0           0\n# 1           5    7                 1           0\n# 2           4   12                 0           1\n# 3           1    3                 0           0"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Agregações por grupo e binning\n\nDuas outras formas de criar sinal:\n\n- **Agregação por grupo**: resumir um grupo em um número e trazer esse resumo pra cada linha. O gasto médio histórico daquele cliente, calculado com `groupby` e `transform`, vira uma feature nova em cada pedido dele. Isso captura \"esse cliente costuma gastar muito\" sem vazar o valor daquele pedido específico.\n- **Binning**: transformar uma variável contínua em faixas categóricas. Idade vira `18-25`, `26-35`, `36-50`, `50+`. Ajuda quando a relação com o alvo não é uma linha reta (crianças e idosos compram menos que adultos, por exemplo, e uma idade contínua sozinha confunde um modelo linear)."
+                    },
+                    {
+                        "type": "code",
+                        "value": "import pandas as pd\n\ndf = pd.DataFrame({\n    'cliente_id': [1, 1, 2, 2, 3],\n    'valor_pedido': [100, 300, 50, 60, 900],\n    'idade': [22, 22, 45, 45, 67]\n})\n\n# agregação: gasto médio histórico do cliente, repetido em cada linha dele\ndf['gasto_medio_cliente'] = df.groupby('cliente_id')['valor_pedido'].transform('mean')\n\n# binning: faixa etária em vez de idade contínua\ndf['faixa_etaria'] = pd.cut(\n    df['idade'],\n    bins=[0, 25, 35, 50, 120],\n    labels=['18-25', '26-35', '36-50', '50+']\n)\n\nprint(df[['cliente_id', 'valor_pedido', 'gasto_medio_cliente', 'faixa_etaria']])\n#    cliente_id  valor_pedido  gasto_medio_cliente faixa_etaria\n# 0           1           100                 200.0        18-25\n# 1           1           300                 200.0        18-25\n# 2           2            50                  55.0        36-50\n# 3           2            60                  55.0        36-50\n# 4           3           900                 900.0          50+"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Criar uma boa feature exige menos matemática e mais pergunta: o que, nesse dado, realmente separa quem eu quero prever de quem eu não quero?"
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual das alternativas é um exemplo de feature de interação?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Multiplicar o preço unitário pela quantidade comprada pra criar uma coluna de receita.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Substituir os valores nulos de uma coluna pela média dos valores existentes nela.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Padronizar uma coluna numérica pra ter média zero e desvio padrão igual a um.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Remover uma coluna que está perfeitamente correlacionada com outra já existente.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que extrair `dia_da_semana` e `eh_feriado` de uma data costuma ajudar mais do que usar a data bruta como número?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque o modelo passa a enxergar direto padrões de calendário que a data bruta esconde num número gigante.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque datas brutas sempre geram erro de tipo quando usadas dentro do scikit-learn, mesmo convertidas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque toda coluna de data tem, por padrão, valores nulos que atrapalham o treino do modelo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque a data bruta, ao contrário do dia da semana, não pode ser normalizada com as outras colunas.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Em qual situação faz mais sentido transformar idade contínua em faixas etárias antes de treinar um modelo linear?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Quando a relação com o alvo não é uma linha reta, como crianças e idosos comprando menos que adultos.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Quando a coluna de idade tem valores faltantes que precisam ser preenchidos antes do treino.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Quando o modelo usado é uma árvore de decisão, já que ela não consegue dividir variáveis contínuas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Quando se quer reduzir o número total de linhas do conjunto de dados antes de treinar.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um cientista de dados calculou `gasto_medio_cliente` com `groupby().transform('mean')` sobre o treino inteiro, incluindo a própria linha prevista, e usou essa feature pra prever se aquele pedido específico é fraude. Qual é o risco dessa abordagem?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "A média inclui o valor do próprio pedido a prever, então carrega informação que só existe por causa do alvo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A função `transform` do pandas devolve um valor por grupo, e esse formato não bate com o número de linhas originais.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O `groupby` por cliente sempre gera uma quantidade de grupos maior do que o número de linhas disponíveis pro treino.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Calcular médias por grupo exige normalizar a coluna antes, senão o `transform` gera valores em escalas diferentes.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de criar `receita = preco_unitario * quantidade`, um colega sugere manter as três colunas no modelo. Qual é a preocupação mais relevante nessa escolha?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Receita é uma combinação determinística das outras duas, o que pode gerar redundância sem informação nova.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Receita nunca deve ser usada como feature, porque é sempre a variável alvo em problemas de previsão de vendas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Manter as três colunas obriga o modelo a normalizar cada uma delas numa escala diferente antes do treino.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O scikit-learn rejeita treinar um modelo quando há colunas calculadas a partir de outras do mesmo conjunto.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Transformar: escala e transformação log",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Retomando escala, agora com mais nuance\n\nNa trilha de Machine Learning você já usou `StandardScaler` pra colocar colunas em escalas comparáveis antes de treinar modelos sensíveis a distância ou a gradiente (KNN, regressão logística, redes neurais). Duas palavras que às vezes se confundem:\n\n- **Padronizar** (`StandardScaler`): subtrai a média e divide pelo desvio padrão. O resultado tem média 0 e desvio padrão 1, sem limite fixo de mínimo e máximo.\n- **Normalizar** (`MinMaxScaler`): reescala pra um intervalo fixo, normalmente 0 a 1. Bom quando os limites de mínimo e máximo observados no treino são confiáveis.\n\nÁrvore de decisão, random forest e gradient boosting não precisam de nada disso: eles decidem os splits comparando valores dentro da própria coluna, e a escala não muda esse resultado."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.preprocessing import StandardScaler, MinMaxScaler\nimport pandas as pd\n\ndf = pd.DataFrame({'renda_mensal': [1800, 3200, 25000, 4100, 2600]})\n\npadronizador = StandardScaler()\ndf['renda_padronizada'] = padronizador.fit_transform(df[['renda_mensal']])\n\nnormalizador = MinMaxScaler()\ndf['renda_normalizada'] = normalizador.fit_transform(df[['renda_mensal']])\n\nprint(df)\n#    renda_mensal  renda_padronizada  renda_normalizada\n# 0          1800            -0.6251             0.0000\n# 1          3200            -0.4672             0.0603\n# 2         25000             1.9928             1.0000\n# 3          4100            -0.3656             0.0991\n# 4          2600            -0.5349             0.0345"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Transformação log pra distribuições assimétricas\n\nRepare no exemplo acima: quatro pessoas ganham entre 1800 e 4100, e uma ganha 25000. Isso é uma **distribuição assimétrica à direita** (poucos valores bem altos puxando a cauda), comum em renda, preço de imóvel, número de visualizações de um vídeo, tempo de espera. Escalar não resolve a assimetria, só muda a unidade. Quem ajuda é a **transformação logarítmica**.\n\nSe você plotasse um histograma dessa renda crua, veria a maioria das barras espremida perto de zero e uma cauda comprida esticando pra direita. Aplicando log, a mesma distribuição fica bem mais próxima de um formato de sino: os valores baixos se espalham e o valor alto deixa de dominar a escala."
+                    },
+                    {
+                        "type": "code",
+                        "value": "import numpy as np\nimport pandas as pd\n\ndf = pd.DataFrame({\n    'renda_mensal': [1500, 1700, 1900, 2100, 2500, 3200, 4000, 8000, 15000, 50000]\n})\n\n# log1p = log(1 + x), evita erro quando x = 0\ndf['log_renda'] = np.log1p(df['renda_mensal'])\n\nprint(df['renda_mensal'].skew().round(2), df['log_renda'].skew().round(2))\n# 2.76 1.37   -> assimetria cai bastante depois do log, mesmo sem sumir de vez\n\n# pra voltar à escala original depois de prever em log:\n# valor_original = np.expm1(valor_previsto_em_log)"
+                    },
+                    {
+                        "type": "text",
+                        "value": "Um detalhe que pega muita gente: se você treinar o modelo pra prever `log_renda` em vez de `renda_mensal`, a previsão sai em escala log. Antes de comparar com o valor real ou mostrar pro usuário, é preciso desfazer a transformação com `np.expm1`. Esquecer esse passo é um erro comum: o modelo até treina e valida bem, mas os números finais não fazem sentido nenhum pra quem vai usar a previsão."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Técnica\", \"O que faz\", \"Quando usar\"], [\"StandardScaler\", \"Deixa a coluna com média 0 e desvio padrão 1\", \"Modelos sensíveis a distância ou gradiente, sem cauda longa\"], [\"MinMaxScaler\", \"Reescala a coluna pro intervalo 0 a 1\", \"Quando os limites de mínimo e máximo do treino são confiáveis\"], [\"Transformação log\", \"Comprime valores altos, espalha valores baixos\", \"Distribuições assimétricas: renda, preço, contagens\"], [\"Nenhuma transformação\", \"Mantém os valores originais\", \"Árvores, random forest, gradient boosting\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Transformar não é maquiar o dado, é apresentar ele numa forma que o algoritmo consegue aproveitar melhor."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual é o efeito de aplicar `StandardScaler` numa coluna numérica?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Transforma a coluna pra ter média 0 e desvio padrão 1.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Transforma a coluna pra ficar sempre entre os valores 0 e 1.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Remove os valores considerados outliers da coluna original.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Substitui os valores ausentes da coluna pela mediana calculada.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que árvores de decisão e random forest não precisam de escala nas features?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque decidem os splits comparando valores dentro da própria coluna, e isso não muda com a escala.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o scikit-learn aplica escala automaticamente por trás dos panos em qualquer modelo de árvore.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque árvores de decisão só aceitam colunas categóricas, nunca colunas numéricas contínuas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque a escala já é corrigida durante a divisão entre os dados de treino e de teste.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um analista percebe que 'preço do imóvel' tem a maioria dos valores entre 200 mil e 600 mil, mas alguns imóveis de luxo passam de 10 milhões, puxando a média pra cima. Qual transformação tende a ajudar mais um modelo linear nesse caso?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Aplicar transformação log, que comprime os valores altos e aproxima a distribuição de um formato simétrico.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Aplicar `MinMaxScaler`, que encaixa os valores extremos entre 0 e 1 sem alterar o formato da distribuição.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Remover a coluna de preço, já que distribuições assimétricas não podem entrar num modelo linear qualquer.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Aplicar `StandardScaler`, que corrige a assimetria ao subtrair a média de cada valor da coluna original.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um modelo foi treinado pra prever `log_preco` em vez de `preco`. Na hora de comparar a previsão com o preço real, o erro médio calculado ficou artificialmente pequeno e sem sentido prático. O que provavelmente foi esquecido?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Aplicar `np.expm1` na previsão antes de comparar com o preço real, desfazendo a transformação do treino.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Aplicar `StandardScaler` na previsão final antes de calcular o erro médio contra o preço real observado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Recalcular a transformação log do teste separadamente, usando a média do conjunto de treino inteiro.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Treinar o modelo de novo, dessa vez sem aplicar nenhuma escala nas variáveis explicativas usadas.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um KNN treinado com 'idade' (0 a 90) e 'renda mensal' (1000 a 30000) sem nenhuma escala teve desempenho ruim, dominado quase inteiramente pela coluna de renda. Qual é a explicação mais provável?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Como o KNN mede distância entre pontos, a coluna de maior magnitude domina o cálculo sem ser mais importante.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A coluna renda mensal tem correlação perfeita com o alvo, o que satura qualquer modelo baseado em distância.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O KNN, diferente de outros modelos, exige que todas as colunas estejam em formato inteiro antes do treino.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A coluna idade tem poucos valores únicos, o que impede o KNN de calcular distância entre os pontos direito.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Selecionar features",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Por que selecionar features\n\nDepois de criar um monte de features novas (interações, datas quebradas, agregações), é tentador jogar tudo pro modelo e deixar ele \"escolher\" o que importa. Só que mais colunas não é de graça:\n\n- **Mais overfitting**: com mais dimensões fica mais fácil o modelo decorar ruído do treino em vez de aprender padrão de verdade, o mesmo problema da árvore funda demais que você viu na trilha de ML, só que aqui causado pelo excesso de colunas em vez de excesso de profundidade.\n- **Mais custo computacional**: treino mais lento, tuning mais caro.\n- **Menos interpretabilidade**: fica mais difícil explicar um modelo com 200 features do que um com 15.\n\nDois tipos de coluna pra cortar logo de cara: **irrelevantes** (sem relação nenhuma com o que você quer prever, como um ID interno ou uma coluna quase constante, o mesmo valor em 99% das linhas) e **redundantes** (carregam basicamente a mesma informação de outra já presente, como `area_m2` e `area_construida` com correlação de 0.99 entre si)."
+                    },
+                    {
+                        "type": "code",
+                        "value": "import pandas as pd\n\ndf = pd.DataFrame({\n    'area_m2': [50, 80, 120, 45, 200],\n    'area_construida': [48, 79, 118, 44, 197],  # quase idêntica a area_m2\n    'quartos': [1, 2, 3, 1, 4],\n    'id_imovel': [1001, 1002, 1003, 1004, 1005]  # irrelevante, é só identificador\n})\n\ncorrelacoes = df[['area_m2', 'area_construida', 'quartos']].corr()\nprint(correlacoes['area_m2'])\n# area_m2            1.000000\n# area_construida    0.999970\n# quartos            0.978595\n# Name: area_m2, dtype: float64\n\n# area_construida é quase redundante com area_m2: manter as duas agrega pouco\ndf_selecionado = df.drop(columns=['area_construida', 'id_imovel'])"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Correlação com o alvo, e um limite importante\n\nUm primeiro filtro simples: calcular a correlação de cada feature com o alvo e cortar as que ficam perto de zero. Funciona bem como triagem inicial, mas tem um limite: correlação de Pearson só enxerga relação **linear**. Uma feature pode ter correlação quase zero com o alvo e ainda ser extremamente útil (por exemplo, se a relação tiver formato de U). Por isso correlação é um primeiro corte, não a palavra final.\n\nPra ir além da correlação simples, o scikit-learn tem `SelectKBest`, que escolhe as `k` melhores features segundo um teste estatístico (`f_classif` pra classificação, `f_regression` pra regressão)."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.feature_selection import SelectKBest, f_classif\nimport pandas as pd\n\nX = pd.DataFrame({\n    'idade': [22, 35, 45, 28, 60, 33],\n    'renda_mensal': [2000, 5000, 8000, 3000, 12000, 4500],\n    'id_cliente': [1, 2, 3, 4, 5, 6],\n    'tempo_no_site_seg': [30, 200, 180, 45, 300, 90]\n})\ny = [0, 1, 1, 0, 1, 0]  # comprou ou não\n\nseletor = SelectKBest(score_func=f_classif, k=2)\nX_selecionado = seletor.fit_transform(X, y)\n\ncolunas_escolhidas = X.columns[seletor.get_support()]\nprint(colunas_escolhidas.tolist())\n# ['renda_mensal', 'tempo_no_site_seg']  -> id_cliente e idade ficaram de fora"
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.ensemble import RandomForestClassifier\nfrom sklearn.feature_selection import SelectFromModel\n\nmodelo = RandomForestClassifier(n_estimators=200, random_state=42)\nseletor_modelo = SelectFromModel(modelo, threshold='median')\nX_selecionado_rf = seletor_modelo.fit_transform(X, y)\n\ncolunas_escolhidas_rf = X.columns[seletor_modelo.get_support()]\nprint(colunas_escolhidas_rf.tolist())\n# ['renda_mensal', 'tempo_no_site_seg']  -> só ficam as features acima da importância mediana"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Método\", \"Como decide\", \"Quando usar\"], [\"Correlação com o alvo\", \"Mede relação linear entre cada feature e o alvo\", \"Triagem inicial rápida, antes de treinar qualquer modelo\"], [\"SelectKBest\", \"Teste estatístico (f_classif, f_regression) por feature\", \"Selecionar um número fixo k de features, de forma simples\"], [\"SelectFromModel\", \"Importância aprendida por um modelo de árvore já treinado\", \"Aproveitar um modelo existente pra escolher as melhores features\"], [\"Correlação entre features\", \"Mede redundância entre pares de colunas explicativas\", \"Cortar redundância antes mesmo de olhar pro alvo\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Selecionar features é editar: tirar o que sobra costuma valorizar mais o modelo do que acrescentar mais uma coluna."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual é um motivo direto pra selecionar features antes de treinar o modelo final?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Reduzir o risco de overfitting causado pelo excesso de colunas pouco úteis.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Garantir que o modelo sempre atinja acurácia de 100% no conjunto de treino.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Aumentar artificialmente o número de linhas disponíveis pro treino do modelo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Eliminar a necessidade de dividir os dados em conjunto de treino e teste.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que uma coluna de ID interno do cliente costuma ser removida antes do treino?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque é um identificador sem relação real com o padrão a prever, e pode confundir o modelo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque colunas numéricas com muitos dígitos sempre quebram o treinamento no scikit-learn.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque colunas de ID sempre têm valores ausentes que atrapalham o cálculo de correlação.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o scikit-learn trata automaticamente qualquer coluna chamada 'id' como o alvo do modelo.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual é a principal limitação de usar só a correlação de Pearson pra decidir quais features manter?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Ela só capta relações lineares, e pode descartar uma feature útil com relação não linear.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Ela só funciona em conjuntos de dados com menos de mil linhas registradas no total.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ela exige que todas as colunas estejam previamente normalizadas entre os valores 0 e 1.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ela não pode ser calculada quando o alvo é uma variável categórica com duas classes.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de aplicar `SelectKBest` com `k=5`, o desempenho de validação caiu em comparação com usar todas as 20 features originais. O que pode explicar essa queda?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Alguma feature descartada captava uma relação não linear com o alvo que o teste estatístico não enxergou.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O `SelectKBest` sempre reduz o desempenho do modelo, independente de quantas features forem mantidas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O valor de `k` escolhido é sempre maior do que o número ideal de features pra qualquer conjunto de dados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Features escolhidas por teste estatístico não podem ser usadas dentro de um `Pipeline` do scikit-learn.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um modelo de regressão linear com duas features quase idênticas (`area_m2` e `area_construida`, correlação 0.99 entre si) apresentou coeficientes instáveis, mudando bastante a cada nova amostra de treino. Qual é a explicação mais provável?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "A redundância entre as duas colunas gera multicolinearidade e deixa os coeficientes instáveis.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O modelo linear não consegue processar duas colunas numéricas com valores parecidos entre si.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A correlação alta entre as duas colunas indica que o alvo foi vazado pras features do treino.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Coeficientes instáveis sempre indicam poucas linhas de dado pro número de colunas do modelo.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Importância e vazamento de features",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Lendo feature_importances_\n\nNa trilha de Machine Learning você treinou árvores e viu como elas decidem cada split escolhendo a feature que mais reduz a bagunça (impureza) dos dados naquele ponto. Depois de treinar uma árvore, random forest ou gradient boosting, o scikit-learn guarda quanto cada feature contribuiu pra essa redução ao longo de todos os splits, de todas as árvores. Isso vira o atributo `feature_importances_`: um número por feature, somando 1 no total, dizendo o quanto o modelo usou cada coluna.\n\nTrês cuidados na hora de interpretar esse número: features correlacionadas dividem o crédito entre si (a importância de cada uma sozinha parece menor do que é de fato); importância não é causalidade (a feature ajuda a prever, isso não quer dizer que ela cause o resultado); e colunas com muitos valores distintos tendem a formar splits \"bons\" por acaso com mais frequência, o que infla a importância aparente delas."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.ensemble import RandomForestClassifier\nimport pandas as pd\n\nX = pd.DataFrame({\n    'idade': [22, 35, 45, 28, 60, 33, 51, 40],\n    'renda_mensal': [2000, 5000, 8000, 3000, 12000, 4500, 9000, 6000],\n    'tempo_no_site_seg': [30, 200, 180, 45, 300, 90, 250, 120],\n    'cor_favorita_cod': [1, 3, 2, 1, 4, 2, 3, 1]  # provavelmente irrelevante\n})\ny = [0, 1, 1, 0, 1, 0, 1, 1]\n\nmodelo = RandomForestClassifier(n_estimators=300, random_state=42)\nmodelo.fit(X, y)\n\nimportancias = pd.Series(modelo.feature_importances_, index=X.columns)\nprint(importancias.sort_values(ascending=False))\n# renda_mensal          0.42\n# tempo_no_site_seg     0.35\n# idade                 0.19\n# cor_favorita_cod      0.04\n# dtype: float64"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O perigo de features vazadas\n\nTem um caso em que importância alta é motivo de alarme, não de comemoração: quando a feature está claramente vazando informação do alvo. **Vazamento (leakage)** acontece quando uma feature só existe por causa do alvo, ou carrega informação que só estaria disponível depois do momento da previsão, um dado do futuro.\n\nDois exemplos clássicos:\n\n- Prever inadimplência usando `valor_total_multas_pagas`: essa coluna praticamente só tem valor diferente de zero pra quem já ficou inadimplente. O modelo não está aprendendo a prever risco, está reconhecendo o próprio resultado disfarçado de feature.\n- Prever cancelamento de assinatura (`churn`) usando `data_de_cancelamento`: essa data só existe depois que o cliente já cancelou. No momento real da previsão, essa informação simplesmente ainda não existe."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.ensemble import GradientBoostingClassifier\nfrom sklearn.model_selection import train_test_split\nimport pandas as pd\n\nX = pd.DataFrame({\n    'dias_em_atraso_atual': [0, 45, 0, 60, 0, 5, 0, 90],\n    'renda_mensal': [3000, 2500, 8000, 2000, 9000, 4000, 7000, 1800],\n    'valor_total_multas': [0, 320, 0, 410, 0, 15, 0, 600]  # existe por causa do alvo\n})\ny = [0, 1, 0, 1, 0, 0, 0, 1]  # inadimplente\n\nX_treino, X_teste, y_treino, y_teste = train_test_split(\n    X, y, test_size=0.25, random_state=42, stratify=y\n)\n\nmodelo = GradientBoostingClassifier(random_state=42)\nmodelo.fit(X_treino, y_treino)\n\nimportancias = pd.Series(modelo.feature_importances_, index=X.columns)\nprint(importancias.sort_values(ascending=False))\n# valor_total_multas       0.94   -> sinal de alerta, uma feature dominando quase tudo\n# dias_em_atraso_atual     0.05\n# renda_mensal             0.01\n\nprint(modelo.score(X_teste, y_teste))\n# 1.0   -> acurácia perfeita é suspeita, não motivo de comemoração"
+                    },
+                    {
+                        "type": "text",
+                        "value": "Acurácia quase perfeita ou importância concentrada quase inteira numa única feature são sinais clássicos de vazamento, o mesmo tipo de desconfiança que a matriz de confusão te ensinou a ter com métricas boas demais pra ser verdade. A pergunta que resolve a maioria dos casos é simples: essa informação estaria disponível no momento em que eu realmente preciso fazer a previsão? Se a resposta for não, a feature sai do conjunto, não importa o quanto ela pareça ajudar a métrica."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Sinal de alerta\", \"O que pode indicar\", \"O que fazer\"], [\"Uma feature concentra quase toda a importância\", \"Possível vazamento: ela pode carregar o próprio alvo disfarçado\", \"Investigar de onde a feature vem e quando ela fica disponível\"], [\"Acurácia ou métrica quase perfeita no teste\", \"Vazamento entre treino e teste, ou feature vazada\", \"Desconfiar antes de comemorar, revisar o pipeline de dados\"], [\"Uma feature nova aumenta muito a métrica de repente\", \"Ela pode usar informação que só existe depois da previsão\", \"Perguntar se o dado estaria disponível no momento real da previsão\"], [\"Duas features quase idênticas com importância dividida\", \"Redundância, não vazamento\", \"Considerar remover uma das duas, sem alarme\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "A melhor feature do mundo não vale nada se ela só existe depois que a resposta já aconteceu."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que o atributo `feature_importances_` de uma random forest treinada representa?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "O quanto cada feature contribuiu, somado nas árvores, pra reduzir a impureza dos splits.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A correlação linear exata entre cada feature e a variável alvo do problema estudado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A porcentagem de valores ausentes que cada feature tinha antes do treino do modelo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A ordem em que cada coluna aparece originalmente no dataframe de entrada usado.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que duas features fortemente correlacionadas entre si tendem a aparecer com importância individual menor do que o esperado?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque o modelo divide o crédito entre as duas ao usar ora uma, ora outra, nos splits das árvores.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o scikit-learn remove automaticamente uma das duas antes de calcular a importância final.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque `feature_importances_` sempre distribui a importância de forma igual entre as colunas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque colunas correlacionadas são combinadas numa única coluna antes do treino da árvore.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual é a definição mais precisa de vazamento de dados (leakage) numa feature?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Uma feature que carrega informação que só fica disponível depois da previsão ser feita.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Uma feature que tem valores ausentes em mais da metade das linhas de todo o conjunto de dados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma feature que está numa escala numérica muito diferente das demais colunas usadas no modelo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma feature categórica que não foi codificada em números antes do treino do modelo utilizado.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um modelo de previsão de churn atingiu 99% de acurácia no teste depois de incluir a feature `motivo_do_cancelamento`. O que essa combinação de resultado e feature sugere?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Que a feature provavelmente só existe pra quem já cancelou, e está vazando o próprio alvo pro treino.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Que o modelo finalmente achou a combinação ideal de hiperparâmetros pra esse problema de negócio.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que a base de dados usada tem poucas linhas, o que facilita atingir acurácia alta em qualquer teste.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que a técnica de balanceamento de classes usada funcionou melhor do que o esperado nesse caso.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Numa previsão de inadimplência, `score_de_credito_na_solicitacao` tem importância alta, e `valor_total_multas_pagas_depois_do_atraso` também tem importância alta. Qual das duas deve ser questionada como possível vazamento, e por quê?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "`valor_total_multas_pagas_depois_do_atraso`, porque essa informação só existe depois do evento que se quer prever.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "`score_de_credito_na_solicitacao`, porque score de crédito nunca tem relação real com risco de inadimplência.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "As duas devem ser questionadas igualmente, já que toda feature com importância alta é sinal de vazamento.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Nenhuma das duas, já que importância alta é sempre um bom sinal de que a feature deve ser mantida.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 2 - Ajuste de hiperparâmetros",
+        "aulas": [
+            {
+                "titulo": "Parâmetro x hiperparâmetro",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Duas coisas com nome parecido, que se confundem\n\nAo longo da trilha de Machine Learning você chamou `.fit()` dezenas de vezes, e nesse processo mexeu tanto em coisas que o modelo aprende sozinho quanto em coisas que você decide antes de treinar, sem sempre separar os dois grupos. Chegou a hora de separar isso direito: **parâmetro** é o que o modelo aprende a partir dos dados durante o treino; **hiperparâmetro** é o que você define antes do treino começar, e que o `fit()` não toca."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Parâmetro: o que sai do fit()\n\nQuando um `LinearRegression` termina o `fit()`, ele guarda o coeficiente de cada feature em `coef_` e o intercepto em `intercept_`. Ninguém escolheu esses números à mão: o algoritmo de otimização encontrou os valores que minimizam o erro nos dados de treino. O mesmo vale para os pesos internos de uma regressão logística, ou para as perguntas (feature e limite) que uma árvore de decisão escolhe em cada nó: tudo isso é parâmetro, aprendido, e muda se você treinar de novo com dados diferentes."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.linear_model import LinearRegression\nfrom sklearn.datasets import make_regression\n\nX, y = make_regression(n_samples=200, n_features=3, noise=10, random_state=42)\n\nmodelo = LinearRegression()\nmodelo.fit(X, y)\n\nprint(modelo.coef_)\n# [45.23 12.87 -3.41]  (aprendido a partir dos dados, ninguem escolheu)\n\nprint(modelo.intercept_)\n# 0.52  (tambem aprendido: nao e argumento do construtor)"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Hiperparâmetro: o que você define antes\n\nJá o `max_depth` de uma `DecisionTreeClassifier`, o `n_neighbors` de um `KNeighborsClassifier` ou o `learning_rate` que você vai ver no Módulo 4, de boosting, são hiperparâmetros: você escolhe o valor antes de chamar `fit()`, e o algoritmo de treino não tem como mudar isso sozinho. Lembra daquele overfitting da árvore, lá na trilha de Machine Learning, quando ela cresceu sem limite e decorou o treino? `max_depth` era exatamente o hiperparâmetro que faltava limitar."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.tree import DecisionTreeClassifier\nfrom sklearn.neighbors import KNeighborsClassifier\n\n# max_depth e n_neighbors sao hiperparametros: voce escolhe antes do fit\narvore = DecisionTreeClassifier(max_depth=4, min_samples_leaf=10, random_state=42)\nknn = KNeighborsClassifier(n_neighbors=7)\n\n# depois do fit, quem \"aprende\" sao os PARAMETROS internos\n# (os limites de cada no da arvore, os pontos guardados pelo knn)\n# max_depth continua sendo 4: o fit nao muda esse valor, so usa ele"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"\", \"Parâmetro\", \"Hiperparâmetro\"], [\"Quem define o valor\", \"O algoritmo, durante o fit()\", \"Você, antes do fit()\"], [\"Muda ao treinar com dados novos?\", \"Sim, cada treino aprende valores novos\", \"Não, continua o mesmo até você trocar\"], [\"Exemplos\", \"coef_, intercept_, os limites de cada nó da árvore\", \"max_depth, n_neighbors, learning_rate, C\"], [\"Onde aparece no código\", \"Atributos com _ no final, lidos depois do fit\", \"Argumentos passados no construtor do modelo\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "O modelo aprende os parâmetros sozinho; os hiperparâmetros são as regras do jogo que você define antes de deixar ele jogar. Escolher bem essas regras é o assunto deste módulo inteiro."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Depois que um LinearRegression termina o treino, os valores guardados em coef_ e intercept_ são um exemplo de:",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "parâmetros: valores que o algoritmo aprendeu a partir dos dados de treino.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "hiperparâmetros: valores que controlam o comportamento geral do modelo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "hiperparâmetros: valores escolhidos à mão antes de chamar o fit().",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "parâmetros: valores que o cientista de dados ajusta antes do treino.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual das opções abaixo é um exemplo de hiperparâmetro, e não de parâmetro aprendido pelo modelo?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "o learning_rate usado num modelo de gradient boosting.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "os coeficientes de uma regressão logística depois do treino.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "os limites de decisão escolhidos em cada nó de uma árvore.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "os pesos internos ajustados por uma regressão linear treinada.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que o max_depth de uma árvore de decisão é considerado um hiperparâmetro, e não um parâmetro?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "porque o valor é definido antes do treino, e o fit() não o altera.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "porque nunca aparece entre os argumentos do construtor do modelo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "porque o valor muda sozinho a cada nova chamada de fit().",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "porque só existe em modelos de classificação, nunca em regressão.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de escolher max_depth e treinar a árvore final, os limites de decisão que ela usa em cada nó (tipo 'idade menor que 30') são:",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "parâmetros, porque foram aprendidos no fit() com esse max_depth fixado.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "hiperparâmetros, porque dependem diretamente do valor escolhido pra max_depth.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "parâmetros, porque foram escolhidos junto com max_depth antes do treino.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "hiperparâmetros, porque só existem depois que a árvore termina de crescer.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Em qual situação abaixo o valor citado é um hiperparâmetro, e não um parâmetro aprendido?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "o C escolhido pra regularizar uma regressão logística antes do treino.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "o coeficiente que a regressão logística atribui a cada variável de entrada.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "a probabilidade que o predict_proba calcula pra cada classe prevista.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "o intercepto que a regressão logística ajusta durante o processo de fit.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "GridSearchCV: busca em grade",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Automatizando a busca manual\n\nVocê já treinou modelos trocando um hiperparâmetro na mão, olhando o score, trocando de novo. Funciona, mas não escala: com dois ou três hiperparâmetros pra testar juntos, o número de combinações cresce rápido, e testar cada uma manualmente vira trabalho repetitivo, sujeito a erro. O `GridSearchCV` do scikit-learn automatiza exatamente isso: você descreve as combinações possíveis, e ele testa todas, usando a mesma validação cruzada que você já conhece da trilha de Machine Learning em cada uma delas."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Montando o param_grid\n\nO `param_grid` é um dicionário: cada chave é o nome do hiperparâmetro, igual ao argumento do construtor do modelo, e o valor é uma lista com as opções que você quer testar. Se você passar `max_depth: [3, 5, 10]` e `min_samples_leaf: [1, 5, 10]`, o GridSearchCV testa as 9 combinações possíveis (3 x 3), cada uma validada com cross-validation."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.model_selection import GridSearchCV\nfrom sklearn.tree import DecisionTreeClassifier\nfrom sklearn.datasets import make_classification\n\nX, y = make_classification(n_samples=500, n_features=8, random_state=42)\n\nparam_grid = {\n    \"max_depth\": [3, 5, 10, None],\n    \"min_samples_leaf\": [1, 5, 10],\n}\n\nbusca = GridSearchCV(\n    DecisionTreeClassifier(random_state=42),\n    param_grid=param_grid,\n    cv=5,\n    scoring=\"accuracy\",\n)\nbusca.fit(X, y)\n# 4 valores de max_depth x 3 de min_samples_leaf x 5 folds = 60 treinos"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Lendo o resultado: best_params_ e best_score_\n\nDepois do `fit()`, o objeto guarda tudo que foi testado. `best_params_` traz o dicionário com a combinação campeã, e `best_score_` traz a média da validação cruzada obtida por ela. Tem também `best_estimator_`, que já é um modelo treinado com essa combinação e com todos os dados passados pro fit, pronto pra usar direto."
+                    },
+                    {
+                        "type": "code",
+                        "value": "print(busca.best_params_)\n# {'max_depth': 5, 'min_samples_leaf': 5}\n\nprint(busca.best_score_)\n# 0.87\n\nmodelo_final = busca.best_estimator_\nprint(modelo_final.max_depth)\n# 5"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O custo de testar tudo\n\nO nome \"grade\" é literal: o GridSearchCV testa cada ponto do cruzamento entre as listas, sem pular nenhum. Isso garante que você não passa batido pela melhor combinação dentro da grade que definiu, mas o custo cresce multiplicando: número de valores de cada hiperparâmetro, vezes o número de folds do cv. Uma grade com 4 hiperparâmetros e 5 valores cada já soma 625 combinações (5 x 5 x 5 x 5), cada uma treinada cv vezes. Em modelos lentos de treinar, isso pode levar horas."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "GridSearchCV não é inteligente, é sistemático: testa cada combinação da grade sem exceção. A inteligência está em você desenhar uma grade que valha a pena testar por inteiro."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que o GridSearchCV faz, na prática?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "testa todas as combinações de uma grade de hiperparâmetros, com validação cruzada.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "escolhe sozinho, sem grade, qual algoritmo de machine learning usar no problema.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "treina o modelo uma única vez, usando os hiperparâmetros padrão do scikit-learn.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "elimina a necessidade de definir hiperparâmetros antes de treinar o modelo.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "No param_grid {'max_depth': [3, 5, 10], 'min_samples_leaf': [1, 10]}, quantas combinações o GridSearchCV testa, antes de multiplicar pelos folds do cv?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "6, o produto entre os 3 valores de max_depth e os 2 de min_samples_leaf.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "5, a soma entre os 3 valores de max_depth e os 2 de min_samples_leaf.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "3, apenas os valores de max_depth, já que ele aparece primeiro na grade.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "2, apenas os valores de min_samples_leaf, testados por último na grade.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Ao criar um GridSearchCV pra um DecisionTreeClassifier sem passar o argumento scoring, qual métrica ele usa por padrão pra decidir a melhor combinação?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "a métrica padrão do estimador, que pra classificação costuma ser a acurácia.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "o F1-score, porque é a métrica padrão de todo GridSearchCV do scikit-learn.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "o erro quadrático médio, usado como padrão em qualquer busca de hiperparâmetros.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "nenhuma: é obrigatório informar scoring, ou o GridSearchCV recusa a rodar.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de rodar GridSearchCV(modelo, param_grid, cv=5).fit(X, y), qual atributo guarda a combinação de hiperparâmetros com a melhor média de validação cruzada?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "best_params_",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "best_estimator_",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "cv_results_",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "best_score_",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe quer testar 5 hiperparâmetros diferentes, cada um com 6 valores possíveis, usando GridSearchCV com cv=10. Qual é o principal problema prático dessa escolha?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "o número de combinações cresce rápido demais, deixando a busca cara e lenta.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "o GridSearchCV trava com mais de três hiperparâmetros numa mesma grade de busca.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "o resultado fica pouco confiável, porque cv=10 é um valor baixo demais ali.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "a grade não aceita hiperparâmetros com mais de cinco valores possíveis cada um.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "RandomizedSearchCV: busca aleatória",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Quando a grade fica grande demais\n\nNo fim da aula passada, uma grade de 4 hiperparâmetros com 5 valores cada virou uma conta de 625 combinações. Esse é o cenário onde o `RandomizedSearchCV` entra: em vez de testar cada ponto da grade, ele sorteia um número fixo de combinações, definido por você em `n_iter`, e testa só essas, cada uma validada com cross-validation como no GridSearchCV."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Como funciona o sorteio\n\nVocê ainda descreve o espaço de busca, agora chamado `param_distributions` (o equivalente ao `param_grid`), mas pode usar tanto listas quanto distribuições estatísticas do `scipy.stats`, por exemplo `randint` pra inteiros num intervalo, ou `uniform` pra números contínuos. A cada uma das `n_iter` rodadas, o RandomizedSearchCV sorteia um valor de cada hiperparâmetro dentro do que foi descrito, monta uma combinação e avalia com CV."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.model_selection import RandomizedSearchCV\nfrom sklearn.ensemble import RandomForestClassifier\nfrom scipy.stats import randint\nfrom sklearn.datasets import make_classification\n\nX, y = make_classification(n_samples=500, n_features=8, random_state=42)\n\nparam_distributions = {\n    \"n_estimators\": randint(50, 500),\n    \"max_depth\": randint(2, 20),\n    \"min_samples_leaf\": randint(1, 20),\n}\n\nbusca = RandomizedSearchCV(\n    RandomForestClassifier(random_state=42),\n    param_distributions=param_distributions,\n    n_iter=30,\n    cv=5,\n    random_state=42,\n)\nbusca.fit(X, y)\n# so 30 combinacoes testadas, sorteadas dentro dos intervalos acima\n\nprint(busca.best_params_)\n# {'max_depth': 14, 'min_samples_leaf': 3, 'n_estimators': 267}"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Por que sortear pode ser tão bom quanto testar tudo\n\nParece contraintuitivo abrir mão de testar tudo, mas na prática, quando o espaço de busca é grande, boa parte dos hiperparâmetros tem pouco efeito no resultado final, e só alguns realmente importam. Testar uma grade inteira gasta boa parte do orçamento repetindo variações de um hiperparâmetro que quase não muda o score, enquanto o sorteio do RandomizedSearchCV cobre uma faixa mais ampla dos hiperparâmetros que de fato importam, com bem menos combinações."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"\", \"GridSearchCV\", \"RandomizedSearchCV\"], [\"Como escolhe as combinações\", \"Testa todas as combinações da grade\", \"Sorteia n_iter combinações do espaço\"], [\"Espaço de busca aceito\", \"Listas de valores discretos\", \"Listas ou distribuições contínuas\"], [\"Custo controlado por\", \"Tamanho da grade (cresce rápido)\", \"Valor de n_iter, escolhido por você\"], [\"Melhor cenário\", \"Poucos hiperparâmetros, poucos valores\", \"Muitos hiperparâmetros, espaço grande\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Quando preferir cada um\n\nComo regra prática: com dois ou três hiperparâmetros e poucos valores plausíveis pra cada um, uma grade pequena no GridSearchCV é direta e garante cobrir tudo. Quando o espaço cresce (mais hiperparâmetros, faixas contínuas, ou um modelo caro de treinar como os de boosting do Módulo 4), o RandomizedSearchCV costuma achar uma combinação quase tão boa gastando uma fração do tempo, e o `n_iter` deixa você decidir quanto orçamento de busca está disposto a gastar."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "GridSearchCV pergunta: e se eu testar tudo? RandomizedSearchCV pergunta: quanto do \"tudo\" eu realmente preciso testar pra achar algo bom? Com espaço de busca grande, a segunda pergunta costuma valer mais a pena."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual é a principal diferença entre RandomizedSearchCV e GridSearchCV?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "o RandomizedSearchCV sorteia um número fixo de combinações, em vez de testar todas.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "o RandomizedSearchCV não usa validação cruzada, ao contrário do GridSearchCV.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "o RandomizedSearchCV só funciona com modelos de ensemble, como random forest.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "o RandomizedSearchCV escolhe hiperparâmetros sem precisar de nenhum espaço de busca.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Pra que serve o argumento n_iter no RandomizedSearchCV?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "define quantas combinações de hiperparâmetros serão sorteadas e testadas.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "define quantos folds de validação cruzada serão usados em cada teste.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "define quantas vezes o modelo final será retreinado depois da busca.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "define o número máximo de hiperparâmetros que podem entrar na busca.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "No param_distributions de um RandomizedSearchCV, um hiperparâmetro pode receber tanto uma lista de valores quanto:",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "uma distribuição do scipy.stats, como randint ou uniform.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "uma função customizada, desde que retorne sempre um número inteiro.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "outro objeto GridSearchCV já treinado com uma grade menor antes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "um segundo param_distributions aninhado, com valores mais específicos.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um modelo de gradient boosting é caro de treinar, e a equipe quer buscar entre 6 hiperparâmetros com faixas contínuas de valores. Qual argumento do RandomizedSearchCV concentra o controle direto sobre o orçamento de tempo da busca?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "n_iter, porque define quantas combinações serão sorteadas e treinadas.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "cv, porque reduzir o número de folds elimina o custo da busca.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "random_state, porque fixá-lo evita que combinações repetidas sejam testadas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "param_distributions, porque menos hiperparâmetros ali reduzem o tempo total.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que o RandomizedSearchCV consegue, muitas vezes, achar uma combinação quase tão boa quanto a do GridSearchCV testando bem menos combinações?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "porque nem todo hiperparâmetro pesa igual no resultado, e sortear cobre bem os que importam.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "porque ele sempre encontra o ótimo global, diferente do GridSearchCV, que é só aproximado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "porque internamente ele ainda testa a grade inteira, só exibe uma amostra do resultado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "porque ele reduz sozinho o número de features do conjunto de dados de entrada.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Não vazar o teste no tuning",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## O mesmo cuidado do vazamento, agora no tuning\n\nLá na trilha de Machine Learning você aprendeu que treinar o scaler com o dataset inteiro, treino e teste juntos, vaza informação e infla a avaliação, e que o Pipeline existe pra isso não acontecer por descuido. A busca de hiperparâmetros tem exatamente o mesmo risco, só que mais sutil: se você usa o conjunto de teste pra escolher qual combinação de hiperparâmetros é a melhor, o teste deixou de medir dado nunca visto, porque ele ajudou a escolher o modelo."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O fluxo certo: CV no treino, teste só no final\n\nA prática correta é separar treino e teste primeiro, com `train_test_split`, e nunca deixar o GridSearchCV ou RandomizedSearchCV ver o conjunto de teste durante a busca. A validação cruzada, dentro da busca, roda inteiramente dentro do conjunto de treino: cada fold usado pra validar ali é uma fatia do treino, não o teste reservado. Só depois de escolher o `best_estimator_` é que ele encosta, uma única vez, no conjunto de teste, pra estimar o desempenho em dado realmente novo."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.model_selection import train_test_split, GridSearchCV\nfrom sklearn.ensemble import RandomForestClassifier\nfrom sklearn.datasets import make_classification\n\nX, y = make_classification(n_samples=1000, n_features=10, random_state=42)\n\n# separa o teste ANTES de qualquer busca\nX_treino, X_teste, y_treino, y_teste = train_test_split(\n    X, y, test_size=0.2, random_state=42\n)\n\nparam_grid = {\"max_depth\": [4, 8, 12, None], \"n_estimators\": [100, 300]}\n\nbusca = GridSearchCV(\n    RandomForestClassifier(random_state=42), param_grid, cv=5\n)\nbusca.fit(X_treino, y_treino)  # o CV inteiro roda dentro do treino\n\nprint(busca.best_params_)\n# {'max_depth': 12, 'n_estimators': 300}\n\nprint(busca.best_score_)\n# 0.89  (media da validacao cruzada, ainda dentro do treino)\n\n# X_teste so aparece aqui, uma vez, no fim de tudo\nprint(busca.score(X_teste, y_teste))\n# 0.87  (estimativa honesta, em dado que a busca nunca viu)"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## A ideia de um conjunto de validação\n\nQuando o GridSearchCV faz cross-validation dentro do treino, ele já está, na prática, usando pedaços do treino como validação: cada fold vira teste temporário das outras rodadas. Por isso, quando alguém fala em \"conjunto de validação\" nesse contexto, normalmente está descrevendo esses folds rotativos, e não um terceiro conjunto fixo. Em alguns projetos, ainda assim, separa-se um conjunto de validação fixo (treino, validação e teste, os três juntos) quando comparar poucos modelos grandes, caros demais pra retreinar a cada fold, não compensa o custo."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Por cima: nested cross-validation\n\nExiste uma pergunta ainda mais rigorosa: e se o próprio processo de escolher os hiperparâmetros, com aquele best_score_, também estiver um pouco otimista, porque a mesma validação cruzada que ajustou a busca também virou a métrica reportada? A resposta mais rigorosa é o nested CV, a validação cruzada aninhada: uma validação cruzada externa avalia o modelo, e dentro de cada fold externo roda uma busca de hiperparâmetros completa, com sua própria validação cruzada interna, só com aquele pedaço de treino. É mais caro ainda de rodar, então na prática costuma aparecer mais em comparações científicas entre algoritmos do que no dia a dia de ajustar um modelo pra produção."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Etapa\", \"Certo\", \"Errado\"], [\"Separar treino e teste\", \"Antes de qualquer busca de hiperparâmetros\", \"Depois de já ter espiado algum resultado\"], [\"Validação cruzada da busca\", \"Roda só dentro do conjunto de treino\", \"Roda no dataset inteiro, treino e teste juntos\"], [\"Conjunto de teste\", \"Usado uma única vez, no final\", \"Usado várias vezes pra comparar combinações\"], [\"Métrica reportada\", \"busca.score(X_teste, y_teste), depois de tudo\", \"best_score_ apresentado como desempenho final\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "best_score_ mede o quão bem a busca foi no treino; o conjunto de teste, tocado uma única vez, mede o quão bem o modelo vai lá fora. Confundir os dois é vazar o teste sem perceber."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Por que o conjunto de teste não deve ser usado dentro do GridSearchCV ou RandomizedSearchCV, durante a busca de hiperparâmetros?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "porque o teste deixaria de medir desempenho em dado nunca visto pelo processo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "porque o GridSearchCV não aceita tecnicamente rodar sobre um conjunto de teste.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "porque o teste, sozinho, é sempre pequeno demais pra qualquer validação cruzada.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "porque hiperparâmetros só podem ser ajustados usando o conjunto de treino inteiro.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "No fluxo correto de tuning, a validação cruzada usada pelo GridSearchCV roda sobre:",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "fatias do conjunto de treino, revezando qual fatia vira validação a cada rodada.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "o conjunto de teste inteiro, repetido uma vez pra cada hiperparâmetro testado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "o dataset completo, treino e teste juntos, embaralhado antes de cada fold.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "uma amostra aleatória nova, sorteada fora do treino e do teste originais.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe rodou GridSearchCV, obteve best_score_ de 0,91 e publicou esse número como o desempenho esperado em produção, sem tocar no conjunto de teste. Qual o problema dessa decisão?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "best_score_ vem só da validação cruzada no treino, e pode ficar otimista.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "best_score_ não existe de fato como atributo do GridSearchCV depois do fit.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "o problema é usar cv na busca: deveria ter usado um único split.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "nenhum problema, já que best_score_ já reflete o desempenho em dado novo.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Sobre o nested cross-validation (validação cruzada aninhada), é correto afirmar que:",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "a cada fold externo, roda uma busca completa de hiperparâmetros só com o treino dali.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "dispensa por completo qualquer validação cruzada dentro do processo de busca inteiro.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "custa bem menos pra rodar, na prática, do que uma busca simples com GridSearchCV.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "elimina de vez a necessidade de testar mais de um valor de hiperparâmetro na grade.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de separar treino e teste, uma pessoa roda GridSearchCV várias vezes no mesmo treino, ajustando o param_grid a cada rodada com base no score que ela vê em busca.score(X_teste, y_teste) entre uma tentativa e outra. Qual o problema disso?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "o teste, mesmo fora do fit, acaba guiando as escolhas e perde a isenção.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "nada muda, desde que o cv dentro do GridSearchCV continue igual a 5.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "o param_grid não pode, por padrão, mudar entre uma rodada e outra.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "o problema é só o tempo gasto: rodar várias vezes não muda o resultado.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Curva de validação e custo x ganho",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Enxergando o efeito de um hiperparâmetro sozinho\n\nGridSearchCV e RandomizedSearchCV respondem \"qual é a melhor combinação\", mas não mostram como o desempenho muda conforme um hiperparâmetro sobe ou desce. Pra isso existe a curva de validação: fixa todos os outros hiperparâmetros, varia só um (por exemplo, max_depth de 1 a 20) e registra o score de treino e o score de validação cruzada em cada valor. Como a plataforma não desenha o gráfico aqui, vale descrever a forma que ele costuma ter, porque ela conta uma história por si só."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## A forma da curva: underfit de um lado, overfit do outro\n\nCom um max_depth muito baixo, tanto o score de treino quanto o de validação ficam baixos e próximos: a árvore é simples demais pra captar o padrão, isso é underfitting. Conforme max_depth sobe, os dois scores sobem junto, até um ponto em que o score de treino continua subindo (a árvore aprende cada vez mais detalhes), mas o score de validação estaciona ou começa a cair: dali em diante, a árvore está decorando particularidades do treino que não se repetem em dado novo, aquele overfitting que você já viu antes. O ponto ideal fica onde os dois scores estão altos e ainda próximos um do outro, antes de abrirem distância."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.model_selection import validation_curve\nfrom sklearn.tree import DecisionTreeClassifier\nfrom sklearn.datasets import make_classification\n\nX, y = make_classification(n_samples=500, n_features=10, random_state=42)\n\nprofundidades = range(1, 21)\n\nscores_treino, scores_val = validation_curve(\n    DecisionTreeClassifier(random_state=42),\n    X, y,\n    param_name=\"max_depth\",\n    param_range=profundidades,\n    cv=5,\n)\n\nmedia_treino = scores_treino.mean(axis=1)\nmedia_val = scores_val.mean(axis=1)\n\nfor prof, tr, val in zip(profundidades, media_treino, media_val):\n    print(prof, round(tr, 2), round(val, 2))\n# 1  0.71 0.70   (underfitting: os dois baixos e colados)\n# 6  0.94 0.89   (os dois sobem, ainda proximos)\n# 12 0.99 0.86   (treino quase perfeito, validacao ja caiu: overfitting)\n# 20 1.00 0.83   (treino decorado, validacao piorando mais ainda)"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Da curva ao trade-off: custo da busca x ganho\n\nA curva de validação não substitui o GridSearchCV (ela varia um hiperparâmetro de cada vez, isolado, enquanto uma busca real combina vários), mas ajuda a desenhar uma grade mais inteligente: se a validação já está caindo a partir de max_depth=10, testar 15, 18 ou 20 na grade é gastar tempo numa região que a curva já descartou. Esse é o trade-off que fecha o módulo: cada combinação a mais custa tempo de treino, mas o ganho de score não cresce na mesma proporção. Sair de uma grade pequena pra uma média costuma trazer ganho real; sair de uma grade grande pra uma gigantesca, na mesma faixa de valores, tende a trazer frações de melhora cada vez menores: o retorno decrescente da busca de hiperparâmetros."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Cenário\", \"Custo da busca\", \"Ganho esperado\"], [\"Poucos valores, longe do ideal\", \"Baixo\", \"Alto: sai do underfitting rápido\"], [\"Grade ampla, cobrindo região desconhecida\", \"Médio a alto\", \"Médio: ainda mapeia o comportamento\"], [\"Grade enorme, refinando casas decimais do score\", \"Muito alto\", \"Baixo: retorno decrescente\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Fechando o Módulo 2\n\nVocê já sabe separar o que o modelo aprende sozinho (parâmetro) do que você decide antes (hiperparâmetro), automatizar essa escolha com GridSearchCV ou RandomizedSearchCV, manter o conjunto de teste isento durante o tuning e ler uma curva de validação pra saber quando parar de buscar. É a mesma disciplina de sempre: validação cruzada guiando a decisão, teste reservado pro veredito final.\n\nNo próximo módulo, o hiperparâmetro dá lugar a outra ideia pra melhorar um modelo: em vez de ajustar um modelo só, treinar vários e combinar as respostas. É o começo dos ensembles, começando pelo bagging e pela random forest."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "A curva de validação mostra onde o modelo para de aprender e começa a decorar. Saber parar de buscar hiperparâmetro na hora certa vale tanto quanto saber buscar."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que a curva de validação mostra, ao variar um único hiperparâmetro?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "como o score de treino e o de validação mudam conforme o hiperparâmetro varia.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "qual é, automaticamente, a melhor combinação entre vários hiperparâmetros diferentes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "quanto tempo, em segundos, cada combinação de hiperparâmetros leva pra treinar.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "qual algoritmo de machine learning generaliza melhor pro conjunto de dados.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Numa curva de validação, o que indica a região onde o score de treino continua subindo, mas o score de validação estaciona ou cai?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "o começo do overfitting: o modelo decorando particularidades do treino.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "um erro de código, já que os dois scores deveriam sempre subir juntos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "o começo do underfitting: o modelo simples demais pra captar o padrão.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "um sinal de que o conjunto de validação está desbalanceado entre classes.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma curva de validação pro max_depth de uma árvore mostra os dois scores baixos e próximos entre si nos valores pequenos de max_depth. O que isso indica?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "underfitting: a árvore está simples demais pra captar o padrão dos dados.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "overfitting: a árvore está decorando detalhes que não se repetem fora do treino.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "vazamento de dados: o conjunto de teste influenciou o treino nesses valores.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "um bug na validation_curve, já que os scores nunca deveriam ficar próximos.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de ver que, a partir de max_depth=8, o score de validação para de melhorar, qual é o uso mais direto dessa informação ao montar o param_grid de um GridSearchCV?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "concentrar a grade numa faixa próxima de 8, sem testar valores bem maiores.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "remover max_depth do param_grid, já que a curva sozinha revelou o valor ideal.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "aumentar o cv da busca, já que a curva substitui os folds do GridSearchCV.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "trocar de algoritmo, porque a estabilização indica um modelo mal escolhido ali.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe expande a grade de busca de 200 pra 4000 combinações, na mesma faixa de valores já testada antes, e o best_score_ sobe de 0,912 pra 0,914. O que essa situação ilustra?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "o retorno decrescente da busca: muito mais custo computacional por um ganho pequeno.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "um sinal claro de que a grade anterior sofria de underfitting nos hiperparâmetros.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "que o RandomizedSearchCV teria, obrigatoriamente, piorado ainda mais esse resultado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "que o conjunto de teste vazou durante a expansão da grade de busca.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 3 - Ensembles: bagging e random forest",
+        "aulas": [
+            {
+                "titulo": "Por que ensembles funcionam",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Por que ensembles funcionam\n\nAté agora, na trilha de Machine Learning, você treinou um modelo de cada vez: uma árvore, uma regressão, um KNN. Funciona, mas tem um limite. Todo modelo individual carrega os próprios pontos cegos, e por melhor que seja o ajuste de hiperparâmetros, sempre sobra erro que aquele modelo específico não consegue resolver sozinho.\n\nA ideia de **ensemble** é simples de enunciar e poderosa na prática: em vez de apostar tudo em um modelo só, treine vários e combine as previsões deles. Se os modelos erram de formas diferentes, os erros de uns tendem a ser compensados pelos acertos dos outros, e o resultado final fica mais preciso e, principalmente, mais estável do que qualquer um dos modelos isolados."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## A sabedoria da multidão\n\nEsse fenômeno tem nome fora do machine learning: sabedoria da multidão (*wisdom of the crowd*). O exemplo clássico é do estatístico Francis Galton, que documentou um concurso numa feira de gado no início do século 20: centenas de pessoas tentaram adivinhar o peso de um boi depois de abatido e limpo. Nenhum palpite individual foi exato, mas a média de todos os palpites ficou impressionantemente próxima do peso real, mais perto do que a maioria dos especialistas individuais presentes.\n\nCom classificadores acontece algo parecido. Se você tem vários modelos, cada um só um pouco melhor do que chutar aleatoriamente, e os erros deles não estão muito correlacionados, a votação da maioria pode superar e muito qualquer um dos modelos sozinho."
+                    },
+                    {
+                        "type": "code",
+                        "value": "import numpy as np\n\nrng = np.random.default_rng(42)\n\ndef acerto_por_votacao(n_modelos, acuracia_individual, n_simulacoes=20000):\n    \"\"\"Simula n_modelos classificadores independentes, cada um certo\n    com probabilidade acuracia_individual, e agrega por voto da maioria.\"\"\"\n    acertos = rng.random((n_simulacoes, n_modelos)) < acuracia_individual\n    votos_certos = acertos.sum(axis=1) > (n_modelos / 2)\n    return votos_certos.mean()\n\nfor n in [1, 5, 15, 51, 101]:\n    print(n, round(acerto_por_votacao(n, 0.6), 3))\n\n# 1    0.6\n# 5    0.683\n# 15   0.755\n# 51   0.856\n# 101  0.911\n# cada modelo sozinho acerta so 60% das vezes, mas a votacao de 101\n# modelos independentes acerta mais de 91%"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## A condição escondida: os modelos precisam errar diferente\n\nA votação só ajuda se duas condições forem verdadeiras:\n\n- cada modelo precisa ser melhor do que o acaso, ainda que só um pouco\n- os erros dos modelos não podem estar muito correlacionados entre si\n\nSe todos os modelos erram exatamente nos mesmos exemplos, a votação não corrige nada, ela só repete o mesmo erro em coro.\n\nÉ por isso que juntar cinquenta cópias idênticas do mesmo modelo, treinadas com os mesmos dados e os mesmos hiperparâmetros, não ajuda em nada: elas vão prever exatamente a mesma coisa, sempre. O ganho de um ensemble vem da **diversidade** entre os modelos, não só da quantidade."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Aspecto\", \"Um modelo só\", \"Ensemble de modelos diversos\"], [\"Variância (sensibilidade aos dados de treino)\", \"Pode ser alta, dependendo do modelo\", \"Tende a ser menor, pela agregação\"], [\"Efeito de um exemplo ruidoso no treino\", \"Pode mudar bastante a previsão final\", \"Efeito diluído entre vários modelos\"], [\"Custo computacional\", \"Baixo: treina e prediz uma vez\", \"Maior: treina e prediz várias vezes\"], [\"Facilidade de interpretar o resultado\", \"Geralmente mais simples de explicar\", \"Mais difícil de explicar diretamente\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que vem a seguir neste módulo\n\nExistem várias formas de montar um ensemble: por votação de modelos diferentes, por combinação sequencial (onde cada modelo corrige o anterior) ou por agregação de várias versões do mesmo modelo treinadas em amostras diferentes dos dados. Este módulo foca nessa última família, com destaque para a mais usada na prática: a **random forest**, que nada mais é do que um ensemble de árvores de decisão construído com bastante inteligência.\n\nAntes de chegar lá, vale relembrar por que a árvore de decisão, sozinha, é uma ótima candidata a entrar num ensemble."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Um modelo só carrega os próprios erros sozinho. Um ensemble bem montado reparte esses erros entre vários modelos, e a votação ou a média cuida de cancelar boa parte deles."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que é a ideia central por trás de um ensemble de modelos em machine learning?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Combinar várias previsões pra que os erros de cada modelo se compensem entre si",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Treinar um único modelo bem grande até memorizar todos os padrões dos dados de treino",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Escolher sempre o algoritmo mais complexo disponível, descartando os mais simples",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Repetir o mesmo algoritmo com os mesmos hiperparâmetros, várias vezes seguidas",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Para que um ensemble de classificadores realmente melhore o resultado em relação a um modelo só, o que se espera dos modelos que o compõem?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Que sejam razoavelmente bons individualmente e errem de formas diferentes entre si",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Que sejam todos exatamente iguais em estrutura e cometam os mesmos erros sempre",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que sejam o mais fracos possível, já que a agregação sempre compensa qualquer fraqueza",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que usem exatamente os mesmos dados de treino, sem nenhuma variação de amostra",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um colega treinou 50 árvores de decisão idênticas, com os mesmos dados e os mesmos hiperparâmetros, e combinou as previsões por votação. O resultado ficou igual ao de uma única árvore. Por que isso aconteceu?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque os modelos idênticos cometem os mesmos erros, sem nada pra votação compensar",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque árvores de decisão não podem, por definição, fazer parte de nenhum ensemble",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque a votação por maioria só funciona corretamente com menos de dez modelos",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque cinquenta árvores já é um número baixo demais pra qualquer ganho estatístico",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Segundo a lógica da 'sabedoria da multidão' aplicada a classificadores, o que tende a acontecer com a acurácia da votação majoritária conforme cresce o número de modelos independentes, cada um com acurácia individual pouco acima de 50%?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "A acurácia da votação tende a subir e se aproximar de 100%, se os erros forem independentes",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A acurácia da votação cai, porque mais modelos aumentam a chance de empates na contagem",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A acurácia da votação fica travada exatamente no valor da acurácia de cada modelo",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A acurácia da votação só sobe se cada modelo individual já acertar mais de 90% sozinho",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Duas equipes montam ensembles com 100 modelos cada, todos com acurácia individual parecida. Na equipe A, os modelos erram de forma bem correlacionada entre si. Na equipe B, os erros são bem menos correlacionados. O que esperar do ganho da agregação em cada caso?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O ensemble da equipe B tende a ganhar mais, porque erros pouco correlacionados se cancelam melhor",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O ensemble da equipe A tende a ganhar mais, porque erros correlacionados são mais fáceis de corrigir",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não faz diferença: a correlação entre os erros dos modelos não influencia o ensemble final",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O ensemble da equipe B tende a piorar, já que erros pouco correlacionados confundem a votação",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "A árvore e seu overfitting (revisão)",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Relembrando a árvore de decisão\n\nLá na trilha de Machine Learning você treinou sua primeira árvore de decisão: um modelo que divide os dados repetidamente em regiões cada vez mais puras, escolhendo em cada passo a feature e o ponto de corte que mais reduzem a impureza (Gini ou entropia). É um modelo fácil de visualizar, fácil de explicar pra qualquer pessoa e capaz de capturar relações bem complexas nos dados.\n\nO problema mora exatamente nessa capacidade. Se você deixar a árvore crescer livre, sem nenhum limite, ela vai dividir os dados até sobrar uma folha quase só pra cada exemplo de treino. Nesse ponto ela não aprendeu o padrão geral, ela decorou o conjunto de treino."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O problema não é só overfitar, é ser instável\n\nVocê já viu como limitar `max_depth` ou `min_samples_leaf` ajuda a controlar o overfitting de uma árvore. Mas sobra um segundo problema, mais sutil: mesmo uma árvore razoavelmente podada é **instável**. Pequenas mudanças no conjunto de treino, como remover ou trocar uma fração pequena dos exemplos, podem mudar qual feature vira a raiz da árvore, e essa mudança lá em cima se propaga pra todas as divisões abaixo dela.\n\nSe fosse possível treinar a mesma árvore em cem amostras ligeiramente diferentes dos mesmos dados, você teria cem árvores com estruturas visivelmente diferentes entre si, mesmo vindo da mesma fonte de dados e do mesmo algoritmo."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.tree import DecisionTreeClassifier\nfrom sklearn.datasets import load_breast_cancer\nfrom sklearn.model_selection import train_test_split\nimport numpy as np\n\nX, y = load_breast_cancer(return_X_y=True, as_frame=True)\nX_train, X_test, y_train, y_test = train_test_split(\n    X, y, test_size=0.3, random_state=42\n)\n\nrng = np.random.default_rng(0)\nraizes = []\nacuracias = []\n\nfor _ in range(5):\n    idx = rng.choice(len(X_train), size=len(X_train), replace=True)\n    arvore = DecisionTreeClassifier(random_state=0)\n    arvore.fit(X_train.iloc[idx], y_train.iloc[idx])\n    raizes.append(X_train.columns[arvore.tree_.feature[0]])\n    acuracias.append(round(arvore.score(X_test, y_test), 3))\n\nprint(raizes)\n# ['worst perimeter', 'worst concave points', 'worst radius',\n#  'mean concave points', 'worst perimeter']\nprint(acuracias)\n# [0.912, 0.936, 0.924, 0.947, 0.918]\n# a raiz muda em quase toda amostra, e a acuracia oscila mais de\n# 3 pontos percentuais so por causa do reamostramento"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Viés baixo, variância alta\n\nEm termos de viés e variância (aquele equilíbrio que você já viu na trilha de Machine Learning), a árvore sem limites tem viés baixo, ela consegue se ajustar a praticamente qualquer formato de fronteira de decisão, mas paga isso com variância alta: o modelo final depende demais da amostra específica de treino que ela recebeu.\n\nLimitar `max_depth` ou aumentar `min_samples_leaf` reduz a variância, mas custa viés: a árvore fica mais simples e passa a errar até em padrões reais que ela poderia ter capturado. Existe um limite no quanto dá pra resolver a instabilidade só ajustando os hiperparâmetros de uma única árvore."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## E se a instabilidade for uma vantagem escondida?\n\nAqui está a virada deste módulo: em vez de tentar podar a árvore até ela parar de balançar, dá pra aceitar a instabilidade e usá-la a favor. Se pequenas variações no treino produzem árvores diferentes, então treinar várias árvores em variações diferentes dos dados e combinar as previsões delas deve reduzir bastante essa variância, exatamente pelo mesmo princípio de ensemble que você viu na aula anterior.\n\nEssa é a ideia por trás do **bagging**, o assunto da próxima aula."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "A árvore sozinha é fácil de entender e fácil de overfitar. E no detalhe ela é instável: um defeito que os ensembles estão prestes a transformar em vantagem."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual característica torna a árvore de decisão propensa a dar overfitting quando cresce sem nenhum limite de profundidade?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Ela continua dividindo os dados até isolar ruídos e casos específicos do treino",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Ela aplica regularização L2 por padrão, o que aumenta bastante o viés do modelo",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ela é limitada por construção a no máximo três níveis de profundidade possíveis",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ela não consegue separar bem as classes, nem mesmo nos próprios dados de treino",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O que significa dizer que uma árvore de decisão é um modelo 'instável'?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Pequenas mudanças no conjunto de treino podem mudar bastante a estrutura da árvore",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O treinamento da árvore falha com frequência e precisa ser reiniciado manualmente",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A árvore muda a previsão pra mesma entrada toda vez que é executada novamente",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A árvore leva um tempo bem variável pra treinar dependendo do hardware disponível",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "No experimento em que cinco árvores foram treinadas em cinco amostras bootstrap diferentes do mesmo conjunto de dados, a feature escolhida como raiz mudou em quase toda árvore, e a acurácia no teste oscilou entre elas. O que esse resultado evidencia?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "A alta variância da árvore de decisão: pequenas mudanças na amostra mudam bastante o modelo",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um erro de implementação, já que a mesma árvore deveria sempre escolher a mesma raiz",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que o conjunto de dados usado é pequeno demais pra qualquer algoritmo de árvore funcionar",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que a árvore de decisão tem viés alto e por isso não se ajusta aos dados de treino",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Limitar a profundidade máxima (max_depth) de uma árvore de decisão, mantendo os outros hiperparâmetros fixos, tende a",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "reduzir a variância do modelo, mas aumentar o viés, já que a árvore fica mais simples",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "reduzir o viés do modelo, mas aumentar a variância, já que a árvore fica mais simples",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "reduzir viés e variância ao mesmo tempo, sem nenhum tipo de custo envolvido nisso",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "não alterar nem o viés nem a variância, apenas o tempo total de treinamento",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que apenas ajustar os hiperparâmetros de uma única árvore (como max_depth ou min_samples_leaf) não resolve completamente o problema da instabilidade, o que motiva o uso de técnicas como o bagging?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Porque limitar a árvore reduz o overfitting, mas ela segue sensível a variações no treino",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque limitar a árvore aumenta a instabilidade, ao forçar decisões de corte mais aleatórias",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque a poda torna a árvore incapaz de fazer previsões em dados nunca vistos antes",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque os hiperparâmetros da árvore afetam só o tempo de execução, não a estrutura aprendida",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Bagging",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## O que é bagging\n\n**Bagging** é abreviação de *bootstrap aggregating*: treinar várias cópias do mesmo tipo de modelo, cada uma em uma amostra bootstrap diferente dos dados de treino, e depois agregar as previsões de todas elas. É a aplicação mais direta da ideia de ensemble que você viu na primeira aula, usando a instabilidade da árvore (vista na aula passada) como matéria-prima.\n\nO nome carrega as duas partes do processo: *bootstrap* é a forma de gerar as amostras de treino, e *aggregating* é a forma de juntar as previsões no final."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Amostragem bootstrap\n\nUma amostra bootstrap tem o mesmo tamanho do conjunto de treino original, mas é sorteada **com reposição**: um mesmo exemplo pode aparecer várias vezes na amostra, e outros podem não aparecer nenhuma vez. Na prática, cada amostra bootstrap costuma conter cerca de 63% dos exemplos originais (alguns repetidos), deixando de fora, em média, os outros 37%.\n\nEsses exemplos deixados de fora em cada amostra têm um nome: dados *out-of-bag* (OOB). Como cada modelo do bagging nunca viu os próprios dados OOB durante o treino, dá pra usá-los como uma espécie de validação gratuita, sem precisar separar um conjunto de validação à parte."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Agregando as previsões\n\nDepois de treinar um modelo em cada amostra bootstrap, o bagging combina as previsões de um jeito simples: em classificação, por votação da maioria entre as classes previstas (ou pela média das probabilidades, se o modelo expõe `predict_proba`); em regressão, pela média das previsões numéricas.\n\nO ganho vem da mesma lógica da aula 1: se cada árvore erra de um jeito um pouco diferente das outras (porque foi treinada numa amostra diferente), a média ou o voto tende a cancelar boa parte desses erros individuais. O resultado é um modelo final com variância bem menor do que qualquer árvore isolada, sem precisar simplificar cada árvore individualmente."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.ensemble import BaggingClassifier\nfrom sklearn.tree import DecisionTreeClassifier\nfrom sklearn.datasets import load_breast_cancer\nfrom sklearn.model_selection import train_test_split, cross_val_score\n\nX, y = load_breast_cancer(return_X_y=True, as_frame=True)\nX_train, X_test, y_train, y_test = train_test_split(\n    X, y, test_size=0.3, random_state=42\n)\n\narvore_unica = DecisionTreeClassifier(random_state=42)\nbagging = BaggingClassifier(\n    estimator=DecisionTreeClassifier(random_state=42),\n    n_estimators=100,\n    oob_score=True,\n    random_state=42,\n)\n\nprint(cross_val_score(arvore_unica, X_train, y_train, cv=5).mean())\n# 0.917 (arvore unica, variancia alta entre os folds)\n\nbagging.fit(X_train, y_train)\nprint(bagging.oob_score_)\n# 0.960 (avaliado nos dados out-of-bag, sem tocar no teste)\nprint(bagging.score(X_test, y_test))\n# 0.953 (o bagging costuma superar a arvore unica, com menos\n# oscilacao entre execucoes diferentes)"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Conceito\", \"O que significa\"], [\"Amostragem com reposição\", \"Cada exemplo pode ser sorteado mais de uma vez na mesma amostra\"], [\"Tamanho da amostra bootstrap\", \"Igual ao do conjunto de treino original\"], [\"Dados out-of-bag (OOB)\", \"Cerca de 37% dos exemplos que ficam fora de cada amostra bootstrap\"], [\"Agregação em classificação\", \"Votação da maioria (ou média das probabilidades previstas)\"], [\"Agregação em regressão\", \"Média das previsões numéricas de cada modelo\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Bagging não deixa nenhuma árvore mais esperta. Ele deixa o grupo mais estável: treinar em amostras bootstrap diferentes faz os erros puxarem pra lados diferentes, e a agregação cancela boa parte deles."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que significa 'bootstrap' no contexto do bagging?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Uma amostragem com reposição, do mesmo tamanho do conjunto original, pra treinar cada modelo",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Uma técnica de normalização aplicada às features antes de treinar cada modelo do ensemble",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um método de validação cruzada que separa treino e teste em cinco partes iguais",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um algoritmo de otimização usado pra ajustar os pesos internos de cada árvore",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Em uma amostra bootstrap do mesmo tamanho do conjunto de treino original, aproximadamente que fração dos exemplos originais costuma aparecer pelo menos uma vez?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Cerca de 63%, e o restante fica de fora, podendo virar validação out-of-bag",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Cerca de 100%, porque a amostragem com reposição sempre inclui todos os exemplos",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Cerca de 50%, o que corresponde exatamente à metade do conjunto de treino original",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Cerca de 10%, o que deixa cada modelo do bagging treinado com pouquíssimo dado",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "No bagging aplicado a um problema de classificação, como as previsões dos modelos individuais costumam ser agregadas em uma previsão final?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Por votação majoritária entre as classes previstas por cada modelo do ensemble",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Pela soma direta dos erros de cada modelo, escolhendo a classe com o menor total",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Pela previsão do primeiro modelo treinado, os demais servem só como validação",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Por um modelo adicional que aprende a corrigir sequencialmente o erro dos anteriores",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que treinar vários modelos com bagging tende a reduzir a variância sem aumentar muito o viés, comparado a um único modelo instável treinado nos mesmos dados?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Porque a média (ou o voto) de vários modelos com erros pouco correlacionados suaviza os erros",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque cada modelo do bagging recebe um viés adicional de propósito, o que cancela a variância",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o bagging elimina o erro de todos os modelos individuais antes de agregar as previsões",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque a amostragem bootstrap reduz o número de exemplos de treino, o que simplifica os modelos",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um cientista de dados aplica bagging usando regressão linear simples como modelo base, em vez de árvores de decisão sem poda. Comparado ao bagging de árvores, o ganho obtido tende a ser",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Menor, porque a regressão linear já é um modelo de baixa variância, com pouco a ganhar",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Maior, porque modelos lineares se beneficiam mais da agregação bootstrap do que as árvores",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O mesmo, já que o ganho do bagging independe completamente do modelo de base escolhido",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Impossível de obter, pois o bagging não pode ser aplicado a modelos lineares simples",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Random Forest",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Bagging de árvores com um toque a mais\n\nA **random forest** é, na essência, um bagging de árvores de decisão. Mas o Breiman, quando propôs o algoritmo, percebeu que dava pra ir além: além de sortear as amostras de treino (o bootstrap que você viu na aula passada), a random forest também sorteia, em **cada divisão** de cada árvore, um subconjunto aleatório das features disponíveis, e escolhe a melhor divisão só dentro desse subconjunto.\n\nIsso significa que, mesmo tendo o dado inteiro disponível, uma árvore da floresta pode ser proibida de usar a feature mais óbvia numa divisão específica, e obrigada a considerar alternativas que uma árvore comum nunca cogitaria naquele ponto."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Por que sortear features ajuda\n\nPense num conjunto de dados onde uma feature é claramente a mais forte pra prever o alvo. No bagging comum de árvores, quase toda amostra bootstrap vai produzir uma árvore que escolhe essa mesma feature forte lá na raiz, porque ela domina o cálculo de impureza na maioria dos casos. O resultado são árvores parecidas entre si, e árvores parecidas cometem erros parecidos, o que limita o quanto a agregação consegue reduzir a variância (lembra da aula 1: a votação só ajuda de verdade quando os erros não são muito correlacionados).\n\nAo restringir as features candidatas em cada divisão, a random forest força as árvores a explorarem caminhos diferentes. Elas ficam menos parecidas entre si, e por isso a média das previsões delas reduz a variância de forma bem mais eficaz do que o bagging simples."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.ensemble import RandomForestClassifier\nfrom sklearn.datasets import load_breast_cancer\nfrom sklearn.model_selection import train_test_split, cross_val_score\n\nX, y = load_breast_cancer(return_X_y=True, as_frame=True)\nX_train, X_test, y_train, y_test = train_test_split(\n    X, y, test_size=0.3, random_state=42\n)\n\nfloresta = RandomForestClassifier(\n    n_estimators=200,\n    max_features='sqrt',\n    random_state=42,\n    n_jobs=-1,\n)\n\nprint(cross_val_score(floresta, X_train, y_train, cv=5).mean())\n# 0.965 (media na validacao cruzada, mais alta e mais estavel entre os folds)\n\nfloresta.fit(X_train, y_train)\nprint(floresta.score(X_test, y_test))\n# 0.959\nprint(floresta.predict(X_test.iloc[:3]))\n# [1 0 1]\nprint(floresta.predict_proba(X_test.iloc[:3]))\n# [[0.02 0.98] [0.91 0.09] [0.05 0.95]]"
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.ensemble import RandomForestRegressor\nfrom sklearn.datasets import fetch_california_housing\nfrom sklearn.model_selection import train_test_split\n\nX, y = fetch_california_housing(return_X_y=True, as_frame=True)\nX_train, X_test, y_train, y_test = train_test_split(\n    X, y, test_size=0.3, random_state=42\n)\n\nregressor = RandomForestRegressor(n_estimators=200, random_state=42, n_jobs=-1)\nregressor.fit(X_train, y_train)\n\nprint(regressor.score(X_test, y_test))\n# 0.807 (R2 no teste)\nprint(regressor.predict(X_test.iloc[:3]))\n# [1.62 1.02 3.45]\n# cada arvore da floresta preve um valor numerico, e o regressor\n# final devolve a media dessas previsoes"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Aspecto\", \"Árvore de decisão única\", \"Random Forest\"], [\"Viés\", \"Baixo, se deixada crescer livre\", \"Parecido ao de uma árvore livre\"], [\"Variância\", \"Alta, sensível à amostra de treino\", \"Bem menor, pela agregação de várias árvores\"], [\"Tendência a overfitar\", \"Alta, sem limitar a profundidade\", \"Bem menor, mesmo com árvores individuais profundas\"], [\"Estabilidade entre execuções\", \"Baixa: pequenas mudanças no treino mudam a árvore\", \"Alta: o resultado agregado varia pouco\"], [\"Tempo de treino e de previsão\", \"Rápido\", \"Mais lento (proporcional ao número de árvores)\"], [\"Interpretar o modelo direto\", \"Fácil de visualizar e explicar\", \"Difícil de visualizar, mas dá feature_importances_\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Uma família, dois usos\n\nRepare que a mesma ideia serve tanto pra classificação (`RandomForestClassifier`) quanto pra regressão (`RandomForestRegressor`): a diferença está só em como as árvores da floresta agregam a previsão final, votação ou média das probabilidades num caso, média direta dos valores previstos no outro. A lógica de bagging mais aleatoriedade nas features é exatamente a mesma nos dois.\n\nNa próxima aula, o foco vira prático: quais hiperparâmetros realmente importam ajustar numa random forest, e por que ela costuma ser o primeiro modelo forte que um cientista de dados tenta antes de partir pra algo mais sofisticado."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Bagging já reduz a variância. A random forest vai além: ao sortear as features em cada divisão, força as árvores a discordarem mais entre si, e é essa discordância controlada que deixa a floresta mais estável que qualquer árvore isolada."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Além de treinar cada árvore em uma amostra bootstrap diferente, o que a random forest faz de adicional em relação ao bagging comum de árvores?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Em cada divisão, considera apenas um subconjunto aleatório das features disponíveis",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Treina cada árvore usando apenas 10% dos exemplos disponíveis no conjunto de treino",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Substitui a votação final por uma média ponderada definida manualmente pelo usuário",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Limita todas as árvores da floresta a terem exatamente a mesma profundidade máxima",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que sortear um subconjunto de features em cada divisão ajuda a random forest a superar o bagging simples de árvores?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque isso decorrelaciona as árvores, deixando a média das previsões mais eficaz na variância",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque isso aumenta o viés de cada árvore individual, o que sempre melhora a acurácia final",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque isso reduz o tempo de treino de cada árvore, sem alterar a qualidade das previsões",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque isso impede qualquer árvore da floresta de overfitar os dados de treino sozinha",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Em um conjunto de dados onde uma única feature é claramente mais forte que as demais para prever o alvo, o que tende a acontecer no bagging simples de árvores (sem sorteio de features), comparado à random forest?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "As árvores do bagging ficam parecidas entre si, já que quase todas escolhem a feature forte",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "As árvores do bagging tendem a ficar mais diversas entre si do que as árvores da random forest",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O bagging simples ignora automaticamente a feature mais forte, pra evitar viés no resultado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Nesse cenário específico, o bagging simples sempre supera a random forest em acurácia final",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "No scikit-learn, o que fazem os métodos fit e predict de um RandomForestClassifier já configurado?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "fit ajusta cada árvore da floresta aos dados de treino; predict agrega o voto das árvores",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "fit apenas valida os hiperparâmetros informados; predict é quem de fato treina e aplica o modelo",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "fit treina só a primeira árvore da floresta; predict treina as demais sob demanda a cada chamada",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "fit e predict fazem exatamente a mesma coisa no RandomForestClassifier, por compatibilidade",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Sobre o uso da random forest tanto para classificação quanto para regressão no scikit-learn, qual afirmação está correta?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "RandomForestClassifier agrega por votação e RandomForestRegressor agrega pela média das previsões",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "RandomForestRegressor não aceita o parâmetro n_estimators, que é exclusivo da versão de classificação",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "RandomForestClassifier só pode ser usado quando o alvo tem exatamente duas classes possíveis",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "RandomForestRegressor treina uma única árvore grande, sem qualquer amostragem bootstrap envolvida",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Usando random forest na prática",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Os hiperparâmetros que mais importam\n\nRandom forest tem bastante hiperparâmetro configurável, mas um punhado deles concentra a maior parte do efeito no resultado:\n\n- `n_estimators`: quantas árvores compõem a floresta\n- `max_depth`: o quanto cada árvore pode crescer\n- `max_features`: quantas features são sorteadas em cada divisão\n- `min_samples_leaf` e `min_samples_split`: o tamanho mínimo de folha e de divisão\n\nAssim como no módulo de ajuste de hiperparâmetros, a forma correta de escolher esses valores é por validação cruzada no conjunto de treino, nunca espiando o conjunto de teste no processo."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Hiperparâmetro\", \"O que controla\", \"Efeito de aumentar o valor\"], [\"n_estimators\", \"Número de árvores na floresta\", \"Mais estável, mais lento; ganho encolhe depois de certo ponto\"], [\"max_depth\", \"Profundidade máxima de cada árvore\", \"Árvores mais complexas; mais risco de cada uma overfitar\"], [\"max_features\", \"Quantas features são sorteadas em cada divisão\", \"Árvores mais parecidas entre si; menos ganho da agregação\"], [\"min_samples_leaf\", \"Tamanho mínimo de exemplos numa folha\", \"Árvores mais simples e mais regularizadas\"], [\"min_samples_split\", \"Mínimo de exemplos para tentar dividir um nó\", \"Árvores mais simples, com divisões menos finas\"], [\"n_jobs\", \"Quantos núcleos de CPU usar no treino\", \"Treino mais rápido; não muda o resultado do modelo\"]]"
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.ensemble import RandomForestClassifier\nfrom sklearn.model_selection import GridSearchCV, train_test_split\nfrom sklearn.datasets import load_breast_cancer\n\nX, y = load_breast_cancer(return_X_y=True, as_frame=True)\nX_train, X_test, y_train, y_test = train_test_split(\n    X, y, test_size=0.3, random_state=42\n)\n\ngrade = {\n    'n_estimators': [100, 300],\n    'max_depth': [None, 8, 16],\n    'max_features': ['sqrt', 0.5],\n}\n\nbusca = GridSearchCV(\n    RandomForestClassifier(random_state=42),\n    param_grid=grade,\n    cv=5,\n    scoring='accuracy',\n    n_jobs=-1,\n)\nbusca.fit(X_train, y_train)\n\nprint(busca.best_params_)\n# {'max_depth': 8, 'max_features': 'sqrt', 'n_estimators': 300}\nprint(busca.best_score_)\n# 0.965 (media na validacao cruzada, dentro do treino)\nprint(busca.score(X_test, y_test))\n# 0.959 (avaliacao final, so agora tocando no teste)"
+                    },
+                    {
+                        "type": "code",
+                        "value": "# continuando o exemplo anterior, com o melhor modelo encontrado pela busca\nfloresta_final = busca.best_estimator_\n\nimportancias = sorted(\n    zip(X.columns, floresta_final.feature_importances_),\n    key=lambda par: par[1],\n    reverse=True,\n)\n\nfor nome, importancia in importancias[:5]:\n    print(f'{nome}: {importancia:.3f}')\n\n# worst concave points: 0.142\n# worst perimeter: 0.129\n# worst radius: 0.108\n# mean concave points: 0.089\n# worst area: 0.081\n# quanto maior o numero, mais aquela feature contribuiu, em media,\n# pra reduzir a impureza nas divisoes de todas as arvores da floresta"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Por que random forest é um baseline tão forte\n\nRandom forest ganhou fama de baseline que funciona quase sempre por um motivo simples: ela costuma entregar um resultado bom com pouquíssimo ajuste, os valores padrão do scikit-learn já resolvem boa parte dos problemas. Ela não exige normalizar as features (diferente de KNN ou regressão logística), lida bem com relações não lineares e com interações entre variáveis sem que você precise criar essas interações manualmente, e é bem mais resistente a overfitar do que uma árvore isolada.\n\nSoma-se a isso o fato de que o treino de cada árvore é independente das demais, o que faz a random forest paralelizar bem entre núcleos de CPU (`n_jobs=-1`), e você tem um modelo que quase sempre vale a pena treinar primeiro, antes de partir pra algo mais sofisticado."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que a random forest não resolve sozinha\n\nVale a honestidade: random forest não é bala de prata. Com árvores muito profundas e pouco dado, ela ainda pode overfitar, só que menos e mais devagar do que uma árvore só. O modelo final é bem mais pesado pra armazenar e mais lento pra prever do que uma árvore única, porque cada previsão passa por centenas de árvores. E embora `feature_importances_` ajude bastante, você perde a leitura direta de uma árvore única: não dá pra simplesmente olhar a floresta inteira e explicar uma previsão específica em poucos passos.\n\nEm regressão existe ainda uma limitação conhecida: como a previsão final é uma média de valores vistos no treino, a random forest tem dificuldade pra **extrapolar** além do intervalo de valores que apareceu nos dados de treino."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Random forest é o baseline que você treina primeiro: robusto, difícil de overfitar feio e generoso com a importância das features. No próximo módulo entra o boosting, que troca parte dessa robustez por um ajuste mais fino e, às vezes, mais preciso."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O hiperparâmetro n_estimators de uma random forest controla o quê?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "O número de árvores independentes que serão treinadas dentro da floresta",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A profundidade máxima permitida para cada árvore dentro da floresta",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O número mínimo de exemplos exigido em cada folha das árvores da floresta",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A fração de features sorteadas em cada divisão das árvores da floresta",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Aumentar bastante o max_depth das árvores de uma random forest, mantendo os outros hiperparâmetros fixos, tende a",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "aumentar o risco de cada árvore individual overfitar, mesmo com a agregação amortecendo o efeito",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "eliminar por completo o risco de overfitting, já que a random forest é imune a esse problema",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "reduzir o número de árvores necessárias na floresta para manter a mesma acurácia final",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "diminuir o tempo total de treino da floresta, pois árvores mais profundas convergem mais rápido",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Ao rodar um GridSearchCV para ajustar max_features de uma random forest, qual cuidado evita que a escolha final do hiperparâmetro fique otimista demais?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Avaliar cada combinação por validação cruzada no treino e reservar o teste só pra avaliação final",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Escolher o valor de max_features que obtém a maior acurácia diretamente no conjunto de teste",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Usar sempre o maior valor possível de max_features, já que testar mais features é sempre melhor",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Rodar o GridSearchCV sobre todo o conjunto de dados de uma vez, sem separar treino e teste",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O que o atributo feature_importances_ de uma random forest treinada representa, de forma resumida?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Uma estimativa de quanto cada feature contribuiu, em média, pra reduzir a impureza nas divisões",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O coeficiente linear exato que cada feature teria numa regressão equivalente nos mesmos dados",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A correlação direta e isolada entre cada feature e a variável alvo, calculada fora do modelo",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A ordem em que cada feature foi originalmente coletada na construção do conjunto de dados",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de treinar uma random forest para regressão, um analista percebe que ela erra sistematicamente as previsões para valores de alvo bem acima de qualquer valor visto no treino. Qual é a explicação mais provável, dada uma limitação conhecida do modelo?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "A random forest agrega médias do treino, por isso não extrapola além do intervalo visto",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A random forest nunca deveria ser usada para problemas de regressão, apenas para classificação",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O número de árvores configuradas na floresta certamente está abaixo do mínimo necessário",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Isso indica um vazamento de dados (leakage) acontecendo entre o treino e o conjunto de teste",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 4 - Ensembles: boosting",
+        "aulas": [
+            {
+                "titulo": "A ideia de boosting (sequencial)",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Ensembles: boosting\n\nLá na trilha de Machine Learning você esbarrou naquele overfitting clássico da árvore de decisão sozinha: profunda demais, decorava o treino e generalizava mal. Random forest, que você viu no módulo passado, resolve isso combinando várias árvores treinadas em paralelo, cada uma numa amostra bootstrap diferente, e tirando a média dos votos. As árvores nem sabem da existência umas das outras, e é essa independência que reduz a variância do conjunto.\n\nBoosting ataca o mesmo problema (juntar modelos fracos pra formar um modelo forte) de um jeito bem diferente. Em vez de treinar tudo em paralelo, sem comunicação entre os modelos, o boosting treina em **sequência**: cada novo modelo nasce olhando pro que o modelo anterior errou."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Do fraco pro forte\n\nA ideia central do boosting é simples de enunciar: comece com um modelo bem fraco (às vezes uma árvore de profundidade 1, um *toco*, que sozinho erra bastante) e vá adicionando novos modelos fracos, cada um treinado pra corrigir o que os anteriores erraram. No fim, você soma as previsões de todos, com pesos, e o conjunto, mesmo formado só por modelos fracos, se comporta como um modelo forte.\n\nRepare na diferença de postura em relação ao random forest. Lá, cada árvore tenta ser razoavelmente boa sozinha, e a força vem da média de várias opiniões independentes. Aqui, cada modelo individual pode ser bem ruim, quase um palpite educado, mas a sequência de correções vai fechando o buraco que sobrou."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Paralelo x sequencial: a diferença que importa\n\nEssa é a diferença fundamental entre as duas famílias de ensemble que você está estudando (bagging no módulo anterior, boosting agora):\n\n- **Bagging (random forest):** os modelos são treinados em paralelo, de forma independente. Dá pra treinar todas as árvores ao mesmo tempo, em processos separados, porque uma não depende da outra. O objetivo principal é reduzir variância.\n- **Boosting:** os modelos são treinados em sequência, um depois do outro, porque cada modelo novo precisa saber o que o anterior errou. A sequência em si não dá pra paralelizar (mesmo que cada árvore, internamente, use vários núcleos). O objetivo principal é reduzir viés.\n\nEssa dependência sequencial tem um preço: treinar um boosting tende a ser mais lento que treinar um random forest com o mesmo número de árvores, já que não dá pra simplesmente distribuir tudo em vários processos ao mesmo tempo."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Aspecto\", \"Bagging (random forest)\", \"Boosting\"], [\"Treinamento\", \"Paralelo, modelos independentes\", \"Sequencial, cada modelo depende do anterior\"], [\"Foco de cada modelo\", \"Amostra bootstrap aleatória dos dados\", \"Erros deixados pelo modelo anterior\"], [\"Objetivo principal\", \"Reduzir variância\", \"Reduzir viés\"], [\"Modelos individuais\", \"Costumam ser razoavelmente fortes\", \"Costumam ser propositalmente fracos\"], [\"Paralelização do treino\", \"Fácil, cada árvore é independente\", \"Limitada, a sequência é obrigatória\"]]"
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.ensemble import AdaBoostClassifier\nfrom sklearn.tree import DecisionTreeClassifier\nfrom sklearn.model_selection import train_test_split\nfrom sklearn.metrics import accuracy_score\n\nX_train, X_test, y_train, y_test = train_test_split(\n    X, y, test_size=0.2, random_state=42\n)\n\n# AdaBoost é um dos algoritmos de boosting mais antigos e didáticos.\n# A cada rodada, ele aumenta o peso das amostras que o modelo anterior\n# errou, forçando o próximo \"toco\" de árvore a prestar atenção nelas.\nmodelo = AdaBoostClassifier(\n    estimator=DecisionTreeClassifier(max_depth=1),\n    n_estimators=100,\n    random_state=42\n)\nmodelo.fit(X_train, y_train)\n\ny_pred = modelo.predict(X_test)\nprint(accuracy_score(y_test, y_pred))\n# 0.87 (um único \"toco\" sozinho mal passaria de 0.60 de acurácia)"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Boosting não é sobre achar um modelo genial de uma vez só. É sobre errar rápido, admitir o erro e treinar o próximo modelo pra cobrir exatamente esse buraco, repetidas vezes, até o conjunto ficar bom."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que caracteriza o treinamento dos modelos num algoritmo de boosting?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Os modelos são treinados em sequência, e cada um foca nos erros do anterior",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Os modelos são treinados em paralelo, cada um numa amostra bootstrap diferente",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os modelos são treinados uma única vez e depois reaproveitados em outras bases",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os modelos são treinados em paralelo e depois combinados por votação simples",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um colega diz que bagging e boosting são basicamente a mesma ideia, só com nomes diferentes. Qual é a diferença conceitual mais importante entre eles?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Bagging reduz variância com modelos independentes; boosting reduz viés em sequência",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Bagging só funciona bem com regressão linear; boosting só funciona com árvores rasas",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Bagging exige obrigatoriamente validação cruzada; boosting dispensa qualquer avaliação",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Bagging serve apenas para problemas de classificação; boosting serve só pra regressão",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "No AdaBoost, o que acontece com o peso das amostras que o modelo anterior classificou errado?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O peso delas aumenta, forçando o próximo modelo a prestar mais atenção nelas",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O peso delas diminui, pra evitar que o próximo modelo repita o mesmo erro",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "As amostras erradas são removidas do conjunto de treino da rodada seguinte",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O peso de todas as amostras é reiniciado do zero a cada nova rodada",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que, em geral, não dá pra paralelizar o treinamento dos modelos dentro de um boosting da mesma forma que se faz num random forest?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Porque cada modelo novo depende do erro deixado pelo modelo treinado antes dele",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque as bibliotecas de boosting não têm suporte a múltiplos núcleos de processamento",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque cada modelo do boosting usa um conjunto de dados completamente diferente",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o boosting sempre treina um único modelo grande, sem etapas separadas",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Você tem vários *tocos* de árvore, cada um acertando pouco mais que o acaso sozinho. Isso é um problema pro boosting?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Não necessariamente: boosting é feito pra combinar modelos fracos assim num conjunto forte",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Sim, porque boosting só funciona bem com modelos já fortes e precisos individualmente",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Sim, porque modelos fracos tornam o treinamento sequencial impossível de executar",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não, mas o resultado final vai ser idêntico ao de um único modelo fraco isolado",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Gradient Boosting",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Gradient Boosting: corrigindo o resíduo aos poucos\n\nO AdaBoost que você viu na aula passada resolve o problema reponderando amostras: erra numa amostra, aumenta o peso dela, o próximo modelo presta mais atenção. O Gradient Boosting generaliza essa ideia de um jeito mais direto: em vez de mexer no peso das amostras, ele ajusta cada novo modelo pra prever o **resíduo**, ou seja, o erro que sobrou da previsão atual.\n\nPensa numa regressão de preço de imóvel. A primeira árvore pode ser só a média dos preços de treino. O erro entre essa média e o preço real de cada imóvel é o resíduo. A segunda árvore não tenta prever o preço de novo: ela tenta prever esse resíduo. A previsão da segunda árvore é somada (com um fator de ajuste) à primeira, o resíduo diminui, e uma terceira árvore tenta prever o que ainda sobrou. E assim por diante."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## E na classificação?\n\nEm classificação não existe um resíduo tão literal quanto em regressão (a diferença entre uma probabilidade prevista e uma classe 0 ou 1 não é bem um erro numérico direto), mas a lógica é parecida: a cada rodada, o algoritmo calcula o quanto errou em relação a uma função de perda e treina a próxima árvore pra reduzir esse erro. É daí que vem o nome *gradient*: cada árvore nova segue a direção que mais reduz essa perda."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.ensemble import GradientBoostingRegressor\nfrom sklearn.model_selection import train_test_split\nfrom sklearn.metrics import mean_absolute_error\n\nX_train, X_test, y_train, y_test = train_test_split(\n    X, y, test_size=0.2, random_state=42\n)\n\nmodelo = GradientBoostingRegressor(\n    n_estimators=200,\n    learning_rate=0.1,\n    max_depth=3,\n    random_state=42\n)\nmodelo.fit(X_train, y_train)\n\ny_pred = modelo.predict(X_test)\nprint(mean_absolute_error(y_test, y_pred))\n# 2.35 (cada árvore nova aprendeu a prever o resíduo que sobrou da anterior)"
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.ensemble import GradientBoostingClassifier\nfrom sklearn.metrics import classification_report\n\nmodelo_clf = GradientBoostingClassifier(\n    n_estimators=150,\n    learning_rate=0.1,\n    max_depth=3,\n    random_state=42\n)\nmodelo_clf.fit(X_train, y_train)\n\ny_pred = modelo_clf.predict(X_test)\nprint(classification_report(y_test, y_pred))\n# a mesma leitura de precision, recall e matriz de confusão que você já\n# conhece, agora calculada em cima das previsões do ensemble sequencial"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Etapa\", \"O que acontece\"], [\"1\", \"Um modelo inicial simples prevê algo básico (por exemplo, a média do alvo)\"], [\"2\", \"Calcula-se o resíduo: a diferença entre essa previsão e o valor real\"], [\"3\", \"Uma nova árvore é treinada pra prever justamente esse resíduo\"], [\"4\", \"A previsão da nova árvore é somada à anterior, escalada pela learning_rate\"], [\"5\", \"O processo se repete por n_estimators rodadas, reduzindo o resíduo a cada passo\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Gradient boosting não tenta acertar tudo de uma vez. Cada árvore nova tem uma tarefa bem específica: aprender só o pedaço do erro que ainda sobrou da rodada anterior."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual classe do scikit-learn você usa pra aplicar gradient boosting num problema de regressão?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "GradientBoostingRegressor",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "GradientBoostingClassifier",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "RandomForestRegressor",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "AdaBoostRegressor",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de treinar a primeira árvore de um gradient boosting pra prever preço de imóveis, os resíduos ainda mostram um padrão forte relacionado ao bairro. O que isso sugere?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Que a próxima árvore ainda tem um erro sistemático pra corrigir, ligado ao bairro",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Que o modelo já convergiu, e novas árvores não vão mudar mais a previsão final",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que a variável bairro deve ser removida do conjunto de dados imediatamente",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que o gradient boosting não consegue lidar com variáveis categóricas como bairro",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual é a diferença central entre gradient boosting e AdaBoost na forma de corrigir os erros do modelo anterior?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Gradient boosting ajusta a árvore ao resíduo do erro; o AdaBoost reforça o peso das amostras erradas",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Gradient boosting reforça o peso das amostras erradas; o AdaBoost ajusta a árvore ao resíduo do erro",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Gradient boosting treina todas as árvores em paralelo; o AdaBoost treina uma árvore só, por vez",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Gradient boosting não usa árvores de decisão; o AdaBoost funciona apenas com árvores bem profundas",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que o método se chama gradient boosting, e não algo como *residual boosting*?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque cada árvore segue a direção que reduz a função de perda usada no treino",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o algoritmo esconde uma rede neural treinada por gradiente descendente",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque gradient é apenas um nome comercial, sem relação com o método usado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque as árvores são treinadas de trás pra frente, da última rodada até a primeira",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de rodar um GradientBoostingClassifier, o recall da classe minoritária ficou bem baixo no classification_report, mesmo com acurácia alta. Isso tem relação direta com o fato de ser um boosting?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Não necessariamente, esse padrão costuma apontar desbalanceamento de classes, comum a qualquer modelo",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Sim, porque gradient boosting sempre ignora por completo as classes minoritárias durante o treino",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Sim, porque o cálculo do resíduo no gradient boosting considera só a classe majoritária",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não, porque gradient boosting nunca deve ser avaliado usando o classification_report",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "XGBoost, LightGBM e CatBoost",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## XGBoost, LightGBM e CatBoost: o estado da arte\n\nO GradientBoostingClassifier e o GradientBoostingRegressor do scikit-learn são ótimos pra entender o algoritmo por dentro, mas no dia a dia, e principalmente em competições de dados tabulares, quem domina é um trio de bibliotecas especializadas: **XGBoost**, **LightGBM** e **CatBoost**. Todas implementam a mesma ideia de gradient boosting que você acabou de ver, só que com anos de engenharia em cima pra treinar mais rápido, usar menos memória e generalizar melhor."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Por que elas dominam\n\nEssas bibliotecas ficaram famosas por um motivo simples: em bases de dados tabulares (linhas e colunas, o tipo mais comum em empresas), elas costumam entregar o melhor resultado com o menor esforço de preparo. Isso vem de otimizações como divisão de nós por histograma (mais rápida que testar cada valor possível), regularização embutida contra overfitting, suporte nativo a valores ausentes e, em alguns casos, treino em GPU.\n\nVale uma nota de honestidade aqui: mesmo com todo esse avanço, gradient boosting bem ajustado costuma superar redes neurais profundas em dados tabulares. Isso não quer dizer que deep learning seja ruim (você vai ver isso lá na frente, no módulo sobre redes neurais), só que, pra tabela de linhas e colunas, árvores em sequência costumam ganhar."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Biblioteca\", \"Origem\", \"Diferencial\", \"Bom pra\"], [\"XGBoost\", \"Projeto open source, famoso em competições desde 2014\", \"Regularização forte embutida, muito testado e documentado\", \"Ponto de partida padrão em quase qualquer problema tabular\"], [\"LightGBM\", \"Microsoft\", \"Crescimento das árvores por folha, treino muito rápido\", \"Bases grandes, quando o tempo de treino importa muito\"], [\"CatBoost\", \"Yandex\", \"Lida nativamente com variáveis categóricas\", \"Bases com muitas colunas categóricas\"]]"
+                    },
+                    {
+                        "type": "code",
+                        "value": "import xgboost as xgb\n\nmodelo = xgb.XGBClassifier(\n    n_estimators=300,\n    learning_rate=0.05,\n    max_depth=4,\n    random_state=42\n)\nmodelo.fit(X_train, y_train)\n\ny_pred = modelo.predict(X_test)\n# XGBoost segue a mesma interface fit/predict do scikit-learn,\n# então dá pra usar dentro de um Pipeline ou de um GridSearchCV normalmente"
+                    },
+                    {
+                        "type": "code",
+                        "value": "import lightgbm as lgb\n\nmodelo = lgb.LGBMClassifier(\n    n_estimators=300,\n    learning_rate=0.05,\n    max_depth=-1,\n    random_state=42\n)\nmodelo.fit(X_train, y_train)\n\ny_pred = modelo.predict(X_test)\n# max_depth=-1 é o padrão do LightGBM: sem limite explícito de profundidade,\n# porque o crescimento é por folha (leaf-wise), e não por nível"
+                    },
+                    {
+                        "type": "code",
+                        "value": "from catboost import CatBoostClassifier\n\nmodelo = CatBoostClassifier(\n    iterations=300,\n    learning_rate=0.05,\n    depth=4,\n    random_seed=42,\n    verbose=False\n)\nmodelo.fit(X_train, y_train)\n\ny_pred = modelo.predict(X_test)\n# no CatBoost os hiperparâmetros mudam de nome (iterations em vez de\n# n_estimators, depth em vez de max_depth), mas a lógica é a mesma:\n# boosting sequencial corrigindo o erro anterior"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Não existe uma biblioteca certa entre XGBoost, LightGBM e CatBoost. Existem trade-offs de velocidade, tipo de dado e facilidade de uso, e a única forma de saber qual funciona melhor no seu problema é testar mais de uma."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Quais três bibliotecas são citadas como o estado da arte em gradient boosting pra dados tabulares?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "XGBoost, LightGBM e CatBoost",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "XGBoost, TensorFlow e Keras",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "LightGBM, PyTorch e CatBoost",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Scikit-learn, XGBoost e TensorFlow",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que XGBoost e LightGBM costumam treinar mais rápido que o GradientBoostingClassifier padrão do scikit-learn em bases grandes?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque usam otimizações de engenharia, como divisão por histograma, no cálculo de cada árvore",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque treinam todas as árvores em paralelo, como um random forest, em vez de sequencialmente",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque usam árvores bem mais profundas, o que exige menos rodadas de treino no total",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque reduzem automaticamente o tamanho da base de dados antes de começar o treino",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual é o diferencial mais citado do CatBoost em relação às outras bibliotecas de boosting?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Lidar nativamente com variáveis categóricas, sem exigir codificação manual antes do treino",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Ser a única entre as três bibliotecas de boosting com suporte a treino em GPU",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não exigir absolutamente nenhum hiperparâmetro configurado pela pessoa que treina",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Treinar exclusivamente modelos de regressão, nunca conseguindo lidar com classificação",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um time está numa tarefa com uma tabela de milhões de linhas e várias colunas categóricas de alta cardinalidade. Qual caminho tende a exigir menos preparo manual?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Testar bibliotecas como CatBoost ou LightGBM, feitas pra lidar bem com esse cenário",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Descartar as colunas categóricas, já que bibliotecas de boosting não aceitam esse tipo de dado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Treinar uma rede neural profunda, porque tabelas grandes sempre favorecem deep learning",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Reduzir a base pra poucas centenas de linhas antes de treinar qualquer boosting",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Em bases de dados tabulares, comuns na maioria dos problemas de negócio, por que gradient boosting bem ajustado costuma superar redes neurais profundas?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Porque árvores lidam bem com poucas amostras e features heterogêneas, sem exigir tanto dado",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque redes neurais só conseguem processar dados de imagem, nunca tabelas numéricas",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque gradient boosting sempre treina mais rápido que qualquer rede neural, em qualquer caso",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque bibliotecas de boosting têm uma rede neural interna que substitui o ajuste manual",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Boosting x random forest",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Boosting x random forest: qual escolher\n\nAgora que você já viu as duas famílias de ensemble (random forest no módulo passado, boosting neste módulo), vale comparar as duas de frente. Na prática, essa é uma decisão que você vai tomar toda vez que for atacar um problema novo de dados tabulares."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Mais preciso, porém mais sensível\n\nBem ajustado, boosting costuma vencer random forest em métrica de desempenho. Faz sentido: ele ataca o viés diretamente, corrigindo erro atrás de erro, em vez de só reduzir variância tirando a média de árvores independentes. Só que essa precisão tem um preço. Boosting é mais sensível ao ajuste de hiperparâmetros: exagerar no número de árvores ou deixar a learning_rate alta demais faz o modelo decorar o ruído do treino, um overfitting parecido com aquele da árvore de decisão sozinha, só que mais difícil de perceber, porque o desempenho no treino continua parecendo ótimo.\n\nRandom forest é mais tolerante. Mesmo com parâmetros bem básicos, dificilmente entrega um resultado ruim, porque a média de várias árvores independentes já freia boa parte do overfitting sozinha. É por isso que ele funciona tão bem como baseline, como você viu no módulo anterior."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Guia prático de escolha\n\nQuando você tem tempo pra ajustar com calma e a precisão importa muito (por exemplo, um modelo que vai rodar em produção por meses, ou uma competição de dados), vale investir em boosting. Quando você quer um resultado sólido rápido, com menos risco de errar no ajuste, random forest costuma ser o caminho mais seguro.\n\nNa prática, muita gente faz as duas coisas: treina um random forest primeiro, como piso de referência, e só parte pra uma biblioteca de boosting se o ganho de desempenho compensar o tempo extra de ajuste."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Aspecto\", \"Random forest\", \"Gradient boosting\"], [\"Treinamento\", \"Paralelo, árvores independentes\", \"Sequencial, cada árvore corrige a anterior\"], [\"Tende a reduzir\", \"Variância\", \"Viés\"], [\"Ajuste de hiperparâmetros\", \"Mais tolerante, funciona bem com padrão\", \"Mais delicado, exige mais cuidado\"], [\"Risco de overfitting\", \"Mais baixo, controlado pela média das árvores\", \"Mais alto, se n_estimators e learning_rate não forem bem ajustados\"], [\"Quando usar\", \"Baseline rápido e robusto\", \"Quando dá pra investir em tuning e precisão importa muito\"]]"
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.ensemble import RandomForestClassifier, GradientBoostingClassifier\nfrom sklearn.model_selection import cross_val_score\n\nrf = RandomForestClassifier(n_estimators=300, random_state=42)\ngb = GradientBoostingClassifier(\n    n_estimators=300, learning_rate=0.05, random_state=42\n)\n\nprint(\"Random forest:\", cross_val_score(rf, X, y, cv=5).mean())\nprint(\"Gradient boosting:\", cross_val_score(gb, X, y, cv=5).mean())\n# Random forest: 0.85\n# Gradient boosting: 0.88 (mais preciso aqui, mas exigiu escolher\n# a learning_rate com cuidado pra não overfitar)"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Random forest costuma ser o baseline sólido que raramente decepciona. Boosting costuma ser o resultado que você busca depois de ajustar com calma. Comece pelo mais simples e só suba de complexidade se o ganho compensar."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Em geral, qual opção descreve corretamente a sensibilidade de cada algoritmo ao ajuste de hiperparâmetros?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Boosting costuma ser mais sensível ao ajuste; random forest costuma ser mais tolerante",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Random forest costuma ser mais sensível ao ajuste; boosting costuma ser mais tolerante",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os dois são igualmente sensíveis, e o ajuste quase nunca muda o resultado final",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Nenhum dos dois é afetado de forma relevante pelo ajuste de hiperparâmetros",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de treinar um GradientBoostingClassifier com n_estimators alto e learning_rate sem limitar bem, o desempenho no treino ficou ótimo, mas caiu bastante no teste. O que provavelmente aconteceu?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O modelo overfitou, um risco mais comum em boosting quando os hiperparâmetros fogem do controle",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O modelo underfitou, já que todo boosting sempre precisa de ainda mais árvores pra melhorar",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Houve vazamento de dados entre treino e teste, um problema exclusivo de modelos de boosting",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O random_state foi definido de forma errada, o que invalida qualquer avaliação do modelo",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que o random forest costuma ser descrito como uma escolha mais segura quando falta tempo pra ajustar hiperparâmetros com calma?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque a média de árvores independentes já protege contra overfitting, mesmo com parâmetros padrão",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o random forest praticamente não erra, não importa a qualidade dos dados de treino",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o random forest não tem nenhum hiperparâmetro que realmente precise ser configurado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o random forest sempre treina muito mais rápido do que qualquer biblioteca de boosting",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma base pequena e bastante ruidosa precisa de um modelo robusto, com pouco tempo disponível pra ajuste cuidadoso. Qual ponto de partida costuma ser mais prudente?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Random forest, que tende a tolerar melhor dados ruidosos e parâmetros padrão nesse cenário",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Gradient boosting com learning_rate alta, que converge mais rápido nesse tipo de cenário ruidoso",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "XGBoost configurado com max_depth bem profundo, já que mais profundidade sempre compensa o ruído",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Qualquer um dos dois, já que o nível de ruído nos dados não influencia essa escolha de modelo",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Comparando random forest e gradient boosting com cross_val_score na mesma base, o gradient boosting teve uma média de acurácia menor que o random forest. Isso significa que boosting é pior de forma geral?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Não necessariamente, já que boosting tende a ser mais sensível ao ajuste de hiperparâmetros",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Sim, porque boosting é, por definição matemática, sempre menos preciso que random forest",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Sim, porque gradient boosting nunca deveria ser avaliado usando a função cross_val_score",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não, porque cross_val_score nunca é uma forma confiável de comparar dois modelos treinados",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Hiperparâmetros do boosting (learning_rate)",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Os hiperparâmetros que mais importam no boosting\n\nVocê já ajustou hiperparâmetros com GridSearchCV lá no módulo de tuning. Em boosting, a lógica de busca é a mesma, mas alguns hiperparâmetros pesam mais que outros na hora de decidir entre um modelo bom e um modelo que decorou o treino. Os três que mais merecem sua atenção são learning_rate, n_estimators e max_depth."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Learning_rate: o tamanho de cada passo\n\nO learning_rate controla o quanto a contribuição de cada nova árvore é reduzida antes de ser somada ao conjunto. Um learning_rate baixo (por exemplo, 0.01) faz cada árvore corrigir só um pedacinho do erro, então você precisa de bem mais árvores (n_estimators alto) pra chegar num ajuste equivalente. Em compensação, esse aprendizado devagar costuma generalizar melhor.\n\nUm learning_rate alto (por exemplo, 0.3) faz cada árvore corrigir uma fatia grande do erro de uma vez, então poucas árvores já bastam. O problema é que esse passo largo facilita passar do ponto ótimo e decorar particularidades do treino, sobretudo se n_estimators também for alto."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"learning_rate\", \"n_estimators necessário\", \"Efeito\"], [\"Baixo (em torno de 0.01)\", \"Alto (centenas a milhares)\", \"Aprendizado devagar e estável, geralmente generaliza melhor, treino mais lento\"], [\"Médio (em torno de 0.05 a 0.1)\", \"Médio (uma centena, aproximadamente)\", \"Ponto de partida comum, equilíbrio razoável entre tempo e generalização\"], [\"Alto (em torno de 0.3)\", \"Baixo (dezenas)\", \"Aprendizado rápido, porém maior risco de passar do ponto ótimo e overfitar\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Max_depth: árvores rasas de propósito\n\nNo random forest, é comum deixar as árvores crescerem bem fundo, porque cada uma precisa ser razoavelmente forte sozinha. Em boosting é o oposto: as árvores costumam ficar rasas (max_depth entre 2 e 5, tipicamente), porque cada uma só precisa aprender um pedaço pequeno e específico do erro. Árvore profunda demais dentro de um boosting tende a memorizar ruído logo nas primeiras rodadas, e sobra pouco espaço útil pras próximas árvores corrigirem alguma coisa."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.ensemble import GradientBoostingClassifier\nfrom sklearn.model_selection import GridSearchCV\n\nparametros = {\n    \"n_estimators\": [100, 300, 500],\n    \"learning_rate\": [0.01, 0.05, 0.1],\n    \"max_depth\": [2, 3, 4]\n}\n\n# a mesma cautela do módulo de tuning vale aqui: a busca roda\n# dentro da validação cruzada, e o conjunto de teste fica de fora,\n# intocado, do mesmo jeito que o Pipeline te ensinou a não vazar dado\nbusca = GridSearchCV(\n    GradientBoostingClassifier(random_state=42),\n    param_grid=parametros,\n    cv=5,\n    scoring=\"accuracy\",\n    n_jobs=-1\n)\nbusca.fit(X_train, y_train)\n\nprint(busca.best_params_)\n# {'learning_rate': 0.05, 'max_depth': 3, 'n_estimators': 300}\nprint(busca.best_score_)\n# 0.89"
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.ensemble import GradientBoostingClassifier\n\nmodelo = GradientBoostingClassifier(\n    n_estimators=1000,\n    learning_rate=0.05,\n    max_depth=3,\n    validation_fraction=0.1,\n    n_iter_no_change=10,\n    tol=1e-4,\n    random_state=42\n)\nmodelo.fit(X_train, y_train)\n\nprint(modelo.n_estimators_)\n# 342 (o treino parou sozinho bem antes de chegar em 1000 árvores,\n# porque a validação interna ficou 10 rodadas seguidas sem melhorar)"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Learning_rate baixo com n_estimators alto, quase sempre, é uma troca mais segura do que learning_rate alto com poucas árvores. Boosting recompensa quem tem paciência de ajustar com calma, e pune rápido quem não tem."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que o hiperparâmetro learning_rate controla no gradient boosting?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "O quanto a contribuição de cada nova árvore é reduzida antes de ser somada ao conjunto",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O número total de árvores que serão treinadas ao longo de toda a sequência do boosting",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A profundidade máxima permitida para cada árvore individual dentro do ensemble treinado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A fração dos dados de treino reservada especificamente pra validação interna do modelo",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual é o trade-off central entre learning_rate e n_estimators no boosting?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Learning_rate baixo costuma exigir mais n_estimators pra chegar num ajuste equivalente",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Learning_rate e n_estimators são parâmetros redundantes, então só um precisa ser ajustado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Learning_rate alto sempre exige mais n_estimators pra evitar qualquer overfitting",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "N_estimators não tem nenhuma influência sobre o tempo total de treino do modelo",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que, em boosting, as árvores individuais costumam usar max_depth baixo, algo entre 2 e 5?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque cada árvore deve continuar sendo um modelo fraco, e a força vem da sequência de correções",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque árvores rasas treinam exatamente na mesma velocidade que árvores bem mais profundas e complexas",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque as bibliotecas de boosting nunca aceitam árvores com profundidade maior do que cinco níveis",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque um max_depth baixo elimina de vez a necessidade de ajustar o learning_rate mais tarde",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um gradient boosting foi treinado com n_estimators=2000 e learning_rate=0.3, e o desempenho no treino ficou quase perfeito, mas despencou no teste. Qual ajuste tem mais chance de resolver isso?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Reduzir o learning_rate e possivelmente o n_estimators também, com early stopping ligado",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Aumentar ainda mais o n_estimators, mantendo o learning_rate fixo em 0.3 do jeito que está",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Aumentar o max_depth de cada árvore individual, pra tentar compensar o learning_rate alto",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Remover o random_state do modelo, já que ele seria a causa principal desse overfitting",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Ao configurar n_iter_no_change e validation_fraction num GradientBoostingClassifier, o que esse mecanismo de early stopping faz na prática?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Reserva parte do treino pra validação interna e para o treino se o desempenho parar de melhorar",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Reserva parte do treino pra validação interna e reinicia o treino do zero a cada rodada sem melhora",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Usa o conjunto de teste final da avaliação inteira pra decidir quando parar de adicionar árvores",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ignora por completo o n_estimators definido pela pessoa, treinando até o desempenho final cair",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 5 - Pipelines e fluxo robusto",
+        "aulas": [
+            {
+                "titulo": "Por que Pipeline",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Por que empacotar preparo e modelo num Pipeline\n\nLá na trilha de Machine Learning você já usou o `Pipeline` do scikit-learn: encadear um `StandardScaler` com um modelo, pra evitar que o scaler visse o teste antes da hora dentro da validação cruzada. Funcionou bem pra dois passos. Só que um projeto real raramente tem só um passo de preparo: você imputa valor faltante, escala colunas numéricas, codifica colunas categóricas, e só depois treina o modelo. Quanto mais passos manuais existem entre o dado bruto e o `fit`, maior a chance de um deles sair fora de ordem, ser esquecido, ou ser aplicado de um jeito no treino e de outro (sem querer) em produção.\n\nEste módulo retoma o Pipeline do ponto onde a trilha de Machine Learning parou e vai além: combinar transformações diferentes por tipo de coluna com `ColumnTransformer`, ajustar hiperparâmetros do preparo e do modelo juntos sem vazar dado, fixar a reprodutibilidade do experimento inteiro, e salvar o modelo treinado pra usar sem retreinar."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O problema que o Pipeline resolve\n\nImagine o fluxo de preparo sem `Pipeline`: ajustar um `SimpleImputer` no treino e transformar treino e teste, ajustar um `StandardScaler` no treino e transformar os dois, só então treinar o modelo. Pra prever um dado novo em produção, alguém precisa lembrar de repetir, na mesma ordem, os mesmos passos, com os mesmos objetos já ajustados (nunca um novo `fit`, só `transform`). Esquecer um passo, trocar a ordem entre `scaler` e `imputer`, ou reajustar por engano um transformador que deveria só transformar: qualquer um desses erros é silencioso, o código roda sem lançar exceção, e o modelo só erra mais (ou parece acertar mais do que deveria, se o erro for vazamento de dado).\n\nO `Pipeline` empacota a sequência inteira, preparo e modelo, num único objeto com a mesma interface `fit`/`predict`/`score` que você já usa em qualquer estimador. Chamar `pipeline.fit(X_treino, y_treino)` roda `fit_transform` em cada etapa de preparo, em ordem, e por fim `fit` no modelo final. Chamar `pipeline.predict(X_novo)` roda `transform` (nunca `fit`) em cada etapa de preparo, na mesma ordem, e por fim `predict` no modelo. Essa sequência é escrita uma única vez, ao montar o pipeline, e o objeto garante que ela se repete sempre igual."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.pipeline import Pipeline\nfrom sklearn.impute import SimpleImputer\nfrom sklearn.preprocessing import StandardScaler\nfrom sklearn.linear_model import LogisticRegression\nfrom sklearn.model_selection import train_test_split\n\nX_treino, X_teste, y_treino, y_teste = train_test_split(\n    X, y, test_size=0.2, random_state=42\n)\n\npipeline = Pipeline([\n    ('imputer', SimpleImputer(strategy='median')),\n    ('scaler', StandardScaler()),\n    ('modelo', LogisticRegression())\n])\n\n# um unico fit roda, em ordem: imputer.fit_transform, scaler.fit_transform,\n# modelo.fit, sempre nessa sequencia e sempre so com o treino\npipeline.fit(X_treino, y_treino)\n\nprint(pipeline.score(X_teste, y_teste))\n# 0.90"
+                    },
+                    {
+                        "type": "code",
+                        "value": "# em producao, chega uma linha nova, com valor faltante e sem escala,\n# exatamente como ela existe no mundo real\ndado_novo = X_teste.iloc[[0]]\n\npipeline.predict(dado_novo)\n# array([1]) -> o pipeline aplicou imputer.transform e scaler.transform\n# (nunca fit) antes de chamar modelo.predict, tudo numa unica chamada\n\n# acessar uma etapa especifica pelo nome\npipeline.named_steps['scaler'].mean_\n# array([...]) -> a media que o StandardScaler aprendeu, so com o treino\n\n# fatiar o pipeline: tudo menos a ultima etapa, ou seja, so o preparo\nX_treino_preparado = pipeline[:-1].transform(X_treino)"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Situação de risco\",\"Sem Pipeline (manual)\",\"Com Pipeline\"],[\"Ordem das etapas de preparo\",\"Depende de lembrar e escrever certo toda vez\",\"Fixada uma única vez, na montagem do objeto\"],[\"Ajustar (fit) um transformador de novo, por engano\",\"Fácil de acontecer ao copiar código pra produção\",\"predict só chama transform, nunca fit, em cada etapa\"],[\"Validação cruzada\",\"Fácil escalar antes e vazar dado entre folds\",\"Cada fold refaz o fit do zero, dentro do próprio CV\"],[\"Código de treino x código de produção\",\"Duas versões que podem divergir com o tempo\",\"O mesmo objeto, salvo e carregado, serve os dois casos\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Um Pipeline não deixa o modelo mais inteligente: deixa o processo mais difícil de estragar sem querer."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que acontece quando você chama pipeline.fit(X_treino, y_treino) num Pipeline com um StandardScaler seguido de uma LogisticRegression?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "O scaler roda fit_transform no treino, e a regressão logística treina com o resultado escalado.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Só a regressão logística é treinada: o scaler precisa ser ajustado numa chamada separada antes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O pipeline treina os dois passos em paralelo, sem nenhuma ordem definida entre eles.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O scaler fica parado durante o fit, e só passa a agir quando o predict é chamado depois.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um colega editou o código de produção e, por engano, chama scaler.fit_transform(dado_novo) manualmente antes de prever, em vez de usar pipeline.predict(dado_novo) direto. Qual o efeito mais provável?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O scaler recalcula média e desvio com o dado novo, gerando uma escala diferente da usada no treino.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Nenhum efeito perceptível, já que fit_transform e transform produzem sempre o mesmo resultado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O pipeline detecta a chamada duplicada e ignora automaticamente o fit_transform feito à parte.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O modelo final recusa a previsão, porque o scaler já tinha sido ajustado antes, no treino.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de treinar um Pipeline com as etapas 'imputer', 'scaler' e 'modelo', qual alternativa descreve como obter um novo pipeline só com as etapas de preparo, sem a etapa final?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Fatiar o pipeline com pipeline[:-1], obtendo um pipeline só com as etapas de preparo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Chamar pipeline.named_steps['modelo'], que devolve todas as etapas exceto o modelo final.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Usar pipeline.steps[-1], que remove automaticamente a última etapa da lista de etapas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Chamar pipeline.drop('modelo'), que descarta essa etapa e devolve as etapas anteriores.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe treinou um modelo com Pipeline (imputer, scaler, modelo), mas na hora de colocar em produção reescreveu o preparo em outra linguagem, direto na API que recebe as requisições, sem usar o pipeline salvo. Qual risco isso cria?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Divergência entre o preparo do treino e o da produção, já que um detalhe reescrito diferente muda o resultado.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Nenhum risco adicional, contanto que a equipe use a mesma versão do scikit-learn nos dois ambientes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O modelo passa a rejeitar automaticamente previsões vindas de um preparo implementado fora do pipeline.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A acurácia de produção sempre fica mais alta, já que o novo preparo não tem as limitações do scikit-learn.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma cientista de dados aplica StandardScaler().fit_transform(X) no dataset inteiro, guarda o resultado em X_norm, e só depois monta um Pipeline com um SimpleImputer e um modelo, treinado com X_norm. O que está errado nessa prática?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O Pipeline só protege o que está dentro dele: a normalização feita antes, fora dele, ainda pode vazar dado.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Nada está errado, porque o Pipeline detecta dados já normalizados e ajusta o restante automaticamente.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O SimpleImputer dentro do pipeline vai falhar, porque não aceita dados que já passaram por um scaler.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O modelo final ignora a normalização feita fora do pipeline e recalcula tudo do zero durante o fit.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "ColumnTransformer: numéricas e categóricas juntas",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# ColumnTransformer: uma transformação para cada tipo de coluna\n\nO Pipeline da aula passada resolve um problema, mas assume algo que quase nunca é verdade num dataset real: que faz sentido aplicar a mesma transformação em todas as colunas. Um dataset de clientes típico mistura colunas numéricas (idade, renda) com colunas categóricas (cidade, plano contratado). Escalar uma coluna de texto com `StandardScaler` não faz sentido, já que não existe média de 'São Paulo', e aplicar `OneHotEncoder` numa coluna numérica criaria uma categoria pra cada valor de idade existente, o que também não ajuda em nada.\n\nO scikit-learn resolve isso com o `ColumnTransformer`: em vez de aplicar uma transformação só a tudo, ele aplica transformações diferentes a grupos diferentes de colunas, ao mesmo tempo, dentro do mesmo objeto."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Como o ColumnTransformer organiza isso\n\nA ideia é declarar uma lista de trincas: um nome, um transformador, e a lista de colunas que aquele transformador deve receber. Cada transformador enxerga só as colunas atribuídas a ele, nunca as colunas das outras trincas. No fim do `fit_transform`, o `ColumnTransformer` concatena, lado a lado, a saída de cada transformador, formando uma única matriz pronta pra alimentar o modelo."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.compose import ColumnTransformer\nfrom sklearn.preprocessing import StandardScaler, OneHotEncoder\n\ncolunas_numericas = ['idade', 'renda']\ncolunas_categoricas = ['cidade', 'plano']\n\npreparo = ColumnTransformer([\n    ('num', StandardScaler(), colunas_numericas),\n    ('cat', OneHotEncoder(handle_unknown='ignore'), colunas_categoricas)\n])\n\nX_treino_preparado = preparo.fit_transform(X_treino)\nprint(X_treino_preparado.shape)\n# (800, 7) -> 2 colunas numericas escaladas + 5 colunas do one-hot,\n# concatenadas lado a lado numa unica matriz"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Sub-pipelines dentro de cada branch\n\nCada uma das trincas pode receber, no lugar de um transformador único, um `Pipeline` inteiro. É assim que se resolve valor faltante separadamente por tipo de coluna: a branch numérica imputa com a mediana e depois escala, a branch categórica imputa com o valor mais frequente e depois aplica o one-hot. E colunas que não aparecem em nenhuma lista? Por padrão (`remainder='drop'`), o `ColumnTransformer` simplesmente as descarta; passar `remainder='passthrough'` faz ele repassar essas colunas sem transformar."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.pipeline import Pipeline\nfrom sklearn.impute import SimpleImputer\nfrom sklearn.ensemble import RandomForestClassifier\n\npipeline_numerico = Pipeline([\n    ('imputer', SimpleImputer(strategy='median')),\n    ('scaler', StandardScaler())\n])\n\npipeline_categorico = Pipeline([\n    ('imputer', SimpleImputer(strategy='most_frequent')),\n    ('onehot', OneHotEncoder(handle_unknown='ignore'))\n])\n\npreparo = ColumnTransformer([\n    ('num', pipeline_numerico, colunas_numericas),\n    ('cat', pipeline_categorico, colunas_categoricas)\n])\n\npipeline_completo = Pipeline([\n    ('preparo', preparo),\n    ('modelo', RandomForestClassifier(random_state=42))\n])\n\npipeline_completo.fit(X_treino, y_treino)\nprint(pipeline_completo.score(X_teste, y_teste))\n# 0.88\n\nprint(preparo.get_feature_names_out())\n# ['num__idade' 'num__renda' 'cat__cidade_Rio de Janeiro'\n#  'cat__cidade_Sao Paulo' 'cat__plano_premium']\n# o prefixo antes de '__' mostra de qual branch cada coluna final veio"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Tipo de coluna\",\"Transformador comum\",\"Problema de usar o transformador errado\"],[\"Numérica contínua (idade, renda)\",\"SimpleImputer + StandardScaler\",\"OneHotEncoder trataria cada valor numérico como categoria própria\"],[\"Categórica nominal (cidade, plano)\",\"SimpleImputer + OneHotEncoder\",\"StandardScaler tenta calcular média e desvio de texto, e falha\"],[\"Categórica ordinal (escolaridade)\",\"Mapeamento numérico ou OrdinalEncoder\",\"OneHotEncoder descarta a ordem natural entre as categorias\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "O ColumnTransformer não inventa nenhuma transformação nova: garante que cada coluna receba o tratamento certo pro seu tipo, sem você remontar a matriz final na mão."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Dentro de um ColumnTransformer, o que a lista de colunas passada junto de cada transformador define?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Quais colunas do DataFrame aquele transformador específico vai receber e transformar.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A ordem em que as colunas vão aparecer na tabela final, depois de qualquer transformação.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O número de colunas mínimo que todo o dataset precisa ter pra esse transformador funcionar.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Quais colunas serão descartadas do dataset antes que qualquer transformador atue nelas.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um dataset tem colunas numéricas (idade, renda) e categóricas (cidade, plano). Por que aplicar um StandardScaler ao DataFrame inteiro, sem ColumnTransformer, não funciona?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O StandardScaler espera valores numéricos, e colunas categóricas em texto quebram o cálculo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O StandardScaler funciona normalmente em texto, mas ignora as colunas categóricas em silêncio.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O StandardScaler exige o mesmo número de colunas numéricas e categóricas pra poder funcionar.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O StandardScaler converte automaticamente qualquer texto em número antes de calcular a escala.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que é comum usar um Pipeline (imputer seguido de scaler) como transformador da branch numérica dentro de um ColumnTransformer, em vez de só o scaler direto?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque a branch pode ter valores faltantes, e o imputer precisa tratá-los antes do scaler agir.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o ColumnTransformer só aceita um Pipeline inteiro, nunca uma classe isolada como o scaler.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque duas etapas na mesma branch dobram automaticamente o peso dessas colunas no modelo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o scaler sozinho não sabe separar colunas numéricas de colunas categóricas no dataset.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um ColumnTransformer foi montado listando só 'idade', 'renda' (numéricas) e 'cidade' (categórica), mas o DataFrame de treino também tem a coluna 'id_cliente', fora das duas listas. Qual o comportamento padrão nesse caso?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Por padrão (remainder='drop'), a coluna 'id_cliente' é descartada e não chega à matriz final.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Por padrão, a coluna 'id_cliente' é escalada automaticamente junto das colunas numéricas listadas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O ColumnTransformer lança um erro no fit, porque toda coluna do DataFrame precisa estar listada.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Por padrão, a coluna 'id_cliente' vira mais uma categoria dentro da coluna 'cidade' codificada.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Num ColumnTransformer com uma branch numérica (imputer + scaler) e outra categórica (imputer + onehot), a branch numérica tem acesso às colunas categóricas durante o fit?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Não: cada branch enxerga só as colunas atribuídas a ela, nunca as das outras branches.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Sim, todas as branches recebem o DataFrame inteiro e decidem sozinhas o que ignorar.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Depende do remainder: com passthrough, as branches passam a enxergar as mesmas colunas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Sim, mas só durante o transform final, quando as saídas das branches são concatenadas.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Pipeline e GridSearchCV sem vazar",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Ajustando hiperparâmetros do preparo e do modelo juntos\n\nNo módulo de ajuste de hiperparâmetros desta trilha, o `GridSearchCV` testou combinações de hiperparâmetros de um modelo isolado, já com os dados prontos. Mas o `pipeline_completo` montado na aula passada tem hiperparâmetros em dois lugares: no `ColumnTransformer` (a estratégia do `SimpleImputer`, por exemplo) e no modelo final (`n_estimators`, `max_depth`). Tratar isso como duas buscas separadas, uma pro preparo e outra pro modelo, ignora que a melhor combinação de preparo pode depender de qual modelo está sendo usado, e vice-versa.\n\nA boa notícia: o `GridSearchCV` aceita um `Pipeline` inteiro como estimador. Ele testa combinações de hiperparâmetros do preparo e do modelo juntos, numa busca só, e continua fazendo isso sem vazar dado do teste."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## A sintaxe com dois underscores\n\nPra apontar um hiperparâmetro de uma etapa específica do pipeline, o nome no `param_grid` segue o padrão `nome_da_etapa__nome_do_parametro`, com dois underscores separando os dois. Se a etapa é o `ColumnTransformer` e o hiperparâmetro está dentro de uma das branches (que também é um `Pipeline`), o caminho encadeia mais um nível: `preparo__num__imputer__strategy` aponta pro `strategy` do `imputer` dentro da branch `num` dentro da etapa `preparo`."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.model_selection import GridSearchCV\n\n# pipeline_completo: o ColumnTransformer (branches 'num' e 'cat') + o modelo,\n# montados na aula anterior, com as etapas nomeadas 'preparo' e 'modelo'\n\ngrade_parametros = {\n    'preparo__num__imputer__strategy': ['mean', 'median'],\n    'modelo__n_estimators': [100, 300],\n    'modelo__max_depth': [None, 10, 20]\n}\n\nbusca = GridSearchCV(\n    pipeline_completo,\n    grade_parametros,\n    cv=5,\n    scoring='f1',\n    n_jobs=-1\n)\nbusca.fit(X_treino, y_treino)\n\nprint(busca.best_params_)\n# {'modelo__max_depth': 10, 'modelo__n_estimators': 300,\n#  'preparo__num__imputer__strategy': 'median'}\n\nprint(busca.best_score_)\n# 0.87 -> media da metrica escolhida nos folds de validacao, so com o treino\n\nmodelo_final = busca.best_estimator_\nprint(modelo_final.score(X_teste, y_teste))\n# 0.86 -> agora sim, avaliado no teste, que ficou fora do tuning inteiro"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Por que isso não vaza\n\nO `GridSearchCV` faz validação cruzada por baixo dos panos: para cada combinação do `param_grid` e cada fold, ele clona o pipeline inteiro do zero e chama `fit` só com a parte de treino daquele fold, depois avalia na parte de validação daquele fold, que nenhuma etapa (nem o `imputer`, nem o `scaler`, nem o `onehot`) viu durante aquele `fit`. Isso vale pra toda etapa dentro do pipeline, não só pro modelo final.\n\nCompare com a alternativa arriscada: ajustar o `ColumnTransformer` uma vez, fora do pipeline, transformar o dataset inteiro, e só então passar esse resultado já transformado pro `GridSearchCV`. Nesse caso, o preparo já viu, durante o seu único `fit`, dados que em algum fold vão parar do lado da validação: um vazamento clássico, que ainda se repete em cada uma das combinações testadas."
+                    },
+                    {
+                        "type": "code",
+                        "value": "import pandas as pd\n\nresultados = pd.DataFrame(busca.cv_results_)\ncolunas = ['param_modelo__n_estimators', 'param_modelo__max_depth', 'mean_test_score']\n\nprint(resultados[colunas].sort_values('mean_test_score', ascending=False).head(3))\n#    param_modelo__n_estimators  param_modelo__max_depth  mean_test_score\n# 7                          300                       10             0.87\n# 6                          300                       10             0.86\n# 10                         300                       20             0.86\n\n# cuidado com o tamanho da grade: cada hiperparametro a mais MULTIPLICA\n# o numero de combinacoes, e cada combinacao roda 'cv' vezes inteiras\nprint(len(resultados))\n# 12 combinacoes (2 x 2 x 3) -> com cv=5, isso e 60 ajustes completos do pipeline"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Abordagem\",\"O que dá pra ajustar\",\"Risco de vazamento\"],[\"GridSearchCV só no modelo, com preparo feito antes, fora do pipeline\",\"Só os hiperparâmetros do modelo\",\"Alto: o preparo já viu treino e validação juntos, de uma vez\"],[\"GridSearchCV no pipeline inteiro (preparo e modelo juntos)\",\"Hiperparâmetros do preparo e do modelo, ao mesmo tempo\",\"Baixo: cada fold refaz o preparo do zero, só com aquele treino\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Um GridSearchCV que não enxerga o preparo otimiza só metade do problema, e ainda corre o risco de comemorar um número que o teste vai desmentir depois."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Num Pipeline com as etapas nomeadas 'preparo' e 'modelo', qual é a forma correta de o param_grid apontar pro hiperparâmetro n_estimators da etapa 'modelo'?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "'modelo__n_estimators', com dois underscores entre o nome da etapa e do hiperparâmetro.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "'modelo.n_estimators', com um ponto entre o nome da etapa e o nome do hiperparâmetro.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "'n_estimators', só o nome do hiperparâmetro, já que o pipeline tem um único modelo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "'modelo->n_estimators', com uma seta entre o nome da etapa e o do hiperparâmetro.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe faz fit_transform do ColumnTransformer no dataset inteiro, guarda o resultado, e só depois roda GridSearchCV passando só o modelo e essa matriz já transformada. O que esse fluxo compromete?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "A validação cruzada deixa de ser confiável, já que o preparo viu dados de cada fold de validação.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Nada é comprometido, contanto que o GridSearchCV use um número alto de folds na validação.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O GridSearchCV recusa a execução, porque exige receber sempre um Pipeline como estimador.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Só o tempo de execução aumenta, já que refazer o preparo em cada fold deixaria tudo mais lento.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um param_grid combina 3 valores de um hiperparâmetro do preparo, 4 valores de um hiperparâmetro do modelo e 3 valores de outro hiperparâmetro do modelo, com cv=5. Quantos ajustes o GridSearchCV realiza no total?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "180, já que as 36 combinações possíveis (3 x 4 x 3) são multiplicadas pelos 5 folds.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "36, já que o número de folds da validação cruzada só conta uma vez, no final da busca.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "10, somando direto os valores possíveis de cada hiperparâmetro do preparo e do modelo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "5, um único ajuste por fold, já que o GridSearchCV reaproveita a mesma combinação.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de montar o pipeline_completo e o param_grid, alguém chama busca.fit(X, y), usando o dataset inteiro em vez de X_treino, y_treino, já separado antes com train_test_split. Qual o problema mais direto?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O conjunto reservado pra teste entra no tuning e deixa de ser uma medida final independente.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O GridSearchCV lança um erro, porque exige receber só o conjunto de treino como argumento.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Nenhum problema, já que a validação cruzada interna do GridSearchCV separa treino e teste sozinha.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O tempo de execução cai bastante, porque o dataset completo tem menos linhas que só o treino.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de busca.fit(X_treino, y_treino), o valor de busca.best_score_ foi 0.89. Qual a interpretação correta desse número?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "A média da métrica nos folds de validação, usando só o treino, pra melhor combinação encontrada.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O desempenho do modelo final no conjunto de teste, já com a melhor combinação encontrada.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A métrica calculada uma única vez, treinando e avaliando no mesmo conjunto de treino inteiro.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A porcentagem de combinações testadas no param_grid que bateram um limite mínimo aceitável.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Reprodutibilidade",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Reprodutibilidade: por que o mesmo código precisa dar o mesmo resultado\n\nDesde o começo da trilha de Machine Learning, o `train_test_split` sempre apareceu com `random_state=42`. Até aqui isso pode ter parecido um detalhe de sintaxe pra copiar sem pensar demais, mas é a ponta de um princípio bem mais amplo: **reprodutibilidade**. Um experimento é reprodutível quando rodar o mesmo código, com o mesmo dado, produz o mesmo resultado de novo, seja amanhã, seja daqui a um ano, seja no computador de outra pessoa da equipe.\n\nIsso importa por um motivo prático e nada abstrato: sem reprodutibilidade, comparar dois modelos de forma justa fica impossível (a diferença de métrica pode ser sorte da divisão dos dados, não mérito de um modelo sobre o outro), depurar um erro relatado por outra pessoa fica muito mais difícil, e ninguém mais consegue auditar ou confiar no resultado que você reportou."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Onde a aleatoriedade se esconde\n\nO `train_test_split` é só uma das fontes de aleatoriedade num pipeline de ML. O `RandomForestClassifier` sorteia, internamente, quais linhas entram em cada amostra bootstrap e quais features cada árvore pode considerar em cada divisão. Um `KFold` ou `StratifiedKFold` com `shuffle=True` embaralha as linhas antes de formar os folds. Até o `RandomizedSearchCV`, que sorteia quais combinações de hiperparâmetros testar, depende de uma semente aleatória. Fixar `random_state` só no `train_test_split` e deixar essas outras fontes soltas ainda deixa o experimento parcialmente irreprodutível."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.model_selection import train_test_split, StratifiedKFold, GridSearchCV\nfrom sklearn.ensemble import RandomForestClassifier\n\nRANDOM_STATE = 42\n\nX_treino, X_teste, y_treino, y_teste = train_test_split(\n    X, y, test_size=0.2, random_state=RANDOM_STATE, stratify=y\n)\n\nvalidacao = StratifiedKFold(n_splits=5, shuffle=True, random_state=RANDOM_STATE)\n\nmodelo = RandomForestClassifier(n_estimators=300, random_state=RANDOM_STATE)\n\nbusca = GridSearchCV(modelo, {'max_depth': [5, 10, None]}, cv=validacao)\nbusca.fit(X_treino, y_treino)\n\n# rodando esse bloco de novo, do zero, em qualquer maquina com as mesmas\n# versoes de biblioteca: mesmos folds, mesma divisao, mesma floresta"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Além do random_state: versão de biblioteca e registro do experimento\n\nFixar a semente resolve a aleatoriedade do código, mas não é a reprodutibilidade inteira. O `scikit-learn`, o `pandas` e o `numpy` mudam de versão com o tempo, e uma mudança de versão pode alterar um valor padrão ou uma implementação interna, produzindo um resultado levemente diferente mesmo com o `random_state` idêntico. Por isso vale fixar as versões usadas (num `requirements.txt` ou `pyproject.toml`) junto do código, e manter uma cópia (ou um identificador claro) do dado exato usado em cada experimento, não só do script que o processa.\n\nTambém vale registrar, pra cada execução, quais hiperparâmetros foram usados e qual métrica saiu no final: sem isso, ninguém sabe depois qual configuração gerou qual modelo salvo. Ferramentas como o `MLflow` automatizam esse registro, mas mesmo uma planilha ou um arquivo de log simples já ajuda bastante. Vale um limite honesto: `random_state` fixo garante uma reprodutibilidade muito forte, mas não é uma garantia absoluta bit a bit em qualquer hardware ou sistema operacional."
+                    },
+                    {
+                        "type": "code",
+                        "value": "import json\nfrom datetime import datetime\nimport sklearn\n\nregistro = {\n    'data': datetime.now().isoformat(),\n    'random_state': RANDOM_STATE,\n    'modelo': 'RandomForestClassifier',\n    'melhores_parametros': busca.best_params_,\n    'score_validacao': busca.best_score_,\n    'score_teste': busca.best_estimator_.score(X_teste, y_teste),\n    'sklearn_version': sklearn.__version__\n}\n\nwith open('experimentos.jsonl', 'a') as arquivo:\n    print(json.dumps(registro), file=arquivo)\n# cada execucao vira uma linha nova: um historico simples, que ja\n# responde 'qual configuracao gerou qual resultado' meses depois"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Fonte de aleatoriedade\",\"Onde aparece\",\"Como fixar\"],[\"Divisão entre treino e teste\",\"train_test_split\",\"random_state=42\"],[\"Amostragem bootstrap e sorteio de features\",\"RandomForestClassifier, RandomForestRegressor\",\"random_state=42\"],[\"Ordem dos folds quando shuffle=True\",\"KFold, StratifiedKFold\",\"random_state=42 junto com shuffle=True\"],[\"Sorteio de quais combinações testar\",\"RandomizedSearchCV\",\"random_state=42\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Fixar random_state não é birra de curso: é o que separa 'meu modelo deu 91 por cento' de um resultado que outra pessoa consegue conferir."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Rodar o mesmo código de treino duas vezes, sem fixar random_state em nenhum lugar, tende a produzir:",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Divisões de treino e teste, e resultados de modelo, ligeiramente diferentes a cada execução.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Exatamente o mesmo modelo e a mesma métrica final, já que o algoritmo é sempre determinístico.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um erro de execução, já que o scikit-learn exige random_state definido em todo objeto aleatório.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um modelo cada vez mais preciso, já que cada execução aprende com a divisão da anterior.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Além de fixar random_state no train_test_split, por que também vale a pena fixá-lo no RandomForestClassifier usado depois?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque a floresta usa amostragem bootstrap e sorteio de features, outra fonte de aleatoriedade.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque sem isso o RandomForestClassifier não converge e lança um erro ao final do treino.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque fixar random_state no modelo aumenta a acurácia final, independente dos dados usados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o RandomForestClassifier reaproveita sozinho o random_state do train_test_split.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um modelo treinado há um ano, com o mesmo código e o mesmo random_state, produz resultado levemente diferente ao ser retreinado hoje. O que pode explicar isso, mesmo com a semente fixada?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "As versões das bibliotecas usadas podem ter mudado, alterando algum padrão ou cálculo interno.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O random_state perde o efeito depois de um tempo, e precisa ser trocado periodicamente.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Isso não poderia acontecer: random_state fixo garante resultado idêntico pra sempre, sempre.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O conjunto de dados muda sozinho com o tempo, mesmo quando ninguém edita o arquivo original.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Dois modelos foram treinados em datas diferentes, com hiperparâmetros diferentes, mas ninguém registrou qual configuração gerou qual resultado salvo. Qual problema prático isso causa?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Fica difícil saber depois qual configuração gerou o modelo, dificultando repetir o resultado.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Os dois modelos param de funcionar automaticamente, por faltar o registro formal de treino.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O scikit-learn recusa carregar um modelo salvo sem um arquivo de registro de experimento.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A acurácia dos dois modelos cai pela metade, por faltar o histórico de parâmetros usados.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Mesmo fixando random_state em tudo, o que ainda pode impedir uma reprodução idêntica, bit a bit, entre duas máquinas diferentes?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Diferenças de versão de biblioteca ou de hardware entre as máquinas ainda podem gerar variações.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Nada: random_state fixo já é garantia absoluta de resultado idêntico, em qualquer hardware.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O tamanho do dataset, já que datasets grandes tornam qualquer semente aleatória inválida.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O tipo de modelo usado, já que só modelos de regressão de fato respeitam o random_state.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Salvando o modelo com joblib e organizando o projeto",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Salvando o modelo treinado com joblib\n\nDepois da aula passada, você tem em mãos `busca.best_estimator_`: um Pipeline inteiro (preparo com ColumnTransformer e modelo) já ajustado com os melhores hiperparâmetros encontrados pelo GridSearchCV, com `random_state` fixado em todo canto que precisava. Falta uma última pergunta prática: precisa retreinar esse pipeline inteiro toda vez que alguém for usar o modelo?\n\nA resposta é não, e é aí que entra o `joblib`, um pacote (que acompanha o scikit-learn, mas é independente dele) especializado em salvar em disco objetos Python que carregam muitos arrays do NumPy por dentro, exatamente o caso de um Pipeline treinado. Dá pra usar o `pickle` da biblioteca padrão pra mesma coisa, mas o `joblib` costuma ser mais rápido e gerar arquivos menores pra esse tipo de objeto, e é o que a própria documentação do scikit-learn recomenda."
+                    },
+                    {
+                        "type": "code",
+                        "value": "import joblib\n\n# apos o busca.fit(X_treino, y_treino) da aula passada\nmodelo_final = busca.best_estimator_\n\n# salva o pipeline inteiro (preparo + modelo) num unico arquivo\njoblib.dump(modelo_final, 'modelos/modelo_v1.joblib')\n# ['modelos/modelo_v1.joblib']\n\n# em outro processo, outro dia, sem repetir nenhum treino:\npipeline_carregado = joblib.load('modelos/modelo_v1.joblib')\n\ndado_novo = X_teste.iloc[[0]]\npipeline_carregado.predict(dado_novo)\n# array([1]) -> imputer, scaler, onehot e o modelo, tudo aplicado de novo,\n# exatamente como foi ajustado no treino, sem escrever esse codigo outra vez\n\n# cuidado: joblib.load executa codigo Python ao desserializar,\n# entao so carregue arquivos .joblib de origem em que voce confia"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Um arquivo .joblib sozinho não é um projeto\n\nSalvar o modelo resolve o 'como reusar', mas um projeto de ML de verdade também precisa responder outras perguntas, meses depois: de onde veio o dado usado nesse modelo? Qual código gerou esse `.joblib`? Quais hiperparâmetros a busca em grade escolheu? Deixar tudo isso espalhado em notebooks soltos ou scripts sem organização é a forma mais comum de um projeto ficar impossível de reproduzir ou de dar manutenção.\n\nA prática comum é separar o projeto em pastas com responsabilidade clara: dado bruto nunca é editado direto, código de preparo fica isolado do código de treino, e os modelos salvos ficam numa pasta própria, versionados por nome ou por data."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Pasta ou arquivo\",\"O que guarda\"],[\"dados/brutos/\",\"O dado original, exatamente como chegou, nunca editado direto\"],[\"dados/processados/\",\"O dado já limpo e pronto pra virar X e y do pipeline\"],[\"notebooks/\",\"Exploração e prototipagem; nada que o projeto final dependa pra rodar\"],[\"src/preparo.py\",\"A construção do ColumnTransformer e do Pipeline de preparo\"],[\"src/treino.py\",\"O treino, o GridSearchCV e a chamada joblib.dump\"],[\"src/avaliacao.py\",\"As métricas calculadas no conjunto de teste, isoladas do treino\"],[\"modelos/modelo_v1.joblib\",\"O pipeline treinado e salvo, pronto pra ser carregado e prever\"],[\"requirements.txt\",\"As versões fixadas das bibliotecas, ligadas à reprodutibilidade\"]]"
+                    },
+                    {
+                        "type": "code",
+                        "value": "# treino.py: o modulo inteiro resumido num fluxo so, do preparo ao arquivo salvo\nfrom sklearn.pipeline import Pipeline\nfrom sklearn.compose import ColumnTransformer\nfrom sklearn.impute import SimpleImputer\nfrom sklearn.preprocessing import StandardScaler, OneHotEncoder\nfrom sklearn.ensemble import RandomForestClassifier\nfrom sklearn.model_selection import train_test_split, GridSearchCV\nimport joblib\n\nRANDOM_STATE = 42\ncolunas_numericas = ['idade', 'renda']\ncolunas_categoricas = ['cidade', 'plano']\n\npreparo = ColumnTransformer([\n    ('num', Pipeline([\n        ('imputer', SimpleImputer(strategy='median')),\n        ('scaler', StandardScaler())\n    ]), colunas_numericas),\n    ('cat', Pipeline([\n        ('imputer', SimpleImputer(strategy='most_frequent')),\n        ('onehot', OneHotEncoder(handle_unknown='ignore'))\n    ]), colunas_categoricas)\n])\n\npipeline_completo = Pipeline([\n    ('preparo', preparo),\n    ('modelo', RandomForestClassifier(random_state=RANDOM_STATE))\n])\n\nX_treino, X_teste, y_treino, y_teste = train_test_split(\n    X, y, test_size=0.2, random_state=RANDOM_STATE, stratify=y\n)\n\nbusca = GridSearchCV(\n    pipeline_completo,\n    {'modelo__n_estimators': [100, 300], 'modelo__max_depth': [None, 10]},\n    cv=5,\n    scoring='f1'\n)\nbusca.fit(X_treino, y_treino)\n\nmodelo_final = busca.best_estimator_\nprint(modelo_final.score(X_teste, y_teste))\n# 0.88\n\njoblib.dump(modelo_final, 'modelos/modelo_v1.joblib')\n# ['modelos/modelo_v1.joblib'] -> pronto pra prever sem retreinar"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Fechando o Módulo 5\n\nVocê fechou o ciclo que faltava pra um projeto de machine learning sair do notebook e virar algo confiável: encadear preparo e modelo num só `Pipeline`, tratar colunas numéricas e categóricas ao mesmo tempo com `ColumnTransformer`, ajustar hiperparâmetros do preparo e do modelo juntos com `GridSearchCV` sem vazar dado, fixar a reprodutibilidade do experimento inteiro, e salvar o resultado com `joblib` dentro de um projeto organizado.\n\nNo próximo módulo, o foco muda pra problemas que aparecem em dado real e que nenhuma dessas ferramentas resolve sozinha: classes desbalanceadas, dado e rótulo ruim, overfitting na prática e a honestidade de reconhecer quando machine learning não é a resposta certa."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Um modelo que só existe no notebook de quem treinou não ajuda ninguém. Pipeline, reprodutibilidade e joblib são o que transforma um experimento pessoal em algo que outra pessoa, ou você mesmo daqui a seis meses, consegue abrir, entender e confiar."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual a função de joblib.dump(modelo_final, 'modelo_v1.joblib')?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Salvar o objeto Python treinado, como um Pipeline, em disco, pra carregar depois sem retreinar.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Treinar o modelo do zero e, em seguida, calcular sua acurácia no conjunto de teste reservado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Enviar o modelo treinado direto pra um servidor de produção, pronto pra receber requisições.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Apagar o modelo da memória do processo atual, liberando espaço depois de um treino longo.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que é melhor persistir o Pipeline inteiro (preparo e modelo) com joblib, em vez de persistir só o modelo final treinado?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque quem for usar o modelo depois não reimplementa o preparo (imputer, scaler, encoder) à parte.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o joblib só consegue salvar objetos do tipo Pipeline, e recusa salvar um estimador sozinho.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque um Pipeline salvo ocupa sempre menos espaço em disco do que um modelo salvo sozinho.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o modelo final sozinho, sem o pipeline, perde a capacidade de fazer previsões corretas.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que o joblib costuma ser preferido ao pickle da biblioteca padrão pra salvar um Pipeline do scikit-learn?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque lida melhor com objetos que carregam muitos arrays do NumPy, como um Pipeline treinado.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o pickle não consegue, de jeito nenhum, salvar nenhum objeto criado pelo scikit-learn.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque arquivos salvos com joblib podem ser abertos e editados direto como texto simples.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o joblib, ao contrário do pickle, salva o código-fonte do scikit-learn junto do modelo.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma aplicação carrega, com joblib.load, um arquivo .joblib enviado por um usuário externo, sem nenhuma validação de origem. Qual o risco mais direto dessa prática?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O carregamento pode rodar código arbitrário embutido no arquivo, já que a desserialização não é segura.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Nenhum risco relevante, já que arquivos .joblib só conseguem armazenar números e texto, nunca código.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O modelo carregado sempre terá uma acurácia pior do que o modelo original salvo pela própria equipe.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O joblib.load recusa automaticamente qualquer arquivo que não tenha sido gerado pela mesma aplicação.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Num projeto de ML organizado, o código que constrói o ColumnTransformer e o Pipeline de preparo fica separado do código que chama o GridSearchCV e o joblib.dump. Qual a principal vantagem prática dessa separação?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Cada parte fica mais fácil de entender, testar e reaproveitar sozinha, sem depender do fluxo inteiro.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O scikit-learn exige, por regra, que preparo e treino estejam sempre em arquivos Python diferentes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A separação em arquivos diferentes torna o treinamento do modelo automaticamente mais rápido.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Sem essa separação, o joblib.dump não consegue salvar corretamente um Pipeline com ColumnTransformer.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 6 - Problemas reais e como lidar",
+        "aulas": [
+            {
+                "titulo": "Classes desbalanceadas",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Da bancada pro mundo real\n\nAté aqui você viu como extrair features melhores, ajustar hiperparâmetros de verdade, montar ensembles fortes (random forest, boosting) e encadear tudo num Pipeline que não vaza dado. É o kit de quem sabe treinar um modelo bom. Só que \"bom\" pressupõe um mundo bem-comportado: dados limpos, classes equilibradas, resultado fácil de explicar. Este módulo é sobre o que fazer quando o mundo não coopera, que é o normal, não a exceção.\n\nComeçando pelo desbalanceamento de classes. Você já esbarrou nisso lá na trilha de Machine Learning: aquele exemplo do detector de fraude com 99% de acurácia que, na prática, não pegava fraude nenhuma. Ali você aprendeu a enxergar o problema com a matriz de confusão e com precisão, recall e F1. Nesta aula, a pergunta muda de \"como eu percebo\" pra \"o que eu faço a respeito\"."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Por que o desbalanceamento atrapalha o treino, não só a métrica\n\nA maioria dos algoritmos de classificação, incluindo os do scikit-learn, aprende minimizando um erro médio sobre todos os exemplos de treino. Quando 97% dos exemplos são da classe majoritária, o jeito mais barato de reduzir esse erro médio é acertar bem a maioria e ignorar a minoria, porque cada exemplo raro pesa pouco na conta final. O modelo não está sendo preguiçoso: está otimizando exatamente o que foi pedido pra otimizar.\n\nIsso aparece o tempo todo: fraude em cartão, churn de um plano caro (a minoria que cancela), falha de uma peça industrial, diagnóstico de uma condição rara. Em quase todos esses casos, é a classe rara que importa mais, o oposto do que o treino padrão prioriza."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.datasets import make_classification\nfrom sklearn.model_selection import train_test_split\nfrom sklearn.ensemble import RandomForestClassifier\nfrom sklearn.metrics import classification_report\n\n# dataset com 97% classe 0 e 3% classe 1 (ex.: falha rara de equipamento)\nX, y = make_classification(\n    n_samples=4000, n_features=12, weights=[0.97, 0.03], random_state=42\n)\nX_treino, X_teste, y_treino, y_teste = train_test_split(\n    X, y, test_size=0.3, stratify=y, random_state=42\n)\n\nmodelo = RandomForestClassifier(random_state=42)\nmodelo.fit(X_treino, y_treino)\ny_pred = modelo.predict(X_teste)\n\nprint(classification_report(y_teste, y_pred, digits=2))\n#               precision    recall  f1-score   support\n#            0       0.97      1.00      0.99      1164\n#            1       0.83      0.14      0.24        36\n#\n#     accuracy                           0.97      1200\n\nprint(\"Acurácia:\", modelo.score(X_teste, y_teste))\n# Acurácia: 0.97"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Estratégias para lidar com o desbalanceamento\n\nNenhuma bala de prata aqui, mas um conjunto de táticas que se combinam:\n\n- **Pesar as classes** (`class_weight='balanced'`): diz ao algoritmo que errar na classe rara custa mais caro, sem tocar nos dados. Costuma ser o primeiro passo, é só um parâmetro a mais.\n- **Undersampling**: descarta parte dos exemplos da classe majoritária pra equilibrar as proporções no treino. Funciona quando sobra dado, mas joga informação fora.\n- **Oversampling simples**: duplica exemplos da classe minoritária. Não perde dado, mas repetir os mesmos pontos aumenta o risco de decorar justamente esses exemplos.\n- **SMOTE** (Synthetic Minority Oversampling Technique): em vez de duplicar, cria exemplos sintéticos da classe minoritária interpolando entre vizinhos no espaço de features. Vive na biblioteca `imbalanced-learn` (`from imblearn.over_sampling import SMOTE`), não no scikit-learn, e entra como uma etapa antes do treino, só no conjunto de treino, nunca no teste.\n- **Trocar a métrica de decisão**: parar de validar pela acurácia e acompanhar recall, F1 ou AUC, escolhendo qual pesa mais conforme o custo de cada tipo de erro no seu problema.\n\nReamostragem sempre acontece depois do split e só no treino: contaminar o teste com exemplo duplicado ou sintético dá uma avaliação otimista que não existe na vida real."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.ensemble import RandomForestClassifier\nfrom sklearn.metrics import classification_report\n\n# mesmo X_treino/X_teste do exemplo anterior, agora com class_weight\nmodelo_balanceado = RandomForestClassifier(\n    class_weight=\"balanced\", random_state=42\n)\nmodelo_balanceado.fit(X_treino, y_treino)\ny_pred_bal = modelo_balanceado.predict(X_teste)\n\nprint(classification_report(y_teste, y_pred_bal, digits=2))\n#               precision    recall  f1-score   support\n#            0       0.98      0.96      0.97      1164\n#            1       0.36      0.53      0.43        36\n#\n#     accuracy                           0.95      1200\n\n# 'balanced' pondera cada classe pelo inverso da sua frequência: errar na\n# classe rara passa a custar bem mais caro pro modelo durante o treino"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Cenário\", \"Estratégia mais indicada\", \"Cuidado\"], [\"Muito dado, desbalanceamento moderado\", \"class_weight='balanced'\", \"Comece por aqui, é a mudança mais simples\"], [\"Pouco dado no total\", \"SMOTE ou oversampling\", \"Não cria dado real, só interpola ou repete\"], [\"Dado abundante e minoria bem rara\", \"Undersampling\", \"Reduz o treino, atenção ao viés que isso introduz\"], [\"Erro na classe rara é bem mais caro\", \"class_weight com recall ou F1 como métrica principal\", \"Aceitar mais falso positivo em troca de menos falso negativo\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Desbalanceamento não se resolve olhando pra acurácia de novo até ela parecer boa. Resolve-se decidindo, antes de treinar, qual erro custa mais caro, e ajustando o modelo pra errar menos exatamente aí."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que faz o parâmetro class_weight='balanced' num classificador do scikit-learn?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Pondera o erro de cada classe pelo inverso da sua frequência nos dados de treino",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Remove automaticamente os exemplos duplicados da classe majoritária antes do treino",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Gera exemplos sintéticos da classe minoritária usando os vizinhos mais próximos",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Troca a métrica de avaliação de acurácia para F1-score durante o treino",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um modelo de detecção de defeito industrial tem acurácia de 98% e recall de 20% na classe \"defeituoso\". Depois de aplicar class_weight='balanced', a acurácia cai pra 94%, mas o recall sobe pra 65%. Como avaliar essa troca?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Uma troca desejável: pegar mais defeitos reais importa mais que a acurácia geral",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um sinal de que o modelo passou a sofrer overfitting grave nos dados de treino",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma prova de que o class_weight piorou o modelo, já que a acurácia geral caiu",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um sinal de vazamento de dados introduzido pelo parâmetro class_weight no treino",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que aplicar SMOTE ou oversampling depois de dividir treino e teste, nunca antes?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque gerar ou duplicar exemplos antes do split espalha a mesma informação pro teste",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o SMOTE só funciona em conjuntos de dados já padronizados com StandardScaler",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque a ordem não muda o resultado, mas é a convenção adotada pelo scikit-learn",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque aplicar a reamostragem antes do split deixa o treino consideravelmente mais lento",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um dataset de crédito tem quase todas as features categóricas, com poucas colunas numéricas. Ao aplicar SMOTE diretamente nesse conjunto, qual risco é mais provável?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "SMOTE interpola no espaço de features e pode gerar combinações pouco realistas nesse caso",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "SMOTE não roda em datasets com colunas categóricas e o código lança um erro de execução",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "SMOTE se comporta de forma idêntica em dados categóricos e numéricos, sem diferença prática",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "SMOTE substitui automaticamente as colunas categóricas por codificação one-hot antes de gerar exemplos",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Num sistema de aprovação de crédito, um falso positivo (aprovar quem não vai pagar) custa muito mais caro que um falso negativo (recusar quem pagaria). Qual prioridade faz mais sentido pra classe \"vai pagar\"?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Priorizar precisão alta, mesmo que isso reduza o recall dessa classe",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Priorizar recall alto, mesmo que isso reduza a precisão dessa classe",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Priorizar a acurácia geral, já que ela pondera os dois tipos de erro igualmente",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Priorizar o F1-score da classe oposta, ignorando as métricas dessa classe",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Dados e rótulos ruins",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Garbage in, garbage out, de novo\n\nLá na trilha de Machine Learning você já ouviu essa frase, na aula sobre preparar features: dado ruim gera modelo ruim, não importa o quão sofisticado seja o algoritmo. Ali o foco era dado faltante e variável fora de escala, problemas mecânicos, fáceis de flagrar com `.isnull()` e resolver com um imputer. Nesta aula o problema é mais traiçoeiro: rótulo errado, ruído e viés, coisas que não aparecem em nenhum `.isnull().sum()`."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Rótulos errados: o modelo aprende a mentira\n\nTodo problema supervisionado depende de um pressuposto: o rótulo (`y`) usado pra treinar reflete a verdade. Na prática, rótulo é produzido por gente, processo ou sensor, e todos os três erram. Um cliente marcado como \"não converteu\" porque o evento de conversão falhou em disparar. Um exame classificado errado por cansaço de quem revisou. Uma etiqueta de produto atribuída à categoria errada no sistema.\n\nO problema é que o modelo não sabe que aquele rótulo está errado, ele aprende a reproduzir o erro como se fosse padrão. Diferente de ruído numa feature, que o modelo consegue aprender a ignorar em parte, ruído no rótulo contamina diretamente aquilo que o modelo está tentando prever."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Ruído e viés não são a mesma coisa\n\n**Ruído** é variação aleatória: um sensor com pequena imprecisão, um outlier que é real mas incomum, uma resposta de pesquisa preenchida às pressas. Em geral, com dado suficiente, o modelo aprende a não se importar tanto com ruído, porque ele não segue um padrão consistente.\n\n**Viés nos dados** é mais grave, porque não é aleatório: é sistemático. Se o histórico de contratação usado pra treinar um modelo reflete anos de preferência por um perfil específico de candidato, o modelo aprende esse padrão como se fosse mérito. Se os dados de um processo refletem onde a fiscalização já era mais presente, o modelo aprende a recomendar mais fiscalização pros mesmos lugares. O modelo não inventa o viés, ele aprende e reproduz um viés que já estava no dado, só que agora automatizado e em escala."
+                    },
+                    {
+                        "type": "code",
+                        "value": "import numpy as np\nfrom sklearn.datasets import make_classification\nfrom sklearn.model_selection import train_test_split\nfrom sklearn.ensemble import RandomForestClassifier\n\nX, y = make_classification(n_samples=3000, n_features=15, random_state=42)\nX_treino, X_teste, y_treino, y_teste = train_test_split(\n    X, y, test_size=0.3, random_state=42\n)\n\n# modelo treinado com os rótulos originais\nmodelo_limpo = RandomForestClassifier(random_state=42)\nmodelo_limpo.fit(X_treino, y_treino)\nprint(\"Acurácia com rótulos corretos:\", modelo_limpo.score(X_teste, y_teste))\n# Acurácia com rótulos corretos: 0.92\n\n# simula 15% de rótulos errados só no treino (o teste continua confiável)\nrng = np.random.default_rng(42)\ny_treino_ruidoso = y_treino.copy()\nindices_embaralhados = rng.choice(\n    len(y_treino_ruidoso), size=int(0.15 * len(y_treino_ruidoso)), replace=False\n)\ny_treino_ruidoso[indices_embaralhados] = 1 - y_treino_ruidoso[indices_embaralhados]\n\nmodelo_ruidoso = RandomForestClassifier(random_state=42)\nmodelo_ruidoso.fit(X_treino, y_treino_ruidoso)\nprint(\"Acurácia com 15% de rótulos errados:\", modelo_ruidoso.score(X_teste, y_teste))\n# Acurácia com 15% de rótulos errados: 0.81"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Antes de treinar, olhar (de novo)\n\nA melhor defesa contra rótulo ruim, ruído e viés é velha conhecida: a EDA (análise exploratória) que você já fez lá em Análise de Dados, agora aplicada com outro objetivo. Não é só entender a distribuição das variáveis, é desconfiar do dado:\n\n- `df['alvo'].value_counts()`: a proporção das classes bate com o que faz sentido pro problema?\n- `df.groupby('categoria')['alvo'].mean()`: existe uma categoria com uma taxa de alvo suspeita, alta ou baixa demais?\n- Amostrar exemplos manualmente, sobretudo os que o modelo erra com mais confiança: às vezes o modelo não errou, o rótulo que estava errado.\n- Verificar se alguma feature é boa demais pra ser verdade (correlação quase perfeita com o alvo costuma ser vazamento, não sorte).\n\nNenhuma dessas checagens está dentro do `fit()`. Elas são trabalho manual, ler e desconfiar, e é exatamente por isso que ficam de fora do pipeline automatizado e dentro da responsabilidade de quem constrói o modelo."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Problema\", \"Como costuma aparecer\", \"O que fazer\"], [\"Rótulo errado\", \"Exemplos que o modelo erra com muita confiança, sempre no mesmo padrão\", \"Amostrar e conferir manualmente um grupo desses casos\"], [\"Ruído aleatório\", \"Erros espalhados pelos dados, sem padrão claro entre eles\", \"Mais dado de treino, ou aceitar um teto de desempenho\"], [\"Viés sistemático\", \"O modelo reproduz uma desigualdade que já existia no histórico\", \"Auditar a origem dos dados, não só ajustar o modelo\"], [\"Feature vazada\", \"Uma variável com correlação quase perfeita com o alvo\", \"Investigar se ela só existe depois do evento a prever\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Um modelo treinado em dado ruim não é neutro: ele aprende exatamente o erro e o viés que você deu a ele, e devolve isso com a aparência de objetividade de um número."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que significa a expressão 'garbage in, garbage out' aplicada a machine learning?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Um modelo treinado com dado de baixa qualidade tende a produzir previsões de baixa qualidade",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um modelo sempre melhora de desempenho quando recebe mais dados de treino, sem exceção",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um modelo descarta automaticamente os exemplos de treino considerados de baixa qualidade",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um modelo com poucos hiperparâmetros ajustados produz resultado pior que um mais complexo",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que um rótulo (y) errado tende a ser mais prejudicial ao treino do que ruído numa feature (X)?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque o modelo aprende a reproduzir o erro do rótulo como se fosse o padrão a prever",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque rótulo errado sempre reduz o tamanho do conjunto de treino disponível",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque ruído em features nunca afeta o desempenho de nenhum algoritmo supervisionado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque rótulo errado impede o fit() do scikit-learn de terminar sem lançar um erro",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma feature apresenta correlação de 0,98 com o alvo, bem mais alta que qualquer outra variável do dataset. O que essa observação deveria motivar?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Investigar se essa feature só fica disponível depois que o alvo já é conhecido",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Usar essa feature sozinha no modelo, já que ela sintetiza bem o padrão dos dados",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Remover todas as outras features, pois elas claramente têm pouca relevância",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Aumentar o max_depth da árvore pra aproveitar melhor essa correlação alta",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um modelo de triagem de currículos, treinado no histórico de contratações de uma empresa, passa a rejeitar sistematicamente um perfil de candidato raramente contratado no passado, mesmo com qualificação equivalente. Isso é evidência de que:",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O modelo aprendeu e automatizou um viés que já existia no processo de contratação",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O modelo está com overfitting, já que aprendeu demais sobre os candidatos do treino",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O dataset de treino tinha rótulos aleatórios e por isso o modelo não aprendeu nada",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O modelo precisa de mais features numéricas pra deixar de considerar o histórico",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Ao investigar manualmente os exemplos em que o modelo erra com mais confiança, uma cientista percebe que boa parte tem o rótulo original incoerente com as demais colunas. Qual conclusão é mais adequada?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Vale revisar e corrigir esses rótulos antes de tentar melhorar o modelo em si",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O modelo precisa de um algoritmo mais complexo pra dar conta desses casos difíceis",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Esses exemplos devem ficar como estão, já que o teste precisa refletir a realidade",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A métrica usada na avaliação está incorreta e precisa ser recalculada do zero",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Overfitting na prática",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## O que a definição não conta\n\nLá na trilha de Machine Learning você aprendeu a definição clássica de overfitting: desempenho ótimo no treino, desempenho ruim no teste, aquela árvore sem limite de profundidade que decorava 100% do treino e caía pra 81% no teste. A definição está correta, só que na prática o overfitting raramente é tão escancarado. Ele aparece disfarçado: numa diferença de poucos pontos entre treino e validação que parece pequena, mas que some quando você simplifica o modelo. Ou aparece depois do próprio processo de tuning, o vilão que ninguém avisa."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Sinais que valem mais atenção do que parecem\n\n- **Gap crescente**: conforme você aumenta a complexidade (mais árvores, mais profundidade, `C` maior), o score de treino sobe e o score de validação estaciona ou cai. É a curva de validação do Módulo 2: como a plataforma não desenha gráfico, imagine duas linhas que começam juntas e se afastam.\n- **Ótimo no CV, decepcionante fora dele**: se a busca de hiperparâmetros (`GridSearchCV`, `RandomizedSearchCV`) testou dezenas de combinações e escolheu a de melhor score médio de validação cruzada, existe uma chance real de ter escolhido a combinação que foi bem naqueles folds por coincidência. Quanto mais combinações testadas, maior essa chance: uma forma sutil de overfitting no próprio processo de tuning, não só no modelo final.\n- **Ensemble complexo demais**: um boosting com `n_estimators` alto e `learning_rate` alto junto tende a decorar o treino rápido; um random forest com árvores muito profundas e poucas amostras por folha, também.\n\nO antídoto pro segundo ponto é o que você já pratica: manter um conjunto de teste isolado do processo de tuning inteiro, e só olhar pra ele uma vez, no fim."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.datasets import make_classification\nfrom sklearn.model_selection import train_test_split\nfrom sklearn.ensemble import GradientBoostingClassifier\n\nX, y = make_classification(n_samples=1500, n_features=20, random_state=42)\nX_treino, X_teste, y_treino, y_teste = train_test_split(\n    X, y, test_size=0.3, random_state=42\n)\n\nfor n in [10, 50, 200, 500]:\n    modelo = GradientBoostingClassifier(\n        n_estimators=n, learning_rate=0.2, max_depth=3, random_state=42\n    )\n    modelo.fit(X_treino, y_treino)\n    print(\n        f\"n_estimators={n:>3} | treino={modelo.score(X_treino, y_treino):.2f} \"\n        f\"| teste={modelo.score(X_teste, y_teste):.2f}\"\n    )\n\n# n_estimators= 10 | treino=0.91 | teste=0.89\n# n_estimators= 50 | treino=0.98 | teste=0.90\n# n_estimators=200 | treino=1.00 | teste=0.88\n# n_estimators=500 | treino=1.00 | teste=0.86"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que fazer quando o modelo overfitou\n\n- **Regularizar**: em modelos lineares, diminuir `C` (regressão logística) ou aumentar `alpha` (Ridge/Lasso) penaliza coeficientes grandes. Em árvores e ensembles, limitar `max_depth` ou aumentar `min_samples_leaf` faz o mesmo papel, impedir que o modelo se ajuste a detalhes pequenos demais.\n- **Mais dados**: quando é possível conseguir, é o remédio mais direto, porque dificulta decorar particularidades que não vão se repetir. Nem sempre está disponível, mas vale sempre perguntar antes de mexer só no modelo.\n- **Features mais simples**: menos features, ou features mais agregadas e menos ruidosas, reduzem o espaço em que o modelo pode se especializar demais no treino. É o que você viu no Módulo 1: nem toda feature nova ajuda, algumas só dão corda pro overfitting.\n- **Early stopping no boosting**: em vez de fixar um `n_estimators` alto e torcer, você monitora o desempenho numa fatia de validação e para de adicionar árvores quando ele para de melhorar. O `GradientBoostingClassifier` faz isso nativamente com `validation_fraction` e `n_iter_no_change`; XGBoost e LightGBM têm o mecanismo equivalente, geralmente chamado de `early_stopping_rounds`.\n- **Reduzir a complexidade do ensemble**: menos árvores, menos profundidade, ou trocar um boosting muito ajustado por um random forest, naturalmente mais resistente a overfitting por causa da votação entre árvores."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.ensemble import GradientBoostingClassifier\n\n# reaproveitando X_treino, X_teste, y_treino, y_teste da célula anterior\n# para de adicionar árvores quando 10 rodadas seguidas não melhoram o\n# desempenho numa fatia de validação separada internamente\nmodelo_early_stop = GradientBoostingClassifier(\n    n_estimators=500,\n    learning_rate=0.2,\n    max_depth=3,\n    validation_fraction=0.15,\n    n_iter_no_change=10,\n    random_state=42,\n)\nmodelo_early_stop.fit(X_treino, y_treino)\n\nprint(\"Estágios (árvores) realmente usados:\", modelo_early_stop.estimators_.shape[0])\n# Estágios (árvores) realmente usados: 63\n\nprint(\"Score no teste:\", modelo_early_stop.score(X_teste, y_teste))\n# Score no teste: 0.91"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Sinal\", \"O que costuma indicar\", \"O que fazer\"], [\"Score de treino bem acima do score de teste\", \"Overfitting clássico, o modelo decorou o treino\", \"Regularizar, reduzir complexidade, buscar mais dado\"], [\"Treino e teste sobem juntos e depois o teste cai\", \"Ponto de complexidade ideal já foi ultrapassado\", \"Voltar pro hiperparâmetro em que só o treino ainda subia\"], [\"Boosting com muitas iterações e teste caindo\", \"Excesso de estágios, learning_rate alto demais\", \"Early stopping, reduzir learning_rate ou n_estimators\"], [\"Score de CV ótimo, desempenho ruim fora do tuning\", \"Overfitting no próprio processo de busca de hiperparâmetro\", \"Testar menos combinações plausíveis, manter teste isolado\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Overfitting não é um defeito visível no código, é uma promessa otimista demais sobre o quanto o modelo realmente aprendeu. A única forma de desmentir a promessa é medir num dado que o modelo, e o processo de tuning inteiro, nunca viram."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual é o sinal mais clássico de que um modelo está com overfitting?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Desempenho bem melhor no conjunto de treino do que no conjunto de teste",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Desempenho parecido e ruim tanto no conjunto de treino quanto no de teste",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um tempo de treinamento maior do que o esperado pro tamanho do dataset",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um número de features maior do que o número de exemplos de treino usados",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de um GridSearchCV testar 200 combinações de hiperparâmetros, o modelo escolhido tem ótimo score médio de validação cruzada, mas desempenho bem pior no conjunto de teste, isolado desde o início. O que provavelmente aconteceu?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "A busca testou tantas combinações que escolheu uma que foi bem nos folds por sorte",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O conjunto de teste ficou desbalanceado, invalidando a comparação com a validação",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O GridSearchCV usou o conjunto de teste internamente sem isso aparecer no código",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O modelo escolhido tem, com certeza, um bug de implementação no scikit-learn",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um GradientBoostingClassifier com n_estimators=500 e learning_rate alto atinge score 1.0 no treino, com queda progressiva no teste conforme mais árvores entram. Qual mudança ataca diretamente essa causa?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Usar validation_fraction e n_iter_no_change para parar antes do ponto de piora",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Aumentar ainda mais o n_estimators, já que o modelo pode não ter convergido",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Trocar o GradientBoostingClassifier por um KNeighborsClassifier, imune a overfitting",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Remover o conjunto de teste da avaliação, já que ele tem distribuição diferente",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe reduziu o max_depth de uma random forest e viu o score de treino cair de 0.99 para 0.90, enquanto o score de teste subiu de 0.78 para 0.87. Como interpretar essa mudança?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "A variância caiu, aproximando treino e teste com ganho real de generalização",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O modelo piorou de forma geral, já que o score de treino caiu bastante após o ajuste",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Houve vazamento de dados introduzido pela redução do max_depth no treinamento",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A random forest deixou de conseguir aprender qualquer padrão útil dos dados",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de simplificar as features (removendo agregações muito específicas) e adicionar mais exemplos de treino, um modelo de boosting manteve o mesmo score de treino, mas o score de teste melhorou bastante. O que essas duas mudanças têm em comum?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "As duas reduzem a chance de o modelo se especializar em detalhes que não se repetem",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "As duas aumentam a complexidade efetiva do modelo, captando padrões mais sutis",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "As duas alteram a métrica usada na avaliação, o que explica a melhora no teste",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "As duas eliminam a necessidade de dividir os dados entre treino e teste",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Interpretar o modelo",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Por que se importar com o motivo\n\nUm modelo que acerta 95% das vezes já convence muita gente, mas em boa parte dos casos reais isso não basta. Quem aprova ou recusa crédito precisa justificar a decisão pro cliente, e em vários contextos isso é exigência regulatória, não gentileza. Um time médico não vai confiar (nem deveria) numa previsão de risco sem entender o que pesou nela. E, como você viu na Aula 2 deste módulo, um modelo pode estar reproduzindo um viés do dado sem que ninguém perceba, e a única forma de flagrar isso é abrindo o motivo da previsão, não só olhando o resultado final.\n\nLá no Módulo 1 você já usou o `feature_importances_` de uma árvore pra ver quais variáveis mais pesavam. Nesta aula, esse instrumento ganha companhia e um olhar mais crítico."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que o feature_importances_ realmente mede\n\nEm árvores e florestas, `feature_importances_` soma o quanto cada feature reduziu a impureza (Gini, geralmente) em todas as divisões onde foi usada, normalizado pra somar 1. É rápido, vem de graça depois do `fit()`, mas tem limitações que vale conhecer:\n\n- Tende a inflar a importância de features numéricas com muitos valores únicos, ou categóricas com muitas categorias, porque elas têm mais pontos de corte possíveis pra testar.\n- É calculada sobre o conjunto de treino, então uma feature que ajudou o modelo a decorar particularidades (aquele overfitting da árvore) pode aparecer como \"importante\" sem ser realmente útil pra generalizar.\n- Lida mal com features correlacionadas entre si: se duas colunas carregam a mesma informação, a árvore pode dividir a importância entre as duas, fazendo cada uma parecer menos relevante do que é."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.inspection import permutation_importance\nfrom sklearn.ensemble import RandomForestClassifier\nfrom sklearn.model_selection import train_test_split\nfrom sklearn.datasets import make_classification\nimport pandas as pd\n\nX, y = make_classification(n_samples=1000, n_features=6, random_state=42)\ncolunas = [f\"feature_{i}\" for i in range(6)]\nX_treino, X_teste, y_treino, y_teste = train_test_split(\n    pd.DataFrame(X, columns=colunas), y, test_size=0.3, random_state=42\n)\n\nmodelo = RandomForestClassifier(random_state=42)\nmodelo.fit(X_treino, y_treino)\n\nresultado = permutation_importance(\n    modelo, X_teste, y_teste, n_repeats=10, random_state=42, scoring=\"accuracy\"\n)\n\nimportancias = pd.Series(resultado.importances_mean, index=colunas)\nprint(importancias.sort_values(ascending=False))\n# feature_1    0.142\n# feature_4    0.098\n# feature_0    0.061\n# feature_3    0.014\n# feature_2    0.003\n# feature_5   -0.002"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Por que a permutation importance costuma ser mais confiável\n\nA ideia é direta: pega o conjunto de teste (ou um holdout), embaralha os valores de uma feature de cada vez (destruindo a relação dela com o alvo, mantendo tudo mais igual) e mede o quanto a métrica do modelo piora. Uma feature importante de verdade faz a métrica desabar quando embaralhada; uma feature inútil quase não muda nada, podendo até flutuar perto de zero.\n\nComo é medida no conjunto de teste, com a métrica final que você realmente se importa (`accuracy`, `f1`, o que fizer sentido), ela reflete o que a feature contribui pra generalização, não só o que ela ajudou a decorar no treino. A troca é custo computacional: embaralhar e prever várias vezes (`n_repeats`) pra cada feature é bem mais caro que ler o `feature_importances_` de graça, mas funciona pra qualquer modelo, não só árvore, porque não depende da estrutura interna dele."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Explicar o modelo inteiro x explicar uma previsão\n\n`feature_importances_` e permutation importance respondem \"o que o modelo usa mais, em média, considerando todos os exemplos\". Muitas vezes a pergunta é outra: \"por que esse cliente específico foi recusado?\". Pra isso existem ferramentas de explicação local, duas viraram padrão de mercado:\n\n- **SHAP** (SHapley Additive exPlanations): baseado num conceito de teoria dos jogos (valores de Shapley), reparte a previsão de um exemplo entre as features, mostrando o quanto cada uma empurrou a previsão pra cima ou pra baixo a partir de uma base. Funciona pra qualquer modelo, incluindo os ensembles deste módulo, e tem versões otimizadas pra árvores.\n- **LIME** (Local Interpretable Model-agnostic Explanations): explica uma previsão treinando, ao redor daquele ponto específico, um modelo bem mais simples (tipo uma regressão linear) que aproxima o comportamento do modelo complexo só naquela vizinhança.\n\nNenhuma das duas vem no scikit-learn, são bibliotecas à parte (`shap`, `lime`), e ambas custam tempo de computação, sobretudo SHAP em modelos grandes. Valem a pena quando a pergunta é sobre um caso específico, não sobre o modelo inteiro."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"\", \"Modelo simples (regressão, árvore rasa)\", \"Caixa-preta (random forest, boosting)\"], [\"Interpretação nativa\", \"Sim: coeficientes ou o caminho de decisão\", \"Fraca: muitas árvores ou pesos combinados\"], [\"Ferramenta extra necessária\", \"Geralmente não\", \"permutation importance, SHAP ou LIME\"], [\"Desempenho típico em dado complexo\", \"Costuma perder pra ensembles\", \"Costuma ganhar em dado tabular complexo\"], [\"Uso comum\", \"Crédito, saúde, contexto regulatório\", \"Quando desempenho pesa mais que explicação direta\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Um modelo que ninguém consegue explicar não é neutro nem infalível, só é opaco. Interpretar não é luxo acadêmico: é a diferença entre confiar num número e entender por que ele apareceu."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que a permutation importance mede pra avaliar a importância de uma feature?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "O quanto a métrica do modelo piora quando os valores dessa feature são embaralhados",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O quanto essa feature está correlacionada com todas as outras do conjunto de dados",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O número de vezes que essa feature aparece nas divisões de uma única árvore",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O tempo de processamento que o modelo leva pra usar essa feature no treinamento",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que a permutation importance costuma ser considerada mais confiável do que o feature_importances_ de uma árvore?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque é medida no conjunto de teste, refletindo o que a feature contribui pra generalizar",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque é calculada automaticamente durante o fit, sem exigir nenhum passo manual",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque funciona exclusivamente com árvores de decisão e ensembles baseados nelas",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque descarta as features correlacionadas antes de calcular a importância de cada uma",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual a diferença central entre o que o feature_importances_ de uma random forest mostra e o que o SHAP mostra pra um exemplo específico?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "feature_importances_ resume a floresta inteira, SHAP reparte a previsão daquele exemplo",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "feature_importances_ funciona pra qualquer modelo, SHAP funciona só pra árvores de decisão",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "feature_importances_ precisa do conjunto de teste, SHAP é calculado inteiramente no treino",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "feature_importances_ mede correlação, SHAP mede exclusivamente features numéricas",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Duas features de um dataset são fortemente correlacionadas entre si, e ambas realmente influenciam o alvo. O que costuma acontecer com o feature_importances_ de uma random forest nesse caso?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "A importância tende a se dividir entre as duas, cada uma parecendo menos relevante",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A importância das duas soma exatamente zero, já que a correlação anula o efeito",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A random forest ignora automaticamente uma das duas features durante o treino",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A importância das duas dobra de valor, já que elas reforçam o mesmo sinal",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma instituição financeira precisa justificar, cliente a cliente, por que um pedido de crédito foi recusado, cumprindo exigência regulatória. Qual ferramenta atende diretamente essa necessidade?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Uma explicação local, como SHAP, mostrando o peso de cada feature naquela previsão",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O feature_importances_ do modelo, que já detalha o motivo de cada previsão individual",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A acurácia geral do modelo no conjunto de teste, reportada junto de cada decisão",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A matriz de confusão do modelo, mostrando o padrão de erro em cada cliente recusado",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Quando ML não é a resposta",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## A pergunta que este módulo inteiro pressupõe\n\nTudo neste módulo assume que ML é a ferramenta certa e o trabalho é fazer ela funcionar apesar do desbalanceamento, do dado ruim, do overfitting. Mas existe uma pergunta anterior a todas essas, fácil de pular quando você já sabe treinar ensemble e ajustar hiperparâmetro: esse problema deveria ir pra machine learning?\n\nDizer não a ML, quando faz sentido, é tão parte do trabalho quanto saber montar um `Pipeline` correto. É a última habilidade prática deste módulo, e talvez a mais madura."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Quando uma regra simples já resolve\n\nSe o problema pode ser descrito numa frase tipo \"recusa automaticamente se o valor da compra for maior que R$ 5.000 e o cliente tiver conta há menos de 30 dias\", vale testar essa regra antes de treinar qualquer modelo. Regras simples têm vantagens que nenhum ensemble oferece de graça: são triviais de explicar, de auditar e de ajustar quando o negócio muda, e não exigem infraestrutura de treino, monitoramento e retreinamento.\n\nO teste prático é o mesmo raciocínio do `DummyClassifier` que você viu na trilha de Machine Learning, ampliado: compare o modelo não só contra \"sempre prever a classe majoritária\", mas contra a melhor regra de negócio que alguém experiente conseguir escrever. Se o ganho do modelo for pequeno perto da complexidade extra que ele traz, a regra simples pode ser a escolha certa, não a escolha preguiçosa."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Quando faltam dados\n\nModelos aprendem padrão repetido; sem repetição suficiente, não tem padrão pra aprender, só ruído. Um dataset de 80 linhas pra um problema com 15 features tende a produzir um modelo instável, que muda bastante de previsão dependendo de quais poucos exemplos entraram no treino, mesmo com toda a regularização deste módulo.\n\nNesse cenário, as alternativas costumam valer mais que forçar um modelo: uma regra simples baseada no conhecimento de quem já vive o problema, um processo manual assistido (o modelo sugere, uma pessoa decide) até o volume de dado crescer, ou simplesmente esperar e coletar mais antes de treinar algo que ninguém vai conseguir validar direito."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Quando o custo do erro é alto demais pra decidir sozinho\n\nMesmo um modelo com métricas boas erra: um recall de 95% ainda deixa 5% passar. A pergunta que importa é se esse erro remanescente é aceitável pra decisão em questão. Automatizar uma recomendação de produto errada custa pouco. Automatizar, sem revisão humana, uma decisão que nega um tratamento ou corta o acesso de alguém a um serviço essencial é outra categoria de risco, mesmo com uma métrica de teste elogiável.\n\nNesses casos, a resposta madura raramente é \"não usar o modelo\", e sim \"não deixar o modelo decidir sozinho\": usar a previsão como apoio pra uma pessoa, manter revisão humana no caminho, e ser honesto sobre o fato de que nenhuma métrica de validação garante o comportamento do modelo em todo caso futuro."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from sklearn.datasets import make_classification\nfrom sklearn.model_selection import train_test_split\nfrom sklearn.linear_model import LogisticRegression\nfrom sklearn.metrics import accuracy_score\n\n# problema simulado em que uma única feature já carrega quase toda a\n# informação (comum quando existe uma regra de negócio forte por trás)\nX, y = make_classification(\n    n_samples=1000, n_features=5, n_informative=1, n_redundant=0,\n    n_clusters_per_class=1, random_state=42\n)\nX_treino, X_teste, y_treino, y_teste = train_test_split(\n    X, y, test_size=0.3, random_state=42\n)\n\n# regra simples: um limiar na primeira feature\nregra_simples = (X_teste[:, 0] > 0).astype(int)\nprint(\"Acurácia da regra simples:\", accuracy_score(y_teste, regra_simples))\n# Acurácia da regra simples: 0.94\n\nmodelo = LogisticRegression()\nmodelo.fit(X_treino, y_treino)\nprint(\"Acurácia da regressão logística:\", modelo.score(X_teste, y_teste))\n# Acurácia da regressão logística: 0.95\n\n# um ponto de acurácia a mais raramente paga a conta de manter um pipeline\n# de ML inteiro rodando no lugar de uma regra de uma linha"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Pergunta\", \"Se a resposta for sim\"], [\"Uma regra simples já cobre a maior parte dos casos?\", \"Comece pela regra, meça, só complique se o ganho justificar\"], [\"Existe dado suficiente e representativo do problema?\", \"Sem isso, considere apoio humano em vez de um modelo\"], [\"O erro automatizado tem consequência grave e pouco reversível?\", \"Mantenha revisão humana no processo, não decisão sozinha do modelo\"], [\"É preciso explicar cada decisão individual por exigência externa?\", \"Priorize modelo interpretável ou reserve tempo pra SHAP e LIME\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "A pergunta mais avançada em machine learning não é qual algoritmo usar, é se este problema precisa de um algoritmo. Um cientista de dados maduro sabe fazer as duas coisas: treinar o modelo certo, e recusar treinar um modelo quando a resposta certa é mais simples que isso."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Em qual situação uma regra de negócio simples costuma ser preferível a um modelo de machine learning?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Quando a regra já explica a maior parte dos casos e é fácil de auditar e ajustar",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Quando o time tem bastante experiência prévia usando GridSearchCV e Pipeline",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Quando o conjunto de dados disponível é grande e cobre bem o problema",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Quando o modelo mais complexo testado teve o melhor score de validação cruzada",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um dataset de apenas 60 exemplos, com 20 features, é usado pra treinar um classificador. Mesmo com regularização, o modelo muda bastante de previsão a cada pequena mudança no conjunto de treino. O que essa instabilidade sugere?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O volume de dado é insuficiente, e uma alternativa mais simples pode valer mais",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O modelo precisa de um ensemble ainda mais complexo pra estabilizar as previsões",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A regularização foi aplicada de forma incorreta e deve ser completamente removida",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O problema tem, com certeza, vazamento de dados entre o treino e o teste usados",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que 'não deixar o modelo decidir sozinho' costuma ser mais adequado do que simplesmente descartar o modelo, em decisões de alto custo de erro?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque o modelo ainda pode apoiar uma decisão humana, mesmo sem garantia de acerto total",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque toda decisão automatizada de alto custo se torna segura acima de 90% de acurácia",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque manter revisão humana elimina a necessidade de medir recall ou precisão",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque um modelo sem supervisão humana sempre tem desempenho pior que uma regra simples",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma regra simples alcança 94% de acurácia num problema, e uma regressão logística treinada nos mesmos dados alcança 95%. O que essa comparação, sozinha, já justifica?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Pouco ainda: vale pesar se o ganho de 1 ponto compensa manter um modelo em produção",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Substituir imediatamente a regra pelo modelo, já que qualquer ganho de acurácia compensa",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que a regra simples está com overfitting, por chegar tão perto de um modelo treinado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que o dataset usado tem vazamento de dados, já que uma regra não deveria competir assim",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe decide não usar machine learning para aprovar automaticamente pedidos de um benefício social, mesmo com um modelo de bom desempenho nos testes, optando por usá-lo só como apoio a um analista humano. Qual argumento justifica melhor essa escolha?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O custo de um erro automatizado nesse contexto é alto e pouco reversível, mesmo com bom teste",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Modelos de machine learning nunca devem ser usados em processos que envolvem pessoas reais",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O modelo certamente tem overfitting, já que nenhum modelo deveria ir bem nesse tipo de problema",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A equipe não confia no scikit-learn, preferindo aguardar uma versão mais recente da biblioteca",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 7 - Introdução a deep learning e o próximo passo",
+        "aulas": [
+            {
+                "titulo": "O que é uma rede neural",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# O que é uma rede neural\n\nVocê passou a trilha inteira combinando árvores (random forest, boosting), ajustando hiperparâmetros e montando pipelines robustos. Isso é, e continua sendo, o coração do trabalho de um cientista de dados no dia a dia. Mas existe uma outra família de modelos que você com certeza já ouviu falar, às vezes com um tom quase místico: as redes neurais, a base do deep learning.\n\nA boa notícia é que a intuição por trás de uma rede neural não é nada mágica. Boa parte dela você já viu, sem saber, lá na regressão logística. Este último módulo fecha a trilha te dando essa intuição, sem afundar na matemática pesada, e te mostrando quando essa ferramenta vale a pena (e quando não vale)."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O neurônio: soma ponderada mais ativação\n\nUm neurônio artificial faz uma conta bem simples. Ele recebe várias entradas (as features do seu problema, ou a saída de outros neurônios), multiplica cada uma por um peso, soma tudo e ainda soma um termo extra chamado viés (bias). Esse resultado passa por uma função de ativação, que decide o quanto aquele neurônio \"dispara\".\n\nSe você já treinou uma regressão logística, essa conta é familiar: soma ponderada das entradas, seguida da função sigmoide, que espreme o resultado entre 0 e 1. Um neurônio com ativação sigmoide é, literalmente, uma regressão logística em miniatura. A diferença de uma rede neural pra um único neurônio é empilhar muitos deles, em várias camadas, um alimentando o outro."
+                    },
+                    {
+                        "type": "code",
+                        "value": "import numpy as np\n\ndef sigmoide(z):\n    return 1 / (1 + np.exp(-z))\n\nentradas = np.array([0.5, 1.2, -0.3])  # as features de um exemplo\npesos = np.array([0.4, -0.6, 0.9])     # pesos aprendidos no treino\nvies = 0.1\n\nsoma_ponderada = np.dot(entradas, pesos) + vies\nsaida = sigmoide(soma_ponderada)\n\nprint(saida)  # algo como 0.33: a ativação desse neurônio\n# essa é a mesma conta por trás da regressão logística: soma ponderada e sigmoide"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Camadas: entrada, ocultas e saída\n\nUma rede neural organiza os neurônios em camadas. A camada de entrada só recebe as features, uma por neurônio, sem fazer conta nenhuma. As camadas ocultas, no meio, combinam essas entradas em representações cada vez mais abstratas. E a camada de saída produz o resultado final: uma probabilidade, uma classe, um número.\n\nA intuição por trás de \"deep\" learning é justamente ter várias camadas ocultas empilhadas (a palavra \"profundo\" se refere à quantidade de camadas). Num modelo que reconhece imagens, por exemplo, as primeiras camadas costumam aprender a detectar bordas e contrastes simples, as camadas seguintes combinam essas bordas em formas e texturas, e as camadas mais profundas juntam essas formas em partes de objetos reconhecíveis. Ninguém programa essa hierarquia à mão: a rede aprende sozinha, camada por camada, a partir dos dados."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Camada\", \"O que faz\"], [\"Entrada\", \"Recebe as features do exemplo, um valor por neurônio, sem transformar nada\"], [\"Oculta (mais rasa)\", \"Combina as entradas em padrões simples e locais\"], [\"Oculta (mais profunda)\", \"Combina os padrões anteriores em representações mais abstratas\"], [\"Saída\", \"Produz o resultado final: uma classe, uma probabilidade ou um número\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Pesos: os parâmetros que a rede aprende sozinha\n\nLembra da diferença entre parâmetro e hiperparâmetro, lá do Módulo 2? Os pesos de uma rede neural são parâmetros: valores que o próprio treino ajusta, exatamente como os coeficientes de uma regressão. Ninguém escolhe o valor de um peso na mão, o algoritmo de treino encontra esses valores sozinho.\n\nJá o número de camadas, quantos neurônios cada camada tem e qual função de ativação usar são hiperparâmetros, escolhas que você faz antes de treinar, do mesmo jeito que escolheu `n_estimators` e `max_depth` de uma random forest. A diferença é de escala: uma rede modesta já tem milhares de pesos pra ajustar, uma rede grande chega a bilhões. É por isso que treinar essas redes pede tanto dado e tanta conta, assunto da próxima aula."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Uma rede neural não esconde nenhum truque: é soma ponderada e ativação, repetida em camadas, muitas e muitas vezes."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que um neurônio artificial faz com as entradas recebidas, antes de aplicar a função de ativação?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Multiplica cada entrada pelo peso correspondente, soma tudo e ainda soma um viés",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Escolhe apenas a entrada de maior valor e descarta todas as outras recebidas",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Calcula a média simples das entradas recebidas, sem usar peso nenhum",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ordena as entradas da maior pra menor e repassa essa ordem adiante",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que se diz que um único neurônio com ativação sigmoide se parece com uma regressão logística?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque os dois calculam uma soma ponderada das entradas e aplicam a função sigmoide nela",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque os dois exigem uma árvore de decisão treinada antes de calcular qualquer resultado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque os dois dependem de agrupar os dados em clusters antes da previsão final",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque os dois usam apenas a mediana das entradas, em vez de somar valor nenhum",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual é o papel da camada de entrada numa rede neural?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Receber as features do exemplo e repassá-las adiante, sem transformar nada",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Aplicar a função de ativação mais complexa da rede antes de qualquer outra camada",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Calcular a função de perda comparando a previsão com o valor real esperado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Combinar os padrões aprendidos nas camadas ocultas numa previsão final",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Numa rede neural, os pesos das conexões e o número de camadas ocultas se diferenciam de que forma?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Os pesos são parâmetros que o treino ajusta; camadas são um hiperparâmetro definido por você",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Os pesos são hiperparâmetros definidos por você; camadas são ajustadas pelo treino sozinho",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ambos são parâmetros aprendidos pelo treino, sem nenhuma escolha manual envolvida",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ambos são hiperparâmetros que você precisa fixar antes de qualquer treino começar",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Numa rede treinada pra reconhecer imagens, o que costuma acontecer conforme os dados atravessam camadas mais profundas?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "As representações ficam mais abstratas, combinando padrões simples em conceitos complexos",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "As representações ficam mais simples, descartando toda combinação das camadas anteriores",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os dados voltam ao formato original de entrada, sem nenhuma transformação acumulada",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Cada camada refaz exatamente a mesma conta da camada de entrada, sem mudar nada",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Como a rede aprende (por cima)",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Da previsão ao erro: a função de perda\n\nTreinar uma rede neural começa com uma previsão. Os dados de um exemplo entram pela camada de entrada, atravessam as camadas ocultas e saem pela camada de saída como um número ou uma probabilidade. Isso é o chamado forward pass, e no início do treino, com pesos aleatórios, essa previsão costuma ser péssima.\n\nO próximo passo é medir o quão errada ela foi. É pra isso que serve a função de perda (loss function): ela compara a previsão da rede com o valor real e devolve um número que representa o erro. Pra regressão, é comum usar algo parecido com o erro quadrático médio que você já viu. Pra classificação, é comum usar a entropia cruzada (cross-entropy), uma prima da ideia por trás do log loss."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Backpropagation e gradiente: a ideia por cima\n\nCom o erro em mãos, a rede precisa descobrir como ajustar cada peso pra errar um pouco menos na próxima rodada. É aí que entra o backpropagation: um jeito de percorrer a rede de trás pra frente, calculando o quanto cada peso contribuiu pro erro final. Esse \"quanto contribuiu\" é o gradiente.\n\nCom o gradiente de cada peso calculado, o algoritmo de gradiente descendente empurra cada peso um pouco na direção que reduz o erro. Não é um salto direto pra resposta certa, é um passo pequeno, repetido milhares de vezes. Se você já acompanhou aquela curva de validação subindo e descendo até estabilizar, é essa mesma lógica de ajuste gradual, só que aplicada a cada peso da rede."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# ideia simplificada de UM passo de gradiente descendente, pra um peso só\npeso = 0.4\ntaxa_aprendizado = 0.01\ngradiente = 0.8  # o quanto esse peso contribuiu pro erro, calculado pelo backpropagation\n\npeso_novo = peso - taxa_aprendizado * gradiente\n\nprint(peso_novo)  # 0.392: o peso se moveu um pouco na direção que reduz o erro\n# repita essa conta pra cada peso da rede, a cada rodada, milhares de vezes"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Épocas, taxa de aprendizado e o custo de treinar\n\nUma rodada completa em que a rede vê todos os exemplos de treino se chama época (epoch). Como treinar com o dataset inteiro de uma vez costuma ser caro, é comum dividir os dados em lotes menores (batches), e ajustar os pesos a cada lote processado.\n\nO tamanho do passo em cada ajuste é a taxa de aprendizado (learning rate), e o nome não é coincidência: é o mesmo `learning_rate` que você ajustou no GradientBoosting do Módulo 4. A ideia de dar passos pequenos numa direção que reduz o erro, repetidos várias vezes, aparece tanto no boosting quanto no treino de uma rede. Uma taxa alta demais faz o treino oscilar sem convergir, uma taxa baixa demais faz o treino andar devagar demais pra ser útil.\n\nCom milhares (ou milhões) de pesos sendo ajustados a cada lote, o volume de conta cresce rápido. Isso explica por que treinar redes maiores pede tanto dado (pra generalizar de verdade, e não decorar o treino, como você já viu no Módulo 6) e tanta capacidade computacional, geralmente numa GPU, que faz esse tipo de multiplicação de matrizes em paralelo bem mais rápido que uma CPU comum."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Termo\", \"O que significa\"], [\"Época (epoch)\", \"Uma passada completa da rede por todos os exemplos de treino\"], [\"Lote (batch)\", \"Um pedaço dos dados usado por vez, em vez do conjunto inteiro\"], [\"Taxa de aprendizado\", \"O tamanho do passo em cada ajuste de peso (o learning_rate do Módulo 4)\"], [\"Função de perda (loss)\", \"A medida de erro que o treino tenta reduzir a cada rodada\"], [\"Backpropagation\", \"O cálculo que descobre o quanto cada peso contribuiu pro erro\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Treinar uma rede neural é isso: prever, medir o erro, empurrar cada peso um pouco na direção que reduz esse erro, e repetir a conta milhares de vezes."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que é a função de perda (loss) no treino de uma rede neural?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Uma medida de erro entre a previsão e o valor real, que o treino tenta reduzir",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Uma camada extra da rede, responsável por armazenar os dados de treino recebidos",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O nome dado à taxa de aprendizado usada em cada atualização de peso da rede",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma técnica de reamostragem usada apenas quando as classes estão desbalanceadas",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Em linhas gerais, o que o backpropagation calcula durante o treino de uma rede neural?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O quanto cada peso da rede contribuiu para o erro, pra saber em que direção ajustá-lo",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A quantidade de camadas ocultas ideal pra rede aprender o problema sem overfitar",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A correlação entre as features de entrada, antes mesmo do treino da rede começar",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O valor final que cada peso deveria ter, sem precisar de nenhuma rodada de treino",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O que a taxa de aprendizado (learning rate) controla no treino de uma rede neural?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O tamanho do passo dado em cada ajuste de peso, na direção que reduz o erro",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O número de camadas ocultas que a rede vai usar durante todo o treino",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A quantidade de exemplos de treino que a rede tem disponível pra aprender",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A função de ativação usada na camada de saída da rede, entre outras opções",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Durante o treino, a perda de uma rede neural oscila bastante e não diminui de forma consistente. Qual costuma ser a primeira causa a se testar?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "A taxa de aprendizado está alta demais, fazendo os pesos darem passos grandes demais",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O conjunto de teste foi usado sem querer no lugar do conjunto de treino da rede",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A camada de entrada está aplicando uma ativação, em vez de só repassar o dado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O número de features do problema é grande demais pra qualquer rede aprender",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que o treino de uma rede neural costuma exigir mais dado e mais poder computacional do que treinar uma random forest?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Porque há muitos pesos pra ajustar por gradiente, o que pede mais exemplo e mais conta",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque a random forest não usa validação cruzada, então precisa de bem menos dado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque redes neurais não conseguem rodar em CPU, apenas em GPU, mesmo com pouco dado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque a função de perda de uma rede é sempre mais difícil de calcular que um erro comum",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Quando deep learning brilha (e quando não)",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Onde deep learning brilha: dado não estruturado e abundante\n\nDeep learning se destaca quando o dado é não estruturado (imagem, texto, áudio, voz) e existe bastante volume disponível. Nesses casos, é difícil descrever à mão o que torna uma foto um gato ou uma frase uma reclamação de cliente: são padrões demais, complexos demais, pra virar uma fórmula de feature engineering como a do Módulo 1 desta trilha.\n\nÉ exatamente aí que uma rede com várias camadas se paga: em vez de você desenhar a feature, a rede aprende sozinha, a partir de milhares ou milhões de exemplos, quais representações internas ajudam a resolver o problema. Reconhecimento de imagem, tradução automática, assistente de voz, esses são os terrenos onde deep learning normalmente lidera."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Tipo de dado\", \"Abordagem que costuma ganhar\", \"Por quê\"], [\"Tabular (planilhas, bancos de dados)\", \"ML clássico (random forest, boosting)\", \"As colunas já são boas features, e funciona bem mesmo com pouco dado\"], [\"Imagem\", \"Deep learning\", \"Os padrões visuais são difíceis de descrever à mão, a rede aprende sozinha\"], [\"Texto (linguagem natural)\", \"Deep learning\", \"Vocabulário, contexto e ordem das palavras pedem representações aprendidas\"], [\"Áudio e voz\", \"Deep learning\", \"A onda sonora bruta pede o mesmo tipo de representação aprendida em camadas\"], [\"Poucos exemplos (centenas ou poucos milhares de linhas)\", \"ML clássico\", \"Uma rede profunda overfita fácil sem dado suficiente pra generalizar\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Onde o ML clássico ainda ganha\n\nBoa parte dos problemas de negócio não é imagem nem texto solto: é uma tabela, com colunas numéricas e categóricas, vindas de um banco de dados ou uma planilha. Nesse terreno, o gradient boosting (e as bibliotecas XGBoost, LightGBM e CatBoost, do Módulo 4) costuma bater rede neural, com menos dado, menos ajuste e menos custo computacional. Não é à toa que domina as competições de dado tabular.\n\nTambém vale lembrar do Módulo 6: quando é preciso explicar uma decisão (negar um crédito, sinalizar uma fraude), a importância de features e o SHAP funcionam muito melhor em cima de árvores e boosting do que em cima de uma rede neural, que continua sendo, na prática, uma caixa-preta bem mais difícil de interpretar."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Aspecto\", \"ML clássico (árvores, boosting)\", \"Deep learning (redes neurais)\"], [\"Dado necessário\", \"Centenas ou milhares de linhas já rendem um bom modelo\", \"Costuma pedir dezenas de milhares de exemplos ou mais\"], [\"Custo computacional\", \"Treina em CPU, em minutos\", \"Geralmente pede GPU, e pode levar horas\"], [\"Interpretabilidade\", \"Alta, com importância de features e SHAP\", \"Baixa, mais parecida com uma caixa-preta\"], [\"Dado ideal\", \"Tabular, com colunas numéricas e categóricas\", \"Não estruturado: imagem, texto, áudio\"], [\"Preparo das features\", \"Você desenha as features, como no Módulo 1\", \"A rede aprende as representações sozinha\"]]"
+                    },
+                    {
+                        "type": "code",
+                        "value": "# regra prática pra começar a pensar (não é lei, é ponto de partida)\ndef abordagem_provavel(tipo_dado, n_amostras):\n    dado_nao_estruturado = tipo_dado in (\"imagem\", \"texto\", \"audio\")\n    if dado_nao_estruturado and n_amostras > 100_000:\n        return \"deep learning\"\n    return \"ML clássico (árvore, random forest, gradient boosting)\"\n\nprint(abordagem_provavel(\"tabular\", 5_000))   # ML clássico (árvore, random forest, gradient boosting)\nprint(abordagem_provavel(\"imagem\", 500_000))  # deep learning\n# a maioria dos problemas de negócio com dado em tabela cai no primeiro caso"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Não é bala de prata pra nenhum dos dois lados\n\nVale reforçar a mesma honestidade que já apareceu com boosting no Módulo 4: nem deep learning nem ML clássico ganham sempre. Deep learning custa dado (muito dado) e custa máquina, e um projeto que não tem nenhum dos dois só vai acumular complexidade sem ganhar acurácia. ML clássico, por outro lado, ainda depende de você desenhar boas features na mão, o que nem sempre é possível quando o dado é bruto demais, como uma imagem ou um áudio.\n\nA pergunta certa nunca é \"qual técnica é mais avançada\", e sim \"qual técnica resolve este problema, com este dado que eu realmente tenho\"."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Deep learning brilha quando o dado é bruto e abundante. Fora disso, a árvore, o random forest e o boosting continuam sendo o caminho mais curto até um bom resultado."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Deep learning costuma se destacar mais em qual tipo de dado?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Dados não estruturados e abundantes, como imagem, texto e áudio",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Dados tabulares organizados em poucas colunas numéricas e categóricas",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Planilhas pequenas, com algumas centenas de linhas ao todo",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Dados já resumidos em poucas métricas agregadas por categoria",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Numa base de dados tabular de porte médio, por que o gradient boosting costuma bater uma rede neural?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque as colunas já são boas features, e o boosting extrai valor delas com pouco ajuste",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque redes neurais não conseguem processar número nenhum, apenas texto e imagem",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o gradient boosting não depende de nenhum hiperparâmetro pra funcionar bem",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque dados tabulares nunca têm relação nenhuma entre as colunas pra rede explorar",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Num problema onde é preciso justificar cada decisão do modelo pro cliente, qual costuma ser a escolha mais adequada?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Um modelo como árvore ou boosting, apoiado em importância de features ou SHAP",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Uma rede neural profunda, porque redes sempre entregam a maior acurácia possível",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Qualquer modelo, já que interpretabilidade não muda conforme o algoritmo escolhido",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um modelo de clustering, porque ele dispensa qualquer explicação sobre o resultado",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe tem apenas 800 linhas rotuladas e decide treinar uma rede neural profunda em vez de um random forest. O que é mais provável de acontecer?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "A rede overfita fácil, porque poucos exemplos não bastam pra ajustar tantos pesos",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A rede treina mais rápido que o random forest, já que tem menos dado pra processar",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O random forest deixa de funcionar, porque exige uma quantidade mínima de linhas",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os dois modelos chegam exatamente ao mesmo resultado, independente da base usada",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma manchete anuncia que \"deep learning substitui todo o machine learning clássico\". Qual afirmação melhor descreve a realidade da prática?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Depende: em dado tabular e com pouco volume, o ML clássico ainda costuma ganhar",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "É verdade: nenhuma equipe séria ainda usa random forest ou boosting em produção hoje",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "É verdade, mas só porque o scikit-learn parou de receber atualização e manutenção",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "É falso: deep learning só funciona em pesquisa acadêmica, nunca em problema real",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "As ferramentas (TensorFlow, PyTorch)",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Outro ferramental: treinar rede não é treinar com scikit-learn\n\nToda a trilha até aqui girou em torno do scikit-learn: `fit`, `predict`, `Pipeline`, `GridSearchCV`. Treinar uma rede neural de verdade, com muitas camadas e muitos pesos, geralmente pede outro ferramental, pensado pra fazer contas de matriz em larga escala e aproveitar GPU. Três nomes aparecem o tempo todo nesse mundo: TensorFlow, Keras e PyTorch.\n\nTensorFlow nasceu no Google e é bastante usado quando o destino final é produção, em times que já treinam e também servem redes grandes no dia a dia. PyTorch nasceu no que hoje é a Meta e é a escolha mais comum em pesquisa, por ser mais flexível de mexer por dentro, embora hoje apareça bastante em produção também. Keras é uma API de alto nível, criada pra tornar a montagem de uma rede mais legível, e hoje roda integrada ao TensorFlow."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Ferramenta\", \"O que é\", \"Onde costuma aparecer\"], [\"TensorFlow\", \"Framework de deep learning do Google, pensado pra produção\", \"Times que treinam e também servem redes grandes\"], [\"Keras\", \"API de alto nível sobre o TensorFlow, fácil de ler e escrever\", \"Primeiro contato com deep learning, prototipagem rápida\"], [\"PyTorch\", \"Framework de deep learning flexível, popular em pesquisa\", \"Pesquisa acadêmica, e cada vez mais também produção\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Um esboço de rede com Keras\n\nRepare como a lógica de fundo se repete: você empilha camadas, compila o modelo dizendo qual função de perda e qual otimizador usar, e chama `fit` passando os dados de treino. No final, `predict` devolve as previsões, do mesmo jeito que em qualquer modelo do scikit-learn. A cara muda, o roteiro (treinar e depois prever) continua o mesmo."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from tensorflow import keras\nfrom tensorflow.keras import layers\n\nmodelo = keras.Sequential([\n    layers.Dense(16, activation=\"relu\", input_shape=(X_treino.shape[1],)),  # camada oculta\n    layers.Dense(8, activation=\"relu\"),                                     # outra camada oculta\n    layers.Dense(1, activation=\"sigmoid\"),                                  # saída: classe binária\n])\n\nmodelo.compile(optimizer=\"adam\", loss=\"binary_crossentropy\", metrics=[\"accuracy\"])\nmodelo.fit(X_treino, y_treino, epochs=20, batch_size=32, validation_split=0.2)\n# validation_split reserva uma fatia do treino pra acompanhar o erro a cada época\n\nprevisoes = modelo.predict(X_teste)\n# de novo um predict() no final, como em qualquer modelo scikit-learn desta trilha"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O preço desse ferramental\n\nVale ser honesto sobre o que essa troca de ferramental custa. Uma rede como a do exemplo já tem mais hiperparâmetro pra decidir do que um RandomForestClassifier: quantas camadas, quantos neurônios por camada, qual ativação, qual taxa de aprendizado, quantas épocas, qual tamanho de lote. Cada escolha dessas pede experimentação, e testar cada combinação custa tempo de GPU, não só tempo de CPU.\n\nIsso não quer dizer que dá pra evitar deep learning sempre. Quer dizer que reaproveitar o que essa trilha já ensinou (validação cruzada, curva de validação, honestidade sobre overfitting) continua necessário, só que agora com um ferramental mais caro de operar."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "TensorFlow, Keras e PyTorch são só o motor. Decidir se vale a pena ligar esse motor continua sendo trabalho seu."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Quais são três das principais ferramentas usadas pra treinar redes neurais, citadas nesta aula?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "TensorFlow, Keras e PyTorch",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "scikit-learn, pandas e NumPy",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "GridSearchCV, RandomForest e Pipeline",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "XGBoost, LightGBM e CatBoost",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual é o papel do Keras no ecossistema de deep learning?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Uma API de alto nível, mais simples de ler e escrever, que roda sobre o TensorFlow",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um banco de dados otimizado pra guardar pesos de redes neurais já treinadas",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma biblioteca de visualização de gráficos, usada só depois do treino da rede",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um algoritmo de ensemble, que combina várias redes neurais treinadas em paralelo",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O que o `.fit()` de um modelo Keras tem em comum com o `.fit()` de um modelo scikit-learn?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Os dois recebem os dados de treino e ajustam os parâmetros internos do modelo",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Os dois exigem que o dado já esteja normalizado dentro de uma rede neural",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os dois só funcionam depois de uma chamada anterior ao método `.predict()`",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os dois calculam automaticamente o SHAP de cada feature usada no treino",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um time troca um GradientBoostingClassifier por uma rede neural em Keras, sem mudar o volume de dado nem o problema. O que é mais provável de acontecer com o custo de desenvolvimento?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Aumenta: agora tem mais hiperparâmetros pra ajustar e mais poder computacional envolvido",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Diminui: redes neurais sempre exigem menos ajuste de hiperparâmetro do que o boosting",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Fica igual: o número de decisões de arquitetura não muda entre os dois tipos de modelo",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Diminui: o Keras dispensa qualquer etapa de validação que o scikit-learn exigia antes",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Ao decidir treinar uma rede neural com TensorFlow ou PyTorch em vez de um modelo scikit-learn, o que continua sendo verdade?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O ciclo de treinar, avaliar e desconfiar do resultado continua o mesmo, mudam as ferramentas",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A validação cruzada deixa de fazer sentido, porque redes neurais não podem ser avaliadas assim",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O overfitting deixa de ser um risco, porque redes neurais generalizam sempre melhor",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A divisão entre treino e teste deixa de ser necessária ao usar esse tipo de ferramenta",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Recap e o próximo passo (Do Modelo ao Produto)",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "## Sete módulos depois: você foi além do básico\n\nQuando você começou esta trilha, já sabia treinar e avaliar um modelo com scikit-learn: regressão, classificação, matriz de confusão, aquele overfitting da árvore de decisão. Sete módulos depois, você foi muito além disso. Sabe criar features que realmente ajudam o modelo, ajustar hiperparâmetros de forma sistemática em vez de no chute, combinar modelos em ensembles que costumam bater qualquer árvore sozinha, montar um pipeline que não vaza dado, lidar com problemas reais como classes desbalanceadas, e agora tem até uma primeira noção de deep learning.\n\nAntes de seguir pro próximo (e último) estágio do roadmap de Ciência de Dados, vale olhar pra trás e ver o caminho inteiro."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Módulo\", \"O que você levou dele\"], [\"1\", \"Feature engineering: criar, selecionar e checar a importância de boas features\"], [\"2\", \"Ajuste de hiperparâmetros com GridSearchCV e RandomizedSearchCV, apoiado em validação cruzada\"], [\"3\", \"Ensembles por bagging: random forest, e por que juntar modelos reduz a variância\"], [\"4\", \"Ensembles por boosting: Gradient Boosting e a família XGBoost, LightGBM e CatBoost\"], [\"5\", \"Pipelines robustos com Pipeline e ColumnTransformer, sem vazamento, prontos pra salvar com joblib\"], [\"6\", \"Lidar com classes desbalanceadas, dado ruim e overfitting, e interpretar o modelo com SHAP\"], [\"7\", \"Uma introdução a deep learning: o que é, quando vale a pena, e as ferramentas do ecossistema\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O fio condutor desta trilha\n\nRepare no caminho que essa sequência percorre. Você começou entendendo que boas features valem tanto quanto (às vezes mais que) o algoritmo escolhido. Aprendeu a buscar hiperparâmetros de forma sistemática, em vez de ajustar um valor de cada vez no escuro. Descobriu que um conjunto de modelos, bem combinado, costuma bater qualquer modelo sozinho, seja votando (bagging) ou corrigindo o erro um do outro em sequência (boosting). Aprendeu que nenhum pipeline sobrevive a dado vazado ou mal preparado. Encarou de frente os problemas que todo projeto real enfrenta mais cedo ou mais tarde. E, por fim, espiou o outro lado do mapa, onde dado bruto e abundante pede um ferramental diferente.\n\nO fio condutor é esse: sair de um modelo que só funciona no notebook e chegar a um modelo em que dá pra confiar, mesmo sabendo onde ele pode falhar."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Honestidade final: complexidade não é sinônimo de qualidade\n\nVale fechar reforçando algo que apareceu em quase todo módulo desta trilha: nem boosting, nem ensemble, nem deep learning são bala de prata. Um modelo mais complexo só vale a pena quando o problema realmente pede essa complexidade, e quando existe dado suficiente pra sustentá-la. Muita vez, um RandomForestClassifier bem ajustado, rodando sobre features bem pensadas, ganha de uma solução chamativa e cara de manter. Julgamento continua valendo mais que a técnica mais nova do momento."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O próximo (e último) estágio: Do Modelo ao Produto\n\nUm modelo que só existe dentro de um notebook não gera valor pra ninguém. O próximo estágio do roadmap de Ciência de Dados, Do Modelo ao Produto, fecha exatamente essa lacuna, com quatro frentes:\n\n- **Colocar o modelo em produção**: sair do notebook e transformar o modelo treinado numa parte de um sistema de verdade.\n- **Servir previsões**: expor o modelo pra que outros sistemas (ou pessoas) consigam pedir uma previsão, geralmente através de uma API.\n- **MLOps**: o ciclo de vida do modelo depois do treino, versionar, re-treinar quando necessário, e automatizar esse processo.\n- **Monitorar o modelo em produção e a ética da IA**: acompanhar se o modelo continua acertando com o tempo (o mundo muda, o dado muda), e pensar com responsabilidade no impacto real de uma decisão automatizada na vida de alguém.\n\nÉ o último estágio do roadmap de Ciência de Dados. Você está a um estágio de fechar esse caminho inteiro."
+                    },
+                    {
+                        "type": "code",
+                        "value": "import joblib\n\n# uma prévia do próximo estágio: o pipeline treinado (Módulo 5) vira parte de um serviço\nmodelo = joblib.load(\"modelo_treinado.pkl\")\n\ndef prever(dados_novos):\n    return modelo.predict(dados_novos)\n\n# no próximo estágio, uma função como essa vira um endpoint de API,\n# chamado em produção toda vez que alguém precisa de uma previsão nova"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Você não sai desta trilha sabendo todo algoritmo que existe. Sai sabendo desconfiar de resultado bom demais, testar de forma sistemática e escolher a ferramenta pelo problema, não pela fama dela."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Ao longo desta trilha, qual foi a ideia central que uniu feature engineering, tuning e ensembles?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Ir além de treinar um modelo básico, buscando ganhos reais de qualidade e robustez",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Abandonar tudo que foi visto na trilha de Machine Learning anterior, do zero",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Trocar o scikit-learn por outra biblioteca em praticamente todos os módulos",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Provar que qualquer modelo simples já basta pra qualquer problema real de negócio",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual é o próximo (e último) estágio do roadmap de Ciência de Dados depois desta trilha?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Do Modelo ao Produto, cobrindo deploy, MLOps, monitoramento e ética em IA",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Machine Learning na Prática, revisando ensembles e deep learning outra vez",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Estatística e Probabilidade, agora aprofundada num nível mais avançado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Banco de Dados, cobrindo SQL avançado e modelagem relacional completa",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual par conecta corretamente um módulo desta trilha à sua ideia central?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Módulo 4: treinar modelos em sequência, cada um corrigindo o erro do anterior",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Módulo 3: treinar vários modelos ao mesmo tempo, cada um corrigindo o erro do anterior",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Módulo 6: escalonar as variáveis numéricas antes de calcular qualquer distância",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Módulo 1: combinar árvores de decisão numa floresta pra reduzir a variância",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de um modelo entrar em produção, os dados do mundo real começam a mudar aos poucos em relação ao dado de treino. Qual frente do próximo estágio trata exatamente disso?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Monitoramento do modelo em produção, de olho em degradação de performance ao longo do tempo",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Feature engineering, criando variáveis novas antes de qualquer modelo ser treinado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ajuste de hiperparâmetros, buscando uma combinação melhor de `n_estimators` e `max_depth`",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Seleção de features, removendo colunas irrelevantes ou redundantes do conjunto de dados",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de aprender ensembles, pipelines e uma introdução a deep learning nesta trilha, qual conclusão resume melhor o critério pra escolher entre eles num problema novo?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Depende dos dados e do objetivo: não existe algoritmo que vença sempre, em qualquer cenário",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Deep learning deve ser a primeira tentativa sempre, por ser a técnica mais recente disponível",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Boosting deve ser descartado sempre que uma rede neural estiver disponível pra uso imediato",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Random forest deve substituir qualquer outro modelo, já que nunca overfita em nenhum caso",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+];
+
+async function seed() {
+    let [trilha] = await db.select().from(trails).where(eq(trails.name, NOME));
+    if (!trilha) {
+        [trilha] = await db
+            .insert(trails)
+            .values({ name: NOME, trailLevel: LEVEL, description: DESCRICAO })
+            .returning();
+        console.log("Trilha criada: " + trilha.name);
+    }
+
+    const existentes = await db.select().from(lessons).where(eq(lessons.trailId, trilha.id));
+    if (existentes.length > 0) {
+        console.log("Trilha " + NOME + " ja tem " + existentes.length + " aulas. Nada a fazer.");
+        return;
+    }
+
+    let totalAulas = 0;
+    let totalQuestoes = 0;
+    for (let mi = 0; mi < MODULOS.length; mi++) {
+        const m = MODULOS[mi];
+        const [mod] = await db
+            .insert(modules)
+            .values({ trailId: trilha.id, title: m.titulo, position: mi + 1 })
+            .returning();
+        for (let li = 0; li < m.aulas.length; li++) {
+            const a = m.aulas[li];
+            const [lesson] = await db
+                .insert(lessons)
+                .values({
+                    trailId: trilha.id,
+                    moduleId: mod.id,
+                    title: a.titulo,
+                    content: null,
+                    contentBlocks: a.blocks,
+                    position: li + 1,
+                    published: true,
+                })
+                .returning();
+            for (let qi = 0; qi < a.questions.length; qi++) {
+                const q = a.questions[qi];
+                const [questao] = await db
+                    .insert(questions)
+                    .values({
+                        lessonId: lesson.id,
+                        statement: q.statement,
+                        difficulty: q.difficulty,
+                        position: qi + 1,
+                    })
+                    .returning();
+                await db.insert(questionOptions).values(
+                    q.options.map((o, k) => ({
+                        questionId: questao.id,
+                        text: o.text,
+                        isCorrect: o.isCorrect,
+                        position: k + 1,
+                    })),
+                );
+            }
+            totalAulas++;
+            totalQuestoes += a.questions.length;
+        }
+    }
+    console.log("Seed concluido: " + MODULOS.length + " modulos, " + totalAulas + " aulas, " + totalQuestoes + " questoes.");
+}
+
+seed()
+    .then(() => process.exit(0))
+    .catch((e) => {
+        console.error("Falha no seed:", e);
+        process.exit(1);
+    });


### PR DESCRIPTION
## Trilha Machine Learning na Prática (estágio 8 do roadmap de Ciência de Dados)

Oitava trilha do roadmap de Ciência de Dados, fase Avançado. Machine learning além do básico, do modelo que funciona ao modelo que ganha.

### Conteúdo (7 módulos, 35 aulas, 175 questões)
1. **Feature engineering na prática** (criar, transformar e selecionar features, importância e vazamento)
2. **Ajuste de hiperparâmetros** (parâmetro x hiperparâmetro, GridSearchCV, RandomizedSearchCV, não vazar o teste)
3. **Ensembles: bagging e random forest** (por que ensembles funcionam, bagging, random forest)
4. **Ensembles: boosting** (gradient boosting, XGBoost/LightGBM, boosting x random forest, learning_rate)
5. **Pipelines e fluxo robusto** (Pipeline, ColumnTransformer, reprodutibilidade, salvar o modelo)
6. **Problemas reais** (classes desbalanceadas, dados ruins, overfitting, interpretabilidade, quando ML não é a resposta)
7. **Introdução a deep learning** (redes neurais, quando brilha e quando não, TensorFlow/PyTorch, ponte pro estágio 9)

Muito código scikit-learn, com a intuição antes da API e honestidade sobre trade-offs (nada de bala de prata). Continuidade forte com a trilha de Machine Learning.

### Roadmap
Adiciona o **estágio 8 (Machine learning na prática)** ao roadmap de Ciência de Dados, na fase avançado. Roadmap contíguo com 8 estágios, 0 refs faltando.

### Qualidade das questões
Regra de opções equilibradas aplicada desde a autoria, com 6 ajustes de redação (respostas longas do módulo de random forest que lideravam por mais de 5 caracteres). Medição final nas 175 questões:
- Vício forte (correta é a mais longa E pelo menos 1.4x a média das erradas): **0%**
- Nenhuma questão com a correta liderando por mais de 5 caracteres
- Zero travessão, zero emoji, zero "todas as anteriores", zero enunciado duplicado

### Empilhado no #178
Esta branch parte da branch do #178 (Machine Learning), porque o estágio 8 do seed do roadmap depende do 7. Enquanto o #178 não entrar na develop, o diff aqui inclui a trilha de Machine Learning também. Ordem de merge: **#178, depois este**.

### Como testar local
```
docker compose exec -T backend node scripts/seed-trilha-ml-na-pratica.ts
docker compose exec -T backend node scripts/seed-roadmap-ciencia-dados.ts
```
Confirmado em dev: 35 aulas publicadas, 175 questões (4 opções, 1 correta cada), roadmap de Ciência de Dados com 8 estágios e 0 refs faltando.
