### PR TITLE
feat: adiciona a trilha Modern Data Stack (estágio 11 do roadmap de Engenharia de Dados)

### DIFF
--- a/backend/scripts/seed-roadmap-engenharia-dados.ts
+++ b/backend/scripts/seed-roadmap-engenharia-dados.ts
@@ -131,6 +131,15 @@ const STAGES: Stage[] = [
         tags: ["Kafka", "Streaming", "Tempo real"],
         refs: [{ type: "trail", ref: "Streaming de Dados" }],
     },
+    {
+        phase: "avancado",
+        position: 11,
+        title: "Modern data stack e analytics engineering",
+        description:
+            "Transformar dados no warehouse com o dbt e entregar métricas confiáveis: o modern data stack e o ELT na nuvem, o dbt (modelos, ref e a linhagem, materializações view/table/incremental), testes e documentação de dados, dbt avançado (Jinja, macros, packages, snapshots) e o modern data stack na prática (semantic layer, CI/CD para dados).",
+        tags: ["dbt", "Analytics Engineering", "ELT"],
+        refs: [{ type: "trail", ref: "Modern Data Stack" }],
+    },
 ];
 
 async function resolverRef(type: RefType, ref: string): Promise<string | null> {

--- a/backend/scripts/seed-roadmap-engenharia-dados.ts
+++ b/backend/scripts/seed-roadmap-engenharia-dados.ts
@@ -122,6 +122,15 @@ const STAGES: Stage[] = [
         tags: ["Data Lake", "Lakehouse", "Delta"],
         refs: [{ type: "trail", ref: "Data Lake e Lakehouse" }],
     },
+    {
+        phase: "avancado",
+        position: 10,
+        title: "Streaming e dados em tempo real",
+        description:
+            "Processar dados em movimento: batch x streaming, o Apache Kafka como espinha dorsal (tópicos, partições, offsets, producers e consumers), as garantias de entrega (at-least-once, exactly-once), tempo de evento, watermark e janelas, o processamento com Spark Structured Streaming e o streaming na prática de engenharia de dados.",
+        tags: ["Kafka", "Streaming", "Tempo real"],
+        refs: [{ type: "trail", ref: "Streaming de Dados" }],
+    },
 ];
 
 async function resolverRef(type: RefType, ref: string): Promise<string | null> {

--- a/backend/scripts/seed-trilha-modern-data-stack.ts
+++ b/backend/scripts/seed-trilha-modern-data-stack.ts
@@ -1,0 +1,5198 @@
+// Seed da trilha Modern Data Stack (roadmap de Engenharia de Dados).
+// Idempotente e nao destrutivo: se a trilha ja tiver aulas, nao faz nada.
+//
+// Rodar em prod: docker compose -f docker-compose.prod.yml exec -T backend node scripts/seed-trilha-modern-data-stack.ts
+import { db } from "../db.ts";
+import { trails, modules, lessons, questions, questionOptions } from "../schema.ts";
+import { eq } from "drizzle-orm";
+
+const NOME = "Modern Data Stack";
+const LEVEL: "iniciante" | "intermediario" | "avancado" = "avancado";
+const DESCRICAO =
+    "Trilha de modern data stack e analytics engineering do roadmap de Engenharia de Dados: transformar dados no warehouse com o dbt e entregar metricas confiaveis. O modern data stack e o ELT na nuvem, o dbt (modelos, ref e a linhagem, materializacoes view/table/incremental), testes e documentacao de dados, dbt avancado (Jinja, macros, packages, snapshots) e o modern data stack na pratica (semantic layer, CI/CD para dados). Assume base de SQL, modelagem, ETL e orquestracao, com foco em decisoes e cenarios.";
+
+type Bloco = { type: "text" | "code" | "quote" | "table"; value: string };
+type Questao = {
+    statement: string;
+    difficulty: "facil" | "medio" | "dificil";
+    options: { text: string; isCorrect: boolean }[];
+};
+type Aula = { titulo: string; blocks: Bloco[]; questions: Questao[] };
+type Modulo = { titulo: string; aulas: Aula[] };
+
+const MODULOS: Modulo[] = [
+    {
+        "titulo": "Módulo 1 - O modern data stack e o analytics engineering",
+        "aulas": [
+            {
+                "titulo": "O que é o modern data stack",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# O que é o modern data stack\n\nDurante décadas, montar um pipeline analítico significava construir uma esteira pesada: extrair o dado da origem, transformá-lo numa ferramenta dedicada, só então carregar o resultado já pronto num banco analítico com capacidade fixa. Cada mudança de regra de negócio passava pela esteira inteira de novo.\n\nO modern data stack é a resposta a esse modelo depois que os warehouses passaram para a nuvem: carregar o dado bruto primeiro, o mais rápido possível, e transformar depois, com SQL, dentro do próprio warehouse. Não é uma ferramenta, é um jeito de organizar o trabalho em torno de um warehouse elástico e de ferramentas gerenciadas que se conectam a ele."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O stack antigo: transformar antes de carregar\n\nNo modelo tradicional, a transformação acontecia fora do destino, normalmente num servidor de ETL dedicado (ferramentas como Informatica, SSIS ou scripts próprios), antes de qualquer linha chegar ao banco analítico. Isso trazia algumas consequências:\n\n- O schema do destino precisava estar decidido de antemão, porque só o dado já modelado entrava nele.\n- Adicionar uma fonte nova ou uma métrica nova significava alterar o pipeline de transformação e esperar uma janela de deploy.\n- O banco analítico, muitas vezes on-premise (um cluster Teradata ou Hadoop), tinha capacidade fixa: escalar significava comprar mais hardware.\n- O servidor de ETL virava um gargalo único: toda regra de negócio da empresa passava por ali."
+                    },
+                    {
+                        "type": "code",
+                        "value": "STACK ANTIGO (transforma antes de carregar)\n\n[ fontes de dados ]\n        |\n        v\n[ servidor de ETL dedicado ]   (aplica a regra de negócio aqui)\n        |\n        v\n[ warehouse on-premise ]   (só recebe o dado já pronto)\n\n\nMODERN DATA STACK (carrega bruto, transforma depois)\n\n[ fontes de dados ]\n        |\n        v\n[ ingestão gerenciada ]   (só extrai e carrega, sem regra de negócio)\n        |\n        v\n[ warehouse na nuvem ]   (recebe o dado bruto)\n        |\n        v\n[ transformação em SQL, dentro do warehouse ]   (aqui mora a regra de negócio)"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Aspecto\",\"Stack antigo (ETL on-premise)\",\"Modern data stack (ELT na nuvem)\"],[\"Onde a transformação acontece\",\"Num servidor de ETL dedicado, antes da carga\",\"Dentro do warehouse, em SQL, depois da carga\"],[\"Escalar o processamento\",\"Comprar e configurar mais hardware próprio\",\"Ajustar a capacidade elástica do warehouse sob demanda\"],[\"Adicionar uma fonte nova\",\"Semanas de desenvolvimento de um pipeline dedicado\",\"Conectar um conector gerenciado de ingestão\"],[\"Armazenamento e computação\",\"Acoplados na mesma infraestrutura fixa\",\"Separados, cada um escalando de forma independente\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "O modern data stack não é uma ferramenta única: é a combinação de um warehouse elástico na nuvem com ferramentas gerenciadas e plugáveis, cada uma responsável por uma etapa do caminho entre a origem e a decisão de negócio."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O gatilho: warehouses baratos e elásticos\n\nA virada só foi possível depois que os warehouses na nuvem (Snowflake, BigQuery, Redshift) separaram armazenamento de computação. Guardar dado passou a ser barato, e processar consultas pesadas passou a escalar sob demanda, sem que ninguém precisasse comprar ou dimensionar hardware com antecedência.\n\nCom isso, carregar tudo bruto primeiro e decidir depois o que transformar deixou de ser um desperdício e virou a opção mais segura: o dado fica disponível assim que chega, e qualquer regra de negócio pode ser aplicada, ou reaplicada, depois, em SQL, sem depender de uma nova extração na origem."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que muda para quem trabalha com dado\n\nCom a transformação vivendo dentro do warehouse, em SQL, o trabalho de moldar o dado deixa de exigir um time inteiro dedicado a operar um servidor de ETL. Times menores passam a conseguir montar um stack completo conectando ferramentas gerenciadas, e o esforço de engenharia se desloca de mover dado de um lugar para o outro para modelar esse dado e garantir que ele seja confiável. Essa mudança é o que abre espaço para times organizarem o trabalho por camadas, cada uma com sua ferramenta, e para um papel novo cuidar da transformação, o que o restante deste módulo vai destrinchar."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual das alternativas descreve melhor a mudança que caracteriza o modern data stack em relação ao stack tradicional de dados?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Carregar o dado bruto num warehouse na nuvem, barato e elástico, e transformar depois com SQL.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Substituir bancos relacionais por bancos de grafos para acelerar consultas analíticas complexas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Eliminar a necessidade de um data warehouse, consultando as origens diretamente em tempo real.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Concentrar toda a transformação num servidor de ETL dedicado antes de qualquer carga no destino.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma empresa mantém um servidor dedicado de ETL que transforma cada fonte antes de carregar num data warehouse on-premise com capacidade fixa. Toda vez que um time pede uma métrica nova, é preciso alterar o pipeline de transformação antes que o dado chegue ao warehouse. Qual mudança caracterizaria a adoção do modern data stack nesse cenário?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Trocar o warehouse on-premise por outro também on-premise, mas com mais disco instalado localmente.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Carregar o dado bruto direto num warehouse na nuvem e mover a transformação para SQL dentro dele.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Manter o servidor de ETL, mas reescrever as transformações numa linguagem de programação mais moderna.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Parar de carregar os dados num warehouse e consultar as fontes originais direto a cada relatório.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O que tornou viável, na prática, carregar o dado bruto num warehouse e só transformar depois, em vez de transformar antes de carregar?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "A criação de uma nova linguagem de consulta que substituiu o SQL dentro dos warehouses modernos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A obrigatoriedade legal de guardar todo dado bruto por motivos de auditoria em qualquer empresa.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A queda no custo de armazenamento e computação elástica na nuvem, que separou os dois recursos.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O fim do uso de ferramentas de ingestão, já que as fontes passaram a gravar direto no warehouse.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "No modern data stack, a ingestão ainda pode aplicar algum tratamento leve ao dado que chega, mas o que efetivamente muda em relação ao stack antigo é:",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "A transformação de regra de negócio deixa de existir, porque o warehouse já entrega os dados prontos assim que chegam.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A transformação de regra de negócio continua acontecendo antes da carga, só que numa ferramenta gerenciada na nuvem.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A transformação de regra de negócio passa a ser responsabilidade exclusiva da ferramenta de BI, no momento do relatório.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A transformação de regra de negócio deixa de acontecer antes da carga e passa a rodar como SQL dentro do warehouse.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que é impreciso descrever o modern data stack como uma única ferramenta que uma empresa compra e instala?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque, na prática, ele é a combinação de ferramentas gerenciadas e plugáveis, conectadas em torno de um warehouse.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque a expressão modern data stack se refere apenas ao hardware usado dentro do data center da empresa.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque cada empresa precisa desenvolver sua própria ferramenta de transformação do zero para usar esse modelo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque nenhuma dessas ferramentas roda na nuvem, sendo todas mantidas em servidores internos da empresa.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "As camadas do stack",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# As camadas do stack\n\nDá para pensar no modern data stack como uma esteira dividida em camadas, cada uma com uma responsabilidade única e uma ferramenta própria cuidando dela. O dado entra bruto numa ponta, passa por cada camada recebendo um tratamento específico, e sai do outro lado como uma resposta que alguém consegue usar para decidir algo.\n\nQuatro camadas aparecem na maioria dos stacks modernos: ingestão, armazenamento, transformação e BI. Entender o que cada uma recebe e o que cada uma entrega é o que permite trocar uma ferramenta por outra sem quebrar o restante do caminho."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Ingestão: extrair e carregar\n\nA camada de ingestão é o E e o L do ELT: ela extrai o dado da origem (um banco transacional, uma API, um arquivo) e carrega esse dado no warehouse, preservando o formato mais próximo possível do original. Ela não aplica regra de negócio, não decide o que uma coluna significa, não junta tabelas de fontes diferentes: o trabalho dela termina quando o dado bruto está pousado no warehouse, disponível para a próxima camada.\n\nÉ por isso que essa camada costuma ser resolvida com ferramentas de conector gerenciado: o trabalho é repetitivo e bem definido (extrair, replicar, lidar com mudança de schema na origem), então faz sentido pagar por uma ferramenta pronta em vez de manter esse código à mão."
+                    },
+                    {
+                        "type": "code",
+                        "value": "[ fontes: banco, API, arquivo, evento ]\n        |\n        v   (extrai e carrega, sem transformar)\n[ camada de ingestão ]   Fivetran, Airbyte\n        |\n        v\n[ camada de armazenamento ]   Snowflake, BigQuery, Redshift   (dado bruto)\n        |\n        v   (o SQL roda dentro do próprio warehouse)\n[ camada de transformação ]   dbt   (dado bruto vira modelo confiável)\n        |\n        v\n[ camada de BI e consumo ]   Looker, Metabase\n        |\n        v\n[ decisão de negócio ]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Armazenamento: o warehouse como hub central\n\nO warehouse é o ponto em que todas as outras camadas se encontram. É nele que o dado bruto pousa assim que a ingestão termina, é nele que a transformação lê o bruto e escreve os modelos prontos, e é dele que a camada de BI consulta o resultado final. Uma única peça de infraestrutura concentra as três outras camadas ao seu redor.\n\nO que torna isso viável é a computação elástica: o mesmo warehouse aguenta a carga contínua da ingestão, as consultas pesadas da transformação e o acesso concorrente de dezenas de painéis de BI, escalando cada tipo de carga sob demanda."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Transformação: onde o dado bruto vira informação confiável\n\nA camada de transformação lê o dado bruto do warehouse e aplica a regra de negócio: o que conta como pedido cancelado, como calcular receita líquida, como juntar cliente e assinatura numa única visão. É aqui que mora o dbt, e é aqui que o analytics engineer passa a maior parte do tempo, escrevendo SQL versionado, testado e documentado.\n\nEssa camada é a fronteira entre dado bruto (fiel à origem, mas difícil de usar direto) e dado modelado (pronto para responder a uma pergunta de negócio sem que cada consumidor precise reinventar a regra)."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## BI e consumo: onde a resposta chega para quem decide\n\nA última camada é onde o dado transformado vira painel, relatório ou consulta ad-hoc para quem vai usar essa informação para decidir algo. O papel dela é explorar e apresentar, não recalcular regra de negócio: quando duas ferramentas de BI diferentes calculam a mesma métrica de dois jeitos, o problema quase sempre é que a regra não estava centralizada na camada de transformação."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Camada\",\"O que recebe\",\"O que entrega\"],[\"Ingestão\",\"Dado na origem (banco, API, arquivo)\",\"Dado bruto, carregado no warehouse\"],[\"Armazenamento\",\"Dado bruto da ingestão\",\"Dado bruto e transformado, disponível para consulta\"],[\"Transformação\",\"Dado bruto do warehouse\",\"Modelos testados, prontos para consumo\"],[\"BI e consumo\",\"Modelos transformados do warehouse\",\"Painéis, métricas e respostas para o negócio\"]]"
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual é a responsabilidade da camada de ingestão dentro do modern data stack?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Aplicar as regras de negócio da empresa antes mesmo de o dado chegar ao warehouse.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Extrair o dado das origens e carregá-lo no warehouse, preservando o formato original.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Gerar os painéis que o time de negócio consulta todo dia para acompanhar métricas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Definir o modelo dimensional que os analistas usam para consultar esse dado depois.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um time decide colocar a lógica que classifica um pedido como cancelado ou concluído dentro do próprio conector que traz os pedidos para o warehouse, na camada de ingestão. Qual problema essa escolha tende a causar?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O conector passa a demorar mais para autenticar na origem dos dados a cada execução.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O time de análise passa a ter acesso mais rápido ao pedido, já que a classificação chega pronta desde a ingestão.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A empresa perde o dado bruto do pedido, que chega ao warehouse já reclassificado, sem o estado original.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O time de BI passa a enxergar o pedido duplicado em todos os painéis que consultam o warehouse.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que o data warehouse costuma ser descrito como o hub central do modern data stack?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque é a única camada do stack em que ferramentas de terceiros não podem se conectar.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque é ele quem decide sozinho qual ferramenta de BI cada time da empresa deve usar.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque é a camada responsável por extrair o dado diretamente das aplicações de origem.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque concentra o dado bruto e o transformado, conectando as demais camadas do stack.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Duas ferramentas de BI, usadas por times distintos, calculam a taxa de cancelamento de pedidos cada uma com sua própria fórmula. Qual é a origem desse problema, do ponto de vista das camadas do stack?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "A regra que define a métrica não está centralizada na transformação, e cada ferramenta reimplementa o próprio cálculo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "As duas ferramentas de BI estão conectadas a warehouses físicos diferentes, um para cada time da empresa.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A camada de ingestão trouxe os pedidos de cada time com um conector separado e incompatível entre si.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O warehouse não consegue armazenar duas tabelas de pedidos ao mesmo tempo, então cada time usa uma cópia própria.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Sobre o fluxo de dado entre as camadas do modern data stack, qual afirmação está correta?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "A camada de BI é quem grava o dado transformado de volta no warehouse, para as outras camadas consultarem.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A camada de ingestão entrega o dado bruto, e a transformação aplica a regra de negócio antes do consumo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A camada de armazenamento aplica as regras de negócio, para que a ingestão só precise mover bytes sem contexto.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A camada de transformação extrai o dado direto das aplicações de origem, sem depender da ingestão.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "O papel do analytics engineer",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# O papel do analytics engineer\n\nAntes do modern data stack, o caminho entre o dado bruto e uma resposta de negócio tinha um vão no meio. De um lado, o data engineer construía e operava a infraestrutura: pipelines, orquestração, o warehouse no ar. Do outro, o analista entendia a pergunta de negócio e escrevia a consulta SQL que respondia a ela, direto no seu relatório.\n\nO problema é que ninguém era dono do meio do caminho: a lógica que transforma dado bruto em algo confiável (o que conta como cliente ativo, como calcular receita líquida) acabava espalhada, duplicada e sem teste, reescrita por um analista diferente toda vez que alguém precisava da mesma resposta."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O vão entre o data engineer e o analista\n\nO data engineer é quem garante que o dado chegue: constrói conectores, orquestra pipelines, mantém o warehouse disponível e com performance. Ele não necessariamente conhece a fundo a semântica de negócio, como o que separa exatamente um pedido cancelado de um pedido devolvido.\n\nO analista conhece essa semântica e sabe qual pergunta o negócio está tentando responder, mas normalmente escreve SQL direto no seu relatório, sem versionar, sem revisar em código e sem testar. Quando dois analistas respondem à mesma pergunta de formas ligeiramente diferentes, a empresa passa a ter duas verdades para a mesma métrica."
+                    },
+                    {
+                        "type": "code",
+                        "value": "[ Data Engineer ]\n   cuida da infraestrutura: conectores, orquestração, o warehouse no ar\n        |\n        v\n[ warehouse, dado bruto ]\n        |\n        v\n[ Analytics Engineer ]\n   dono da transformação: modelos em SQL, testes, documentação, métricas\n        |\n        v\n[ warehouse, modelos confiáveis ]\n        |\n        v\n[ Analista de Dados / Cientista de Dados ]\n   interpreta os números e responde às perguntas de negócio"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "O analytics engineer é dono da camada de transformação e da definição das métricas: fica entre a infraestrutura que o data engineer mantém e a pergunta de negócio que o analista precisa responder."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que o analytics engineer faz, na prática\n\n- Escreve e mantém os modelos de transformação em SQL, hoje majoritariamente em dbt, lendo o dado bruto do warehouse.\n- Define a métrica uma única vez, num lugar versionado, para que qualquer relatório consulte a mesma fonte de verdade.\n- Escreve testes que verificam o dado antes de publicá-lo, e documenta o que cada modelo representa.\n- Aplica prática de engenharia de software ao trabalho de análise: controle de versão, revisão de código, integração contínua, modelos pequenos e reutilizáveis em vez de uma consulta gigante."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Aspecto\",\"Data Engineer\",\"Analytics Engineer\",\"Analista de Dados\"],[\"Foco principal\",\"Infraestrutura, pipelines e orquestração\",\"Camada de transformação e definição de métricas\",\"Perguntas de negócio e interpretação dos números\"],[\"Ferramentas típicas\",\"Orquestrador, ferramentas de ingestão, o warehouse em si\",\"dbt, SQL versionado, testes de dado\",\"Ferramenta de BI, planilhas, SQL exploratório\"],[\"Entregável\",\"Pipeline de dados confiável, rodando em produção\",\"Modelos testados e documentados, prontos para consumo\",\"Relatório, painel ou recomendação para o negócio\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Por que essa função surgiu justamente agora\n\nO papel só ganhou força depois que a transformação passou a rodar como SQL dentro do warehouse. Antes, essa lógica ficava presa dentro de uma ferramenta de ETL que só o data engineer operava, ou espalhada em consultas ad-hoc que ninguém versionava. Quando transformar virou escrever SQL testável, um profissional que entende tanto de negócio quanto de prática de engenharia passou a ter onde atuar: exatamente no meio do caminho que antes ficava sem dono."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual das opções descreve melhor o papel do analytics engineer dentro do modern data stack?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Cuida da infraestrutura dos conectores de ingestão que trazem o dado bruto das aplicações de origem.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Decide, sozinho, quais decisões de negócio a empresa deve tomar a partir dos números do warehouse.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "É dono da camada de transformação e da definição das métricas, entre a infraestrutura e a análise de negócio.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Substitui o analista de dados, respondendo diretamente às perguntas pontuais que o negócio faz todo dia.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um analista escreve, direto no seu próprio relatório, uma consulta SQL que calcula a receita líquida da empresa. Duas semanas depois, outro analista escreve uma consulta parecida, mas com uma regra de desconto ligeiramente diferente, para outro relatório. Qual tarefa do analytics engineer ajudaria a evitar essa divergência?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Impedir que qualquer analista escreva consultas SQL, transferindo toda consulta para os data engineers.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Migrar o warehouse para outro provedor de nuvem que calcule a receita líquida de forma automática.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Adicionar mais um conector de ingestão para trazer a mesma fonte de receita de duas formas diferentes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Modelar a receita líquida uma vez na camada de transformação, para que os relatórios usem a mesma definição.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O que significa, na prática, dizer que o analytics engineer aplica engenharia de software ao trabalho de análise?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Versionar os modelos de transformação, revisar as mudanças em código e testar o dado antes de publicá-lo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Escrever os modelos de transformação numa linguagem de programação de propósito geral, em vez de SQL.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Substituir o data warehouse por um repositório de código onde o dado passa a ser armazenado direto.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Automatizar por completo a criação de novos painéis de BI, sem qualquer intervenção humana no processo.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual das alternativas descreve corretamente a diferença de foco entre o data engineer e o analytics engineer no modern data stack?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O data engineer cuida da camada de transformação em SQL, e o analytics engineer cuida da infraestrutura de ingestão.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O data engineer cuida da infraestrutura de pipelines e do warehouse, e o analytics engineer cuida da transformação e métricas.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O data engineer só trabalha com dado já transformado, e o analytics engineer só trabalha com dado ainda bruto.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O data engineer decide as perguntas de negócio que a empresa deve responder, e o analytics engineer mantém a infraestrutura.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que o papel do analytics engineer só ganhou força depois da adoção do modern data stack, e não antes, no modelo de ETL tradicional?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Porque antes do modern data stack não existia a função de analista de dados dentro das empresas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o SQL só passou a existir como linguagem de consulta depois da adoção de warehouses na nuvem.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque a transformação passou a rodar como SQL dentro do warehouse, um trabalho versionável e testável.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque os data engineers pararam de existir, e alguém precisava assumir toda a infraestrutura de pipelines.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Por que o ELT no warehouse mudou o jogo",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Por que o ELT no warehouse mudou o jogo\n\nA ideia de carregar o dado bruto e transformar depois, dentro do warehouse, parece simples quando descrita numa frase. O que essa inversão de ordem muda na prática é mais profundo do que parece: ela desloca onde o processamento acontece, quem precisa dimensionar esse processamento, e o que custa mudar uma regra de negócio depois que o dado já foi carregado."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Transformar onde o dado já está\n\nNo modelo antigo, a transformação rodava num servidor de ETL dimensionado à parte, e só o resultado já pronto chegava ao destino. Esse servidor virava mais uma peça de infraestrutura para o time manter, com capacidade própria para planejar e escalar.\n\nNo ELT, a transformação roda dentro do warehouse, usando a mesma capacidade elástica que já guarda o dado. Não existe um servidor extra para dimensionar: o time escreve SQL, e o warehouse decide como paralelizar e escalar aquele processamento."
+                    },
+                    {
+                        "type": "code",
+                        "value": "ETL tradicional: mudou a regra de negócio? Volta lá atrás.\n\n[ fonte original ] --> [ servidor de ETL, aplica a regra ] --> [ warehouse, já transformado ]\n        ^\n        |\n        (para aplicar uma regra nova ao histórico, geralmente é preciso reextrair da fonte)\n\n\nELT no warehouse: mudou a regra de negócio? Roda de novo.\n\n[ fonte original ] --> [ ingestão, só carrega ] --> [ warehouse, dado bruto guardado ]\n                                                              |\n                                                              v\n                                                   [ SQL roda de novo sobre o bruto ]\n                                                              |\n                                                              v\n                                                   [ warehouse, modelos atualizados ]"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Aspecto\",\"ETL tradicional (transforma antes)\",\"ELT no warehouse (transforma depois)\"],[\"Onde processa a transformação\",\"Servidor de ETL externo, dimensionado à parte\",\"Dentro do próprio warehouse, usando a capacidade elástica dele\"],[\"Reprocessar o histórico com uma regra nova\",\"Normalmente exige voltar à fonte original\",\"Basta rodar de novo o modelo em SQL sobre o dado já carregado\"],[\"Escalabilidade da transformação\",\"Limitada pela capacidade do servidor de ETL\",\"Escala junto com o warehouse, sob demanda\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Guardar o dado bruto no warehouse significa que qualquer regra de transformação pode ser refeita do zero, sem precisar voltar à fonte original para buscar o mesmo dado outra vez."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que se ganha: reprocessar fica barato\n\nComo o bruto continua guardado, mudar uma regra de negócio não exige uma nova extração: basta rodar de novo o modelo em SQL sobre o dado que já está lá. Isso reduz risco, já que a fonte original pode nem ter mais o histórico completo disponível, e torna a transformação mais fácil de corrigir: um modelo com um erro pode ser ajustado e reprocessado, em vez de exigir uma reextração inteira da origem."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que exige cuidado\n\nProcessar dentro do warehouse tem custo, e esse custo aparece na mesma fatura do armazenamento: uma transformação que refaz um histórico inteiro a cada execução pode sair caro, o que torna a escolha da materialização, assunto do próximo módulo, uma decisão de custo, não só de código. E guardar o dado bruto não elimina a responsabilidade sobre ele: se a origem tem dado sensível, o bruto no warehouse também tem, e continua exigindo controle de acesso, mesmo antes de qualquer transformação."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "No modelo ELT, em que momento a transformação de regra de negócio acontece?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Antes de o dado sair da aplicação de origem, direto no banco transacional.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Num servidor de ETL dedicado, separado do warehouse, antes da carga dos dados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Na ferramenta de ingestão, no mesmo passo em que o dado é extraído da origem.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Depois de o dado já estar carregado no warehouse, rodando como SQL dentro dele.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma empresa muda a regra que define quando um cliente é considerado inativo. No modelo ELT, com o dado bruto preservado no warehouse, o que é necessário para aplicar a nova regra a todo o histórico?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Reexecutar os modelos de transformação em SQL sobre o dado bruto já carregado, sem voltar à fonte original.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Reextrair todo o histórico de novo das aplicações de origem, já que o bruto não fica guardado no warehouse.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Reconfigurar o servidor de ETL externo para aplicar a nova regra antes da próxima carga de dados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Pedir ao time de BI que ajuste manualmente os números antigos em cada painel já publicado.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual é a vantagem prática de rodar a transformação como SQL dentro do warehouse, em vez de num servidor de ETL separado?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O SQL passa a não precisar mais ser testado, porque o warehouse garante sozinho a qualidade do resultado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A transformação usa a capacidade elástica do warehouse, sem que o time precise dimensionar um servidor à parte.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O warehouse deixa de cobrar pelo processamento das consultas de transformação, cobrando só o armazenamento.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "As fontes de dados originais deixam de precisar de qualquer conector de ingestão para alimentar o warehouse.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual cuidado o ELT no warehouse coloca em evidência, que o modelo antigo, com transformação num servidor de ETL à parte, não colocava?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "A necessidade de nomear as colunas do dado extraído, algo que simplesmente não existia no modelo ETL tradicional.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A obrigação de agendar a execução da transformação, algo que o ETL tradicional nunca precisou fazer.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O custo de processar a transformação passa a aparecer na fatura do warehouse, e cresce com a complexidade do SQL.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A necessidade de dar nome às tabelas de destino, uma exigência que só passou a existir a partir do ELT.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Sobre a preservação do dado bruto no warehouse, no modelo ELT, qual afirmação está correta?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O dado bruto pode ser descartado assim que a primeira transformação é aplicada, já que ele perde a utilidade.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O dado bruto some do warehouse automaticamente depois de um número fixo de dias, definido pelo próprio ELT.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O dado bruto não precisa de nenhum controle de acesso, porque só times técnicos chegam até essa camada.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O dado bruto continua no warehouse depois de transformado, e ainda exige controle de acesso.",
+                                "isCorrect": true
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "O ecossistema de ferramentas",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# O ecossistema de ferramentas\n\nO modern data stack não vem numa caixa só. Em vez de uma plataforma monolítica que promete resolver tudo, o mercado se organizou em torno de ferramentas especializadas, cada uma dona de uma camada, plugadas umas nas outras por meio do warehouse. Trocar uma ferramenta de ingestão, por exemplo, não deveria exigir reescrever os modelos de transformação, desde que o dado continue chegando ao warehouse com a mesma estrutura essencial."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Camada\",\"Ferramentas de mercado\",\"O que fazem\"],[\"Ingestão\",\"Fivetran, Airbyte\",\"Conectam-se às origens e carregam o dado bruto no warehouse\"],[\"Armazenamento\",\"Snowflake, BigQuery, Redshift\",\"Guardam o dado e processam consultas com computação elástica\"],[\"Transformação\",\"dbt\",\"Transforma o dado bruto em modelos testados, em SQL versionado\"],[\"BI e consumo\",\"Looker, Metabase\",\"Exploram os modelos transformados em painéis e consultas de negócio\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Ingestão gerenciada: Fivetran e Airbyte\n\nFivetran e Airbyte resolvem a mesma camada, com filosofias diferentes. O Fivetran é um serviço proprietário totalmente gerenciado: a empresa configura o conector e o restante, autenticação, sincronização incremental, mudança de schema na origem, fica por conta do fornecedor. O Airbyte nasceu como projeto de código aberto, pode ser auto-hospedado ou usado como serviço gerenciado (Airbyte Cloud), com uma comunidade que mantém boa parte dos conectores.\n\nOs detalhes de extração incremental, CDC e formatos de arquivo são assunto da trilha de ETL e ingestão: aqui, o que importa é o papel que essa camada ocupa no stack."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O warehouse: Snowflake, BigQuery e Redshift\n\nOs três resolvem o mesmo papel: guardar o dado, bruto e transformado, e processar consultas, com armazenamento e computação escalando de forma elástica e independente. Diferem em detalhes de precificação, arquitetura interna e integração com o restante do ecossistema de cada provedor de nuvem, mas, do ponto de vista de quem monta o stack, são intercambiáveis como destino: qualquer um deles recebe a ingestão de um lado e alimenta a transformação e o BI do outro."
+                    },
+                    {
+                        "type": "code",
+                        "value": "[ fonte: banco, API, evento ]\n        |\n        v\n[ Fivetran ou Airbyte ]   (ingestão gerenciada)\n        |\n        v\n[ Snowflake, BigQuery ou Redshift ]   (warehouse, dado bruto)\n        |\n        v\n[ dbt ]   (transformação em SQL, versionada e testada)\n        |\n        v\n[ Snowflake, BigQuery ou Redshift ]   (warehouse, modelos prontos)\n        |\n        v\n[ Looker ou Metabase ]   (painéis e consultas de negócio)"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Nenhuma ferramenta do modern data stack faz sentido sozinha: o valor está em como elas se conectam em torno do warehouse, e é o dbt quem dá coerência à camada de transformação nesse meio de campo."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Transformação e consumo: dbt, Looker e Metabase\n\nO dbt ocupa a camada de transformação em praticamente qualquer combinação do modern data stack, por ser vendor-neutral em relação ao warehouse: os mesmos modelos em SQL rodam sobre Snowflake, BigQuery ou Redshift, trocando só a configuração de conexão.\n\nNa ponta de consumo, Looker e Metabase resolvem o mesmo problema, explorar o dado transformado em painéis e consultas de negócio, para públicos diferentes: o Looker tem uma camada de modelagem própria voltada a empresas que já centralizaram a definição de métricas, enquanto o Metabase prioriza um uso mais simples e direto, comum em times menores ou numa adoção inicial de self-service."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual conjunto de ferramentas representa uma combinação típica do modern data stack, camada por camada (ingestão, warehouse, transformação, BI)?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Fivetran para ingestão, Snowflake como warehouse, dbt para transformação e Metabase para BI.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "dbt para ingestão, Looker como warehouse, Fivetran para transformação e Snowflake para BI.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Metabase para ingestão, dbt como warehouse, Airbyte para transformação e BigQuery para BI.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Snowflake para ingestão, Fivetran como warehouse, Looker para transformação e dbt para BI.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Do ponto de vista conceitual, qual é uma diferença comumente associada entre Fivetran e Airbyte como ferramentas de ingestão?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Fivetran é uma ferramenta de transformação em SQL, enquanto Airbyte é uma ferramenta de armazenamento de dados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Fivetran é um serviço proprietário gerenciado, enquanto Airbyte também existe como projeto de código aberto.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Fivetran só se conecta a warehouses on-premise, enquanto Airbyte só se conecta a warehouses na nuvem.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Fivetran substitui o data warehouse da empresa, enquanto Airbyte substitui a ferramenta de BI usada pelo time.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O que Snowflake, BigQuery e Redshift têm em comum, do ponto de vista do papel que ocupam no modern data stack?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Todos são ferramentas de BI usadas para montar painéis de acompanhamento de métricas de negócio.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Todos são pacotes de macros da comunidade dbt para reaproveitar lógica de transformação.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Todos são data warehouses na nuvem, que separam armazenamento e computação de forma elástica.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Todos são conectores de ingestão mantidos pela comunidade para trazer dado até o warehouse.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que o dbt costuma ser descrito como a ferramenta central da camada de transformação, mesmo sendo vendor-neutral em relação ao warehouse escolhido?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque o dbt substitui o warehouse, armazenando os dados transformados fora do Snowflake, BigQuery ou Redshift.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o dbt é a única ferramenta da lista capaz de extrair dado direto das aplicações de origem.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o dbt roda como um painel de BI, entregando o resultado final direto para quem toma a decisão.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o dbt organiza as transformações em SQL versionado e testável, plugável em warehouses diferentes.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma empresa troca sua ferramenta de ingestão de Airbyte para Fivetran, mantendo o mesmo warehouse e os mesmos modelos dbt. O que essa troca, por si só, tende a exigir da camada de transformação?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Pouca ou nenhuma mudança nos modelos dbt, desde que o dado chegue ao warehouse com a mesma estrutura essencial.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A reescrita completa dos modelos dbt, já que cada ferramenta de ingestão exige uma sintaxe própria de SQL.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A troca obrigatória do warehouse, porque o Fivetran só se conecta a um provedor de nuvem específico.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A substituição do dbt por uma ferramenta de transformação própria do Fivetran, incompatível com o resto do stack.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 2 - dbt: o que é e por que existe",
+        "aulas": [
+            {
+                "titulo": "O problema que o dbt resolve",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# O problema que o dbt resolve\n\nAntes de ferramentas como o dbt existirem, a transformação de dados dentro do warehouse acontecia de um jeito parecido em praticamente toda empresa: alguém abria o console do banco, escrevia um `CREATE VIEW` ou um `CREATE TABLE AS SELECT`, e pronto, a lógica de negócio ficava gravada ali, sem passar por nenhuma das práticas que já eram padrão no desenvolvimento de software havia anos.\n\nEsse SQL de transformação virava um artefato descartável: funcionava até alguém precisar mudar, entender ou confiar nele."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Quatro coisas que faltavam\n\n- **Versão**: não existia histórico de quem mudou o quê, nem como voltar a um estado anterior.\n- **Teste**: nada verificava se uma coluna ficou nula, se um ID se duplicou ou se uma soma bateu.\n- **Documentação**: a definição de uma métrica ou de uma tabela vivia só na cabeça de quem escreveu a query.\n- **Linhagem**: ninguém conseguia responder, com confiança, de onde vinha uma coluna nem quem dependia dela."
+                    },
+                    {
+                        "type": "code",
+                        "value": "-- view criada direto no console do warehouse, sem revisão nem histórico\n-- (o comentário abaixo é tudo que restou de contexto)\n-- ajustado por alguém do financeiro em algum momento, motivo perdido\nCREATE OR REPLACE VIEW analytics.clientes_ativos AS\nSELECT\n    c.id AS cliente_id,\n    c.nome,\n    MAX(p.data_pedido) AS ultima_compra\nFROM raw.clientes c\nJOIN raw.pedidos p ON p.cliente_id = c.id\nWHERE p.data_pedido >= CURRENT_DATE - INTERVAL '90 days'\nGROUP BY 1, 2"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Prática ausente\",\"O que acontecia na prática\"],[\"Versionamento\",\"Duas pessoas alteravam a mesma view em dias diferentes e uma sobrescrevia a outra\"],[\"Teste\",\"Um campo nulo só era percebido quando o dashboard já estava errado havia semanas\"],[\"Documentação\",\"Cada analista explicava o conceito de cliente ativo de um jeito diferente numa reunião\"],[\"Linhagem\",\"Ninguém sabia se podia apagar uma view sem quebrar outro relatório\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O mesmo sintoma em times diferentes\n\nEsse cenário se repete de formas parecidas, em praticamente qualquer empresa:\n\n- Marketing e vendas calculam a métrica de receita com filtros diferentes, e cada time chega a um número, sem que ninguém perceba a divergência até uma reunião de resultado.\n- Uma view depende de outra, que depende de uma tabela removida meses atrás: a query só quebra na próxima vez que alguém tentar rodá-la.\n- A origem muda o nome de uma coluna, e a mudança se propaga em silêncio até um relatório parar de bater, sem nenhum aviso no meio do caminho."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "O SQL de transformação virou código de produção, mas sem nenhuma das práticas que o resto da engenharia de software já usava havia anos: controle de versão, teste automatizado e documentação."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que precisava mudar\n\nO problema não era o SQL em si, e sim o jeito como ele era tratado: escrito direto no warehouse, sem repositório, sem teste, sem dono claro. Era exatamente esse o espaço que o dbt viria preencher, tratando a camada de transformação como um projeto de software normal, versionado em git e com testes automatizados."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Antes de ferramentas como o dbt se popularizarem, como a lógica de transformação de dados costumava viver dentro do warehouse?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Em macros Jinja, documentadas automaticamente pelo próprio warehouse.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Em views e tabelas criadas manualmente no console, sem controle de versão.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Em arquivos YAML que um orquestrador convertia em SQL antes de rodar.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Em modelos SQL versionados em git, revisados por pull request antes de subir.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Os times de marketing e de vendas calculam a métrica de receita com filtros diferentes e só percebem a divergência numa reunião de resultados. Qual prática, se existisse, atacaria diretamente esse sintoma, dando aos dois times um lugar único para consultar como a métrica é definida?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Versionamento em git de cada consulta, escrita e mantida de forma isolada por cada time.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Testes automatizados de not_null nas colunas usadas no cálculo da métrica.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Linhagem automática mostrando de qual tabela bruta vem cada coluna usada.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Documentação centralizada da definição da métrica, visível para os dois times.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma view depende de outra view, que depende de uma tabela que já foi removida do warehouse há meses. O erro só aparece quando alguém tenta rodar essa cadeia de novo. Antes de existir uma ferramenta que gera o grafo de dependências automaticamente, qual prática ausente explica por que ninguém percebeu o problema antes?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Linhagem: sem o mapa de dependências, ninguém sabia da view ligada à tabela removida.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Teste: sem um teste de unicidade, o warehouse impede a remoção de qualquer tabela.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Documentação: sem uma descrição escrita, o warehouse recusa o comando de remoção.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Versionamento: sem um histórico em git, o warehouse recria sozinho a tabela apagada.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "A tabela de origem `pedidos` tem a coluna `status` renomeada para `situacao` pelo time do sistema transacional, sem aviso a mais ninguém. Um relatório de vendas passa a trazer números errados, e isso só é percebido dias depois. Esse tipo de falha silenciosa é sintoma direto da ausência de qual prática?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Backups diários do warehouse, que permitiriam restaurar a coluna antiga quando necessário.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Réplicas de leitura do banco transacional, que isolariam o relatório da tabela de origem.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Testes automatizados que verificassem a estrutura esperada dos dados a cada execução.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Índices nas colunas mais consultadas, que agilizariam a leitura da tabela de pedidos.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Num warehouse sem nenhuma camada de transformação compartilhada, cada analista escreve sua própria versão da lógica de pedido válido dentro da query que ele mesmo roda. Além do retrabalho, qual problema isso tende a causar?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Pequenas divergências entre versões da lógica, gerando números diferentes para a mesma pergunta.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Aumento no tempo de resposta do warehouse, já que cada query passa a rodar num cluster isolado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Bloqueio de escrita nas tabelas de origem, impedindo o sistema transacional de gravar pedidos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Redução no espaço em disco do warehouse, já que cada query cria uma tabela temporária permanente.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "O que o dbt faz",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# O que o dbt faz\n\nO dbt (data build tool) é uma ferramenta de transformação: ela pega dados que já estão dentro do warehouse e os transforma em modelos prontos para análise, usando apenas SQL (mais alguns recursos de Jinja, que o módulo 6 cobre em detalhe). A unidade básica de trabalho é o modelo: um arquivo `.sql` com um único `SELECT`."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Você escreve SELECT, o dbt cuida do DDL/DML\n\nNum modelo dbt, você não escreve `CREATE VIEW`, `CREATE TABLE` nem `INSERT`. Você escreve só a lógica de negócio, como um `SELECT` comum. O dbt lê essa definição e gera, por trás dos panos, o comando de DDL/DML certo para materializar aquele modelo no warehouse, de acordo com a estratégia configurada (view, table, incremental ou ephemeral, tema do módulo 4)."
+                    },
+                    {
+                        "type": "code",
+                        "value": "-- models/marts/fct_pedidos.sql\n-- o analytics engineer escreve só o SELECT\nSELECT\n    p.pedido_id,\n    p.cliente_id,\n    p.valor_total,\n    c.segmento\nFROM {{ ref('stg_pedidos') }} p\nLEFT JOIN {{ ref('stg_clientes') }} c ON c.cliente_id = p.cliente_id\n\n-- o dbt gera algo como o comando abaixo, de acordo com a materialização:\n-- CREATE OR REPLACE TABLE analytics.fct_pedidos AS ( ...o SELECT acima... )"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Versionado, testável e documentado\n\n- **Versionado**: os arquivos `.sql` e `.yml` do projeto vivem num repositório git, como qualquer outro código: histórico, revisão em pull request, branch por mudança.\n- **Testável**: cada modelo pode ter testes declarados em YAML (por exemplo, `unique` e `not_null` numa coluna), rodados com um único comando.\n- **Documentado**: descrições de modelos e colunas ficam no próprio projeto, em YAML, e viram um site de documentação navegável, gerado automaticamente."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"O que faltava (aula anterior)\",\"Como o dbt resolve\"],[\"Sem versão\",\"Projeto inteiro (modelos, testes, docs) vive num repositório git\"],[\"Sem teste\",\"Testes declarados em YAML, rodados junto com a transformação\"],[\"Sem documentação\",\"Descrições em YAML viram um site de documentação gerado pelo próprio dbt\"],[\"Sem linhagem\",\"O DAG é montado sozinho a partir das referências entre modelos\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que o dbt não faz\n\nO dbt não se conecta a um banco transacional para extrair dados, e não carrega dados de um arquivo ou de uma API no warehouse. Ele parte do princípio de que os dados brutos já estão lá, carregados por uma ferramenta de ingestão (como Fivetran ou Airbyte) ou por um pipeline próprio. O dbt entra depois, cuidando só da transformação.\n\nEm termos de ELT, o dbt é o T: ele não é o E (extract) nem o L (load)."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "O dbt não extrai nem carrega dado nenhum: ele assume que o dado bruto já chegou ao warehouse e cuida só da transformação, o T do ELT."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que um analytics engineer escreve, na prática, dentro de um modelo dbt?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Um `CREATE TABLE` completo, incluindo tipos de coluna e chaves primárias.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um script Python que gera o SQL de acordo com o volume de dados de entrada.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um `SELECT`, sem escrever o `CREATE VIEW` ou `CREATE TABLE` correspondente.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um job de orquestração que decide em que ordem os modelos vão rodar.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe usa o Fivetran para trazer dados de um CRM ao warehouse todas as manhãs, e o dbt para transformar esses dados em modelos prontos para os dashboards. Se a extração do CRM falhar silenciosamente, qual afirmação está correta sobre o papel do dbt nesse cenário?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O dbt não detecta essa falha por conta própria: ele só transforma o que já chegou ao warehouse.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O dbt refaz a extração automaticamente, já que ele também orquestra a camada de ingestão.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O dbt pausa todos os modelos até que o Fivetran confirme que a extração terminou sem erro.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O dbt substitui o Fivetran nesse fluxo, porque os dois fazem exatamente a mesma função.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Dois modelos dbt têm exatamente o mesmo `SELECT`, mas um está configurado como `view` e o outro como `table`. O que muda no comportamento do dbt ao rodar cada um?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O `SELECT` escrito pelo time, que precisa ser reescrito de forma diferente em cada caso.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O motor de banco de dados usado, já que `view` e `table` exigem warehouses diferentes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A possibilidade de testar, já que só modelos materializados como `table` podem ser testados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O comando de DDL que o dbt gera por trás do SELECT: um vira `view`, o outro vira `table`.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um time novo em dbt planeja usá-lo para capturar as mudanças na tabela `pedidos` do banco transacional a cada 5 minutos e gravá-las direto no warehouse, sem nenhuma outra ferramenta no meio. Por que esse plano não funciona como o time espera?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Porque o dbt só roda uma vez por dia e nunca aceita execuções mais frequentes que essa.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o dbt não extrai dados de bancos transacionais, só transforma o que já está no warehouse.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o dbt exige que os dados cheguem primeiro em formato Parquet, nunca direto de um banco.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o dbt precisa de um Airflow instalado na mesma máquina para conseguir rodar um modelo.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Além de gerar o SQL que materializa cada modelo, o que mais o dbt entrega automaticamente a partir do mesmo projeto, sem esforço manual extra do analytics engineer?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Um cluster de processamento dedicado, provisionado para cada execução do projeto.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma cópia de segurança diária de todas as tabelas de origem do warehouse.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um grafo de dependências entre os modelos, construído a partir das referências entre eles.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um pipeline de ingestão configurado automaticamente para cada fonte usada nos modelos.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "dbt Core x dbt Cloud",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# dbt Core x dbt Cloud\n\n\"dbt\" não é um produto único: existem duas formas de usar a mesma ferramenta. O dbt Core é o motor open source, distribuído como linha de comando. O dbt Cloud é um produto comercial, hospedado pela dbt Labs, construído em cima do mesmo motor. Os conceitos (modelos, `ref()`, testes, o DAG) são idênticos nos dois; o que muda é onde e como o projeto roda."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## dbt Core: o motor, na sua infraestrutura\n\nO dbt Core é instalado via linha de comando, roda local na máquina de quem desenvolve, dentro de um container, ou dentro de um orquestrador como o Airflow. É open source e gratuito. Em troca dessa liberdade, o time precisa montar o resto ao redor: onde o código fica versionado, quem dispara as execuções e em qual horário, e onde a documentação gerada fica publicada."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## dbt Cloud: o produto hospedado\n\nO dbt Cloud é um produto comercial da dbt Labs, construído sobre o dbt Core. Ele entrega, hospedado, o que o Core deixa por conta do time: um IDE no navegador para escrever e rodar modelos sem instalar nada localmente, um scheduler embutido para agendar execuções, um site de documentação já publicado, e uma interface de administração para controlar acesso e ambientes."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Aspecto\",\"dbt Core\",\"dbt Cloud\"],[\"Distribuição\",\"Open source, linha de comando\",\"Produto comercial, hospedado\"],[\"Onde roda\",\"Onde o time instalar (local, container, orquestrador próprio)\",\"Na infraestrutura da dbt Labs\"],[\"Scheduler\",\"Nenhum embutido, o time traz o seu (cron, Airflow)\",\"Embutido, configurado pela interface\"],[\"IDE\",\"Nenhum, usa o editor de código local\",\"IDE no navegador, sem instalação\"],[\"Documentação\",\"Gerada localmente, o time decide onde publicar\",\"Hospedada automaticamente\"]]"
+                    },
+                    {
+                        "type": "code",
+                        "value": "# dbt Core: quem dispara a execução e onde ela roda fica por conta do time\n$ dbt run --select stg_pedidos\n\n# dbt Cloud: o mesmo comando roda por baixo de um job agendado\n# ou disparado pela interface, sem o time gerenciar onde o processo executa"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## A mesma engine por baixo\n\nUm projeto dbt (os arquivos `.sql` e `.yml` dentro de `models/`, `tests/` etc.) não muda de um lado para o outro: os mesmos modelos, o mesmo `ref()`, os mesmos testes rodam tanto no Core quanto no Cloud. A escolha entre os dois é operacional (quem cuida da infraestrutura, do scheduler, da IDE), não conceitual: aprender dbt é aprender o mesmo conjunto de ideias nos dois casos."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "dbt Core e dbt Cloud rodam a mesma engine por baixo: a diferença não está nos conceitos, está em quem cuida do scheduler, da IDE e da infraestrutura ao redor do projeto."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que caracteriza o dbt Core?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "É um produto comercial que só roda na infraestrutura hospedada pela dbt Labs.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "É um plugin que só funciona dentro do dbt Cloud, sem uso independente.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "É uma extensão paga que adiciona um IDE no navegador ao dbt Cloud.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "É open source, distribuído como uma ferramenta de linha de comando.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um time de dados já opera um Airflow próprio para orquestrar outros pipelines e não quer adicionar mais um serviço hospedado ao ambiente. Para rodar as transformações dbt dentro desse Airflow existente, qual é a opção mais direta?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "dbt Cloud, porque só ele consegue se conectar a um Airflow já existente.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "dbt Core, instalado onde o Airflow roda, disparado como mais uma tarefa do pipeline.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "dbt Core, mas só depois de migrar todo o Airflow para dentro do dbt Cloud.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "dbt Cloud, configurando o Airflow para funcionar como scheduler substituto do próprio dbt Cloud.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe pequena, sem tempo para manter infraestrutura própria, quer escrever modelos dbt direto pelo navegador, sem instalar nada na máquina, com as execuções agendadas numa interface visual. O que essa necessidade aponta como escolha mais natural?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "dbt Cloud, pelo IDE no navegador e o scheduler já embutidos na própria interface.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "dbt Core, porque o navegador já é suficiente para instalá-lo sem linha de comando.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "dbt Cloud, mas só depois de instalar o dbt Core manualmente em cada máquina do time.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "dbt Core, configurando o cron do sistema operacional para funcionar como um IDE.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um time desenvolveu seu projeto no dbt Cloud por seis meses e decide migrar para dbt Core, rodando dentro do próprio Airflow, para reduzir custo de licença. O que precisa mudar na lógica dos modelos `.sql` e dos arquivos `.yml` para essa migração funcionar?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Todo `ref()` precisa virar uma chamada direta às tabelas, já que o Core não suporta `ref()`.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Todo teste em YAML precisa ser reescrito em Python, formato exigido pelo dbt Core.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Nada na lógica dos modelos ou dos testes: a mesma estrutura de projeto vale para os dois.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Toda a estrutura de pastas precisa mudar, já que Core e Cloud usam layouts diferentes.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual é a diferença mais precisa entre dbt Core e dbt Cloud, em termos de modelo de distribuição?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Core é pago e roda na nuvem; Cloud é gratuito e roda só na máquina local do usuário.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Core é uma linguagem de consulta própria e independente; Cloud é a implementação dela em SQL padrão.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Core é um plugin do dbt Cloud, usado só para gerar documentação offline.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Core é open source e roda por linha de comando; Cloud é comercial e hospedado sobre o Core.",
+                                "isCorrect": true
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "A estrutura de um projeto dbt",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# A estrutura de um projeto dbt\n\nUm projeto dbt é, na prática, uma pasta com uma convenção de subpastas mais ou menos fixa e dois arquivos de configuração centrais. Depois de ver o que o dbt é e as duas formas de rodá-lo, esta aula mapeia o que vive em cada parte dessa estrutura, antes de entrar em modelos e materializações nos próximos módulos."
+                    },
+                    {
+                        "type": "code",
+                        "value": "meu_projeto_dbt/\n|-- dbt_project.yml        (configuração do projeto)\n|-- models/\n|   |-- staging/           (1:1 com a fonte, só limpeza e renomeação)\n|   |-- intermediate/      (combina modelos de staging)\n|   `-- marts/              (modelos finais, prontos para consumo)\n|-- seeds/                  (arquivos .csv pequenos, viram tabela)\n|-- snapshots/               (captura de mudanças ao longo do tempo, SCD tipo 2)\n|-- tests/                   (testes singulares, um SELECT customizado)\n`-- macros/                  (Jinja reutilizável entre modelos)\n\nprofiles.yml fica fora desta pasta, normalmente em ~/.dbt/"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que vive em cada pasta\n\n- **models/**: os arquivos `.sql` com os SELECTs que viram views, tables ou outras materializações, mais os `.yml` que documentam e testam esses modelos.\n- **seeds/**: arquivos `.csv` pequenos e estáveis (uma tabela de códigos de país, por exemplo), carregados como tabela pelo dbt.\n- **snapshots/**: modelos especiais que registram como uma linha mudou ao longo do tempo, a base para um histórico tipo SCD Tipo 2 (o módulo 6 aprofunda).\n- **tests/**: testes singulares, cada um um SELECT que não deveria retornar nenhuma linha se os dados estiverem corretos (o módulo 5 aprofunda; testes genéricos costumam ficar declarados em YAML, junto do próprio modelo).\n- **macros/**: trechos de Jinja reutilizáveis entre modelos, o equivalente a funções (o módulo 6 aprofunda)."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Pasta ou arquivo\",\"O que guarda\"],[\"models/\",\"Os SELECTs que viram modelos, mais o YAML de teste e documentação\"],[\"seeds/\",\"Arquivos CSV pequenos e estáveis, carregados como tabela\"],[\"snapshots/\",\"Definições que capturam o histórico de mudanças de uma tabela\"],[\"tests/\",\"Testes singulares, escritos como um SELECT customizado\"],[\"macros/\",\"Jinja reutilizável entre modelos\"],[\"dbt_project.yml\",\"Configuração do projeto: nome, caminhos, materialização padrão\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## dbt_project.yml: a configuração do projeto\n\nTodo projeto dbt tem, na raiz, um `dbt_project.yml`. É ali que ficam o nome do projeto, o nome do profile de conexão que ele usa (referenciando uma entrada do `profiles.yml`), os caminhos das pastas (`model-paths`, `seed-paths` etc.) e configurações padrão, como qual materialização usar por subpasta de `models/`."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# dbt_project.yml\nname: 'meu_projeto_dbt'\nversion: '1.0.0'\nprofile: 'meu_projeto_dw'\n\nmodel-paths: ['models']\nseed-paths: ['seeds']\nsnapshot-paths: ['snapshots']\n\nmodels:\n  meu_projeto_dbt:\n    staging:\n      +materialized: view\n    marts:\n      +materialized: table"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## profiles.yml: a conexão, fora do projeto\n\nO `profiles.yml` guarda os dados de conexão com o warehouse (host, usuário, credenciais, banco) organizados por target (por exemplo, dev e prod). Diferente do `dbt_project.yml`, ele normalmente não fica dentro do repositório do projeto: por padrão, o dbt procura por ele em `~/.dbt/profiles.yml`, na máquina de quem está rodando, ou num caminho apontado por variável de ambiente.\n\nEssa separação existe porque o `profiles.yml` tem credenciais e detalhes de ambiente (cada pessoa, ou cada execução em CI, pode ter os seus), enquanto o `dbt_project.yml` descreve o projeto em si, igual para todo mundo que o usa, e por isso faz sentido ficar versionado em git."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Num projeto dbt, onde ficam os arquivos `.sql` que definem os modelos?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Na pasta `models/`, organizada por subpastas como staging, intermediate e marts.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Na pasta `seeds/`, junto com os arquivos `.csv` de dados de referência.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "No `dbt_project.yml`, dentro de uma seção reservada para SQL.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Na pasta `snapshots/`, ao lado das definições completas do histórico de mudanças.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um analytics engineer precisa de uma tabela pequena e estável com o mapeamento entre sigla de estado e região do Brasil, que não vem de nenhum sistema de origem e quase nunca muda. Onde esse dado deve entrar no projeto dbt?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Como um modelo em `models/staging/`, com um SELECT que gera as siglas por código.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Como uma entrada em `snapshots/`, já que o mapeamento precisa de histórico de mudanças.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Como uma macro em `macros/`, retornando o mapeamento inteiro direto em Jinja.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Como um seed: um arquivo `.csv` dentro de `seeds/`, carregado como tabela pelo dbt.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma organização quer que o nome do projeto e os caminhos de pastas do dbt fiquem versionados em git, mas que as credenciais de acesso ao warehouse nunca sejam commitadas junto com o código. Como o dbt já separa isso, sem esforço extra de configuração?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Os dois ficam no mesmo `dbt_project.yml`, numa seção marcada para ser ignorada pelo git.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "`dbt_project.yml` guarda a configuração do projeto e vai para o git; `profiles.yml` guarda a conexão e fica fora.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "`profiles.yml` guarda tudo, incluindo o nome do projeto, e o dbt oculta sozinho as credenciais.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "`dbt_project.yml` guarda a conexão com o warehouse, e `profiles.yml` guarda só os caminhos de pastas do projeto inteiro.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma pessoa nova no time clona o repositório do projeto dbt e roda os comandos pela primeira vez na própria máquina. O projeto builda sem erro para o resto do time, mas a conexão com o warehouse falha só para ela, mesmo com as credenciais corretas. Qual é a causa mais provável?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O `dbt_project.yml` clonado do repositório está apontando para o warehouse de outra pessoa do time.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A pasta `models/` clonada do git perdeu a permissão de leitura ao ser copiada.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ela ainda não tem um `profiles.yml` configurado na própria máquina, já que ele não vem no repositório.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O arquivo `seeds/` precisa ser recriado manualmente a cada nova máquina do time.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual é a diferença entre o que vive em `snapshots/` e o que vive em `seeds/` num projeto dbt?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "`snapshots/` guarda a captura de como os dados mudam ao longo do tempo; `seeds/` guarda arquivos CSV estáticos.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "`snapshots/` guarda arquivos CSV estáticos; `seeds/` guarda a captura de como os dados mudam ao longo do tempo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "As duas guardam a mesma coisa, são só nomes alternativos para a mesma pasta de configuração.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "`snapshots/` guarda testes de dados; `seeds/` guarda a documentação gerada pelo dbt.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "O ciclo: run, test, build, compile",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# O ciclo: run, test, build, compile\n\nO dia a dia com o dbt gira em torno de poucos comandos. Cada um faz uma coisa específica, e usar o comando errado no momento errado é uma fonte comum de confusão para quem está começando: rodar só `dbt run` e achar que os testes também rodaram, por exemplo, é um engano frequente."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## dbt run: materializa os modelos\n\nO comando `dbt run` executa os SELECTs de cada modelo e os materializa no warehouse (cria ou atualiza views, tables, ou processa o incremento, dependendo da configuração), respeitando a ordem do DAG. Ele não roda os testes declarados no projeto: um modelo pode rodar com sucesso e, mesmo assim, ter dados inconsistentes que só um teste pegaria."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## dbt test: roda os testes\n\nO comando `dbt test` executa os testes genéricos (como `unique` e `not_null`) e os testes singulares definidos no projeto, contra o que já existe no warehouse. Ele não materializa nada: se um modelo referenciado por um teste ainda não existir no warehouse, o teste falha, porque não há dado nenhum para verificar."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# rodando run e test separados: tudo é construído antes de qualquer teste rodar\ndbt run\ndbt test\n# se um modelo no meio do DAG tiver dado ruim, os modelos a jusante\n# já foram construídos em cima dele antes de o teste avisar do problema\n\n# dbt build: testa cada modelo logo depois de construí-lo, na ordem do DAG\ndbt build\n# se um teste falhar num modelo, os modelos a jusante que dependem dele\n# são pulados (skipped), em vez de rodar em cima de um dado já sabido ruim"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## dbt build: o ciclo completo, na ordem do DAG\n\nO comando `dbt build` roda seeds, snapshots, modelos e testes juntos, respeitando a ordem de dependência do DAG: cada nó é construído e testado antes de o próximo nó, que depende dele, começar. Se um teste falhar num modelo, o `dbt build` pula (skip) os modelos a jusante daquele nó, em vez de construí-los em cima de um dado que já se sabe problemático. É o comando mais indicado para rodar o projeto inteiro de uma vez, principalmente em CI."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## dbt compile: só gera o SQL, não roda nada\n\nO comando `dbt compile` resolve o Jinja de cada modelo (`ref()`, `source()`, macros) e gera o SQL final, exatamente como ele seria enviado ao warehouse, sem de fato executá-lo: nada é criado, atualizado ou testado. É útil para depurar o que uma macro está gerando, ou para conferir a query final antes de rodar de verdade."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Comando\",\"O que faz\",\"Materializa algo?\"],[\"dbt run\",\"Executa os SELECTs e materializa os modelos\",\"Sim\"],[\"dbt test\",\"Roda os testes genéricos e singulares\",\"Não\"],[\"dbt build\",\"Roda seeds, snapshots, models e tests juntos, na ordem do DAG\",\"Sim\"],[\"dbt compile\",\"Gera o SQL final, com o Jinja resolvido\",\"Não\"]]"
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que o comando `dbt run` faz com os testes declarados no projeto?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Roda todos os testes genéricos, mas pula os testes singulares do projeto.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não roda os testes: só executa os SELECTs e materializa os modelos.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Roda os testes antes de materializar cada modelo, seguindo a ordem do DAG.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Roda os testes só dos modelos que falharam na execução anterior.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um time roda `dbt run` todos os dias, sem nunca rodar `dbt test`, porque os modelos sempre terminam sem erro. Um dia, uma coluna que nunca podia ser nula passa a vir nula da origem, e o dashboard só percebe o problema dias depois. O que esse cenário evidencia sobre o `dbt run`?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Que o `dbt run` deveria ter travado sozinho ao encontrar o valor nulo na coluna.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que o `dbt run` corrige valores nulos automaticamente antes de gravar no warehouse.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que o `dbt run` terminar sem erro não garante dado correto, só que o SQL rodou.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Que o `dbt test` teria o mesmo resultado do `dbt run`, já que os dois materializam modelos.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Dentro de um `dbt build`, um teste falha num modelo intermediário do qual vários modelos de marts dependem, via `ref()`. O que o dbt faz com esses modelos de marts, na mesma execução?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Pula (skip) a construção desses modelos, já que dependem de um nó que falhou no teste.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Constrói todos eles normalmente, porque o `dbt build` ignora falhas de teste nos modelos intermediários.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Reverte a última execução bem-sucedida desses modelos para o estado anterior.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Envia um alerta por e-mail e pausa a execução de todo o projeto até alguém intervir.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um analytics engineer suspeita que uma macro está gerando um filtro de data errado dentro de um modelo, mas não quer criar nem alterar nenhuma tabela no warehouse enquanto investiga. Qual comando permite ver o SQL final, já com a macro resolvida, sem esse risco?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "`dbt test`, que mostra o SQL final de qualquer modelo antes de validar os dados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "`dbt run`, que grava o resultado numa tabela temporária e apaga automaticamente depois.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "`dbt build`, que sempre mostra o SQL gerado antes de decidir se materializa ou não.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "`dbt compile`, que gera o SQL final sem executá-lo contra o warehouse.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um pipeline roda `dbt run` e, na sequência, `dbt test`, sempre como dois passos separados. Comparado a substituir os dois por um único `dbt build`, qual é a principal desvantagem prática dessa sequência?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O `dbt run` seguido de `dbt test` deixa de rodar os testes genéricos, executando somente os singulares do projeto.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Modelos a jusante de um nó com dado ruim já são construídos antes de qualquer teste apontar o problema.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Rodar os dois separados impede o dbt de montar corretamente o DAG de dependências.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O `dbt test`, sozinho depois do `dbt run`, materializa os modelos de novo do zero.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 3 - Modelos, ref e a linhagem",
+        "aulas": [
+            {
+                "titulo": "O que é um modelo dbt",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# O que é um modelo dbt\n\nUm modelo dbt é, na prática, um arquivo `.sql` guardado na pasta `models/` de um projeto dbt, contendo um único comando `SELECT`. Não há `CREATE TABLE`, não há `INSERT`, não há DDL nem DML escrito à mão: só a lógica de transformação, em SQL puro (ou SQL com Jinja, quando é preciso lógica dinâmica). O dbt lê esse arquivo e decide, sozinho, como transformar esse SELECT num objeto real dentro do warehouse."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Do arquivo ao objeto no warehouse\n\n- O **nome do arquivo** vira o nome do objeto criado no warehouse: um arquivo `models/marts/fct_pedidos.sql` gera, por padrão, um objeto chamado `fct_pedidos`.\n- O **schema** onde o objeto é criado segue a configuração do projeto, e pode variar por camada, por pasta ou por ambiente.\n- A **materialização** (view, table, incremental, ephemeral) decide como o SELECT vira objeto: sem nenhuma configuração explícita, o padrão do dbt é criar uma **view**.\n- `dbt run` é o comando que executa esse processo de fato: compila os modelos e cria, ou atualiza, os objetos no warehouse, na ordem correta."
+                    },
+                    {
+                        "type": "code",
+                        "value": "-- models/marts/fct_pedidos.sql\n-- Um exemplo simples, só para mostrar o formato\n-- (o nome físico escrito direto no FROM tem um problema,\n-- assunto da próxima aula)\n\nSELECT\n    id_pedido,\n    id_cliente,\n    status,\n    valor_total,\n    data_criacao\nFROM bruto.pedidos\nWHERE status != 'cancelado'"
+                    },
+                    {
+                        "type": "code",
+                        "value": "-- O que o dbt run faz com o SELECT acima:\n-- traduz para o dialeto do warehouse configurado\n-- e materializa como view (o padrão, sem configuração extra)\n\nCREATE OR REPLACE VIEW analytics.marts.fct_pedidos AS (\n    SELECT\n        id_pedido,\n        id_cliente,\n        status,\n        valor_total,\n        data_criacao\n    FROM bruto.pedidos\n    WHERE status != 'cancelado'\n)"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"No arquivo do modelo\",\"No warehouse, depois do dbt run\"],[\"Nome do arquivo (fct_pedidos.sql)\",\"Nome do objeto criado (fct_pedidos)\"],[\"Um SELECT, sem DDL/DML escrito à mão\",\"CREATE VIEW ou CREATE TABLE, gerado pelo dbt\"],[\"Materialização configurada (ou o padrão view)\",\"O tipo real do objeto: view, table, etc.\"],[\"Uma definição versionada no Git\",\"Um objeto recriado a cada dbt run, a partir dela\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Um modelo dbt não é a tabela: é a definição de como essa tabela deve ser construída. A tabela, ou view, é só o resultado, recriado a cada execução do dbt run a partir dessa definição."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Por que isso importa\n\nTratar transformação como um SELECT versionado, e não como um script solto de DDL, é o que abre a porta para tudo que vem depois: linhagem automática, testes, documentação. Mas o exemplo do bloco acima ainda tem um problema: `bruto.pedidos` escrito direto no FROM. Na próxima aula, veja por que isso é uma prática a evitar, e como `ref()` e `source()` resolvem isso."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Um analista cria o arquivo `models/marts/fct_vendas.sql` contendo apenas um comando SELECT, sem nenhum DDL escrito à mão. O que esse arquivo representa dentro de um projeto dbt?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "A definição de um modelo: o dbt materializa esse SELECT como view ou table no warehouse, usando o nome do arquivo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um script de infraestrutura que cria o schema marts inteiro no warehouse antes de qualquer outro comando rodar.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma cópia física dos dados de vendas, carregada no warehouse automaticamente assim que o arquivo é salvo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um relatório pronto para consumo em BI, que substitui a necessidade de dashboards em ferramentas como Metabase.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma engenheira cria um modelo novo, `fct_pagamentos.sql`, sem configurar nenhuma materialização, nem no arquivo nem no `dbt_project.yml`. Depois de rodar `dbt run`, que tipo de objeto ela deve encontrar no warehouse?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Uma table, porque essa é a materialização padrão do dbt quando nenhuma outra é configurada.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma view, porque essa é a materialização padrão do dbt quando nenhuma outra é configurada.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Nenhum objeto, porque o dbt exige que toda materialização seja configurada explicitamente antes do run.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um modelo ephemeral, porque essa é a materialização padrão quando o modelo fica na pasta marts.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um modelo estava em `models/marts/fct_pedidos.sql` e, numa refatoração, o arquivo foi renomeado para `fct_pedidos_v2.sql`, sem nenhuma outra mudança no SQL. O que acontece no warehouse depois do próximo `dbt run`?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Nada muda no warehouse, porque o dbt identifica modelos pelo conteúdo do SELECT, não pelo nome do arquivo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O dbt renomeia o objeto antigo automaticamente, preservando o histórico de dados já carregados na tabela.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O dbt passa a criar um objeto chamado fct_pedidos_v2, já que o nome do objeto segue o nome do arquivo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O próximo run falha, porque o dbt não permite renomear um arquivo de modelo depois de criado no projeto.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de um `dbt run` bem-sucedido, alguém apaga manualmente, direto no warehouse, a view criada para um modelo dbt. O que acontece com o modelo em si, dentro do projeto?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O modelo também é apagado, já que o arquivo .sql depende da existência prévia do objeto no warehouse.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O próximo dbt run falha, porque o dbt exige que o objeto anterior ainda exista antes de recriar a view.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O dbt detecta a exclusão automaticamente e desfaz a operação, restaurando a view apagada no warehouse.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Nada muda: o modelo continua definido no arquivo .sql, e a view volta a existir no próximo dbt run.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um desenvolvedor roda `dbt compile` num modelo novo e confere, na pasta de arquivos compilados, um SQL válido, sem nenhuma referência a Jinja. Nenhum objeto novo aparece no warehouse. Por que isso acontece?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "dbt compile só traduz o Jinja em SQL puro; quem cria os objetos no warehouse é o dbt run (ou o dbt build).",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "dbt compile só funciona corretamente em modelos materializados como table, nunca em views ou ephemeral.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "dbt compile cria os objetos automaticamente, mas apenas no schema de desenvolvimento, nunca em produção.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "dbt compile exige que o warehouse tenha permissão de escrita liberada antes de gerar qualquer resultado.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "ref() e source()",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# ref() e source()\n\nNa aula anterior, o modelo `fct_pedidos` tinha um problema: `FROM bruto.pedidos`, o nome físico da tabela escrito direto no SQL. Funciona, mas quebra duas coisas importantes: o dbt não sabe que esse modelo depende dessa tabela, porque não está olhando para dentro do FROM, e o SQL fica preso a um schema fixo, difícil de promover entre ambientes. É para resolver isso que existem `ref()` e `source()`."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## ref(): referenciar outro modelo\n\n- `{{ ref('nome_do_modelo') }}` substitui, no SQL compilado, o nome completo (schema e nome do objeto) do modelo referenciado no ambiente atual.\n- Não importa se esse modelo é uma view em desenvolvimento ou uma table em produção: o `ref()` resolve para o lugar certo, automaticamente.\n- Cada `ref()` usado num modelo cria uma dependência: o dbt passa a saber que esse modelo só pode rodar depois do modelo referenciado."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## source(): referenciar uma tabela bruta\n\n- `{{ source('nome_da_fonte', 'nome_da_tabela') }}` referencia uma tabela carregada por uma ferramenta de ingestão, como Fivetran ou Airbyte, fora do controle do dbt.\n- Antes de usar, a fonte precisa ser **declarada** num arquivo `.yml`, com o schema e o nome real da tabela no warehouse.\n- Assim como o `ref()`, o `source()` também vira uma dependência visível no grafo, só que apontando para uma tabela bruta, não para outro modelo."
+                    },
+                    {
+                        "type": "code",
+                        "value": "-- models/staging/erp/_erp__sources.yml\n\nversion: 2\n\nsources:\n  - name: erp\n    schema: bruto\n    tables:\n      - name: pedidos\n      - name: clientes"
+                    },
+                    {
+                        "type": "code",
+                        "value": "-- models/staging/erp/stg_erp__pedidos.sql\n-- Sem nome físico escrito à mão\n\nSELECT\n    id_pedido,\n    id_cliente,\n    status,\n    valor_total,\n    data_criacao\nFROM {{ source('erp', 'pedidos') }}\nWHERE status != 'cancelado'\n\n\n-- models/marts/fct_pedidos.sql\n-- Depende de um modelo, não de uma fonte bruta\n\nSELECT\n    id_pedido,\n    id_cliente,\n    valor_total\nFROM {{ ref('stg_erp__pedidos') }}"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Aspecto\",\"ref()\",\"source()\"],[\"O que referencia\",\"Outro modelo dbt, definido em SQL\",\"Uma tabela bruta, carregada por ingestão\"],[\"Precisa de declaração prévia\",\"Não: o modelo já é parte do projeto\",\"Sim: a fonte precisa existir num arquivo .yml\"],[\"Aparece no grafo de dependências\",\"Sim, como nó de modelo\",\"Sim, como nó de fonte (source)\"],[\"Nome físico escrito no SQL\",\"Nunca: o dbt resolve o schema certo\",\"Nunca: o dbt resolve o schema certo\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Se o FROM de um modelo dbt tem um nome de schema.tabela escrito à mão, alguma coisa está errada: ou falta um ref(), ou falta um source() declarado."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Um modelo dbt tem `FROM {{ ref('stg_erp__pedidos') }}` no lugar de `FROM dev_ana.stg_erp__pedidos` escrito à mão. Qual é o principal motivo prático dessa troca?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "O ref() executa o modelo referenciado em paralelo, reduzindo o tempo total de execução do dbt run.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O ref() resolve o nome completo do modelo no ambiente atual, e cria a dependência no grafo do dbt.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O ref() valida automaticamente os tipos de dado das colunas antes de compilar o SQL do modelo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O ref() aplica um cache de resultados, evitando reprocessar o modelo referenciado a cada execução.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma analista tenta usar `{{ source('vendas', 'pedidos') }}` num modelo novo, mas o `dbt compile` falha, avisando que essa fonte não existe. Qual é a causa mais provável?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O nome do modelo que contém esse source() não segue a convenção de prefixo stg_ exigida pelo dbt.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A tabela pedidos está materializada como view, e o source() só funciona com tabelas físicas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A fonte vendas, com a tabela pedidos, ainda não foi declarada num arquivo .yml de sources do projeto.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O projeto dbt não tem um dbt_project.yml configurado com a lista de todas as tabelas brutas.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um modelo precisa ler duas entradas: a tabela `bruto.clientes`, carregada pelo Fivetran e ainda não tratada por nenhum modelo dbt, e o modelo `stg_erp__pedidos`, já existente no projeto. Como cada leitura deve ser escrita no FROM/JOIN desse modelo?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "ref('clientes') para a tabela bruta do Fivetran, e source('stg_erp__pedidos') para o modelo já existente.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "source('erp', 'clientes') para as duas leituras, já que as duas tabelas vêm do mesmo sistema de origem.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "ref('bruto.clientes') para a tabela bruta, e ref('stg_erp__pedidos') para o modelo já existente.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "source('erp', 'clientes') para a tabela bruta, e ref('stg_erp__pedidos') para o modelo já existente.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe promove seu projeto dbt de desenvolvimento para produção, e cada ambiente usa um schema diferente no warehouse. Um modelo antigo, que ainda tem `FROM dev_joana.stg_vendas` escrito à mão, passa a devolver dados vazios em produção. Qual é a explicação mais provável?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O nome do schema foi fixado à mão, então o modelo aponta para o schema de dev mesmo rodando em produção.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O modelo está com a materialização configurada como ephemeral, que não é suportada em produção pelo dbt.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O usuário de produção do warehouse não tem permissão de leitura em nenhuma tabela criada por outros modelos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A ordem de execução dos modelos mudou entre ambientes, e o modelo passou a rodar antes da sua dependência.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um modelo referencia `{{ source('financeiro', 'faturas') }}`, mas ninguém jamais criou um arquivo `.yml` com um bloco `sources:` para `financeiro`. O que acontece ao rodar `dbt run`?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O dbt cria a declaração da fonte automaticamente, inferindo o schema a partir do nome usado no source().",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O comando falha na compilação, porque o dbt não encontra nenhuma fonte financeiro declarada no projeto.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O modelo roda normalmente, mas fica de fora do grafo de dependências, sem aparecer na linhagem do dbt.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O dbt materializa o modelo como ephemeral por padrão, já que não localizou a fonte declarada no projeto.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "A linhagem automática",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# A linhagem automática\n\nCada `ref()` e `source()` usado nos modelos de um projeto dbt é, ao mesmo tempo, uma instrução de SQL e uma declaração de dependência. O dbt lê todos os modelos do projeto, encontra essas chamadas, e monta com elas um grafo: o DAG (directed acyclic graph, grafo acíclico dirigido) do projeto. Esse grafo não é desenhado à mão por ninguém, ele é derivado automaticamente do próprio SQL."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Para que serve o DAG\n\n- **Ordem de execução**: um modelo só roda depois que todos os modelos e fontes que ele referencia, seus 'pais' no grafo, já rodaram com sucesso.\n- **Paralelismo seguro**: modelos sem dependência entre si podem rodar ao mesmo tempo, porque o dbt sabe exatamente quem depende de quem.\n- **Linhagem visível**: `dbt docs generate` gera um site com o grafo completo, navegável, mostrando de onde cada modelo vem e para onde seus dados seguem.\n- **Impacto de mudança**: antes de alterar um modelo ou uma fonte, dá para ver exatamente quais modelos, diretos e indiretos, dependem dele."
+                    },
+                    {
+                        "type": "code",
+                        "value": "                 +--> stg_erp__pedidos -------+\n                 |                             |\n                 |                             v\nerp (source) ----+                    int_pedidos_enriquecidos --> fct_pedidos\n                 |                             ^\n                 |                             |\n                 +--> stg_erp__clientes -------+\n                                  |\n                                  +--> dim_clientes"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Uma fonte mudou: quem é afetado?\n\nSuponha que o time de vendas renomeia uma coluna na tabela bruta `erp.pedidos`. Sem o DAG, a pergunta 'quem quebra com essa mudança' só seria respondida na tentativa e erro, esperando algum painel falhar. Com a linhagem automática, a resposta está no próprio grafo: basta olhar tudo que é descendente de `stg_erp__pedidos`, que lê o source `erp.pedidos`. Nesse caso, `int_pedidos_enriquecidos` e `fct_pedidos` são afetados. `dim_clientes`, que nunca leu essa fonte, fica de fora."
+                    },
+                    {
+                        "type": "code",
+                        "value": "-- Roda o modelo e tudo que depende dele (descendentes)\ndbt run --select stg_erp__pedidos+\n\n-- Roda o modelo e tudo de que ele depende (ancestrais)\ndbt run --select +fct_pedidos"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Termo\",\"Significado no DAG do dbt\"],[\"Nó (node)\",\"Um modelo, uma fonte, um seed ou um snapshot no grafo\"],[\"Pai (parent, upstream)\",\"Um nó referenciado por ref() ou source() dentro de outro modelo\"],[\"Filho (child, downstream)\",\"Um nó que referencia o modelo atual, direta ou indiretamente\"],[\"Ciclo\",\"Uma dependência circular; o dbt recusa compilar um projeto com ciclos\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "O DAG de um projeto dbt não é um diagrama mantido à parte: é a soma exata de todos os ref() e source() escritos no SQL, sempre atualizado, nunca desatualizado."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que o dbt usa para montar automaticamente o DAG, o grafo de dependências, de um projeto?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Um arquivo separado, mantido manualmente, onde a equipe desenha a ordem de execução dos modelos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A ordem alfabética dos nomes de arquivo dentro da pasta models do projeto dbt.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "As chamadas a ref() e source() escritas dentro dos próprios modelos SQL do projeto.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O histórico de execuções anteriores, registrado automaticamente a cada rodada de dbt run.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma coluna é renomeada na tabela bruta `erp.pedidos`. Antes de aplicar a mudança, a equipe quer saber quais modelos dbt seriam afetados. Qual é a forma correta de responder a isso usando o próprio projeto dbt?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Procurar, em cada arquivo .sql do projeto, o texto erp.pedidos escrito literalmente no FROM ou no JOIN.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Rodar dbt test em todos os modelos do projeto e verificar quais deles retornam alguma falha.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Perguntar para o time responsável por cada modelo se ele usa dados vindos do sistema ERP.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Consultar o grafo de linhagem e identificar todos os modelos descendentes do source erp.pedidos.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Num projeto dbt, `stg_pedidos` e `stg_clientes` não têm nenhuma dependência entre si, mas ambos são referenciados por `int_pedidos_enriquecidos`. O que o DAG permite que o dbt faça nesse caso?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Executar stg_pedidos e stg_clientes em paralelo, já que nenhum dos dois depende do outro.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Executar os três modelos em paralelo, incluindo int_pedidos_enriquecidos, para ganhar tempo no run.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Pular a execução de um dos dois modelos de staging, já que ambos alimentam o mesmo modelo intermediário.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Combinar os dois modelos de staging automaticamente num único objeto, simplificando o grafo.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um engenheiro quer rodar apenas o modelo `fct_pedidos` e todos os modelos dos quais ele depende, sem tocar em nada que vem depois dele no grafo. Qual comando faz exatamente isso?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "dbt run --select fct_pedidos+",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "dbt run --select +fct_pedidos",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "dbt run --select fct_pedidos",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "dbt run --select fct_pedidos+2",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Durante um `dbt compile`, o dbt retorna um erro informando um ciclo no grafo de dependências entre os modelos `int_a` e `int_b`. O que provavelmente causou esse erro?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "int_a e int_b foram criados no mesmo commit, e o dbt não permite compilar dois modelos novos ao mesmo tempo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "int_a e int_b estão configurados com a mesma materialização, o que o dbt trata como dependência circular.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "int_a tem um ref('int_b'), e ao mesmo tempo int_b tem um ref('int_a'), criando uma dependência circular.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "int_a referencia uma fonte que também é referenciada, separadamente, pelo modelo int_b.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Camadas: staging, intermediate e marts",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Camadas: staging, intermediate e marts\n\nUm projeto dbt pode, tecnicamente, ter todos os modelos numa pasta só, sem organização nenhuma. Mas a comunidade dbt consolidou, ao longo dos anos, uma convenção de camadas que resolve um problema recorrente: sem padrão, cada pessoa junta fontes e aplica regra de negócio onde bem entende, e a linhagem vira um emaranhado difícil de acompanhar. A convenção divide os modelos em três camadas: staging, intermediate e marts."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## staging: limpeza 1:1 com a fonte\n\n- Um modelo de staging lê **uma única fonte**, via `source()`, e faz limpeza leve: renomear colunas, ajustar tipos, talvez filtrar linhas claramente inválidas.\n- Não há junção com outras fontes nem regra de negócio aqui. A relação com a fonte original é 1:1: uma tabela bruta, um modelo de staging.\n- É a camada mais próxima do dado cru, e normalmente a mais barata de manter: costuma ser materializada como view."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## intermediate: juntar e preparar\n\n- Um modelo intermediate combina **múltiplos modelos de staging**, ou outros intermediates, aplicando lógica que ainda não é o produto final: joins, agregações parciais, pivôs.\n- Não costuma ser consumido diretamente por ferramentas de BI. Existe para organizar lógica complexa em passos menores, cada um testável e legível sozinho.\n- É comum usar a materialização ephemeral aqui, tema da próxima aula, já que ninguém precisa consultar esse modelo diretamente no warehouse."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## marts: pronto para o negócio\n\n- Um modelo de marts é o produto final: uma tabela de fato ou de dimensão, nomeada e estruturada em torno de um processo de negócio (pedidos, pagamentos, campanhas), não em torno de uma fonte.\n- É a camada consumida por ferramentas de BI, como Looker ou Metabase, e por qualquer consulta ad-hoc no warehouse.\n- Organizada por domínio ou área (financeiro, marketing, vendas), e não por sistema de origem: várias fontes já foram unificadas antes de chegar aqui."
+                    },
+                    {
+                        "type": "code",
+                        "value": "sources (brutos)       -->  staging (stg_)        -->  intermediate (int_)    -->  marts (fct_/dim_)\n\nerp.pedidos                  stg_erp__pedidos            int_pedidos_                 fct_pedidos\nerp.clientes                 stg_erp__clientes           enriquecidos                 dim_clientes\n\n1 fonte = 1 modelo,          limpeza 1:1 com a           junta modelos de             organizado por\nsem tratamento                fonte, sem junção           staging, ainda não           domínio de negócio,\n                              entre fontes                é o produto final           pronto para BI"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Camada\",\"Lê de\",\"O que faz\",\"Consumida por\"],[\"staging\",\"Uma única fonte (source)\",\"Renomeia, tipa, filtra o óbvio\",\"Outros modelos dbt\"],[\"intermediate\",\"Modelos de staging ou outros intermediate\",\"Junta, agrega, prepara\",\"Outros modelos dbt\"],[\"marts\",\"Modelos de intermediate, ou staging quando não há lógica intermediária\",\"Organiza por domínio de negócio\",\"BI, análises, outros consumidores\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "A staging responde qual é essa fonte, já limpa. A intermediate responde como essas fontes se combinam. A marts responde o que o negócio precisa consultar. Cada camada resolve uma pergunta diferente, por isso elas não se misturam num único modelo gigante."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Das camadas de um projeto dbt (staging, intermediate, marts), qual delas costuma ser organizada por domínio de negócio, como financeiro ou marketing, e não por sistema de origem dos dados?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "staging",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "intermediate",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "sources",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "marts",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um modelo precisa juntar `stg_erp__pedidos` com `stg_erp__clientes`, aplicando uma lógica de enriquecimento que nenhum modelo de negócio usa diretamente, mas que dois marts diferentes, `fct_pedidos` e `fct_pagamentos`, vão reaproveitar. Em qual camada esse modelo deveria viver?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "intermediate, já que junta modelos de staging e não é destinado ao consumo direto por ferramentas de BI.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "staging, já que ainda está perto da fonte original e não representa um processo de negócio completo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "marts, já que o resultado será reaproveitado por mais de um modelo de fatos dentro do projeto.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "staging, desde que o modelo receba um prefixo diferente para indicar que junta duas fontes distintas.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um modelo chamado `stg_erp__pedidos` foi escrito fazendo um JOIN entre a tabela bruta de pedidos e a tabela bruta de clientes, ambas via `source()`. Qual princípio da convenção de camadas esse modelo está violando?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Staging deve sempre ser materializado como table, nunca como view, para garantir performance de leitura.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Staging deve manter relação 1:1 com uma única fonte, sem juntar dados de outras tabelas brutas.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Staging deve conter apenas colunas numéricas, deixando texto e datas para os modelos de intermediate.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Staging deve ser nomeado sempre no plural, e pedidos já está no plural, então o nome está incorreto.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um analista de BI pergunta em qual modelo deve basear um novo dashboard de vendas, que precisa de dados já unificados e prontos para consumo direto. Qual camada é a resposta esperada?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "staging, porque é a camada mais próxima da fonte, com os dados mais atualizados possíveis para o dashboard.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "intermediate, porque já combina os dados de múltiplas fontes antes de qualquer regra de negócio ser aplicada.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "marts, porque é a camada organizada em torno do negócio, pensada para consumo direto por ferramentas de BI.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "source, porque representa a tabela bruta original, sem nenhuma transformação que possa distorcer os números.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um modelo de staging já contém exatamente os dados que um mart de dimensão precisa, sem nenhuma junção ou lógica adicional necessária. Nesse caso, o que a convenção de camadas recomenda?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Um modelo de intermediate deve ser criado mesmo assim, já que pular essa camada não é permitido pelo dbt.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O modelo de staging deve ser renomeado com o prefixo fct_ ou dim_, já que ele virou o mart nesse cenário.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os dados devem ser duplicados manualmente da staging para um novo modelo de marts, mantendo os dois separados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O mart pode referenciar o modelo de staging diretamente, sem exigir um modelo de intermediate desnecessário.",
+                                "isCorrect": true
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Nomear e organizar modelos",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Nomear e organizar modelos\n\nA convenção de camadas (staging, intermediate, marts) só cumpre sua promessa, deixar a linhagem fácil de entender de relance, se vier acompanhada de nomes e pastas consistentes. Sem isso, um projeto com centenas de modelos vira um labirinto: para saber o que um modelo faz, seria preciso abrir o arquivo e ler o SQL inteiro. Com convenção, o nome já entrega boa parte da resposta."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Prefixos por camada\n\n- **stg_**: modelos de staging. Convenção comum: `stg_[fonte]__[entidade]`, como `stg_stripe__pagamentos` ou `stg_erp__pedidos` (o sistema de origem no nome ajuda quando duas fontes têm entidades com nome parecido).\n- **int_**: modelos de intermediate, como `int_pedidos_enriquecidos` ou `int_pagamentos_pivotados`.\n- **fct_**: fatos, no sentido de modelagem dimensional (eventos, transações, algo que aconteceu), como `fct_pedidos` ou `fct_pagamentos`.\n- **dim_**: dimensões, entidades com atributos que descrevem o fato, como `dim_clientes` ou `dim_produtos`."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Organização de pastas\n\n- **staging**: uma subpasta por sistema de origem, `models/staging/erp/`, `models/staging/stripe/`, cada uma com seus modelos e o arquivo de sources correspondente.\n- **intermediate**: geralmente uma pasta única, `models/intermediate/`, já que esses modelos tendem a ser específicos de um fluxo, não de uma fonte.\n- **marts**: uma subpasta por domínio de negócio, `models/marts/financeiro/`, `models/marts/marketing/`, reunindo os fatos e dimensões daquele domínio."
+                    },
+                    {
+                        "type": "code",
+                        "value": "models/\n  staging/\n    erp/\n      _erp__sources.yml\n      stg_erp__pedidos.sql\n      stg_erp__clientes.sql\n    stripe/\n      _stripe__sources.yml\n      stg_stripe__pagamentos.sql\n  intermediate/\n    int_pedidos_enriquecidos.sql\n  marts/\n    financeiro/\n      fct_pedidos.sql\n      fct_pagamentos.sql\n      dim_clientes.sql\n    marketing/\n      fct_campanhas.sql"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Prefixo\",\"Camada\",\"Exemplo\",\"Convenção de nome\"],[\"stg_\",\"staging\",\"stg_erp__pedidos\",\"stg_[fonte]__[entidade]\"],[\"int_\",\"intermediate\",\"int_pedidos_enriquecidos\",\"int_[entidade]_[verbo no particípio]\"],[\"fct_\",\"marts (fato)\",\"fct_pedidos\",\"fct_[processo de negócio]\"],[\"dim_\",\"marts (dimensão)\",\"dim_clientes\",\"dim_[entidade descritiva]\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Um bom nome de modelo dbt responde duas perguntas antes de abrir o arquivo: em qual camada ele está, e o que ele representa. Se o nome não responde isso, a convenção não está sendo seguida de verdade."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Consistência acima de tudo\n\nO prefixo exato, ou a forma de dividir pastas, importa menos do que a equipe inteira seguir a mesma convenção. Um projeto onde metade dos modelos de fato começa com `fct_` e a outra metade não segue nenhum padrão perde justamente o benefício que a convenção deveria trazer: reconhecer a camada e o papel de um modelo só pelo nome, sem precisar abrir o arquivo."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Na convenção de nomenclatura mais comum em projetos dbt, qual prefixo é usado para um modelo de staging que limpa a tabela bruta de pagamentos vinda do Stripe?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "stg_, como em stg_stripe__pagamentos",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "int_, como em int_stripe__pagamentos",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "fct_, como em fct_stripe__pagamentos",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "dim_, como em dim_stripe__pagamentos",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um time está nomeando dois modelos novos: um representa cada pedido feito por um cliente, um evento com data e valor, e outro representa os atributos de cada cliente, nome, segmento, data de cadastro. Como esses modelos devem ser nomeados, seguindo a convenção fct_/dim_?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "dim_pedidos para o evento de pedido, e fct_clientes para os atributos do cliente.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "fct_pedidos para o evento de pedido, e dim_clientes para os atributos do cliente.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "fct_pedidos para os dois modelos, já que ambos pertencem ao mesmo domínio de vendas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "dim_pedidos para os dois modelos, já que representam entidades do mesmo processo.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um projeto dbt ingere dados de dois sistemas diferentes, um ERP e o Stripe, cada um com uma tabela chamada `pagamentos`. Qual organização de pastas evita a colisão de nomes entre os dois modelos de staging?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Uma única pasta staging/ para todos os modelos, distinguindo os dois pela ordem no dbt_project.yml.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma pasta staging/pagamentos/ compartilhada pelos dois sistemas, com um modelo único que junta as fontes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma subpasta por sistema de origem, staging/erp/ e staging/stripe/, cada uma com seu modelo de staging.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Duas pastas com o mesmo nome stg_pagamentos/, diferenciadas apenas pelo schema de cada ambiente.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Numa revisão de código, um revisor percebe que um modelo chamado `pedidos_completos.sql` está na pasta `marts/financeiro/`, sem nenhum prefixo fct_ ou dim_, enquanto os demais modelos da pasta seguem a convenção. Qual é o problema prático dessa inconsistência?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O dbt recusa compilar o projeto, porque todo modelo dentro de marts precisa obrigatoriamente ter um prefixo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O modelo pedidos_completos deixa de aparecer no grafo de linhagem, já que não segue o padrão de nomenclatura.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A materialização configurada para esse modelo é ignorada pelo dbt, que aplica sempre a materialização view.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Quem olhar a lista de modelos não consegue saber, só pelo nome, se pedidos_completos é um fato ou dimensão.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Diferente de staging e marts, a pasta intermediate costuma não ser dividida em subpastas por fonte ou por domínio, ficando com todos os modelos direto em `models/intermediate/`. Qual é a justificativa mais consistente com o papel dessa camada?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Modelos de intermediate tendem a ser específicos de um fluxo, não de uma fonte ou de um domínio inteiro.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A pasta intermediate é opcional e raramente usada, então criar subpastas não compensaria o esforço extra.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O dbt exige, por padrão, que todos os modelos intermediate fiquem numa única pasta, sem suporte a subpastas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Modelos de intermediate não aparecem na documentação gerada, então a organização em pastas não teria efeito.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 4 - Materializações",
+        "aulas": [
+            {
+                "titulo": "view: leve e sempre atual",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# view: leve e sempre atual\n\nA materialização é a decisão de como o SELECT de um modelo dbt vira um objeto no warehouse (ou nem vira nenhum). Ela é configurada com `{{ config(materialized='...') }}` no topo do modelo, ou por pasta no `dbt_project.yml`. Esta aula abre o módulo pela mais simples das quatro: **view**, que também é a materialização padrão do dbt quando nenhuma é configurada explicitamente."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Como funciona\n\nAo rodar `dbt run` sobre um modelo materializado como view, o dbt compila o SQL do modelo e executa um `CREATE VIEW AS SELECT ...` no warehouse. Nenhum dado é copiado ou duplicado: a view é só a query salva com um nome. Toda vez que alguém consulta essa view (uma ferramenta de BI, outro modelo dbt, um analista rodando um SELECT manual), o warehouse reexecuta o SELECT inteiro por trás dela, contra as tabelas de origem, na hora da leitura."
+                    },
+                    {
+                        "type": "code",
+                        "value": "{{ config(materialized='view') }}\n\n-- Camada de staging: renomeia e tipa as colunas da fonte, 1:1 com a origem\nselect\n    id as pedido_id,\n    cliente_id,\n    cast(valor_total as numeric(10,2)) as valor_total,\n    status,\n    cast(criado_em as timestamp) as criado_em\nfrom {{ source('vendas', 'pedidos') }}"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Onde ela brilha\n\n- **Camada de staging**: modelos `stg_` costumam ser só limpeza e renomeação, 1:1 com a fonte. Sem agregação pesada, o custo de recalcular a cada leitura é baixo.\n- **Dado sempre atual**: como a view não guarda nenhum snapshot, uma mudança na tabela de origem aparece imediatamente na próxima consulta, sem esperar o próximo `dbt run`.\n- **Sem duplicação de armazenamento**: nenhum byte extra é gravado no warehouse, só a definição da query.\n\nPor isso a view costuma ser o padrão para a staging na maioria dos projetos dbt: modelos leves, numerosos, e onde frescor importa mais do que velocidade de leitura."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O custo fica na leitura\n\nA troca é simples: a view não paga custo de escrita (o `dbt run` só valida a sintaxe e cria a definição), mas empurra todo o custo de processamento para quem lê. Se um modelo view tem lógica pesada (vários joins, agregações, window functions) e é consultado com frequência, esse custo se repete a cada consulta, o que pode deixar dashboards lentos ou multiplicar o gasto de computação no warehouse. Encadear várias views (uma view sobre outra view) agrava o problema: a query final carrega a lógica de todas as camadas empilhadas."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Momento\", \"O que acontece numa view\"], [\"dbt run\", \"Só cria ou atualiza a definição da view (CREATE VIEW), sem processar dados\"], [\"Consulta (SELECT)\", \"O warehouse reexecuta o SELECT completo contra as tabelas de origem\"], [\"Armazenamento\", \"Nenhum dado adicional é gravado, só a query salva\"], [\"Atualização dos dados\", \"Imediata: reflete a origem na consulta seguinte, sem esperar novo dbt run\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Uma view não guarda dado nenhum, guarda uma pergunta. Toda vez que alguém consulta, o warehouse refaz essa pergunta do zero contra a origem, e é isso que garante o dado sempre atual, ao custo de repetir o processamento a cada leitura."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual é a materialização padrão de um modelo dbt quando nenhuma é configurada explicitamente?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "view, que cria uma view no warehouse sem duplicar nenhum dado da origem",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "table, que materializa o modelo como uma tabela física recriada a cada dbt run",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "incremental, que processa só as linhas novas ou alteradas desde o último run",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "ephemeral, que injeta o modelo como um CTE nos modelos que o referenciam",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um modelo de staging (`stg_clientes`) faz só renomeação de colunas e um cast de tipos, sem nenhuma agregação, e precisa refletir a fonte imediatamente após qualquer mudança. É consultado por poucos modelos downstream, nunca direto por dashboards. Qual materialização atende melhor esse cenário?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "table, porque uma tabela física sempre reflete o dado mais atualizado do warehouse",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "view, porque é leve e o dado deve refletir a origem sem esperar um novo run",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "incremental, porque processar só as linhas novas reduz o custo de qualquer staging",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "ephemeral, porque um modelo de staging nunca deveria virar objeto consultável",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um analista encadeou três modelos view, cada um fazendo joins e agregações sobre o anterior (view sobre view sobre view), e agora um dashboard que consulta o modelo final demora minutos para carregar. Qual é a causa mais provável da lentidão?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O warehouse limita quantas views podem existir dentro de um mesmo schema do projeto",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Views não suportam joins nem agregações, então cada uma dessas operações roda como subquery lenta",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A cada consulta do dashboard, o warehouse reprocessa a lógica das três camadas de view empilhadas",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O dbt recompila o SQL das três views a cada consulta feita pelo dashboard ao warehouse",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Duas equipes de BI apontam para o mesmo modelo view (`stg_pedidos`) e rodam, juntas, cerca de 200 consultas por hora contra ele, cada uma repetindo os mesmos joins e casts. O time de dados quer reduzir o custo de warehouse sem perder o frescor total dos dados. Qual ação é mais coerente com as características da materialização view?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Manter view e aceitar o custo, pois é a única materialização com frescor imediato garantido",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Trocar para ephemeral, que elimina esse custo injetando a lógica como CTE em cada consulta de BI",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Trocar para incremental, que reduz o custo reprocessando só as linhas alteradas a cada consulta",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Aceitar perda de frescor e trocar para table, pagando o custo uma vez no run, não a cada consulta",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "A tabela de origem que alimenta a view `stg_clientes` teve a coluna `telefone` removida numa migração recente, mas o modelo dbt não foi atualizado e ninguém rodou `dbt run` de novo. A definição da view ainda faz SELECT explícito dessa coluna. O que acontece na próxima vez que alguém consultar `stg_clientes`?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "A consulta falha, porque a definição da view referencia uma coluna que não existe mais na origem",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A consulta funciona normalmente, porque a view guarda uma cópia dos dados no momento da criação",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A coluna telefone aparece com valor nulo em todas as linhas, sem gerar nenhum erro na consulta",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O warehouse atualiza a definição da view automaticamente, removendo a coluna telefone sozinha",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "table: rápida de ler",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# table: rápida de ler\n\nA view (aula anterior) guarda uma pergunta e a refaz a cada leitura. A materialização **table** faz o oposto: guarda a resposta. Em vez de salvar só a definição do SELECT, o dbt executa a query e grava o resultado como uma tabela física no warehouse, com os dados fisicamente copiados e prontos para ler."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Como funciona\n\nAo rodar `dbt run` sobre um modelo `materialized='table'`, o dbt executa um `CREATE TABLE AS SELECT` (CTAS) com a lógica do modelo, e o resultado é gravado como uma tabela nova no warehouse (a maioria dos adaptadores cria a tabela num lugar temporário e faz a troca ao final, para não deixar o modelo indisponível durante o rebuild). A partir daí, qualquer consulta lê diretamente os dados já calculados, sem reprocessar o SELECT original."
+                    },
+                    {
+                        "type": "code",
+                        "value": "{{ config(materialized='table') }}\n\n-- Marts: pedidos agregados por dia, consultado direto pelo dashboard financeiro\nselect\n    data_pedido,\n    count(*) as total_pedidos,\n    sum(valor_total) as receita_total,\n    avg(valor_total) as ticket_medio\nfrom {{ ref('stg_pedidos') }}\ngroup by data_pedido"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Onde ela brilha\n\n- **Marts consultados com frequência**: uma tabela de métricas aberta o dia inteiro num dashboard não pode pagar o custo do SELECT completo a cada clique de filtro.\n- **Lógica pesada**: joins entre várias tabelas grandes, agregações e window functions compensam ser calculados uma vez no `dbt run` e lidos várias vezes depois.\n- **Muitos consumidores simultâneos**: quando dezenas de analistas ou uma ferramenta de BI consultam o mesmo modelo ao mesmo tempo, ler uma tabela pronta é muito mais barato do que recalcular a mesma lógica em paralelo várias vezes."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O custo fica na escrita\n\nA troca em relação à view é: a table processa tudo de novo a cada `dbt run`, não importa se a origem mudou uma linha ou um milhão. Numa tabela de milhões (ou bilhões) de linhas, refazer o CTAS inteiro todo dia consome tempo de processamento e créditos de warehouse, mesmo quando a maior parte dos dados já estava correta desde ontem. Some a isso o espaço de armazenamento: os dados da table ficam duplicados em relação à origem (e a qualquer staging view por trás dela). Quando esse custo de reprocessar tudo fica alto demais, a resposta costuma ser a materialização incremental, tema da próxima aula."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Aspecto\", \"view\", \"table\"], [\"Onde o SELECT roda\", \"A cada leitura\", \"Só no dbt run\"], [\"Dado fica armazenado?\", \"Não\", \"Sim, cópia física\"], [\"Velocidade de leitura\", \"Depende da lógica, recalculada sempre\", \"Rápida, dado já pronto\"], [\"Custo do dbt run\", \"Baixo, só cria a definição\", \"Alto, reprocessa tudo\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Uma table troca o custo de leitura pelo custo de escrita: cada dbt run paga o preço de recalcular o modelo inteiro, para que cada consulta depois disso seja barata. Vale a troca quando o modelo é lido muito mais vezes do que é reconstruído."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que o dbt executa no warehouse ao rodar `dbt run` sobre um modelo materializado como table?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Um CREATE VIEW AS SELECT, guardando apenas a definição da query",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um CREATE TABLE AS SELECT, gravando o resultado como dados físicos",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um MERGE entre a tabela existente e apenas as linhas novas da origem",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um INSERT INTO acrescentando linhas novas à tabela já existente",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um dashboard financeiro é consultado por dezenas de pessoas ao longo do dia e faz agregações pesadas (joins entre três tabelas grandes e somas por período) sobre um modelo dbt. Hoje esse modelo é uma view, e o dashboard está lento porque cada clique reprocessa os joins do zero. Qual mudança de materialização resolve a lentidão sem trocar a lógica do modelo?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Trocar para ephemeral, para que o modelo seja injetado como CTE direto na consulta do dashboard",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Manter a view, mas adicionar mais índices nas tabelas de origem consultadas pelos joins",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Trocar para table, para que os joins e as somas sejam calculados uma vez no dbt run",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Trocar para incremental, para que cada consulta do dashboard processe só os dados mais recentes",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma tabela de fatos com 800 milhões de linhas está materializada como table. Todo dia, menos de 0,1% das linhas (as vendas do dia anterior) são novas; o resto já estava certo desde a véspera. Mesmo assim, o dbt run demora quase uma hora processando esse modelo. Por que isso acontece?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "A materialização table sempre falha em tabelas com mais de 500 milhões de linhas, por limite do warehouse",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O modelo está usando ref() em vez de source(), o que força o dbt a reler a tabela inteira sempre",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A tabela não tem um teste unique_key configurado, então o dbt não sabe quais linhas já existem",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A materialização table reprocessa o SELECT inteiro a cada run, mesmo quando quase nada mudou na origem",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um modelo já materializado como table no warehouse é alterado (uma nova coluna calculada é adicionada ao SELECT) e o time roda `dbt run` de novo. O que acontece com a tabela existente?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "A tabela inteira é reconstruída a partir do novo SELECT, substituindo a versão anterior por completo",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O dbt adiciona só a coluna nova à tabela existente, com ALTER TABLE, preservando as linhas já gravadas",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O dbt bloqueia a execução e pede um --full-refresh explícito antes de aceitar mudanças no SELECT",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A tabela antiga é mantida intacta e uma segunda tabela com sufixo _v2 é criada ao lado dela",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O projeto tem `stg_pedidos` (view) e, sobre ele, `fct_pedidos` (table) com agregações pesadas. Um analista afirma que toda consulta a `fct_pedidos` continua pagando o custo de reprocessar `stg_pedidos`, já que um depende do outro no DAG. Essa afirmação está correta?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Sim, porque toda table que referencia uma view precisa reabrir essa view a cada consulta feita depois",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não, o custo de stg_pedidos é pago uma vez, durante o CTAS que constrói fct_pedidos no dbt run",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Sim, porque o dbt grava a dependência entre os dois modelos direto dentro da tabela fct_pedidos",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não, porque fct_pedidos ignora stg_pedidos no build e lê a fonte original direto pelo source()",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "incremental: só o novo",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# incremental: só o novo\n\nA materialização table (aula anterior) resolve a velocidade de leitura, mas reprocessa o modelo inteiro a cada `dbt run`, não importa quantas linhas realmente mudaram. Numa tabela de fatos com centenas de milhões de linhas, onde só uma fração pequena é nova a cada dia, isso desperdiça tempo e créditos de warehouse. A materialização **incremental** ataca exatamente esse problema: em vez de refazer tudo, processa só as linhas novas ou alteradas desde a última execução, e as combina com o que já existe na tabela."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Como funciona\n\nNa primeira execução (ou quando a tabela ainda não existe), um modelo incremental se comporta como uma table comum: roda o SELECT inteiro e materializa todo o histórico. A partir da segunda execução em diante, o dbt usa a macro `is_incremental()` para envolver um trecho do SQL num filtro condicional, que só entra em vigor quando a tabela de destino já existe, o modelo está configurado como incremental e a execução não foi disparada com `--full-refresh`. Fora dessas condições, `is_incremental()` retorna falso e o filtro é simplesmente ignorado, então o modelo volta a processar tudo, como na primeira vez."
+                    },
+                    {
+                        "type": "code",
+                        "value": "{{\n  config(\n    materialized='incremental',\n    unique_key='pedido_id'\n  )\n}}\n\nselect\n    pedido_id,\n    cliente_id,\n    valor_total,\n    status,\n    atualizado_em\nfrom {{ source('vendas', 'pedidos') }}\n\n{% if is_incremental() %}\n-- Este filtro só entra no SQL a partir da segunda execução em diante:\n-- processa apenas pedidos alterados depois do último valor já gravado\nwhere atualizado_em > (select max(atualizado_em) from {{ this }})\n{% endif %}"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## unique_key: o que fazer com o que já existe\n\nFiltrar as linhas novas resolve só metade do problema: o dbt também precisa saber o que fazer quando uma dessas linhas já tem uma versão anterior na tabela de destino, por exemplo um pedido que mudou de status depois de já ter sido carregado. É para isso que serve o `unique_key`: ele diz ao dbt qual coluna (ou combinação de colunas) identifica um registro de forma única, para que a linha nova substitua a antiga em vez de virar uma duplicata.\n\nSem `unique_key`, a estratégia incremental padrão tende a só inserir as linhas retornadas pelo filtro, sem checar se elas já existem, o que reproduz o mesmo risco de duplicação de um append cego quando uma linha \"nova\" é, na verdade, a atualização de uma linha antiga."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O cuidado com dados atrasados\n\nO filtro `where atualizado_em > (select max(atualizado_em) from {{ this }})` parte de uma suposição: que os dados chegam na origem em ordem, sem atraso. Na prática isso nem sempre é verdade. Um evento pode ser gravado na origem horas ou dias depois de acontecer (atraso de rede, um sistema batch que consolida no fim do dia, uma correção manual num registro antigo), com uma data de referência anterior ao maior `atualizado_em` que o filtro já considerou como processado. Se isso acontecer, a linha atrasada nunca entra no filtro, e o dado fica faltando na tabela de destino de forma silenciosa, sem nenhum erro para avisar.\n\nA mitigação mais comum é abrir uma janela de reprocessamento (lookback), revisitando por exemplo os últimos dias a cada run, em vez de só o que é estritamente mais novo que o máximo já gravado. Como o `unique_key` já cuida do merge, reprocessar uma janela que inclui linhas já existentes não gera duplicata, só garante que atualizações atrasadas dentro dessa janela sejam capturadas. Um `dbt run --full-refresh` periódico, reconstruindo a tabela inteira, é o reforço final contra qualquer drift acumulado."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Situação\", \"is_incremental()\"], [\"Primeira execução, tabela ainda não existe\", \"Falso, roda o SELECT completo\"], [\"Execução normal, tabela já existe\", \"Verdadeiro, aplica o filtro incremental\"], [\"Execução com a flag --full-refresh\", \"Falso, reconstrói a tabela inteira\"], [\"Modelo não está configurado como incremental\", \"Falso, a macro não se aplica\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "incremental não é sobre nunca reprocessar tudo, é sobre reprocessar só o necessário na maioria das vezes. O ganho de custo vem daí: uma tabela de bilhões de linhas paga o preço cheio uma vez, e depois só paga pelo que realmente mudou, run após run."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que a macro `is_incremental()` permite fazer dentro de um modelo dbt materializado como incremental?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Definir automaticamente qual coluna deve ser usada como unique_key na configuração do modelo",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Bloquear a execução do modelo até que a tabela de destino tenha pelo menos uma linha gravada",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Aplicar um filtro condicional que só processa as linhas novas ou alteradas desde o último run",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Substituir a necessidade de rodar dbt run, processando o modelo direto na leitura pela ferramenta de BI",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma tabela incremental de pedidos usa o filtro `where atualizado_em > (select max(atualizado_em) from {{ this }})`, mas o modelo não tem `unique_key` configurado. Um pedido já carregado teve o status alterado, e seu `atualizado_em` foi atualizado na origem. O que acontece na tabela de destino após o próximo `dbt run`?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O pedido é ignorado pelo filtro incremental, porque seu pedido_id já existe na tabela de destino",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O dbt run falha com erro, porque a ausência de unique_key é obrigatória em modelos incrementais",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O dbt identifica que o pedido_id já existe e atualiza a linha, mesmo sem unique_key configurado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma nova linha para o mesmo pedido é inserida, e a tabela passa a ter duas linhas para esse pedido",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um modelo é configurado como `materialized='incremental'` pela primeira vez, num projeto onde essa tabela nunca existiu antes no warehouse. Ao rodar `dbt run`, o que acontece?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O bloco dentro de is_incremental() é ignorado, e o modelo roda o SELECT completo, como uma table",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O dbt recusa a execução, porque modelos incrementais exigem que a tabela de destino já exista",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O dbt cria a tabela vazia primeiro, e o filtro incremental é aplicado já na primeira execução",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Apenas a primeira linha retornada pelo SELECT é carregada, e o restante espera o próximo run",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma tabela incremental de eventos usa `where evento_em > (select max(evento_em) from {{ this }})` e tem `unique_key` configurado. O time percebe que eventos corrigidos manualmente pela equipe de suporte, com `evento_em` de dias atrás, nunca aparecem na tabela de destino, mesmo depois de várias execuções. Qual mudança resolve esse problema sem exigir `--full-refresh` a cada run?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Trocar a coluna do filtro de evento_em para pedido_id, comparando pelo identificador do evento",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Abrir uma janela de reprocessamento no filtro, revisitando por exemplo os últimos dias já gravados",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Remover o unique_key do modelo, para que qualquer linha retornada pelo filtro seja sempre inserida",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Configurar o modelo como ephemeral, para que ele seja reprocessado por completo a cada referência",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um engenheiro suspeita que a tabela incremental de pedidos acumulou inconsistências ao longo de meses (por causa de janelas de atraso não capturadas antes de uma correção recente no filtro). Qual comando reconstrói a tabela inteira do zero, reaplicando o SELECT completo do modelo, sem alterar a configuração do modelo?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "dbt run --incremental, que reprocessa todo o histórico ignorando o filtro configurado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "dbt seed, que recarrega os dados de origem e reconstrói todos os modelos dependentes",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "dbt run --full-refresh, que força a reconstrução completa mesmo em modelos incrementais",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "dbt run, repetido três vezes seguidas, até que o filtro capture todo o histórico faltante",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "ephemeral: um CTE reutilizável",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# ephemeral: um CTE reutilizável\n\nAs três materializações anteriores (view, table, incremental) sempre criam algum objeto no warehouse: uma view, uma tabela, ou uma tabela atualizada incrementalmente. A materialização **ephemeral** é a exceção: `materialized='ephemeral'` não cria view, não cria tabela, não cria nada consultável no warehouse. O modelo existe só dentro do projeto dbt, como um passo intermediário de lógica."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Como funciona\n\nQuando um modelo `B` faz `ref('A')` e `A` é ephemeral, o dbt não gera uma referência de tabela ou view para `A` no SQL compilado de `B`. Em vez disso, o dbt pega o SELECT compilado de `A` inteiro e injeta como uma CTE (`with a as (...)`) no topo do SQL de `B`, trocando `ref('A')` pelo nome dessa CTE. O warehouse nunca vê o modelo `A` como um objeto separado, só vê a query final de `B`, já com a lógica de `A` embutida dentro dela."
+                    },
+                    {
+                        "type": "code",
+                        "value": "-- models/intermediate/int_pedidos_validos.sql\n{{ config(materialized='ephemeral') }}\n\nselect *\nfrom {{ ref('stg_pedidos') }}\nwhere status != 'cancelado'\n  and valor_total > 0\n\n-- models/marts/fct_receita_diaria.sql\nselect\n    data_pedido,\n    sum(valor_total) as receita_total\nfrom {{ ref('int_pedidos_validos') }}\ngroup by data_pedido\n\n-- SQL compilado de fct_receita_diaria (aproximado): int_pedidos_validos\n-- não existe como tabela nem view, vira uma CTE dentro da própria query\n-- with int_pedidos_validos as (\n--     select * from staging.stg_pedidos\n--     where status != 'cancelado' and valor_total > 0\n-- )\n-- select data_pedido, sum(valor_total) as receita_total\n-- from int_pedidos_validos\n-- group by data_pedido"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Onde ela brilha\n\n- **Lógica intermediária leve**: um filtro, uma renomeação, um cálculo simples que existe só para deixar outro modelo mais legível, sem merecer virar um objeto próprio no warehouse.\n- **Reuso sem objeto extra**: se dois ou três modelos precisam da mesma lógica de filtro, um ephemeral evita copiar e colar o mesmo SQL em cada um, mantendo a regra escrita uma única vez.\n- **Warehouse mais limpo**: nenhuma view ou tabela extra aparece no schema só para representar um passo de transformação que ninguém consulta diretamente. Isso reduz ruído tanto no warehouse quanto na navegação do `dbt docs`."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que se perde\n\nA principal limitação é literal: um modelo ephemeral não pode ser consultado direto, porque não existe como objeto no warehouse. Não dá para abrir uma ferramenta de BI, ou rodar um `SELECT * FROM` no schema, e olhar os dados desse modelo isolado, ele só existe embutido dentro de quem o referencia.\n\nO outro cuidado é o reuso em cadeia: se vários modelos fazem `ref()` do mesmo ephemeral, a lógica dele é recompilada e injetada em cada um deles, sem ser calculada uma vez só. Encadear vários modelos ephemeral um sobre o outro empilha CTEs dentro do SQL compilado final, o que deixa a query mais longa e mais difícil de debugar quando algo dá errado."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Materialização\", \"Objeto no warehouse\", \"Dá para consultar direto\", \"Quando roda o SELECT\"], [\"view\", \"View\", \"Sim\", \"A cada leitura\"], [\"table\", \"Tabela física\", \"Sim\", \"No dbt run, sempre completo\"], [\"incremental\", \"Tabela física\", \"Sim\", \"No dbt run, só o novo ou alterado\"], [\"ephemeral\", \"Nenhum\", \"Não, só embutido em quem referencia\", \"Quando o modelo que a referencia é construído\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "ephemeral não elimina o processamento, só elimina o objeto. A lógica ainda roda, só que embutida dentro de quem a referencia, sem deixar rastro consultável no warehouse."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que a materialização `ephemeral` cria no warehouse quando o dbt executa o modelo?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Uma tabela temporária, apagada automaticamente ao final de cada execução do dbt run",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma view, que recalcula a lógica do modelo a cada consulta feita por quem a referencia",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma tabela física idêntica à da materialização table, mas armazenada em um schema separado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Nenhum objeto: a lógica é injetada como CTE dentro do SQL dos modelos que a referenciam",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um modelo `int_clientes_ativos` (ephemeral) é referenciado por `ref()` em três marts diferentes. O que acontece com a lógica desse modelo no SQL compilado de cada um dos três marts?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Ela é injetada como CTE, de forma independente, dentro do SQL compilado de cada um dos três marts",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Ela é calculada uma única vez num objeto compartilhado, e os três marts leem esse mesmo resultado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ela é ignorada nos dois últimos marts, porque um modelo ephemeral só pode ser referenciado uma vez",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ela é convertida automaticamente em view na segunda referência, para evitar recompilar o SQL de novo",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um analista quer investigar os dados de um modelo ephemeral chamado `int_pedidos_validos`, rodando um `SELECT * FROM int_pedidos_validos` direto no editor SQL do warehouse. O que acontece?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "A consulta retorna vazio, porque modelos ephemeral são recriados a cada acesso, sempre sem linhas",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A consulta falha, porque não existe view nem tabela com esse nome no warehouse para ser encontrada",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A consulta funciona normalmente, porque todo modelo dbt vira um objeto consultável, mudando só o custo",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A consulta funciona, mas só retorna as linhas que já foram lidas por algum modelo downstream antes",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um projeto encadeia quatro modelos ephemeral, um referenciando o outro (int_a, int_b, int_c, int_d), até chegar a um mart final que faz `ref('int_d')`. Um erro de SQL aparece só na execução do mart final. Qual é a dificuldade adicional de depurar esse erro, específica do uso de ephemeral em cadeia?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O erro não indica linha nem mensagem alguma, porque modelos ephemeral suprimem toda mensagem de erro do banco",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O dbt não permite encadear modelos ephemeral, então esse projeto não chegaria a compilar de jeito nenhum",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O SQL que efetivamente roda no warehouse é uma única query grande, com as quatro CTEs empilhadas dentro dela",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O erro sempre aponta para int_a, o primeiro da cadeia, mesmo quando o problema está em outro CTE",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um modelo intermediário de deduplicação de clientes precisa, além de alimentar dois marts, também ser consultado ocasionalmente por um analista direto no editor SQL do warehouse, para investigar casos duvidosos. Qual materialização NÃO atende esse segundo requisito?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "table, porque a materialização table nunca grava um objeto físico, só mantém a definição da query",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "incremental, porque a tabela incremental permanece bloqueada para leitura durante todo o dbt run",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "view, porque uma view não armazena dado nenhum e por isso nunca pode ser lida por fora do dbt",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "ephemeral, porque não existe view nem tabela criada para esse modelo no warehouse",
+                                "isCorrect": true
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Escolher a materialização",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Escolher a materialização\n\nAs quatro aulas anteriores mostraram cada materialização isoladamente: view, table, incremental e ephemeral. Na prática, escolher entre elas não é uma questão de qual é \"melhor\", e sim de qual equilíbrio faz sentido para aquele modelo específico, entre três forças que puxam em direções opostas: **custo** de processamento, **frescor** do dado e **complexidade** de manter."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O trade-off entre custo, frescor e complexidade\n\n- **view**: custo de escrita quase zero (só grava a definição), frescor máximo (reflete a origem a cada leitura), complexidade mínima. O custo reaparece na leitura, multiplicado por cada consulta.\n- **table**: custo de escrita alto e constante (reprocessa tudo a cada dbt run), frescor limitado à última execução, complexidade mínima. Em compensação, a leitura fica barata e rápida.\n- **incremental**: o melhor custo em escala (processa só o que mudou), frescor também limitado à última execução, mas com a maior complexidade de configurar e manter (o filtro do is_incremental(), o unique_key, o cuidado com dados atrasados).\n- **ephemeral**: não entra nessa mesma balança de custo de warehouse, porque não é lido diretamente, é reuso de lógica sem gerar objeto. A decisão para ela é sobre organização do projeto, não sobre desempenho de leitura."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Materialização\", \"Custo de escrita\", \"Frescor\", \"Complexidade\"], [\"view\", \"Muito baixo\", \"Sempre atual\", \"Baixa\"], [\"table\", \"Alto, a cada run\", \"Da última execução\", \"Baixa\"], [\"incremental\", \"Baixo após o primeiro run\", \"Da última execução\", \"Alta\"], [\"ephemeral\", \"Nenhum objeto gerado\", \"Não se aplica, sem leitura direta\", \"Baixa a média\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## A regra prática\n\nUma regra de bolso cobre a maioria dos casos, e serve como ponto de partida, não como lei fixa:\n\n- **Staging = view**: modelos `stg_` são numerosos, leves (renomear, tipar, limpar) e servem de base para tudo depois. Frescor barato importa mais do que velocidade de leitura, porque raramente são consultados direto por um dashboard.\n- **Marts muito consultados = table**: um modelo de métricas aberto o dia inteiro numa ferramenta de BI compensa pagar o custo do dbt run para deixar cada leitura rápida.\n- **Fatos grandes = incremental**: quando o volume cresce a ponto de o dbt run de uma table ficar caro ou lento, e só uma fração dos dados muda a cada execução, o custo extra de manter o filtro incremental compensa.\n- **Lógica intermediária leve e reutilizada = ephemeral**: um passo de transformação que existe só para organizar o SQL, sem valor em ser consultado sozinho.\n\nEsses padrões mudam com o tempo: um modelo de staging que passa a ser consultado direto por vários times pode migrar para table, e uma table que cresceu demais pode virar incremental. A escolha inicial não é definitiva."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# dbt_project.yml: define um padrão de materialização por pasta\nmodels:\n  meu_projeto:\n    staging:\n      +materialized: view\n    marts:\n      +materialized: table\n      fatos:\n        +materialized: incremental\n\n-- models/staging/stg_taxas_cambio.sql\n-- Exceção: essa staging é consultada direto por várias ferramentas de BI,\n-- então sobrescreve o padrão da pasta (view) para table\n{{ config(materialized='table') }}\n\nselect\n    moeda_origem,\n    moeda_destino,\n    taxa,\n    data_referencia\nfrom {{ source('financeiro', 'taxas_cambio') }}"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Onde configurar: modelo x dbt_project.yml\n\nA materialização pode ser definida em dois lugares, e os dois convivem:\n\n- **`dbt_project.yml`**: define um padrão por pasta (`+materialized: view` para tudo em `staging/`, por exemplo). É a forma mais prática de manter consistência num projeto com dezenas ou centenas de modelos, sem repetir a mesma config em cada arquivo.\n- **`{{ config(...) }}` no modelo**: sobrescreve o padrão da pasta só para aquele modelo específico. Serve para as exceções, como uma staging que virou table por ser muito consultada, ou um mart que virou incremental por causa do volume.\n\nA prioridade é do modelo: se o `dbt_project.yml` diz view para a pasta inteira e um modelo tem `{{ config(materialized='table') }}` no próprio arquivo, esse modelo específico é uma table, o resto da pasta continua view."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Não existe materialização certa em abstrato, só a que equilibra custo, frescor e complexidade para aquele modelo, naquele volume de dados, com aquele padrão de consulta. A regra prática é o ponto de partida, revisar conforme o projeto cresce é parte do trabalho do analytics engineer."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual das quatro materializações do dbt costuma ser a escolha padrão para a camada de staging, onde os modelos são leves e numerosos?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "view, porque a lógica é leve e o baixo custo de escrita compensa o frescor imediato dos dados",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "table, porque staging é a camada mais consultada por dashboards de BI em qualquer projeto dbt",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "incremental, porque staging processa o maior volume de dados entre todas as camadas do projeto",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "ephemeral, porque staging nunca precisa ser consultada por nenhum modelo downstream depois dela",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um modelo de staging simples (`stg_produtos`) passou a ser consultado direto por três ferramentas de BI diferentes, várias vezes por hora, além de alimentar dois marts. Hoje ele é view e os times reclamam de lentidão nos relatórios. Qual ajuste é mais coerente com a regra prática de materialização?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Mover a lógica desse modelo para dentro de cada mart que o referencia, eliminando o ref() direto",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Sobrescrever esse modelo para table, já que agora ele tem um padrão de leitura pesado e frequente",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Manter como view, porque staging deve permanecer view independente do padrão de consulta observado",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Trocar para ephemeral, para que a lógica seja embutida direto nas ferramentas de BI que o consultam",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um `dbt_project.yml` define `+materialized: view` para toda a pasta `marts/`, mas o arquivo `fct_vendas.sql` tem `{{ config(materialized='incremental', unique_key='venda_id') }}` no topo. Como esse modelo é materializado?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Como view, porque a configuração no dbt_project.yml tem prioridade sobre a do modelo",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O dbt run falha, porque um modelo não pode ter uma config diferente da pasta em que está",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Como incremental, porque a configuração dentro do modelo sobrescreve o padrão da pasta",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Como table, porque configs conflitantes entre modelo e projeto sempre caem no padrão do dbt",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma tabela de fatos recebe 5 mil linhas novas por dia, tem 300 mil linhas no total, e o dbt run atual (table completa) demora 40 segundos. Um engenheiro sugere migrar para incremental para \"economizar custo\". Qual é a consideração mais importante antes de fazer essa mudança?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Migrar sempre compensa, porque incremental é estritamente mais barato que table em qualquer volume",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "incremental só funciona corretamente em tabelas com mais de 1 milhão de linhas, então esse caso não se aplica",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A migração é obrigatória, porque nenhum projeto dbt em produção deveria ter modelos table de fatos",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O ganho de custo pode não compensar a complexidade extra, quando a table atual já roda rápido e barata",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe está decidindo a materialização de um modelo intermediário que só existe para filtrar linhas inválidas antes de dois marts, e nunca é consultado diretamente por ninguém fora do projeto dbt. O volume de dados é pequeno e o custo de processamento não é a preocupação principal. Qual materialização é mais coerente com esse cenário?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "ephemeral, porque a lógica é leve, reutilizada só dentro do projeto, e não precisa virar objeto algum",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "table, para garantir que o filtro fique fisicamente armazenado e disponível para consulta futura",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "incremental, porque qualquer modelo intermediário deve evitar reprocessar dados desnecessariamente",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "view, porque modelos intermediários devem sempre ficar visíveis como objeto no schema do warehouse",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 5 - Testes, documentação e qualidade no dbt",
+        "aulas": [
+            {
+                "titulo": "Testes genéricos",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Testes genéricos\n\nUm modelo dbt é um SELECT, e um SELECT sozinho não avisa quando o resultado está errado. Uma coluna que deveria ser única pode passar a ter duplicatas depois que a fonte muda um comportamento, uma chave estrangeira pode apontar para um cliente que não existe mais, um status pode chegar com um valor novo que ninguém mapeou. Sem teste, esse tipo de problema só aparece quando alguém do negócio desconfia de um número no dashboard.\n\nO dbt resolve isso com testes que rodam como parte do próprio projeto, declarados em YAML, sem precisar escrever uma linha de SQL para os casos mais comuns. São os testes genéricos: `unique`, `not_null`, `accepted_values` e `relationships`, os quatro testes que já vêm prontos no dbt Core."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Os quatro testes genéricos\n\nCada teste genérico verifica uma afirmação específica sobre uma coluna:\n\n- **`unique`**: nenhum valor se repete na coluna, o teste natural para uma chave primária, como `order_id` numa tabela de pedidos.\n- **`not_null`**: a coluna nunca vem vazia, essencial em chaves e em qualquer campo que uma métrica soma ou agrupa.\n- **`accepted_values`**: o valor da coluna está sempre dentro de uma lista fechada, como `status` só podendo ser `pending`, `shipped` ou `cancelled`.\n- **`relationships`**: todo valor da coluna existe como valor de referência em outro modelo, a checagem clássica de integridade referencial.\n\nOs quatro são declarados sob a coluna, dentro do `schema.yml` que descreve o modelo."
+                    },
+                    {
+                        "type": "code",
+                        "value": "models:\n  - name: stg_orders\n    columns:\n      - name: order_id\n        tests:\n          - unique\n          - not_null\n      - name: status\n        tests:\n          - accepted_values:\n              values: ['pending', 'shipped', 'cancelled']\n      - name: customer_id\n        tests:\n          - not_null\n          - relationships:\n              to: ref('stg_customers')\n              field: customer_id"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Teste genérico\",\"O que verifica\"],[\"unique\",\"Nenhum valor se repete na coluna\"],[\"not_null\",\"A coluna não tem nenhum valor nulo\"],[\"accepted_values\",\"O valor está dentro de uma lista fixa permitida\"],[\"relationships\",\"Todo valor existe como referência em outro modelo\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Rodando os testes\n\nO comando `dbt test` executa todos os testes declarados no projeto. Para rodar só os de um modelo, `dbt test --select stg_orders`. Cada teste genérico vira, por trás, uma consulta que conta quantas linhas violam a condição: zero linhas é `PASS`, uma ou mais é `FAIL`.\n\nPor padrão, uma falha marca o teste como erro. Quando o time quer só ser avisado, sem travar o build por causa de um caso que ainda não virou prioridade, dá para configurar a severidade desse teste como `warn` no lugar de `error`.\n\nComo testes e modelos moram no mesmo grafo de dependências, `dbt build` constrói e testa cada modelo na ordem certa, um depois do outro, em vez de rodar tudo primeiro para só testar no final."
+                    },
+                    {
+                        "type": "code",
+                        "value": "$ dbt test --select stg_orders\n\n1 of 4 START test not_null_stg_orders_order_id ......... [RUN]\n1 of 4 PASS not_null_stg_orders_order_id ................ [PASS in 0.41s]\n2 of 4 START test unique_stg_orders_order_id ............ [RUN]\n2 of 4 PASS unique_stg_orders_order_id .................. [PASS in 0.38s]\n3 of 4 START test accepted_values_stg_orders_status ..... [RUN]\n3 of 4 FAIL 2 accepted_values_stg_orders_status ......... [FAIL 2 in 0.35s]\n4 of 4 START test relationships_stg_orders_customer_id .. [RUN]\n4 of 4 PASS relationships_stg_orders_customer_id ......... [PASS in 0.44s]\n\nCompleted with 1 error and 0 warnings"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Um teste genérico não substitui a modelagem, ele confirma que uma suposição sobre o dado continua verdadeira a cada execução do pipeline."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "No dbt, o teste genérico `unique` aplicado à coluna `order_id` verifica o quê?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Se o order_id nunca se repete entre as linhas do modelo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Se o order_id nunca aparece vazio em nenhuma linha do modelo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Se o order_id está sempre dentro de uma lista de valores aceitos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Se o order_id existe como referência em outro modelo do projeto.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "A tabela stg_pedidos tem a coluna customer_id, e o time quer garantir que todo pedido aponte para um cliente que realmente existe em stg_clientes. Qual teste genérico resolve isso?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "unique, aplicado à customer_id de stg_pedidos, para impedir que o mesmo cliente apareça duas vezes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "relationships, aplicado à customer_id de stg_pedidos, apontando para o customer_id de stg_clientes.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "not_null, aplicado à customer_id de stg_pedidos, para impedir que o campo fique vazio em algum pedido.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "accepted_values, aplicado à customer_id de stg_pedidos, com a lista de clientes ativos no momento.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um pipeline de pedidos historicamente só usava os status pending, shipped e cancelled no accepted_values de status. A origem passou a emitir um novo status, returned, sem avisar ninguém. O que acontece na próxima execução de dbt test?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O teste accepted_values de status é ignorado, porque esse teste só falha quando um valor conhecido some da lista.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O modelo stg_orders para de compilar, porque o SELECT rejeita qualquer valor fora da lista de status.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O teste accepted_values de status passa a falhar, sinalizando o valor returned que ainda não está na lista.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O arquivo schema.yml é atualizado automaticamente pelo dbt, incluindo returned na lista de valores aceitos.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Ao rodar dbt test, o teste relationships aplicado a customer_id de stg_pedidos falha e aponta 12 linhas problemáticas. O que essas 12 linhas representam?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "12 clientes de stg_clientes que ainda não têm nenhum pedido em stg_pedidos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "12 pedidos com o mesmo customer_id repetido mais de uma vez em stg_pedidos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "12 pedidos com o campo customer_id vazio, sem nenhum valor preenchido.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "12 pedidos cujo customer_id não existe entre os valores de stg_clientes.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O time decidiu que o teste not_null na coluna telefone de stg_clientes deve alertar quando falhar, mas sem quebrar o dbt build, já que telefone é opcional para clientes antigos. Qual configuração aplica esse comportamento?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Configurar a severidade desse teste como warn, para ele reportar como aviso em vez de quebrar o build.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Trocar not_null por unique na mesma coluna, para o teste falhar só em caso de duplicidade.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Remover o teste do schema.yml e acompanhar os nulos manualmente pelo dashboard de BI.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Configurar a severidade desse teste como error, para o dbt test sempre interromper o build ao falhar.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Testes singulares",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Testes singulares\n\nNem toda regra de negócio cabe em `unique`, `not_null`, `accepted_values` ou `relationships`. Como garantir que o valor total de um pedido é igual à soma dos seus itens? Que a receita de uma linha nunca fica negativa? Que a data de um pedido nunca é posterior à data de hoje? Essas são comparações entre colunas, entre modelos, ou cálculos que um teste genérico de coluna não expressa.\n\nPara esses casos existe o teste singular: um arquivo `.sql` dentro da pasta `tests/`, escrito à mão, que aplica exatamente a mesma lógica de um modelo comum, um SELECT com `ref()` e `source()`."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## A regra do teste singular\n\nUm teste singular é um SELECT que não deveria retornar nenhuma linha. O dbt roda a query, e se ela devolver zero linhas, o teste passa. Se devolver uma ou mais linhas, o teste falha, e cada linha retornada é um registro que quebrou a regra, útil para investigar o problema depois.\n\nNão existe sintaxe especial: é só escrever a consulta que encontraria os casos ruins, o oposto do que a regra permite. Se a regra é \"o total do pedido bate com a soma dos itens\", o teste seleciona os pedidos em que isso não acontece."
+                    },
+                    {
+                        "type": "code",
+                        "value": "-- tests/assert_total_pedido_bate_com_itens.sql\n-- Falha se existir pedido cujo total declarado diverge da soma dos itens\n\nselect\n    p.order_id,\n    p.total_pedido,\n    sum(i.valor_item) as total_calculado\nfrom {{ ref('stg_orders') }} p\njoin {{ ref('stg_order_items') }} i on i.order_id = p.order_id\ngroup by p.order_id, p.total_pedido\nhaving abs(p.total_pedido - sum(i.valor_item)) > 0.01"
+                    },
+                    {
+                        "type": "code",
+                        "value": "-- tests/assert_receita_nao_negativa.sql\n-- Falha se existir alguma linha de receita menor que zero\n\nselect *\nfrom {{ ref('fct_receita') }}\nwhere valor_receita < 0"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Quando escolher cada um\n\nTestes genéricos cobrem a maior parte do dia a dia porque são rápidos de declarar, uma linha de YAML por coluna, e cobrem os casos mais comuns: unicidade, nulo, domínio de valores, integridade referencial. O teste singular entra quando a regra envolve mais de uma coluna, mais de um modelo, um cálculo, ou uma condição específica do negócio que nenhum teste genérico consegue expressar sozinho."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Aspecto\",\"Teste genérico\",\"Teste singular\"],[\"Onde é declarado\",\"No schema.yml, sob a coluna\",\"Um arquivo .sql na pasta tests/\"],[\"Como é escrito\",\"Nome do teste mais parâmetros em YAML\",\"Um SELECT completo, em SQL\"],[\"Bom para\",\"Regras comuns de uma coluna isolada\",\"Regras de negócio específicas, entre colunas ou modelos\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Um teste singular é uma pergunta que só devia ter uma resposta possível: nenhuma linha. Toda vez que aparece uma linha, a realidade quebrou a regra que alguém do time decidiu proteger."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Sobre um teste singular no dbt, arquivo .sql dentro de tests/, o que determina se ele passa ou falha?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "O teste falha sempre que a query demora mais que um limite de tempo configurado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O teste passa quando a query não retorna nenhuma linha, e falha quando retorna alguma.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O teste passa quando a query retorna ao menos uma linha, confirmando a regra aplicada.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O teste falha somente quando a query lança um erro de sintaxe ao ser compilada.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um analista quer garantir que, em fct_pedidos, a soma dos itens de cada pedido em fct_itens_pedido sempre bate com o total_pedido registrado. Qual é a forma correta de implementar essa checagem no dbt?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Um teste accepted_values na coluna total_pedido, listando os totais válidos permitidos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um teste relationships entre total_pedido e a coluna valor_item de fct_itens_pedido.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um teste singular que soma os itens por pedido e seleciona os casos em que o total diverge.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um teste not_null na coluna total_pedido, para impedir que o campo fique vazio em algum pedido.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de rodar dbt test, o teste singular assert_receita_nao_negativa retornou 3 linhas. O que isso significa?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O teste passou, e as 3 linhas são um resumo estatístico do resultado da checagem.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A query do teste tem um erro de sintaxe, e as 3 linhas mostram onde o erro ocorreu.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Existem 3 modelos no projeto que dependem de fct_receita e podem estar afetados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Existem 3 linhas em fct_receita cujo valor_receita ficou menor que zero.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma regra de negócio diz que a data_pedido nunca pode ser posterior à data de hoje. Por que essa checagem exige um teste singular, e não um teste genérico como accepted_values?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Porque accepted_values exige uma lista fixa de valores, e essa regra depende de um cálculo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque accepted_values só pode ser aplicado a colunas numéricas, e data_pedido é do tipo data.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque accepted_values exige que a coluna testada seja a chave primária do modelo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque accepted_values não pode ser combinado com not_null na mesma coluna do modelo.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um teste singular chamado assert_pedidos_sem_cliente_orfao.sql foi criado em tests/ e usa ref('stg_orders') e ref('stg_customers') dentro do mesmo SELECT, com um join entre os dois. Isso é uma prática válida no dbt?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Não, testes singulares só podem referenciar um único modelo por arquivo, nunca dois com join.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Sim, um teste singular usa ref() e source() como um modelo, e entra no grafo de dependências.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Não, ref() e source() só funcionam dentro da pasta models/, nunca dentro de tests/.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Sim, mas apenas se o arquivo for registrado manualmente na lista de testes do dbt_project.yml.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Documentação e o dbt docs",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Documentação e o dbt docs\n\nUm modelo dbt pronto, testado e rodando em produção ainda pode ser inútil para quem chega depois, se ninguém souber o que uma coluna significa, de onde vêm os números de fct_receita, ou por que um filtro específico existe no meio do SELECT. Documentação não é um extra: é a diferença entre um projeto que qualquer pessoa do time consegue navegar e um projeto que só quem escreveu entende.\n\nO dbt trata documentação como parte do mesmo arquivo YAML que já declara os testes, e gera um site navegável a partir dela, sem precisar manter um documento separado que desatualiza sozinho."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## description no schema.yml\n\nCada modelo e cada coluna podem receber uma `description` no `schema.yml`. A descrição do modelo explica o propósito dele, o que representa uma linha, para que serve; a descrição de cada coluna explica o significado do campo, principalmente quando o nome sozinho não é óbvio, como status, tipo ou códigos internos do negócio.\n\nEssas descrições aceitam markdown, e viram parte do artefato que o dbt compila: aparecem no site de documentação exatamente como foram escritas."
+                    },
+                    {
+                        "type": "code",
+                        "value": "models:\n  - name: stg_orders\n    description: 'Um pedido por linha, já limpo e renomeado a partir da fonte bruta de vendas.'\n    columns:\n      - name: order_id\n        description: 'Identificador único do pedido, chave primária do modelo.'\n        tests:\n          - unique\n          - not_null\n      - name: status\n        description: 'Situação atual do pedido: pending, shipped ou cancelled.'\n        tests:\n          - accepted_values:\n              values: ['pending', 'shipped', 'cancelled']"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## dbt docs generate e dbt docs serve\n\n`dbt docs generate` compila a documentação do projeto: lê as descriptions do schema.yml, os testes declarados, o SQL de cada modelo, bruto e compilado, e consulta o warehouse para trazer metadados reais, como o tipo de cada coluna. O resultado vira um site estático.\n\n`dbt docs serve` sobe um servidor local para navegar nesse site pelo navegador, sem precisar publicar nada externamente só para conferir o resultado."
+                    },
+                    {
+                        "type": "code",
+                        "value": "$ dbt docs generate\nDocumentação compilada: 24 modelos, 3 seeds, 2 snapshots\n\n$ dbt docs serve\nServindo o site de documentação em http://localhost:8080"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Seção do site\",\"O que mostra\"],[\"Overview de cada modelo\",\"Description do modelo, colunas, tipos e descriptions de cada coluna\"],[\"Grafo de linhagem (DAG)\",\"Todas as dependências via ref() e source(), navegável visualmente\"],[\"Testes\",\"Quais testes genéricos e singulares cobrem cada coluna ou modelo\"],[\"Código\",\"O SQL bruto escrito e o SQL compilado, pronto para rodar no warehouse\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "O site de documentação não é escrito à parte, ele nasce do mesmo schema.yml que já declara os testes: documentar deixa de ser tarefa extra e vira parte de terminar o modelo."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que o comando dbt docs generate faz?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Roda todos os testes genéricos e singulares do projeto, gerando um relatório de cobertura.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Materializa os modelos no warehouse, criando as tabelas e views do projeto.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Compila a documentação do projeto: descriptions, testes e metadados do warehouse, num site.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Publica o projeto dbt num repositório remoto, versionando as mudanças automaticamente.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um analista roda dbt docs generate e depois quer navegar pelo site no navegador, sem publicar nada externamente. Qual comando ele usa em seguida?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "dbt run, para materializar os modelos antes de qualquer visualização ser possível.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "dbt build, para rodar modelos e testes juntos antes de abrir a documentação.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "dbt test, para validar que a documentação gerada não tem nenhum erro de sintaxe.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "dbt docs serve, que sobe um servidor local para navegar pelo site já compilado.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um modelo mart_receita_mensal tem 15 colunas, mas nenhuma delas recebeu description no schema.yml. Qual é a consequência mais direta disso no site do dbt docs?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O site é gerado normalmente, mas as colunas aparecem sem nenhuma explicação para quem consultar.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O comando dbt docs generate falha, porque toda coluna precisa de uma description preenchida.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "As colunas somem do grafo de linhagem, porque o dbt só desenha nós que têm description.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O modelo deixa de ser materializado no próximo dbt run, até que as descriptions sejam adicionadas.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "No grafo de linhagem do site do dbt docs, as setas que ligam um modelo a outro são construídas a partir de qual informação?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Da ordem em que os arquivos aparecem dentro da pasta models/ no sistema de arquivos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Das chamadas a ref() e source() usadas dentro do SQL de cada modelo, que definem o DAG.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Da ordem alfabética dos nomes dos modelos, calculada automaticamente pelo dbt docs generate.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Das descriptions escritas no schema.yml, que indicam manualmente de qual modelo cada um depende.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um time de analytics engineering decide que nenhum modelo pode ser mesclado sem description no modelo e nas colunas principais. Qual é o principal ganho dessa política?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Os modelos passam a rodar mais rápido no warehouse, porque a documentação otimiza o SQL compilado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os testes genéricos passam a ser gerados automaticamente a partir do texto de cada description.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Quem consulta o modelo depois entende seu propósito no site, sem precisar perguntar a quem escreveu.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O dbt passa a bloquear qualquer alteração no modelo que não venha acompanhada de um novo teste.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Sources e freshness",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Sources e freshness\n\nAntes do primeiro modelo dbt rodar, o dado já está em algum lugar do warehouse: uma ferramenta de ingestão como Fivetran ou Airbyte carregou uma tabela bruta, replicando o que existe num banco transacional ou numa API. O dbt não faz essa ingestão, isso é tema de outra trilha, mas precisa saber onde essa tabela bruta está para poder começar a transformar a partir dela.\n\nÉ para isso que existe o source: uma forma de declarar, em YAML, que uma tabela bruta existe num determinado schema do warehouse, e de referenciá-la nos modelos sem espalhar o nome físico dela pelo projeto inteiro."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Declarando uma source\n\nUma source é declarada sob a chave `sources:` no schema.yml, separada da chave `models:`, com o nome do schema físico e a lista de tabelas que interessam ao projeto. A partir daí, qualquer modelo referencia essa tabela com `source('nome_da_source', 'nome_da_tabela')`, em vez de escrever o schema e a tabela direto no SELECT.\n\nIsso dá ao dbt visibilidade sobre onde o projeto começa: o source vira o primeiro nó do grafo de linhagem, antes de qualquer modelo de staging."
+                    },
+                    {
+                        "type": "code",
+                        "value": "sources:\n  - name: erp\n    database: raw\n    schema: erp_raw\n    tables:\n      - name: orders\n      - name: customers\n\n-- models/staging/stg_orders.sql\nselect\n    id as order_id,\n    customer_id,\n    status,\n    created_at as data_pedido\nfrom {{ source('erp', 'orders') }}"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Freshness: o dado ainda está atualizado?\n\nUma tabela bruta pode existir e mesmo assim estar velha: a ferramenta de ingestão pode ter parado de rodar, uma credencial pode ter expirado, um job pode estar falhando silenciosamente há dois dias. Sem checar isso, o dbt run continua funcionando normalmente, e os modelos são recalculados em cima de dados que já não mudam há muito tempo, sem ninguém perceber até um número parecer estranho no BI.\n\nO dbt resolve isso com freshness: uma configuração que compara o valor mais recente de uma coluna de data ou timestamp, o `loaded_at_field`, com o momento atual, e classifica a source como em dia, atrasada ou vencida."
+                    },
+                    {
+                        "type": "code",
+                        "value": "sources:\n  - name: erp\n    database: raw\n    schema: erp_raw\n    tables:\n      - name: orders\n        loaded_at_field: _loaded_at\n        freshness:\n          warn_after: {count: 12, period: hour}\n          error_after: {count: 24, period: hour}"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## dbt source freshness\n\nO comando `dbt source freshness` roda essa checagem para cada tabela declarada: busca o valor mais recente de `loaded_at_field`, compara com os limites de `warn_after` e `error_after`, e reporta o resultado por tabela. Uma source com mais de 12 horas desde a última carga aparece como `WARN`; com mais de 24 horas, como `ERROR`.\n\nEsse comando costuma rodar antes do resto do pipeline, num job agendado separado: não faz sentido gastar tempo transformando dados que já estão velhos na origem, e o resultado serve como alerta para o time responsável pela ingestão."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Um dbt run que termina com sucesso não garante que o dado está atualizado, só que o SELECT rodou sem erro. Freshness é quem responde a pergunta que realmente importa: esse dado ainda serve para decisão?"
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Por que um modelo de staging usa source('erp', 'orders') em vez de escrever direto o nome do schema e da tabela bruta no SELECT?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Porque source() converte automaticamente os tipos de dado da tabela bruta para os tipos de destino.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque source() aplica os testes genéricos da tabela bruta antes de qualquer modelo poder lê-la.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque source() materializa uma cópia da tabela bruta dentro do schema de destino do projeto.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque source() registra a tabela como nó do grafo de dependências, além de centralizar sua localização.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma fonte erp.orders é declarada com loaded_at_field igual a _loaded_at, warn_after de 12 horas e error_after de 24 horas. A última linha carregada tem _loaded_at de 30 horas atrás. O que dbt source freshness reporta para essa tabela?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "ERROR, porque o intervalo desde a última carga passou do limite de error_after.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "WARN, porque o intervalo desde a última carga ainda está dentro do limite de error_after.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "PASS, porque a tabela existe e tem ao menos uma linha com valor em _loaded_at.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "PASS, porque o freshness só é calculado na primeira vez que a source é declarada no projeto.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma source foi declarada em schema.yml com name, database, schema e a lista de tables, mas sem nenhum bloco freshness nem loaded_at_field. O que acontece ao rodar dbt source freshness para essa tabela?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O comando inteiro falha com erro, porque toda source do projeto precisa ter freshness configurado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Essa tabela é simplesmente ignorada na checagem, já que faltam loaded_at_field e limites.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O dbt assume um valor padrão de 24 horas para warn_after e error_after nessa tabela.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O dbt usa a data de criação da tabela no warehouse como loaded_at_field automaticamente.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe roda dbt source freshness antes de dbt build, num job separado e agendado mais cedo. Qual é a principal razão para checar freshness antes de transformar, e não só depois que os modelos já rodaram?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Porque dbt source freshness precisa rodar antes de qualquer source ser declarada no schema.yml.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque rodar freshness depois faz o dbt build falhar automaticamente em qualquer cenário de atraso.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque não compensa gastar tempo e custo transformando dados que já chegaram desatualizados na origem.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque a ordem de execução não influencia o resultado, e checar antes é só uma convenção sem efeito.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Numa source com warn_after de 6 horas e error_after de 48 horas, uma tabela está há 20 horas sem carga nova. O que o resultado WARN, em vez de ERROR, comunica para o time?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Que a tabela nunca recebeu nenhuma carga desde que o projeto dbt foi criado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que o teste de freshness falhou de forma definitiva e bloqueou o restante do dbt build.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que o loaded_at_field configurado para essa tabela está com o nome errado no schema.yml.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que o atraso passou do limite de atenção, mas não chegou ao limite considerado crítico.",
+                                "isCorrect": true
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Testar cedo e a confiança no pipeline",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Testar cedo e a confiança no pipeline\n\nO mesmo problema custa preços muito diferentes dependendo de onde é encontrado. Um customer_id duplicado pego por um teste unique na staging é uma linha no log do dbt test. O mesmo customer_id duplicado, não pego, pode se multiplicar em cada join feito rio abaixo, inflar métricas em três ou quatro marts diferentes, e só ser percebido quando alguém do financeiro pergunta por que a receita do mês fechou maior do que o esperado.\n\nTestar cedo não é só uma questão de disciplina, é uma questão de custo: quanto mais perto da fonte um problema é pego, mais barato costuma ser corrigir."
+                    },
+                    {
+                        "type": "code",
+                        "value": "fonte bruta (source)\n      |\n      v\n  staging       <- teste unique/not_null aqui pega o problema com 1 modelo afetado\n      |\n      v\nintermediate    <- o mesmo problema, se escapou, já contamina joins e agregações\n      |\n      v\n    marts       <- e aqui aparece multiplicado em várias métricas de negócio\n      |\n      v\n      BI        <- e aqui vira um número errado na frente de quem decide"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Testar na camada certa\n\nCada camada tem uma responsabilidade diferente, e o teste certo em cada uma reflete isso. A staging é a fronteira entre o dado bruto e o projeto dbt: é ali que faz sentido validar as suposições sobre a fonte, como o customer_id ser único, o status estar dentro dos valores esperados, e as colunas obrigatórias nunca virem nulas. Se a fonte quebrar uma dessas suposições, o teste falha bem no início do grafo, antes de qualquer modelo de intermediate ou marts sequer usar aquele dado.\n\nIsso não elimina a necessidade de testes em marts: regras de negócio, como o total do pedido bater com a soma dos itens, continuam fazendo mais sentido perto do modelo final que calcula esse número. Mas a integridade básica da fonte se testa o quanto antes."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Camada\",\"O que faz sentido testar ali\",\"Exemplo\"],[\"staging\",\"Suposições sobre a fonte bruta\",\"unique e not_null em customer_id, accepted_values em status\"],[\"intermediate\",\"Resultado de joins e agregações intermediárias\",\"not_null em colunas calculadas que alimentam os marts\"],[\"marts\",\"Regras de negócio do número final entregue ao BI\",\"teste singular comparando total do pedido com a soma dos itens\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## A confiança que testes dão\n\nUm projeto dbt com testes e documentação em dia muda a relação do time com o próprio pipeline. Alguém pode alterar um modelo de intermediate sem precisar conferir manualmente todo o histórico de dashboards: os testes fazem essa conferência. Um novo integrante do time consegue entender o que um modelo garante lendo o schema.yml, sem precisar perguntar para quem escreveu.\n\nEssa confiança é o que permite mudar o pipeline com velocidade, e é também a porta de entrada para temas mais amplos de qualidade e governança de dados, como contratos de dados e catálogos, que pertencem a uma trilha própria e não são o foco aqui."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Antes de considerar um modelo pronto\n\nFechando o módulo, vale reunir num checklist curto o que as cinco aulas cobriram: testes genéricos nas colunas óbvias, chaves, domínios, referências; um teste singular onde a regra de negócio exige; description no modelo e nas colunas principais; e a source de onde ele parte com freshness configurada, se depender de uma fonte que pode atrasar. Nenhum desses itens é opcional por padrão: são o que separa um SELECT que funciona hoje de um modelo em que o time inteiro pode confiar amanhã."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Teste não existe para provar que o pipeline funciona uma vez, existe para avisar rápido no dia em que ele parar de funcionar."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Por que faz sentido concentrar os testes que validam suposições sobre a fonte bruta, como a unicidade de uma chave, já na camada de staging?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Porque ali o problema é pego na entrada do projeto, antes de se espalhar pelos joins seguintes.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque a camada de staging é a única em que o dbt test consegue rodar testes genéricos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque modelos de staging não fazem parte do grafo de linhagem, então testar ali é mais barato.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque a camada de marts não permite declarar tests no schema.yml dos seus modelos.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um customer_id duplicado na fonte não foi pego por nenhum teste em staging. O modelo de intermediate faz join dessa tabela com outras três, e os marts finais somam valores a partir desse resultado. Qual é o efeito mais provável desse duplicado não pego cedo?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Nenhum efeito prático, porque duplicatas em customer_id nunca afetam o resultado de um join.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O duplicado se multiplica nos joins, inflando os valores agregados em mais de um mart ao mesmo tempo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O dbt run seguinte falha automaticamente, porque duplicatas em qualquer coluna interrompem a execução.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O problema fica isolado no modelo de intermediate, sem chegar a nenhum modelo de marts.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "A regra 'o total do pedido bate com a soma dos itens' depende de dois modelos e de um cálculo de soma. Em qual camada esse teste faz mais sentido, e por quê?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Na camada de staging, porque toda regra de negócio deve ser testada antes de qualquer transformação.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Fora do dbt, num script separado, porque testes que envolvem dois modelos não são suportados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Perto do modelo de marts que calcula esse total, porque é ali que a regra de negócio final é conferida.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Em nenhuma camada específica, porque testes singulares não pertencem ao grafo de dependências.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um time percebe que corrigir um dado errado identificado por um teste em staging leva minutos, enquanto o mesmo tipo de erro, quando só é percebido depois de aparecer num dashboard executivo, leva dias de investigação para rastrear a causa. Que conclusão sobre testes esse cenário sustenta?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Que testes em staging são opcionais, já que o problema seria descoberto de qualquer forma mais tarde.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que apenas testes na camada de marts têm valor, porque é ali que o negócio enxerga o número final.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que o custo de um erro é sempre o mesmo, independentemente de em qual camada ele é encontrado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que quanto mais cedo no pipeline um teste pega o problema, mais barato costuma ser corrigi-lo.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Segundo o conteúdo desta aula, qual é a relação entre os testes de dbt cobertos no módulo e os temas mais amplos de qualidade e governança de dados?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Os testes de dbt constroem a confiança básica do pipeline, a porta de entrada para os temas mais amplos.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Os testes de dbt substituem por completo os temas de governança, sem depender de uma trilha própria.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os testes de dbt não têm nenhuma relação com qualidade de dados, sendo assuntos independentes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os testes de dbt só passam a ter valor depois que o time implementa um catálogo de dados completo.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 6 - dbt avançado e reuso",
+        "aulas": [
+            {
+                "titulo": "Jinja e macros",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Jinja e macros\n\nTodo modelo dbt é, na essência, um arquivo `.sql` com um `select`. A diferença para um script solto é que esse `select` pode conter Jinja, uma linguagem de templates que o dbt processa antes de mandar qualquer coisa para o warehouse. O resultado desse processamento é o SQL compilado: só esse SQL final, sem nenhuma marca de Jinja, é o que roda no banco."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## As marcas do Jinja\n\nDentro de um modelo dbt, Jinja aparece em três formatos:\n\n- `{{ ... }}`: uma expressão que devolve um valor, como `{{ ref('stg_pedidos') }}` ou `{{ config(materialized='table') }}`.\n- `{% ... %}`: uma instrução de controle, como um `{% if %}`, um `{% for %}` ou a abertura de um `{% macro %}`.\n- `{# ... #}`: um comentário, que some completamente do SQL compilado.\n\n`ref()` e `source()`, vistos no módulo 3, já são Jinja: são funções embutidas do próprio dbt, que resolvem o nome completo da tabela no warehouse em tempo de compilação."
+                    },
+                    {
+                        "type": "code",
+                        "value": "-- models/marts/financeiro/fin_pedidos.sql\nselect\n    pedido_id,\n    cliente_id,\n    receita,\n    custo\nfrom {{ ref('int_pedidos_financeiro') }}\n\n{% if target.name == 'dev' %}\n-- em desenvolvimento, roda só numa amostra para ser mais rápido\nlimit 1000\n{% endif %}"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Macros: uma função que devolve SQL\n\nUm macro é um pedaço de Jinja, geralmente misturado com SQL, que recebe parâmetros e devolve texto, do mesmo jeito que uma função recebe argumentos e devolve um valor. A diferença é que o que ele devolve não é um número ou uma string qualquer: é um trecho de SQL, que entra no lugar em que o macro foi chamado, antes da compilação.\n\nMacros ficam em arquivos `.sql` dentro da pasta `macros/` do projeto e ficam disponíveis para qualquer modelo, sem nenhum import explícito."
+                    },
+                    {
+                        "type": "code",
+                        "value": "-- macros/divisao_segura.sql\n{% macro divisao_segura(numerador, denominador) %}\n    case\n        when {{ denominador }} = 0 then null\n        else {{ numerador }} / {{ denominador }}\n    end\n{% endmacro %}\n\n-- uso dentro de um modelo\nselect\n    pedido_id,\n    {{ divisao_segura('receita - custo', 'receita') }} as margem_pct\nfrom {{ ref('int_pedidos_financeiro') }}"
+                    },
+                    {
+                        "type": "code",
+                        "value": "-- SQL compilado (dbt compile), o que de fato roda no warehouse\nselect\n    pedido_id,\n    case\n        when receita = 0 then null\n        else (receita - custo) / receita\n    end as margem_pct\nfrom analytics.intermediate.int_pedidos_financeiro"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "O warehouse nunca recebe Jinja, só SQL. Quem faz a ponte entre o `{{ }}` do modelo e o select final é a compilação do dbt, e é esse SQL compilado, não o arquivo fonte, que roda de fato no banco."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "No dbt, qual é a função de um macro escrito em Jinja dentro de um projeto?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Gerar um trecho de SQL reutilizável, que é expandido dentro dos modelos antes da compilação.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Agendar a ordem de execução dos modelos, definindo qual roda antes de qual dentro do DAG.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Validar os dados depois da carga, retornando erro quando uma linha foge da regra esperada.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Declarar uma tabela que já existe no warehouse, tornando-a disponível para os modelos.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um time percebe que a mesma expressão de divisão segura, com um `case when denominador = 0 then null else numerador/denominador end`, está copiada em oito modelos diferentes. Toda vez que alguém corrige um detalhe de arredondamento, precisa repetir a mudança nos oito arquivos. Qual é a melhor forma de resolver isso no dbt?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Transformar os oito modelos em snapshots, para que o dbt versione a expressão automaticamente.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Extrair a expressão para um macro Jinja e chamá-lo nos oito modelos, mudando a lógica num só lugar.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Aplicar um teste genérico de `not_null` na coluna calculada, o que corrige o arredondamento na origem.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Extrair a expressão para um source único e referenciá-lo a partir dos oito modelos existentes.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Dentro de um modelo dbt, um desenvolvedor abre um bloco `{% if target.name == 'dev' %}` para limitar o volume de dados só em desenvolvimento. Por que essa instrução usa chaves com percentual (`{% %}`), e não chaves duplas (`{{ }}`)?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque `{% %}` só funciona dentro de macros, enquanto `{{ }}` só funciona dentro de modelos comuns.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque `{% %}` é a sintaxe usada só por `ref()` e `source()`, diferente das demais funções do dbt.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque `{% %}` marca uma instrução de controle do Jinja, e não um valor a inserir no SQL.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque `{% %}` roda em tempo de execução no warehouse, enquanto `{{ }}` roda antes, na compilação.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma pessoa nova no time cria um macro chamado `receita_liquida`, que retorna a expressão `(receita - impostos)`, e depois reclama que, ao rodar `dbt run`, nenhuma tabela `receita_liquida` foi criada no warehouse. Qual é a explicação correta para isso?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O macro precisava estar listado no `dbt_project.yml`, na seção de models, para ser materializado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Macros só materializam quando o projeto roda em produção, nunca durante execuções locais de desenvolvimento.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O nome do macro colidiu com uma palavra reservada do dbt, e por isso a criação da tabela falhou em silêncio.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um macro não materializa nada sozinho: ele só gera SQL, que precisa ser chamado dentro de um modelo.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um modelo com uma chamada de macro está retornando erro de sintaxe SQL no `dbt run`, mas a mensagem não deixa claro qual parte do Jinja causou o problema. Qual é o caminho mais direto para ver exatamente o SQL que o dbt tentou executar no warehouse?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Rodar `dbt compile` e inspecionar o arquivo gerado em `target/compiled`, já sem nenhum Jinja.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Rodar `dbt debug`, comando que existe justamente para mostrar o SQL compilado de cada modelo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Rodar `dbt seed` de novo, já que erro de sintaxe em macro costuma vir de um seed desatualizado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Abrir direto o log do warehouse, porque o dbt não guarda em lugar nenhum o SQL que foi executado.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Packages",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Packages\n\nUm projeto dbt não precisa resolver tudo do zero. Assim como uma aplicação importa bibliotecas prontas em vez de reescrever cada função utilitária, um projeto dbt pode depender de outros projetos dbt, chamados packages. Um package é, na prática, um conjunto de macros, e às vezes também modelos e testes, publicado para ser reaproveitado por qualquer projeto."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## dbt_utils: o package mais usado\n\nO `dbt_utils`, mantido pela comunidade dbt, é o package mais instalado do ecossistema. Ele reúne macros genéricas que praticamente todo projeto analítico precisa em algum momento: gerar uma chave substituta a partir de várias colunas, montar uma tabela de datas, pivotar valores de linha para coluna, comparar o schema de duas relações, entre outras. Também existem packages mais específicos, para um sistema de origem conhecido ou um domínio de negócio particular."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# packages.yml, na raiz do projeto\npackages:\n  - package: dbt-labs/dbt_utils\n    version: [\">=1.1.0\", \"<2.0.0\"]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## dbt deps: instalando o package\n\nDeclarar o package no `packages.yml` não é suficiente para usá-lo: é preciso rodar `dbt deps`, que baixa a versão compatível de cada package listado para dentro do projeto. A partir daí, as macros do package ficam disponíveis em qualquer modelo, chamadas com o prefixo do package, como `{{ dbt_utils.generate_surrogate_key([...]) }}`. Um projeto real também gera um arquivo de lock com a versão exata resolvida de cada package, para que o build seja reprodutível entre máquinas."
+                    },
+                    {
+                        "type": "code",
+                        "value": "-- gerando uma chave substituta a partir de colunas naturais\nselect\n    {{ dbt_utils.generate_surrogate_key(['pedido_id', 'item_id']) }} as sk_item_pedido,\n    pedido_id,\n    item_id,\n    quantidade\nfrom {{ ref('stg_itens_pedido') }}"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Decisão\",\"Escrever a macro do zero\",\"Usar um package como o dbt_utils\"],[\"Tempo\",\"Reimplementa e testa uma lógica já resolvida\",\"Já vem testada e usada por milhares de projetos\"],[\"Manutenção\",\"Fica só a cargo do time interno\",\"Mantida pela comunidade, com versões estáveis\"],[\"Quando faz sentido\",\"Regra de negócio específica, sem equivalente genérico\",\"Necessidade genérica, como chave substituta ou date spine\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Antes de escrever um macro novo do zero, vale perguntar se essa necessidade já não é genérica o suficiente para já ter sido resolvida, e testada, por um package como o dbt_utils."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual é a função do arquivo `packages.yml` num projeto dbt?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Guardar a lista de seeds que devem ser recarregados a cada execução do `dbt build`.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Declarar quais packages externos o projeto usa, como o `dbt_utils`, e suas versões.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Configurar o schema de destino de cada modelo, separando os ambientes de dev e prod.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Listar as sources externas que os modelos podem referenciar com a função `source()`.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Antes de codificar uma dimensão, um analista percebe que precisa gerar uma chave substituta combinando três colunas naturais, e está prestes a escrever um macro Jinja do zero para concatenar e fazer hash dessas colunas. Qual alternativa está mais alinhada às boas práticas do modern data stack?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Escrever o macro mesmo assim, porque hashear colunas é lógica simples demais para um package externo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Resolver isso com um snapshot, já que gerar chave substituta é justamente a função do `dbt snapshot`.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Usar a macro `generate_surrogate_key` do `dbt_utils`, já testada pela comunidade para esse caso.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Criar a chave como seed, cadastrando manualmente a combinação de colunas num CSV versionado.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um projeto lista `dbt_utils` no `packages.yml`, mas ao rodar um modelo que chama `{{ dbt_utils.generate_surrogate_key(...) }}`, o dbt informa que essa macro não existe. O que provavelmente ficou faltando antes de rodar o modelo?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Adicionar `dbt_utils` também no `dbt_project.yml`, já que só o `packages.yml` não é suficiente.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Rodar `dbt seed` para carregar os arquivos do `dbt_utils` como tabelas no schema de desenvolvimento.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Publicar o próprio projeto como um package, porque só packages publicados enxergam outros packages.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Rodar `dbt deps` para instalar de fato o package declarado, antes de compilar ou rodar os modelos.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma financeira tem uma regra própria de cálculo de imposto, que não existe em nenhum lugar fora da empresa. Um analista sugere procurar um package pronto no lugar de escrever essa lógica como macro interna. Por que essa não é a melhor decisão nesse caso?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque a regra é específica do negócio, sem equivalente genérico, e um macro interno resolve de forma mais direta.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque packages só podem ser instalados em projetos que já usam `dbt Cloud`, nunca em projetos com `dbt Core`.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque regra de imposto não pode virar macro, só teste singular aplicado direto no modelo final.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque só é possível instalar um package por projeto, e o `dbt_utils` provavelmente já ocupa essa vaga.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Dois desenvolvedores do mesmo projeto rodam `dbt deps` em máquinas diferentes, em dias diferentes, e um deles percebe que uma macro do `dbt_utils` se comporta de um jeito diferente do esperado pelo outro. O `packages.yml` fixa só um intervalo de versão, não uma versão exata. Qual prática evita esse tipo de inconsistência?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Substituir o `dbt_utils` por macros escritas à mão, já que package externo nunca garante versão estável.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Fixar um intervalo de versão mais estrito no `packages.yml`, e comitar o arquivo de lock gerado pelo `dbt deps`.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Rodar `dbt deps` sempre em produção antes de cada deploy, o que sincroniza as versões locais de cada máquina.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Migrar o projeto inteiro para `dbt Cloud`, ambiente em que a versão de cada package é sempre fixada pela plataforma.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Snapshots: SCD Tipo 2 no dbt",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Snapshots: SCD Tipo 2 no dbt\n\nNa trilha de Modelagem de Dados e Data Warehousing, SCD tipo 2 foi definido como a estratégia que versiona uma dimensão: cada mudança relevante numa linha de origem vira uma nova linha, com data de início e fim de vigência, em vez de sobrescrever o valor antigo. O snapshot é o recurso do dbt que implementa esse padrão de forma automática, a partir de uma fonte que só entrega o estado atual."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Por que capturar, e não só transformar\n\nA maioria dos sistemas de origem sobrescreve dados: um update no ERP troca o endereço do cliente na mesma linha, sem deixar rastro do valor anterior. Se ninguém captura esse estado antes da sobrescrita, o histórico está perdido para sempre, porque nenhuma transformação de SQL recupera um dado que a origem já apagou. É por isso que um snapshot precisa rodar sobre a fonte periodicamente, a cada execução agendada, e não sob demanda: ele só enxerga o estado que existe no instante em que roda."
+                    },
+                    {
+                        "type": "code",
+                        "value": "-- snapshots/snap_clientes.sql\n{% snapshot snap_clientes %}\n\n{{\n    config(\n      target_schema='snapshots',\n      unique_key='id_cliente',\n      strategy='timestamp',\n      updated_at='atualizado_em',\n    )\n}}\n\nselect * from {{ source('erp', 'clientes') }}\n\n{% endsnapshot %}"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## As duas estratégias: timestamp x check\n\nUm snapshot decide se uma linha mudou de dois jeitos possíveis:\n\n- **timestamp**: confia numa coluna de controle mantida pela origem (`updated_at`), que muda de valor sempre que a linha é alterada. Simples e barato, desde que essa coluna seja confiável.\n- **check**: compara o valor de um conjunto de colunas (`check_cols`, uma lista ou `all`) entre a última captura e a origem atual. Usada quando não existe uma coluna de data confiável para detectar mudanças."
+                    },
+                    {
+                        "type": "code",
+                        "value": "-- estratégia check, para quando a origem não tem uma coluna de data confiável\n{{\n    config(\n      target_schema='snapshots',\n      unique_key='id_produto',\n      strategy='check',\n      check_cols=['categoria', 'preco'],\n    )\n}}"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Coluna gerada pelo snapshot\",\"O que guarda\"],[\"dbt_scd_id\",\"Identificador único de cada versão da linha\"],[\"dbt_valid_from\",\"O instante em que essa versão passou a valer\"],[\"dbt_valid_to\",\"O instante em que essa versão deixou de valer, nulo se ainda vigente\"],[\"dbt_updated_at\",\"O valor da coluna de controle usada para detectar a mudança\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Um snapshot não transforma dado, ele preserva um estado que a origem apagaria na próxima sobrescrita. É o elo entre o pipeline que extrai da origem e a dimensão SCD tipo 2 que os modelos de marts vão consumir."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual é a função do comando `dbt snapshot` dentro de um projeto?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Rodar todos os testes genéricos e singulares que estão configurados nos modelos do projeto inteiro.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Instalar os packages declarados no `packages.yml`, deixando as macros deles disponíveis no projeto.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Capturar o estado atual da fonte e gravar uma nova versão, se algo mudou desde a última captura.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Compilar os modelos escritos em Jinja para SQL puro, sem executar nada de fato no warehouse.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "A tabela de clientes de um ERP tem uma coluna `atualizado_em`, mantida automaticamente pelo próprio sistema toda vez que qualquer campo da linha muda. Um time está configurando o snapshot dessa tabela no dbt. Qual estratégia melhor aproveita essa característica da origem?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "`strategy='check'` com `check_cols='all'`, comparando o valor de cada coluna a cada execução do snapshot.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Qualquer uma das duas estratégias, já que `timestamp` e `check` sempre produzem o mesmo resultado final.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Nenhuma estratégia sozinha resolve isso: seria preciso combinar `timestamp` e `check` no mesmo snapshot.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "`strategy='timestamp'`, usando `atualizado_em` como o `updated_at` que indica quando a linha mudou.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de configurar um snapshot para a tabela de clientes, um analista percebe que a tabela gerada tem várias linhas com o mesmo `id_cliente`, cada uma com um `dbt_valid_from` e um `dbt_valid_to` diferentes. Isso é esperado, e representa o quê?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O histórico de versões do cliente: cada linha vale para um intervalo de tempo específico.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um erro de configuração do `unique_key`, que deveria garantir uma única linha por cliente.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma duplicação criada por rodar `dbt snapshot` mais de uma vez no mesmo dia, sem necessidade real.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O efeito de usar `strategy='check'` por engano, que sempre gera duas linhas extras por execução.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um desenvolvedor tenta colocar a definição de um snapshot dentro da pasta `models/`, junto dos demais arquivos `.sql`, e o dbt não reconhece esse arquivo como snapshot. Qual é o motivo mais provável?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Snapshots exigem uma extensão de arquivo diferente, `.snap`, em vez do `.sql` usado pelos modelos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Snapshots vivem numa pasta própria, por padrão `snapshots/`, e usam o bloco `{% snapshot %}`.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O dbt só reconhece snapshot quando o projeto roda no `dbt Cloud`, nunca em instalações de `dbt Core`.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Faltou declarar o snapshot também como um `source()`, já que ele depende de uma fonte para existir.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma dimensão de produtos é alimentada por um snapshot com `strategy='check'`. Um fato de vendas precisa relacionar cada venda à categoria do produto que valia no momento exato da venda, não à categoria atual. Como o modelo do fato deve usar a saída do snapshot para garantir isso?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Filtrando a saída do snapshot só pelas linhas em que `dbt_valid_to` é nulo, o que reflete a época da venda.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ignorando `dbt_valid_from` e `dbt_valid_to`, e cruzando direto pelo `id_produto`, que já identifica a versão certa.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Cruzando pela data da venda entre `dbt_valid_from` e `dbt_valid_to`, escolhendo a versão vigente naquele momento.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Rodando o snapshot de novo na data da venda, para que ele gere uma versão retroativa específica do pedido.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Seeds e a diferença para source",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Seeds e a diferença para source\n\ndbt tem duas formas de trazer dado para dentro de um modelo que não são um `select` sobre outro modelo: seeds e sources. São conceitos frequentemente confundidos, mas resolvem problemas bem diferentes."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que é um seed\n\nUm seed é um arquivo CSV pequeno, guardado na pasta `seeds/` do projeto dbt e versionado no git junto com o resto do código. Rodar `dbt seed` lê esse CSV e carrega como uma tabela no warehouse; a partir daí, o seed é referenciado em outros modelos com `ref()`, exatamente como um modelo comum.\n\nUso típico: mapeamentos e listas de referência pequenas, que mudam raramente e são mantidas pelo próprio time de analytics engineering, como um de-para de sigla de estado para região, ou uma tabela fixa de câmbio usada num contexto específico."
+                    },
+                    {
+                        "type": "code",
+                        "value": "-- seeds/mapa_regiao.csv\nuf,regiao\nSP,Sudeste\nRJ,Sudeste\nBA,Nordeste\nRS,Sul\n\n-- uso num modelo, depois de rodar dbt seed\nselect\n    p.pedido_id,\n    m.regiao\nfrom {{ ref('stg_pedidos') }} as p\nleft join {{ ref('mapa_regiao') }} as m\n    on p.uf = m.uf"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que é um source\n\nUm source é uma tabela que já existe no warehouse, normalmente carregada por um processo de ingestão (Fivetran, Airbyte, ou um pipeline próprio), com dado bruto vindo de um sistema de origem. O dbt não cria nem é dono desse dado: ele só declara essa tabela num arquivo `.yml`, com nome, schema e, opcionalmente, uma checagem de freshness. A partir dessa declaração, os modelos referenciam a tabela com `source()`, em vez de escrever o schema na mão."
+                    },
+                    {
+                        "type": "code",
+                        "value": "-- models/staging/erp/_erp__sources.yml\nsources:\n  - name: erp\n    schema: erp_raw\n    tables:\n      - name: clientes\n      - name: pedidos\n\n-- uso num modelo de staging\nselect * from {{ source('erp', 'clientes') }}"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Aspecto\",\"Seed\",\"Source\"],[\"Onde o dado mora\",\"CSV dentro do projeto dbt, versionado no git\",\"Tabela que já existe no warehouse, fora do dbt\"],[\"Quem carrega\",\"`dbt seed`, a partir do arquivo versionado\",\"Um processo externo de ingestão\"],[\"Tamanho e mudança\",\"Pequeno, muda raramente\",\"Qualquer volume, atualizado pela ingestão\"],[\"Uso típico\",\"Mapeamento e lista de referência fixa\",\"Dado operacional bruto de um sistema de origem\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Um seed é dado que o próprio time de analytics engineering possui e versiona; um source é dado que já existe no warehouse, e o dbt só declara, sem nunca ter sido dono dele."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual é a diferença central entre um seed e um source no dbt?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Seed é lido com `source()`, e source é lido com `ref()`: só uma troca de função no select do modelo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Seed serve só para ambientes de teste, e source serve só para modelos que vão para produção de fato.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Seed é criado automaticamente pela ferramenta de ingestão, e source é digitado à mão pelo time.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Seed é um CSV versionado e carregado pelo dbt; source é uma tabela que já existe, só declarada.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um time de analytics engineering precisa de uma tabela pequena e estável, com o de-para entre sigla de estado e região do país, mantida e revisada pelo próprio time dentro do repositório do projeto dbt. Qual é a forma mais adequada de disponibilizar esse dado para os modelos?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Como um seed: um CSV versionado em `seeds/`, carregado com `dbt seed` e referenciado com `ref()`.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Como um source: declarado num `schema.yml`, apontando para uma tabela mantida pela ingestão.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Como um snapshot: capturando o de-para periodicamente, para preservar histórico de mudanças.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Como um teste singular: um select reaproveitado pelos modelos de staging como se fosse uma fonte.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um desenvolvedor cria um seed com a extração diária de dez mil linhas de pedidos vindas do ERP, versionando o CSV atualizado no repositório toda manhã antes de rodar `dbt build`. Qual é o problema dessa abordagem?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Nenhum problema: seeds servem exatamente para isso, incluindo grande volume que muda todo dia.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Seed é para dado pequeno e estável; volume diário e operacional pede ingestão real como source.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "É só uma questão de performance, resolvida aumentando o número de `threads` usado pelo `dbt seed`.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Nenhum problema técnico, mas cada linha carregada via seed cobra uma licença extra no warehouse.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um modelo de staging tenta acessar uma tabela carregada via `dbt seed` usando `{{ source('seeds', 'mapa_regiao') }}`, e o dbt informa que essa fonte não foi declarada. Qual é a causa do erro?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Seeds precisam ser declarados manualmente num `sources.yml` antes de qualquer modelo referenciá-los.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O nome do seed está errado: deveria incluir a extensão `.csv` dentro da chamada de `source()`.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Seed se referencia com `ref('mapa_regiao')`, como um modelo comum; `source()` é só para tabela externa.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Faltou rodar `dbt docs generate` depois do `dbt seed`, passo que registra o seed como fonte válida.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um time quer configurar uma checagem de freshness (o quanto um dado pode estar desatualizado) para o seed de mapeamento de regiões, do mesmo jeito que já faz para os sources vindos do ERP. Por que essa configuração não se aplica a um seed?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Porque freshness só funciona em warehouses na nuvem, e seed não pode ser carregado nesse tipo de warehouse.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não é bem assim: freshness pode, sim, ser configurada para um seed do mesmo jeito que para um source.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque freshness é um teste genérico, e teste genérico só pode ser aplicado a modelo, nunca a seed ou source.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque freshness vale para source, dado de um processo externo; o seed só muda quando o time versiona um CSV.",
+                                "isCorrect": true
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Configuração e ambientes",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Configuração e ambientes\n\nUm mesmo projeto dbt roda, sem alterar o código dos modelos, tanto na máquina de um desenvolvedor quanto em produção. O que muda de uma execução para outra é a configuração: para onde escrever, com qual conexão, com qual volume de dado. O SQL continua sendo o mesmo."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Configuração em dois lugares: dbt_project.yml e o modelo\n\nO `dbt_project.yml` configura por pasta: tudo dentro de `models/marts/`, por exemplo, pode ser materializado como table de uma vez só. Um modelo específico pode sobrescrever essa configuração com um bloco `{{ config(...) }}` no topo do próprio arquivo `.sql`. Quando as duas fontes conflitam, a mais específica vence: a configuração do modelo prevalece sobre a da pasta, e a da pasta mais interna prevalece sobre a de uma pasta mais externa."
+                    },
+                    {
+                        "type": "code",
+                        "value": "-- dbt_project.yml (configuração por pasta)\nmodels:\n  meu_projeto:\n    staging:\n      +materialized: view\n    marts:\n      +materialized: table\n      financeiro:\n        +materialized: incremental\n\n-- dentro de models/marts/financeiro/fin_margem.sql (a config mais específica vence)\n{{ config(materialized='table') }}\n\nselect\n    pedido_id,\n    receita,\n    custo\nfrom {{ ref('int_pedidos_financeiro') }}"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Targets: dev e prod\n\nUm target é um ambiente de execução nomeado, declarado no `profiles.yml`, com sua própria conexão, schema e credenciais. Um mesmo projeto pode ter vários targets, tipicamente um `dev` e um `prod`, cada um apontando para um schema diferente. Escolher o target ativo muda para onde os modelos são construídos, sem mudar uma linha sequer do SQL: o mesmo `select` gera uma tabela num schema pessoal em `dev`, e na tabela compartilhada de verdade em `prod`."
+                    },
+                    {
+                        "type": "code",
+                        "value": "-- profiles.yml, geralmente fora do projeto, em ~/.dbt/\nmeu_projeto:\n  target: dev\n  outputs:\n    dev:\n      type: snowflake\n      schema: dev_joao\n      threads: 4\n    prod:\n      type: snowflake\n      schema: analytics\n      threads: 8"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Aspecto\",\"Target dev\",\"Target prod\"],[\"Schema de destino\",\"Pessoal, como `dev_joao`\",\"Compartilhado, consumido por BI e outros times\"],[\"Quem roda\",\"O próprio desenvolvedor, local ou num PR\",\"Um agendador, em produção\"],[\"Volume de dado\",\"Às vezes uma amostra, para ciclo rápido\",\"Completo, o dado real usado nas decisões\"],[\"Código dos modelos\",\"O mesmo\",\"O mesmo\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "A configuração muda para onde o dbt escreve e como ele se conecta; o SQL dos modelos não muda uma linha entre dev e prod. É essa separação que permite testar com segurança antes de publicar."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Num projeto dbt, quando uma materialização é definida por pasta no `dbt_project.yml` e também dentro de um modelo específico com `{{ config(...) }}`, qual configuração prevalece?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "A do modelo específico, porque a configuração mais específica tem prioridade sobre a mais geral.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A do `dbt_project.yml`, porque configuração no nível do projeto sempre tem prioridade sobre o modelo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Nenhuma das duas: o dbt ignora ambas e usa sempre view como a materialização padrão do projeto.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "As duas juntas, gerando dois objetos diferentes no warehouse para o mesmo modelo.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma desenvolvedora roda `dbt build` na própria máquina usando o target `dev`, e depois o mesmo comando roda em produção com o target `prod`. Os modelos SQL não têm nenhuma diferença entre as duas execuções. O que explica os dados aparecerem em schemas diferentes em cada caso?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O dbt detecta sozinho se a máquina é de um desenvolvedor ou de um servidor, e escolhe o schema.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Cada target no `profiles.yml` aponta para um schema próprio; o código roda contra conexões diferentes.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Os modelos têm, sim, uma diferença: um `{% if %}` interno que troca o schema em cada arquivo `.sql`.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O schema muda porque `dbt build` em produção sempre recria o projeto inteiro num banco de dados novo.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um modelo tem, escrito direto no select, o nome do schema de produção referenciado (`analytics.marts.fin_pedidos`) em vez de usar `{{ ref(...) }}`. O modelo funciona em produção, mas quebra sempre que alguém tenta rodá-lo no target `dev`. Qual é o problema dessa prática?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Nenhum: escrever o schema direto é mais rápido de ler, e o problema está no target `dev`, mal configurado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O modelo deveria estar na pasta `marts/` do `dbt_project.yml`, e não na raiz de `models/`, para resolver sozinho.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O nome fixo ignora o schema do target ativo; `ref()` deixa o dbt resolver o schema certo em cada ambiente.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O erro é de sintaxe: nome de schema com ponto exige aspas duplas ao redor de cada parte do caminho.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um novo integrante do time sugere eliminar o target `dev` e fazer todo mundo rodar `dbt build` direto contra o schema de produção, para simplificar a configuração. Qual é o principal risco dessa sugestão?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Nenhum risco real: como o SQL dos modelos é idêntico entre ambientes, rodar direto em prod não muda nada.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O dbt bloqueia por padrão qualquer `dbt build` fora do target `prod`, então a sugestão nem é possível.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O risco é só de custo, já que rodar em prod sempre cobra mais caro do que rodar num target de desenvolvimento.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Modelo ainda em desenvolvimento passaria a sobrescrever tabela usada por relatório e time que depende de produção.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "No `dbt_project.yml`, a pasta `marts` está configurada com `+materialized: table`, e a subpasta `marts/financeiro`, dentro dela, está configurada com `+materialized: incremental`. Um modelo dentro de `models/marts/financeiro/` não tem nenhum `config()` próprio. Com qual materialização ele é construído?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Incremental, porque a configuração da subpasta mais próxima do modelo prevalece sobre a pasta mais geral.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Table, porque a configuração de `marts` é a primeira que o dbt encontra ao ler o `dbt_project.yml`.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "View, porque sem um `config()` no próprio arquivo, o dbt sempre volta para a materialização padrão do projeto.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O build falha com erro, porque duas pastas aninhadas não podem declarar materializações diferentes.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 7 - O modern data stack na prática",
+        "aulas": [
+            {
+                "titulo": "dbt + orquestrador: quem chama o dbt",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# dbt + orquestrador: quem chama o dbt\n\nO dbt compila e executa modelos SQL, resolve a ordem certa de execução através do DAG de `ref()` e `source()`, e sabe dizer se um teste passou ou falhou. O que o dbt não faz sozinho é responder a pergunta mais básica de qualquer pipeline: quando rodar? Ele não tem um relógio interno esperando as 6 da manhã, nem um jeito nativo de saber que a carga do Fivetran daquela madrugada já terminou. Alguém, ou alguma coisa, precisa chamar `dbt build` no momento certo, depois que os dados certos já chegaram.\n\nEsta aula é sobre esse \"alguém\": como um orquestrador, como o Airflow, ou o scheduler do próprio dbt Cloud, encaixa o dbt dentro de um pipeline maior, e por que o dbt foi desenhado de propósito para não resolver esse problema sozinho."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## dbt é uma ferramenta de transformação, não um agendador\n\nO dbt Core, a versão open source que roda por linha de comando, não tem um processo em segundo plano esperando a hora certa. Rodar `dbt run` ou `dbt build` executa os modelos pendentes naquele instante, e o processo termina: não existe um daemon do dbt Core verificando o relógio a cada minuto. Isso é uma escolha de design, não uma limitação esquecida. O dbt se concentra em fazer uma coisa bem feita (compilar e executar SQL de forma versionada, testável e documentada) e deixa agendamento, retries entre sistemas diferentes e dependências externas para uma ferramenta especializada nisso.\n\nO dbt Cloud, a versão gerenciada, adiciona um scheduler próprio por cima do mesmo motor: um job pode rodar todo dia às 6h, ou ser disparado por uma chamada de API depois que outro sistema termina. Mesmo assim, esse scheduler só enxerga o mundo do dbt: ele não sabe orquestrar uma extração do Fivetran, esperar um arquivo chegar num bucket ou disparar um modelo de machine learning depois do `dbt build` passar. Para pipelines com mais de uma ferramenta envolvida, a orquestração de ponta a ponta continua sendo trabalho de um orquestrador externo, como o Airflow, já estudado a fundo na trilha de Orquestração de Pipelines."
+                    },
+                    {
+                        "type": "code",
+                        "value": "Uma pipeline tipica orquestrada de ponta a ponta\n\n  Orquestrador (Airflow, ou o scheduler do dbt Cloud)\n  |\n  |-- 1. aciona a extracao e carga (Fivetran, Airbyte, script proprio)\n  |        |\n  |        v\n  |   warehouse: tabelas RAW atualizadas\n  |\n  |-- 2. so depois do passo 1 confirmar sucesso, roda `dbt build`\n  |        |\n  |        v\n  |   staging -> intermediate -> marts, dentro do warehouse\n  |\n  |-- 3. so depois do dbt build/test passar, libera o refresh do BI\n           |\n           v\n      Looker / Metabase leem os marts atualizados\n\n  o dbt controla o DAG de dentro do passo 2; o orquestrador controla a ordem entre 1, 2 e 3"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Aspecto\", \"Scheduler do dbt Cloud\", \"Orquestrador externo (Airflow)\"], [\"O que agenda\", \"Só jobs de dbt (run, test, build, docs generate)\", \"Qualquer sistema: extração, dbt, ML, notificações\"], [\"Dependência entre sistemas\", \"Só via API, chamando outro sistema de fora\", \"Nativo: uma task espera a outra terminar\"], [\"Onde vive o DAG\", \"DAG interno dos modelos, dentro do projeto dbt\", \"DAG do pipeline inteiro, com o dbt como um nó\"], [\"Setup\", \"Mais simples quando o pipeline é só dbt\", \"Mais trabalho, compensa com várias ferramentas\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Como um orquestrador chama o dbt\n\nNa prática, existem algumas formas comuns de um orquestrador acionar o dbt:\n\n- **Chamar o comando diretamente**: uma task do Airflow (ou de qualquer orquestrador) executa `dbt build` como um comando de shell, dentro de um container ou ambiente onde o projeto dbt está instalado.\n- **Chamar a API do dbt Cloud**: em vez de rodar o dbt localmente, a task dispara um job já configurado no dbt Cloud através de uma chamada HTTP, e opcionalmente espera a resposta antes de seguir.\n- **Uma integração que expande o DAG do dbt dentro do DAG do orquestrador**: ferramentas do ecossistema leem o `manifest.json` do dbt e criam uma task para cada modelo, em vez de rodar o projeto inteiro como um bloco único. Isso dá visibilidade por modelo dentro da interface do orquestrador, ao custo de mais complexidade de configuração.\n\nEm qualquer uma dessas formas, o dbt continua resolvendo sozinho a ordem entre os próprios modelos. O orquestrador só decide quando aquele bloco inteiro começa, e o que acontece antes e depois dele."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "O dbt sabe exatamente em que ordem os próprios modelos devem rodar; ele só não sabe, e não deveria saber, que horas são."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Por padrão, ao terminar de executar `dbt build`, o dbt Core encerra o processo. O que isso revela sobre o papel do dbt dentro de um pipeline de dados?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "O dbt executa a transformação quando chamado, mas não decide sozinho a hora certa de rodar.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O dbt mantém um processo em segundo plano, verificando a cada minuto se há um novo modelo para compilar.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O dbt reinicia sozinho a cada seis horas, usando um agendador embutido no próprio dbt Core.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O dbt aguarda, em segundo plano, a confirmação de que a carga do warehouse terminou antes de sair.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um time roda todo o pipeline de dados só com dbt Cloud: a extração já chega pronta por um conector nativo, sem nenhuma outra ferramenta envolvida além do warehouse e do BI. Nesse cenário, qual opção de agendamento é suficiente, sem exigir um orquestrador externo?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Configurar um cron no servidor de BI para disparar a transformação antes de qualquer leitura.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Usar o scheduler do próprio dbt Cloud para rodar o job num horário fixo ou por gatilho de API.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Instalar um orquestrador externo apenas para acionar o mesmo comando que o dbt Cloud já executaria.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Escrever um script Python separado que reimplementa o DAG de modelos fora do projeto dbt.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma pipeline extrai dados de uma API com Airbyte, carrega no warehouse, roda os modelos dbt e, só depois, precisa disparar um modelo de recomendação em outro serviço. O time quer uma ferramenta só para coordenar essas quatro etapas, na ordem certa. Qual é a alternativa mais adequada?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Ampliar o `dbt_project.yml` para declarar a extração do Airbyte e o serviço de recomendação como fontes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Usar apenas testes de source freshness do dbt para garantir que as quatro etapas rodem na ordem certa.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Usar um orquestrador externo, como o Airflow, para coordenar as quatro etapas, com o dbt como uma delas.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Rodar `dbt build --full-refresh` para que o próprio dbt acione a extração e o serviço de recomendação.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe decide criar, dentro do próprio projeto dbt, uma tabela de controle e uma rotina em Python que verifica a cada minuto se é hora de rodar cada modelo, replicando um agendador. Qual é o principal problema dessa decisão?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O dbt não permite a criação de tabelas de controle dentro de um projeto, então a rotina falharia ao rodar.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Tabelas de controle escritas em SQL não podem ser referenciadas por modelos dbt através de `ref()`.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O dbt Core bloqueia qualquer execução que não tenha sido iniciada por um scheduler externo configurado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A equipe está reconstruindo, por conta própria, algo que um orquestrador já resolve de forma testada.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual afirmação descreve corretamente a divisão de responsabilidade entre o dbt e um orquestrador como o Airflow?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O Airflow compila e executa os modelos SQL, e o dbt apenas registra o horário em que cada um rodou.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O dbt e o Airflow disputam o mesmo papel, e um projeto maduro deveria escolher usar só um dos dois.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O dbt resolve o DAG interno de modelos e os transforma; o Airflow decide quando e em que contexto isso roda.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O Airflow substitui o `ref()` e o `source()` do dbt, montando o DAG de modelos a partir das próprias tasks.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "O semantic layer e métricas consistentes",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# O semantic layer e métricas consistentes\n\nÉ comum uma pergunta simples virar uma discussão de meia hora: qual é a receita do mês passado? O time financeiro olha para uma planilha e diz um número. O dashboard de vendas, construído no Looker, mostra outro. O relatório automático que o time de growth manda por e-mail toda segunda mostra um terceiro. Nenhum dos três está necessariamente errado: cada um define receita de um jeito ligeiramente diferente (bruta ou líquida, com ou sem cancelamento, na data do pedido ou na data do pagamento). O problema não é o cálculo em si, é ele existir em três lugares diferentes, calculado três vezes.\n\nEsta aula trata do semantic layer: a camada que existe para acabar com essa pergunta, definindo cada métrica uma única vez e deixando qualquer ferramenta de BI consultar essa mesma definição."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O problema: métrica duplicada em cada dashboard\n\nSem um lugar central para definir métricas, cada analista que constrói um dashboard reescreve a lógica do zero: um SQL direto no Looker, uma fórmula calculada no Metabase, uma coluna derivada numa planilha. Cada uma dessas versões tende a divergir com o tempo, porque são mantidas por pessoas diferentes, em ferramentas diferentes, sem nenhuma delas ser \"a fonte de verdade\". A consequência não é só o número errado numa reunião: é a erosão da confiança no dado como um todo. Depois que alguém vê duas ferramentas mostrando receitas diferentes, o próximo instinto é desconfiar de qualquer número, mesmo dos corretos.\n\nIsso é diferente de um modelo dbt mal escrito ou de um teste faltando: mesmo com os marts corretos e bem testados, nada impede que duas pessoas somem colunas diferentes, filtrem status diferentes, ou apliquem um `WHERE` diferente ao montar a mesma métrica em ferramentas separadas."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Uma métrica que existe em três lugares não é uma métrica, são três opiniões parecidas com números."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# definicao conceitual de uma metrica no semantic layer do dbt\n# (a metrica referencia um measure, que por sua vez vem de um modelo)\n\nsemantic_models:\n  - name: pedidos\n    model: ref('fct_pedidos')\n    defaults:\n      agg_time_dimension: data_pedido\n    measures:\n      - name: receita_liquida\n        agg: sum\n        expr: valor_total - valor_cancelado\n    dimensions:\n      - name: data_pedido\n        type: time\n        type_params:\n          time_granularity: day\n\nmetrics:\n  - name: receita_total\n    label: Receita Total\n    description: Soma da receita liquida de pedidos, usada em todos os dashboards\n    type: simple\n    type_params:\n      measure: receita_liquida\n\n# qualquer ferramenta de BI conectada ao semantic layer consulta \"receita_total\"\n# e recebe sempre o mesmo calculo, sem reescrever a logica"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Sem semantic layer\", \"Com semantic layer\"], [\"Cada dashboard tem sua própria fórmula de receita\", \"Receita definida uma vez, reusada por todos os dashboards\"], [\"Divergência só aparece quando alguém compara dois relatórios\", \"Divergência fica difícil de acontecer, a fonte é única\"], [\"Mudar a regra de negócio exige editar cada dashboard\", \"Mudar a regra de negócio exige editar só a definição da métrica\"], [\"Dimensão (por mês, por região) recalculada em cada ferramenta\", \"Dimensão consultada junto da métrica, com o mesmo grain\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Onde o semantic layer se encaixa\n\nO semantic layer fica entre os marts, já modelados e testados pelo dbt, e as ferramentas de consumo (Looker, Metabase, uma planilha, um assistente de perguntas em linguagem natural). Ele não substitui os marts, depende deles: a métrica `receita_total` só existe porque aponta para um measure que vem de um modelo dbt já confiável. O que o semantic layer adiciona é uma camada de definição (nome, cálculo, granularidade, dimensões permitidas) que qualquer ferramenta pode consultar, em vez de cada ferramenta reimplementar o cálculo do zero em sua própria sintaxe.\n\nIsso também muda quem consegue definir uma métrica nova. Sem semantic layer, qualquer pessoa com acesso ao dashboard pode criar uma métrica calculada, sem revisão. Com semantic layer, a métrica nasce como código versionado, dentro do projeto dbt, passando pelo mesmo processo de revisão de qualquer outro modelo."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Métrica não é a mesma coisa que modelo\n\nVale separar dois conceitos que se confundem fácil. Um modelo dbt (uma tabela ou view num mart) guarda linhas: um pedido por linha, um cliente por linha. Uma métrica é um número agregado a partir dessas linhas, sempre acompanhado de uma granularidade (por dia, por mês, por região) e, geralmente, de uma forma de agregação (soma, contagem, média). `fct_pedidos` é um modelo. \"Receita total por mês\" é uma métrica com uma dimensão. O semantic layer trabalha nesse segundo nível, em cima de modelos que o dbt já materializou.\n\nEssa camada não substitui a governança de dados, vista com mais profundidade em outra trilha da plataforma: ela resolve o problema específico da métrica calculada de formas diferentes, não o controle de quem pode acessar qual dado."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual é o principal problema que um semantic layer resolve dentro do modern data stack?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "A demora para carregar grandes volumes de dados brutos até o warehouse.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A mesma métrica sendo calculada de formas diferentes em cada ferramenta de BI.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A falta de espaço em disco para armazenar tabelas materializadas como table.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A ausência de testes genéricos como `not_null` e `unique` nos modelos dbt.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O dashboard de vendas mostra receita de R$ 500 mil no mês, enquanto o relatório financeiro, calculado numa planilha separada, mostra R$ 480 mil para o mesmo período. Os dois times garantem que seus números estão certos. Qual mudança ataca a causa raiz desse tipo de divergência?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Trocar a planilha do financeiro por um novo dashboard, também com fórmula própria.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Aumentar a frequência de atualização dos dois relatórios para reduzir o atraso entre eles.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Definir a métrica de receita uma vez no semantic layer e conectar as duas ferramentas a ela.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Adicionar um teste `unique` na tabela de pedidos usada por um dos dois relatórios.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe já tem um modelo dbt `fct_pedidos`, testado e documentado, com uma linha por pedido. Um analista quer expor receita total por região e por mês de forma consistente para várias ferramentas de BI. Qual é o próximo passo mais adequado, além do modelo já existente?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Definir uma métrica no semantic layer, apontando para um measure do modelo, com a granularidade desejada.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Recriar `fct_pedidos` como uma tabela nova, já agregada por região e por mês, no lugar da original.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Adicionar um teste `accepted_values` na coluna de região para garantir que os valores existentes sejam válidos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Duplicar o modelo em cada ferramenta de BI, ajustando o agrupamento conforme a necessidade de cada uma.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um time decide não usar semantic layer e, em vez disso, documentar num arquivo compartilhado a fórmula oficial de cada métrica, confiando que cada analista vai seguir a receita ao montar seu próprio dashboard. Por que essa abordagem tende a falhar com o tempo, mesmo com a documentação correta?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Porque arquivos compartilhados não podem ser lidos por mais de uma pessoa da equipe ao mesmo tempo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o dbt exige que toda métrica esteja formalmente declarada em YAML para ser considerada válida.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque documentação escrita num arquivo compartilhado não consegue descrever fórmulas de agregação.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque nada impede que a fórmula seja reescrita de forma levemente diferente em cada ferramenta.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de ver o problema da métrica duplicada, qual afirmação descreve corretamente o papel do semantic layer dentro do modern data stack?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Ele define uma métrica uma única vez, sobre os marts, para ser reutilizada por qualquer ferramenta de BI.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Ele substitui a necessidade de modelos dbt, calculando métricas direto sobre as tabelas raw do warehouse.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ele garante que os dados de origem estejam livres de valores nulos antes de qualquer transformação.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ele controla quais usuários têm permissão para acessar cada tabela dentro do data warehouse.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "CI/CD para dados",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# CI/CD para dados\n\nUm pull request muda uma linha de SQL num modelo dbt: troca um `LEFT JOIN` por um `INNER JOIN`. Sozinha, a mudança parece pequena. Só que esse modelo alimenta outros três, e um deles vira uma métrica de receita usada pelo financeiro. Sem nada verificando esse PR antes do merge, o erro só aparece quando alguém do financeiro percebe que a receita do mês caiu 8% da noite para o dia, sem nenhuma explicação de negócio.\n\nCI/CD para dados aplica ao SQL versionado no dbt a mesma disciplina que já existe para código de aplicação: testar antes do merge, não depois. Esta aula cobre como isso funciona na prática, incluindo uma técnica do próprio ecossistema dbt para manter esse teste rápido mesmo em projetos grandes: o slim CI."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que roda no CI de um projeto dbt\n\nA ideia central é simples: toda vez que alguém abre um pull request mudando algo em `models/`, um pipeline de CI sobe um ambiente isolado (um schema separado no warehouse, por exemplo) e roda `dbt build`, que compila, executa e testa os modelos afetados nesse ambiente. Se algum modelo falhar ao compilar, se um teste `not_null` ou `unique` quebrar, ou se um teste singular retornar linhas, o pipeline falha e o PR fica bloqueado até alguém corrigir. Ninguém revisando o PR manualmente precisa notar o problema primeiro: o CI já provou, antes da revisão humana, que os modelos ao menos rodam e passam nos testes declarados.\n\nEsse ambiente isolado de CI importa: rodar os testes direto contra o schema de produção arriscaria sobrescrever dados reais com uma versão ainda não revisada do modelo."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# .ci/pipeline.yml (configuracao ilustrativa de CI para um projeto dbt)\nstages: [build_pr]\n\nbuild_pr:\n  trigger: pull_request\n  script:\n    - dbt deps\n    # roda so os modelos modificados e o que depende deles, contra o estado de producao\n    - dbt build --select state:modified+ --state ./prod-manifest\n\n# fluxo:\n# PR aberto -> CI cria schema isolado -> dbt build (state:modified+) -> testes rodam\n#   -> passou: PR liberado para revisao e merge\n#   -> falhou: PR bloqueado, autor corrige antes de pedir revisao de novo"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Slim CI: testar só o que mudou\n\nUm projeto dbt grande pode ter centenas de modelos. Rodar `dbt build` completo a cada PR, testando tudo de novo, fica caro e lento rápido: minutos viram dezenas de minutos, e o time começa a evitar abrir PRs pequenos só para não esperar o CI inteiro. O slim CI resolve isso comparando o estado do PR contra o `manifest.json` da última execução em produção: só os modelos que de fato mudaram, mais tudo que depende deles no DAG, entram na seleção `state:modified+`. Um modelo que não mudou, e que nada a jusante dele mudou, nem é reconstruído.\n\nIsso não é uma otimização cosmética. É a diferença entre um CI que roda em dois minutos e um que roda em quarenta, e entre um time que testa cada PR de bom grado e um time tentado a pular o CI \"só dessa vez\"."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Critério\", \"CI completo\", \"Slim CI (state:modified+)\"], [\"O que roda\", \"Todos os modelos do projeto, a cada PR\", \"Só os modelos alterados e o que depende deles\"], [\"Tempo de execução\", \"Cresce junto com o tamanho do projeto\", \"Proporcional ao tamanho da mudança, não do projeto\"], [\"Depende de\", \"Nada além do projeto dbt\", \"Um manifest.json de uma execução anterior, como referência\"], [\"Cobertura do downstream\", \"Total, por definição\", \"Total, desde que o DAG enxergue a dependência\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Um PR de dado só devia inspirar confiança depois que o pipeline provou, sozinho, que os modelos ainda compilam e os testes ainda passam."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Do PR à produção, promovendo com confiança\n\nO caminho típico segue os mesmos passos de qualquer entrega de software, adaptado para dados: o PR roda no CI contra um ambiente isolado, alguém revisa a mudança de SQL como revisaria qualquer outro código, e só depois do merge na branch principal é que a mudança é promovida para o ambiente de produção, seja pelo job agendado do dbt Cloud, seja por uma etapa de deploy dentro do próprio pipeline de CI/CD. Os ambientes (dev, CI, produção) mantêm o mesmo projeto dbt, diferindo só nas variáveis de ambiente e no schema de destino, do mesmo jeito que uma aplicação usa a mesma imagem em ambientes diferentes.\n\nEssa esteira completa, o caminho que leva um commit até a produção com portões de qualidade no meio, é o assunto central da trilha de CI/CD e Cloud. Aqui, o que importa é que dados seguem a mesma lógica: testar antes de promover, nunca depois."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual é o objetivo principal de rodar `dbt build` dentro de um pipeline de CI, a cada pull request?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Reduzir o tempo de resposta das consultas feitas pelo BI em produção.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Verificar, antes do merge, se os modelos compilam e os testes passam.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Gerar automaticamente a documentação de todos os modelos do projeto.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Aumentar o número de linhas processadas por execução do pipeline.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um projeto dbt tem 400 modelos. Um PR altera apenas um modelo de staging usado por dois modelos de marts. Rodando `dbt build --select state:modified+` contra o manifest de produção, quais modelos o CI reconstrói?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Os 400 modelos do projeto, porque `state:modified+` sempre reconstrói tudo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Nenhum modelo, porque `state:modified+` só roda testes, sem executar SQL.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Só o modelo alterado e os modelos a jusante dele, que dependem do resultado.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Só os modelos de marts, ignorando o modelo de staging que de fato mudou.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Para economizar tempo de configuração, um time decide rodar os testes de CI de um PR diretamente contra o schema de produção, em vez de um schema isolado. Qual é o principal risco dessa decisão?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O `dbt build` passa a ignorar testes singulares quando aponta para produção.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O `manifest.json` da execução deixa de ser gerado quando o schema é o de produção.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O `ref()` e o `source()` do PR deixam de resolver corretamente o DAG de modelos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um modelo ainda não revisado pode sobrescrever dados reais usados por outras pessoas.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de adotar slim CI, um time percebe que um PR alterando um modelo de staging passa rápido pelo CI, mas quebra em produção um mart que deveria depender dele. Investigando, descobrem que esse mart usa `FROM analytics.stg_pedidos` direto no SQL, em vez de `{{ ref('stg_pedidos') }}`. Por que isso explica o CI não ter pego o problema?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Sem `ref()`, o dbt não enxerga essa dependência no DAG, e o mart nunca entra na seleção `state:modified+`.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque `FROM` direto faz o modelo rodar antes do staging, invertendo a ordem correta do DAG.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque nomes de tabela fixos são ignorados pelos testes genéricos, mesmo quando declarados corretamente.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o slim CI só analisa modelos materializados como view, ignorando os materializados como table.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual conjunto de práticas melhor descreve CI/CD aplicado a um projeto dbt?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Rodar `dbt docs generate` a cada PR e revisar manualmente a documentação antes do merge.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Testar o PR num ambiente isolado, com slim CI, e só promover para produção depois do merge.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Aumentar o número de threads do projeto dbt para acelerar qualquer pipeline de CI.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Rodar os testes uma vez por semana, num horário fixo, direto no schema de produção.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Analytics engineering na prática",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Analytics engineering na prática\n\nChegou a hora de ver o fluxo inteiro, de ponta a ponta, sem cortar em pedaços por módulo. Uma tabela `orders` nasce dentro do banco transacional de um sistema de e-commerce, linha por linha, pedido por pedido, sem nenhuma preocupação com análise: ela existe para o sistema funcionar, não para alguém tirar uma métrica dela. Entre essa tabela crua e o número de receita mensal que aparece no dashboard do time comercial existe uma cadeia de transformações inteira, e é essa cadeia que esta aula percorre.\n\nQuem constrói e mantém essa cadeia, na prática, é o analytics engineer: a pessoa que conecta o dado bruto que a engenharia de dados entrega ao número em que o time de negócio confia."
+                    },
+                    {
+                        "type": "code",
+                        "value": "Fluxo completo, de uma fonte crua a uma metrica confiavel (exemplo: e-commerce)\n\n  [ fonte: banco transacional, tabela orders ]\n                  |\n                  |  ingestao (Fivetran / Airbyte / pipeline proprio)\n                  v\n  [ warehouse: raw.orders ]                      <- dado cru, tal como chegou\n                  |\n                  |  dbt: source('erp', 'orders')\n                  v\n  [ staging: stg_orders ]                        <- limpo, renomeado, tipado, 1:1 com a fonte\n                  |\n                  |  dbt: ref('stg_orders') + ref('stg_customers')\n                  v\n  [ intermediate: int_orders_enriquecidos ]      <- juntado com clientes, regras intermediarias\n                  |\n                  |  dbt: ref('int_orders_enriquecidos')\n                  v\n  [ marts: fct_pedidos, dim_clientes ]           <- modelos de negocio, testados e documentados\n                  |\n                  |  semantic layer: metrica receita_total\n                  v\n  [ BI: Looker / Metabase ]                      <- receita mensal, mesma definicao em todo lugar"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O analytics engineer: entre o dado e o negócio\n\nO papel nasceu do meio de dois outros. A engenharia de dados garante que o dado saia da fonte e chegue ao warehouse: pipelines de ingestão, orquestração, infraestrutura, volume, latência. O analista de negócio sabe o que uma métrica deveria significar para a empresa e o que o time comercial precisa enxergar no dashboard, mas nem sempre tem o hábito de versionar SQL, escrever teste ou documentar uma coluna. O analytics engineer mora nesse meio: usa práticas de engenharia de software (controle de versão, revisão de código, testes, CI) para transformar o dado já ingerido em modelos que respondem às perguntas do negócio.\n\nNo dia a dia, isso significa conversar com um stakeholder para entender o que \"cliente ativo\" ou \"receita reconhecida\" deveriam significar, traduzir essa definição em modelos e métricas dentro do dbt, testar e documentar o resultado, e só então liberar para consumo no BI. A ferramenta central desse trabalho é o dbt, mas o valor entregue não é o SQL em si, é a métrica em que alguém do negócio pode confiar sem checar de novo."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Camada\", \"Exemplo neste fluxo\", \"Responsabilidade\"], [\"Raw\", \"raw.orders\", \"Cópia fiel da fonte, sem transformação\"], [\"Staging\", \"stg_orders\", \"Limpa, renomeia e tipa, ainda 1:1 com a fonte\"], [\"Intermediate\", \"int_orders_enriquecidos\", \"Junta fontes, aplica regra de negócio intermediária\"], [\"Marts\", \"fct_pedidos, dim_clientes\", \"Modelo de negócio, pronto para consumo e testado\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Um fluxo de ponta a ponta, na prática\n\nUm pedido do time comercial chega assim: \"precisamos saber a receita mensal por região, considerando só pedidos entregues\". O analytics engineer parte da pergunta, não do SQL. Primeiro, confirma que a fonte já está disponível como `source()` (a tabela `orders`, ingerida pela engenharia de dados). Depois, verifica se já existe um `stg_orders` reaproveitável, ou cria um, aplicando apenas limpeza e renomeação. Em seguida, decide se a regra \"só pedidos entregues\" e o join com região pertencem a um modelo intermediate (se outros modelos também vão precisar dessa mesma junção) ou já podem ir direto para o mart.\n\nSó depois do modelo de mart pronto é que a métrica de receita entra em cena: uma definição no semantic layer, apontando para o measure certo, testada com `dbt build` no CI antes de qualquer PR ser aceito. O time comercial só vê o resultado final, mas cada camada no meio existiu para que aquele número pudesse ser confiável e reproduzível."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Entre a tabela crua e o número que aparece no dashboard existe uma cadeia inteira de decisões, e cada uma delas tem a assinatura de um analytics engineer."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que fica com quem\n\nVale reforçar as fronteiras, ainda que na prática elas se sobreponham em times pequenos. Ingestão, trazer o dado da fonte até o warehouse, é trabalho de engenharia de dados, com ferramentas como Fivetran, Airbyte ou pipelines próprios. Orquestrar quando cada etapa roda é trabalho de um orquestrador como o Airflow. Transformar o dado já ingerido, em camadas testadas e documentadas, é o núcleo do analytics engineering, com o dbt como ferramenta central. Nenhuma dessas responsabilidades substitui a outra: um analytics engineer não costuma escrever o conector de ingestão, e quem cuida da ingestão não costuma decidir o que \"cliente ativo\" significa para o negócio."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "No fluxo staging -> intermediate -> marts, qual característica melhor define um modelo de staging?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Junta múltiplas fontes já aplicando regras de negócio complexas do domínio.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Limpa e renomeia uma única fonte, mantendo uma relação de um para um com ela.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Expõe a métrica final, já testada, pronta para consumo direto no BI.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Agrega dados de várias tabelas de marts numa única visão consolidada.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um time de e-commerce precisa que alguém converse com o setor comercial para entender o que \"cliente ativo\" deve significar, traduza isso em modelos dbt testados e documentados, e libere a métrica correspondente no BI. Qual papel concentra esse trabalho?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O engenheiro de dados, responsável por manter os conectores de ingestão do warehouse.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O administrador do warehouse, responsável por gerenciar custo e permissões de acesso.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O analytics engineer, que traduz a necessidade de negócio em modelos e métricas.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O engenheiro de orquestração, responsável por agendar quando os modelos vão rodar.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um analytics engineer precisa juntar `stg_orders` com `stg_customers` e aplicar uma regra de negócio (excluir pedidos cancelados) que será reaproveitada por dois modelos de marts diferentes. Em qual camada essa lógica deveria viver?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Direto na fonte, alterando a tabela `orders` antes mesmo da ingestão acontecer.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Num modelo intermediate, reaproveitado pelos dois marts que precisam da mesma junção.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Duplicada dentro de cada um dos dois marts, para manter os modelos independentes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Num modelo de staging, já que staging é o lugar de aplicar regras de negócio.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um analytics engineer entrega rápido uma métrica de receita, direto de `raw.orders` para um dashboard, pulando staging, intermediate e marts, porque \"o prazo era curto\". Duas semanas depois, a fonte muda um nome de coluna e o dashboard quebra sem aviso. Qual teria sido o principal benefício de seguir as camadas normalmente?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O prazo de entrega teria sido menor, porque staging elimina a necessidade de testes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A métrica teria ficado disponível automaticamente no semantic layer, sem configuração.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A mudança de nome ficaria isolada dentro de `stg_orders`, sem quebrar o restante do fluxo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O warehouse passaria a validar sozinho qualquer alteração feita na tabela de origem.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de acompanhar o fluxo completo desta aula, qual afirmação melhor resume o papel do analytics engineer dentro do modern data stack?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Construir e manter os pipelines de ingestão que trazem o dado até o warehouse.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Decidir a infraestrutura de hardware do cluster que roda o data warehouse.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Configurar os alertas de disponibilidade da API que serve os dados ao BI.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Transformar o dado ingerido em modelos e métricas testadas e confiáveis.",
+                                "isCorrect": true
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Boas práticas e antipadrões do modern data stack",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Boas práticas e antipadrões do modern data stack\n\nEssa é a última aula da trilha, e também o fechamento de uma fase inteira do roadmap de Engenharia de Dados: depois de processamento distribuído com Spark e de data lake e lakehouse, o modern data stack fecha o bloco mais avançado do caminho, antes de o roadmap seguir para os temas de operação, qualidade e governança de uma plataforma de dados madura.\n\nO objetivo aqui não é apresentar conceito novo, é consolidar. Boa parte do que aparece nesta aula já foi vista, espalhada, ao longo dos módulos anteriores: camadas, testes, documentação, `ref()` no lugar de nome de tabela fixo. Junto, isso forma uma checklist do que revisar antes de considerar um projeto dbt pronto para produção, e uma lista do que evitar."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Boa prática\", \"Por que importa\"], [\"Camadas claras (staging, intermediate, marts)\", \"Isola mudança de fonte, deixa o DAG fácil de entender\"], [\"Testar cedo (genéricos e singulares)\", \"Pega problema no CI, antes de chegar ao dashboard\"], [\"Uma fonte de verdade para métricas\", \"O semantic layer evita a mesma métrica calculada duas vezes\"], [\"Nunca pular a staging\", \"Mesmo um join simples merece uma camada 1:1 com a fonte\"], [\"Documentar (descriptions, dbt docs)\", \"A próxima pessoa entende o modelo sem perguntar no chat\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Antipadrões comuns\n\n- **O modelo deus**: um único `SELECT` de centenas de linhas, misturando limpeza, várias junções e regra de negócio, direto de tabelas raw até uma saída pronta para o BI. Funciona até a primeira mudança de requisito, depois disso ninguém entende mais o que cada trecho faz nem onde alterar com segurança.\n- **Nome de tabela fixo em vez de `ref()` e `source()`**: escrever `FROM analytics.orders` direto no SQL quebra a linhagem automática do dbt e some do grafo de dependências, o que impede que o `state:modified+` saiba que aquele modelo depende de outro.\n- **Pular a staging**: ir direto da fonte raw para um modelo de mart parece economizar um passo, mas espalha a mesma limpeza (tipos, nomes de coluna) por vários modelos diferentes, cada um reimplementando a mesma correção.\n- **BI consultando a tabela raw direto**: quando um dashboard aponta para uma tabela raw ou staging, em vez de um mart testado, qualquer mudança de schema na fonte quebra o relatório sem passar por nenhum teste no caminho.\n- **Métrica reescrita em cada dashboard**: a ausência de um semantic layer, ou ao menos de uma convenção clara, faz cada analista calcular receita, churn ou LTV do seu próprio jeito."
+                    },
+                    {
+                        "type": "code",
+                        "value": "-- antipadrao: modelo deus, nome de tabela fixo, sem camadas\nSELECT\n    o.id,\n    c.nome,\n    o.valor - o.desconto AS receita,\n    r.nome AS regiao\nFROM analytics.orders o                       -- nome fixo, sem source()\nJOIN analytics.customers c ON c.id = o.customer_id\nJOIN analytics.regioes r ON r.id = c.regiao_id\nWHERE o.status = 'entregue'\n\n\n-- corrigido: em camadas, com ref()/source(), cada modelo com uma responsabilidade\n\n-- models/staging/stg_orders.sql\nSELECT id, customer_id, valor, desconto, status\nFROM {{ source('erp', 'orders') }}\n\n-- models/intermediate/int_orders_enriquecidos.sql\nSELECT\n    o.id,\n    o.valor - o.desconto AS receita,\n    c.regiao_id\nFROM {{ ref('stg_orders') }} o\nJOIN {{ ref('stg_customers') }} c ON c.id = o.customer_id\nWHERE o.status = 'entregue'\n\n-- models/marts/fct_pedidos.sql\nSELECT oe.id, oe.receita, r.nome AS regiao\nFROM {{ ref('int_orders_enriquecidos') }} oe\nJOIN {{ ref('stg_regioes') }} r ON r.id = oe.regiao_id"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Um projeto dbt maduro não se reconhece pelo número de modelos, se reconhece pela confiança de quem lê um SQL escrito por outra pessoa e entende, na hora, o que ele faz."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Fechando a trilha\n\nAo longo desta trilha, o modern data stack deixou de ser uma lista de nomes de ferramentas e virou um jeito de organizar trabalho: ingestão gerenciada (Fivetran, Airbyte) trazendo o dado cru até o warehouse (Snowflake, BigQuery), o dbt transformando esse dado em camadas versionadas e testadas, um semantic layer garantindo que a métrica seja uma só, e um pipeline de CI/CD dando confiança a cada mudança antes dela chegar num BI (Looker, Metabase). Como o restante do roadmap de Engenharia de Dados construído até aqui (lógica, Python, SQL, modelagem, ingestão, orquestração, Spark, lakehouse), nenhuma peça sozinha resolve o problema todo: é a combinação, mantida com disciplina, que faz um time confiar no dado que consome todo dia.\n\nIsso também fecha a fase mais avançada do roadmap. A partir daqui, os próximos passos olham menos para \"como processar e transformar\" e mais para \"como operar, garantir qualidade e governar\" uma plataforma de dados que já funciona, o assunto de trilhas futuras dedicadas a isso."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Por que escrever `FROM analytics.orders` direto no SQL, em vez de usar `{{ source('erp', 'orders') }}`, é considerado um antipadrão num projeto dbt?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Porque quebra a linhagem do dbt, e o modelo some do grafo de dependências.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o dbt bloqueia a compilação de qualquer modelo que não use `source()`.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque nomes fixos de tabela tornam a consulta mais lenta dentro do warehouse.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque `FROM` direto impede a criação de testes genéricos como `not_null`.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um modelo único, com mais de 300 linhas de SQL, faz limpeza, três junções e o cálculo final de receita, direto das tabelas raw até uma saída consumida pelo BI. Um novo integrante do time leva dias para entender onde alterar uma regra de negócio. Qual mudança ataca diretamente esse problema?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Aumentar o número de comentários dentro do mesmo `SELECT`, sem separar em modelos menores.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Materializar esse modelo como table em vez de view, para acelerar a leitura no BI.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Reduzir o número de testes aplicados a esse modelo, já que ele já é complexo o bastante.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Dividir o modelo em camadas (staging, intermediate, marts), cada uma com uma responsabilidade.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um dashboard no Metabase aponta direto para uma tabela de staging, ignorando os marts já testados e documentados. Depois que a fonte de origem muda um tipo de coluna, o dashboard passa a mostrar números incorretos, sem nenhum alerta. Qual prática teria reduzido esse risco?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Conectar o BI apenas aos marts, deixando staging e intermediate como camadas internas.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Aumentar a frequência de atualização do dashboard, para refletir a mudança mais rápido.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Adicionar mais colunas à tabela de staging, cobrindo qualquer mudança futura de tipo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Materializar a tabela de staging como table, em vez de deixá-la como view.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Dois dashboards diferentes mostram churn mensal com números distintos: um calcula churn sobre clientes com contrato ativo, o outro sobre todos os clientes já cadastrados. Ambos os SQLs estão, cada um dentro da própria lógica, corretos. Qual mudança estrutural evita esse tipo de divergência silenciosa no futuro?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Padronizar o nome da coluna churn em todas as tabelas envolvidas nos dois dashboards.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Aumentar a frequência de execução do `dbt build` para reduzir o atraso entre os dashboards.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Migrar os dois dashboards para a mesma ferramenta de BI, mantendo cada fórmula como está.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Definir churn uma única vez no semantic layer, com a regra de negócio explícita e documentada.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de ver camadas, testes, semantic layer e CI/CD ao longo da trilha, qual conjunto de práticas melhor caracteriza um projeto de modern data stack maduro?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Um único modelo por domínio de negócio, otimizado para reduzir o número total de arquivos SQL.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Testes aplicados só nos modelos de staging, já que marts raramente mudam depois de prontos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Métricas calculadas dentro de cada ferramenta de BI, ajustadas conforme o público de cada uma.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Camadas claras, testes desde cedo, métricas centralizadas e CI validando cada mudança.",
+                                "isCorrect": true
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+];
+
+async function seed() {
+    let [trilha] = await db.select().from(trails).where(eq(trails.name, NOME));
+    if (!trilha) {
+        [trilha] = await db
+            .insert(trails)
+            .values({ name: NOME, trailLevel: LEVEL, description: DESCRICAO })
+            .returning();
+        console.log("Trilha criada: " + trilha.name);
+    }
+
+    const existentes = await db.select().from(lessons).where(eq(lessons.trailId, trilha.id));
+    if (existentes.length > 0) {
+        console.log("Trilha " + NOME + " ja tem " + existentes.length + " aulas. Nada a fazer.");
+        return;
+    }
+
+    let totalAulas = 0;
+    let totalQuestoes = 0;
+    for (let mi = 0; mi < MODULOS.length; mi++) {
+        const m = MODULOS[mi];
+        const [mod] = await db
+            .insert(modules)
+            .values({ trailId: trilha.id, title: m.titulo, position: mi + 1 })
+            .returning();
+        for (let li = 0; li < m.aulas.length; li++) {
+            const a = m.aulas[li];
+            const [lesson] = await db
+                .insert(lessons)
+                .values({
+                    trailId: trilha.id,
+                    moduleId: mod.id,
+                    title: a.titulo,
+                    content: null,
+                    contentBlocks: a.blocks,
+                    position: li + 1,
+                    published: true,
+                })
+                .returning();
+            for (let qi = 0; qi < a.questions.length; qi++) {
+                const q = a.questions[qi];
+                const [questao] = await db
+                    .insert(questions)
+                    .values({
+                        lessonId: lesson.id,
+                        statement: q.statement,
+                        difficulty: q.difficulty,
+                        position: qi + 1,
+                    })
+                    .returning();
+                await db.insert(questionOptions).values(
+                    q.options.map((o, k) => ({
+                        questionId: questao.id,
+                        text: o.text,
+                        isCorrect: o.isCorrect,
+                        position: k + 1,
+                    })),
+                );
+            }
+            totalAulas++;
+            totalQuestoes += a.questions.length;
+        }
+    }
+    console.log("Seed concluido: " + MODULOS.length + " modulos, " + totalAulas + " aulas, " + totalQuestoes + " questoes.");
+}
+
+seed()
+    .then(() => process.exit(0))
+    .catch((e) => {
+        console.error("Falha no seed:", e);
+        process.exit(1);
+    });

--- a/backend/scripts/seed-trilha-streaming.ts
+++ b/backend/scripts/seed-trilha-streaming.ts
@@ -1,0 +1,5202 @@
+// Seed da trilha Streaming de Dados (roadmap de Engenharia de Dados).
+// Idempotente e nao destrutivo: se a trilha ja tiver aulas, nao faz nada.
+//
+// Rodar em prod: docker compose -f docker-compose.prod.yml exec -T backend node scripts/seed-trilha-streaming.ts
+import { db } from "../db.ts";
+import { trails, modules, lessons, questions, questionOptions } from "../schema.ts";
+import { eq } from "drizzle-orm";
+
+const NOME = "Streaming de Dados";
+const LEVEL: "iniciante" | "intermediario" | "avancado" = "avancado";
+const DESCRICAO =
+    "Trilha de streaming e dados em tempo real do roadmap de Engenharia de Dados: processar dados em movimento. Batch x streaming, o Apache Kafka como espinha dorsal (topicos, particoes, offsets, producers e consumers), produzir e consumir com garantias, as garantias de entrega (at-least-once, exactly-once), tempo de evento, watermark e janelas, o processamento com Spark Structured Streaming e o streaming na pratica de engenharia de dados. Assume base de Spark, ETL e lakehouse, com foco em decisoes e cenarios.";
+
+type Bloco = { type: "text" | "code" | "quote" | "table"; value: string };
+type Questao = {
+    statement: string;
+    difficulty: "facil" | "medio" | "dificil";
+    options: { text: string; isCorrect: boolean }[];
+};
+type Aula = { titulo: string; blocks: Bloco[]; questions: Questao[] };
+type Modulo = { titulo: string; aulas: Aula[] };
+
+const MODULOS: Modulo[] = [
+    {
+        "titulo": "Módulo 1 - Batch x streaming: por que tempo real",
+        "aulas": [
+            {
+                "titulo": "Dados em repouso x dados em movimento",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Dados em repouso x dados em movimento\n\nAté aqui, cada pipeline que você construiu partiu de uma pergunta parecida: “que dados eu tenho armazenados e como processo esse lote inteiro?”. Um job de ETL lê uma tabela, um arquivo Parquet ou uma partição inteira, aplica transformações e grava o resultado. O dado já está parado em algum lugar (um data lake, um banco, um data warehouse), esperando ser lido.\n\nStreaming inverte essa pergunta. Em vez de “que dados eu tenho parados”, ela vira “que evento acabou de acontecer, e o que eu faço com ele agora?”. O dado não espera: é processado no instante em que é produzido, um registro (ou um pequeno grupo de registros) de cada vez, por um processo que fica rodando indefinidamente.\n\nEssa troca de pergunta é a raiz do que vem nos próximos módulos: Kafka, garantias de entrega, janelas de tempo, Spark Structured Streaming. Antes de entrar em ferramenta, vale entender bem a mudança de mentalidade."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Dado em repouso\n\nDado em repouso (data at rest) é qualquer coisa já persistida, parada até alguém ler: uma tabela de data warehouse, um conjunto de arquivos Parquet num data lake, uma tabela transacional num banco OLTP. Um pipeline batch lê esse conjunto, que tem início e fim bem definidos, processa tudo (ou uma partição dele) e termina.\n\n## Dado em movimento\n\nDado em movimento (data in motion) é um fluxo contínuo de eventos sendo gerados: um clique num site, uma transação de cartão, a leitura de um sensor, uma atualização de estoque. Não existe “o conjunto inteiro” para ler, porque o fluxo não tem fim conhecido. Um processo de streaming não roda uma vez e termina: ele fica de pé, consumindo eventos conforme chegam, potencialmente para sempre."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Aspecto\", \"Dados em repouso (batch)\", \"Dados em movimento (streaming)\"], [\"Onde o dado vive\", \"Armazenado em data lake, warehouse ou banco\", \"Em trânsito, num log ou tópico de mensageria\"], [\"Quando é processado\", \"Sob demanda ou em horário agendado\", \"No instante em que é produzido\"], [\"Limite do conjunto\", \"Finito e conhecido, com início e fim\", \"Sem fim conhecido, fluxo contínuo\"], [\"Duração do processo\", \"Job roda, termina e libera recursos\", \"Aplicação fica de pé, rodando sem parar\"], [\"Pergunta típica\", \"Quanto vendemos no mês passado, por região?\", \"Essa transação agora parece fraude?\"]]"
+                    },
+                    {
+                        "type": "code",
+                        "value": "Dado em repouso (batch):\n\n  [ Data Lake / Tabela completa ]\n              |\n     (job agendado, 1x por dia)\n              |\n              v\n   lê tudo -> transforma -> grava resultado -> job termina\n\n\nDado em movimento (streaming):\n\n  evento -> evento -> evento -> evento -> ...\n    |         |         |         |\n    v         v         v         v\n  [   processo rodando continuamente, sem fim definido   ]\n    |         |         |         |\n    v         v         v         v\n resultado  resultado  resultado  resultado   (um por evento, ou por pequeno grupo)"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Em batch, o dado espera o processamento. Em streaming, o processamento espera o dado. É essa inversão que muda a forma de projetar o pipeline inteiro."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que muda na prática de engenharia\n\n- **Unidade de trabalho**: em batch, a unidade é o lote (uma partição, um arquivo, uma tabela inteira). Em streaming, a unidade é o evento, ou um micro-lote de poucos segundos.\n- **Ciclo de vida do processo**: um job batch tem início, meio e fim. Uma aplicação de streaming, em geral, não tem fim: ela roda 24 horas por dia, e “terminar” costuma significar falha, não sucesso.\n- **Recomputar o passado**: em batch, se algo sair errado, geralmente basta rodar o job de novo sobre os mesmos dados parados. Em streaming, o evento já passou; reprocessar exige reler um histórico retido em algum log (é aqui que o log distribuído do Kafka, visto no próximo módulo, entra) ou aceitar que aquele instante se perdeu.\n- **Estado**: um job batch costuma ser sem estado entre execuções, ou reconstrói tudo do zero a cada rodada. Um job de streaming precisa manter estado vivo (contadores, agregações parciais, últimas chaves vistas) enquanto roda, porque não há “o conjunto todo” para reconsultar a qualquer momento."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O ponto não é abandonar o batch\n\nStreaming não substitui batch: ele complementa. A maioria das plataformas de dados maduras usa os dois, batch para relatórios, históricos e cargas pesadas em que uma janela de algumas horas é aceitável, streaming para os casos em que o valor do dado cai rápido com o tempo. Os próximos módulos tratam Kafka e streaming como mais uma ferramenta na caixa, não como substituto do que você já viu em ETL e orquestração."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual característica define melhor “dado em movimento” (data in motion), em contraste com dado em repouso?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "É produzido de forma contínua e processado assim que surge, sem conjunto final fechado.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Fica guardado numa tabela até que um job agendado faça a leitura completa dela.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "É replicado em múltiplos data centers antes que qualquer consulta seja permitida.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "É compactado em arquivos colunares para reduzir o custo de armazenamento em disco a longo prazo.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um analista precisa saber quantos pedidos foram cancelados no mês passado, por região. Do ponto de vista de dado em repouso x dado em movimento, qual abordagem combina melhor com essa pergunta?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Streaming, porque cancelamentos são eventos e só podem ser lidos no instante em que ocorrem.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Batch, porque o conjunto de pedidos do mês passado é finito e já está parado em algum armazenamento.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Streaming, porque manter um processo rodando sem parar é sempre mais barato que agendar uma consulta.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Batch, porque tabelas de data warehouse não conseguem guardar dados de mais de um mês por vez.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de reescrever um pipeline batch como uma aplicação de streaming, o time de infraestrutura notou que o processo nunca aparece como “concluído com sucesso” nos logs, mesmo com tudo saudável. Por que isso é esperado?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque aplicações de streaming têm uma falha conhecida que impede o encerramento normal do processo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o agendador de jobs da empresa não reconhece processos ligados a um tópico de mensageria.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque uma aplicação de streaming roda continuamente por natureza, e terminar costuma indicar falha.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o cluster ficou subdimensionado e o processo repete o mesmo lote sem nunca concluir.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um job batch falhou por um bug, foi corrigido, e a equipe rodou o job de novo sobre a mesma partição sem problema. Um pipeline de streaming teve um bug parecido durante duas horas. Por que “rodar de novo” não é tão simples nesse segundo caso?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Porque o Kafka apaga cada evento automaticamente no instante em que ele é lido por um consumidor.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque aplicações de streaming nunca permitem qualquer tipo de reprocessamento, mesmo com o dado retido em log.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o Spark Structured Streaming não oferece nenhum suporte a leitura de dados históricos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque os eventos já passaram: reprocessar exige reler um histórico retido, não repetir sobre dados parados.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Sobre a relação entre pipelines batch e pipelines de streaming numa plataforma de dados madura, qual afirmação está correta?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "As duas coexistem: batch ainda cobre históricos e cargas pesadas, streaming atende ao que perde valor rápido.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Streaming substitui o batch por completo, porque todo processamento em lote pode virar evento sem custo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Batch substitui o streaming sempre, porque o hardware atual não sustenta processos rodando sem parar.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Streaming só existe fora do data warehouse, porque as duas arquiteturas nunca operam lado a lado.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "O que é processamento de streams e quando vale a pena",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# O que é processamento de streams e quando vale a pena\n\nProcessar um stream não é apenas mover dados rapidamente de um lugar para outro. É aplicar lógica continuamente sobre um fluxo de eventos: filtrar, agregar, enriquecer, cruzar com outra fonte, detectar um padrão, tudo enquanto o dado ainda está “quente”. Mover dado rápido é condição necessária, mas quem faz o trabalho de processamento de streams é a computação contínua em cima desse fluxo, não o transporte em si.\n\nEssa distinção importa porque nem todo problema com “dado chegando rápido” precisa de streaming. Vale entender primeiro onde streaming resolve um problema real, para depois (nos módulos seguintes) aprender a ferramenta."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Casos de uso onde streaming compensa\n\n- **Detecção de fraude**: uma transação de cartão precisa ser avaliada em milissegundos ou poucos segundos, antes de ser aprovada. Analisar isso à noite, em lote, chega tarde demais: o dinheiro já saiu.\n- **Dashboards operacionais ao vivo**: pedidos por minuto, erros por segundo, fila de atendimento em tempo real. Um painel que atualiza de hora em hora não serve para quem precisa agir agora.\n- **Alertas e monitoramento**: detectar uma anomalia (queda de um sensor, pico de erro numa API) e agir antes que o problema se espalhe para o resto do sistema.\n- **Personalização em tempo real**: ajustar uma recomendação com base no clique que acabou de acontecer, não só no comportamento de ontem.\n- **Manutenção preditiva com IoT**: um sensor emite leituras continuamente, e o streaming detecta um desvio de padrão assim que ele aparece."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Caso de uso\", \"Por que streaming compensa\", \"O que aconteceria em batch\"], [\"Detecção de fraude\", \"A decisão de aprovar ou barrar precisa vir antes da transação se completar\", \"A fraude só seria descoberta horas depois, com o prejuízo já feito\"], [\"Dashboard operacional\", \"Métricas de operação perdem sentido se não refletem o agora\", \"O painel mostraria uma foto de várias horas atrás\"], [\"Personalização\", \"A próxima recomendação depende do clique que acabou de acontecer\", \"A recomendação usaria só o comportamento do dia anterior\"], [\"Manutenção preditiva\", \"Um desvio no sensor precisa virar alerta antes da falha do equipamento\", \"O desvio só apareceria no relatório do dia seguinte\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Streaming compensa quando o custo de chegar atrasado é maior que o custo extra de manter um processo rodando sem parar. Fora disso, é complexidade sem retorno."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Quando o batch ainda resolve, e resolve bem\n\nRelatório mensal de vendas, cálculo de folha de pagamento, treinamento de um modelo sobre um histórico grande, migração de dados, carga noturna de um data warehouse: nenhum desses casos perde valor se levar algumas horas. Forçar esses processos para streaming só adiciona complexidade operacional sem trazer benefício de negócio.\n\nUma pergunta de bolso ajuda a decidir: “se esse dado chegasse seis horas atrasado, alguém notaria, perderia dinheiro ou perderia uma oportunidade?”. Se a resposta for não, o batch resolve com bem menos esforço de operação."
+                    },
+                    {
+                        "type": "code",
+                        "value": "O dado atrasar importa de verdade?\n        |\n    -------------\n    |           |\n   sim          não\n    |           |\n    v           v\nStreaming    Batch resolve\ncompensa a   (mais simples\ncomplexidade  de operar e\nadicional      de manter)"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Streaming não é só “mover dados rápido”\n\nÉ comum confundir “ter um fluxo de eventos chegando rápido” com “fazer processamento de streams”. Kafka movendo eventos em milissegundos, sozinho, ainda não é processamento de streams: é transporte. O processamento acontece quando alguma lógica roda continuamente sobre esse fluxo, como o Spark Structured Streaming faz, filtrando, agregando ou cruzando dados a cada novo evento (assunto dos módulos seguintes)."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que caracteriza, de fato, o processamento de streams, e não apenas o transporte rápido de dados?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "A entrega de cada evento em menos de um segundo entre o produtor e o consumidor final da cadeia.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Aplicar alguma lógica de forma contínua sobre o fluxo, como filtrar, agregar ou detectar um padrão.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O uso obrigatório de um cluster com mais de dez máquinas dedicado apenas à camada de mensageria.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A compactação dos eventos num formato binário compacto antes de qualquer envio pela rede interna.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe de folha de pagamento pediu para migrar o cálculo mensal de salários para uma arquitetura de streaming, achando mais moderno. O cálculo já roda uma vez por mês, sem reclamação de atraso. O que essa mudança traria?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Redução real de custo, porque manter um processo rodando sem parar é sempre mais barato que agendar uma execução.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Maior precisão no cálculo, porque folha de pagamento processada evento a evento erra menos que em lote.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Mais complexidade operacional sem ganho de negócio, já que um atraso de horas nesse cálculo não afeta ninguém.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Melhor governança dos dados de salário, porque streaming aplica controle de acesso mais rígido que batch.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Num sistema de detecção de fraude em cartão de crédito, por que rodar a análise em lote, uma vez por dia, costuma ser inadequado?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque jobs em lote não conseguem ler tabelas com informações de transações financeiras por restrição técnica.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o volume de transações de um dia é sempre grande demais para caber num único job batch.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque times de fraude são obrigados por lei a usar apenas ferramentas de streaming em qualquer banco.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque a decisão de aprovar ou barrar a transação precisa vir antes de o dinheiro sair, e um dia já é tarde demais.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma fábrica instalou sensores de vibração em motores e quer detectar desvios que antecedem falhas mecânicas. Os dados fluem continuamente, mas o time de dados sugeriu processar tudo em lote, a cada hora. Qual é o risco principal dessa escolha?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Um desvio que antecede a falha pode passar despercebido por até uma hora antes de o equipamento quebrar.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O lote horário vai custar mais processamento do que streaming, porque sensores geram muito mais dados que cliques.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Sensores de vibração não produzem dados em formato compatível com jobs batch, exigindo conversão manual constante.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O modelo de manutenção preditiva perde acurácia sempre que roda sobre dados agregados, independente do caso.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual cenário é o que melhor se encaixa em batch, mesmo numa empresa que já usa streaming em outras partes do negócio?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Aprovar ou recusar uma transação de cartão de crédito no momento em que ela é solicitada.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Gerar o relatório mensal de vendas por região para a diretoria revisar na reunião do mês seguinte.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Atualizar um painel de erros por segundo para o time de plantão durante um incidente em produção.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ajustar a recomendação de produto exibida ao cliente logo depois do clique que ele acabou de dar.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Latência x throughput e o custo do tempo real",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Latência x throughput e o custo do tempo real\n\nDois números resumem boa parte da conversa sobre streaming: latência e throughput. Latência é o tempo entre um evento acontecer e o resultado daquele processamento ficar disponível. Throughput é o volume de eventos que o sistema consegue processar por unidade de tempo. Os dois raramente melhoram juntos de graça: otimizar para latência baixa costuma custar throughput, custo operacional, ou ambos.\n\nEntender esse trade-off é o que separa “queremos tempo real” de “meu sistema realmente precisa de tempo real, e está disposto a pagar por isso”."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O trade-off na prática\n\nReduzir latência geralmente significa lotes menores (mais overhead relativo por lote processado), recursos sempre ativos (cluster de pé 24 horas por dia, mesmo com pouco tráfego às três da manhã) e checkpoints mais frequentes para tolerância a falha.\n\nAumentar throughput geralmente significa lotes maiores e mais paralelismo, aceitando que cada resultado individual demore mais para ficar pronto. Nenhuma das duas escolhas é “errada”: são pontos diferentes de uma mesma régua, e a escolha certa depende do que o negócio realmente precisa."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Perfil\", \"Latência típica\", \"Throughput\", \"Custo operacional\"], [\"Batch diário\", \"Horas\", \"Alto, processa tudo de uma vez\", \"Baixo, roda numa janela e libera recursos\"], [\"Micro-batch\", \"Segundos a minutos\", \"Médio a alto\", \"Médio, cluster fica ativo por mais tempo\"], [\"Streaming por evento\", \"Milissegundos\", \"Depende do paralelismo configurado\", \"Alto, infraestrutura ativa o tempo todo\"]]"
+                    },
+                    {
+                        "type": "code",
+                        "value": "Latência baixa <-------------------------------------> Throughput alto\n (evento a evento)                                     (grandes lotes)\n\n     streaming          micro-batch               batch\n     por evento          (segundos)               (horas)\n        |                    |                       |\n   mais overhead        equilíbrio              menos overhead\n   por registro           típico                 por registro\n        |                                              |\n   custo operacional                           custo operacional\n       maior                                          menor"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Tempo real não é grátis: você paga com infraestrutura sempre ligada, engenharia mais cuidadosa e uma operação mais exigente. A pergunta certa não é “dá para deixar mais rápido?”, é “precisa ser mais rápido?”."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## A pergunta que guia a decisão: quão fresco o dado precisa ser?\n\nEm vez de mirar “o mais rápido possível”, defina um SLA de frescor: o atraso máximo aceitável entre o evento acontecer e o resultado estar disponível. Dimensione a solução para esse número, não para o limite técnico da ferramenta.\n\nAlguns exemplos de SLA de frescor:\n- Fraude em cartão: segundos.\n- Nível de estoque num e-commerce: minutos.\n- Relatório executivo de vendas: um dia.\n\nCada um desses exemplos aceita um ponto diferente do espectro entre batch e streaming, e forçar todos para “o mais rápido possível” custaria caro sem necessidade."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O custo do tempo real vai além da infraestrutura\n\nStreaming também custa em operação: alguém precisa ficar de plantão para um processo que roda 24 horas por dia, depurar um problema é mais difícil quando não dá para simplesmente “rodar de novo o dia inteiro”, e o time precisa de familiaridade com conceitos que batch não exige, como janelas de tempo e watermark (módulo 5). Tratar streaming como padrão só porque parece mais moderno costuma trazer esse custo sem o benefício correspondente."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Um time reduziu o tamanho dos lotes de processamento para diminuir o tempo entre o evento acontecer e o resultado ficar pronto. Que métrica esse time está otimizando diretamente?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Throughput, porque lotes menores sempre aumentam o volume total processado por segundo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Retenção, porque lotes menores fazem o dado ficar armazenado por menos tempo no log.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Latência, porque o foco é reduzir o tempo entre o evento e o resultado disponível.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Paralelismo, porque lotes menores exigem automaticamente mais máquinas no cluster.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um analista pediu para o time de engenharia entregar o relatório de vendas do mês “assim que cada venda acontecer”. O relatório é revisado uma vez por mês, na reunião de fechamento. Qual é a avaliação mais adequada desse pedido?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O pedido está correto, porque todo relatório de negócio se beneficia de estar sempre atualizado ao segundo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O pedido é tecnicamente impossível, porque não existe forma de agregar vendas em tempo real com precisão.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O pedido é obrigatório por lei, porque relatórios financeiros exigem atualização contínua em qualquer empresa.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O pedido adiciona complexidade sem necessidade, já que o relatório só é olhado uma vez por mês.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um e-commerce quer manter o nível de estoque exibido no site atualizado. Testes internos mostram que os clientes não percebem diferença entre um atraso de trinta segundos e um de três minutos, mas notam quando o atraso passa de dez minutos. Qual SLA de frescor faz mais sentido?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Poucos minutos, o suficiente para ficar bem abaixo do limite de dez minutos percebido pelos clientes.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Milissegundos, processando cada venda individualmente para garantir a menor latência tecnicamente possível.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma hora, já que qualquer atualização de estoque abaixo desse tempo já seria considerada tempo real.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um dia, alinhado ao mesmo ritmo usado no relatório executivo de vendas da diretoria.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um pipeline foi desenhado para maximizar throughput, com lotes grandes processados a cada trinta minutos. O negócio, porém, precisa aprovar ou recusar transações em até dois segundos. Qual é a tensão nesse cenário?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Não existe tensão real, porque throughput alto sempre implica automaticamente em latência baixa também.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O pipeline está otimizado para o eixo errado: o negócio exige latência baixa, não throughput alto.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O problema é de volume, porque nenhum pipeline consegue aprovar mais de uma transação por vez ao todo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O problema é de custo, porque throughput alto é sempre a opção mais barata de operar na nuvem.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Além da infraestrutura sempre ligada, qual é outro custo real de operar um pipeline de streaming, em comparação com um pipeline batch equivalente?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Nenhum: uma vez paga a infraestrutura, streaming não traz custo adicional de operação.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um custo de licenciamento obrigatório, já que streaming não tem opções de código aberto.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Mais exigência operacional: plantão para o processo contínuo e depuração mais difícil.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um custo de armazenamento maior, porque streaming sempre duplica todo o histórico em disco.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "A arquitetura orientada a eventos",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# A arquitetura orientada a eventos\n\nArquitetura orientada a eventos (event-driven architecture) organiza um sistema em torno da produção, detecção e reação a eventos, em vez de chamadas diretas entre serviços. Um evento é o registro imutável de algo que aconteceu: “pedido_criado”, “pagamento_aprovado”, “sensor_leu_temperatura”. Ele descreve um fato, não uma ordem.\n\nEssa forma de organizar sistemas já apareceu na trilha de mensageria; aqui o foco é como ela vira a base concreta que sustenta o processamento de streams."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Produtores, eventos e consumidores\n\nUm **produtor** emite um evento quando algo acontece no sistema que ele representa. Ele não sabe, e não precisa saber, quem vai consumir esse evento, nem quantos consumidores existem.\n\nUm **consumidor** reage ao evento de forma independente: lê o que aconteceu e decide o que fazer com aquilo, sem depender de uma resposta síncrona do produtor.\n\nA diferença entre **evento** e **comando** importa: um evento diz “isso aconteceu” (fato, o passado), um comando diz “faça isso” (ordem, o futuro). Sistemas orientados a eventos trocam fatos, não ordens."
+                    },
+                    {
+                        "type": "code",
+                        "value": "Chamada síncrona (acoplamento direto):\n\n  Serviço A ---chama---> Serviço B ---chama---> Serviço C\n     (A só continua depois que B e C responderem)\n     (se C cair, A trava esperando)\n\n\nArquitetura orientada a eventos:\n\n                      +-----------------+\n  Produtor --emite--> |  Log de eventos | --evento--> Consumidor 1\n                      |     (broker)    | --evento--> Consumidor 2\n                      +-----------------+ --evento--> Consumidor 3\n\n     (o produtor não sabe quantos consumidores existem)\n     (cada consumidor lê no seu próprio ritmo)"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Aspecto\", \"Chamada síncrona (ponto a ponto)\", \"Arquitetura orientada a eventos\"], [\"Acoplamento\", \"Alto: quem chama precisa saber o endereço de quem responde\", \"Baixo: produtor não conhece os consumidores\"], [\"Adicionar novo consumo\", \"Exige alterar o serviço que originou a chamada\", \"Basta o novo consumidor se inscrever no evento\"], [\"Falha de um consumidor\", \"Pode travar quem fez a chamada, esperando resposta\", \"Não afeta o produtor nem os demais consumidores\"], [\"Quem sabe de quem\", \"As duas pontas se conhecem\", \"Produtor não sabe quem, nem quantos, consomem\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "O produtor não sabe, e não precisa saber, quem consome o evento. Esse desacoplamento é o que permite adicionar um novo consumidor sem tocar em uma linha do produtor."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O log de eventos como fonte central\n\nEm vez de mensagens efêmeras trocadas ponto a ponto, arquiteturas de streaming colocam um log de eventos durável e ordenado no centro: cada evento é gravado nesse log e permanece disponível por um período de retenção, não só no instante em que foi emitido. Um consumidor novo pode entrar e ler desde o início; um consumidor que ficou fora do ar por um tempo pode retomar de onde parou.\n\nEssa ideia de log central, ordenado e durável é exatamente o que o Kafka implementa, e é o assunto do próximo módulo."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Por que isso importa para streaming\n\nProcessamento de streams só existe porque há, antes dele, uma arquitetura orientada a eventos com um lugar durável para os eventos ficarem: sem produtores e consumidores desacoplados em torno de um log, não haveria onde plugar uma computação contínua. O módulo 2 detalha como o Kafka materializa essa ideia."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Num sistema orientado a eventos, o que melhor descreve um evento como “pagamento_aprovado”?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Uma ordem enviada a um serviço específico, exigindo que ele execute uma ação em seguida.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma pergunta enviada ao consumidor, que deve responder antes do produtor continuar.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma cópia de segurança do banco de dados, gerada automaticamente a cada transação aprovada.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O registro de um fato que já aconteceu, sem exigir uma ação imediata de quem o emitiu.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um time quer adicionar um novo sistema de recomendação que reage ao evento “pedido_criado”, sem alterar o serviço que cria pedidos. Isso só é simples de fazer porque:",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O produtor do evento não conhece nem depende de quem consome, então um novo consumidor entra sem mudar nada nele.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Todo evento é automaticamente enviado a qualquer sistema novo criado na mesma empresa, por padrão de rede.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O serviço de recomendação sempre roda no mesmo servidor do serviço que cria pedidos, lendo a memória direto.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Eventos são reprocessados a cada minuto por um job batch, que distribui os dados para todos os sistemas.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Numa cadeia de chamadas síncronas (A chama B, que chama C), o serviço C fica indisponível por alguns minutos. Qual é a consequência mais provável para o serviço A?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Nenhuma: chamadas síncronas isolam automaticamente cada serviço da falha dos demais.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A pode travar ou falhar esperando a resposta de B, que por sua vez depende da resposta de C.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A troca automaticamente para um modo assíncrono até que C volte a responder normalmente.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Apenas C perde as requisições recebidas nesse intervalo, sem qualquer efeito sobre A ou B.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um consumidor de eventos ficou fora do ar por uma hora por causa de uma manutenção. Num sistema de mensageria comum, sem retenção, esses eventos seriam perdidos. Por que um log de eventos durável evita esse problema?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Porque o log de eventos duplica cada evento automaticamente para todos os consumidores possíveis, mesmo os inativos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque consumidores em arquiteturas de streaming nunca ficam fora do ar, já que rodam em múltiplas réplicas sempre.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o evento permanece gravado e disponível por um período de retenção, e o consumidor pode retomar de onde parou.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o produtor reenvia manualmente cada evento perdido assim que percebe que um consumidor ficou indisponível.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual é a principal diferença entre um “evento” e um “comando” numa arquitetura orientada a eventos?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Evento é sempre menor em tamanho de dados; comando costuma carregar arquivos anexos maiores.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Evento trafega apenas dentro do mesmo serviço; comando sempre cruza os limites de uma rede externa.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Evento é processado por streaming; comando só pode ser processado por um job batch tradicional.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Evento descreve um fato que já ocorreu; comando é uma ordem para que algo aconteça.",
+                                "isCorrect": true
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Batch, micro-batch e streaming verdadeiro",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Batch, micro-batch e streaming verdadeiro\n\n“Tempo real” não é um interruptor ligado ou desligado: é um espectro. Numa ponta está o batch tradicional, rodando sobre um conjunto fechado de dados uma vez por dia ou por hora. Na outra ponta está o streaming verdadeiro, processando cada evento no instante em que ele chega. No meio, e é onde a maior parte dos sistemas de streaming do mundo real vive de fato, está o micro-batch.\n\nEste é o fechamento do módulo: juntar tudo que foi visto (o custo do tempo real, os casos de uso, a arquitetura orientada a eventos) num mapa de onde cada abordagem se encaixa."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Abordagem\", \"Latência típica\", \"Como processa\", \"Exemplo de ferramenta\"], [\"Batch\", \"Horas\", \"Lê e processa uma partição ou tabela inteira de uma vez\", \"Spark em modo batch, jobs agendados no orquestrador\"], [\"Micro-batch\", \"Segundos a poucos minutos\", \"Acumula um pequeno lote e processa em ciclos curtos e repetidos\", \"Spark Structured Streaming, no modo padrão\"], [\"Streaming verdadeiro\", \"Milissegundos\", \"Processa cada evento (ou grupo mínimo) assim que ele chega\", \"Kafka Streams, Apache Flink\"]]"
+                    },
+                    {
+                        "type": "code",
+                        "value": "Espectro de latência:\n\n Batch diário          Micro-batch            Streaming por evento\n   (horas)          (segundos a min)             (milissegundos)\n     |------------------|------------------------|\n     |                  |                         |\n   lê tudo          processa em              processa cada\n  de uma vez       ciclos curtos            evento assim que\n   e termina        e repetidos                ele chega\n\n       menos overhead                     mais overhead\n       por registro    <---------------->  por registro\n       custo menor                         custo maior"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Micro-batch não é “streaming fraco”: é um ponto de equilíbrio deliberado entre a simplicidade operacional do batch e a agilidade do streaming verdadeiro."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Micro-batch: o meio-termo mais usado na prática\n\nA maior parte dos pipelines chamados de “streaming” no mundo real roda em micro-batch: o Spark Structured Streaming, no seu modo padrão, acumula os eventos chegados num intervalo curto (poucos segundos) e processa esse pequeno lote de uma vez, repetindo o ciclo sem parar. Isso reaproveita boa parte do motor de execução batch, o que simplifica tolerância a falha e operação, e entrega uma latência baixa o suficiente para a grande maioria dos casos de uso.\n\nMotores de streaming verdadeiro, evento a evento, como Apache Flink e Kafka Streams (ou serviços gerenciados como o Amazon Kinesis), existem para os casos em que nem alguns segundos de espera são aceitáveis, ao custo de mais complexidade operacional."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Escolhendo o ponto do espectro\n\nVoltando ao SLA de frescor da aula anterior: a maioria das necessidades reais de negócio cabe confortavelmente dentro do micro-batch, com latência de segundos a poucos minutos. Migrar para streaming verdadeiro, evento a evento, deve ser uma decisão justificada por um requisito concreto de milissegundos, não pela sensação de que é “mais moderno” ou “mais correto”."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Fechando o módulo\n\nEste módulo respondeu “por que tempo real”: o que muda quando o dado deixa de estar em repouso, quando streaming vale o investimento, o trade-off entre latência e throughput, e a arquitetura orientada a eventos que sustenta tudo isso. O módulo 2 entra na ferramenta que materializa essas ideias na prática: o Apache Kafka, o log distribuído que serve de espinha dorsal para qualquer ponto desse espectro, do micro-batch ao streaming verdadeiro."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Onde o micro-batch se encaixa no espectro entre batch tradicional e streaming verdadeiro?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "No meio: latência menor que o batch tradicional, mas ainda em pequenos lotes, não evento a evento.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Na mesma ponta do batch tradicional, apenas rodando com uma frequência de execução maior por dia.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Na mesma ponta do streaming verdadeiro, processando cada evento individual no instante em que chega.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Fora do espectro, porque micro-batch é uma técnica de armazenamento e não de processamento.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um pipeline em Spark Structured Streaming processa um novo micro-lote a cada trinta segundos, usando o modo de disparo (trigger) padrão. Como esse pipeline deve ser classificado dentro do espectro batch a streaming?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Como batch tradicional, porque qualquer processamento organizado em lotes conta como batch, sem exceção.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Como micro-batch, porque processa pequenos lotes em ciclos curtos e repetidos, com latência de segundos.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Como streaming verdadeiro, porque o Spark Structured Streaming só sabe operar evento a evento, nunca em lotes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Como uma arquitetura orientada a eventos, porque o conceito de lote deixa de existir dentro do Spark.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um sistema de reposição de estoque tolera até dois minutos de atraso entre a venda e a atualização do saldo disponível. A equipe avalia adotar Apache Flink, com processamento evento a evento, para esse caso. Qual é a avaliação mais adequada?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Correta: qualquer sistema de estoque deve sempre processar evento a evento, sem exceção, para evitar overselling.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Incorreta: Apache Flink não é capaz de processar eventos ligados a controle de estoque em nenhuma hipótese.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Provavelmente desnecessária: micro-batch já entrega folga dentro dos dois minutos, com menos complexidade.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Incorreta: controle de estoque deve sempre rodar em batch diário, por ser um dado financeiro sensível.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma mesa de operações financeiras precisa reagir a mudanças de preço em menos de cem milissegundos para tomar uma decisão automática. Um protótipo em micro-batch, com ciclos de dois segundos, não atende ao requisito. Qual caminho resolve o problema de latência descrito?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Reduzir o período de retenção do log de eventos, o que diminui automaticamente a latência de qualquer consumidor.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Aumentar o número de partições do tópico, já que mais partições sempre reduzem a latência para cem milissegundos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Trocar o micro-batch por um batch diário consolidado, processando as mudanças de preço num único job maior.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Adotar um motor de streaming verdadeiro, evento a evento, como Flink ou Kafka Streams, feito para milissegundos.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que o micro-batch, e não o streaming evento a evento, é a abordagem mais comum na maioria dos pipelines chamados de “streaming” hoje?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque reaproveita o motor de execução batch, simplificando operação e falha, com latência baixa.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque motores de streaming evento a evento, como Flink, foram descontinuados pelos mantenedores nos últimos anos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque micro-batch é a única abordagem compatível com o Apache Kafka como sistema de transporte de eventos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque órgãos reguladores de dados exigem que todo processamento contínuo seja feito em pequenos lotes.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 2 - Apache Kafka: fundamentos",
+        "aulas": [
+            {
+                "titulo": "O que é o Kafka: um log distribuído",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# O que é o Kafka: um log distribuído\n\nO Apache Kafka é a peça de transporte que sustenta a maior parte das arquiteturas de streaming. A trilha de Spark tratou dados que já pousaram em algum lugar antes de serem processados; o Kafka existe para o momento anterior a esse, o trânsito dos eventos enquanto eles ainda estão em movimento entre um sistema e outro. Antes de entrar em produtores, consumidores ou garantias de entrega, vale entender a abstração que sustenta tudo isso: o log distribuído."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Um log, não uma fila\n\nUm log é a estrutura de dados mais simples que existe: uma sequência ordenada de registros, em que cada novo registro é adicionado ao final. Ninguém edita um registro já escrito, ninguém insere um registro no meio. O Kafka usa exatamente essa ideia para guardar eventos: cada mensagem publicada vira uma nova entrada no fim do log, e essa entrada não muda mais depois de escrita.\n\nIsso contrasta com uma fila de mensagens tradicional. Numa fila clássica, a mensagem é removida assim que um consumidor a processa e confirma o recebimento: ela existe para ser entregue uma vez e depois desaparece. No Kafka, o evento publicado continua guardado depois de ser lido. Ler um evento não é o mesmo que consumi-lo no sentido de apagá-lo."
+                    },
+                    {
+                        "type": "code",
+                        "value": "Log de eventos (visão simplificada)\n\n  posição:   0     1     2     3     4     5     6     7\n            [e0]  [e1]  [e2]  [e3]  [e4]  [e5]  [e6]  [e7]   <- próximo evento entra aqui\n                                     ^                 ^\n                              consumidor A        consumidor B\n                              já leu até aqui     já leu até aqui\n\n# cada consumidor guarda sua própria posição e avança no seu próprio ritmo\n# um evento lido continua no log: outro consumidor pode chegar depois e lê-lo desde o início"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Dimensão\",\"Fila tradicional\",\"Kafka (log distribuído)\"],[\"Evento após a leitura\",\"Removido assim que um consumidor confirma o recebimento\",\"Permanece no log durante o período de retenção\"],[\"Consumidores independentes\",\"Concorrem pela mesma mensagem, entregue uma única vez\",\"Cada grupo lê sua própria cópia, no seu próprio ritmo\"],[\"Reler o passado\",\"Não é possível, a mensagem já foi descartada\",\"Possível, enquanto o evento ainda estiver retido\"],[\"Papel do consumidor\",\"Passivo: a mensagem é empurrada e depois some\",\"Ativo: o consumidor controla sua própria posição de leitura\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Por que isso importa\n\n- **Replay**: um consumidor novo pode entrar meses depois de o tópico existir e ler o histórico inteiro, respeitando a retenção configurada, útil para reprocessar dados ou alimentar um sistema recém-criado.\n- **Consumidores independentes**: o time de fraude e o time de BI podem ler os mesmos eventos de pedidos, cada um no seu próprio ritmo, sem que um interfira no outro.\n- **Desacoplamento no tempo**: quem publica o evento não precisa saber quem vai lê-lo, nem esperar que algum consumidor esteja pronto para escrever."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "O Kafka não entrega uma mensagem e a esquece: ele guarda um histórico de eventos que pode ser lido, e relido, por quem precisar, no ritmo que for preciso."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que vem a seguir\n\nEsse log não é um arquivo único e infinito: ele é organizado em tópicos, divididos em partições, e cada posição dentro de uma partição tem um nome formal, o offset. É o assunto da próxima aula."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual característica descreve corretamente o que acontece com um evento no Kafka depois que um consumidor o lê?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "O evento permanece no log, disponível para outros consumidores, até o fim do período de retenção.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O evento é apagado do log assim que o primeiro consumidor confirma a leitura, como numa fila clássica.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O evento é bloqueado para leitura por outros consumidores até ser reprocessado manualmente.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O evento é movido para uma partição de arquivamento, fora do alcance de novas leituras.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Dois times, fraude e BI, precisam ler os mesmos eventos de pagamentos publicados no Kafka, cada um processando no seu próprio ritmo e sem interferir no outro. Qual propriedade do Kafka viabiliza diretamente esse cenário?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O balanceamento automático de carga entre os brokers do cluster, que redistribui eventos entre times.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A leitura não remove o evento do log: consumidores independentes leem cada um no seu ritmo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A compressão dos eventos no log, que reduz o espaço ocupado por cada mensagem publicada.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A criptografia dos eventos em trânsito, que isola o acesso de cada time aos dados publicados.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe está migrando de uma fila de mensagens tradicional para o Kafka e espera que o comportamento de consumo continue idêntico. Qual mudança de comportamento essa equipe deveria esperar?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "As mensagens continuarão sendo removidas automaticamente assim que forem entregues a um consumidor.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "As mensagens passarão a exigir um único consumidor autorizado por tópico, diferente da fila anterior.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "As mensagens deixarão de ser removidas na leitura e poderão ser relidas enquanto durar a retenção.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "As mensagens passarão a ser entregues fora de ordem, já que o Kafka não preserva sequência alguma.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um pipeline publica eventos de sensores no Kafka, mas por uma falha na infraestrutura de consumo, nenhum consumidor lê o tópico durante três dias. A retenção do tópico está configurada para sete dias. O que acontece com os eventos publicados nesses três dias?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "São perdidos, porque o Kafka descarta eventos automaticamente quando não existe consumidor ativo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ficam retidos apenas parcialmente, já que a ausência de leitura acelera o descarte por espaço em disco.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "São movidos para uma partição de reprocessamento, criada automaticamente após três dias sem leitura.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Continuam disponíveis no log, porque a retenção depende do tempo configurado, não da leitura.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual é a analogia mais precisa para a forma como o Kafka armazena os eventos publicados num tópico?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Um log de registros, em que cada evento é adicionado ao final e permanece disponível depois disso.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Uma fila de atendimento, em que cada evento sai de circulação assim que é atendido por um consumidor.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma tabela mutável, em que cada evento pode ser atualizado conforme novos dados chegam ao sistema.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma pilha de eventos, em que o último evento publicado é sempre o primeiro a ser consumido.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Tópicos, partições e offsets",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Tópicos, partições e offsets\n\nUm tópico é o nome que o Kafka dá a uma categoria de eventos, algo como \"pedidos\", \"cliques\" ou \"pagamentos\". Mas um tópico não é um único log gigante: por baixo, ele é dividido em partições, e é essa divisão que permite ao Kafka escalar horizontalmente. Esta aula formaliza três conceitos que aparecem em qualquer conversa sobre Kafka: tópico, partição e offset."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Tópico: a categoria do evento\n\nUm tópico funciona como um canal nomeado para um tipo de evento: todo pedido criado vai para o tópico \"pedidos\", todo clique no site vai para o tópico \"cliques\". Produtores publicam num tópico sem saber quem vai consumir; consumidores se inscrevem num tópico sem saber quem publicou. É essa separação que desacopla os dois lados."
+                    },
+                    {
+                        "type": "code",
+                        "value": "Tópico \"pedidos\" (3 partições)\n\n  partição 0:  [e0][e1][e2][e3][e4]      offsets 0,1,2,3,4\n  partição 1:  [e0][e1][e2]              offsets 0,1,2\n  partição 2:  [e0][e1][e2][e3]          offsets 0,1,2,3\n\n# cada partição é um log independente, com sua própria sequência de offsets\n# a ordem só é garantida dentro de uma mesma partição, não entre partições diferentes"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Partição: a unidade de paralelismo e escala\n\nO número de partições é definido na criação do tópico, e pode ser aumentado depois, mas não reduzido. Cada partição pode ficar em um broker diferente do cluster, o que permite distribuir a carga de escrita e leitura entre várias máquinas. Mais partições significam mais paralelismo possível na leitura; menos partições significam menos overhead de coordenação. O número certo é uma decisão de capacidade, não um detalhe de configuração qualquer."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Offset: a posição dentro da partição\n\nO offset é um número inteiro sequencial que identifica a posição de um evento dentro da sua partição: o primeiro evento fica no offset 0, o segundo no offset 1, e assim por diante. O offset é local à partição, não ao tópico inteiro: o offset 5 da partição 0 e o offset 5 da partição 1 são eventos completamente diferentes. É por meio do offset que um consumidor sabe até onde já leu e de onde deve continuar."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Conceito\",\"O que representa\",\"Ordem garantida?\"],[\"Tópico\",\"Categoria lógica de eventos, como \\\"pedidos\\\"\",\"Não, apenas dentro de cada partição\"],[\"Partição\",\"Subdivisão do tópico, um log ordenado e imutável\",\"Sim, dentro da própria partição\"],[\"Offset\",\"Posição sequencial de um evento dentro de uma partição\",\"É o que define essa ordem\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Um tópico não é um log: é um conjunto de logs paralelos, um por partição, e a ordem só existe dentro de cada um deles."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que é o offset de um evento no Kafka?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Um identificador global e único do evento dentro de todo o tópico, independente da partição.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um número sequencial que identifica a posição do evento dentro da sua própria partição.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um carimbo de tempo atribuído pelo broker no momento em que o evento é lido por um consumidor.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um valor calculado a partir da chave do evento, usado para localizar a partição de destino.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um tópico 'cliques' tem 3 partições. Um evento está gravado no offset 10 da partição 0, e outro evento está gravado no offset 10 da partição 1. O que se pode afirmar sobre a relação entre esses dois eventos?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "São o mesmo evento, duplicado automaticamente pelo Kafka entre as partições do tópico.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O evento da partição 1 foi necessariamente publicado depois do evento da partição 0.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "São eventos distintos: o offset só identifica uma posição dentro da própria partição.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um dos dois registros está corrompido, já que offsets não podem se repetir num tópico.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe precisa aumentar a capacidade de leitura paralela de um tópico que hoje tem apenas 1 partição e já virou gargalo. Qual ação resolve diretamente essa limitação?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Reduzir o período de retenção do tópico, liberando espaço em disco para novas leituras simultâneas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Trocar o formato de serialização dos eventos para um formato mais compacto e rápido de ler.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Aumentar o fator de replicação do tópico, criando mais cópias da partição existente nos brokers.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Aumentar o número de partições do tópico, permitindo mais consumidores lendo em paralelo.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual afirmação descreve corretamente a relação entre tópico e partição no Kafka?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Um tópico é dividido em uma ou mais partições, definidas na criação do tópico.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Uma partição é dividida em um ou mais tópicos, conforme o volume de eventos publicados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Tópico e partição são sinônimos: dois nomes para a mesma estrutura de armazenamento.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma partição existe de forma independente, sem estar associada a nenhum tópico específico.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um consumidor lê a partição 2 de um tópico e observa que o próximo evento está no offset 47. Ele então passa a consumir a partição 0 do mesmo tópico. Que valor de offset ele deve esperar encontrar como ponto de partida coerente?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Também 47, já que o offset avança de forma sincronizada entre todas as partições do tópico.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Qualquer valor, porque cada partição mantém sua própria sequência de offsets, independente das demais.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um valor menor que 47, porque partições com índice menor sempre têm menos eventos publicados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Zero, porque toda troca de partição reinicia a contagem de offsets do consumidor para aquele tópico.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Producers e a chave de particionamento",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Producers e a chave de particionamento\n\nQuem decide em qual partição um evento vai parar não é o broker, é o produtor. Essa decisão acontece a cada mensagem publicada e depende de uma escolha simples, mas com consequências grandes: enviar ou não uma chave junto com o evento. Esta aula explica como essa escolha afeta paralelismo e, principalmente, ordem."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Quem decide a partição\n\nAo publicar um evento, o produtor pode enviar uma chave (key) junto com o valor. Se uma chave é informada, o produtor aplica uma função determinística sobre ela para escolher a partição: a mesma chave sempre resulta na mesma partição, para aquele tópico. Se nenhuma chave é informada, o produtor distribui os eventos entre as partições disponíveis (round-robin), sem nenhuma relação com o conteúdo do evento."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# produtor publica eventos de pedidos usando o id do pedido como chave\n\nprodutor.enviar(\n    topico=\"pedidos\",\n    chave=pedido.id,          # mesma chave -> sempre a mesma partição\n    valor=pedido.para_json(),\n)\n\n# sem chave, o evento vai para uma partição escolhida por distribuição,\n# sem relação alguma com o conteúdo do evento\nprodutor.enviar(topico=\"pedidos\", chave=None, valor=evento.para_json())"
+                    },
+                    {
+                        "type": "code",
+                        "value": "chave \"pedido-101\" -> partição 0\nchave \"pedido-102\" -> partição 2\nchave \"pedido-101\" -> partição 0     (mesma chave, sempre a mesma partição)\nchave \"pedido-103\" -> partição 1\nchave \"pedido-101\" -> partição 0     (de novo, sempre a mesma partição)\n\nsem chave (null): distribuição entre as partições disponíveis,\nsem relação com o conteúdo do evento"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Ordem é uma garantia por partição, não por tópico\n\nO Kafka garante ordem apenas dentro de uma mesma partição. Se os eventos de um mesmo pedido forem publicados sem chave, cada um pode cair numa partição diferente, e não existe garantia sobre em que ordem os consumidores vão processá-los entre si. Usar o id do pedido como chave resolve isso: todos os eventos daquele pedido caem sempre na mesma partição e, portanto, são lidos na ordem em que foram publicados."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Necessidade\",\"Estratégia de chave recomendada\"],[\"Ordem entre eventos do mesmo pedido\",\"Usar o id do pedido como chave\"],[\"Distribuir a carga o mais uniformemente possível, sem exigir ordem\",\"Publicar sem chave\"],[\"Eventos de um mesmo cliente processados sempre em sequência\",\"Usar o id do cliente como chave\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "A chave não é um detalhe do payload: é a decisão que define se dois eventos relacionados caem na mesma partição e, por consequência, na mesma ordem."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que determina em qual partição um evento publicado no Kafka será armazenado?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "O broker que recebe a requisição, escolhido por menor carga no momento da publicação.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O consumidor que primeiro se inscrever no tópico, definindo a partição de destino.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O produtor, com base na chave do evento ou por distribuição, quando não há chave.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O tamanho em bytes do evento, que determina automaticamente a partição mais adequada.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um sistema publica eventos de pedidos sem informar chave, e o tópico tem 4 partições. Os eventos de um mesmo pedido, criado e depois atualizado, precisam ser processados na ordem correta. O que provavelmente vai dar errado nesse cenário?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Os eventos serão rejeitados pelo broker, que exige chave obrigatória em tópicos com mais de uma partição.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os eventos serão duplicados automaticamente em todas as partições, gerando reprocessamento indevido.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os eventos ficarão retidos por menos tempo, já que eventos sem chave têm retenção reduzida por padrão.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os eventos podem cair em partições diferentes e serem lidos fora da ordem em que foram publicados.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma aplicação publica todos os eventos de um mesmo cliente usando o id do cliente como chave. Qual comportamento o Kafka garante para esses eventos?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Todos caem na mesma partição, preservando entre si a ordem em que foram publicados.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Todos são replicados imediatamente para todas as partições do tópico, por segurança.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Todos recebem prioridade de leitura sobre eventos de outros clientes no mesmo tópico.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Todos são comprimidos juntos num único registro, reduzindo o número de offsets usados.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um tópico de eventos de login usa o país do usuário como chave de particionamento, e 90% dos usuários estão no mesmo país. O tópico tem 6 partições. Qual problema esse desenho de chave provavelmente causa?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Perda de mensagens na partição que recebe mais tráfego, por exceder o limite de retenção configurado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma partição concentra a maior parte da carga, enquanto as demais ficam praticamente ociosas.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O produtor passa a rejeitar novos eventos, já que uma chave não pode se repetir entre publicações.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O cluster reequilibra automaticamente os dados, redistribuindo a chave entre as partições existentes.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual afirmação descreve corretamente o comportamento padrão de um produtor Kafka quando um evento é publicado sem chave?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O evento é descartado, porque o Kafka exige uma chave para localizar a partição de destino.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O evento é replicado em todas as partições do tópico, para garantir que algum consumidor o leia.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O evento é distribuído entre as partições disponíveis, sem relação com o seu conteúdo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O evento é direcionado sempre para a partição 0, usada como destino padrão sem chave.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Consumers, consumer groups e rebalanceamento",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Consumers, consumer groups e rebalanceamento\n\nUm consumidor sozinho lê eventos de um tópico. Um consumer group é o que permite que vários consumidores dividam esse trabalho entre si, cada um cuidando de uma parte das partições. Esta aula explica como essa divisão acontece, qual é o limite de paralelismo que ela impõe e o que muda quando um consumidor entra ou sai do grupo."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Consumer group: consumindo em equipe\n\nUm consumer group é um conjunto de consumidores que se identificam com o mesmo nome de grupo e dividem entre si a leitura das partições de um tópico. Dentro de um grupo, cada partição é atribuída a exatamente um consumidor por vez: dois consumidores do mesmo grupo nunca leem a mesma partição simultaneamente. Cada grupo mantém seu próprio controle de offset por partição, de forma independente de outros grupos que leiam o mesmo tópico."
+                    },
+                    {
+                        "type": "code",
+                        "value": "Tópico \"pedidos\" (4 partições: P0, P1, P2, P3)\n\n  grupo \"faturamento\"                grupo \"analytics\"\n  consumidor C1 -> lê P0, P1         consumidor C3 -> lê P0, P1, P2, P3\n  consumidor C2 -> lê P2, P3\n\n# os dois grupos leem o mesmo tópico de forma totalmente independente\n# cada grupo controla seu próprio offset por partição"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O limite do paralelismo\n\nDentro de um mesmo consumer group, o número de partições limita quantos consumidores conseguem trabalhar ao mesmo tempo. Com menos consumidores do que partições, alguns consumidores acumulam mais de uma partição. Com mais consumidores do que partições, os consumidores excedentes ficam ociosos, sem nenhuma partição atribuída, porque uma partição não pode ser dividida entre dois consumidores do mesmo grupo."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Partições no tópico\",\"Consumidores no grupo\",\"O que acontece\"],[\"4\",\"4\",\"Cada consumidor lê exatamente uma partição\"],[\"4\",\"2\",\"Cada consumidor lê, em média, duas partições\"],[\"4\",\"6\",\"Quatro consumidores ativos, dois ficam ociosos\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Rebalanceamento\n\nO rebalanceamento é o processo de redistribuir as partições entre os consumidores ativos de um grupo. Ele acontece quando um consumidor novo entra no grupo, quando um consumidor sai (de forma controlada ou por falha) ou quando o número de partições do tópico muda. Durante o rebalanceamento, o grupo pausa brevemente a leitura enquanto as partições são reatribuídas, o que é esperado, mas deve ser considerado ao dimensionar o grupo."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Um consumidor a mais do que partições disponíveis não acelera nada: ele fica esperando uma partição que nunca chega a ser atribuída a ele."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que caracteriza um consumer group no Kafka?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Um conjunto de brokers que compartilham a responsabilidade de armazenar as partições de um tópico.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um conjunto de tópicos relacionados, agrupados para facilitar a administração do cluster.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um conjunto de partições que armazenam o mesmo evento, replicadas para maior disponibilidade.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um conjunto de consumidores que dividem entre si a leitura das partições de um tópico.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um tópico tem 6 partições e um consumer group tem 9 consumidores ativos. Qual é a consequência direta dessa configuração?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Seis consumidores recebem uma partição cada, e três ficam sem nenhuma partição atribuída.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O Kafka cria automaticamente três partições adicionais para atender aos consumidores excedentes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os nove consumidores se revezam periodicamente na leitura de cada uma das seis partições.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O grupo é dividido automaticamente em dois consumer groups menores, com nomes gerados pelo Kafka.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Dois consumer groups distintos, 'faturamento' e 'analytics', leem o mesmo tópico de pedidos. O grupo 'faturamento' está lendo eventos publicados há poucos segundos, enquanto o grupo 'analytics' está processando eventos de dois dias atrás. Isso é possível porque:",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O Kafka prioriza o grupo com nome alfabeticamente anterior, adiantando sua leitura em relação aos demais.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Cada consumer group mantém seu próprio controle de offset, avançando de forma independente dos demais.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O tópico mantém cópias separadas dos eventos para cada consumer group inscrito, isoladas entre si.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O grupo 'analytics' está lendo de uma réplica desatualizada da partição, ainda não sincronizada.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Durante um rebalanceamento causado pela queda inesperada de um consumidor, o que acontece com as partições que estavam atribuídas a ele?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Ficam sem leitura até que o mesmo consumidor volte a ficar disponível e reassuma suas partições.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "São descartadas do tópico, já que não há garantia de que os offsets do consumidor caído sejam recuperados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "São reatribuídas aos consumidores restantes do grupo, que retomam a leitura do último offset confirmado.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Passam a ser lidas simultaneamente por todos os consumidores restantes do grupo, para garantir cobertura.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe quer aumentar a velocidade de consumo de um tópico e decide adicionar mais consumidores ao consumer group existente, além do número de partições do tópico. Qual é o resultado esperado?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "A velocidade de leitura aumenta proporcionalmente ao número total de consumidores adicionados ao grupo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Kafka aumenta automaticamente o número de partições para acomodar os novos consumidores ativos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os consumidores excedentes assumem partições de outros consumer groups que leem o mesmo tópico.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os consumidores excedentes ficam ociosos, já que o número de partições limita o paralelismo do grupo.",
+                                "isCorrect": true
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Retenção, replicação e durabilidade",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Retenção, replicação e durabilidade\n\nAté aqui, vimos como um evento é organizado (tópico, partição, offset) e como ele chega e é lido (produtor, consumidor, consumer group). Faltam duas perguntas: por quanto tempo um evento fica disponível, e o que acontece se um broker cair no meio do caminho. São as perguntas desta aula: retenção e replicação."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Retenção: por quanto tempo o evento fica disponível\n\nCada tópico tem uma política de retenção, configurada por tempo, por tamanho, ou pelos dois ao mesmo tempo. Quando o limite é atingido, os eventos mais antigos são descartados por causa do tempo ou do espaço configurado, não por causa da leitura. Um evento nunca lido e um evento já lido por todos os consumidores são descartados exatamente na mesma hora, se a política de retenção for a mesma."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Tipo de retenção\",\"Critério de descarte\",\"Exemplo\"],[\"Por tempo\",\"Idade do evento ultrapassa o limite configurado\",\"Reter por 7 dias\"],[\"Por tamanho\",\"A partição ultrapassa o limite de espaço configurado\",\"Reter até 50 GB por partição\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Replicação: sobrevivendo à queda de um broker\n\nCada partição pode ser replicada em mais de um broker, conforme o fator de replicação (replication factor) definido no tópico. Entre as réplicas de uma partição, uma é a líder: é ela que recebe todas as escritas e leituras daquela partição. As demais são seguidoras, que replicam continuamente os dados a partir da líder, prontas para assumir se a líder falhar."
+                    },
+                    {
+                        "type": "code",
+                        "value": "Partição 0 do tópico \"pedidos\" (replication factor = 3)\n\n  broker 1: [líder]      <- produtor escreve aqui\n  broker 2: [seguidor]   <- replica continuamente a partir do líder\n  broker 3: [seguidor]   <- replica continuamente a partir do líder\n\n# se o broker 1 cair:\n\n  broker 1: [fora do ar]\n  broker 2: [novo líder]   <- eleito entre os seguidores em sincronia\n  broker 3: [seguidor]     <- passa a replicar a partir do novo líder"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que garante durabilidade\n\nDurabilidade não é uma propriedade automática de gravar em disco uma vez: ela depende de existir mais de uma cópia da partição, com fator de replicação maior que 1, e de a escrita ser confirmada em réplicas suficientes antes de ser considerada concluída. Uma partição sem réplicas, com fator de replicação igual a 1, perde os dados se o broker que a hospeda falhar antes de qualquer cópia existir em outro lugar. A definição exata de \"confirmação\" é o assunto do próximo módulo."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Durabilidade não vem de gravar em disco uma vez: vem de ter cópias do mesmo dado em brokers diferentes, prontas para assumir se uma delas cair."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que determina quando um evento é descartado de um tópico Kafka, segundo a política de retenção?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "O tempo decorrido ou o espaço ocupado pela partição, conforme o limite configurado no tópico.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O número de consumidores que já confirmaram a leitura completa daquele evento específico.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A prioridade atribuída ao evento no momento da publicação, definida pelo produtor de origem.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O tamanho individual do evento, descartado automaticamente se ultrapassar um limite por mensagem.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um tópico tem fator de replicação igual a 1, ou seja, cada partição existe em um único broker, sem seguidores. Qual é o risco direto dessa configuração?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O tópico não aceita publicação de eventos sem chave, exigindo ajuste no produtor antes de operar.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os dados da partição são perdidos se o broker que a hospeda falhar antes de serem replicados.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O throughput de leitura cai significativamente, já que não há réplicas para distribuir consultas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O offset dos eventos passa a ser reiniciado periodicamente, por falta de réplicas de apoio.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Numa partição com fator de replicação 3, o broker que hospeda a réplica líder falha repentinamente. O que acontece com a disponibilidade dessa partição, supondo que os seguidores estejam em sincronia com a líder?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "A partição fica indisponível até que o broker original volte a funcionar e reassuma a liderança.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A partição é descartada do tópico, e uma nova partição vazia é criada para substituí-la no cluster.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um dos seguidores em sincronia é eleito novo líder, e a partição continua disponível.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "As escritas futuras nessa partição passam a ser distribuídas entre todos os seguidores restantes.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe configura um tópico crítico com fator de replicação 3, mas exige que a escrita seja confirmada por apenas uma réplica, a líder, antes de considerar a publicação concluída. Que risco essa combinação ainda mantém?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Nenhum: fator de replicação 3 já elimina qualquer risco de perda, independente de quantas réplicas confirmam.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O tópico passa a aceitar no máximo 3 consumidores simultâneos, um por réplica configurada.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "As partições desse tópico deixam de suportar mais de um consumer group lendo ao mesmo tempo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Se a líder falhar antes de replicar o dado para os seguidores, esse evento pode se perder.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual é o papel da réplica líder de uma partição, em contraste com as réplicas seguidoras?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "A líder recebe todas as escritas e leituras da partição; as seguidoras replicam esses dados continuamente.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A líder armazena apenas metadados da partição; as seguidoras armazenam os eventos publicados de fato.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A líder é escolhida uma única vez na criação do tópico e nunca muda durante a vida da partição.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A líder distribui as escritas recebidas entre as seguidoras, que processam parte de cada evento.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 3 - Produzindo e consumindo no Kafka",
+        "aulas": [
+            {
+                "titulo": "O produtor: acks, batching e idempotência",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# O produtor: acks, batching e idempotência\n\nNo módulo anterior o produtor já aparecia enviando eventos para um tópico e escolhendo a partição pela chave. Falta a parte que decide quanto o produtor espera antes de considerar a mensagem entregue, e como ele agrupa mensagens para não afogar o broker em requisições pequenas. Essas duas escolhas, mais o produtor idempotente, são o que separa um pipeline que perde ou duplica dado silenciosamente de um que não perde.\n\n## Acks: quanto o produtor espera pela durabilidade\n\n`acks` define quantas réplicas precisam confirmar a escrita antes do broker responder ao produtor. Não é uma configuração de velocidade, é uma configuração de risco de perda."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Config\",\"O que o produtor espera\",\"Risco de perda\"],[\"acks=0\",\"Nenhuma confirmação do broker\",\"Alto: perde silenciosamente se o broker cair antes de escrever\"],[\"acks=1\",\"Confirmação do broker líder, após escrever no log local\",\"Perde se o líder cair antes de replicar para o ISR\"],[\"acks=all (-1)\",\"Confirmação do líder e de todas as réplicas do ISR\",\"Mínimo: só perde se o ISR inteiro cair junto\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Batching e linger.ms: throughput sem multiplicar requisições\n\nPor padrão o produtor já tenta agrupar, num único lote, os registros destinados à mesma partição, em vez de mandar uma requisição de rede por mensagem (o tamanho desse lote é o `batch.size`). `linger.ms` estica isso de propósito: o produtor espera alguns milissegundos a mais antes de enviar, na esperança de encher o lote com mais registros. O resultado é menos requisições, melhor compressão e menos I/O no broker, ao custo de uma latência extra pequena e previsível."
+                    },
+                    {
+                        "type": "code",
+                        "value": "linger.ms = 0 (envio imediato, sem agrupar)\n\n  msg1 --------> [ requisição 1 ]\n  msg2 --------> [ requisição 2 ]\n  msg3 --------> [ requisição 3 ]\n\n  3 mensagens = 3 idas e voltas na rede\n\nlinger.ms = 10 (agrupa por até 10ms antes de enviar)\n\n  msg1 -\\\n  msg2 --+--> [ lote único ] --------> [ requisição 1 ]\n  msg3 -/\n\n  3 mensagens = 1 ida e volta na rede, +10ms de espera no pior caso"
+                    },
+                    {
+                        "type": "code",
+                        "value": "config_produtor = {\n    \"bootstrap.servers\": \"kafka1:9092,kafka2:9092\",\n    \"acks\": \"all\",              # espera o líder e o ISR confirmarem\n    \"retries\": 5,                # reenvia em falha transitória (timeout, líder indisponível)\n    \"linger.ms\": 10,             # espera até 10ms para agrupar mais registros no lote\n    \"batch.size\": 32768,         # tamanho máximo do lote, em bytes\n}\n\nprodutor = Produtor(config_produtor)\nprodutor.enviar(\n    topico=\"pedidos\",\n    chave=str(pedido.cliente_id),   # mesma chave sempre cai na mesma partição\n    valor=serializar(pedido),\n    callback=confirmar_entrega,\n)\nprodutor.flush()   # espera as confirmações pendentes antes de encerrar"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O produtor idempotente: retry sem duplicar\n\nCom `retries` ativo, um timeout de rede depois que o broker já escreveu o registro, mas antes do ack voltar, faz o produtor reenviar a mesma mensagem e criar um duplicado no log. `enable.idempotence=true` resolve isso sem lógica extra na aplicação: o produtor ganha um identificador (producer ID) e numera cada registro por partição; o broker reconhece o par producer ID e número de sequência repetido e descarta o reenvio. Ativar idempotência também força `acks=all` automaticamente, é a base sobre a qual as transações do Kafka (módulo 4) são construídas."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Acks decide quanto o produtor espera pela durabilidade, linger.ms decide quanto ele espera pelo throughput, e o produtor idempotente resolve o duplicado que o próprio retry cria, sem exigir dedup na aplicação."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Um time configura o produtor Kafka com acks=0 em um pipeline de métricas de clique, buscando a menor latência possível. Qual é a consequência direta dessa escolha?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "O produtor não espera nenhuma confirmação do broker, então uma mensagem pode se perder sem que ele perceba.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O produtor espera a confirmação apenas do broker líder, então só perde mensagem se o líder cair antes de replicar.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O produtor espera a confirmação do líder e de todas as réplicas do ISR, então a perda fica praticamente descartada.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O produtor só envia a próxima mensagem depois que o consumidor confirma o processamento da mensagem anterior.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um sistema de pagamentos publica eventos de transação no Kafka e não pode aceitar perda de mensagem nem com a queda de um broker. Qual configuração de acks do produtor atende essa exigência?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "acks=1, pois a confirmação do broker líder já garante que a mensagem foi replicada para as demais cópias.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "acks=all, pois a mensagem só é confirmada depois que o líder e todas as réplicas do ISR escrevem o registro.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "acks=0, pois desligar a confirmação evita que o produtor fique bloqueado esperando os brokers responderem.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "acks=all, mas só funciona se o produtor também tiver enable.idempotence ligado, senão o ack é ignorado.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma aplicação envia picos de milhares de eventos por segundo para o Kafka, e o time percebe muitas requisições pequenas saindo do produtor, sobrecarregando a rede. Qual ajuste tende a reduzir esse problema, sem trocar de broker?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Reduzir o número de partições do tópico, para que o produtor tenha menos destinos possíveis por mensagem.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Trocar acks=all por acks=0, pois menos confirmações esperadas reduzem a quantidade de requisições enviadas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Aumentar linger.ms e o batch.size, deixando o produtor agrupar mais registros por requisição antes de enviar.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Diminuir o retries do produtor, para que ele pare de reenviar as mesmas mensagens em cada requisição.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma requisição de escrita do produtor chega ao broker e é persistida, mas a confirmação se perde por timeout de rede antes de voltar ao produtor. Com enable.idempotence=true, o que evita que a mensagem fique duplicada quando o produtor reenviar?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O consumidor identifica a chave repetida ao ler as duas cópias e descarta a segunda antes de processar.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O produtor guarda um hash local de cada mensagem enviada e nunca reenvia duas mensagens com o mesmo hash.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O broker aceita as duas cópias no log, mas marca a segunda como duplicada para o consumidor ignorar depois.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O broker reconhece o par producer ID e número de sequência repetido e descarta o reenvio duplicado.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um produtor Kafka está configurado com linger.ms=0. O que isso significa na prática para o envio das mensagens?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O produtor tenta enviar cada registro assim que possível, sem esperar para juntar mais registros no lote.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O produtor espera o batch.size encher completamente antes de fazer qualquer envio, mesmo que isso demore.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O produtor só respeita o linger.ms configurado quando o enable.idempotence está desligado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O produtor agrupa um lote por partição a cada um milissegundo, independente da quantidade de dados acumulada.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "O consumidor: poll, commit de offset e at-least-once",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# O consumidor: poll, commit de offset e at-least-once\n\nO produtor decide acks e batching; o consumidor decide quando avisa o Kafka \"já processei até aqui\". Essa segunda decisão, o commit do offset, é tão importante quanto a primeira: é ela que determina se uma falha no meio do processamento vira mensagem reprocessada ou mensagem perdida.\n\n## O loop de poll\n\nUm consumidor Kafka não recebe mensagens via push, ele puxa. O `poll()` busca o próximo lote de registros das partições atribuídas ao consumidor dentro do consumer group (como já visto no módulo 2) e também delimita o tempo entre uma chamada e outra: não chamar `poll()` dentro do intervalo configurado em `max.poll.interval.ms` tira o consumidor do grupo e dispara um rebalanceamento, mesmo que o heartbeat continue rodando em paralelo numa thread separada."
+                    },
+                    {
+                        "type": "code",
+                        "value": "config_consumidor = {\n    \"bootstrap.servers\": \"kafka1:9092,kafka2:9092\",\n    \"group.id\": \"servico-notificacoes\",\n    \"enable.auto.commit\": False,     # commit manual, controlado pela aplicação\n    \"auto.offset.reset\": \"earliest\", # de onde começar se não houver offset salvo\n}\n\nconsumidor = Consumidor(config_consumidor)\nconsumidor.subscribe([\"pedidos\"])\n\nenquanto True:\n    lote = consumidor.poll(timeout=1000)\n    para registro em lote:\n        processar(registro.valor)     # só avança depois de processar com sucesso\n    consumidor.commitSync()           # confirma o offset do lote inteiro"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Commit automático x commit manual\n\n`enable.auto.commit=true` é o padrão mais simples: a cada `auto.commit.interval.ms` o cliente confirma o maior offset já entregue ao poll(), sem saber se a aplicação realmente terminou de processar aquele lote. Para controlar a semântica de entrega, a aplicação precisa desligar o auto-commit e chamar `commitSync()` (bloqueante, confirma e espera resposta) ou `commitAsync()` (não bloqueia, mas exige tratar falha de commit por callback) no momento certo do próprio código."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Estratégia\",\"Quando confirma o offset\",\"Quem controla o momento\"],[\"Auto-commit\",\"Em intervalo fixo, em paralelo ao processamento\",\"O cliente Kafka, não a aplicação\"],[\"commitSync()\",\"Síncrono, só retorna após o broker confirmar\",\"A aplicação, no ponto exato do código\"],[\"commitAsync()\",\"Assíncrono, não bloqueia o loop de poll\",\"A aplicação, com callback de erro\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Commit depois de processar: at-least-once na prática\n\nChamar o commit depois que o registro foi processado com sucesso é a base do at-least-once: se o processo cair entre o fim do processamento e o commit, o offset não avançou, e o consumidor reprocessa o mesmo lote ao reiniciar. Isso é seguro (nenhum dado se perde), mas exige que o processamento seja idempotente ou tolere duplicata, porque o mesmo registro pode ser entregue mais de uma vez."
+                    },
+                    {
+                        "type": "code",
+                        "value": "commit DEPOIS de processar (at-least-once)\n\n  poll -> processar registro -> [ crash aqui ] -> commit\n  reinício: offset não avançou -> registro é entregue de novo\n  resultado: pode reprocessar, nunca perde\n\ncommit ANTES de processar (at-most-once)\n\n  poll -> commit -> [ crash aqui ] -> processar registro\n  reinício: offset já avançou -> registro não é entregue de novo\n  resultado: pode perder, nunca reprocessa"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "A ordem entre processar e confirmar o offset é a decisão: confirmar depois de processar dá at-least-once, que pode reprocessar; confirmar antes de processar dá at-most-once, que pode perder."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Um consumidor Kafka fica preso processando um registro muito pesado e demora mais que o max.poll.interval.ms para chamar poll() de novo. O que o Kafka faz nesse caso?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Aumenta automaticamente o max.poll.interval.ms daquele consumidor, para dar mais tempo ao processamento.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O grupo considera o consumidor inativo e dispara um rebalanceamento das partições para os demais membros.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O broker armazena o registro pendente numa fila separada até o consumidor liberar o processamento.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O consumidor perde a assinatura do tópico e precisa reiniciar a aplicação para voltar a consumir.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um serviço usa enable.auto.commit=true com intervalo padrão de 5 segundos. Um lote é recebido do poll(), mas o processo cai 2 segundos depois, antes de terminar de processar todos os registros do lote. O que pode ter acontecido com esses registros?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Nenhum registro se perde, porque o auto-commit só confirma offsets de registros já processados pela aplicação.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os registros ficam automaticamente numa fila de retry interna do consumidor, aguardando o próximo poll().",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Se o auto-commit já confirmou aquele offset antes da queda, os registros pendentes ficam perdidos de vez.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O Kafka percebe a queda pelo heartbeat do grupo e reenvia só os registros que ainda não foram processados.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um pipeline de cobrança processa um registro, gera a cobrança num sistema externo e só depois chama commitSync(). Em um teste, o processo é morto logo após o sistema externo responder com sucesso, mas antes do commitSync() retornar. O que acontece ao reiniciar o consumidor?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O commitSync() é reexecutado automaticamente na inicialização, então o offset avança sem reprocessar nada.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O offset fica corrompido, e o consumidor precisa ser removido do grupo manualmente para voltar a funcionar.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Kafka detecta que o commit estava em andamento e completa a confirmação pendente antes de entregar novos registros.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O offset não foi confirmado, então o mesmo registro é entregue de novo, e a cobrança pode ser gerada duas vezes.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um pipeline coleta métricas de monitoramento, onde a perda ocasional de um ponto é aceitável, mas reprocessar e gerar métrica duplicada distorce o gráfico. Qual estratégia de commit se encaixa melhor nesse cenário?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Confirmar o offset com commitSync() logo após o poll(), antes de processar o lote, aceitando perder registros em falha.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Confirmar o offset com commitSync() logo após processar cada registro, garantindo que nenhuma métrica seja perdida.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Desligar o commit de offset por completo, e reprocessar o tópico inteiro a cada reinício do consumidor.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Usar commitAsync() apenas para os registros que falharem no processamento, mantendo o restante sem confirmar.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um time troca commitSync() por commitAsync() no loop de consumo para reduzir a latência entre lotes. Qual cuidado adicional essa troca exige?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Nenhum cuidado extra, porque commitAsync() é apenas uma variante síncrona por baixo, só muda o nome do método.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Tratar falhas de commit via callback, porque commitAsync() não bloqueia o loop nem garante que o offset já foi confirmado.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Desligar o consumer group, porque commitAsync() só funciona fora de um grupo, com atribuição manual de partições.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Reduzir o número de partições do tópico, porque commitAsync() não suporta consumidores com mais de uma partição atribuída.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Ordem, particionamento e paralelismo",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Ordem, particionamento e paralelismo\n\nO Kafka garante ordem, mas com um detalhe que costuma pegar gente de surpresa em entrevista: a ordem só é garantida dentro de uma partição, nunca entre partições diferentes do mesmo tópico. A partição é ao mesmo tempo a unidade de ordem e a unidade de paralelismo, e as duas coisas vêm do mesmo lugar: cada partição é lida por, no máximo, um consumidor por vez dentro do mesmo consumer group."
+                    },
+                    {
+                        "type": "code",
+                        "value": "Tópico \"pedidos\" com 3 partições\n\nPartição 0: [ evento A1 ][ evento A5 ][ evento A9 ]   -> ordem garantida dentro da partição 0\nPartição 1: [ evento B2 ][ evento B4 ][ evento B7 ]   -> ordem garantida dentro da partição 1\nPartição 2: [ evento B3 ][ evento A6 ][ evento B8 ]   -> ordem garantida dentro da partição 2\n\nOrdem entre partições (A1, B2, B3, A5, ...): NÃO garantida"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Mais partições, mais paralelismo (até um limite)\n\nDentro de um consumer group, cada partição é atribuída a no máximo um consumidor. Isso significa que o paralelismo real do consumo é limitado pelo número de partições: com 6 partições, no máximo 6 consumidores do mesmo grupo processam em paralelo. Adicionar um sétimo consumidor não acelera nada, ele fica ocioso, esperando um rebalanceamento lhe dar uma partição."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Consumidores no grupo\",\"Partições no tópico\",\"Resultado\"],[\"3\",\"6\",\"Cada consumidor recebe 2 partições, paralelismo parcial\"],[\"6\",\"6\",\"Cada consumidor recebe 1 partição, paralelismo máximo\"],[\"9\",\"6\",\"6 consumidores ativos, 3 ficam ociosos sem partição\"]]"
+                    },
+                    {
+                        "type": "code",
+                        "value": "6 partições, grupo com 3 consumidores:\n\n  Consumidor 1  <- partição 0, partição 1\n  Consumidor 2  <- partição 2, partição 3\n  Consumidor 3  <- partição 4, partição 5\n\n6 partições, grupo com 9 consumidores:\n\n  Consumidor 1..6     <- uma partição cada\n  Consumidor 7, 8, 9  <- ociosos, sem partição atribuída"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## A chave de particionamento e a partição quente\n\nA chave do registro decide a partição via hash, e é ela que define o \"escopo\" da ordem: eventos com a mesma chave (o mesmo cliente_id, por exemplo) sempre caem na mesma partição e saem na ordem em que foram produzidos. O risco é escolher uma chave de baixa cardinalidade ou muito desbalanceada: se a maior parte dos eventos usa a mesma chave, essa partição vira uma partição quente, concentra a carga num consumidor só, e o resto do paralelismo fica ocioso, mesmo com várias partições disponíveis."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "A partição é a unidade de paralelismo e a unidade de ordem ao mesmo tempo; aumentar partições só aumenta o paralelismo real se a chave distribuir a carga de forma razoavelmente uniforme entre elas."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Um sistema precisa garantir que os eventos de um mesmo pedido (criado, pago, enviado) sejam processados na ordem exata em que aconteceram, sem abrir mão do paralelismo entre pedidos diferentes. Qual decisão de particionamento atende os dois requisitos?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Usar uma única partição para o tópico inteiro, o que mantém a ordem global mas elimina o paralelismo entre pedidos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Aumentar o número de partições do tópico, contando que o consumidor cubra mais eventos em paralelo automaticamente.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Usar o id do pedido como chave de particionamento, mantendo os eventos de um mesmo pedido sempre na mesma partição.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Configurar acks=all no produtor, para que o broker só confirme os eventos na ordem exata em que foram produzidos.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Em um tópico Kafka com múltiplas partições, onde a ordem dos registros é garantida?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Em todo o tópico, independente de quantas partições ele tenha configuradas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Apenas entre registros que têm o mesmo timestamp de produção, dentro do tópico inteiro.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Apenas entre os registros lidos pelo mesmo consumidor, independente da partição de origem.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Apenas dentro de cada partição, entre os registros que são gravados naquela mesma partição.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um tópico tem 4 partições e um consumer group com 4 consumidores, cada um processando uma partição. O time aumenta o tópico para 8 partições para ganhar paralelismo, mas mantém os mesmos 4 consumidores. O que acontece com o paralelismo de consumo?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Não aumenta, porque cada consumidor passa a receber 2 partições e continua processando uma de cada vez, só revezando.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Dobra automaticamente, porque o Kafka distribui o processamento de cada partição entre todos os consumidores do grupo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Dobra, mas só depois que o rebalanceamento termina de mover as partições novas para os consumidores existentes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Fica igual a antes, porque partições novas só passam a receber registros depois de um reinício manual do tópico.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um tópico tem 12 partições, mas o produtor usa sempre a mesma chave fixa para 90% dos eventos, por engano. O time nota que um único consumidor do grupo está sobrecarregado, enquanto os outros ficam quase ociosos. Qual é a causa raiz?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O tópico tem partições demais para o volume de eventos, e o ideal é reduzir para 1 partição apenas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A chave de baixa cardinalidade concentra quase todos os eventos numa única partição, criando uma partição quente.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O consumer group está mal configurado, e precisa de mais instâncias de consumidor para se equilibrar sozinho.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O broker líder daquela partição está com replicação atrasada, o que faz o consumidor processar mais devagar.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Antes de criar um tópico de eventos de cliques com alto volume, o time discute quantas partições usar. Qual afirmação sobre esse número é verdadeira?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O número de partições pode ser reduzido livremente depois, sem nenhum impacto na chave de particionamento existente.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O número ideal de partições deve ser sempre igual ao número de brokers do cluster, nunca maior nem menor.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Aumentar partições depois é possível, mas muda o mapeamento de chave para partição dos novos registros, exigindo cuidado.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O número de partições só afeta a durabilidade dos dados, não tem relação nenhuma com paralelismo de consumo.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Serialização e schema",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Serialização e schema\n\nO Kafka não sabe nem se importa com o que tem dentro de uma mensagem: para o broker, cada registro é só um array de bytes numa partição. Quem dá significado a esses bytes é o par serializador (no produtor) e desserializador (no consumidor), e os dois precisam concordar sobre o formato. Esse acordo é o contrato entre quem produz e quem consome, e é ele que quebra silenciosamente quando alguém muda um campo sem avisar."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"\",\"JSON\",\"Avro\"],[\"Schema\",\"Não tem schema embutido por padrão\",\"Schema explícito, definido separadamente\"],[\"Tamanho da mensagem\",\"Maior, repete os nomes dos campos em cada registro\",\"Menor, os dados vêm sem os nomes dos campos\"],[\"Leitura humana\",\"Legível diretamente, fácil de debugar\",\"Binário, precisa do schema para ler\"],[\"Evolução de schema\",\"Não valida nada, a quebra só aparece em runtime\",\"Validada no Schema Registry, com regras de compatibilidade\"]]"
+                    },
+                    {
+                        "type": "code",
+                        "value": "Mensagem em JSON (o que trafega na partição):\n\n{\n  \"pedido_id\": \"9f3a2e\",\n  \"cliente_id\": 4821,\n  \"valor_total\": 189.90,\n  \"status\": \"pago\"\n}\n\nO mesmo evento com schema Avro (.avsc):\n\n{\n  \"type\": \"record\",\n  \"name\": \"PedidoPago\",\n  \"fields\": [\n    { \"name\": \"pedido_id\", \"type\": \"string\" },\n    { \"name\": \"cliente_id\", \"type\": \"long\" },\n    { \"name\": \"valor_total\", \"type\": \"double\" },\n    { \"name\": \"status\", \"type\": \"string\" },\n    { \"name\": \"cupom\", \"type\": [\"null\", \"string\"], \"default\": null }\n  ]\n}\n\n// campo \"cupom\": novo, opcional, com default null -> evolução compatível"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O Schema Registry: o contrato centralizado\n\nO Schema Registry guarda as versões de cada schema e associa cada uma a um ID. O produtor, antes de enviar, registra (ou valida contra) o schema esperado para o tópico; o consumidor, ao ler, usa o ID embutido na mensagem para buscar o schema certo no registry e desserializar. O ganho prático: a mensagem carrega só o ID do schema, não o schema inteiro, e o registry aplica as regras de compatibilidade antes de aceitar qualquer mudança."
+                    },
+                    {
+                        "type": "code",
+                        "value": "Produtor              Schema Registry             Kafka                Consumidor\n\nregistra/valida   -->  guarda o schema,\n    schema             retorna um ID\n\nenvia [ID + bytes Avro] -----------------------> grava na partição\n\n                                                  entrega [ID + bytes] --> lê o ID\n                                                                            busca o schema pelo ID\n                                                                            (na Schema Registry)\n                                                                            desserializa com o\n                                                                            schema correto"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Evolução de schema: mudar sem quebrar quem já consome\n\nSchemas mudam: um campo novo, um tipo que precisa ajustar. O Schema Registry classifica a compatibilidade de uma mudança antes de aceitá-la. Na prática, o padrão mais seguro é a compatibilidade backward: todo campo novo entra como opcional, com valor padrão, e nenhum campo existente é removido ou muda de tipo sem uma migração planejada. É o mesmo cuidado de evolução de schema que já apareceu na trilha de ETL, só que aqui o consumidor pode estar lendo em tempo real, sem uma janela de manutenção para se ajustar."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Serializar é mais que escolher um formato, é assumir um contrato entre quem produz e quem consome; o Schema Registry existe para que esse contrato só mude de um jeito que não quebra quem já está lendo."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Do ponto de vista do broker Kafka, o que de fato é armazenado dentro de uma partição?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Objetos JSON estruturados, que o broker consegue ler e validar antes de gravar no log.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Registros no formato Avro, único formato nativamente suportado pelo protocolo do Kafka.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma tabela relacional com colunas fixas, definidas no momento da criação do tópico.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Sequências de bytes, sem que o broker interprete ou valide o conteúdo de cada registro.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um time está decidindo o formato de serialização para um tópico de altíssimo volume, onde o custo de armazenamento e rede importa, e já existe um Schema Registry disponível na empresa. Qual decisão tende a reduzir mais o volume de dados trafegado?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Usar Avro com o Schema Registry, porque o registro não carrega os nomes dos campos em cada mensagem.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Usar JSON com compressão gzip habilitada no produtor, porque a compressão elimina totalmente o overhead do schema.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Usar Avro sem o Schema Registry, incluindo o schema inteiro em cada mensagem para garantir compatibilidade.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Usar JSON sem alterações, porque o parser de JSON do broker já é otimizado para grandes volumes.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um produtor adiciona ao schema Avro um campo obrigatório, sem valor default, e tenta registrar a mudança num Schema Registry com compatibilidade backward. O que provavelmente acontece?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "A mudança é aceita normalmente, porque adicionar campos nunca afeta a compatibilidade de um schema Avro.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Schema Registry rejeita o novo schema, porque um campo obrigatório sem default quebra a compatibilidade backward.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O Kafka reverte automaticamente a mensagem para o schema anterior, mantendo os consumidores funcionando sem alteração.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os consumidores existentes passam a ignorar o Schema Registry e desserializam direto como JSON, sem erro aparente.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um produtor adiciona um novo campo opcional, com valor default definido, a um schema Avro já usado em produção. Consumidores antigos, que não conhecem esse campo, continuam rodando sem atualização. O que tende a acontecer com esses consumidores?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Param de conseguir desserializar qualquer mensagem, porque todo consumidor precisa da versão mais recente do schema.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Passam a receber erro de compatibilidade do Schema Registry a cada mensagem lida, até serem atualizados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Continuam funcionando normalmente, porque um campo novo opcional com default mantém a compatibilidade do schema.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Continuam funcionando, mas o Kafka descarta silenciosamente o campo novo antes de gravar a mensagem na partição.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um pipeline lê um tópico Avro e grava os dados num data lake, e o job de ETL downstream depende de um campo específico do schema. O time precisa mudar o tipo desse campo, de int para string. Qual abordagem preserva a compatibilidade com quem já consome?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Alterar o tipo do campo diretamente no schema existente, porque o Schema Registry converte o tipo automaticamente para os consumidores antigos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Remover o campo antigo e adicionar um novo com outro nome e o tipo novo, sem nenhuma coordenação adicional com quem consome.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Trocar o schema no Schema Registry para o modo de compatibilidade \"none\", o que libera qualquer alteração de tipo sem quebrar ninguém.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Introduzir um campo novo com o tipo string, manter o campo antigo por um período de transição e migrar os consumidores antes de removê-lo.",
+                                "isCorrect": true
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Log compaction x retenção por tempo",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Log compaction x retenção por tempo\n\nAté aqui todo tópico foi tratado como um log que cresce e, em algum momento, descarta o que é antigo. Essa é só uma das duas políticas de limpeza que o Kafka oferece. A outra, log compaction, não olha para a idade do registro, olha para a chave: em vez de apagar o que é velho, ela apaga o que está desatualizado."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"\",\"Retenção por tempo/tamanho (delete)\",\"Log compaction (compact)\"],[\"O que mantém\",\"Registros dentro da janela de tempo ou tamanho configurada\",\"Apenas o último valor gravado para cada chave\"],[\"O que remove\",\"Segmentos inteiros mais antigos que o limite\",\"Versões antigas da mesma chave, mesmo que recentes\"],[\"Histórico\",\"Preserva a sequência completa de eventos, até expirar\",\"Perde eventos intermediários, só o estado final de cada chave\"],[\"Uso típico\",\"Eventos: cliques, pedidos criados, logs de aplicação\",\"Changelog: último endereço do cliente, estado de uma sessão\"]]"
+                    },
+                    {
+                        "type": "code",
+                        "value": "retention.ms = 7 dias (cleanup.policy=delete)\n\n[ seg. dia1 ][ seg. dia2 ][ seg. dia3 ] ... [ seg. dia7 ][ seg. dia8 (novo) ]\n     ^ expira e é apagado assim que o segmento passa dos 7 dias\n\na partição só cresce até o limite e depois descarta os segmentos mais antigos"
+                    },
+                    {
+                        "type": "code",
+                        "value": "cleanup.policy=compact, chave = cliente_id\n\nantes da compactação (offsets em ordem):\n[ cliente_1=SP ][ cliente_2=RJ ][ cliente_1=MG ][ cliente_3=BA ][ cliente_1=RS ]\n\ndepois da compactação (só o último valor por chave):\n[ cliente_2=RJ ][ cliente_3=BA ][ cliente_1=RS ]\n\ncliente_1=SP e cliente_1=MG somem: já foram substituídos por um valor mais novo da mesma chave"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Tombstone: como apagar uma chave num tópico compactado\n\nUm tópico compactado não tem \"delete\" tradicional; para remover uma chave de vez, o produtor grava um registro com aquela chave e valor nulo, chamado de tombstone. A compactação remove a chave inteira (todas as versões antigas mais o próprio tombstone) depois que ele fica disponível por `delete.retention.ms`, tempo suficiente para consumidores lentos ainda conseguirem lê-lo antes de sumir de vez."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Quando usar cada política\n\nRetenção por tempo é a escolha natural para fluxos de eventos: um clique, um pedido criado, uma medição de sensor, cada registro é um fato imutável e todos importam, mesmo que velhos. Log compaction é a escolha para changelog e estado: o endereço atual de um cliente, o saldo mais recente de uma conta, o último status de um pedido, onde só o valor mais recente por chave importa, geralmente para reconstruir uma tabela a partir do tópico."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Retenção por tempo pergunta há quanto tempo isso foi gravado; log compaction pergunta se existe uma versão mais nova desta chave; escolher a política errada faz o tópico crescer sem necessidade ou perder histórico que deveria existir."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Um time quer manter no Kafka o endereço de entrega mais recente de cada cliente, para reconstruir esse estado numa tabela sempre que precisar, sem guardar o histórico completo de mudanças de endereço. Qual política de limpeza do tópico atende essa necessidade?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "cleanup.policy=compact, usando o id do cliente como chave, para manter só o último endereço gravado por cliente.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "cleanup.policy=delete, com retention.ms alto o suficiente para nunca expirar nenhum registro do tópico.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "cleanup.policy=compact, usando o timestamp do evento como chave, para manter os endereços mais recentes em ordem.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "cleanup.policy=delete, com retention.bytes baixo, para forçar o tópico a manter só os endereços mais recentes.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Em um tópico com cleanup.policy=compact, o que a compactação mantém para cada chave?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Apenas o primeiro valor gravado para aquela chave, descartando todas as atualizações posteriores.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Apenas o valor mais recente gravado para aquela chave, descartando as versões anteriores.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Todos os valores gravados para aquela chave, sem nenhum descarte, igual à retenção por tempo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Nenhum valor: a compactação remove a chave inteira depois de um certo número de versões.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um produtor precisa remover definitivamente a chave cliente_42 de um tópico compactado, porque o cliente pediu exclusão dos dados. O time grava um tombstone (valor nulo) para essa chave. O que garante que consumidores lentos ainda consigam ver essa exclusão antes dela sumir de vez?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O tombstone fica marcado como imutável no log e nunca é removido, mesmo depois da compactação rodar novamente.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Schema Registry mantém uma cópia do tombstone separada do tópico, disponível sob demanda para consumidores atrasados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O tombstone só é removido após delete.retention.ms, dando tempo para consumidores atrasados ainda lerem a exclusão.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O consumer group bloqueia a compactação daquela partição até que todos os membros confirmem a leitura do tombstone.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um tópico usado como changelog de estado de sessão (uma chave por usuário, valor = estado atual) está configurado com cleanup.policy=delete e retention.ms=24 horas. Usuários com sessão inativa por mais de um dia começam a sumir da tabela reconstruída a partir do tópico, mesmo sem ter sido explicitamente removidos. Qual é o problema?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O consumer group está com poucos consumidores para o volume de sessões, causando perda de registros no rebalanceamento.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A chave de particionamento está mal escolhida, criando uma partição quente que perde registros sob carga.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Schema Registry está rejeitando as atualizações de estado por incompatibilidade de schema após 24 horas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A política deveria ser cleanup.policy=compact, porque delete apaga o registro só pela idade da mensagem.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um tópico de changelog precisa manter só o último valor por chave, mas o time também quer garantir que chaves não atualizadas há muito tempo eventualmente saiam do tópico, mesmo sem um tombstone explícito. Isso é possível no Kafka?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Sim, configurando cleanup.policy=compact,delete no tópico, combinando as duas políticas de limpeza ao mesmo tempo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Não, um tópico só pode ter uma política de limpeza ativa por vez, compact ou delete, nunca as duas juntas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Sim, mas só gravando um tombstone manual para cada chave depois de um tempo, não existe combinação automática de políticas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não, a única forma de expirar chaves antigas num tópico compactado é recriar o tópico do zero periodicamente.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 4 - Garantias de entrega",
+        "aulas": [
+            {
+                "titulo": "At-most-once, at-least-once e exactly-once",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# At-most-once, at-least-once e exactly-once\n\nVocê já viu, no módulo 3, um consumidor Kafka processando uma mensagem e só depois comitando o offset, sabendo que uma falha bem cronometrada pode levar à reentrega da mesma mensagem. Esta aula dá nome a esse comportamento, e às suas alternativas: existem exatamente três garantias de entrega possíveis, e todo sistema de streaming escolhe uma delas, mesmo quando ninguém decidiu conscientemente.\n\nChamam-se **at-most-once**, **at-least-once** e **exactly-once**. Elas não são detalhe de configuração isolado, são a base de qualquer decisão de design em streaming, do Kafka ao Spark Structured Streaming."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## As três semânticas\n\n- **At-most-once** (no máximo uma vez): cada mensagem é entregue zero ou uma vez. Nunca duplica, mas pode se perder para sempre.\n- **At-least-once** (pelo menos uma vez): cada mensagem é entregue uma ou mais vezes. Nunca se perde, mas pode chegar duplicada.\n- **Exactly-once** (exatamente uma vez): o efeito de cada mensagem é aplicado uma única vez, sem perda e sem duplicidade. É a mais difícil de sustentar, e exige mecanismos extras (assunto das próximas aulas deste módulo).\n\nNenhuma das três é \"melhor\" isoladamente: cada uma troca um risco por outro, e a escolha certa depende do que está sendo processado."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# At-most-once: commit do offset ANTES de processar\nconsumidor le a mensagem (offset 100)\nconsumidor faz commit do offset 100        <- offset avanca aqui\nconsumidor comeca a processar a mensagem\n   *** falha aqui ***                       <- mensagem NUNCA e reprocessada: perdida\n\n# At-least-once: commit do offset DEPOIS de processar\nconsumidor le a mensagem (offset 100)\nconsumidor processa a mensagem inteira\n   *** falha aqui ***                       <- offset ainda nao avancou\nconsumidor reinicia, le o offset 100 de novo\nconsumidor processa a MESMA mensagem outra vez   <- duplicata"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Semântica\",\"O que pode acontecer\",\"Onde o risco mora\"],[\"At-most-once\",\"Mensagem pode se perder e nunca ser reprocessada\",\"Commit do offset acontece antes do processamento terminar\"],[\"At-least-once\",\"Mensagem pode chegar duplicada, mas nunca se perde\",\"Processamento termina antes do commit, retry reprocessa\"],[\"Exactly-once\",\"Nenhuma perda e nenhuma duplicidade no efeito final\",\"Exige produtor idempotente, transação e consumidor coordenado\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Qual é a mais comum na prática\n\nNa maioria dos pipelines reais, incluindo o comportamento padrão de um consumidor Kafka, a escolha é **at-least-once**. O motivo é simples: entre perder um dado silenciosamente e processá-lo duas vezes, duplicar é o erro mais barato de corrigir depois. Perder costuma ser irreversível.\n\nIsso empurra a responsabilidade para a camada seguinte: se o transporte garante at-least-once, quem consome precisa saber lidar com duplicata. Essa é exatamente a ligação com a próxima aula, sobre idempotência no consumidor."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Nenhuma garantia de entrega é gratuita: at-most-once troca confiabilidade por simplicidade, at-least-once troca duplicidade por segurança contra perda, e exactly-once troca simplicidade por coordenação extra em cada etapa."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Um cenário para cada semântica\n\n- **At-most-once** cabe bem numa métrica que se autocorrige a cada leitura, como uma temperatura reportada a cada poucos segundos: perder uma leitura isolada não muda o quadro geral.\n- **At-least-once** é a escolha padrão para pedidos, cliques e eventos de negócio: perder um pedido é inaceitável, e a duplicata pode ser tratada com idempotência no consumidor.\n- **Exactly-once** se justifica quando duplicar o efeito custa caro de verdade, como lançar duas vezes o mesmo débito numa conta ou contar duas vezes a mesma venda num fechamento financeiro."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Um consumidor Kafka faz commit do offset de uma mensagem antes de processá-la, e falha logo em seguida, antes de terminar o processamento. Qual garantia de entrega esse comportamento produz?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "At-most-once, porque o offset avança antes de garantir que o processamento terminou.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "At-least-once, porque o consumidor volta a ler a mesma mensagem depois da falha.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Exactly-once, porque o commit garante que a mensagem não será processada de novo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "At-least-once, porque o Kafka reenvia automaticamente qualquer mensagem não confirmada.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um pipeline de contagem de visualizações usa um consumidor que processa a mensagem e só depois comita o offset. Depois de um pico de tráfego, o processo foi reiniciado algumas vezes por falta de memória, e a contagem final ficou um pouco acima do número real. Qual é a explicação mais provável?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O consumidor está em at-most-once, e o Kafka perdeu offsets durante os reinícios sucessivos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O consumidor está em at-least-once, e mensagens já processadas foram reprocessadas nos reinícios.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O consumidor está em exactly-once, e um bug no código de contagem soma cada evento duas vezes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O consumidor está em at-least-once, mas o problema é do Kafka, sem relação com os reinícios.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um painel mostra a temperatura média de um sensor industrial, atualizada a cada 5 segundos a partir de um stream. Perder uma leitura isolada não muda a tendência exibida, mas duplicar uma leitura infla a média por um instante. Qual garantia de entrega é a mais adequada, considerando o custo de cada erro nesse caso?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "At-least-once, porque perder qualquer leitura do sensor é sempre pior do que duplicar um valor.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Exactly-once, porque um painel de monitoramento sempre exige a garantia mais forte disponível.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "At-most-once, porque perder uma leitura isolada é inofensivo e evitar duplicata importa mais aqui.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Nenhuma garantia específica, já que painéis de monitoramento não sofrem com perda ou duplicata.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um serviço debita o cartão do cliente sempre que recebe um evento de assinatura renovada. Processar o mesmo evento duas vezes cobra o cliente em dobro, e perder o evento significa deixar de cobrar uma renovação legítima. O que esse cenário exige da garantia de entrega escolhida?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Exige apenas at-most-once, já que cobrar em dobro é mais grave do que deixar de cobrar uma vez.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Exige apenas at-least-once, já que perder a cobrança é sempre pior do que duplicá-la depois.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Exige um broker mais rápido, para reduzir a janela de tempo em que a falha pode ocorrer.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Exige exactly-once no efeito final: sem perda do evento e sem aplicar o débito duas vezes.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um desenvolvedor afirma: 'meu consumidor processa e só depois comita o offset, então a garantia é at-least-once, o que significa que toda mensagem sempre vai chegar duplicada'. O que está errado nessa afirmação?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Nada está errado, at-least-once de fato garante que toda mensagem chega duplicada ao menos uma vez.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "At-least-once significa que duplicata é possível se há falha entre processar e comitar, não garantida.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O erro é a ordem: comitar antes de processar é que caracteriza at-least-once, não o contrário.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O erro é achar que existe duplicata no Kafka, já que o protocolo elimina duplicatas no broker.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Duplicatas e idempotência",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Duplicatas e idempotência\n\nA aula anterior deixou um combinado: a garantia mais comum em streaming é at-least-once, e o preço dela é duplicata. Isso não é um bug do Kafka nem do consumidor, é a consequência direta de nunca arriscar perder uma mensagem. A pergunta que sobra é prática: o que fazer quando a mesma mensagem chega duas vezes?\n\nA resposta de novo tem nome: **idempotência**. Um consumidor idempotente processa a mesma mensagem uma, duas ou dez vezes e deixa o destino exatamente no mesmo estado que uma única execução deixaria."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## De onde vêm as duplicatas, na prática\n\nAlém da janela clássica entre processar e comitar, duplicata aparece por outros motivos comuns:\n\n- Um rebalanceamento acontece logo depois de processar uma mensagem, mas antes de comitar. A partição é reatribuída a outro consumidor do grupo, que reprocessa a partir do último offset comitado.\n- Um produtor reenvia a mesma mensagem por causa de um timeout de rede, mesmo que a escrita original já tenha sido bem-sucedida no broker (assunto da próxima aula, sobre produtor idempotente).\n- Alguém reprocessa manualmente um intervalo do tópico, por exemplo para corrigir um bug já resolvido, e replays eventos que já tinham sido processados antes."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# Consumidor NAO idempotente: acumula um delta a cada mensagem\ndef processar(evento):\n    saldo_cliente[evento.cliente_id] += evento.valor\n    # reprocessar o mesmo evento soma o valor de novo: saldo fica errado\n\n# Consumidor idempotente: upsert por chave de negocio\ndef processar(evento):\n    # grava o estado final da chave, nao acumula um delta\n    db.execute(\n        'INSERT INTO saldo (cliente_id, saldo) VALUES (%s, %s) '\n        'ON CONFLICT (cliente_id) DO UPDATE SET saldo = EXCLUDED.saldo',\n        [evento.cliente_id, evento.saldo_apos_evento]\n    )\n    # reprocessar o mesmo evento grava o mesmo saldo final: sem efeito colateral"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Duas técnicas para deduplicar\n\n- **Upsert por chave de negócio**: em vez de acumular um delta a cada evento, o consumidor grava o estado final daquela chave. Reprocessar o mesmo evento sobrescreve com o mesmo valor, sem duplicar efeito. Funciona quando o evento carrega o estado resultante, não só a variação.\n- **Deduplicar por id de evento**: quando o evento só carrega um delta (\"debitar R$ 50\") e não dá para simplesmente sobrescrever, o consumidor guarda os ids de evento já processados e ignora qualquer id repetido antes de aplicar o efeito de novo.\n\nAs duas técnicas já são familiares de outra trilha: são as mesmas ideias de upsert e deduplicação usadas na carga de um pipeline de ETL, agora aplicadas dentro de um consumidor que nunca para de rodar."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Técnica\",\"Quando usar\",\"Exige\"],[\"Upsert por chave\",\"O evento carrega o estado final, não só a variação\",\"Uma chave de negócio estável, como cliente_id\"],[\"Deduplicar por id de evento\",\"O evento carrega um delta que não pode ser sobrescrito\",\"Um id único por evento e um registro do que já foi visto\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## A ligação com o lakehouse\n\nO mesmo problema aparece na escrita de um stream numa tabela do lakehouse: um `MERGE INTO` por chave (Delta Lake, Iceberg) é o equivalente do upsert em streaming, e a deduplicação nativa do Spark Structured Streaming (`dropDuplicates`, aprofundada no módulo 6) implementa a segunda técnica direto na engine de processamento. A garantia de entrega do Kafka cuida do transporte; a idempotência na escrita é sempre responsabilidade de quem consome."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Idempotência não elimina a duplicata, ela elimina o efeito da duplicata. A mensagem pode chegar duas vezes; o estado final do destino não pode."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que significa dizer que um consumidor de streaming é idempotente?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Ele nunca recebe uma mensagem duplicada, porque o broker filtra repetições antes da entrega.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ele processa mais rápido a cada mensagem nova, porque reaproveita o estado da anterior.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Processar a mesma mensagem mais de uma vez deixa o destino no mesmo estado de uma única vez.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Ele rejeita qualquer mensagem que não tenha um id de evento explícito no cabeçalho.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um consumidor mantém saldo_cliente[id] += evento.valor para calcular saldo a partir de eventos de crédito. Depois de um rebalanceamento, um evento já processado foi entregue de novo ao consumidor. Qual é a consequência mais provável?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O saldo fica maior do que deveria, porque o mesmo valor é somado uma segunda vez.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O saldo fica menor do que deveria, porque o rebalanceamento desfaz a última soma aplicada.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O saldo permanece correto, porque o consumer group evita reprocessar eventos automaticamente.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O consumidor trava, porque um offset já lido antes não pode ser lido de novo.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um evento representa 'debitar R$ 30 da carteira do usuário', carregando apenas o valor do débito, não o saldo final. Duplicar o processamento não pode ser resolvido só com upsert, porque upsert sobrescreveria o mesmo delta em vez de aplicá-lo uma única vez. Qual técnica resolve esse caso?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Aumentar o número de partições do tópico, para reduzir a chance de reentrega da mensagem.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Trocar o consumidor para at-most-once, o que elimina a duplicata já na origem do problema.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Fazer upsert pelo id do usuário, sobrescrevendo o saldo a cada novo evento recebido.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Guardar o id de cada evento processado e ignorar qualquer id repetido antes do débito.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma tabela de controle guarda os ids de evento já processados para deduplicar, mas o time apaga os registros com mais de 24 horas para economizar espaço. Um produtor com problema de rede reenviou um evento com 3 dias de atraso. O que acontece?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O evento é aplicado normalmente pela primeira vez, sem nenhum risco, já que 3 dias é incomum.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O evento é tratado como novo e processado de novo, porque seu id de controle já foi apagado.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O evento é rejeitado automaticamente pelo Kafka, que reconhece o atraso como inválido.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O evento é deduplicado normalmente, porque a chave de negócio ainda está na mensagem.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe escreve o resultado de um stream direto numa tabela Delta usando MERGE INTO por pedido_id. O time se pergunta se ainda precisa se preocupar com duplicata vinda do Kafka. Qual é a resposta correta?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Não precisa, porque o Delta Lake nunca recebe uma linha duplicada vinda de um stream.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não precisa, porque o MERGE INTO só funciona quando a origem já garante exactly-once.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não precisa se preocupar com o efeito, porque o MERGE por chave já é a técnica de upsert na escrita.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Precisa, porque o MERGE INTO no Delta Lake só sobrescreve colunas, nunca gera efeito idempotente.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "O produtor idempotente e as transações no Kafka",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# O produtor idempotente e as transações no Kafka\n\nO módulo 3 já citou o produtor idempotente de passagem, ao lado de acks e batching. Esta aula abre o mecanismo por dentro: como o Kafka evita que um retry de rede grave a mesma mensagem duas vezes, e como as transações vão além disso, permitindo escrever em vários tópicos e partições como uma única unidade atômica."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O problema que o produtor idempotente resolve\n\nSem idempotência, um retry de produtor é uma fonte silenciosa de duplicata:\n\n1. O produtor envia a mensagem para o broker.\n2. O broker grava a mensagem com sucesso e tenta responder com o ack.\n3. O ack se perde na rede antes de chegar ao produtor, ou demora além do timeout configurado.\n4. O produtor, sem receber confirmação, assume falha e reenvia a mesma mensagem.\n5. O broker grava a mensagem de novo: agora existem duas cópias no tópico.\n\nO dado nunca se perdeu, mas duplicou por causa de uma falha de comunicação sobre um sucesso que já tinha acontecido."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# Produtor idempotente (enable.idempotence=true)\n# o broker atribui um Producer ID (PID) unico a sessao do produtor\n\nprodutor envia: PID=77, particao=2, sequencia=501, msg='pedido-123'\nbroker grava e responde ack\n   *** ack se perde na rede ***\nprodutor reenvia (retry): PID=77, particao=2, sequencia=501, msg='pedido-123'\nbroker reconhece a sequencia 501 do PID 77 como JA GRAVADA\nbroker descarta o reenvio, responde ack sem duplicar a mensagem\n   -> apenas UMA copia fica gravada na particao"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Produtor\",\"Retry por timeout de ack\",\"Requisito\"],[\"Produtor comum\",\"Pode duplicar a mensagem no broker\",\"Nenhum requisito extra\"],[\"Produtor idempotente\",\"Broker descarta o reenvio pela sequência já vista\",\"enable.idempotence=true, acks=all\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Transações: atomicidade entre partições e tópicos\n\nO produtor idempotente resolve duplicata dentro de uma única partição. Ele não resolve um problema diferente: um serviço que lê de um tópico, processa, e escreve o resultado em outro tópico (padrão consume-transform-produce) precisa que a leitura do offset de entrada e a escrita de saída aconteçam como uma coisa só, tudo ou nada.\n\nÉ para isso que existem as **transações** do Kafka. Um produtor transacional agrupa várias escritas, possivelmente em partições e tópicos diferentes, junto com o commit dos offsets de entrada, numa única transação: ou tudo fica visível, ou nada fica."
+                    },
+                    {
+                        "type": "code",
+                        "value": "produtor.initTransactions()\n\nprodutor.beginTransaction()\ntry {\n    resultado = transformar(mensagemLida)\n    produtor.send(new ProducerRecord('topico-saida', resultado))\n    produtor.sendOffsetsToTransaction(offsetsConsumidos, grupoConsumidor)\n    produtor.commitTransaction()\n} catch (erro) {\n    produtor.abortTransaction()\n    // nada do que foi enviado nesta transacao fica visivel\n    // para quem le com isolation.level=read_committed\n}"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O consumidor precisa optar por ver só o que foi commitado\n\nTransação só protege quem lê com `isolation.level=read_committed`. O padrão do Kafka é `read_uncommitted`, que enxerga inclusive mensagens de transações ainda abertas ou já abortadas. Sem configurar o isolamento certo do lado de quem consome, a atomicidade do produtor transacional não tem efeito prático nenhum."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que o produtor idempotente do Kafka evita, especificamente?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Que um consumidor processe a mesma mensagem duas vezes depois de um rebalanceamento.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que um retry do produtor, causado pela perda do ack, grave a mesma mensagem duas vezes.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Que uma mensagem seja perdida quando o líder da partição fica indisponível.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que duas partições diferentes recebam mensagens com a mesma chave de particionamento.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um produtor com enable.idempotence=true envia uma mensagem, o broker grava com sucesso, mas o ack se perde na rede. O produtor reenvia por timeout. O que o broker faz ao receber esse reenvio?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Grava a mensagem novamente, já que não tem como saber que o primeiro envio teve sucesso.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Rejeita o reenvio inteiro e devolve um erro fatal, encerrando a sessão do produtor.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Grava a mensagem numa partição diferente, para preservar as duas tentativas separadas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Reconhece o número de sequência já visto para aquele produtor e descarta o reenvio.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um serviço lê pedidos de um tópico, calcula o frete, e escreve o resultado em outro tópico. O time quer garantir que, se o processo cair no meio, ou o offset de entrada avança e o resultado é escrito, ou nenhum dos dois acontece. Que mecanismo do Kafka atende esse requisito?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Transações, agrupando a escrita de saída e o commit do offset de entrada numa única unidade.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Produtor idempotente, que já garante atomicidade entre ler de um tópico e escrever em outro.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Configurar acks=all, garantindo que a escrita e o commit do offset fiquem sincronizados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um único consumer group compartilhado entre os dois tópicos envolvidos na operação.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um produtor transacional escreve um lote de mensagens e a transação é abortada por causa de uma exceção na aplicação. Um consumidor lendo o mesmo tópico com isolation.level=read_uncommitted está rodando ao mesmo tempo. O que esse consumidor enxerga?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Nada, mensagens de uma transação abortada são removidas do tópico antes de qualquer leitura.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Apenas as mensagens que seriam válidas, porque read_uncommitted ignora transações por padrão.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "As mensagens da transação abortada também, porque read_uncommitted não distingue commitado de abortado.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um erro de leitura, porque read_uncommitted é incompatível com tópicos que recebem escrita transacional.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma aplicação ativa enable.idempotence=true no produtor, mas não usa transações. Ela lê de um tópico A, processa, e escreve em um tópico B, sem nenhum cuidado adicional no commit do offset. Contra o que essa aplicação está protegida, e contra o que ainda não está?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Protegida contra duplicata por retry na escrita em B, mas não contra inconsistência entre A e B.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Protegida contra as duas coisas, já que idempotência cobre tanto o retry quanto a consistência entre tópicos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não está protegida contra nenhuma das duas, já que toda idempotência exige transação para funcionar.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Protegida contra a inconsistência entre A e B, mas não contra duplicata por retry na escrita.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Exactly-once fim a fim",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Exactly-once fim a fim\n\nAs duas aulas anteriores mostraram duas peças que o Kafka oferece: o produtor idempotente, que evita duplicata de escrita por retry, e as transações, que tornam atômica a escrita em vários tópicos e partições. Nenhuma das duas, sozinha, é \"exactly-once\". Esta aula fecha o quadro: o que realmente é preciso para exactly-once fim a fim, e por que essa expressão é mais sutil do que parece."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## As três peças, juntas\n\nExactly-once de ponta a ponta, da entrada até o destino final, exige as três coisas ao mesmo tempo:\n\n1. **Produtor idempotente**, para que retries de rede não dupliquem a escrita em nenhum tópico intermediário.\n2. **Transações**, para que a escrita de saída e o commit do offset de entrada sejam atômicos, sem um acontecer sem o outro.\n3. **Consumidor final com leitura transacional (read_committed) ou sink idempotente**, para que o destino de fato só enxergue, ou só aplique, cada efeito uma vez.\n\nFaltar qualquer uma das três reabre uma janela de duplicata ou de perda em algum ponto do caminho."
+                    },
+                    {
+                        "type": "code",
+                        "value": "topico A -> [consumidor le] -> [processa] -> [produtor transacional escreve] -> topico B\n                  |                                    |\n        offset de A comitado          escrita em B + commit do offset\n        DENTRO da mesma transacao (sendOffsetsToTransaction)\n\ntopico B -> [consumidor final, isolation.level=read_committed] -> sink\n\n  sink transacional (outro topico Kafka, outra transacao)\n        OU\n  sink idempotente (upsert por chave: reescrever o mesmo efeito nao duplica)"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Kafka-para-Kafka é o caso fácil\n\nQuando origem e destino são dois tópicos Kafka, produtor idempotente mais transação mais leitura com read_committed entregam exactly-once de verdade, ponta a ponta. O Kafka controla as duas pontas.\n\nO caso difícil é quando o destino final é um sistema fora do Kafka: um banco relacional, uma tabela do lakehouse, uma API de terceiro. Aí a transação do Kafka não alcança mais nada, porque ela não conversa com o sistema de fora. Nesse caso, exactly-once só existe se o sink for **idempotente** (aula 2), não porque o Kafka garante, mas porque reaplicar o mesmo efeito não muda o resultado."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Destino final\",\"O que garante exactly-once\"],[\"Outro tópico Kafka\",\"Produtor idempotente, mais transação, mais consumidor com read_committed\"],[\"Banco relacional ou lakehouse\",\"Transação do Kafka até a saída, mais um sink idempotente (upsert/merge) no destino\"],[\"API externa sem idempotência própria\",\"Não existe exactly-once garantido, só mitigação com deduplicação por id de evento\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Por que exactly-once é um termo sutil\n\nNa prática, exactly-once quase sempre significa **exactly-once no efeito observável**, não que a mensagem fisicamente passou pelo pipeline uma única vez sem exceção. Um micro-batch do Spark Structured Streaming pode ser reprocessado depois de uma falha (módulo 6), e o resultado final ainda ser exactly-once, porque o sink é idempotente e reescrever o mesmo micro-batch produz o mesmo estado. O nome mais preciso, usado por parte da comunidade, é **effectively-once**: o efeito é único, mesmo que o processamento por trás não seja.\n\nVale lembrar que exactly-once tem custo: mais coordenação, mais latência, produtores e consumidores mais restritos. Muitos pipelines, como métricas agregadas ou painéis operacionais, toleram bem uma duplicata ocasional, e forçar exactly-once nesses casos é complexidade sem benefício real."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Exactly-once não é uma promessa de que nada nunca vai ser reprocessado. É uma promessa de que o efeito final, no destino, é como se tivesse sido processado uma única vez."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Quais três elementos, juntos, sustentam exactly-once fim a fim num pipeline Kafka-para-Kafka?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Alta replicação de partição, retenção longa de log e compactação de tópico.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um consumer group grande, muitas partições e um broker dedicado por tópico.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Apenas transações, já que elas sozinhas cobrem produtor e consumidor ao mesmo tempo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Produtor idempotente, transações, e um consumidor final lendo com read_committed.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um pipeline lê de um tópico Kafka, processa e grava o resultado direto numa tabela de um banco relacional externo, sem usar transação nenhuma do Kafka nessa escrita. O que esse pipeline precisa para alcançar exactly-once no efeito final?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Nada além de aumentar o acks do produtor para all, garantindo durabilidade suficiente.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "É impossível nesse cenário, porque exactly-once só existe entre dois tópicos Kafka diretamente.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que a escrita no banco seja idempotente, pois a transação do Kafka não cobre sistemas externos.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Apenas ativar o produtor idempotente também no lado da leitura do tópico de entrada.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de uma falha, um micro-batch do Spark Structured Streaming é reprocessado do zero. Ao final, a tabela de destino tem exatamente os mesmos valores que teria se o micro-batch tivesse rodado com sucesso uma única vez. Esse pipeline é considerado exactly-once?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Não, porque exactly-once exige que nenhum dado seja fisicamente reprocessado em hipótese alguma.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Sim, porque o que importa é o efeito final no destino, não se algum processamento foi repetido.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Não, porque reprocessar um micro-batch inteiro já é, por definição, apenas at-least-once.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Sim, mas só porque o Spark Structured Streaming nunca reprocessa um micro-batch já iniciado.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um pipeline financeiro adota exactly-once completo: produtor idempotente, transações Kafka de ponta a ponta, e um sink idempotente no banco de destino. A latência de escrita sobe e o throughput cai, mesmo com o mesmo volume de dados de antes. Qual explicação é mais consistente com as trocas de exactly-once?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "A coordenação extra de transações e commits atômicos tem custo real, é a troca que exactly-once exige.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Nenhuma explicação técnica, o time provavelmente introduziu um bug sem relação com as garantias.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Exactly-once corretamente configurado reduz o número de partições disponíveis para leitura.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A queda é esperada só na primeira execução, enquanto o produtor idempotente gera seu Producer ID.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um painel interno mostra a contagem aproximada de cliques por hora, atualizada em streaming. Uma duplicata ocasional altera o número em uma unidade, num total que passa de milhares. O time cogita implementar exactly-once completo para esse painel. É uma boa decisão?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Sim, porque qualquer pipeline em produção deveria buscar exactly-once sempre que possível.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Sim, porque sem exactly-once o painel corre risco real de ficar com números incorretos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não, porque exactly-once é tecnicamente impossível fora de um pipeline Kafka-para-Kafka.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Não, o custo extra de coordenação não se justifica para um erro de uma unidade.",
+                                "isCorrect": true
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Dead-letter e mensagens problemáticas",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Dead-letter e mensagens problemáticas\n\nNem toda falha de processamento é igual. Um timeout de rede ao chamar uma API externa costuma se resolver sozinho numa nova tentativa. Já uma mensagem com um campo obrigatório nulo, um JSON malformado, ou um valor que viola uma regra de negócio, vai falhar de novo, e de novo, e de novo, não importa quantas vezes o consumidor tentar. Esse segundo tipo tem um apelido conhecido: **poison message** (mensagem venenosa)."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O risco específico do Kafka: a partição inteira trava\n\nNuma fila tradicional, uma mensagem problemática costuma poder ser descartada ou reencaminhada sozinha, sem afetar as vizinhas. No Kafka isso é mais delicado, porque uma partição é um log ordenado, consumido em sequência: se o consumidor insiste em reprocessar a mesma mensagem sem nunca avançar o offset, nenhuma mensagem depois dela naquela partição é processada, mesmo que sejam mensagens boas, sem nenhum problema.\n\nUma única poison message, sem tratamento, é suficiente para parar o consumo de uma partição inteira até alguém intervir manualmente."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# Sem dead-letter: a particao trava na mensagem 104\nparticao: [101:ok] [102:ok] [103:ok] [104:falha] [105:...] [106:...]\nconsumidor:                            ^\n                       tenta 104 sem parar, nunca avanca o offset\n                       105 e 106 nunca sao processadas\n\n# Com dead-letter: a particao segue andando\nparticao: [101:ok] [102:ok] [103:ok] [104:falha] [105:ok] [106:ok]\nconsumidor:                            |\n                                        v\n                              topico-dead-letter (104 + motivo do erro)\n                       offset avanca, 105 e 106 sao processadas normalmente"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Retriável x não retriável\n\nAntes de mandar algo para a dead-letter, vale distinguir dois tipos de erro:\n\n- **Retriável**: falhas transitórias, como um timeout de rede ou uma dependência externa momentaneamente fora do ar. Tentar de novo, com um intervalo entre tentativas, costuma resolver.\n- **Não retriável**: um erro de desserialização, uma violação de schema, ou uma regra de negócio claramente quebrada. Tentar de novo sempre dá o mesmo erro: retry aqui só atrasa o inevitável e mantém a partição travada por mais tempo.\n\nMensagens não retriáveis, e mensagens retriáveis que já esgotaram um número razoável de tentativas, são candidatas diretas à dead-letter."
+                    },
+                    {
+                        "type": "code",
+                        "value": "def consumir(mensagem):\n    try:\n        processar(mensagem)\n        commit_offset(mensagem)\n    except ErroNaoRetriavel as erro:\n        # nao adianta tentar de novo: desvia e segue andando\n        produzir('pedidos-dead-letter', {\n            'mensagem_original': mensagem,\n            'erro': str(erro),\n            'topico_origem': mensagem.topico,\n            'offset_original': mensagem.offset,\n        })\n        commit_offset(mensagem)\n    except ErroRetriavel as erro:\n        # deixa o mecanismo de retry, com backoff, tentar de novo\n        raise erro"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Estratégia\",\"O que acontece com a partição\",\"Quando usar\"],[\"Reprocessar sem limite\",\"Trava até alguém intervir manualmente\",\"Nunca, sozinha\"],[\"Descartar em silêncio\",\"Segue andando, mas perde o dado e a visibilidade do erro\",\"Quase nunca, esconde o problema\"],[\"Dead-letter (tópico ou tabela)\",\"Segue andando, e o dado problemático fica preservado\",\"Padrão recomendado para erros não retriáveis\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Uma poison message que trava a partição não é um problema de uma mensagem só, é um problema de todas as mensagens boas que ficam presas atrás dela na fila."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que é uma poison message, num pipeline de streaming?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Uma mensagem que sempre falha no processamento, não importa quantas vezes seja reprocessada.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Qualquer mensagem que chega duplicada ao consumidor por causa da garantia at-least-once.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma mensagem grande demais para caber no tamanho máximo configurado no tópico Kafka.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma mensagem enviada por um produtor sem enable.idempotence configurado corretamente.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um consumidor encontra uma mensagem com um campo obrigatório nulo e entra em loop: tenta processar, falha, e como não avança o offset, tenta a mesma mensagem de novo, indefinidamente. Qual é a consequência para as mensagens seguintes na mesma partição?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Nenhuma, o Kafka processa as mensagens seguintes em paralelo, independente da mensagem atual.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ficam presas atrás da mensagem problemática, porque o consumidor não avança o offset da partição.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "São redirecionadas automaticamente para outro consumidor do grupo até o problema ser resolvido.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "São perdidas, porque o Kafka descarta mensagens de uma partição travada há muito tempo.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um consumidor recebe uma mensagem cujo payload não corresponde ao schema Avro esperado, um erro de desserialização. O time configura 3 tentativas de retry antes de desistir. O que está errado nessa decisão, considerando a natureza desse erro?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Nada, 3 tentativas é um número padrão razoável para qualquer tipo de falha de processamento.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O número deveria ser maior, erros de desserialização costumam se resolver após algumas tentativas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O erro deveria ser ignorado em silêncio, sem nenhuma tentativa nem envio à dead-letter.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Erro de desserialização é não retriável: as 3 tentativas sempre falham igual, só atrasam a dead-letter.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe decide que, ao encontrar uma mensagem problemática, o consumidor deve simplesmente descartá-la e avançar o offset, sem registrar nada em lugar nenhum. A partição para de travar. Que problema essa decisão introduz, comparada a usar uma dead-letter?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Nenhum, descartar e avançar o offset é tecnicamente equivalente a mandar para uma dead-letter.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A partição volta a travar do mesmo jeito, porque descartar sem registrar não libera o offset.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O dado problemático se perde de vez, sem nenhum registro do que falhou ou por quê.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O throughput do consumidor cai, porque descartar uma mensagem custa mais do que reprocessá-la.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um consumidor com lógica de dead-letter manda para o tópico pedidos-dead-letter tanto os erros de desserialização quanto os timeouts de uma API externa instável, sem distinguir os dois casos, e sem nenhum retry antes de desviar. Qual é o problema dessa implementação?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Nenhum, toda mensagem problemática deve ir direto para a dead-letter, sem exceção, por simplicidade.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Erros transitórios, como o timeout da API, deveriam ter uma chance de retry antes de virarem definitivos.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A dead-letter só deveria existir para timeouts de API, nunca para erros de desserialização.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O problema é técnico: o Kafka não permite escrever numa dead-letter sem esgotar os retries antes.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 5 - Tempo, janelas e estado",
+        "aulas": [
+            {
+                "titulo": "Event time x processing time",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Event time x processing time\n\nEm qualquer pipeline de streaming, cada registro carrega dois horários possíveis: o momento em que o fato aconteceu no mundo real e o momento em que o motor de processamento colocou as mãos nesse registro. Confundir os dois é uma das causas mais comuns de agregação errada em streaming."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Os dois relógios do evento\n\n- **Event time**: o instante em que o evento de fato ocorreu. Normalmente vem dentro do próprio payload, escrito por quem gerou o dado (um app, um sensor, um serviço).\n- **Processing time**: o instante em que o motor de streaming (Spark, Flink, Kafka Streams) lê e processa aquele registro. É o relógio da máquina que está rodando o job.\n\nOs dois quase nunca coincidem. Rede lenta, fila cheia, particionamento, reprocessamento: qualquer coisa no caminho entre a origem e o motor de streaming empurra o processing time para depois do event time."
+                    },
+                    {
+                        "type": "code",
+                        "value": "linha do tempo real (quando o evento aconteceu)\n\n  evento gerado às 08:00:00\n        |\n        v\n  08:00:00 ------------------------------------------->\n\ncaminho até o motor de streaming (fila, rede, buffer)\n        |________________ atraso _________________|\n                                                   v\n  08:00:00 .......................... 08:00:07 (motor lê o registro)\n\n  event time no payload   = 08:00:00  (fixo, não muda nunca)\n  processing time do job  = 08:00:07  (varia a cada execução)"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Por que a diferença importa para agregação\n\nSe uma janela agrega por processing time, o resultado depende da velocidade do pipeline naquele momento: um pico de tráfego, um restart do job ou uma lentidão na rede empurram eventos para a janela seguinte, mesmo que eles tenham acontecido dentro da janela anterior. Reprocessar o mesmo dado histórico em outro dia, com outra velocidade de leitura, pode gerar um número diferente.\n\nAgregar por event time resolve isso: cada evento cai na janela que corresponde ao momento em que ele realmente aconteceu, não ao momento em que o pipeline conseguiu processá-lo. O resultado fica reprodutível e correto em relação ao mundo real, ao custo de um problema novo: dados atrasados podem chegar depois que a janela já parecia fechada (o tema das próximas aulas)."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O exemplo do celular offline\n\nUm app de corrida registra passos e distância com o horário do próprio celular. O usuário entra no metrô às 08:00 e fica sem sinal por 40 minutos; o app continua gravando localmente. Quando o sinal volta, às 08:40, o celular envia de uma vez os eventos acumulados desde as 08:00.\n\nSe a agregação usar processing time, todos esses eventos caem na janela das 08:40, o horário em que o servidor finalmente os recebeu: a janela das 08:00 fica sem os passos que realmente aconteceram ali, e a das 08:40 recebe um pico artificial. Se a agregação usar o event time gravado no próprio evento, cada registro volta para a janela correta, mesmo chegando 40 minutos atrasado."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Característica\",\"Event time\",\"Processing time\"],[\"Quando é definido\",\"No momento em que o evento aconteceu, dentro do payload\",\"No momento em que o motor de streaming lê o registro\"],[\"Varia com atraso de rede ou fila\",\"Não, é fixo no evento\",\"Sim, muda a cada execução\"],[\"Resultado ao reprocessar o histórico\",\"O mesmo, sempre\",\"Pode mudar conforme a velocidade da leitura\"],[\"Exige um campo de timestamp no dado\",\"Sim\",\"Não, usa o relógio da máquina\"]]"
+                    },
+                    {
+                        "type": "code",
+                        "value": "# lê cliques de um tópico Kafka; cada mensagem traz \"event_ts\" no payload\ndf = spark.readStream.format(\"kafka\") \\\n    .option(\"kafka.bootstrap.servers\", \"broker:9092\") \\\n    .option(\"subscribe\", \"cliques\") \\\n    .load()\n\neventos = (\n    df.selectExpr(\"CAST(value AS STRING) AS json\")\n      .select(from_json(\"json\", esquema_clique).alias(\"c\"))\n      .select(\"c.event_ts\", \"c.usuario_id\", \"c.pagina\")\n)\n\n# agrupar por event_ts reflete quando o clique aconteceu de verdade,\n# não o instante em que este job leu a mensagem do Kafka\ncontagem = eventos.groupBy(window(\"event_ts\", \"5 minutes\")).count()"
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Em um pipeline de streaming, qual é a definição correta de event time?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "O instante em que o evento realmente aconteceu, segundo o horário registrado no payload.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O instante em que o broker do Kafka grava a mensagem no log da partição, segundo o offset atribuído.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O instante em que o motor de streaming lê e processa o registro, segundo o relógio da máquina local.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O instante em que o consumidor confirma o commit do offset, segundo o relógio do servidor atual.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um time agrega o faturamento em janelas de 1 minuto usando o horário em que o Spark processa cada registro (processing time), não o horário da venda. Depois de um pico de tráfego que atrasou o consumo do tópico em 3 minutos, o total de uma hora específica mudou ao reprocessar o mesmo histórico no dia seguinte. Qual é a causa mais provável?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O tópico Kafka perdeu mensagens durante o pico de tráfego, reduzindo bastante o total contabilizado na nova execução inteira do job.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A agregação por processing time depende da velocidade de leitura do pipeline, e a mesma venda cai em janelas diferentes a cada execução.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O Spark Structured Streaming corrompeu o checkpoint durante o pico, obrigando a nova execução a recomeçar do zero.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A chave de particionamento das vendas mudou entre as duas execuções, alterando a ordem de leitura dos registros.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma rede de sensores IoT grava, dentro do payload, o horário exato de cada leitura de temperatura. A equipe quer um relatório diário que reflita fielmente quando cada leitura ocorreu, mesmo com sensores de conectividade instável. Qual escolha de tempo a equipe deve usar para agrupar as leituras?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Processing time, porque reflete o momento exato em que o cluster Spark recebeu e processou cada leitura enviada.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Processing time, porque garante que a janela feche assim que o último lote inteiro for processado, sem esperar atrasados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Event time, porque agrupa cada leitura no momento em que ela realmente ocorreu no sensor, independente do atraso de rede.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Processing time, porque elimina por completo a necessidade de sincronizar o relógio dos sensores com o servidor.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um aplicativo de corrida grava localmente os passos de um usuário que ficou 40 minutos sem sinal no metrô e envia tudo de uma vez quando a conexão volta. Se a agregação horária for feita por event time, o que acontece com os passos registrados durante o período sem sinal?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "São descartados pelo pipeline, porque chegaram fora de ordem em relação ao restante do fluxo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "São contados todos na janela do momento em que o celular reconectou e enviou os dados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "São somados a uma janela especial de atrasados que o Spark cria automaticamente para eventos fora de ordem.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "São contados nas janelas correspondentes ao horário real de cada passo, mesmo chegando 40 minutos depois.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Sobre event time e processing time em streaming, qual afirmação está correta?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Usar event time para agregações torna o resultado reprodutível ao reprocessar o mesmo histórico, pois cada registro sempre cai na mesma janela.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Usar processing time para agregações torna o resultado reprodutível ao reprocessar o mesmo histórico, pois o relógio da máquina é sempre o mesmo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Event time e processing time sempre coincidem quando o cluster Spark tem recursos suficientes para processar sem fila.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Processing time exige um campo de timestamp no payload, enquanto event time usa apenas o relógio do sistema.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Dados atrasados e fora de ordem",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Dados atrasados e fora de ordem\n\nEm um sistema distribuído, esperar que os eventos cheguem na mesma ordem em que aconteceram é uma expectativa que a realidade não cumpre. Redes têm caminhos diferentes, produtores têm latências diferentes, partições são lidas em paralelo. Streaming de dados precisa ser projetado assumindo que atraso e desordem são a regra, não a exceção."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Por que isso acontece\n\n- **Múltiplos produtores**: dois clientes emitem eventos quase ao mesmo tempo, mas um deles está numa rede mais lenta e chega depois.\n- **Múltiplas partições**: o Kafka garante ordem dentro de uma partição, mas não entre partições diferentes de um mesmo tópico. Um consumidor lê várias partições em paralelo e pode processar um evento mais novo de uma partição antes de um evento mais antigo de outra.\n- **Reentrega e retry**: uma falha de rede faz o produtor reenviar um evento que já tinha sido gerado minutos antes.\n- **Dispositivos offline**: sensores, celulares e aplicações desktop guardam eventos localmente e os enviam em lote quando a conexão volta, fora de ordem em relação ao que chegou nesse meio tempo."
+                    },
+                    {
+                        "type": "code",
+                        "value": "ordem de geração (event time):      E1(08:01)   E2(08:02)   E3(08:03)\n                                          \\           |           /\n                                     caminhos de rede diferentes\n                                          /           |           \\\nordem de chegada (processing time):  E2(08:02)   E3(08:03)   E1(08:01)\n                                                                  ^\n                                                        chegou por último,\n                                                        mas aconteceu primeiro"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O problema para janelas por event time\n\nUma janela agrupa eventos pelo intervalo de event time em que eles caem, por exemplo `[08:00, 08:05)`. O motor de streaming só sabe que uma janela está completa quando para de receber eventos que pertencem a ela. Mas em um fluxo com atraso e desordem, como saber se realmente não vai chegar mais nenhum evento com event time dentro daquele intervalo, ou se é só uma questão de tempo?\n\nSe o motor fechar a janela cedo demais, perde eventos legítimos que ainda estão a caminho. Se esperar demais antes de fechar qualquer janela, a latência do resultado cresce e o estado guardado em memória aumenta, porque mais janelas ficam abertas ao mesmo tempo."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Em streaming distribuído, ordem de chegada e ordem de acontecimento são coisas diferentes; o pipeline precisa decidir o que fazer quando as duas discordam."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Escopo\",\"Ordem garantida\",\"Motivo\"],[\"Dentro de uma partição\",\"Sim\",\"O log da partição é append-only e o consumidor lê sequencialmente\"],[\"Entre partições do mesmo tópico\",\"Não\",\"Cada partição é lida de forma independente e em paralelo\"],[\"Entre tópicos diferentes\",\"Não\",\"Não há relação de ordem entre logs de tópicos distintos\"],[\"Após uma reentrega do produtor\",\"Não garantida sem configuração extra\",\"Um retry pode inserir um evento antigo depois de eventos mais novos\"]]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que fazer com um evento que chega tarde\n\nAlgumas saídas práticas, que os motores de streaming combinam:\n\n- **Atualizar o resultado da janela**, se ela ainda estiver aberta: o motor refaz a agregação incluindo o evento atrasado.\n- **Definir até quando vale a pena esperar**, usando um limite explícito (o watermark, tema da próxima aula) para decidir quando uma janela deixa de aceitar atualizações.\n- **Enviar para um fluxo separado de atrasados** (uma tabela ou tópico próprio), para auditoria ou reprocessamento manual, quando o evento chega depois do limite aceito.\n- **Descartar**, quando o caso de uso tolera perder uma fração pequena de eventos muito atrasados em troca de fechar janelas mais rápido."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "No Kafka, a garantia de ordem das mensagens vale:",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Entre todas as partições de um mesmo tópico, na ordem em que os produtores enviaram.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Dentro de uma mesma partição, na ordem em que as mensagens foram gravadas no log.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Entre todos os tópicos de um mesmo cluster Kafka, respeitando o horário de produção.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Apenas quando existe um único consumer group lendo o tópico inteiro.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um consumidor lê duas partições de um tópico de pedidos em paralelo. Ele processa um pedido com event time 09:05:10 vindo da partição 0 antes de processar um pedido com event time 09:05:02 vindo da partição 1. Por que isso acontece, mesmo com o Kafka garantindo ordem?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque o produtor enviou os dois pedidos fora de ordem, e o broker gravou exatamente na ordem recebida.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque a partição 1 sofreu perda de mensagens durante o envio e precisou reenviar o pedido das 09:05:02.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque a garantia de ordem do Kafka vale dentro de cada partição, e as partições são lidas de forma independente e em paralelo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o consumer group ainda não tinha terminado o rebalanceamento quando os dois pedidos finalmente chegaram ao consumidor.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma janela de vendas por minuto é fechada assim que o pipeline para de receber eventos novos por alguns segundos. Um evento de venda com event time dentro dessa janela, mas atrasado por um problema de rede, chega logo depois do fechamento. Qual é a consequência direta, se nada for feito para tratar esse atraso?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O Spark rejeita a conexão do produtor até que o atraso na rede seja corrigido manualmente pela equipe.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O evento é automaticamente movido para a próxima janela, sem nenhuma perda de informação no resultado final.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O consumer group inteiro entra em rebalanceamento para reprocessar a janela que já tinha sido fechada.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A venda fica de fora do total daquela janela, distorcendo o resultado que já foi considerado fechado.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe decide que eventos de cliques atrasados em mais de 10 minutos não valem a pena reprocessar, mas não quer perdê-los para investigações futuras. Qual estratégia atende esse requisito?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Enviar os eventos muito atrasados para um tópico ou tabela separada, em vez de tentar atualizar a janela já fechada.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Configurar o consumer para nunca fazer commit de offset, forçando a releitura de toda a partição a cada execução.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Aumentar o número de partições do tópico para que os eventos atrasados cheguem mais rápido.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ativar o log compaction no tópico para manter apenas a versão mais recente de cada clique.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Sobre desordem e atraso em streaming, qual afirmação está correta?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Aumentar o número de partições de um tópico elimina totalmente a chance de eventos chegarem fora de ordem ao consumidor final.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Mesmo sem falha de rede, ler várias partições em paralelo pode entregar eventos ao consumidor fora da ordem em que aconteceram.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um evento só é considerado atrasado quando o produtor demora mais de um minuto inteiro para enviá-lo até o broker.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Configurar acks=all no produtor garante que os consumidores sempre recebam os eventos na mesma ordem em que ocorreram.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Watermark: até quando esperar o atrasado",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Watermark: até quando esperar o atrasado\n\nA aula anterior deixou uma pergunta em aberto: se os eventos podem chegar atrasados, quando um motor de streaming pode dizer que uma janela está finalmente completa? O watermark é a resposta que o Spark, o Flink e outros motores usam para essa pergunta."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que é um watermark\n\nUm watermark é uma marca de tempo que o motor de streaming propaga junto com os dados, dizendo, na prática: já vi eventos com event time até aqui, não espero mais ver nada com event time anterior a este ponto.\n\nEle costuma ser calculado como o maior event time já visto no fluxo, menos uma margem de tolerância definida pela equipe (por exemplo, 10 minutos). Se o maior event time visto foi `08:20` e a tolerância é de `10 minutes`, o watermark fica em `08:10`: qualquer evento novo com event time anterior a `08:10` é tratado como atrasado demais."
+                    },
+                    {
+                        "type": "code",
+                        "value": "maior event time já visto:  08:20\ntolerância definida:        10 minutos\nwatermark atual:            08:20 - 10min = 08:10\n\neventos que ainda chegam:\n  event time 08:12  -> aceito (está depois do watermark)\n  event time 08:07  -> atrasado demais (está antes do watermark)\n\nlinha do tempo (event time) --------------------------------->\n     08:00        08:10 (watermark)        08:20 (mais recente visto)\n                    |\n             tudo antes daqui é considerado já visto por completo"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Como o watermark fecha as janelas\n\nUma janela `[08:00, 08:05)` só emite ou fecha seu resultado quando o watermark ultrapassa o fim da janela, `08:05`. Até esse momento, qualquer evento com event time dentro do intervalo ainda pode chegar e atualizar o resultado.\n\nDepois que o watermark passa de `08:05`, o motor considera a janela encerrada. Um evento que chega depois disso com event time `08:03`, por exemplo, é tratado como tardio demais: dependendo da configuração, ele é descartado ou desviado para tratamento à parte, mas não volta a alterar o resultado já emitido."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "O watermark não promete que nenhum evento vai chegar atrasado; ele só define o ponto em que o pipeline para de esperar e assume o risco de não ver mais nada antes dali."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Configuração do watermark\",\"Efeito na latência\",\"Efeito na completude\"],[\"Tolerância curta (ex.: 1 minuto)\",\"Janelas fecham rápido, resultado sai cedo\",\"Mais eventos atrasados chegam depois do fechamento e são perdidos\"],[\"Tolerância longa (ex.: 30 minutos)\",\"Janelas demoram mais para fechar, resultado sai depois\",\"Menos eventos atrasados são perdidos, mais dados chegam a tempo\"],[\"Tolerância mal dimensionada para o domínio\",\"Latência alta sem necessidade, ou perda evitável\",\"Não resolve nem latência nem completude direito\"]]"
+                    },
+                    {
+                        "type": "code",
+                        "value": "# watermark de 10 minutos sobre o campo de event time \"event_ts\":\n# o Spark só considera uma janela encerrada quando o event time mais\n# recente visto no fluxo avança 10 minutos além do fim da janela\ncontagem = (\n    eventos\n    .withWatermark(\"event_ts\", \"10 minutes\")\n    .groupBy(window(\"event_ts\", \"5 minutes\"))\n    .count()\n)\n\n# eventos com event_ts anterior ao watermark atual chegam tarde demais\n# e são descartados da agregação acima"
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O watermark, em um pipeline de streaming, representa:",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "O número máximo de mensagens que uma partição inteira do Kafka pode reter antes de começar a descartar de vez as mais antigas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O identificador único que o Schema Registry atribui a cada nova versão registrada de um schema Avro.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma marca de tempo que sinaliza até onde o motor já considera ter visto os eventos, usada para decidir quando fechar uma janela.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O offset mais recente que um consumer group confirmou, fazendo commit, em uma partição específica do tópico.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe configura watermark de 2 minutos sobre event time para agregar pedidos por minuto. Durante um pico de tráfego, alguns pedidos chegam com 5 minutos de atraso em relação ao maior event time já visto. O que acontece com esses pedidos?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "São automaticamente movidos para a próxima janela que ainda estiver aberta, sem qualquer alteração no resultado total já calculado antes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Fazem o Spark pausar por completo o consumo do tópico até que o atraso na rede seja resolvido pela equipe.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "São somados normalmente ao resultado, porque o watermark só afeta janelas com mais de 5 minutos de duração total.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Chegam depois que o watermark já passou do fim da janela correspondente e são tratados como tardios demais para atualizar o resultado.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um painel de fraude precisa de alertas com a menor latência possível e tolera perder uma fração pequena de transações muito atrasadas. Qual ajuste de watermark é mais coerente com esse requisito?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Uma tolerância curta, fechando as janelas mais rápido mesmo correndo o risco de descartar mais eventos atrasados.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Uma tolerância longa, priorizando nunca perder nenhuma transação, mesmo que o alerta demore bem mais para sair.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Nenhum watermark configurado, deixando todas as janelas abertas indefinidamente até o job ser reiniciado manualmente.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um watermark calculado a partir do processing time em vez do event time, para não depender do relógio de origem.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Como o watermark de um fluxo costuma ser calculado pelo motor de streaming?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Pela média entre o event time e o processing time de todos os eventos recebidos na última hora.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Pelo maior event time já observado no fluxo, subtraída uma margem de tolerância definida pela equipe.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Pelo horário do relógio do servidor no momento em que a janela é criada, sem depender dos eventos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Pelo menor event time entre os eventos que ainda estão na fila de entrada do tópico.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Sobre watermark em streaming, qual afirmação está correta?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Um watermark garante que nenhum evento chegará atrasado depois que uma janela for fechada.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Diminuir a tolerância do watermark reduz a latência e também reduz a quantidade de eventos descartados por atraso.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Aumentar a tolerância do watermark reduz a perda de eventos atrasados, ao custo de aumentar a latência dos resultados.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O watermark é um mecanismo exclusivo do Kafka e não existe em motores de processamento como Spark ou Flink.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Janelas: tumbling, sliding e session",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Janelas: tumbling, sliding e session\n\nAgregar um fluxo sem fim (contar, somar, calcular uma média) exige recortar esse fluxo em pedaços finitos. Esses pedaços são as janelas. Os três formatos mais comuns, tumbling, sliding e session, recortam o tempo de jeitos diferentes, e a escolha certa depende da pergunta que a agregação precisa responder."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Tumbling windows (fixas, sem sobreposição)\n\nJanelas tumbling têm duração fixa e não se sobrepõem: cada evento pertence a exatamente uma janela. Uma janela de 5 minutos produz os intervalos `[08:00, 08:05)`, `[08:05, 08:10)`, `[08:10, 08:15)`, e assim por diante, sem nenhum instante contado duas vezes. É o formato natural para perguntas como quantos pedidos por minuto ou faturamento por hora.\n\n## Sliding windows (deslizantes, com sobreposição)\n\nJanelas sliding também têm duração fixa, mas avançam em passos menores que a própria duração, então se sobrepõem e um evento pode pertencer a mais de uma janela ao mesmo tempo. Uma janela de 10 minutos que desliza a cada 5 minutos produz `[08:00, 08:10)`, `[08:05, 08:15)`, `[08:10, 08:20)`. Serve para métricas suavizadas, como média móvel dos últimos 10 minutos, atualizada a cada 5."
+                    },
+                    {
+                        "type": "code",
+                        "value": "tumbling (janela de 5 min, sem sobreposição):\n08:00        08:05        08:10        08:15\n  |-----W1-----|-----W2-----|-----W3-----|\n  cada evento cai em exatamente uma janela\n\nsliding (janela de 10 min, deslizando a cada 5 min):\n08:00        08:05        08:10        08:15        08:20\n  |------------W1------------|\n              |------------W2------------|\n                          |------------W3------------|\n  um evento às 08:07 cai dentro de W1 e de W2 ao mesmo tempo"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Session windows (por inatividade)\n\nJanelas session não têm duração fixa: elas agrupam eventos que estão próximos no tempo e se encerram quando passa um intervalo de inatividade (o gap) sem nenhum evento novo daquela chave. Cada usuário, dispositivo ou chave tem suas próprias janelas, com tamanhos diferentes.\n\nSão o formato natural para sessão de navegação no site ou sequência de cliques de um usuário: o que importa é agrupar a atividade contínua, não um relógio fixo de parede."
+                    },
+                    {
+                        "type": "code",
+                        "value": "eventos de um mesmo usuário ao longo do tempo (gap de inatividade = 5 min):\n\n09:00  09:02  09:03                 09:12  09:14              09:25\n  |------|------|                     |------|                  |\n  \\____________/                     \\______/                  |\n     sessão 1                         sessão 2                sessão 3\n  (fecha: 8 min sem evento)      (fecha: 11 min sem evento)  (ainda aberta)\n\n  gap > 5 min entre 09:03 e 09:12  -> fecha a sessão 1 e abre a sessão 2\n  gap > 5 min entre 09:14 e 09:25  -> fecha a sessão 2 e abre a sessão 3"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "A pergunta que a agregação precisa responder é que define a janela certa: um relógio fixo pede tumbling ou sliding, um comportamento contínuo por chave pede session."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Tipo de janela\",\"Sobreposição\",\"Quando usar\"],[\"Tumbling\",\"Não, cada evento cai em uma única janela\",\"Métricas por intervalo fixo: pedidos por minuto, faturamento por hora\"],[\"Sliding\",\"Sim, um evento pode cair em várias janelas\",\"Métricas suavizadas: média móvel, detecção de tendência recente\"],[\"Session\",\"Não entre sessões, mas a duração varia por chave\",\"Atividade contínua por usuário: sessão de navegação, sequência de cliques\"]]"
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual característica define uma janela do tipo tumbling?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Sua duração varia de acordo com o intervalo de inatividade entre eventos de uma mesma chave.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ela avança em passos menores que sua própria duração, fazendo com que um evento caia em mais de uma janela.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ela só existe em pipelines que usam processing time, nunca event time.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ela tem duração fixa e não se sobrepõe, então cada evento pertence a exatamente uma janela.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um painel precisa mostrar a média móvel de temperatura dos últimos 10 minutos, atualizada a cada 1 minuto, para detectar tendências de aquecimento rápido. Qual tipo de janela atende melhor esse requisito?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Sliding, com duração de 10 minutos e passo de 1 minuto, para suavizar a média e atualizá-la com frequência.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Tumbling, com duração de 10 minutos, para evitar que uma mesma leitura seja contada em mais de uma janela.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Session, com um gap de 1 minuto de inatividade entre leituras do sensor.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Tumbling, com duração de 1 minuto, somando as dez últimas janelas fechadas para formar a média.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um site quer medir a duração de cada visita, agrupando os cliques de um mesmo usuário enquanto ele estiver ativo, e fechando a contagem quando o usuário ficar 15 minutos sem interagir. Qual tipo de janela é o mais adequado?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Tumbling de 15 minutos, reiniciando do zero a contagem de cliques a cada intervalo fixo de tempo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Session, com gap de inatividade de 15 minutos, encerrando a janela quando esse tempo passa sem nenhum clique novo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Sliding de 15 minutos com passo de 1 minuto, somando os cliques de todas as janelas sobrepostas ainda ativas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Tumbling de 1 minuto, concatenando as janelas seguidas até encontrar uma sem nenhum clique registrado.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Em uma janela sliding de 20 minutos com passo de 5 minutos, um único evento pode ser contado em quantas janelas ao mesmo tempo, no máximo?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Em exatamente uma janela, porque esse comportamento de não sobreposição é exclusivo das janelas tumbling.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Em todas as janelas que já foram abertas desde o início do stream inteiro, já que as janelas sliding nunca fecham janelas antigas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Em até quatro janelas, pois 20 minutos de duração com passo de 5 minutos geram quatro janelas sobrepostas cobrindo o mesmo instante.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Em nenhuma janela, porque o watermark ainda precisa confirmar o fechamento da primeira antes de contar o evento.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Sobre tumbling, sliding e session windows, qual afirmação está correta?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Janelas session têm duração fixa, definida previamente pela equipe, exatamente igual ao que acontece nas janelas tumbling.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Janelas sliding garantem que cada evento seja contado em exatamente uma única janela, assim como as tumbling.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Janelas tumbling passam a se sobrepor quando o passo configurado fica menor do que a duração da própria janela.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Janelas session variam de duração conforme a atividade de cada chave, ao contrário de tumbling e sliding, que são fixas.",
+                                "isCorrect": true
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Estado e agregações em streaming",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Estado e agregações em streaming\n\nFiltrar um campo ou transformar um valor são operações sem memória: o motor olha um registro, decide o que fazer com ele e esquece. Contar pedidos por minuto ou somar faturamento por cliente é diferente: o resultado de agora depende de tudo que já foi visto para aquela janela e aquela chave. Isso é processamento com estado (stateful), e é o que torna agregações em streaming mais caras e mais delicadas do que transformações simples."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Por que agregar exige estado\n\nUma transformação sem estado (stateless), como filtrar pedidos cancelados ou converter uma moeda, processa cada registro isoladamente: não precisa lembrar nada do registro anterior. Uma agregação com estado (stateful) é diferente: para responder quantos pedidos já chegaram nesta janela para este cliente, o motor precisa guardar um contador parcial em algum lugar entre um micro-batch e o próximo, atualizá-lo a cada novo evento e só descartá-lo quando a janela realmente se encerra, ou seja, quando o watermark passa do fim dela.\n\nEsse contador parcial, por chave e por janela, é o estado da aplicação."
+                    },
+                    {
+                        "type": "code",
+                        "value": "fluxo de eventos (chave = cliente, janela = 5 min)\n\nmicro-batch 1: chegam 3 pedidos do cliente A\n  state store: { (cliente=A, janela=[08:00,08:05)): contador=3 }\n\nmicro-batch 2: chegam 2 pedidos do cliente A e 1 do cliente B\n  state store: { (cliente=A, janela=[08:00,08:05)): contador=5,\n                  (cliente=B, janela=[08:00,08:05)): contador=1 }\n\nmicro-batch 3: watermark passa de 08:05\n  state store: emite o resultado final da janela [08:00,08:05) para A e B,\n               remove essas chaves do estado (a janela não existe mais)"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O custo do estado\n\nO estado precisa ficar disponível entre um micro-batch e o próximo, normalmente em memória no executor, com uma cópia durável em disco (o checkpoint, aprofundado na trilha de Spark Structured Streaming) para sobreviver a uma falha. Isso tem custo:\n\n- **Cresce com o número de chaves distintas em aberto**: contar por `usuario_id` em uma base com milhões de usuários ativos guarda muito mais estado do que contar por `regiao`.\n- **Cresce com o número de janelas abertas ao mesmo tempo**: um watermark com tolerância muito longa mantém mais janelas antigas vivas, cada uma com seu próprio estado.\n- **Pode crescer sem limite** se o watermark estiver mal configurado, ou ausente, e o motor nunca considerar nenhuma janela encerrada, acumulando estado até faltar memória.\n\nDimensionar o watermark, como visto na aula anterior, também é uma decisão sobre o tamanho do estado, não só sobre latência."
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Toda agregação em streaming é uma promessa de guardar alguma coisa na memória até que o watermark diga que está na hora de soltar."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"\",\"Transformação sem estado (stateless)\",\"Agregação com estado (stateful)\"],[\"Exemplo\",\"Filtrar, converter um campo, validar um schema\",\"Contar, somar, calcular média por janela e chave\"],[\"Depende de eventos anteriores\",\"Não, cada registro é independente\",\"Sim, acumula um resultado parcial por chave\"],[\"Precisa de state store\",\"Não\",\"Sim, para guardar o resultado parcial entre micro-batches\"],[\"Custo de memória\",\"Constante, não cresce com o fluxo\",\"Cresce com o número de chaves e janelas em aberto\"]]"
+                    },
+                    {
+                        "type": "code",
+                        "value": "# contagem de pedidos por cliente, em janelas de 5 minutos:\n# cada combinação (cliente_id, janela) mantém um contador no state store\n# do Spark até que o watermark feche a janela correspondente\ncontagem = (\n    pedidos\n    .withWatermark(\"event_ts\", \"10 minutes\")\n    .groupBy(col(\"cliente_id\"), window(\"event_ts\", \"5 minutes\"))\n    .count()\n)\n\n# o Spark guarda esse estado em memória no executor e faz checkpoint\n# em um storage durável, para conseguir retomar após uma falha\n# (checkpoint e tolerância a falha é o tema do próximo módulo)"
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Por que uma agregação como contar pedidos por cliente a cada janela de 5 minutos exige processamento com estado (stateful)?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Porque o resultado de cada janela depende de todos os eventos daquela chave já vistos até o momento, não só do evento atual.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o Kafka exige que toda contagem seja feita dentro da própria partição, sem nenhuma passagem pelo Spark.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque toda operação de streaming, mesmo um filtro bem simples, precisa guardar o registro anterior inteiro na memória.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o watermark obriga o motor a guardar uma cópia de cada evento antes mesmo de poder descartá-lo depois.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um pipeline agrega o total gasto por usuario_id em janelas de 1 hora. Depois de alguns dias em produção, com dezenas de milhões de usuários distintos ativos por hora, o job começa a falhar por falta de memória nos executores. Qual é a explicação mais provável?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O Kafka está reenviando mensagens duplicadas para o tópico de origem, dobrando por completo o volume processado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O state store mantém um contador por combinação de usuário e janela, e a alta cardinalidade fez o estado crescer muito.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O watermark foi configurado com uma tolerância curta demais, fechando as janelas horárias muito antes da hora certa.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Spark está lendo a mesma partição do Kafka mais de uma vez por causa de um rebalanceamento mal sucedido.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um job agrega vendas por janela de 10 minutos, mas a equipe esqueceu de configurar um watermark sobre o event time. Depois de rodar por vários dias sem reiniciar, o estado guardado pelo Spark só cresce, sem nunca diminuir. Qual é a causa mais provável?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Sem watermark, o Spark passa a agregar automaticamente por processing time, dobrando o número total de janelas.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Sem watermark, o Kafka para completamente de fazer commit de offset, então o mesmo dado acaba sendo lido repetidas vezes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Sem watermark, o motor nunca tem um sinal para considerar uma janela encerrada, então nenhuma chave de estado é liberada.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Sem watermark, o state store deixa de gravar checkpoint em disco e passa a acumular tudo apenas em memória.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual das operações a seguir é um exemplo de transformação sem estado (stateless) em um pipeline de streaming?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Somar o valor total de pedidos feitos por cada cliente dentro de janelas de 15 minutos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Contar quantos eventos distintos de erro ocorreram em cada serviço a cada minuto corrido.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Calcular a média móvel da temperatura de cada sensor ao longo dos últimos 10 minutos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Converter o campo de moeda de cada pedido de centavos para reais antes de gravar no sink.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Sobre estado em processamento de streams, qual afirmação está correta?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Reduzir a tolerância do watermark tende a diminuir o estado em aberto, pois as janelas fecham e liberam chaves mais cedo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O tamanho do estado depende apenas do volume de eventos por segundo, e nunca do número de chaves distintas usadas na agregação.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Transformações sem estado também precisam manter um state store próprio, ainda que menor do que o das agregações.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um job de streaming sem nenhuma agregação ainda assim guarda estado proporcional ao número total de janelas abertas.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 6 - Processando streams com Spark Structured Streaming",
+        "aulas": [
+            {
+                "titulo": "O modelo: uma tabela sem fim e micro-batch",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# O modelo: uma tabela sem fim e micro-batch\n\nNos módulos anteriores desta trilha, o Kafka apareceu como um log distribuído e append-only: cada partição só cresce, um evento novo vira um offset novo. O Spark Structured Streaming parte dessa mesma ideia para processar esse log (ou qualquer outra fonte contínua): trata o stream inteiro como uma tabela que nunca para de crescer, e processa essa tabela em pequenos lotes automáticos, os micro-batches.\n\nA trilha de Spark já apresentou essa abstração numa introdução. Este módulo aprofunda: como ler e escrever de verdade (`readStream`/`writeStream`), os modos de saída, o checkpoint, e como as agregações com janela e watermark do módulo anterior viram código."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## A tabela ilimitada (unbounded table)\n\nUma consulta em Structured Streaming é escrita contra uma tabela de entrada que, na cabeça do Spark, é ilimitada: a cada novo dado que chega na fonte (uma mensagem nova no tópico Kafka, um arquivo novo na pasta monitorada), uma linha é acrescentada ao final dessa tabela. A consulta (`select`, `filter`, `groupBy`, `join`) é escrita uma única vez, com a mesma API de DataFrame do batch, e é aplicada de forma incremental conforme a tabela cresce.\n\nO resultado dessa consulta também é modelado como uma tabela, a tabela de resultado. É ela que, a cada micro-batch, é total ou parcialmente escrita no sink, conforme o output mode (assunto da próxima aula)."
+                    },
+                    {
+                        "type": "code",
+                        "value": "-- a tabela de entrada cresce a cada offset novo consumido do topico\n\ntempo:          t1              t2              t3\nparticao 0:  [offsets 0-40]  [offsets 41-58] [offsets 59-77]\n                   |               |               |\n                   v               v               v\ntabela de     +----------+    +----------+    +----------+\nentrada       | linhas   | -> | linhas   | -> | linhas   |   (so cresce)\n(ilimitada)   | 0..40    |    | 0..58    |    | 0..77    |\n              +----------+    +----------+    +----------+\n                   |               |               |\n                   v               v               v\n             micro-batch 1   micro-batch 2   micro-batch 3\n             (consulta roda   (consulta roda   (consulta roda\n              sobre o que      sobre o que      sobre o que\n              e novo)          e novo)          e novo)"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Micro-batch: o motor por baixo do modelo\n\nPor padrão, o Structured Streaming não processa registro a registro: ele acumula o que chegou desde o último ciclo e roda essa fatia como um job Spark comum, pelo mesmo otimizador e pelo mesmo motor de execução usados em batch. Terminado um micro-batch, o Spark registra até onde avançou na fonte (quais offsets do Kafka já foram lidos, por exemplo) e dispara o próximo ciclo.\n\nIsso significa que tudo o que a trilha de Spark ensinou sobre plano de consulta, particionamento e tarefas continua valendo: um micro-batch é, na prática, um job Spark como outro qualquer, só que disparado automaticamente e de forma repetida."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Streaming verdadeiro x micro-batch\n\nNem todo motor de streaming processa em micro-batches. Um motor de streaming verdadeiro, como o modo padrão do Apache Flink, processa evento a evento, assim que cada um chega, o que reduz a latência mas exige um modelo de execução diferente do batch. O Spark tem um modo experimental de baixíssima latência, o processamento contínuo, mas o motor padrão e mais usado em produção continua sendo o micro-batch: a latência fica na casa de segundos, não de milissegundos, em troca de reaproveitar toda a engenharia de batch já madura do Spark."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Característica\", \"Batch\", \"Structured Streaming (micro-batch)\"], [\"Quando roda\", \"Uma vez, do início ao fim, e termina\", \"Continuamente, em ciclos repetidos\"], [\"Tamanho da entrada\", \"Conhecido antes de começar\", \"Desconhecido, cresce sem parar\"], [\"API usada\", \"DataFrame (read, transformações, write)\", \"A mesma API de DataFrame (readStream, writeStream)\"], [\"Unidade de execução\", \"Um job Spark\", \"Vários jobs Spark, um por micro-batch\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "O Structured Streaming não troca a API de DataFrame por uma nova: ele reaplica a mesma consulta em fatias incrementais de uma tabela que nunca termina de crescer."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual é a abstração central que o Spark Structured Streaming usa para representar um stream de dados?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Uma tabela que nunca para de crescer, onde cada dado novo vira uma linha ao final.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Uma fila que descarta cada mensagem assim que um consumidor confirma a leitura dela.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um conjunto de RDDs isolados, um novo RDD criado a cada registro recebido da fonte.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um índice reconstruído do zero a cada novo lote de dados que chega para processar.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por padrão, como o Structured Streaming processa os dados recebidos desde o último ciclo?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Processa cada registro isoladamente, no instante exato em que ele chega à fonte.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Acumula o que chegou e roda essa fatia como um job Spark comum, em ciclos repetidos.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Espera acumular um volume fixo em disco antes de iniciar qualquer processamento.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Recalcula a consulta inteira sobre todo o histórico a cada novo dado recebido.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Depois de um micro-batch terminar, o que o Spark usa para saber até onde já avançou na leitura de um tópico Kafka?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O horário do relógio do cluster, comparado ao horário de criação de cada mensagem.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O tamanho em bytes acumulado do tópico, comparado ao tamanho no ciclo anterior.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os offsets já lidos de cada partição, que também orientam o próximo ciclo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O número de linhas do micro-batch anterior, usado como meta para o próximo ciclo.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual é a principal diferença entre um motor de streaming verdadeiro (processamento evento a evento) e o motor padrão de micro-batch do Structured Streaming?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O motor de micro-batch não consegue reaproveitar nenhum otimizador usado em batch.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O motor evento a evento não existe de fato, sendo só um nome alternativo para micro-batch.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O motor de micro-batch só funciona com fontes de arquivo, nunca com filas como o Kafka.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O motor evento a evento processa cada registro assim que chega, com latência menor.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma consulta em Structured Streaming aplica um groupBy seguido de um count, escrita com a mesma sintaxe de uma consulta batch equivalente. Por que isso é possível sem aprender uma API nova?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Porque o motor aplica a mesma API de DataFrame de forma incremental sobre a tabela ilimitada.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque o Spark converte automaticamente o groupBy num join otimizado só em streaming.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque toda consulta em streaming roda primeiro em batch antes de virar streaming de fato.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o groupBy em streaming ignora linhas antigas, considerando só o último micro-batch.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "readStream e writeStream",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# readStream e writeStream\n\nToda consulta em Structured Streaming tem duas pontas: `spark.readStream` cria a tabela ilimitada a partir de uma fonte, e `.writeStream` pega a tabela de resultado e escreve num sink, em ciclos controlados por um trigger. Fora essas duas pontas, o meio da consulta (as transformações) é DataFrame normal, exatamente como em batch."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Lendo com readStream\n\nLer de um tópico Kafka é o caso mais comum em produção. O DataFrame resultante traz colunas fixas (`key`, `value`, `topic`, `partition`, `offset`, `timestamp`), com `key` e `value` como binário, quase sempre desserializadas logo em seguida com `CAST` ou `from_json`. Ler de uma pasta monitorada (arquivos Parquet, JSON, CSV) usa o mesmo `readStream`, mas exige schema explícito: diferente do batch, o Structured Streaming não infere o schema de arquivos automaticamente."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# lendo de um topico Kafka\neventos_raw = (\n    spark.readStream\n    .format(\"kafka\")\n    .option(\"kafka.bootstrap.servers\", \"broker1:9092,broker2:9092\")\n    .option(\"subscribe\", \"cliques\")\n    .option(\"startingOffsets\", \"latest\")\n    .load()\n)\n\n# key e value chegam em binario; desserializando o value como JSON\neventos = (\n    eventos_raw\n    .selectExpr(\"CAST(value AS STRING) AS json\")\n    .select(from_json(col(\"json\"), schema_cliques).alias(\"dado\"))\n    .select(\"dado.*\")\n)\n\n# lendo de uma pasta monitorada (schema explicito e obrigatorio)\npedidos = (\n    spark.readStream\n    .schema(schema_pedidos)\n    .format(\"json\")\n    .load(\"s3://bronze/pedidos/\")\n)"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Escrevendo com writeStream\n\n`.writeStream` define o `format` do sink (`kafka`, `delta`, `parquet`, `console`, entre outros), o `outputMode` (aula seguinte) e o `checkpointLocation` (aula depois desta), e é encerrado com `.start()`, que devolve uma `StreamingQuery` rodando em segundo plano. Escrever de volta no Kafka exige pelo menos uma coluna `value` (a `key` é opcional); escrever em Delta ou Parquet grava arquivos incrementalmente, como uma série de pequenas escritas em batch."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# escrevendo de volta num topico Kafka\nconsulta = (\n    eventos.selectExpr(\"CAST(pagina_id AS STRING) AS key\", \"to_json(struct(*)) AS value\")\n    .writeStream\n    .format(\"kafka\")\n    .option(\"kafka.bootstrap.servers\", \"broker1:9092,broker2:9092\")\n    .option(\"topic\", \"cliques-validados\")\n    .option(\"checkpointLocation\", \"/chk/cliques-validados\")\n    .start()\n)\n\n# escrevendo numa tabela Delta\nconsulta_delta = (\n    eventos.writeStream\n    .format(\"delta\")\n    .option(\"checkpointLocation\", \"/chk/cliques-delta\")\n    .start(\"/lake/silver/cliques\")\n)\n\nconsulta.awaitTermination()"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O trigger: quando cada micro-batch dispara\n\nO `trigger` controla o ritmo dos micro-batches. Sem um trigger explícito, o Spark dispara o próximo micro-batch assim que o anterior termina, o mais rápido possível. `trigger(processingTime=\"1 minute\")` fixa um intervalo mínimo entre ciclos, útil para controlar custo e previsibilidade. `trigger(availableNow=True)` processa tudo o que já está disponível na fonte, em um ou mais micro-batches, e encerra a consulta sozinho, um jeito de rodar streaming como se fosse um job batch agendado."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Trigger\", \"Comportamento\"], [\"Sem trigger (padrão)\", \"Dispara o próximo micro-batch assim que o anterior termina\"], [\"processingTime=\\\"1 minute\\\"\", \"Dispara em intervalos fixos, no mínimo a cada 1 minuto\"], [\"availableNow=True\", \"Processa tudo o que já chegou e encerra a consulta sozinho\"], [\"continuous=\\\"1 second\\\"\", \"Modo experimental de baixíssima latência, sem micro-batch\"]]"
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Ao ler de um tópico Kafka com spark.readStream.format(\"kafka\"), em que formato as colunas key e value chegam no DataFrame?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Já como um struct tipado, com um campo para cada atributo do schema do tópico.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Em binário, normalmente desserializadas em seguida com CAST ou from_json.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Em texto puro, sempre no formato JSON pronto para leitura direta.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Como um array de inteiros, um valor por byte da mensagem original.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe precisa ler arquivos Parquet de uma pasta que recebe novos arquivos continuamente, usando readStream. Diferente do mesmo código em batch, o que passa a ser obrigatório?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Definir um outputMode antes mesmo de chamar o load(), algo exigido só para arquivos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Configurar um consumer group, do mesmo jeito exigido para ler um tópico Kafka qualquer.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Declarar o schema manualmente, já que streaming de arquivos não infere schema sozinho.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Converter cada arquivo Parquet para JSON antes da leitura, exigido pela API de streaming.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um job precisa rodar em streaming mas ser disparado por um agendador externo uma vez por hora, processando de uma vez tudo o que se acumulou desde a última execução e encerrando sozinho. Qual trigger atende esse cenário?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "trigger(processingTime=\"1 hour\"), que mantém a consulta rodando indefinidamente.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "trigger(continuous=\"1 hour\"), que ativa o modo de processamento contínuo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Nenhum trigger definido, deixando o Spark disparar um micro-batch por hora sozinho.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "trigger(availableNow=True), que processa o disponível e encerra a consulta.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma consulta escreve os resultados de volta em um tópico Kafka via writeStream.format(\"kafka\"). O job falha porque falta uma coluna obrigatória no DataFrame final. Qual coluna é essa?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "value, a única coluna que o sink Kafka exige em toda escrita.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "partition, exigida para o Spark decidir em qual partição gravar cada linha.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "offset, exigida porque o sink Kafka recalcula a posição de cada mensagem.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "timestamp, exigida para o broker ordenar as mensagens recebidas na escrita.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "O que o método .start() retorna ao final da definição de um writeStream?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Um número inteiro, o total de linhas processadas até aquele momento exato.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma StreamingQuery, que representa a execução em segundo plano da consulta.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Nada: start() apenas inicia a consulta e não devolve nenhum valor ao chamador.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um DataFrame estático, com o resultado do primeiro micro-batch já calculado.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Output modes: append, update, complete",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Output modes: append, update, complete\n\nO `outputMode` decide o que exatamente é escrito no sink a cada micro-batch: só as linhas novas, só as linhas que mudaram, ou a tabela de resultado inteira. Escolher o modo errado para o tipo de consulta é um dos erros mais comuns de quem começa em Structured Streaming, e o Spark recusa algumas combinações de propósito."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## append: só o que é novo\n\n`append` é o modo padrão. A cada micro-batch, só as linhas adicionadas à tabela de resultado desde o último ciclo são escritas, e uma linha escrita nunca é reescrita depois. Funciona bem para consultas sem agregação (filtros, transformações linha a linha, junções simples), onde cada linha de entrada gera uma linha de saída definitiva. Para consultas com agregação, `append` só é aceito se houver um watermark definido: sem ele, o Spark não tem como garantir que uma linha já escrita não vá mudar de valor depois."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## update: só o que mudou\n\n`update` escreve, a cada micro-batch, apenas as linhas do resultado que mudaram de valor desde o último ciclo. É o modo natural para agregações que evoluem com o tempo, como uma contagem corrente por chave: a cada novo dado, só as chaves afetadas saem no micro-batch, em vez da tabela inteira. Sem watermark, o estado de todas as chaves fica guardado indefinidamente; com watermark, o Spark descarta o estado de janelas antigas, mas o modo de escrita continua sendo só o que mudou."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## complete: a tabela inteira, sempre\n\n`complete` reescreve a tabela de resultado inteira a cada micro-batch, mesmo as linhas que não mudaram. Só faz sentido quando essa tabela é pequena, tipicamente uma agregação com poucas chaves de saída (um total geral, uma contagem por poucas categorias); usar `complete` numa consulta sem agregação não é suportado, porque reescrever toda a entrada bruta a cada ciclo não escala."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# mesma agregacao, output modes diferentes\ncontagem = eventos.groupBy(\"categoria\").count()\n\n# complete: reescreve a tabela inteira (todas as categorias) a cada micro-batch\nconsulta_completa = (\n    contagem.writeStream\n    .outputMode(\"complete\")\n    .format(\"console\")\n    .option(\"checkpointLocation\", \"/chk/contagem-complete\")\n    .start()\n)\n\n# update: escreve so as categorias cujo count mudou neste micro-batch\nconsulta_update = (\n    contagem.writeStream\n    .outputMode(\"update\")\n    .format(\"console\")\n    .option(\"checkpointLocation\", \"/chk/contagem-update\")\n    .start()\n)\n\n# append numa agregacao exige watermark (a proxima aula cobre o motivo);\n# sem watermark, este start() falha com AnalysisException\nconsulta_append = (\n    contagem.writeStream\n    .outputMode(\"append\")\n    .format(\"console\")\n    .option(\"checkpointLocation\", \"/chk/contagem-append\")\n    .start()\n)"
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Output mode\", \"O que escreve a cada micro-batch\", \"Uso típico\"], [\"append\", \"Só as linhas novas, nunca reescritas depois\", \"Transformações sem agregação (filtro, join simples)\"], [\"update\", \"Só as linhas do resultado que mudaram\", \"Agregações que evoluem por chave ao longo do tempo\"], [\"complete\", \"A tabela de resultado inteira, do zero\", \"Agregações pequenas (poucas chaves de saída)\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Sem agregação, append é a escolha natural. Com agregação, a pergunta é se o sink aguenta a tabela inteira a cada ciclo (complete) ou só o que mudou já basta (update)."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual output mode é o padrão do Structured Streaming quando nenhum é especificado explicitamente?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "complete, que reescreve a tabela de resultado inteira a cada ciclo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "update, que escreve apenas as linhas que mudaram desde o ciclo anterior.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "append, que escreve apenas as linhas novas da tabela de resultado.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Nenhum: toda consulta em streaming exige um outputMode definido manualmente.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma consulta faz um groupBy por categoria seguido de count, sem nenhum watermark definido, e tenta rodar com outputMode(\"append\"). O que acontece?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "A consulta roda, mas ignora silenciosamente todo micro-batch depois do primeiro.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A consulta roda normalmente, escrevendo cada categoria assim que aparece pela primeira vez.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Spark troca automaticamente o modo para complete, sem avisar quem escreveu a consulta.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Spark recusa a consulta, porque append em agregação exige um watermark.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um relatório precisa mostrar sempre a lista completa de todas as lojas com seus totais, inclusive lojas sem nenhum pedido novo no ciclo, sobrescrevendo o mesmo arquivo de saída a cada execução. Qual output mode atende esse requisito?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "complete, que reescreve a tabela de resultado inteira a cada micro-batch.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um trigger específico, já que output mode não influencia esse comportamento.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "append, que nunca reescreve uma linha já emitida em ciclos anteriores.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "update, que emite só as lojas cujo total mudou desde o último ciclo.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma agregação por janela de tempo usa withWatermark e outputMode(\"append\"). Quando uma linha de resultado (uma janela fechada) é efetivamente escrita no sink?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Assim que a primeira mensagem daquela janela chega, antes de qualquer atualização.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Só depois que o watermark ultrapassa o fim da janela, quando ela é considerada final.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A cada micro-batch, reescrevendo o valor mais recente daquela janela até o fim.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Nunca: append não é compatível com agregações por janela, mesmo com watermark.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Por que o Structured Streaming não aceita outputMode(\"complete\") numa consulta sem nenhuma agregação?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Porque o modo complete é exclusivo de sinks Kafka, incompatível com outras fontes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque o modo complete exige um watermark configurado, mesmo sem nenhuma janela.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque reescrever toda a entrada bruta a cada micro-batch não escalaria.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque toda consulta sem agregação já usa complete por padrão, tornando-o redundante.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Checkpoint e tolerância a falha",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Checkpoint e tolerância a falha\n\nUma consulta em streaming roda por dias, semanas, às vezes indefinidamente. Em algum momento o processo cai: um executor falha, o cluster reinicia, alguém faz o deploy de uma nova versão do job. O checkpoint é o que permite a consulta retomar exatamente de onde parou, sem reprocessar tudo desde o início nem perder o que já estava em andamento."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O que o checkpoint guarda\n\nUm `checkpointLocation` guarda três coisas: os offsets já processados de cada fonte (em que ponto do tópico Kafka, ou quais arquivos, a consulta já leu), o estado de operações com estado (o valor acumulado de cada chave numa agregação, por exemplo) e metadados da própria consulta (o plano da consulta, o schema). Ao reiniciar, o Spark lê esse diretório antes de tocar na fonte de novo, e retoma dali."
+                    },
+                    {
+                        "type": "code",
+                        "value": "consulta = (\n    contagem.writeStream\n    .outputMode(\"update\")\n    .format(\"delta\")\n    .option(\"checkpointLocation\", \"/chk/contagem-por-pagina\")\n    .start(\"/lake/gold/contagem_por_pagina\")\n)\n\n# se o processo cair e for reiniciado com o MESMO checkpointLocation:\n# - os offsets ja lidos do Kafka nao sao relidos\n# - o estado acumulado de cada chave (contagem corrente) e recuperado\n# - a consulta continua dali, sem reprocessar nem pular dados"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Por que o checkpoint é praticamente obrigatório\n\nToda consulta pensada para durar em produção declara um `checkpointLocation` próprio: é esse caminho persistente que sustenta a garantia de retomada. Sem ele, reiniciar a consulta depois de uma queda é começar sem nenhuma memória do que já foi processado: dependendo da opção de offset inicial, isso pode significar reprocessar tudo (duplicando o que já tinha sido escrito no sink) ou pular direto para o que há de mais novo (perdendo o que ficou no meio)."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Um checkpoint por consulta, e cuidado ao trocar o código\n\nCada consulta em streaming precisa do seu próprio diretório de checkpoint: duas consultas nunca podem compartilhar o mesmo caminho. E o checkpoint não é compatível com qualquer mudança no código: alterar as colunas de uma agregação existente, por exemplo, pode fazer o Spark recusar retomar a partir de um checkpoint antigo, porque o estado guardado não corresponde mais ao novo plano de execução. Nesses casos, a saída costuma ser um checkpoint novo, o que custa o histórico de progresso."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Situação\", \"O checkpoint resolve sozinho?\"], [\"Processo caiu e foi reiniciado com o mesmo checkpoint e o mesmo código\", \"Sim, retoma de onde parou\"], [\"Checkpoint apagado manualmente antes do reinício\", \"Não, a consulta perde toda a memória de progresso\"], [\"Lógica da agregação mudou de forma incompatível com o estado salvo\", \"Não necessariamente, o Spark pode recusar retomar\"], [\"Duas consultas diferentes apontando para o mesmo checkpoint\", \"Não, é uma configuração inválida a evitar\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "O checkpoint não é um detalhe operacional opcional: é o que transforma uma consulta que reinicia do zero numa consulta que retoma de onde parou."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que o checkpointLocation de uma consulta em Structured Streaming guarda?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Uma cópia completa de todos os dados já lidos da fonte, para fins de auditoria.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Somente os logs de erro gerados durante a execução da consulta em produção.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Apenas o código-fonte da consulta, para permitir reiniciar com outra versão.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os offsets já processados, o estado da consulta e metadados dela.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma consulta cai depois de processar metade dos dados de um micro-batch. Ela é reiniciada com o mesmo checkpointLocation de antes. O que acontece com esses dados?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "A consulta retoma a partir do último progresso salvo, sem pular nem duplicar dados.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Todo o histórico da fonte é reprocessado do zero, para garantir que nada falte.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O micro-batch inteiro é pulado, e a consulta retoma só a partir do próximo ciclo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Apenas os dados chegados depois do reinício são considerados, o resto é perdido.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Duas consultas de streaming diferentes, escrevendo em sinks distintos, são configuradas por engano com o mesmo checkpointLocation. Qual é o problema dessa configuração?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Nenhum: o checkpoint identifica a consulta pelo nome do sink, não pelo caminho.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "É inválida: cada consulta precisa do próprio diretório de checkpoint, exclusivo.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "É válida, mas a segunda consulta reescreve o checkpoint da primeira a cada ciclo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Só afeta a consulta que iniciar primeiro; a segunda ignora o checkpoint existente.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe altera a lógica de uma agregação em produção (muda as colunas do groupBy) e reinicia a consulta apontando para o mesmo checkpointLocation de antes da mudança. Qual é o risco mais direto dessa operação?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "A consulta ignora o checkpoint automaticamente e recomeça sozinha do zero.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Spark aplica a lógica nova só aos dados futuros, mantendo o estado antigo intacto.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Spark pode recusar retomar, porque o estado salvo não bate com o novo plano.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O checkpoint é migrado automaticamente para o formato exigido pela lógica nova.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Qual é a consequência prática de rodar uma consulta de streaming em produção sem definir um checkpointLocation próprio e estável?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O outputMode passa a ser ignorado, e a consulta sempre se comporta como complete.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A consulta roda mais rápido, já que não precisa gravar progresso em disco a cada ciclo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Spark bloqueia por completo a escrita no sink, mesmo em modo append simples.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A consulta perde a garantia de retomar de onde parou após uma falha real.",
+                                "isCorrect": true
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Agregações com janela e watermark na prática",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Agregações com janela e watermark na prática\n\nO módulo anterior desta trilha cobriu event time, dados atrasados e watermark em conceito. Esta aula fecha o módulo mostrando como esses conceitos viram código: `window()` dentro de um `groupBy`, combinado com `withWatermark`, numa consulta de Structured Streaming completa, do `readStream` no Kafka até o `writeStream` no sink."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## window() dentro do groupBy\n\nA função `window()` transforma uma coluna de tempo numa coluna de intervalos (a janela tumbling ou sliding vista no módulo anterior), e essa coluna entra no `groupBy` como mais uma chave de agrupamento. Agrupar por `window(coluna_tempo, \"5 minutes\")` produz uma linha de resultado por janela de 5 minutos; agrupar por `window(coluna_tempo, \"5 minutes\"), coluna_chave` produz uma linha por combinação de janela e chave, como página e intervalo de tempo."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## withWatermark: dizendo ao Spark até quando esperar\n\n`withWatermark(\"coluna_tempo\", \"10 minutes\")` declara o quanto de atraso a consulta tolera: dados com event time mais de 10 minutos atrás do event time máximo já visto passam a ser considerados tarde demais. É o watermark que permite ao Spark descartar o estado de janelas antigas (sem ele, o estado de toda janela desde o início da consulta ficaria acumulado indefinidamente) e, em append, decidir quando uma janela está finalmente pronta para ser escrita."
+                    },
+                    {
+                        "type": "code",
+                        "value": "from pyspark.sql.functions import from_json, col, window\n\nschema_cliques = \"pagina_id STRING, horario_evento TIMESTAMP\"\n\ncliques = (\n    spark.readStream\n    .format(\"kafka\")\n    .option(\"kafka.bootstrap.servers\", \"broker1:9092,broker2:9092\")\n    .option(\"subscribe\", \"cliques\")\n    .load()\n    .selectExpr(\"CAST(value AS STRING) AS json\")\n    .select(from_json(col(\"json\"), schema_cliques).alias(\"dado\"))\n    .select(\"dado.*\")\n)\n\ncontagem_por_janela = (\n    cliques\n    .withWatermark(\"horario_evento\", \"10 minutes\")\n    .groupBy(\n        window(col(\"horario_evento\"), \"5 minutes\"),\n        col(\"pagina_id\")\n    )\n    .count()\n)\n\nconsulta = (\n    contagem_por_janela.writeStream\n    .outputMode(\"update\")\n    .format(\"console\")\n    .option(\"checkpointLocation\", \"/chk/contagem-por-janela\")\n    .trigger(processingTime=\"1 minute\")\n    .start()\n)\n\nconsulta.awaitTermination()"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## A ordem importa: watermark antes do groupBy\n\n`withWatermark` precisa vir antes do `groupBy` que usa a mesma coluna de tempo, na mesma cadeia de transformações. Essa ordem não é estilo: é o que permite ao Spark associar o limite de atraso à agregação que vem depois, e sem essa associação o `outputMode(\"append\")` numa agregação por janela nem se comporta como esperado, pela mesma regra vista na aula sobre output modes."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Peça\", \"Papel na consulta\"], [\"window(coluna_tempo, \\\"5 minutes\\\")\", \"Transforma o tempo do evento numa coluna de janelas, usada no groupBy\"], [\"withWatermark(coluna_tempo, \\\"10 minutes\\\")\", \"Define até quando um evento atrasado ainda é aceito\"], [\"groupBy(window(...), chave)\", \"Agrega por janela e, opcionalmente, por uma chave adicional\"], [\"outputMode(\\\"update\\\")\", \"Emite só as janelas cujo valor mudou neste micro-batch\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "window() diz por qual intervalo agrupar; withWatermark diz até quando vale a pena esperar um atrasado antes de considerar aquele intervalo fechado."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Dentro de uma consulta de Structured Streaming, o que a função window() faz quando usada dentro de um groupBy?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Transforma uma coluna de tempo em intervalos, usados como chave de agrupamento.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Define quantos executores o Spark aloca para processar cada micro-batch da consulta.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Filtra do stream qualquer evento que chegue fora da ordem cronológica esperada.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Converte a agregação inteira para rodar em modo complete, ignorando outros modos.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Numa consulta com withWatermark(\"horario_evento\", \"10 minutes\") seguida de groupBy(window(\"horario_evento\", \"5 minutes\")), o que o watermark de 10 minutos permite ao Spark fazer?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Eliminar a necessidade de configurar um checkpointLocation para essa consulta.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Descartar o estado de janelas antigas, em vez de acumulá-lo para sempre.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Ignorar por completo qualquer evento que chegue fora de ordem, mesmo a tempo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Reduzir o tamanho da janela de agregação automaticamente, de 5 para 10 minutos.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Numa consulta de streaming, o withWatermark é escrito depois do groupBy que agrega pela mesma coluna de tempo, numa ordem diferente da usual. Qual é a consequência mais provável?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Nenhuma: a ordem entre withWatermark e groupBy não influencia o resultado final.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O watermark passa a valer para todas as colunas de tempo do DataFrame, não só uma.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Spark não associa o limite de atraso à agregação, e o comportamento esperado falha.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A consulta roda normalmente, só que com o dobro do atraso tolerado configurado.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma consulta agrupa por window(col(\"horario_evento\"), \"5 minutes\"), col(\"pagina_id\") e aplica count(). O que representa cada linha da tabela de resultado?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "A contagem total de eventos de todas as páginas somadas em cada janela de 5 minutos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A contagem de janelas de 5 minutos que tiveram ao menos um evento daquela página.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A contagem de eventos de uma página em todas as janelas desde o início da consulta.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A contagem de eventos de uma página específica dentro de uma janela de 5 minutos.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Com withWatermark(\"horario_evento\", \"10 minutes\"), um evento chega com event time 15 minutos mais antigo que o event time máximo já visto pela consulta. O que acontece com esse evento?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Ele é tratado como tarde demais e descartado da agregação daquela janela.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Ele gera um erro que interrompe a consulta até alguém tratar o caso manualmente.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ele é somado à janela seguinte, ainda em aberto, no lugar da janela original.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ele é reprocessado no próximo micro-batch, junto dos dados mais recentes recebidos.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "titulo": "Módulo 7 - Streaming na prática de engenharia de dados",
+        "aulas": [
+            {
+                "titulo": "Kafka como espinha dorsal e o streaming para o lakehouse",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Kafka como espinha dorsal e o streaming para o lakehouse\n\nOs módulos anteriores desta trilha cobriram o Kafka por dentro: tópicos, partições, offsets, garantias de entrega, tempo de evento e o processamento com Spark Structured Streaming. Este último módulo muda de ângulo: como esse conhecimento aparece no dia a dia de uma plataforma de dados real, quando o Kafka deixa de ser um tópico isolado de estudo e passa a ser a peça que conecta sistemas operacionais à camada analítica.\n\n## Kafka como espinha dorsal\n\nNuma plataforma de dados madura, dezenas de sistemas produzem eventos o tempo todo: o serviço de pedidos, o de pagamentos, o de catálogo, cada aplicação publicando o que acontece assim que acontece. Em vez de cada consumidor se conectar diretamente a cada produtor, uma malha de integrações ponto a ponto cara de manter, todos publicam no Kafka e todos os interessados assinam de lá. O Kafka funciona como o sistema nervoso central da plataforma: quem produz um evento não precisa saber quem vai consumi-lo, e quantos consumidores diferentes lerem o mesmo tópico, o produtor nem percebe."
+                    },
+                    {
+                        "type": "code",
+                        "value": "  [app pedidos]      [app pagamentos]      [app catalogo]\n         |                   |                    |\n         +-------------------+--------------------+\n                             |\n                             v\n                 topico: eventos.pedidos\n             (particoes 0, 1, 2, 3, ..., N)\n                             |\n              ---------------------------------\n              |                               |\n              v                               v\n   job Structured Streaming            consumidor de alertas\n   (grava a camada bronze)              (regras quase em tempo real)\n              |\n              v\n   lakehouse: bronze/eventos_pedidos/\n   (append-only, particionado por data de ingestao)"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O padrão streaming-para-o-lakehouse\n\nO padrão mais comum de usar o Kafka numa plataforma de engenharia de dados é como porta de entrada da camada bronze do lakehouse (a trilha de Data Lake já cobriu o papel de cada camada: bronze crua, silver limpa, gold agregada). Um job de Structured Streaming lê continuamente um ou mais tópicos e grava na bronze fazendo o mínimo de transformação possível: decodifica o payload, talvez adicione metadados de ingestão, mas deixa a limpeza e as regras de negócio para as camadas seguintes.\n\nManter a bronze próxima do formato original do evento tem um motivo prático: se uma regra de transformação mudar ou tiver um bug, a silver pode ser reconstruída reprocessando a bronze, sem depender de o Kafka ainda ter aquele evento disponível. Isso importa porque o Kafka não guarda dado para sempre."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# le o topico Kafka de eventos de pedidos em streaming\neventos = (\n    spark.readStream\n    .format('kafka')\n    .option('kafka.bootstrap.servers', 'broker1:9092,broker2:9092')\n    .option('subscribe', 'eventos.pedidos')\n    .option('startingOffsets', 'latest')\n    .load()\n)\n\n# bronze: decodifica o value e adiciona metadados de ingestao, sem regra de negocio\nbronze = (\n    eventos\n    .selectExpr('CAST(value AS STRING) AS payload', 'timestamp AS kafka_timestamp')\n    .withColumn('data_ingestao', F.current_timestamp())\n)\n\n(\n    bronze.writeStream\n    .format('delta')\n    .option('checkpointLocation', 's3://checkpoints/bronze_pedidos/')\n    .outputMode('append')\n    .trigger(processingTime='30 seconds')\n    .start('s3://bronze/eventos_pedidos/')\n)"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Retenção do Kafka x retenção do lakehouse\n\nO Kafka e o lakehouse guardam o mesmo dado por motivos diferentes. O tópico existe para transportar o evento entre quem produz e quem consome, e sua retenção costuma ser curta (horas a poucos dias), configurada para o tópico não crescer indefinidamente. A bronze existe para guardar o histórico: uma vez materializada, ela conserva o evento por meses ou anos, pelo custo baixo do object storage.\n\nEssa diferença é o motivo pelo qual o job de ingestão para a bronze deve rodar continuamente e sem grandes intervalos de inatividade: um consumidor que fica muito tempo parado corre o risco de o Kafka já ter descartado, pela retenção, eventos que ele ainda não processou."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Aspecto\",\"Kafka\",\"Camada bronze do lakehouse\"],[\"Retenção típica\",\"Horas a poucos dias, definida por tópico\",\"Meses a anos, limitada pelo custo de storage\"],[\"Papel principal\",\"Transporte entre produtores e consumidores\",\"Cópia durável e consultável do evento\"],[\"Reprocessamento histórico\",\"Só dentro da janela de retenção configurada\",\"Qualquer período já materializado na bronze\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "O Kafka carrega o evento enquanto ele está em trânsito; o lakehouse guarda o evento depois que ele já aconteceu."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Por que o Kafka costuma ser descrito como a espinha dorsal de uma plataforma de dados moderna?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Porque desacopla produtores de consumidores: quem publica não sabe quem vai ler.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Porque substitui a necessidade de qualquer camada de armazenamento no lakehouse.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque aplica sozinho as regras de negócio antes de o dado chegar à camada bronze.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Porque garante, por padrão, que nenhum tópico jamais perca uma mensagem publicada.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um job de Structured Streaming consome um tópico Kafka e grava a camada bronze de um lakehouse. Seguindo o padrão de ingestão em streaming, o que essa etapa deve priorizar?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Aplicar todas as regras de negócio já na bronze, deixando a silver praticamente pronta.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Decodificar o payload e gravar próximo do formato original, deixando a limpeza para depois.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Pular a bronze e gravar direto na gold, já agregado por dia e por loja.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Descartar os metadados de offset do Kafka assim que a mensagem é gravada em disco.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um tópico Kafka está configurado com retenção de 3 dias, e a equipe assume que não precisa materializar o dado em lugar nenhum, já que ele fica salvo no Kafka. Qual é o risco dessa decisão?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O Kafka passa a rejeitar novas mensagens no tópico assim que a retenção é atingida.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os consumidores existentes perdem automaticamente o offset commitado após 3 dias.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "As mensagens mais antigas que a retenção são descartadas, perdendo o reprocessamento.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O tópico troca sozinho o número de partições configurado após o prazo de retenção.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um job de ingestão para a bronze fica parado por 2 dias por uma falha de infraestrutura, e o tópico de origem está configurado com retenção de 24 horas. Ao voltar, o job não consegue recuperar os eventos do primeiro dia da parada. O que essa situação evidencia sobre o padrão streaming-para-o-lakehouse?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Que a bronze deveria ter sido descartada em favor de consultar o Kafka a cada relatório.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que o Kafka deveria substituir a bronze por completo, eliminando a necessidade do lakehouse.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que a retenção do tópico deveria ser reduzida ainda mais, forçando reprocessamentos frequentes.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Que o job de ingestão precisa rodar de forma contínua, perto da janela de retenção do tópico.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um mesmo tópico eventos.pedidos alimenta, ao mesmo tempo, o job que grava a bronze e um consumidor separado que dispara alertas quase em tempo real. O que permite que os dois leiam o mesmo tópico de forma independente, sem que um afete o outro?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Cada um pertence a um consumer group diferente, com seu próprio controle de offset.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O tópico duplica fisicamente as mensagens, uma cópia para cada consumidor inscrito.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O producer envia a mensagem duas vezes, uma para cada consumidor configurado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Kafka prioriza automaticamente o consumidor mais rápido, atrasando o mais lento.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Kafka Connect e a integração",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Kafka Connect e a integração\n\nA aula anterior mostrou o Kafka no centro da plataforma, recebendo eventos de aplicações e alimentando a camada bronze do lakehouse. Uma pergunta prática fica em aberto: como os dados de um banco relacional ou de um sistema legado chegam até um tópico, e como o conteúdo de um tópico chega até um data warehouse, sem que alguém escreva um producer ou um consumer customizado para cada integração?\n\n## O que é o Kafka Connect\n\nKafka Connect é o componente do ecossistema Kafka dedicado a integração: um framework que roda como seu próprio cluster de workers e distribui o trabalho de mover dados entre o Kafka e sistemas externos por meio de connectors configurados, não de código escrito à mão. Cada connector se divide internamente em tasks, unidades de trabalho que os workers distribuem entre si para paralelizar a carga, da mesma forma que partições paralelizam o trabalho de um consumer group."
+                    },
+                    {
+                        "type": "code",
+                        "value": "   [banco de dados transacional]\n               |\n               v   (write-ahead log / binlog)\n   source connector (ex.: Debezium)\n               |\n               v\n   topicos Kafka (um por tabela, ex.: db.public.pedidos)\n               |\n               v\n   sink connector (ex.: S3 Sink Connector)\n               |\n               v\n   [data lake / data warehouse]"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Source connectors: trazer dados para dentro do Kafka\n\nUm source connector lê de um sistema externo e publica em um tópico. O caso mais comum em engenharia de dados é o CDC (change data capture, já visto na trilha de ETL): um connector como o Debezium lê o log de transações do banco (o write-ahead log no Postgres, o binlog no MySQL) e publica um evento para cada INSERT, UPDATE ou DELETE, normalmente um tópico por tabela. A vantagem sobre consultar a tabela periodicamente é não gerar carga extra de leitura no banco de produção e não perder nenhuma mudança entre uma consulta e outra."
+                    },
+                    {
+                        "type": "code",
+                        "value": "// connector fonte (source): captura mudancas da tabela pedidos via CDC\n{\n  \"name\": \"source-pedidos\",\n  \"connector.class\": \"io.debezium.connector.postgresql.PostgresConnector\",\n  \"database.hostname\": \"db-pedidos.interno\",\n  \"database.dbname\": \"loja\",\n  \"table.include.list\": \"public.pedidos\",\n  \"topic.prefix\": \"db\"\n}\n\n// connector destino (sink): leva o topico para o data lake em S3\n{\n  \"name\": \"sink-pedidos-s3\",\n  \"connector.class\": \"io.confluent.connect.s3.S3SinkConnector\",\n  \"topics\": \"db.public.pedidos\",\n  \"s3.bucket.name\": \"bronze-datalake\",\n  \"tasks.max\": \"4\"\n}"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Sink connectors: levar dados do Kafka para fora\n\nUm sink connector faz o caminho inverso: lê de um ou mais tópicos e escreve num sistema externo, como um bucket S3, um data warehouse via JDBC ou um índice de busca. É a alternativa configurada a escrever um consumer customizado só para copiar dados de um tópico para outro lugar sem transformação nenhuma.\n\nNem toda garantia de entrega é igual entre connectors: a maioria opera com at-least-once por padrão, então o destino pode receber a mesma mensagem mais de uma vez após um restart de task, e cabe a quem configura o sink garantir que a escrita do outro lado seja idempotente, como um upsert por chave, quando isso importa."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Tipo\",\"Direção\",\"Exemplos\"],[\"Source connector\",\"De um sistema externo para dentro do Kafka\",\"Debezium (CDC), JDBC Source, FileStream Source\"],[\"Sink connector\",\"De dentro do Kafka para um sistema externo\",\"S3 Sink, JDBC Sink, Elasticsearch Sink\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Kafka Connect transforma integração em configuração: o código de mover dado já existe pronto, resta descrever de onde e para onde."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual é o principal papel do Kafka Connect dentro do ecossistema Kafka?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Substituir os brokers do Kafka pelo armazenamento direto das mensagens em disco.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Integrar sistemas externos ao Kafka usando connectors configurados, sem código customizado.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Executar joins SQL entre tópicos diferentes antes de qualquer consumidor ler os dados.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Gerenciar sozinho as transações do producer idempotente em todos os tópicos.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe precisa replicar continuamente cada INSERT, UPDATE e DELETE de uma tabela de um banco relacional para um tópico Kafka, sem sobrecarregar o banco com consultas repetidas. Qual abordagem resolve isso sem escrever um producer customizado?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Um sink connector apontado para o banco, configurado para ler a cada poucos segundos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um producer customizado consultando a tabela inteira a cada minuto via SELECT.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um source connector de CDC, como o Debezium, lendo o log de transações do banco.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Um job de batch no Spark, agendado de hora em hora para copiar a tabela inteira.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe quer enviar automaticamente o conteúdo de um tópico Kafka para um índice do Elasticsearch, usado por um sistema de busca. Sem escrever um consumer customizado, qual tipo de connector atende essa necessidade?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Um source connector, configurado para ler o índice do Elasticsearch periodicamente.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um connector de replicação entre clusters, apontado para o Elasticsearch como broker.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um schema registry conectado ao tópico, exportando os dados automaticamente.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Um sink connector, configurado para escrever no índice a partir do tópico.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um source connector de CDC configurado para uma tabela de altíssimo volume está com tasks.max definido como 4 num cluster de Kafka Connect com workers disponíveis. Qual é o efeito esperado dessa configuração?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O trabalho do connector é dividido em até 4 tasks, paralelizadas entre os workers.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O connector cria 4 tópicos separados, um para cada task, sem intervenção manual.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O connector passa a garantir exactly-once automaticamente a partir de 4 tasks.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O número de partições do tópico de destino é ajustado para 4 automaticamente.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma task de um sink connector cai e é reiniciada automaticamente pelo Kafka Connect. Depois do restart, o time percebe registros repetidos no destino. O que explica esse comportamento, considerando o padrão de entrega da maioria dos connectors?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O Kafka Connect descarta mensagens antigas sempre que uma task reinicia sem checkpoint.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A maioria dos connectors opera com at-least-once por padrão, reprocessando após uma falha.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O connector trocou sozinho de sink connector para source connector após a falha.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O tópico de origem perdeu partições durante o restart, duplicando os offsets restantes.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Stream x tabela e a dualidade",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Stream x tabela e a dualidade\n\nAté aqui, a trilha tratou stream e tabela como dois mundos separados: o stream é o que o Kafka transporta, a tabela é o que um banco ou o lakehouse guarda. Na prática, essa separação é só de perspectiva. Um stream e uma tabela são duas formas de olhar para o mesmo dado, e é possível transformar um no outro nas duas direções.\n\n## A dualidade stream-tabela\n\nUma tabela é um retrato do estado acumulado num instante: o saldo atual de uma conta, o status atual de um pedido. Um stream é a sequência de eventos que, aplicados em ordem, produz esse estado: cada depósito e saque que levou ao saldo, cada mudança de status que levou ao estado atual do pedido. Dessa relação nascem as duas conversões da dualidade: fazer o replay do stream inteiro, aplicando cada evento em ordem, chega à tabela; capturar cada mudança feita numa tabela como um evento chega a um stream."
+                    },
+                    {
+                        "type": "code",
+                        "value": "sentido stream -> tabela (agregar por chave, mantendo so o ultimo estado)\n\n  pedido_criado(id=1)\n  pedido_pago(id=1)\n  pedido_criado(id=2)\n  pedido_cancelado(id=2)\n        |\n        v   agrega por pedido_id, mantem o ultimo evento\n  tabela:  id=1 -> status=pago\n           id=2 -> status=cancelado\n\nsentido tabela -> stream (capturar cada mudanca, CDC)\n\n  tabela pedidos\n        |\n        v   cada INSERT/UPDATE/DELETE vira um evento\n  stream:  pedido_atualizado(id=1, status=pago), pedido_atualizado(id=2, status=cancelado), ..."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Materializar uma tabela a partir do stream\n\nMaterializar significa manter, de forma contínua e persistida, o resultado dessa agregação: não é uma consulta feita uma vez, é uma tabela que se atualiza sozinha a cada novo evento que chega no stream. O Structured Streaming faz exatamente isso quando uma agregação com estado, como as agregações por chave e janela já vistas nos módulos anteriores, roda em modo update: cada micro-batch atualiza só as linhas cuja chave recebeu um evento novo, e o restante da tabela permanece como estava."
+                    },
+                    {
+                        "type": "code",
+                        "value": "# stream de eventos de pedido, materializando o status atual por pedido\neventos = (\n    spark.readStream\n    .format('kafka')\n    .option('kafka.bootstrap.servers', 'broker1:9092')\n    .option('subscribe', 'eventos.pedidos')\n    .load()\n)\n\nstatus_atual = (\n    eventos\n    .selectExpr('CAST(key AS STRING) AS pedido_id', 'CAST(value AS STRING) AS evento')\n    .groupBy('pedido_id')\n    # mantem so o ultimo evento de cada pedido: a tabela e o resultado sempre atualizado\n    .agg(F.last('evento').alias('status'))\n)\n\n(\n    status_atual.writeStream\n    .format('delta')\n    .option('checkpointLocation', 's3://checkpoints/status_pedidos/')\n    .outputMode('update')\n    .start('s3://silver/status_pedidos/')\n)"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O changelog e a log compaction\n\nO módulo de fundamentos do Kafka já cobriu a log compaction: uma política de retenção que mantém só a mensagem mais recente de cada chave, descartando as versões antigas. Um tópico compactado é, na prática, a dualidade stream-tabela materializada dentro do próprio Kafka: ler o tópico do início ao fim entrega o estado atual de cada chave, como uma tabela, mesmo o dado tendo sido escrito como uma sequência de eventos ao longo do tempo. É esse mecanismo de changelog que sistemas de processamento de stream usam por baixo para tornar uma tabela de estado tolerante a falha, sem depender só da memória do processo."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Aspecto\",\"Stream\",\"Tabela\"],[\"O que representa\",\"Uma sequência de eventos ao longo do tempo\",\"O estado acumulado num instante\"],[\"Pergunta que responde\",\"O que aconteceu, e em que ordem\",\"O que é verdade agora\"],[\"Exemplo\",\"pedido_criado, pedido_pago, pedido_cancelado\",\"status atual de cada pedido\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Uma tabela é um retrato de um stream num instante; um stream é a tabela contada evento a evento."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Como a dualidade stream-tabela descreve a relação entre os dois conceitos?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "Stream e tabela são formatos de armazenamento incompatíveis, sem conversão possível entre eles.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Toda tabela precisa ser exportada por completo, todo dia, para alimentar um stream de eventos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Uma tabela nasce do replay do stream; um stream nasce ao capturar as mudanças da tabela.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A dualidade só existe dentro do Structured Streaming, sem relação com o funcionamento do Kafka.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um sistema de e-commerce publica eventos pedido_criado, pedido_pago e pedido_cancelado num tópico. O time quer uma tabela que mostre sempre o status mais recente de cada pedido, não o histórico completo de eventos. Qual abordagem atende essa necessidade?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Gravar cada evento como uma nova linha na tabela, sem nenhuma agregação por chave.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Aumentar a retenção do tópico para garantir que nenhum evento antigo seja descartado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Configurar o producer para reenviar o último evento de cada pedido a cada hora.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Agregar o stream por pedido_id, mantendo apenas o último evento recebido de cada chave.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um sistema legado guarda o cadastro de clientes numa tabela relacional, e outra equipe precisa receber um stream com cada mudança feita nesse cadastro assim que ela acontece. Qual caminho transforma essa tabela num stream de forma confiável?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Capturar cada INSERT, UPDATE e DELETE da tabela como evento, via CDC.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Consultar a tabela inteira a cada poucos segundos, reemitindo todas as linhas mesmo sem mudança.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Configurar um sink connector apontado para a tabela, publicando o resultado num tópico.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Exportar um snapshot completo da tabela uma vez por dia, num arquivo compactado.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um tópico Kafka está configurado com log compaction, mantendo só a última mensagem de cada chave. O que uma leitura desse tópico do início ao fim efetivamente reconstrói?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "O volume total de mensagens já publicadas, incluindo cada versão antiga de cada chave.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O estado atual de cada chave, funcionando como uma tabela codificada dentro do tópico.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Uma cópia idêntica de um tópico configurado com retenção por tempo, sem diferença prática.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Apenas as chaves que nunca mais receberam uma nova mensagem depois da primeira.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um job de Structured Streaming mantém o saldo atual por conta a partir de um stream de transações, com checkpoint configurado. Depois de uma queda e um restart, os saldos continuam corretos sem reprocessar todas as transações desde o início. O que explica isso?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "O tópico de transações foi configurado com retenção infinita, guardando tudo para sempre.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Kafka recalcula o saldo de cada conta sozinho, antes mesmo de o consumidor reiniciar.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O estado da agregação é persistido junto ao checkpoint, permitindo retomar de onde parou.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "A log compaction do tópico de origem soma automaticamente os valores de cada chave.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "O ecossistema: Flink, Kinesis, Pulsar",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# O ecossistema: Flink, Kinesis, Pulsar\n\nA trilha inteira usou Kafka como transporte e Spark Structured Streaming como motor de processamento, a combinação mais comum em engenharia de dados e uma base sólida para entender streaming em qualquer stack. Não é, porém, a única combinação que existe no mercado. Esta aula apresenta em conceito as alternativas mais relevantes, e quando cada uma tende a fazer mais sentido que a dupla Kafka e Spark.\n\n## Apache Flink: streaming nativo\n\nA diferença mais importante entre Flink e Spark está no modelo de execução. O Spark Structured Streaming, como os módulos anteriores mostraram, processa em micro-batches: agrupa os dados chegados num intervalo e roda cada lote como um job Spark comum. O Flink nasceu como motor de streaming nativo: cada evento é processado assim que chega, sem esperar um lote se formar, o que tende a produzir latências menores. O Flink também trouxe o caminho inverso do Spark: em vez de um motor batch que ganhou streaming, ele trata batch como um caso particular de streaming, um stream finito, com um único motor para os dois. Sua gestão de estado, usada em agregações e janelas, é reconhecida como particularmente robusta para pipelines complexos e de longa duração."
+                    },
+                    {
+                        "type": "code",
+                        "value": "Spark Structured Streaming (micro-batch)\n\ntempo:  |---lote 1---|---lote 2---|---lote 3---|---lote 4---|\n        processa em ciclos, por exemplo a cada 10 segundos\n\nApache Flink (streaming nativo)\n\ntempo:  evento -> processa -> evento -> processa -> evento -> processa\n        cada evento e tratado assim que chega, sem esperar um ciclo fechar"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Amazon Kinesis: streaming gerenciado na AWS\n\nO Kinesis Data Streams cobre um espaço conceitualmente parecido com o do Kafka: shards fazem o papel das partições, cada registro tem uma chave e uma ordem dentro do shard, e produtores e consumidores publicam e leem de forma parecida. A diferença central é operacional: o Kinesis é um serviço totalmente gerenciado pela AWS, sem broker para provisionar ou atualizar.\n\nO Kinesis Data Firehose vai um passo além: entrega o conteúdo de um stream direto num destino como S3, Redshift ou OpenSearch, sem exigir nenhum consumidor escrito por quem usa o serviço, um pouco como um sink connector totalmente gerenciado. O outro lado dessa comodidade é o vínculo com a AWS: portar um pipeline construído sobre Kinesis para outra nuvem exige trocar a peça de transporte inteira."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Apache Pulsar: multi-tenant e armazenamento em camadas\n\nO Pulsar separa duas responsabilidades que o Kafka mantém juntas: os brokers, que atendem produtores e consumidores, e a camada de armazenamento (Apache BookKeeper), que persiste os dados. Essa separação facilita a multi-tenancy nativa: muitos times isolados, com namespaces e permissões próprias, compartilhando um único cluster sem interferir uns nos outros. O Pulsar também oferece geo-replicação embutida entre regiões e tiered storage, movendo segmentos antigos automaticamente para um object storage mais barato, sem deixar de expô-los para consulta. O Kafka chega a resultados parecidos, mas normalmente com ferramentas adicionais por cima, como o MirrorMaker para replicação entre regiões, não como parte nativa do broker.\n\n## Quando ainda faz sentido ficar com Kafka e Spark\n\nTrocar de ferramenta tem custo: aprender um motor novo, treinar o time, migrar operação. Para a maioria dos pipelines de engenharia de dados, latência de alguns segundos é suficiente, o volume não exige um motor especializado em estado, e a portabilidade entre nuvens com um ecossistema maduro de conectores pesam mais do que qualquer ganho pontual de outra ferramenta. Reconhecer as alternativas não significa trocar de stack a cada projeto, nem sempre que aparece uma novidade."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Necessidade\",\"Ferramenta mais indicada\"],[\"Latência sub-segundo com estado complexo por evento\",\"Apache Flink\"],[\"Streaming gerenciado dentro da AWS, sem operar broker\",\"Amazon Kinesis\"],[\"Multi-tenancy nativa e geo-replicação sem ferramenta extra\",\"Apache Pulsar\"],[\"Ecossistema amplo de conectores e portabilidade entre nuvens\",\"Apache Kafka\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "A dupla Kafka e Spark é a referência desta trilha, não a única resposta certa: a ferramenta certa depende do requisito, não da popularidade."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "Qual é a diferença fundamental entre o modelo de execução do Spark Structured Streaming e o do Apache Flink?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "O Flink não guarda estado entre eventos; só o Spark suporta agregações com estado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Spark não oferece checkpoint; a tolerância a falha existe somente no Flink.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Flink funciona apenas como sistema de armazenamento, sem motor de processamento.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O Spark processa em micro-batches; o Flink processa evento a evento, nativamente.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um sistema de detecção de fraude precisa pontuar cada evento em poucos milissegundos após ele acontecer, e os ciclos de micro-batch do Structured Streaming, mesmo no menor intervalo configurável, ainda somam uma latência alta demais. Qual mudança atende melhor esse requisito?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Trocar o motor de processamento para o Apache Flink, com execução nativa evento a evento.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Reduzir o intervalo do trigger do Structured Streaming até chegar a um valor de zero segundos.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Trocar o transporte para o Kinesis Data Firehose, mantendo o Spark como motor.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Trocar o transporte para o Apache Pulsar, mantendo o Spark como motor de processamento.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um time na AWS precisa entregar dados de um stream direto em S3 e Redshift, sem operar nenhum broker nem escrever um consumidor próprio para essa entrega. Qual serviço atende essa necessidade da forma mais direta?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Kafka Connect, com um sink connector operado pelo próprio time.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Amazon Kinesis Data Firehose, como entrega totalmente gerenciada.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Apache Pulsar, configurado com tiered storage apontando para o S3.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Apache Flink, com um sink customizado escrito para o Redshift.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma plataforma central atende dezenas de times isolados num único cluster de streaming, e precisa replicar nativamente alguns namespaces entre duas regiões, sem somar ferramentas externas de replicação. Qual tecnologia atende as duas exigências por design?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Apache Kafka, com um cluster único compartilhado e ACLs por tópico.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Amazon Kinesis, com um stream separado por time e replicação em nível de aplicação.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Apache Pulsar, com multi-tenancy e geo-replicação nativas do broker.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Spark Structured Streaming, com um job isolado por time e checkpoint por região.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Uma equipe escolhe a stack de streaming de um novo projeto valorizando um ecossistema maduro de conectores e a possibilidade de rodar a mesma arquitetura em qualquer nuvem, sem depender de um único provedor. Qual escolha reflete melhor essa prioridade?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Amazon Kinesis, pela integração profunda com os demais serviços da AWS.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Apache Pulsar, ainda consolidando um ecossistema de conectores tão amplo quanto o do Kafka.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Apache Flink isolado, sem um sistema de transporte de mensagens dedicado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Apache Kafka, pela maturidade do ecossistema e portabilidade entre nuvens.",
+                                "isCorrect": true
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "titulo": "Boas práticas, monitoramento e antipadrões",
+                "blocks": [
+                    {
+                        "type": "text",
+                        "value": "# Boas práticas, monitoramento e antipadrões\n\nEsta é a última aula da trilha de Streaming de Dados, e o objetivo é reunir, numa lista prática, o que os módulos anteriores construíram peça por peça: garantias de entrega, tempo de evento e janelas, o processamento com Spark Structured Streaming, o Kafka Connect e a dualidade stream-tabela. Cada item apareceu isolado em algum momento; a diferença agora é olhar para eles como uma checklist de produção.\n\n## Consumer lag: o consumidor está acompanhando?\n\nConsumer lag é a distância entre o offset mais recente já publicado numa partição e o offset que o consumer group já processou. Lag zero significa que o consumidor está em dia; lag crescendo significa que ele está ficando para trás, seja por falta de paralelismo, processamento lento por mensagem, ou um pico de produção acima do que o consumidor aguenta. De todas as métricas de um pipeline de streaming, lag é a que mais diretamente responde à pergunta se o pipeline está saudável agora, mais até do que o throughput sozinho, que não diz se o consumidor está acompanhando ou só processando devagar um volume que já se acumulou."
+                    },
+                    {
+                        "type": "code",
+                        "value": "$ kafka-consumer-groups.sh --bootstrap-server broker1:9092 --describe --group grupo-ingestao-bronze\n\nTOPIC             PARTITION  CURRENT-OFFSET  LOG-END-OFFSET  LAG\neventos.pedidos   0          184023          184023          0\neventos.pedidos   1          179884          181950          2066\neventos.pedidos   2          190112          190112          0\neventos.pedidos   3          177200          185430          8230\n\n# LAG = LOG-END-OFFSET menos CURRENT-OFFSET: quanto falta o consumidor processar\n# particoes 1 e 3 estao acumulando atraso; e ali que investigar o gargalo primeiro"
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Dimensionar partições para aguentar a carga\n\nO número de partições de um tópico define o teto de paralelismo de um consumer group: como cada partição só é lida por um consumidor do grupo por vez, um tópico com poucas partições limita quantos consumidores conseguem trabalhar em paralelo, não importa quantas instâncias o time suba. Poucas partições também travam o throughput de gravação, já que o producer não consegue distribuir a carga.\n\nO excesso também custa: cada partição soma overhead de réplica entre os brokers e aumenta o tempo de um rebalanceamento. E aumentar o número de partições de um tópico existente não é uma operação neutra: como a partição de uma chave normalmente vem de um hash sobre a chave, adicionar partições muda esse mapeamento, e mensagens da mesma chave podem passar a cair numa partição diferente da que caíam antes, quebrando a ordem que o consumidor esperava para aquela chave. Por isso, dimensionar para o pico esperado de antemão vale mais do que corrigir depois."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## Idempotência como rede de segurança\n\nOs módulos de garantias de entrega já deixaram claro: at-least-once é o padrão realista da maioria dos pipelines, e duplicatas eventualmente acontecem, depois de um restart de consumidor ou de uma task de connector. A defesa prática não é perseguir exactly-once em cada etapa do pipeline, e sim projetar a escrita final para ser idempotente, como um upsert por uma chave única do evento, de forma que reprocessar a mesma mensagem não mude o resultado."
+                    },
+                    {
+                        "type": "text",
+                        "value": "## O antipadrão de usar streaming sem necessidade\n\nStreaming tem um custo de operação que o batch não tem: infraestrutura sempre ligada, checkpoint para gerenciar, lag para monitorar, um tipo de depuração mais difícil que a de um job que roda e termina. Quando o requisito de negócio aceita uma atualização a cada hora ou uma vez por dia, um job batch agendado por um orquestrador entrega o mesmo resultado com uma operação bem mais simples. O primeiro módulo desta trilha já colocou essa pergunta: o motivo de usar streaming precisa ser a exigência real de baixa latência, não o hábito de tratar todo pipeline novo como um caso de tempo real."
+                    },
+                    {
+                        "type": "table",
+                        "value": "[[\"Prática\",\"Pergunta a fazer\"],[\"Consumer lag\",\"O consumidor está acompanhando o ritmo de produção, partição por partição?\"],[\"Partições\",\"O número atual sustenta o pico de throughput sem exagerar no overhead?\"],[\"Idempotência\",\"Uma mensagem duplicada corrompe o resultado, ou a escrita é segura para repetir?\"],[\"Necessidade real de streaming\",\"O requisito exige tempo real de fato, ou um lote periódico já resolve?\"]]"
+                    },
+                    {
+                        "type": "quote",
+                        "value": "Streaming não é o padrão a aplicar sempre que existe um evento: é a resposta certa quando o tempo entre o evento e a decisão realmente precisa ser curto."
+                    }
+                ],
+                "questions": [
+                    {
+                        "statement": "O que significa consumer lag crescendo numa partição?",
+                        "difficulty": "facil",
+                        "options": [
+                            {
+                                "text": "O consumidor está ficando para trás em relação ao ritmo de produção naquela partição.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O broker responsável pela partição está sem espaço em disco para novas mensagens.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O producer parou de aguardar confirmação (acks) antes de enviar a próxima mensagem.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "A partição está configurada com um fator de replicação abaixo do recomendado.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um tópico tem 6 partições, e um consumer group sobe 10 instâncias para lê-lo, na esperança de acelerar o processamento. O que acontece com as 4 instâncias além do número de partições?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Dividem o consumo de cada partição em turnos de tempo com as demais instâncias.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Ficam ociosas, já que cada partição só é lida por um consumidor do grupo por vez.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Forçam o Kafka a criar automaticamente mais partições para o tópico em questão.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Processam as mesmas mensagens das outras instâncias, como uma réplica de leitura.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Para aumentar o throughput, um time eleva o número de partições de um tópico já em produção, particionado pela chave cliente_id para preservar a ordem por cliente. Qual é o risco dessa mudança para os consumidores existentes?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Todo o histórico do tópico é redistribuído automaticamente entre as novas partições à noite.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Os consumidores existentes são obrigados a reiniciar com uma nova versão do client Kafka.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "O hash da chave para partição muda, e eventos do mesmo cliente podem cair numa partição diferente.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "O producer perde a capacidade de definir uma chave de particionamento a partir dessa mudança.",
+                                "isCorrect": false
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um pipeline opera com at-least-once e, ocasionalmente, reprocessa o mesmo evento após um restart do consumidor. O destino é uma tabela que deve refletir cada evento uma única vez. Qual prática evita que a duplicata corrompa o resultado?",
+                        "difficulty": "medio",
+                        "options": [
+                            {
+                                "text": "Configurar o producer com acks igual a zero, para acelerar o envio das mensagens.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Contar com o Kafka para deduplicar mensagens repetidas automaticamente por padrão.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Desligar o checkpoint do consumidor, para que ele nunca retome de onde parou.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Escrever como um upsert idempotente, usando o identificador único do evento como chave.",
+                                "isCorrect": true
+                            }
+                        ]
+                    },
+                    {
+                        "statement": "Um painel só precisa exibir o total do dia anterior, atualizado uma vez por noite, mas a equipe já mantém um tópico Kafka com os eventos e, por padrão, sobe um job de streaming rodando 24 horas para manter um agregado sempre atualizado. Qual decisão melhor se encaixa nesse requisito?",
+                        "difficulty": "dificil",
+                        "options": [
+                            {
+                                "text": "Substituir o job de streaming por um lote agendado uma vez por dia, já que a SLA não exige tempo real.",
+                                "isCorrect": true
+                            },
+                            {
+                                "text": "Trocar a retenção do tópico para infinita, sem mudar a forma como o agregado é calculado.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Trocar o motor de streaming para o Flink, reduzindo o custo de manter o job ligado o tempo todo.",
+                                "isCorrect": false
+                            },
+                            {
+                                "text": "Manter o streaming, já que dados publicados num tópico Kafka só podem ser lidos por outro job de streaming.",
+                                "isCorrect": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+];
+
+async function seed() {
+    let [trilha] = await db.select().from(trails).where(eq(trails.name, NOME));
+    if (!trilha) {
+        [trilha] = await db
+            .insert(trails)
+            .values({ name: NOME, trailLevel: LEVEL, description: DESCRICAO })
+            .returning();
+        console.log("Trilha criada: " + trilha.name);
+    }
+
+    const existentes = await db.select().from(lessons).where(eq(lessons.trailId, trilha.id));
+    if (existentes.length > 0) {
+        console.log("Trilha " + NOME + " ja tem " + existentes.length + " aulas. Nada a fazer.");
+        return;
+    }
+
+    let totalAulas = 0;
+    let totalQuestoes = 0;
+    for (let mi = 0; mi < MODULOS.length; mi++) {
+        const m = MODULOS[mi];
+        const [mod] = await db
+            .insert(modules)
+            .values({ trailId: trilha.id, title: m.titulo, position: mi + 1 })
+            .returning();
+        for (let li = 0; li < m.aulas.length; li++) {
+            const a = m.aulas[li];
+            const [lesson] = await db
+                .insert(lessons)
+                .values({
+                    trailId: trilha.id,
+                    moduleId: mod.id,
+                    title: a.titulo,
+                    content: null,
+                    contentBlocks: a.blocks,
+                    position: li + 1,
+                    published: true,
+                })
+                .returning();
+            for (let qi = 0; qi < a.questions.length; qi++) {
+                const q = a.questions[qi];
+                const [questao] = await db
+                    .insert(questions)
+                    .values({
+                        lessonId: lesson.id,
+                        statement: q.statement,
+                        difficulty: q.difficulty,
+                        position: qi + 1,
+                    })
+                    .returning();
+                await db.insert(questionOptions).values(
+                    q.options.map((o, k) => ({
+                        questionId: questao.id,
+                        text: o.text,
+                        isCorrect: o.isCorrect,
+                        position: k + 1,
+                    })),
+                );
+            }
+            totalAulas++;
+            totalQuestoes += a.questions.length;
+        }
+    }
+    console.log("Seed concluido: " + MODULOS.length + " modulos, " + totalAulas + " aulas, " + totalQuestoes + " questoes.");
+}
+
+seed()
+    .then(() => process.exit(0))
+    .catch((e) => {
+        console.error("Falha no seed:", e);
+        process.exit(1);
+    });


### PR DESCRIPTION
## Trilha Modern Data Stack (estágio 11 do roadmap de Engenharia de Dados)

Décima primeira trilha do roadmap de Engenharia de Dados, e a que fecha a fase avançada.

### Empilhado no #190
Parte da pilha do roadmap: **#190 (Streaming) -> este (#191)**, porque o estágio 11 do seed depende do estágio 10. Ordem de merge: #190, depois este. Quando o #190 entrar na develop, o diff aqui encolhe para só o Modern Data Stack.

### Trilha Modern Data Stack
7 módulos, 35 aulas, 175 questões de quiz (5 por aula), nível avançado. Assume base de SQL, modelagem, ETL e orquestração. dbt como ferramenta central de transformação:

1. O modern data stack e o analytics engineering
2. dbt: o que é e por que existe
3. Modelos, ref e a linhagem
4. Materializações (view, table, incremental, ephemeral)
5. Testes, documentação e qualidade no dbt
6. dbt avançado e reuso (Jinja, macros, packages, snapshots)
7. O modern data stack na prática (semantic layer, CI/CD para dados)

Blocos text/table/code/quote, com modelos dbt (ref/source), schema.yml de testes e diagramas do fluxo staging/intermediate/marts em ASCII. Vendor-neutral, citando Fivetran/Airbyte, Snowflake/BigQuery, Looker/Metabase.

### Roadmap Engenharia de Dados (estágio 11)
Adiciona o estágio 11 (Modern data stack e analytics engineering, fase avançado) ao `seed-roadmap-engenharia-dados.ts`, que passa a ter 11 estágios. Fecha a fase Avançado. Idempotente por estágio.

### Qualidade das questões
- Vício forte (correta é a mais longa E pelo menos 1.4x a média das erradas): 0%
- Nenhuma questão com a correta liderando a maior errada por mais de 5 caracteres
- 0 duplicatas de enunciado, 0 travessão, 0 emoji, 0 "todas/nenhuma das anteriores"
- Toda questão com exatamente 1 correta; posição bem distribuída (48/42/42/43)
- Verificação cega de gabarito: 7 revisores independentes responderam as 175 questões sem ver a resposta marcada, 100% de acordo com o gabarito (0 divergências)

### Sem migração
Usa tabelas que já existem. Nenhuma mudança de schema.

### Como testar local
```
docker compose exec -T backend node scripts/seed-trilha-modern-data-stack.ts
docker compose exec -T backend node scripts/seed-roadmap-engenharia-dados.ts
```
Confirmado no dev: trilha com 7 módulos, 35 aulas e 175 questões; roadmap `engenharia-dados` com 11 estágios, 0 refs faltando, cada um resolvendo para a trilha certa.
