### PR TITLE
feat: adiciona os simulados do Databricks Data Engineer (Associate e Professional)

### DIFF
--- a/backend/scripts/seed-databricks-de-associate.ts
+++ b/backend/scripts/seed-databricks-de-associate.ts
@@ -1,0 +1,1244 @@
+// Seed do simulado Databricks Certified Data Engineer Associate (databricks-de-associate). Idempotente: se ja tiver questoes, nao faz nada.
+//
+// Rodar em dev:  node --env-file=.env scripts/seed-databricks-de-associate.ts
+// Rodar em prod: docker compose -f docker-compose.prod.yml exec -T backend node scripts/seed-databricks-de-associate.ts
+import { db } from "../db.ts";
+import { simulados, simuladoQuestions, simuladoOptions } from "../schema.ts";
+import { eq, count } from "drizzle-orm";
+
+const SLUG = "databricks-de-associate";
+
+type Questao = { statement: string; explanation: string; topic: string; options: [string, boolean][] };
+
+const QUESTOES: Questao[] = [
+    {
+        statement:
+            "Uma equipe de engenharia de dados quer que cada desenvolvedor edite notebooks em sua própria branch de feature, sincronizando o código com um repositório remoto no GitHub e alternando entre branches sem sair da interface do Databricks. Qual recurso atende esse requisito?",
+        explanation:
+            "Git Folders do Databricks integra o workspace diretamente a um repositório Git remoto, permitindo clonar o repositório, criar e alternar branches, e sincronizar com pull e push sem sair da interface. Volumes do Unity Catalog e armazenamento DBFS montado servem para arquivos e dados, sem controle de versão Git. Arquivos comuns do workspace não têm integração nativa com branches remotas.",
+        topic: "Databricks Git Folders",
+        options: [
+            ["Sincronizar o workspace com o repositório usando Git Folders do Databricks", true],
+            ["Sincronizar o workspace com o repositório usando Volumes do Unity Catalog", false],
+            ["Sincronizar o workspace com o repositório usando armazenamento DBFS montado", false],
+            ["Sincronizar o workspace com o repositório usando arquivos comuns do workspace", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe quer que a tarefa de um Lakeflow Job em produção sempre execute o código de uma tag de release imutável de um repositório Git, sem depender de alguém sincronizar manualmente um Git Folder antes de cada execução agendada. Qual abordagem atende esse requisito com menos esforço operacional?",
+        explanation:
+            "Jobs Lakeflow podem referenciar um repositório Git remoto diretamente como fonte da tarefa, fixando branch, tag ou commit; a cada execução o Databricks busca automaticamente essa versão, sem sincronização manual. Um Git Folder é uma cópia no workspace que precisa de pull manual para refletir a tag mais recente, reintroduzindo o passo manual que a equipe quer eliminar. Copiar notebooks manualmente e salvar em um volume do Unity Catalog também exigem intervenção manual e não usam controle de versão Git nativo do job.",
+        topic: "Lakeflow Jobs - fonte Git remota",
+        options: [
+            ["Copiar manualmente os notebooks da tag de release para o workspace antes da execução", false],
+            ["Apontar a tarefa do job para o repositório Git remoto, usando a tag de release", true],
+            ["Criar um Git Folder e orientar a equipe a fazer pull antes de cada execução agendada", false],
+            ["Salvar os notebooks da tag de release em um volume do Unity Catalog e apontar o job", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe quer definir jobs, pipelines e a configuração de implantação de um projeto de dados inteiro como arquivos de código versionáveis, para implantar o mesmo projeto de forma consistente em workspaces de desenvolvimento e produção. Qual recurso do Databricks foi projetado para isso?",
+        explanation:
+            "Automation Bundles descrevem jobs, pipelines e demais recursos de um projeto como arquivos de configuração versionados, permitindo implantar o mesmo projeto em targets diferentes, como dev e prod, de forma consistente. Git Folders do Databricks sincroniza pastas do workspace com um repositório remoto, mas não empacota nem implanta recursos. Políticas de cluster padronizam apenas a configuração de computação permitida. O Databricks CLI isolado é uma ferramenta de linha de comando, e sozinho não substitui o arquivo de configuração de implantação de um bundle.",
+        topic: "Automation Bundles",
+        options: [
+            ["Git Folders do Databricks, que sincronizam pastas do workspace com um repositório remoto", false],
+            ["Políticas de cluster, que padronizam a configuração de computação permitida", false],
+            ["Databricks CLI isoladamente, sem nenhum arquivo de configuração de implantação", false],
+            ["Automation Bundles, que descrevem jobs e pipelines como configuração versionada", true],
+        ],
+    },
+    {
+        statement:
+            "Um engenheiro está criando o arquivo de configuração principal de um Automation Bundle, que vai descrever os jobs, os pipelines e os targets de implantação de um projeto. Qual arquivo, na raiz do projeto, concentra essa definição?",
+        explanation:
+            "O databricks.yml é o arquivo de configuração raiz de um Automation Bundle: nele ficam as seções bundle, resources (jobs, pipelines e outros recursos) e targets (ambientes como dev e prod). cluster-policy.json define políticas de cluster, requirements.txt lista dependências Python, e spark-defaults.conf configura parâmetros do Spark; nenhum desses é o arquivo de definição de um bundle.",
+        topic: "databricks.yml",
+        options: [
+            ["cluster-policy.json", false],
+            ["requirements.txt", false],
+            ["databricks.yml", true],
+            ["spark-defaults.conf", false],
+        ],
+    },
+    {
+        statement:
+            "Uma engenheira implanta o mesmo Automation Bundle em dois targets diferentes: um configurado com mode: development e outro com mode: production. Ao implantar no target de desenvolvimento, o que o Databricks faz por padrão com os gatilhos e agendamentos dos jobs e pipelines do bundle?",
+        explanation:
+            "No modo development de um Automation Bundle, o Databricks pausa automaticamente gatilhos e agendamentos dos jobs e pipelines implantados, evitando execuções acidentais durante o desenvolvimento; no modo production esse comportamento não ocorre. Manter os gatilhos ativos sem alteração é o comportamento típico do modo production, não do development. Exigir aprovação manual e converter agendamentos em execução contínua não são comportamentos automáticos desse modo.",
+        topic: "Automation Bundles - modo development",
+        options: [
+            ["Mantém os gatilhos e agendamentos ativos, sem alteração", false],
+            ["Pausa os gatilhos e agendamentos automaticamente", true],
+            ["Exige aprovação manual antes de qualquer execução", false],
+            ["Converte todos os agendamentos em execução contínua", false],
+        ],
+    },
+    {
+        statement:
+            "Depois de validar a configuração, um engenheiro precisa implantar os recursos de um Automation Bundle no target chamado prod usando a linha de comando. Qual comando do Databricks CLI faz isso?",
+        explanation:
+            "O comando databricks bundle deploy -t prod empacota e implanta os recursos definidos no bundle no target especificado. databricks bundle init cria um novo projeto de bundle a partir de um template, databricks bundle destroy remove os recursos implantados, e databricks bundle summary apenas exibe um resumo dos recursos, sem implantá-los.",
+        topic: "Databricks CLI - bundle deploy",
+        options: [
+            ["databricks bundle init -t prod", false],
+            ["databricks bundle destroy -t prod", false],
+            ["databricks bundle summary -t prod", false],
+            ["databricks bundle deploy -t prod", true],
+        ],
+    },
+    {
+        statement:
+            "Um Automation Bundle define um Lakeflow Spark Declarative Pipeline que deve gravar no catálogo dev_catalogo quando implantado no target de desenvolvimento e no catálogo prod_catalogo quando implantado no target de produção, sem duplicar a definição do pipeline em dois arquivos. Qual recurso do bundle permite isso?",
+        explanation:
+            "Automation Bundles suportam variables definidas uma única vez e referenciadas nos recursos, como o catálogo do pipeline; cada target pode sobrescrever o valor da variable, permitindo usar dev_catalogo em desenvolvimento e prod_catalogo em produção a partir da mesma definição de pipeline. Duplicar o arquivo de definição quebra o princípio de uma única fonte de verdade. Políticas de cluster controlam configuração de computação, não o catálogo de destino. Um repositório Git exclusivo para produção não resolve a parametrização entre ambientes.",
+        topic: "Automation Bundles - variables",
+        options: [
+            ["Definir uma variable no bundle e sobrescrever o valor por target", true],
+            ["Duplicar o arquivo de definição do pipeline para cada target", false],
+            ["Aplicar uma política de cluster apenas no target de produção", false],
+            ["Usar um repositório Git exclusivo para o target de produção", false],
+        ],
+    },
+    {
+        statement:
+            "Antes de implantar um Automation Bundle em produção, um engenheiro quer verificar se o databricks.yml e os recursos referenciados estão configurados corretamente, sem de fato criar ou alterar nada no workspace. Qual comando ele deve executar?",
+        explanation:
+            "databricks bundle validate verifica a sintaxe e a configuração do databricks.yml e dos recursos referenciados, apontando erros, sem implantar nada no workspace. databricks bundle deploy efetivamente cria ou atualiza os recursos no workspace, databricks bundle run executa um job ou pipeline já implantado, e databricks bundle summary lista os recursos de uma implantação existente; nenhum desses substitui a validação prévia.",
+        topic: "Databricks CLI - bundle validate",
+        options: [
+            ["databricks bundle deploy", false],
+            ["databricks bundle run", false],
+            ["databricks bundle validate", true],
+            ["databricks bundle summary", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe está migrando a implantação de pipelines Lakeflow para um processo de CI/CD automatizado, usando Automation Bundles disparados por um pipeline no GitHub Actions a cada merge na branch principal. Quais DUAS práticas são recomendadas nesse cenário? (Selecione DUAS opções.)",
+        explanation:
+            "Separar um target de produção do de desenvolvimento no databricks.yml permite aplicar mode: production, com nomes de recursos estáveis e controles próprios de cada ambiente. Usar um service principal dedicado para autenticar implantações automatizadas evita atrelar o pipeline de CI/CD a credenciais de uma pessoa específica. Autenticar com o token pessoal de um desenvolvedor cria dependência de uma identidade individual, o que é desaconselhado. Implantar sempre em desenvolvimento e renomear manualmente descaracteriza a separação de ambientes. Editar jobs de produção diretamente pela UI depois do deploy quebra a definição do bundle como fonte de verdade, pois a próxima implantação sobrescreve a alteração manual.",
+        topic: "CI/CD com Automation Bundles",
+        options: [
+            ["Autenticar as implantações automatizadas com o token pessoal de um desenvolvedor", false],
+            ["Definir um target de produção separado do target de desenvolvimento no databricks.yml", true],
+            ["Implantar sempre no target de desenvolvimento e renomear os recursos manualmente depois", false],
+            ["Autenticar as implantações automatizadas com um service principal dedicado", true],
+            ["Editar os jobs implantados diretamente pela UI do workspace de produção após cada deploy", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer uma arquitetura única, capaz de armazenar dados estruturados, semiestruturados e não estruturados com governança centralizada, e que suporte tanto cargas de BI/SQL quanto machine learning sobre os mesmos dados, sem duplicar dados entre um data warehouse e um data lake separados. Qual arquitetura o Databricks implementa para atender esse requisito?",
+        explanation:
+            "O Lakehouse é a arquitetura que o Databricks implementa para unir, sobre o mesmo armazenamento de dados abertos, a governança, as transações ACID e o desempenho típicos de um data warehouse com a flexibilidade e o custo de um data lake, suportando BI e machine learning sobre a mesma cópia dos dados. Um data warehouse isolado ou um data lake isolado exigem duplicar dados entre sistemas separados, e um data mart atende apenas uma única equipe, sem ser a arquitetura de plataforma completa.",
+        topic: "Arquitetura Lakehouse",
+        options: [
+            ["Um data warehouse tradicional isolado, com os dados replicados manualmente do data lake", false],
+            ["Um data lake isolado, sem nenhuma camada de governança ou controle de qualidade", false],
+            ["Lakehouse, unindo governança e desempenho de data warehouse à flexibilidade de um data lake", true],
+            ["Um data mart dedicado exclusivamente às cargas de BI de uma única equipe", false],
+        ],
+    },
+    {
+        statement:
+            "Uma organização com vários workspaces do Databricks quer administrar permissões de acesso a tabelas, registrar a linhagem dos dados e aplicar um único modelo de nomes no formato catálogo.esquema.tabela de forma centralizada, válida para todos os workspaces da conta. Qual componente da Databricks Data Intelligence Platform fornece isso?",
+        explanation:
+            "O Unity Catalog é o sistema de governança unificado do Databricks: administra o namespace de três níveis (catálogo, esquema e tabela ou volume), controla permissões com GRANT, REVOKE e DENY, e registra a linhagem de dados de forma centralizada, compartilhada entre os workspaces vinculados à mesma conta. Lakeflow Jobs orquestra execuções, Databricks SQL executa consultas analíticas, e um cluster de all-purpose compute é apenas um recurso de computação interativo; nenhum dos três fornece o namespace e a governança centralizada descritos.",
+        topic: "Unity Catalog",
+        options: [
+            ["Unity Catalog", true],
+            ["Lakeflow Jobs", false],
+            ["Databricks SQL", false],
+            ["All-purpose compute", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe agenda um Lakeflow Job para rodar toda madrugada, sem nenhuma interação humana durante a execução, e quer o menor custo possível por hora de computação para essa carga, já que nenhum notebook será aberto interativamente nesse cluster. Qual tipo de compute é o mais adequado para esse job agendado?",
+        explanation:
+            "Job compute é provisionado automaticamente para a execução de um job agendado e encerrado ao final dela, com preço por hora menor que o all-purpose compute, sendo a opção recomendada para cargas sem interação humana. All-purpose compute é pensado para uso interativo em notebooks compartilhados, custa mais por hora e permanece ativo entre execuções. Um SQL warehouse serverless é otimizado para consultas SQL e BI, não para orquestrar um job genérico. Um cluster de all-purpose compartilhado tem o mesmo problema de custo do all-purpose comum.",
+        topic: "Job compute x all-purpose compute",
+        options: [
+            ["All-purpose compute, mantido ativo para uso interativo em notebooks", false],
+            ["Job compute, criado e encerrado automaticamente para a execução do job", true],
+            ["Um SQL warehouse serverless dedicado exclusivamente a consultas de BI", false],
+            ["Um cluster de all-purpose compute compartilhado com toda a equipe", false],
+        ],
+    },
+    {
+        statement:
+            "Ao criar uma tabela gerenciada no Databricks sem especificar a cláusula USING, qual é o formato de tabela padrão, que grava arquivos Parquet acompanhados de um log de transações com garantias ACID, time travel e suporte nativo a UPDATE, DELETE e MERGE?",
+        explanation:
+            "Delta Lake é o formato de tabela padrão do Databricks: ao criar uma tabela gerenciada sem USING, o Databricks usa Delta, que grava arquivos Parquet e adiciona um log de transações, garantindo transações ACID, time travel e suporte nativo a UPDATE, DELETE e MERGE. Apache Iceberg é outro formato de tabela aberto com o qual o Databricks interopera, mas não é o formato padrão ao omitir USING. Apache Parquet puro não tem log de transações, e Apache Avro é um formato de serialização de linha, sem as garantias transacionais de uma tabela Delta.",
+        topic: "Delta Lake",
+        options: [
+            ["Apache Iceberg", false],
+            ["Apache Parquet", false],
+            ["Apache Avro", false],
+            ["Delta Lake", true],
+        ],
+    },
+    {
+        statement:
+            "Durante o desenvolvimento de um notebook, um engenheiro quer descrever em linguagem natural o que uma célula deve fazer e receber uma sugestão de código SQL ou PySpark, além de pedir uma explicação sobre um erro que apareceu na execução. Qual recurso da Databricks Data Intelligence Platform oferece essa ajuda dentro do próprio notebook?",
+        explanation:
+            "O Databricks Assistant é o assistente de IA integrado ao workspace, incluindo notebooks e o editor SQL, que gera e explica código a partir de linguagem natural, sugere correções e ajuda a interpretar erros com o contexto do próprio ambiente Databricks. Unity Catalog trata da governança de dados, o Databricks CLI é uma interface de linha de comando para operar a plataforma, e Job compute é um tipo de cluster para execução de jobs; nenhum desses oferece assistência de código em linguagem natural.",
+        topic: "Databricks Assistant",
+        options: [
+            ["Unity Catalog", false],
+            ["Databricks Assistant", true],
+            ["CLI do Databricks", false],
+            ["Cluster de job compute", false],
+        ],
+    },
+    {
+        statement:
+            "Uma organização está descrevendo os componentes da Databricks Data Intelligence Platform para um time que vai iniciar um projeto de engenharia de dados. Quais DUAS afirmações sobre esses componentes estão corretas? (Selecione DUAS opções.)",
+        explanation:
+            "O Lakeflow é o nome atual da solução unificada de engenharia de dados do Databricks, reunindo ingestão, transformação com Lakeflow Spark Declarative Pipelines (antes conhecido como Delta Live Tables ou DLT) e orquestração com Lakeflow Jobs. O Unity Catalog fornece governança e um namespace único, compartilhado tanto para dados quanto para ativos de IA, em todos os workspaces vinculados à conta. O Databricks SQL é um motor de consultas e BI, e não substitui o Unity Catalog como camada de governança. Notebooks do Databricks suportam múltiplas linguagens na mesma sessão, como SQL, Python, Scala e R, não apenas Python. Um cluster de job compute é criado para a execução do job e encerrado ao final dela, não permanece ativo indefinidamente.",
+        topic: "Lakeflow e Unity Catalog",
+        options: [
+            ["O Lakeflow reúne as ferramentas de ingestão, transformação e orquestração de dados da plataforma", true],
+            ["O Databricks SQL substitui o Unity Catalog como sistema de governança de dados", false],
+            ["Notebooks do Databricks só podem ser escritos em Python, sem suporte a SQL", false],
+            ["O Unity Catalog fornece um modelo de governança e um namespace comuns para dados e IA em toda a plataforma", true],
+            ["Um cluster de job compute permanece ativo indefinidamente após o job terminar, para reaproveitamento", false],
+        ],
+    },
+    {
+        statement:
+            "Uma engenheira de dados está escrevendo uma consulta em Databricks SQL que será executada por vários usuários, cada um com um catálogo padrão diferente configurado na sessão. Para garantir que a consulta sempre aponte para a tabela pedidos do schema comercial dentro do catálogo vendas, independentemente do contexto de sessão de quem executa, qual referência ela deve usar?",
+        explanation:
+            "O Unity Catalog organiza os dados em uma hierarquia de três níveis: metastore, que contém catálogos, que contêm schemas, que contêm tabelas (além de views, volumes e functions). Para referenciar um objeto de forma completa e independente do contexto de sessão, o namespace usado em consultas é sempre catalog.schema.table, neste caso vendas.comercial.pedidos. O metastore não entra no namespace de uma consulta, ele é apenas o container de nível mais alto associado ao workspace, por isso a opção com metastore_principal está errada. Nomes com apenas dois níveis são ambíguos, porque o mesmo nome de schema ou de tabela pode existir em catálogos diferentes.",
+        topic: "Unity Catalog - hierarquia e namespace",
+        options: [
+            ["vendas.comercial.pedidos, seguindo a hierarquia catalog.schema.table do Unity Catalog.", true],
+            ["metastore_principal.vendas.comercial.pedidos, incluindo o metastore como primeiro nível do namespace.", false],
+            ["comercial.pedidos, pois o schema já identifica a tabela de forma única no metastore.", false],
+            ["vendas.pedidos, pois o catálogo e a tabela são suficientes para localizar o objeto.", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe está revisando como o Unity Catalog trata tabelas managed (gerenciadas) e tabelas external (externas). Quais DUAS afirmações estão corretas? (Selecione DUAS opções.)",
+        explanation:
+            "Tabelas managed têm os dados armazenados no local gerenciado configurado no metastore, catálogo ou schema, e o Unity Catalog controla todo o ciclo de vida dos arquivos, por isso o DROP TABLE remove metadados e dados. Tabelas external são criadas com LOCATION apontando para um External Location em nuvem, e o Unity Catalog governa apenas os metadados e o acesso, então o DROP TABLE só remove o registro no catálogo, sem apagar os arquivos. As demais afirmações invertem esse comportamento: tabelas external são normalmente registradas no metastore e consultáveis por qualquer cluster com Unity Catalog habilitado, e uma tabela criada com a cláusula LOCATION deixa de ser managed, passando a ser external.",
+        topic: "Managed x external tables",
+        options: [
+            ["Uma tabela external só pode ser lida por clusters sem Unity Catalog habilitado, já que ela nunca fica registrada no metastore da conta.", false],
+            ["Tabela managed: os dados ficam no local gerenciado pelo metastore, catálogo ou schema, e o DROP TABLE apaga metadados e arquivos juntos.", true],
+            ["Uma tabela managed pode apontar para qualquer bucket externo, bastando informar a cláusula LOCATION no momento da criação dela.", false],
+            ["Tabela external: criada com LOCATION para um External Location, e o DROP TABLE remove só os metadados, mantendo os arquivos intactos.", true],
+            ["Um DROP TABLE em uma tabela external também apaga os arquivos no armazenamento em nuvem, do mesmo jeito que em uma tabela managed.", false],
+        ],
+    },
+    {
+        statement:
+            "Um analista recebeu SELECT diretamente na tabela vendas.comercial.pedidos, mas ao executar SELECT * FROM vendas.comercial.pedidos no Databricks SQL a consulta falha com um erro de permissão. Esse analista nunca havia acessado o catálogo vendas nem o schema comercial antes. Considerando o modelo de privilégios do Unity Catalog, o que provavelmente falta conceder a ele?",
+        explanation:
+            "No Unity Catalog, ler uma tabela exige uma cadeia de privilégios: USE CATALOG no catálogo e USE SCHEMA no schema, que permitem atravessar esses containers, além do SELECT na própria tabela. Ter SELECT na tabela não basta se o principal não pode navegar até o catálogo e o schema onde ela vive. MODIFY controla operações de escrita, como INSERT, UPDATE, DELETE e MERGE, não leitura. OWNER concede controle total sobre o objeto, mas não é o privilégio mínimo necessário nem costuma ser concedido só para liberar consultas. CREATE TABLE autoriza criar novas tabelas no catálogo, sem relação com consultar as que já existem.",
+        topic: "Privilégios - USE CATALOG e USE SCHEMA",
+        options: [
+            ["MODIFY na tabela pedidos, que é obrigatório mesmo para consultas somente de leitura.", false],
+            ["OWNER no schema comercial, único privilégio capaz de liberar consultas SELECT em suas tabelas.", false],
+            ["USE CATALOG no catálogo vendas e USE SCHEMA no schema comercial, para navegar até a tabela.", true],
+            ["CREATE TABLE no catálogo vendas, necessário para abrir qualquer tabela já existente no catálogo.", false],
+        ],
+    },
+    {
+        statement:
+            "Uma pipeline precisa que uma service principal execute comandos MERGE INTO na tabela vendas.comercial.pedidos para aplicar atualizações incrementais. A service principal já possui USE CATALOG, USE SCHEMA e SELECT em toda a cadeia até a tabela, mas o comando falha por falta de permissão de escrita. Qual privilégio adicional deve ser concedido na tabela?",
+        explanation:
+            "O privilégio MODIFY é o que autoriza comandos que alteram linhas de uma tabela, como INSERT, UPDATE, DELETE e MERGE INTO; SELECT cobre apenas leitura, e não existe uma variante de SELECT que libere escrita, mesmo em nível de coluna. CREATE TABLE autoriza criar novos objetos no schema, sem relação com escrever em uma tabela que já existe. OWNER concederia controle total sobre a tabela, o que resolveria o problema, mas não é o privilégio mínimo nem o mais adequado para uma service principal de pipeline, MODIFY já é suficiente.",
+        topic: "Privilégios - MODIFY",
+        options: [
+            ["CREATE TABLE no schema comercial, necessário para sobrescrever linhas de uma tabela já existente.", false],
+            ["MODIFY, que autoriza operações de inserção, atualização e remoção de linhas na tabela.", true],
+            ["SELECT concedido novamente, agora em nível de coluna, para liberar a escrita.", false],
+            ["OWNER da tabela, único privilégio capaz de permitir a execução de comandos MERGE INTO.", false],
+        ],
+    },
+    {
+        statement:
+            "O grupo analistas_comercial recebeu SELECT no schema vendas.comercial, o que dá acesso de leitura a todas as tabelas do schema por herança. A empresa precisa impedir que um único integrante desse grupo, o usuário joao@empresa.com, consulte especificamente a tabela vendas.comercial.salarios, mantendo o acesso às demais tabelas do schema para ele e para o restante do grupo. Qual comando atende esse requisito com menos esforço?",
+        explanation:
+            "DENY cria uma restrição explícita que sempre prevalece sobre qualquer GRANT herdado, mesmo vindo de um grupo, e pode ser aplicada exatamente no objeto que se quer bloquear, neste caso a tabela salarios, sem afetar o restante do schema nem os outros integrantes do grupo. Como o SELECT de joao vem por herança do grupo no nível do schema, e não de um grant direto na tabela, um REVOKE na tabela para ele não tem nenhum efeito. Um REVOKE no grupo, por sua vez, tiraria o acesso de todos os integrantes às demais tabelas do schema, não só da tabela sensível. Um DENY no nível do schema resolveria o bloqueio, mas impediria joao de acessar todas as tabelas ali, não apenas a tabela salarios.",
+        topic: "GRANT, REVOKE e DENY",
+        options: [
+            ["REVOKE SELECT ON TABLE vendas.comercial.salarios FROM `joao@empresa.com`", false],
+            ["REVOKE SELECT ON SCHEMA vendas.comercial FROM analistas_comercial", false],
+            ["DENY SELECT ON SCHEMA vendas.comercial TO `joao@empresa.com`", false],
+            ["DENY SELECT ON TABLE vendas.comercial.salarios TO `joao@empresa.com`", true],
+        ],
+    },
+    {
+        statement:
+            "Uma administradora concede USE CATALOG, USE SCHEMA e SELECT no catálogo analytics para o grupo bi_team, cobrindo o catálogo inteiro. Duas semanas depois, um engenheiro cria um novo schema chamado marketing dentro desse catálogo e carrega uma tabela campanhas nele, sem conceder nenhum privilégio adicional. O grupo bi_team consegue consultar analytics.marketing.campanhas assim que ela é criada?",
+        explanation:
+            "No Unity Catalog, privilégios concedidos em um nível superior, como o catálogo, são herdados por todos os schemas e tabelas dentro dele, incluindo objetos criados depois do GRANT, a menos que um DENY mais específico bloqueie o acesso em um nível mais baixo. Como o grupo recebeu USE CATALOG, USE SCHEMA e SELECT sobre o catálogo inteiro, ele já consegue consultar a nova tabela sem nenhuma ação adicional. A herança não se limita a objetos preexistentes, e não é preciso repetir o GRANT a cada schema criado. Quem criou o objeto não interfere no acesso herdado que outros principals já possuíam.",
+        topic: "Herança de privilégios",
+        options: [
+            ["Não, porque a herança de privilégios só vale para objetos que já existiam no momento do GRANT original ter sido feito.", false],
+            ["Sim, porque privilégios do catálogo são herdados por schemas e tabelas criados depois, salvo DENY mais específico.", true],
+            ["Não, porque USE SCHEMA teria que ser concedido individualmente em cada novo schema criado.", false],
+            ["Sim, mas só porque o engenheiro que criou a tabela também é integrante do grupo bi_team nesse momento.", false],
+        ],
+    },
+    {
+        statement:
+            "A tabela clientes.perfil.cadastro tem a coluna cpf com dados sensíveis. A área de auditoria precisa continuar vendo o CPF completo, mas todos os demais usuários devem ver o valor mascarado. Qual abordagem do Unity Catalog aplica essa regra diretamente na tabela original, sem duplicar dados em uma view separada?",
+        explanation:
+            "Column mask é o recurso do Unity Catalog em que uma function SQL, tipicamente usando is_account_group_member() para checar a identidade de quem consulta, é associada a uma coluna via ALTER TABLE ... ALTER COLUMN ... SET MASK. A mesma tabela passa a devolver o CPF completo para o grupo de auditoria e o valor mascarado para os demais, sem criar views adicionais. Row filter atua sobre linhas, não sobre o conteúdo de uma coluna. Negar SELECT para os demais grupos bloquearia o acesso à tabela inteira, não só ao CPF. GENERATED ALWAYS AS define como uma coluna é calculada na escrita dos dados, sem relação com controle de acesso na leitura.",
+        topic: "Column masking",
+        options: [
+            ["Criar um row filter na tabela, associando uma function que oculta a coluna cpf para quem está fora do grupo de auditoria.", false],
+            ["Conceder SELECT na tabela apenas para o grupo de auditoria e aplicar DENY SELECT explícito para todos os demais grupos.", false],
+            ["Criar uma function de mascaramento com is_account_group_member() e aplicá-la via ALTER TABLE ... ALTER COLUMN cpf SET MASK.", true],
+            ["Definir a coluna cpf como GENERATED ALWAYS AS, recalculando um valor já mascarado a cada nova consulta feita.", false],
+        ],
+    },
+    {
+        statement:
+            "A tabela global.rh.funcionarios deve ser consultada pelos gestores de cada regional, mas cada gestor só pode ver as linhas de funcionários da sua própria região, sem que existam cópias separadas da tabela por região. Qual recurso do Unity Catalog aplica essa restrição de linhas diretamente na tabela original?",
+        explanation:
+            "Row filter é o recurso de segurança em nível de linha do Unity Catalog: uma function é associada à tabela com ALTER TABLE ... SET ROW FILTER, e o Unity Catalog aplica esse predicado a cada consulta, retornando somente as linhas que o usuário pode ver, na mesma tabela física. Column mask altera o conteúdo de uma coluna, não filtra linhas. Particionamento organiza fisicamente os arquivos para otimizar leitura, mas não impede, por si só, que um usuário com SELECT na tabela leia partições de outras regiões. Criar views ou tabelas separadas por região contraria o requisito de não duplicar a tabela e aumenta o esforço de manutenção a cada nova região.",
+        topic: "Row-level security (row filter)",
+        options: [
+            ["Column mask, que oculta a coluna regiao para gestores de outras regionais.", false],
+            ["Particionamento da tabela por regiao, que restringe automaticamente o acesso às partições de outras regionais.", false],
+            ["Views separadas por regiao, com GRANT SELECT individual para cada gestor.", false],
+            ["Row filter, que aplica uma function de filtro à tabela para restringir quais linhas cada usuário enxerga.", true],
+        ],
+    },
+    {
+        statement:
+            "Um engenheiro de dados vai implementar, pela primeira vez, um row filter na tabela global.rh.funcionarios para restringir linhas por região. Quais DUAS ações fazem parte do processo correto de implementação no Unity Catalog? (Selecione DUAS opções.)",
+        explanation:
+            "Implementar um row filter no Unity Catalog envolve dois passos: primeiro criar uma function SQL que recebe as colunas relevantes e retorna um booleano dizendo se a linha é visível para o usuário atual, por exemplo usando is_account_group_member(), depois aplicar essa function à tabela com ALTER TABLE ... SET ROW FILTER. SET MASK é o comando usado para column masking, um recurso diferente que altera o conteúdo de uma coluna, não filtra linhas. Não existe um privilégio ROW FILTER concedido via GRANT, o controle é feito pela function associada à tabela. CHECK CONSTRAINT é um mecanismo de qualidade de dados que valida valores na escrita, sem relação com controle de acesso na leitura.",
+        topic: "Row filter - implementação",
+        options: [
+            ["Criar uma function SQL que recebe a coluna regiao e retorna um booleano de visibilidade da linha atual.", true],
+            ["Aplicar a function à tabela com o comando ALTER TABLE global.rh.funcionarios ALTER COLUMN regiao SET MASK.", false],
+            ["Aplicar a function à tabela com o comando ALTER TABLE global.rh.funcionarios SET ROW FILTER.", true],
+            ["Conceder o privilégio ROW FILTER ao grupo de gestores usando o comando GRANT ROW FILTER ON TABLE.", false],
+            ["Criar uma CHECK CONSTRAINT na coluna regiao que bloqueia a leitura de linhas fora do escopo do usuário.", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa tem centenas de tabelas no Unity Catalog com colunas classificadas como PII espalhadas por vários catálogos. Em vez de criar uma function de mascaramento e um ALTER TABLE para cada coluna sensível individualmente, a equipe de governança quer uma única regra que mascare automaticamente qualquer coluna marcada com a tag pii, atual ou futura, em qualquer tabela. Qual abordagem do Unity Catalog atende esse requisito com menos manutenção?",
+        explanation:
+            "ABAC (attribute-based access control) no Unity Catalog permite definir policies baseadas em atributos, como tags, aplicadas automaticamente a qualquer objeto que tenha aquela tag, presente ou futuro, sem precisar de uma function e um ALTER TABLE por tabela. Isso reduz bastante a manutenção comparado a aplicar column masks manualmente objeto por objeto, mesmo que via script. Row filter atua sobre linhas, não sobre colunas, então não mascara PII, e não existe um row filter global no nível do metastore. Criar um catálogo separado e migrar os dados sensíveis exige reestruturar o layout de dados existente e não escala para colunas espalhadas em tabelas de negócio variadas.",
+        topic: "ABAC policies",
+        options: [
+            ["Criar uma function de mascaramento genérica e aplicar ALTER TABLE ... SET MASK em cada tabela por meio de um script que percorre o metastore inteiro.", false],
+            ["Definir uma policy ABAC baseada na tag pii, aplicada uma vez e reutilizada automaticamente por todas as colunas com essa tag.", true],
+            ["Marcar as colunas sensíveis com a tag pii e configurar um row filter padrão no nível do metastore.", false],
+            ["Criar um catálogo separado somente para colunas com a tag pii e migrar os dados sensíveis para ele.", false],
+        ],
+    },
+    {
+        statement:
+            "Uma organização quer compartilhar uma tabela do Unity Catalog com uma empresa parceira que também usa Databricks com Unity Catalog habilitado. Além de não duplicar os dados, a organização quer que o parceiro consiga aplicar as próprias políticas de governança, como auditoria e linhagem, sobre os dados recebidos, dentro do metastore dele. Qual abordagem do Delta Sharing atende esse cenário?",
+        explanation:
+            "No compartilhamento Databricks-to-Databricks, o destinatário, que também tem Unity Catalog, anexa o share recebido como um catálogo no próprio metastore. Isso evita copiar os dados e permite que o parceiro aplique as próprias políticas de governança, auditoria e linhagem sobre o catálogo compartilhado. Open Sharing é voltado a destinatários sem conta Databricks, usando um token de credencial com um client open source, sem esse mesmo nível de integração de governança do lado de quem recebe. Exportar arquivos duplica os dados e perde a sincronização com a fonte. Adicionar o parceiro como usuário do workspace resolveria colaboração interna, não o compartilhamento governado de dados entre metastores de organizações diferentes.",
+        topic: "Delta Sharing (Databricks-to-Databricks)",
+        options: [
+            ["Open Sharing (D2O), em que o parceiro acessa os dados por um token de credencial em um client open source.", false],
+            ["Exportar a tabela para arquivos Parquet e enviar por um bucket intermediário compartilhado entre as duas empresas.", false],
+            ["Compartilhamento Databricks-to-Databricks (D2D), em que o parceiro anexa o share como catálogo no próprio metastore.", true],
+            ["Adicionar o parceiro como usuário do workspace da própria organização e conceder SELECT diretamente na tabela para ele.", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa precisa compartilhar uma tabela com um parceiro que não tem workspace Databricks e usa apenas ferramentas como pandas e Power BI para consumir dados. A empresa não quer exigir que o parceiro crie uma conta Databricks só para acessar esses dados. Qual modelo do Delta Sharing atende esse cenário?",
+        explanation:
+            "Open Sharing, também chamado de D2O, é o modelo do Delta Sharing pensado para destinatários sem conta Databricks: a empresa que compartilha gera um arquivo de credencial que o parceiro usa em qualquer client open source do protocolo Delta Sharing, como pandas, Power BI ou Spark puro, sem precisar de workspace próprio. Databricks-to-Databricks exige que o destinatário tenha Unity Catalog para anexar o share como catálogo. Compartilhar um cluster expõe o ambiente de computação da empresa, sem relação com compartilhamento de dados governado. O Databricks SQL não publica tabelas em endpoints públicos sem autenticação.",
+        topic: "Delta Sharing (Open Sharing)",
+        options: [
+            ["Open Sharing (D2O): o Databricks gera uma credencial usada pelo parceiro em qualquer client open source do Delta Sharing.", true],
+            ["Databricks-to-Databricks (D2D), configurando o parceiro como recipient dentro do metastore de Unity Catalog da empresa.", false],
+            ["Compartilhar um cluster all-purpose com o parceiro, concedendo a ele acesso direto ao Databricks Runtime da empresa.", false],
+            ["Publicar a tabela em um endpoint público do Databricks SQL, acessível via URL sem nenhuma autenticação exigida.", false],
+        ],
+    },
+    {
+        statement:
+            "Antes de remover a coluna status_pagamento da tabela vendas.comercial.pedidos, um engenheiro de dados precisa identificar quais tabelas downstream, jobs e dashboards dependem dela, para avaliar o impacto da mudança. Qual recurso do Unity Catalog fornece essa visibilidade sem exigir nenhuma instrumentação manual prévia?",
+        explanation:
+            "O Unity Catalog captura automaticamente a linhagem em nível de tabela e de coluna a partir da execução real de consultas, jobs, notebooks e dashboards, sem exigir instrumentação manual, e exibe esse grafo no Catalog Explorer, permitindo ver rapidamente quais objetos downstream dependem de uma tabela ou coluna antes de uma mudança de schema. DESCRIBE HISTORY mostra o histórico de operações da própria tabela no Delta Lake, como inserts e merges, mas não lista quem consome os dados dela. Tags são rótulos de metadados aplicados manualmente para classificação e governança, por exemplo em policies ABAC, não um mecanismo automático de rastreamento de dependências. Vasculhar logs de auditoria manualmente é possível, mas trabalhoso, sujeito a erro e não é o recurso do Unity Catalog pensado para essa finalidade.",
+        topic: "Linhagem de dados no Unity Catalog",
+        options: [
+            ["O histórico de versões do Delta Lake (DESCRIBE HISTORY), que lista todas as tabelas que já leram dados dessa tabela.", false],
+            ["As tags aplicadas manualmente na coluna, que precisam ser configuradas para cada consumidor downstream conhecido.", false],
+            ["Os logs de auditoria do workspace, filtrados manualmente por todas as queries que mencionam o nome da coluna.", false],
+            ["O grafo de linhagem do Catalog Explorer, capturado automaticamente a partir de consultas, jobs e dashboards na tabela.", true],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe de engenharia de dados recebe arquivos JSON continuamente em um diretório de object storage na nuvem, em volumes e horários imprevisíveis ao longo do dia. Eles precisam carregar de forma incremental, para uma tabela Delta na camada bronze, somente os arquivos que ainda não foram processados, sem manter controle manual de quais arquivos já foram lidos. Qual abordagem atende esse requisito com menos esforço de implementação?",
+        explanation:
+            "O Auto Loader (cloudFiles) foi criado para ingestão incremental de arquivos em object storage: ele usa checkpoint para saber quais arquivos já foram processados e lê somente os novos, sem lógica manual. Reler o diretório inteiro com spark.read, consultar uma tabela externa por completo ou reprocessar tudo em um cluster all purpose voltam a processar dados já carregados, com custo maior e risco de duplicidade.",
+        topic: "Auto Loader",
+        options: [
+            ["Usar o Auto Loader (cloudFiles) em uma leitura streaming que ingere só os arquivos novos", true],
+            ["Programar um job em lote que executa spark.read sobre o diretório inteiro a cada agendamento", false],
+            ["Criar uma tabela externa do Unity Catalog e consultá-la por completo a cada nova execução", false],
+            ["Usar um cluster all purpose compartilhado para reprocessar o diretório inteiro todos os dias", false],
+        ],
+    },
+    {
+        statement:
+            "Um diretório recebe poucos arquivos por hora em um volume do Unity Catalog. A equipe vai usar o Auto Loader e quer o modo de descoberta de arquivos mais simples, sem configurar filas de mensagens ou notificações de eventos na nuvem. Qual modo do Auto Loader atende esse cenário, sendo também o comportamento padrão?",
+        explanation:
+            "O modo directory listing é o padrão do Auto Loader e atende bem volumes menores: ele lista periodicamente o diretório de origem e compara com o estado salvo no checkpoint para achar arquivos novos, sem exigir fila de eventos. File notification é mais indicado para altos volumes, mas exige configurar recursos de notificação na nuvem. COPY INTO não é um modo do Auto Loader, e o trigger de chegada de arquivo do Lakeflow Jobs apenas dispara a execução do job, não substitui a descoberta de arquivos feita pelo Auto Loader.",
+        topic: "Auto Loader - directory listing",
+        options: [
+            ["File notification, que exige configurar uma fila de eventos do provedor de nuvem antes do uso", false],
+            ["COPY INTO, que identifica arquivos novos comparando o histórico salvo no log da tabela Delta", false],
+            ["Directory listing, que lista periodicamente o diretório de origem e compara com o checkpoint", true],
+            ["Um trigger de chegada de arquivo do Lakeflow Jobs, dispensando qualquer listagem do diretório", false],
+        ],
+    },
+    {
+        statement:
+            "Um diretório na nuvem recebe milhões de arquivos por dia, distribuídos em muitas subpastas. A equipe percebeu que a listagem periódica do diretório pelo Auto Loader está ficando lenta e cara. Qual configuração resolve esse problema de escala?",
+        explanation:
+            "Para altíssimos volumes de arquivos, o Auto Loader recomenda o modo file notification: ele usa recursos de notificação de eventos do provedor de nuvem para saber quando um arquivo novo chega, evitando listagens caras do diretório. Reduzir o intervalo do trigger ou particionar o diretório ainda dependem de listagem e não resolvem o custo em grande escala, e o COPY INTO não usa esse mecanismo orientado a eventos nem escala da mesma forma para volumes muito altos.",
+        topic: "Auto Loader - file notification",
+        options: [
+            ["Reduzir o intervalo do trigger da leitura streaming para listar o diretório com mais frequência", false],
+            ["Habilitar o file notification do Auto Loader, que usa eventos da nuvem para achar arquivos novos", true],
+            ["Migrar a ingestão para COPY INTO, que escala automaticamente para qualquer volume de arquivos", false],
+            ["Particionar o diretório de origem por data para reduzir os arquivos percorridos a cada listagem", false],
+        ],
+    },
+    {
+        statement:
+            "Ao usar o Auto Loader sem informar um schema, uma equipe percebe que todas as colunas de um JSON, inclusive campos numéricos, são inferidas como string. Eles querem que a inferência automática reconheça tipos mais específicos, como números, datas e booleanos, sem informar o schema manualmente. Qual opção resolve isso?",
+        explanation:
+            "Por padrão, ao inferir o schema de fontes semiestruturadas como JSON, o Auto Loader trata as colunas como string. A opção cloudFiles.inferColumnTypes definida como true faz a inferência considerar tipos mais específicos, como números, datas e booleanos. schemaEvolutionMode controla como novas colunas são tratadas após a inferência inicial, não o tipo inferido; useNotifications controla o mecanismo de descoberta de arquivos; e mudar schemaLocation apenas reinicia o rastreamento do schema, sem alterar como os tipos são inferidos.",
+        topic: "Auto Loader - inferencia de schema",
+        options: [
+            ["Definir cloudFiles.schemaEvolutionMode como failOnNewColumns para obrigar tipos numéricos", false],
+            ["Definir cloudFiles.useNotifications como true para recalcular os tipos a cada novo arquivo", false],
+            ["Apontar cloudFiles.schemaLocation para um novo diretório, reiniciando o rastreamento do schema", false],
+            ["Definir cloudFiles.inferColumnTypes como true para que a inferência use tipos mais específicos", true],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe deixa o Auto Loader inferir o schema automaticamente, mas precisa garantir que a coluna valor_pedido seja sempre tratada como DECIMAL(10,2), sem informar manualmente o tipo de todas as outras colunas do arquivo. Qual opção atende exatamente essa necessidade?",
+        explanation:
+            "cloudFiles.schemaHints permite declarar o tipo de uma ou mais colunas específicas para orientar a inferência do Auto Loader, sem informar o schema inteiro da tabela. schemaEvolutionMode trata apenas como colunas futuras são incorporadas, não o tipo de uma coluna já existente; informar o schema completo funciona mas exige mais esforço do que o necessário para esse caso; e inferColumnTypes melhora a inferência de forma geral, mas não garante um tipo específico e uma precisão exata para uma única coluna.",
+        topic: "Auto Loader - schema hints",
+        options: [
+            ["Usar a opção cloudFiles.schemaHints para declarar o tipo somente da coluna valor_pedido", true],
+            ["Definir cloudFiles.schemaEvolutionMode como rescue para fixar o tipo da coluna valor_pedido", false],
+            ["Informar manualmente o schema completo da tabela, com o tipo de cada coluna do arquivo", false],
+            ["Ativar cloudFiles.inferColumnTypes e aguardar a correção automática do tipo ao longo do tempo", false],
+        ],
+    },
+    {
+        statement:
+            "Uma leitura com Auto Loader está configurada sem definir explicitamente cloudFiles.schemaEvolutionMode. Uma nova coluna passa a aparecer nos arquivos JSON de origem, sem nunca ter existido antes. Qual é o comportamento padrão do Auto Loader nesse caso?",
+        explanation:
+            "No modo padrão de evolução de schema do Auto Loader (addNewColumns), uma coluna nunca vista antes faz o stream falhar uma vez de propósito: nesse momento o schema é atualizado para incluir a coluna nova e, ao reiniciar, o processamento continua de onde parou, sem reprocessar arquivos já lidos. Ignorar a coluna silenciosamente é o comportamento do modo none, exigir recriação manual da tabela não é o padrão, e mandar tudo para _rescued_data é o comportamento do modo rescue, não do addNewColumns.",
+        topic: "Auto Loader - evolucao de schema",
+        options: [
+            ["A coluna nova é ignorada silenciosamente e o processamento continua sem nenhuma interrupção", false],
+            ["O stream para de forma definitiva e só volta com a recriação manual da tabela de destino", false],
+            ["O stream falha uma vez, o schema é atualizado e o processamento é retomado automaticamente", true],
+            ["A coluna nova é descartada e seu conteúdo passa a ser gravado somente em _rescued_data", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe quer que o stream do Auto Loader nunca falhe por causa de divergências de schema, como coluna extra ou tipo diferente do esperado, mas ainda assim quer capturar esses dados divergentes para análise posterior, em vez de simplesmente perdê-los. Qual configuração atende essa necessidade?",
+        explanation:
+            "O modo rescue mantém o schema da tabela fixo e nunca falha o stream por divergência: qualquer dado fora do schema esperado, como coluna extra ou tipo diferente, é capturado na coluna _rescued_data para análise posterior. addNewColumns também evolui o schema, mas provoca uma falha controlada do stream a cada coluna nova; failOnNewColumns interrompe o stream exigindo intervenção manual, sem arquivar nada automaticamente em outra tabela; e o Auto Loader não tem uma opção cloudFiles.validateOptions para desativar a validação de schema.",
+        topic: "Auto Loader - rescued data",
+        options: [
+            ["Definir cloudFiles.schemaEvolutionMode como addNewColumns, que nunca interrompe o stream", false],
+            ["Definir cloudFiles.schemaEvolutionMode como rescue, que grava os dados divergentes em _rescued_data", true],
+            ["Definir cloudFiles.schemaEvolutionMode como failOnNewColumns, que arquiva os dados em outra tabela", false],
+            ["Desativar a validação de schema do Auto Loader pela opção cloudFiles.validateOptions", false],
+        ],
+    },
+    {
+        statement:
+            "Um stream do Auto Loader que ingere arquivos para uma tabela bronze cai por instabilidade de rede e é reiniciado horas depois. A equipe quer ter certeza de que arquivos já ingeridos antes da queda não serão lidos de novo, evitando duplicidade na tabela de destino. O que garante esse comportamento?",
+        explanation:
+            "checkpointLocation é o mecanismo de tolerância a falhas do Auto Loader: ele guarda o progresso da leitura, então, ao reiniciar, o stream retoma exatamente de onde parou, sem reprocessar arquivos já ingeridos. Tabelas Delta não removem duplicatas automaticamente sem uma lógica explícita de deduplicação; schemaLocation guarda o schema inferido e seu histórico de evolução, não a lista de arquivos processados; e o Auto Loader não recalcula hash de arquivos para decidir reprocessamento.",
+        topic: "Auto Loader - checkpoint",
+        options: [
+            ["A tabela Delta remove automaticamente qualquer linha duplicada após cada reinício do stream", false],
+            ["cloudFiles.schemaLocation guarda a lista de arquivos já lidos e impede a releitura deles", false],
+            ["O Databricks recalcula o hash de cada arquivo do diretório para decidir se ele será reprocessado", false],
+            ["checkpointLocation registra o progresso do processamento, retomando exatamente de onde parou", true],
+        ],
+    },
+    {
+        statement:
+            "Dentro de um pipeline declarativo do Lakeflow, uma equipe quer declarar uma streaming table na camada bronze que ingere arquivos JSON de um diretório na nuvem de forma incremental, aproveitando a lógica do Auto Loader dentro do próprio SQL do pipeline. Qual definição faz isso corretamente?",
+        explanation:
+            "Dentro de um pipeline declarativo do Lakeflow, a forma correta de ingerir arquivos de forma incremental na bronze é declarar uma streaming table lendo com STREAM read_files, o que aplica a lógica do Auto Loader, leitura incremental com checkpoint automático, sobre o diretório de origem. Uma materialized view sobre read_files trata a fonte como uma consulta que pode ser recalculada, não como um fluxo incremental linha a linha; declarar STREAMING TABLE mas ler com read_files sem a palavra chave STREAM não aplica a semântica incremental esperada; e um CREATE TABLE comum também não processa a fonte de forma incremental.",
+        topic: "Auto Loader com Lakeflow Spark Declarative Pipelines",
+        options: [
+            ["CREATE OR REFRESH STREAMING TABLE bronze_eventos AS SELECT * FROM STREAM read_files('/raw/eventos', format => 'json')", true],
+            ["CREATE MATERIALIZED VIEW bronze_eventos AS SELECT * FROM read_files('/raw/eventos', format => 'json')", false],
+            ["CREATE OR REFRESH STREAMING TABLE bronze_eventos AS SELECT * FROM read_files('/raw/eventos', format => 'json')", false],
+            ["CREATE TABLE bronze_eventos AS SELECT *, current_timestamp() AS data_hora_da_carga, input_file_name() AS arquivo_origem FROM json.`/raw/eventos`", false],
+        ],
+    },
+    {
+        statement:
+            "Um job agendado executa o mesmo comando COPY INTO uma vez por dia, apontando sempre para a mesma pasta de origem, onde novos arquivos podem ter sido adicionados desde a última execução. A equipe quer garantir que arquivos já carregados em execuções anteriores não sejam carregados de novo, sem escrever nenhuma lógica de controle própria. Por que esse comportamento é garantido?",
+        explanation:
+            "O COPY INTO foi projetado para ser idempotente e retomável: a cada execução, ele verifica quais arquivos do local de origem já foram carregados na tabela de destino, com base no histórico mantido pelo próprio comando, e processa somente os arquivos novos, mesmo que seja executado várias vezes sobre o mesmo diretório. Ele não recria a tabela de destino a cada execução, não exige esvaziar o diretório de origem manualmente, e não bloqueia a tabela de destino para leitura entre execuções.",
+        topic: "COPY INTO",
+        options: [
+            ["Porque cada execução do COPY INTO recria a tabela de destino vazia antes de carregar os dados", false],
+            ["Porque o COPY INTO exige que o diretório de origem seja esvaziado após cada carga bem sucedida", false],
+            ["Porque o COPY INTO é idempotente: ele rastreia os arquivos já carregados e ignora os repetidos", true],
+            ["Porque o COPY INTO bloqueia a tabela de destino para leitura entre duas execuções agendadas", false],
+        ],
+    },
+    {
+        statement:
+            "Uma pasta recebe algumas centenas de arquivos por dia, sempre na mesma janela noturna, e a equipe quer a solução mais simples em SQL para uma carga diária agendada, sem montar infraestrutura de streaming nem gerenciar checkpoint. Qual opção é a MAIS adequada para esse cenário?",
+        explanation:
+            "Para cargas periódicas e previsíveis, com um volume moderado de arquivos e sem necessidade de processamento contínuo, o COPY INTO é a opção mais simples: um único comando SQL, idempotente, sem exigir streaming nem checkpoint. O Auto Loader com file notification ou trigger contínuo é mais indicado quando o volume de arquivos é muito grande ou a ingestão precisa ser contínua, o que adiciona complexidade desnecessária aqui. AUTO CDC serve para aplicar mudanças de um feed de CDC com chaves definidas, não para comparar o conteúdo de um diretório de arquivos brutos.",
+        topic: "COPY INTO x Auto Loader",
+        options: [
+            ["Auto Loader com o modo file notification, por escalar melhor para grandes volumes contínuos", false],
+            ["COPY INTO, por ser um comando SQL simples adequado a cargas periódicas com poucos arquivos", true],
+            ["Auto Loader com trigger contínuo, mantendo o cluster ligado para captar os arquivos assim que chegam", false],
+            ["Um pipeline com AUTO CDC comparando o diretório de origem com o estado atual da tabela", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer trazer dados do Salesforce para tabelas do Unity Catalog, com atualização incremental ao longo do tempo, sem escrever código customizado de integração com a API nem gerenciar autenticação e paginação manualmente. Qual é a abordagem recomendada?",
+        explanation:
+            "O Lakeflow Connect oferece conectores gerenciados prontos para aplicações SaaS como Salesforce: a configuração é feita via interface gráfica ou API, sem código customizado, e o próprio conector cuida da extração incremental ao longo do tempo. Escrever integração manual com a API REST, depender de exportações manuais para um bucket ou usar consultas federadas via Lakeflow Jobs exigem muito mais esforço de engenharia e manutenção do que usar o conector gerenciado já existente para esse fim.",
+        topic: "Lakeflow Connect - conectores gerenciados",
+        options: [
+            ["Usar um conector gerenciado do Lakeflow Connect para Salesforce, com atualização incremental", true],
+            ["Escrever um notebook PySpark que chama a API REST do Salesforce e grava os dados com COPY INTO", false],
+            ["Configurar o Auto Loader sobre um export manual periódico do Salesforce em um bucket na nuvem", false],
+            ["Criar um job do Lakeflow Jobs com consultas SQL federadas diretamente contra o Salesforce", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa precisa replicar dados de um banco SQL Server on premises para o Unity Catalog, capturando mudanças de forma incremental por meio de um conector de banco de dados do Lakeflow Connect. Que componente, implantado próximo à origem, normalmente é necessário para capturar e preparar essas mudanças antes da pipeline de ingestão aplicá-las?",
+        explanation:
+            "Para bancos de dados como o SQL Server, o Lakeflow Connect usa um gateway de ingestão: um componente implantado próximo à origem, na mesma rede, que captura as mudanças do banco e as prepara antes que a pipeline de ingestão gerenciada as aplique nas tabelas do Unity Catalog. Não existe a noção de cluster job do Unity Catalog para esse fim; o AUTO CDC roda do lado do Databricks para aplicar mudanças em uma tabela Delta, não dentro do banco de origem; e Databricks Git Folders servem para versionar código, não para capturar dados de um banco.",
+        topic: "Lakeflow Connect - conector de banco de dados",
+        options: [
+            ["Um cluster job compartilhado do Unity Catalog, instalado na mesma rede do banco de origem", false],
+            ["Uma pipeline com AUTO CDC executando diretamente dentro do próprio banco SQL Server", false],
+            ["Um gateway de ingestão, implantado próximo à origem, que captura e prepara as mudanças", true],
+            ["Um Databricks Git Folder sincronizado com o servidor do banco para versionar o schema", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe quer ingerir arquivos novos na camada bronze usando Auto Loader, mas sem manter um cluster de streaming ativo 24 horas por dia. A ideia é um job do Lakeflow Jobs que liga o cluster de hora em hora, processa tudo o que chegou desde a última execução e desliga o cluster em seguida, preservando o rastreamento incremental do Auto Loader entre as execuções. Qual trigger do Structured Streaming permite esse padrão?",
+        explanation:
+            "Trigger.AvailableNow processa, em modo micro batch, todos os dados novos disponíveis no momento da execução e encerra o stream automaticamente ao terminar, o que combina bem com um job agendado do Lakeflow Jobs que liga o cluster, processa o que chegou e desliga o cluster, preservando o rastreamento incremental do Auto Loader entre execuções. O trigger contínuo mantém o cluster ativo indefinidamente buscando baixa latência; reduzir o processingTime deixa o stream contínuo mais frequente, sem encerrá-lo; e a ausência de trigger explícito não faz o Auto Loader controlar o ciclo de vida do cluster sozinho.",
+        topic: "Ingestao incremental - trigger AvailableNow",
+        options: [
+            ["Trigger contínuo (continuous), que mantém baixa latência com o cluster ativo o tempo todo", false],
+            ["Trigger.AvailableNow, que processa os arquivos novos disponíveis no momento e encerra o stream", true],
+            ["Trigger com processingTime bem curto, de poucos segundos, entre cada execução do cluster", false],
+            ["Ausência de trigger explícito, deixando o Auto Loader decidir sozinho quando desligar o cluster", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe precisa ingerir um diretório com arquivos PDF e imagens, conteúdo não estruturado, para uma tabela bronze, de forma que uma etapa posterior de machine learning acesse os bytes brutos de cada arquivo junto com metadados como caminho, data de modificação e tamanho, sem que o Databricks tente interpretar a estrutura interna dos arquivos. Qual formato do Auto Loader deve ser usado?",
+        explanation:
+            "O formato binaryFile do Auto Loader foi feito para ingerir arquivos não estruturados, como imagens e PDFs, sem tentar interpretar o conteúdo: cada registro traz o conteúdo binário bruto do arquivo, além de metadados como caminho, data de modificação e tamanho. O formato text pressupõe conteúdo textual linha a linha e não preserva os mesmos metadados; parquet exige que os arquivos sigam o layout colunar do Parquet; e usar json sobre arquivos binários não faz sentido, pois não há estrutura JSON para inferir.",
+        topic: "Formatos de arquivo - binaryFile",
+        options: [
+            ["O formato text, que lê cada arquivo como uma única coluna de texto corrido", false],
+            ["O formato parquet, que exige que os arquivos sigam o layout de colunas do Parquet", false],
+            ["O formato json combinado com cloudFiles.inferColumnTypes para inferir a estrutura dos arquivos", false],
+            ["O formato binaryFile, que traz o conteúdo bruto de cada arquivo junto com seus metadados", true],
+        ],
+    },
+    {
+        statement:
+            "Dentro de um pipeline declarativo do Lakeflow, uma equipe decide entre streaming table e materialized view para a camada bronze. O requisito é que cada registro de origem seja processado exatamente uma vez, de forma incremental e append-only, sem recalcular o que já foi processado. Qual objeto atende esse requisito e por quê?",
+        explanation:
+            "A streaming table é a escolha adequada para a camada bronze porque processa cada registro de entrada exatamente uma vez, de forma incremental e append-only, apoiada em Structured Streaming, sem recalcular o que já foi processado. A materialized view representa o resultado de uma consulta, inclusive com agregações, e pode recalcular parte ou todo o resultado quando os dados de entrada mudam, além de não oferecer o mesmo controle de checkpoint de uma leitura streaming. Uma streaming table também não recalcula o conteúdo inteiro a cada atualização, apenas o incremento novo.",
+        topic: "Streaming tables",
+        options: [
+            ["Materialized view, pois recalcula o resultado da consulta sempre que uma agregação muda", false],
+            ["Materialized view, pois oferece o mesmo controle de checkpoint de uma leitura streaming", false],
+            ["Streaming table, pois recalcula o conteúdo inteiro da tabela a cada atualização do pipeline", false],
+            ["Streaming table, pois processa cada registro de entrada exatamente uma vez, de forma append-only", true],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe está avaliando o comportamento do Auto Loader antes de adotá-lo para a camada bronze. Quais DUAS afirmações a seguir estão corretas? (Selecione DUAS opções.)",
+        explanation:
+            "checkpointLocation é essencial para o Auto Loader retomar a leitura sem reprocessar arquivos já ingeridos, e o modo de evolução rescue evita falhas do stream por schema divergente, enviando os dados fora do schema esperado para _rescued_data. O Auto Loader suporta vários formatos além de Parquet, como JSON, CSV, Avro, texto e binaryFile; o modo padrão de descoberta de arquivos é directory listing, não file notification; e o Auto Loader consegue inferir o schema automaticamente, sem exigir que ele seja informado manualmente antes da primeira execução.",
+        topic: "Auto Loader",
+        options: [
+            ["O Auto Loader lê apenas arquivos no formato Parquet, sem suportar JSON, CSV ou Avro", false],
+            ["checkpointLocation guarda o progresso da ingestão, evitando reprocessar arquivos já lidos", true],
+            ["O modo file notification é o padrão do Auto Loader, independente do volume de arquivos", false],
+            ["O modo de evolução rescue grava dados fora do schema esperado na coluna _rescued_data", true],
+            ["O schema completo da fonte precisa ser informado manualmente antes da primeira execução", false],
+        ],
+    },
+    {
+        statement:
+            "Sobre o comando COPY INTO no Databricks, quais DUAS afirmações a seguir estão corretas? (Selecione DUAS opções.)",
+        explanation:
+            "O COPY INTO é idempotente, não recarrega arquivos já processados, e é expresso como um comando SQL simples, o que o torna adequado para cargas agendadas e periódicas. Ele não é a melhor opção para volumes muito altos e contínuos de arquivos, cenário em que o Auto Loader escala melhor; o COPY INTO também não cria uma pipeline de streaming contínua, sendo executado sob demanda ou por agendamento; e o conceito de checkpoint de streaming pertence ao Auto Loader e ao Structured Streaming, não ao COPY INTO.",
+        topic: "COPY INTO",
+        options: [
+            ["É idempotente: arquivos já carregados em execuções anteriores não são carregados de novo", true],
+            ["Substitui com vantagem o Auto Loader em qualquer cenário com milhões de arquivos contínuos", false],
+            ["É executado como um comando SQL, o que facilita seu uso em cargas agendadas simples", true],
+            ["Cria automaticamente uma pipeline de streaming contínua para manter a tabela atualizada", false],
+            ["Exige a criação prévia de um checkpoint de streaming para conseguir funcionar corretamente", false],
+        ],
+    },
+    {
+        statement:
+            "Sobre o Lakeflow Connect, quais DUAS afirmações a seguir estão corretas? (Selecione DUAS opções.)",
+        explanation:
+            "O Lakeflow Connect disponibiliza conectores gerenciados prontos para aplicações SaaS e bancos de dados, como Salesforce e SQL Server, e alguns conectores de banco de dados dependem de um gateway implantado próximo à origem para capturar as mudanças antes de aplicá-las no Unity Catalog. Ler arquivos de object storage é o papel típico do Auto Loader ou do COPY INTO, não uma exclusividade do Lakeflow Connect; os conectores gerenciados existem justamente para dispensar código customizado de extração; e o Lakeflow Connect suporta atualização incremental, inclusive CDC, não apenas cargas totais.",
+        topic: "Lakeflow Connect",
+        options: [
+            ["É a única forma suportada no Databricks para ler arquivos de um bucket de object storage", false],
+            ["Os conectores gerenciados exigem código customizado de extração para cada nova fonte", false],
+            ["Oferece conectores gerenciados para SaaS e bancos de dados, como Salesforce e SQL Server", true],
+            ["Só realiza cargas totais (full load) dos dados de origem, sem suporte a atualização incremental", false],
+            ["Para alguns conectores de banco de dados, usa um gateway implantado próximo à origem", true],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe de engenharia de dados está construindo um job no Lakeflow Jobs com quatro tasks: ingest_bronze, transform_silver, transform_gold e publish_dashboard. A task publish_dashboard só pode começar depois que transform_silver e transform_gold tiverem terminado com sucesso. Qual é a forma correta de configurar essa exigência?",
+        explanation:
+            "A dependência entre tasks em um job multi-task do Lakeflow Jobs é definida no campo Depends on de cada task: ao adicionar transform_silver e transform_gold como dependências de publish_dashboard, essa task só inicia quando as duas terminarem com sucesso, formando o DAG do job. Colocar tudo em um notebook único elimina o paralelismo e o controle individual de cada etapa. Um trigger table update controla quando o job inteiro começa a rodar, não a ordem interna das tasks. O parâmetro max_concurrent_runs limita quantas execuções do job podem rodar ao mesmo tempo, sem nenhum efeito sobre a ordem das tasks dentro de uma mesma execução.",
+        topic: "Lakeflow Jobs - DAG e dependencias entre tasks",
+        options: [
+            ["Colocar as quatro tasks em sequência dentro de um único notebook, sem criar tasks separadas no job", false],
+            ["Configurar um trigger do tipo table update apontando para as tabelas silver e gold usadas pelo job", false],
+            ["Adicionar transform_silver e transform_gold como dependência (Depends on) da task publish_dashboard", true],
+            ["Definir o parâmetro max_concurrent_runs do job como 1 para forçar uma ordem sequencial entre as tasks", false],
+        ],
+    },
+    {
+        statement:
+            "A equipe financeira da empresa Nortis precisa que um job de consolidação contábil rode todos os dias úteis às 06:00 no horário de Brasília, processando os dados fechados no dia anterior. Qual configuração de trigger do Lakeflow Jobs atende esse requisito com menor esforço operacional?",
+        explanation:
+            "O requisito é um horário fixo e recorrente (dias úteis às 06:00 no fuso de Brasília), que é exatamente o que o trigger Scheduled resolve com uma expressão cron e fuso horário configurável. O trigger Continuous mantém o job reiniciando sem parar, sem respeitar um horário específico. O trigger File arrival reage à chegada de arquivos, não a um horário fixo, então o job só rodaria quando algo fosse gravado no volume. O trigger Table update reage a mudanças em uma tabela Delta, também sem garantir o horário exato exigido pela equipe financeira.",
+        topic: "Lakeflow Jobs triggers (Scheduled)",
+        options: [
+            ["Um trigger Scheduled com expressão cron para dias úteis às 06:00 e fuso horário America/Sao_Paulo", true],
+            ["Um trigger Continuous, que reinicia o job automaticamente assim que cada execução anterior termina", false],
+            ["Um trigger File arrival apontando para o volume onde os arquivos contábeis são gravados todo dia", false],
+            ["Um trigger Table update monitorando a tabela de lançamentos contábeis usada como origem do job", false],
+        ],
+    },
+    {
+        statement:
+            "Um time de dados recebe arquivos CSV de um parceiro em um volume do Unity Catalog em horários irregulares, às vezes várias vezes ao dia, às vezes nenhuma. Eles querem que o job de ingestão comece assim que novos arquivos chegarem, sem manter o job rodando o tempo todo e sem depender de um horário fixo. Qual trigger do Lakeflow Jobs resolve isso?",
+        explanation:
+            "O trigger File arrival monitora um caminho (como um volume do Unity Catalog ou um external location) e dispara uma nova execução automaticamente quando novos arquivos chegam, sem manter o job ativo o tempo todo e sem depender de um horário fixo, exatamente o que o time precisa. Um Scheduled a cada 5 minutos gera execuções desnecessárias quando não há arquivo novo, além de não reagir de forma imediata. Continuous mantém o job rodando sem parar, o que contraria o requisito de não manter o job ativo o tempo todo. Table update reage a mudanças em tabelas Delta gerenciadas, não à chegada de arquivos brutos em um volume.",
+        topic: "Lakeflow Jobs triggers (File arrival)",
+        options: [
+            ["Trigger Scheduled configurado para rodar a cada 5 minutos, verificando se há arquivos novos no volume", false],
+            ["Trigger Continuous, mantendo uma execução ativa o tempo todo para ler o volume continuamente", false],
+            ["Trigger Table update apontando para uma tabela externa que referencia os arquivos do volume", false],
+            ["Trigger File arrival apontando para o caminho do volume onde os arquivos do parceiro chegam", true],
+        ],
+    },
+    {
+        statement:
+            "A tabela Delta silver.pedidos é atualizada em horários irregulares por um pipeline mantido por outra equipe. Sempre que essa tabela recebe dados novos, um job downstream precisa recalcular os agregados da camada gold o quanto antes, sem que a equipe consumidora precise saber em que horário o pipeline upstream roda. Qual trigger atende esse cenário?",
+        explanation:
+            "O trigger Table update permite que um job seja disparado automaticamente quando uma tabela específica do Unity Catalog recebe novos dados, desacoplando o job downstream do horário em que o pipeline upstream roda, que é exatamente o requisito descrito. Um Scheduled de hora em hora não garante que o job rode logo após a atualização, podendo processar dados atrasados ou rodar sem necessidade. File arrival monitora a chegada de arquivos brutos em um caminho, não mudanças lógicas em uma tabela Delta gerenciada. É falso que tabelas Delta só possam ser monitoradas por jobs contínuos, o trigger Table update foi criado justamente para esse cenário reativo sem precisar de um job rodando sem parar.",
+        topic: "Lakeflow Jobs triggers (Table update)",
+        options: [
+            ["Trigger Scheduled configurado para rodar a cada hora, na tentativa de acompanhar o pipeline upstream", false],
+            ["Trigger Table update, monitorando diretamente a tabela silver.pedidos registrada no Unity Catalog", true],
+            ["Trigger File arrival apontando para o diretório de armazenamento físico da tabela silver.pedidos", false],
+            ["Trigger Continuous, já que tabelas Delta só podem ser monitoradas por jobs contínuos no Lakeflow", false],
+        ],
+    },
+    {
+        statement:
+            "Um job lê eventos de um tópico Kafka usando Structured Streaming e precisa processar os dados com a menor latência possível, iniciando uma nova execução automaticamente assim que a execução anterior for encerrada, inclusive após uma falha. Qual configuração de trigger do Lakeflow Jobs é mais adequada?",
+        explanation:
+            "O trigger Continuous mantém o job sempre em execução, iniciando automaticamente uma nova tentativa assim que a execução atual termina (inclusive após falha), o que dá a menor latência possível para um job de streaming contínuo. O Scheduled, mesmo com a granularidade mínima em minutos, sempre deixa uma lacuna entre execuções, incompatível com o requisito de reinício imediato. File arrival não faz sentido para um checkpoint location, que não é um caminho de chegada de dados de origem. Table update monitorando a própria tabela de saída do job criaria uma dependência circular e não atende o requisito de latência contínua.",
+        topic: "Lakeflow Jobs triggers (Continuous)",
+        options: [
+            ["Trigger Continuous, que inicia uma nova execução automaticamente assim que a anterior termina", true],
+            ["Trigger Scheduled com a menor granularidade permitida pela expressão cron do Lakeflow Jobs", false],
+            ["Trigger File arrival apontando para o checkpoint location usado pelo Structured Streaming", false],
+            ["Trigger Table update monitorando a própria tabela de destino gravada por esse mesmo job", false],
+        ],
+    },
+    {
+        statement:
+            "A task ingest_api de um job falha ocasionalmente porque a API externa retorna erro 503 por instabilidade momentânea, mas costuma funcionar normalmente quando executada de novo minutos depois. A equipe quer que o Lakeflow Jobs tente executar essa task automaticamente mais uma vez antes de marcar o job como falho. Qual configuração resolve isso sem intervenção manual?",
+        explanation:
+            "Cada task de um job do Lakeflow Jobs pode ter um número de retries e um intervalo mínimo entre tentativas configurados diretamente nela: quando a task falha, o Databricks tenta executá-la novamente de forma automática, sem precisar de nenhuma intervenção manual, o que resolve falhas transitórias como o erro 503. Um trigger Continuous reinicia o job inteiro, não apenas a task que falhou, sendo bem mais disruptivo. O Repair Run é um recurso manual (ou disparado via API), acionado depois que uma execução já terminou com falha, e não um mecanismo automático dentro da própria execução. Aumentar o timeout apenas dá mais tempo para a task rodar, mas não faz o Databricks tentar de novo depois de um erro 503.",
+        topic: "Lakeflow Jobs retries",
+        options: [
+            ["Configurar um trigger Continuous para o job inteiro reiniciar automaticamente após qualquer falha", false],
+            ["Usar o Repair Run para que o Databricks vá reexecutando essa task até que ela funcione sozinha", false],
+            ["Configurar um número de retries e o intervalo entre tentativas na própria task ingest_api", true],
+            ["Aumentar o timeout da task para que ela espere mais tempo antes de ser considerada com falha", false],
+        ],
+    },
+    {
+        statement:
+            "Em um job multi-task do Lakeflow Jobs, cada task com dependências pode configurar uma condição de Run if dependencies, que controla quando ela deve rodar de acordo com o resultado das tasks das quais depende. Quais afirmações abaixo sobre esse recurso estão corretas? (Selecione DUAS opções.)",
+        explanation:
+            "Run if dependencies é configurável individualmente em cada task que tem dependências (Depends on), com opções como All succeeded (padrão), At least one failed, All done, entre outras: por isso a condição At least one failed de fato faz a task rodar quando pelo menos uma dependência falhou, e o padrão quando nada é alterado é mesmo All succeeded. É falso que a condição se propague igual para todas as tasks do job, cada task define a sua própria de forma independente. Também é falso que Run if dependencies substitua o Depends on, os dois recursos trabalham juntos: o Depends on define as arestas do DAG e o Run if dependencies define a condição de disparo sobre essas arestas. É falso que o recurso seja exclusivo de tasks do tipo Notebook, ele se aplica a qualquer tipo de task.",
+        topic: "Lakeflow Jobs Run If (tratamento de falha por task)",
+        options: [
+            ["O recurso Run if dependencies substitui a necessidade de configurar Depends on entre as tasks", false],
+            ["A condição At least one failed faz a task rodar quando ao menos uma dependência direta falhou", true],
+            ["Depois de definida em uma task, a mesma condição passa a valer para todas as outras tasks do job", false],
+            ["A condição padrão para uma task com dependências é All succeeded: ela só roda se todas tiverem sucesso", true],
+            ["O recurso Run if dependencies só pode ser configurado em tasks do tipo Notebook, e não nos demais tipos", false],
+        ],
+    },
+    {
+        statement:
+            "Um job com seis tasks encadeadas falhou porque a quarta task, load_gold, não conseguiu escrever na tabela de destino devido a uma indisponibilidade momentânea de storage. As três primeiras tasks foram concluídas com sucesso e as duas últimas foram puladas por dependerem da que falhou. Depois de confirmar que o storage está normal, qual é a forma mais eficiente de retomar a execução sem reprocessar o que já funcionou?",
+        explanation:
+            "O Repair Run foi feito exatamente para esse cenário: ele reexecuta apenas as tasks que falharam ou foram puladas (e as que dependem delas), reaproveitando os resultados das tasks que já tinham sido concluídas com sucesso, sem custo de reprocessar o que já funcionou. Rodar o job inteiro de novo com Run Now repete desnecessariamente as três primeiras tasks. Remover tasks da definição do job é uma forma manual, arriscada e não pensada para esse fim, além de não preservar o histórico da execução original. Clonar o job inteiro só para rodar uma task isolada perde as dependências e o contexto da execução original, sendo bem mais trabalhoso que um Repair Run.",
+        topic: "Lakeflow Jobs Repair Run",
+        options: [
+            ["Disparar uma nova execução completa do job (Run Now), repetindo as seis tasks desde o início", false],
+            ["Usar o Repair Run para reexecutar somente a task load_gold e as tasks que dependem dela", true],
+            ["Editar a definição do job para remover temporariamente as três primeiras tasks já concluídas", false],
+            ["Clonar o job inteiro e rodar o clone apenas com a task load_gold configurada nele", false],
+        ],
+    },
+    {
+        statement:
+            "A mesma definição de job precisa processar um catálogo diferente dependendo do ambiente: dev no catálogo dev_vendas e produção no catálogo prod_vendas. A equipe quer evitar duplicar a definição do job só para trocar o nome do catálogo, podendo alterar esse valor facilmente a cada execução manual, sem editar o código do notebook. Qual recurso do Lakeflow Jobs atende essa necessidade?",
+        explanation:
+            "Job parameters são definidos uma vez no nível do job e podem ser referenciados por qualquer task usando uma referência dinâmica como {{job.parameters.catalog_name}}, além de poderem ser sobrescritos facilmente a cada execução manual, sem duplicar a definição do job nem editar código. Criar duas cópias do job é exatamente a duplicação que a equipe quer evitar. Variável de ambiente no cluster job compute não é o mecanismo que o Lakeflow Jobs expõe para parametrizar tasks, e não é fácil de alterar por execução. O Repair Run serve para retomar uma execução que já falhou, não para definir ou alterar parâmetros de entrada de novas execuções.",
+        topic: "Lakeflow Jobs parametros de job",
+        options: [
+            ["Criar duas cópias completas do job, uma fixa para o ambiente dev e outra fixa para produção", false],
+            ["Definir o nome do catálogo como uma variável de ambiente fixada na configuração do cluster job compute", false],
+            ["Usar o Repair Run a cada execução manual apenas para sobrescrever o nome do catálogo usado", false],
+            ["Definir um job parameter, como catalog_name, e referenciá-lo nas tasks com {{job.parameters.catalog_name}}", true],
+        ],
+    },
+    {
+        statement:
+            "A task validate_bronze conta quantos registros inválidos foram descartados durante a validação, e a task decide_alert, que roda logo em seguida, precisa usar essa contagem para decidir se dispara um alerta. As duas tasks rodam em notebooks separados dentro do mesmo job. Qual é a forma nativa do Lakeflow Jobs de passar esse número de uma task para a outra?",
+        explanation:
+            "Task values é o mecanismo nativo do Lakeflow Jobs para passar pequenos valores entre tasks: usa-se dbutils.jobs.taskValues.set(chave, valor) na task de origem e dbutils.jobs.taskValues.get(nome_da_task, chave) na task seguinte, feito exatamente para esse tipo de comunicação. As tasks de um job rodam em execuções isoladas, podendo até usar clusters diferentes, então não compartilham processo Spark nem variáveis Python em memória. O disco local do driver também não é garantido entre tasks diferentes, já que cada uma pode rodar em um cluster distinto. Job parameters são valores de entrada definidos antes do job começar a rodar, não um mecanismo para gravar resultados calculados durante a execução.",
+        topic: "Lakeflow Jobs task values",
+        options: [
+            ["Gravar o valor com dbutils.jobs.taskValues.set() em validate_bronze e lê-lo com taskValues.get() em decide_alert", true],
+            ["Salvar o número em uma variável Python global, assumindo que as duas tasks compartilham o mesmo processo Spark", false],
+            ["Escrever o valor em um arquivo temporário no disco local do driver e tentar lê-lo a partir da task seguinte", false],
+            ["Usar um job parameter definido antes da execução para armazenar um resultado calculado durante o próprio job", false],
+        ],
+    },
+    {
+        statement:
+            "A equipe de plataforma quer ser avisada automaticamente pelo Lakeflow Jobs em duas situações de um job crítico: quando a execução falhar e quando a execução ultrapassar um tempo de duração considerado normal, mesmo que ainda esteja rodando. Quais recursos nativos de notificação do Lakeflow Jobs atendem essas duas situações? (Selecione DUAS opções.)",
+        explanation:
+            "O Lakeflow Jobs permite configurar notificações nativas por e-mail (ou por webhooks de destino, como Slack e Microsoft Teams) para eventos como início, sucesso e falha da execução, o que cobre o aviso de falha. Além disso, é possível configurar um alerta de duration threshold, que dispara uma notificação quando a execução ultrapassa um tempo esperado configurado, mesmo que o job ainda esteja rodando, cobrindo a segunda situação. O alerta de streaming backlog existe para tasks de streaming específicas, não para jobs sem nenhuma task, o que nem faz sentido como conceito. Também é falso que notificações fiquem restritas ao notebook via print() ou que dependam de uma ferramenta externa, o envio de e-mail e webhook é um recurso nativo do próprio job.",
+        topic: "Lakeflow Jobs notificacoes e alertas",
+        options: [
+            ["Notificação no evento On failure, configurável para enviar e-mail ou acionar um webhook de destino", true],
+            ["Alerta de streaming backlog, disponível apenas para jobs que não possuem nenhuma task configurada", false],
+            ["Alerta de duration threshold, que dispara uma notificação quando a execução ultrapassa o tempo esperado", true],
+            ["Notificações só podem ser recebidas dentro do próprio notebook da task, através de comandos print()", false],
+            ["É necessário integrar uma ferramenta externa de terceiros, pois o Lakeflow Jobs não envia e-mail nativamente", false],
+        ],
+    },
+    {
+        statement:
+            "Um job de produção roda todas as madrugadas anexado a um cluster all-purpose que a equipe de analistas também usa durante o dia para consultas interativas. A equipe notou que o custo em DBUs está mais alto do que o necessário e que, às vezes, o job disputa recursos com notebooks abertos manualmente. Qual mudança reduz o custo e o conflito de recursos sem alterar a lógica do job?",
+        explanation:
+            "Job compute é um cluster efêmero, criado quando a execução do job começa e encerrado automaticamente quando ela termina, cobrado em uma taxa de DBU mais baixa que a de all-purpose compute e sem disputar recursos com clusters interativos usados por analistas: é a mudança recomendada para jobs de produção. Aumentar os workers do cluster all-purpose só aumenta o custo, sem resolver a diferença de tarifa entre os dois tipos de compute. Rodar o job direto em um notebook agendado no cluster all-purpose, sem o Lakeflow Jobs, abandona recursos como DAG, retries e Repair Run, além de não mudar o tipo de compute usado. Fixar o cluster em modo single user muda controle de acesso, mas não resolve nem o custo nem a disputa real de recursos entre job e analistas.",
+        topic: "Job compute x all-purpose compute",
+        options: [
+            ["Aumentar o número de workers do cluster all-purpose para atender o job e os analistas ao mesmo tempo", false],
+            ["Migrar o job para rodar direto no cluster all-purpose através de um notebook agendado, sem usar o Lakeflow Jobs", false],
+            ["Trocar o cluster all-purpose por um job compute, criado e encerrado automaticamente só para a execução do job", true],
+            ["Fixar o cluster all-purpose em modo single user para que o job tenha prioridade sobre os analistas", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe pequena de dados não quer definir tipo de instância, versão de runtime nem política de autoscaling para os clusters dos seus jobs, e precisa que as execuções iniciem rápido, mesmo em jobs esporádicos que rodam poucas vezes por semana. Qual opção de compute do Lakeflow Jobs elimina a necessidade de configurar e gerenciar cluster manualmente?",
+        explanation:
+            "O compute serverless para jobs elimina a necessidade de escolher tipo de instância, versão de runtime ou política de autoscaling: a própria Databricks provisiona e escala o compute automaticamente, com início rápido mesmo para jobs esporádicos, exatamente o que a equipe pequena precisa. Job compute com autoscaling ainda exige escolher tipo de instância e configurar o range de escalonamento manualmente. Manter um cluster all-purpose sempre ativo aumenta o custo contínuo e ainda exige configuração manual do cluster. Um pool de instâncias pré-inicializadas reduz o tempo de start, mas continua exigindo que a equipe configure e gerencie o pool manualmente.",
+        topic: "Lakeflow Jobs compute serverless",
+        options: [
+            ["Job compute com autoscaling configurado para o menor tamanho possível de instância disponível", false],
+            ["Compute serverless, provisionado e escalado automaticamente pela Databricks sem configuração manual", true],
+            ["All-purpose compute compartilhado, mantido sempre ativo para atender novas execuções rapidamente", false],
+            ["Job compute usando um pool de instâncias pré-inicializadas configurado previamente pela equipe", false],
+        ],
+    },
+    {
+        statement:
+            "A equipe mantém um Lakeflow Spark Declarative Pipeline que atualiza as camadas bronze, silver e gold de vendas. Além de rodar esse pipeline, o time quer, na mesma execução orquestrada, rodar antes uma task de validação de esquema dos arquivos de origem e, depois, uma task que publica um relatório em um dashboard, com dependências claras entre as etapas. Qual é a forma correta de orquestrar isso no Lakeflow Jobs?",
+        explanation:
+            "O Lakeflow Jobs permite criar uma task do tipo Pipeline que dispara uma atualização do Declarative Pipeline existente, e essa task pode ser encadeada via Depends on com outras tasks de tipos diferentes, como Notebook, formando um DAG único com validação, pipeline e publicação do relatório. Usar apenas o agendamento próprio do pipeline não permite incluir as tasks de validação e publicação na mesma orquestração, já que o pipeline sozinho não orquestra tasks heterogêneas. Colar o código do pipeline em uma task Notebook comum abandona o motor declarativo do Lakeflow Spark Declarative Pipelines, perdendo recursos como o gerenciamento automático de streaming tables e materialized views. Criar três jobs independentes sem dependência entre eles não garante a ordem exigida entre validação, pipeline e publicação.",
+        topic: "Lakeflow Jobs task tipo Pipeline",
+        options: [
+            ["Configurar apenas o agendamento próprio do Declarative Pipeline, que substitui o Lakeflow Jobs para qualquer orquestração", false],
+            ["Colar o código do pipeline dentro de uma task do tipo Notebook comum, junto com a lógica de validação e publicação", false],
+            ["Criar três jobs separados e independentes, um para cada etapa, sem nenhuma dependência configurada entre eles", false],
+            ["Criar um job com uma task do tipo Pipeline apontando para o pipeline existente, encadeada via Depends on com as demais tasks", true],
+        ],
+    },
+    {
+        statement:
+            "Uma tabela Delta de pedidos recebe milhares de eventos por hora e é filtrada com frequência pela coluna order_id, que tem cardinalidade quase única por linha. A equipe particionou a tabela por order_id e passou a ver um número excessivo de diretórios pequenos, com consultas mais lentas em vez de mais rápidas. Qual abordagem resolve melhor esse cenário?",
+        explanation:
+            "Particionar por uma coluna de altíssima cardinalidade como order_id cria praticamente um diretório por linha, gerando excesso de arquivos pequenos e sobrecarga de metadados. O Liquid Clustering foi criado para colunas assim: reorganiza os dados de forma incremental através de CLUSTER BY, sem exigir a escolha de colunas de partição, e evita essa explosão de diretórios. Manter o particionamento atual e só rodar ZORDER não remove a causa raiz do problema, que é particionar por uma coluna de altíssima cardinalidade. Adicionar mais uma coluna de particionamento só piora a fragmentação dos dados. Reduzir o tamanho alvo dos arquivos do OPTIMIZE tende a criar ainda mais arquivos pequenos, o oposto do que a tabela precisa.",
+        topic: "Liquid Clustering x particionamento",
+        options: [
+            ["Manter o particionamento atual e executar ZORDER BY (order_id) após cada carga de dados", false],
+            ["Adicionar mais uma coluna de particionamento para dividir melhor os diretórios existentes", false],
+            ["Remover o particionamento por order_id e habilitar Liquid Clustering na tabela com CLUSTER BY (order_id)", true],
+            ["Reduzir o tamanho alvo dos arquivos gerados pelo OPTIMIZE para compensar o excesso de partições criadas", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe de dados mantém centenas de tabelas Delta gerenciadas pelo Unity Catalog e tem dificuldade em manter jobs agendados de OPTIMIZE e VACUUM atualizados para cada uma delas, o que causa acúmulo de arquivos pequenos e crescimento do custo de armazenamento. Qual recurso reduz esse esforço operacional com a menor manutenção manual?",
+        explanation:
+            "A Predictive Optimization é um recurso do Unity Catalog que analisa o padrão de leitura e escrita de cada tabela gerenciada e decide automaticamente quando rodar OPTIMIZE, incluindo clustering, e VACUUM, sem exigir jobs agendados manualmente. Criar um único job com horário fixo para todas as tabelas ainda exige manutenção manual da agenda e roda mesmo quando desnecessário para uma tabela específica. Aumentar o cluster de manutenção só acelera a execução, sem remover o esforço de gerenciar quando e onde rodar cada tarefa. É o oposto do real: a Predictive Optimization é voltada para tabelas gerenciadas (managed) pelo Unity Catalog, não para tabelas externas.",
+        topic: "Predictive Optimization",
+        options: [
+            ["Habilitar a Predictive Optimization para as tabelas, deixando a Databricks decidir quando executar OPTIMIZE e VACUUM automaticamente", true],
+            ["Criar um único job no Lakeflow Jobs que executa OPTIMIZE e VACUUM em todas as tabelas, sempre na mesma janela de horário noturno", false],
+            ["Aumentar o tamanho do cluster que executa a manutenção para concluir o OPTIMIZE de todas as tabelas mais rápido", false],
+            ["Migrar as tabelas para o formato de tabela externa (external) no Unity Catalog, já que a Predictive Optimization só está disponível para tabelas externas", false],
+        ],
+    },
+    {
+        statement:
+            "Uma streaming table alimentada pelo Auto Loader recebe centenas de micro-lotes pequenos por dia. Com o tempo, os analistas notam que as consultas nessa tabela ficam cada vez mais lentas, mesmo sem aumento real no volume de dados consultado. Ao investigar, a equipe encontra um número muito grande de arquivos Parquet pequenos no diretório da tabela. Qual ação resolve diretamente esse problema?",
+        explanation:
+            "O cenário descrito é o clássico small files problem: muitas escritas pequenas geram muitos arquivos, aumentando a sobrecarga de metadados e piorando a performance de leitura. O comando OPTIMIZE compacta esses arquivos pequenos em arquivos maiores através de bin-packing, sem alterar os dados armazenados. VACUUM remove apenas arquivos que já não pertencem a nenhuma versão válida da tabela, e não compacta arquivos que ainda estão ativos. Mudar spark.sql.shuffle.partitions afeta o processamento em memória durante o shuffle, não o layout de arquivos já gravados em disco. Diminuir o intervalo de trigger do Auto Loader aumentaria ainda mais a frequência de escritas pequenas, piorando o problema em vez de resolvê-lo.",
+        topic: "OPTIMIZE e small files",
+        options: [
+            ["Executar VACUUM na tabela para remover os arquivos pequenos que não são mais necessários", false],
+            ["Aumentar o valor de spark.sql.shuffle.partitions no cluster que processa os micro-lotes", false],
+            ["Diminuir o intervalo de trigger do Auto Loader para processar os dados com mais frequência", false],
+            ["Executar o comando OPTIMIZE na tabela para compactar os arquivos pequenos em arquivos maiores", true],
+        ],
+    },
+    {
+        statement:
+            "Uma tabela Delta com 50 colunas é otimizada regularmente com OPTIMIZE. Ainda assim, consultas que filtram pela coluna status_pagamento, que é a coluna de número 40 da tabela, não apresentam ganho de data skipping, enquanto filtros nas primeiras colunas da tabela conseguem eliminar arquivos normalmente. Qual é a causa mais provável?",
+        explanation:
+            "O Delta Lake coleta e armazena estatísticas de mínimo, máximo e contagem de nulos apenas para as primeiras 32 colunas de cada tabela por padrão, através da propriedade delta.dataSkippingNumIndexedCols, e usa isso para decidir quais arquivos podem ser ignorados numa consulta. Como status_pagamento é a coluna de número 40, ela fica fora do conjunto padrão de colunas indexadas, o que explica a ausência de pruning. Data skipping funciona em qualquer coluna dentro do conjunto indexado, não apenas em colunas de partição. O OPTIMIZE já atualiza as estatísticas dos arquivos que reescreve, sem depender de ANALYZE TABLE para o data skipping do Delta Lake funcionar. O tipo de dado da coluna não é o fator limitante nesse cenário.",
+        topic: "Data skipping e file pruning",
+        options: [
+            ["Data skipping só funciona em colunas usadas como chave de particionamento da tabela", false],
+            ["Por padrão, o Delta Lake coleta estatísticas de data skipping apenas para as primeiras 32 colunas da tabela", true],
+            ["O OPTIMIZE não recalcula estatísticas de colunas, sendo necessário rodar ANALYZE TABLE após cada compactação", false],
+            ["A coluna status_pagamento precisa ser convertida para o tipo STRING para ficar elegível a data skipping", false],
+        ],
+    },
+    {
+        statement:
+            "Um engenheiro precisa liberar espaço de armazenamento rapidamente. Ele desabilita a verificação de segurança de retenção (spark.databricks.delta.retentionDurationCheck.enabled = false) e executa VACUUM vendas RETAIN 0 HOURS em uma tabela de produção que é lida continuamente por dashboards e por jobs de longa duração. Qual é o principal risco dessa ação?",
+        explanation:
+            "VACUUM remove arquivos de dados que não pertencem mais à versão atual da tabela e que são mais antigos que o período de retenção configurado. O padrão de 7 dias (168 horas) existe justamente para preservar arquivos que consultas de longa duração, leitores concorrentes ou consultas de time travel ainda podem precisar. Ao reduzir a retenção para 0 horas com a verificação desabilitada, o engenheiro corre o risco real de apagar arquivos que operações em andamento ainda referenciam, causando falhas de leitura. VACUUM não compacta arquivos pequenos, essa é a função do OPTIMIZE. Com a verificação desabilitada, o comando executa normalmente com a retenção informada, então não é verdade que ele sempre falhe. E o VACUUM remove sim arquivos de dados no armazenamento, não apenas metadados do log de transação.",
+        topic: "VACUUM e retencao",
+        options: [
+            ["O VACUUM com retenção zero passa a compactar automaticamente os arquivos pequenos da tabela, dispensando o uso do comando OPTIMIZE", false],
+            ["Mesmo com a verificação desabilitada, o comando ainda falha, pois o Delta Lake nunca permite retenção abaixo de 7 dias em produção", false],
+            ["Nada muda na prática, pois o comando VACUUM só remove arquivos do log de transação, nunca arquivos de dados da tabela", false],
+            ["Arquivos de dados ainda necessários para consultas em andamento ou para operações de time travel podem ser removidos, causando falhas", true],
+        ],
+    },
+    {
+        statement:
+            "A atualização (update) de um pipeline criado com o Lakeflow Spark Declarative Pipelines, que normalmente leva 20 minutos, passou a levar mais de 2 horas, sem mudança aparente no volume de dados de entrada. A equipe precisa descobrir qual tabela ou fluxo específico do pipeline está causando a lentidão antes de agir. Qual é a MELHOR forma de investigar?",
+        explanation:
+            "O event log do Lakeflow Spark Declarative Pipelines registra, para cada atualização, métricas por fluxo e tabela como linhas processadas, duração, erros e métricas de qualidade de dados, permitindo identificar exatamente qual tabela ou fluxo está consumindo mais tempo. A partir daí, o Spark UI da execução específica pode ser usado para investigar shuffle, spill ou skew naquele estágio pontual. Aumentar workers às cegas e disparar uma nova atualização pode mascarar o problema sem identificar a causa raiz, além de aumentar o custo sem necessidade. O pipeline não roda como consultas registradas no histórico de um SQL warehouse, então essa fonte não reflete a execução do pipeline. Um full refresh é caro, reprocessa dados desnecessariamente e não isola sozinho onde está o gargalo.",
+        topic: "Event log de Declarative Pipelines",
+        options: [
+            ["Consultar o event log do pipeline para ver a duração e as métricas de cada fluxo e tabela, e identificar o gargalo", true],
+            ["Aumentar o número máximo de workers do pipeline e disparar uma nova atualização, só para ver se o tempo total melhora", false],
+            ["Consultar o histórico de queries do SQL warehouse padrão do workspace, já que todo pipeline executa como consultas SQL registradas lá", false],
+            ["Reiniciar o pipeline do zero (full refresh) para forçar o recálculo de todas as tabelas e comparar o tempo total gasto", false],
+        ],
+    },
+    {
+        statement:
+            "Um job com várias tasks no Lakeflow Jobs vem apresentando duração total cada vez maior nas últimas execuções, sem nenhuma mudança recente no código ou no volume de dados de entrada. Antes de alterar qualquer configuração, a equipe quer descobrir qual task específica está demorando mais do que o normal. Qual é a forma mais direta de investigar isso?",
+        explanation:
+            "A aba Runs de um job no Lakeflow Jobs guarda o histórico de execuções com a duração de cada task, permitindo comparar execuções recentes lado a lado e identificar exatamente qual task específica passou a demorar mais, antes de decidir onde otimizar. O painel de billing e uso mostra custo agregado em DBUs, útil para acompanhar gasto, mas não aponta qual task específica ficou mais lenta. Olhar somente os logs do driver do cluster não dá a granularidade por task que a aba Runs oferece. Assumir que a task com mais linhas de código é a culpada é um chute sem base em métricas reais de execução, podendo levar a equipe a otimizar a task errada.",
+        topic: "Lakeflow Jobs - duracao por task",
+        options: [
+            ["Consultar o painel de billing e uso (usage) do workspace para ver o total de DBUs consumidos pelo job no mês", false],
+            ["Abrir a aba Runs do job e comparar a duração de cada task entre as últimas execuções, buscando a que mais cresceu", true],
+            ["Observar apenas os logs do driver do cluster, sem abrir os detalhes de execução de cada task individualmente", false],
+            ["Assumir que a task com mais linhas de código é a responsável e otimizá-la diretamente, sem checar métricas de execução", false],
+        ],
+    },
+    {
+        statement:
+            "Um pipeline Spark SQL no Databricks faz uma agregação (GROUP BY) pesada sobre uma tabela de eventos e, na mesma consulta, cruza o resultado com uma tabela de referência de 6 MB. O cluster usa as configurações padrão de Spark SQL, incluindo Adaptive Query Execution (AQE) habilitada. Quais DUAS afirmações sobre o comportamento do Spark SQL nesse cenário estão corretas? (Selecione DUAS opções.)",
+        explanation:
+            "O valor padrão de spark.sql.autoBroadcastJoinThreshold é 10 MB: tabelas menores que esse limite são candidatas a broadcast join, o que evita o shuffle da tabela de referência e acelera a consulta. Com Adaptive Query Execution habilitada, que é o padrão em runtimes recentes, o Spark reavalia o plano em tempo de execução e pode coalescer partições de shuffle pequenas geradas pela agregação, tornando o número efetivo de partições diferente do valor bruto configurado em spark.sql.shuffle.partitions. Mais partições de shuffle não é sempre melhor: com poucos dados, o excesso de partições gera overhead de tarefas pequenas em vez de reduzir o tempo total. O limite do broadcast é medido em bytes, e não em número de linhas da tabela. Definir o limite como -1 desabilita o broadcast automático por completo, o oposto do recomendado para acelerar consultas com tabelas pequenas.",
+        topic: "spark.sql.shuffle.partitions x autoBroadcastJoinThreshold",
+        options: [
+            ["Aumentar o valor de spark.sql.shuffle.partitions sempre reduz o tempo total da consulta, independentemente do volume de dados processados", false],
+            ["A tabela de referência está abaixo do padrão de spark.sql.autoBroadcastJoinThreshold (10 MB), então o Spark faz broadcast automático", true],
+            ["O valor de spark.sql.autoBroadcastJoinThreshold é definido em número de linhas da tabela de referência, e não em bytes armazenados", false],
+            ["Com AQE habilitada, o Spark pode coalescer partições de shuffle pequenas, ajustando na prática o valor de spark.sql.shuffle.partitions", true],
+            ["Definir spark.sql.autoBroadcastJoinThreshold como -1 é a forma recomendada para acelerar consultas com tabelas de referência pequenas", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe quer reduzir o custo de computação dos seus jobs agendados, que têm carga variável ao longo do dia, sem comprometer a confiabilidade das execuções. Quais DUAS práticas realmente ajudam a reduzir custo nesse cenário? (Selecione DUAS opções.)",
+        explanation:
+            "Compute serverless remove a necessidade de dimensionar e manter um cluster: a Databricks gerencia o provisionamento e a cobrança é pelo uso efetivo do job, sem custo de cluster ocioso esperando a próxima execução. Autoscaling permite que o cluster cresça durante os picos e reduza nos momentos de menor carga, evitando pagar por capacidade parada. Desativar o auto termination mantém o cluster ligado mesmo sem uso, aumentando o custo em vez de reduzi-lo. Selecionar sempre o maior tipo de instância disponível gera capacidade ociosa na maior parte do tempo, já que a carga é variável ao longo do dia. Fixar um número alto de workers mínimos garante capacidade mesmo quando ela não é necessária, aumentando o custo basal do cluster.",
+        topic: "Custo: serverless e autoscaling",
+        options: [
+            ["Usar compute serverless nos jobs: a Databricks gerencia o provisionamento e cobra pelo uso efetivo, sem cluster ocioso", true],
+            ["Desativar o encerramento automático (auto termination) do cluster, para reduzir o tempo de espera no início de cada execução", false],
+            ["Habilitar autoscaling no cluster de job, deixando o número de workers variar automaticamente conforme a carga de cada execução", true],
+            ["Sempre selecionar o maior tipo de instância disponível para os workers, garantindo margem de sobra em qualquer pico de carga", false],
+            ["Fixar um número alto de workers mínimos no cluster, eliminando qualquer espera por escalonamento durante os picos de carga", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe de engenharia recebe arquivos CSV de um sistema de pedidos que chegam continuamente em um volume do Unity Catalog. O pipeline em Lakeflow Spark Declarative Pipelines precisa ingerir cada arquivo novo exatamente uma vez, de forma incremental, para compor a camada bronze. Qual objeto do pipeline atende esse requisito?",
+        explanation:
+            "Streaming tables são feitas para fontes que só crescem, processando cada arquivo novo de forma incremental e exatamente uma vez, o que é ideal para ingestão contínua na camada bronze. Materialized views recalculam ou atualizam o resultado de uma consulta, sem a garantia de ler cada arquivo novo uma única vez. Uma view tradicional apenas lê a definição a cada consulta, sem persistir nem processar dados de forma incremental. E um INSERT OVERWRITE agendado reprocessaria a pasta inteira a cada execução, sem incrementalidade real.",
+        topic: "Streaming Tables",
+        options: [
+            ["Uma streaming table, criada com CREATE OR REFRESH STREAMING TABLE, lendo os arquivos de forma incremental", true],
+            ["Uma materialized view, criada com CREATE OR REFRESH MATERIALIZED VIEW, apontando para a pasta de arquivos", false],
+            ["Uma view tradicional do Databricks SQL, apontando diretamente para o caminho do volume de arquivos", false],
+            ["Uma tabela Delta gerenciada, populada por um comando INSERT OVERWRITE agendado a cada hora do dia", false],
+        ],
+    },
+    {
+        statement:
+            "Um time de BI precisa de uma tabela na camada gold com o total de vendas por dia, sempre consistente com o resultado de uma consulta de agregação sobre a camada silver, deixando o motor do pipeline decidir entre recálculo completo ou atualização incremental. Qual objeto do Lakeflow Spark Declarative Pipelines atende essa necessidade?",
+        explanation:
+            "Materialized views armazenam o resultado de uma consulta de agregação, e o motor do pipeline escolhe automaticamente entre recomputar tudo ou atualizar incrementalmente, sempre entregando um resultado equivalente ao de rodar a consulta inteira. Streaming tables são voltadas a fontes incrementais que só crescem, não a agregações que revisitam o histórico da silver. AUTO CDC serve para aplicar mudanças de um feed de CDC, não para agregar métricas de vendas. E uma view de sessão não persiste dados nem se integra ao agendamento do pipeline.",
+        topic: "Materialized Views - selecao de objeto",
+        options: [
+            ["Uma streaming table, criada com CREATE OR REFRESH STREAMING TABLE sobre a tabela silver", false],
+            ["Uma materialized view, criada com CREATE OR REFRESH MATERIALIZED VIEW sobre a tabela silver", true],
+            ["Uma tabela populada por AUTO CDC INTO, configurada a partir da própria camada silver", false],
+            ["Uma view temporária, criada apenas para durar a sessão atual do notebook de análise", false],
+        ],
+    },
+    {
+        statement:
+            "Um engenheiro está avaliando se deve usar materialized views para uma nova tabela gold e revisa o comportamento desse objeto no Lakeflow Spark Declarative Pipelines. Sobre as materialized views, quais DUAS afirmações estão corretas? (Selecione DUAS opções.)",
+        explanation:
+            "Materialized views garantem um resultado equivalente ao de rodar a consulta de definição contra os dados atuais, e o motor decide internamente se atualiza de forma incremental ou recalcula tudo, o que for mais eficiente. Elas podem ser definidas sobre fontes batch ou streaming, então não são exclusivas de fontes de streaming. A garantia de processar cada linha da fonte exatamente uma vez é característica de streaming tables, não de materialized views. E materialized views são consultáveis normalmente via SQL, como qualquer tabela do Unity Catalog.",
+        topic: "Materialized Views - caracteristicas",
+        options: [
+            ["Elas só podem ser definidas a partir de fontes de streaming, nunca de fontes batch", false],
+            ["O resultado retornado é sempre equivalente ao de rodar a consulta de definição contra os dados atuais", true],
+            ["Cada linha da fonte é garantidamente processada exatamente uma única vez, como em uma streaming table", false],
+            ["O motor do pipeline pode atualizar os resultados de forma incremental quando isso for mais eficiente", true],
+            ["Elas não podem ser consultadas com comandos SQL, apenas lidas diretamente via PySpark", false],
+        ],
+    },
+    {
+        statement:
+            "Um engenheiro precisa decidir entre streaming table e materialized view para popular a camada silver a partir de uma tabela bronze que só recebe registros novos, nunca updates ou deletes. O requisito é processar cada registro da bronze exatamente uma vez, sem reprocessar o histórico a cada atualização do pipeline. Qual objeto atende melhor esse requisito?",
+        explanation:
+            "Streaming tables são feitas exatamente para esse cenário: fontes append-only, onde cada registro é lido e processado uma única vez, de forma incremental, sem revisitar o histórico já processado. Materialized views existem para consultas que podem precisar revisitar o conjunto de dados inteiro, não para simplesmente propagar registros novos. AUTO CDC serve para aplicar inserções, atualizações e deleções vindas de um feed de CDC com chaves, o que não é o caso aqui. E uma tabela externa do Unity Catalog apenas aponta para arquivos, sem processamento incremental gerenciado pelo pipeline.",
+        topic: "Streaming Tables x Materialized Views",
+        options: [
+            ["Materialized view, pois recalcula o resultado completo a cada atualização para garantir consistência", false],
+            ["Uma tabela externa do Unity Catalog, pois não depende do mecanismo de atualização do pipeline", false],
+            ["Streaming table, pois processa incrementalmente e uma única vez cada registro novo da origem", true],
+            ["AUTO CDC, pois foi desenhado para processar dados que só crescem, sem chave de deduplicação", false],
+        ],
+    },
+    {
+        statement:
+            "A tabela silver de clientes deve sempre refletir apenas o estado mais atual de cada cliente, sobrescrevendo valores antigos quando chega uma atualização, sem manter histórico de versões anteriores. O feed de mudanças chega em uma tabela bronze de CDC. Qual configuração do AUTO CDC atende essa regra?",
+        explanation:
+            "STORED AS SCD TYPE 1 faz o AUTO CDC sobrescrever o registro existente com os valores mais recentes, sem manter histórico, que é exatamente o requisito descrito. STORED AS SCD TYPE 2 faria o oposto, preservando todas as versões históricas com colunas de vigência. Um MERGE manual com WHEN MATCHED THEN INSERT não é uma combinação válida (a cláusula MATCHED só aceita UPDATE ou DELETE), então não atualizaria os clientes existentes. E uma materialized view com GROUP BY não trata corretamente inserções, atualizações e deleções vindas de um feed de CDC como o AUTO CDC trata nativamente.",
+        topic: "AUTO CDC - SCD Type 1",
+        options: [
+            ["Configurar AUTO CDC INTO a tabela silver com a cláusula STORED AS SCD TYPE 2", false],
+            ["Executar um MERGE INTO manual, sem AUTO CDC, usando somente WHEN MATCHED THEN INSERT", false],
+            ["Criar uma MATERIALIZED VIEW que seleciona o último registro de cada cliente com GROUP BY", false],
+            ["Configurar AUTO CDC INTO a tabela silver com a cláusula STORED AS SCD TYPE 1", true],
+        ],
+    },
+    {
+        statement:
+            "Uma tabela silver de assinaturas é configurada com AUTO CDC INTO e STORED AS SCD TYPE 2 para manter o histórico completo de mudanças de plano de cada cliente. Ao revisar a tabela após a primeira execução, o time quer confirmar quais colunas de controle foram criadas automaticamente. Quais DUAS colunas o AUTO CDC adiciona ao destino para registrar o período de vigência de cada versão do registro? (Selecione DUAS opções.)",
+        explanation:
+            "Quando uma tabela é alvo de AUTO CDC com STORED AS SCD TYPE 2, o Lakeflow Spark Declarative Pipelines adiciona automaticamente as colunas __START_AT e __END_AT, que registram o intervalo de vigência de cada versão do registro (a versão vigente fica com __END_AT nulo). Nomes como __CURRENT_FLAG, __VERSION_ID e __CDC_TIMESTAMP não são colunas geradas por esse recurso.",
+        topic: "AUTO CDC - SCD Type 2",
+        options: [
+            ["A coluna __START_AT", true],
+            ["A coluna __CURRENT_FLAG", false],
+            ["A coluna __VERSION_ID", false],
+            ["A coluna __END_AT", true],
+            ["A coluna __CDC_TIMESTAMP", false],
+        ],
+    },
+    {
+        statement:
+            "Um feed de CDC de pedidos pode entregar eventos fora de ordem, e a tabela silver precisa refletir sempre o valor mais recente de cada pedido, mesmo quando um evento antigo chega atrasado após um mais novo. Qual cláusula do AUTO CDC garante que o registro final aplicado seja o logicamente mais recente, independente da ordem de chegada?",
+        explanation:
+            "SEQUENCE BY define qual coluna representa a ordem cronológica ou lógica dos eventos, permitindo que o AUTO CDC resolva corretamente eventos atrasados e aplique sempre a versão mais recente ao destino. KEYS apenas identifica o registro, para saber qual linha atualizar, sem tratar ordenação. APPLY AS DELETE WHEN trata exclusões vindas do feed, não a ordem de chegada dos eventos. E STORED AS SCD TYPE 2 define se o histórico é mantido, mas não resolve, por si só, o problema de eventos fora de ordem.",
+        topic: "AUTO CDC - SEQUENCE BY",
+        options: [
+            ["SEQUENCE BY, apontando para uma coluna que representa a ordem lógica dos eventos", true],
+            ["KEYS, apontando para a coluna ou colunas que identificam unicamente cada pedido", false],
+            ["APPLY AS DELETE WHEN, apontando para a coluna que indica operações de exclusão", false],
+            ["STORED AS SCD TYPE 2, para manter todas as versões recebidas do pedido", false],
+        ],
+    },
+    {
+        statement:
+            "O feed de CDC de clientes inclui uma coluna operation que pode valer INSERT, UPDATE ou DELETE. Quando o valor é DELETE, o registro correspondente deve ser removido da tabela silver de clientes durante a aplicação do AUTO CDC. Qual cláusula deve ser adicionada ao AUTO CDC INTO para tratar essa exclusão corretamente?",
+        explanation:
+            "APPLY AS DELETE WHEN indica ao AUTO CDC qual condição identifica uma exclusão no feed de origem, fazendo com que o registro correspondente seja removido da tabela de destino. STORED AS SCD TYPE 1 controla se o histórico é mantido ou sobrescrito, mas não interpreta exclusões por si só. Uma expectation com ON VIOLATION DROP ROW descartaria a própria linha de CDC antes do processamento, apagando o sinal de exclusão em vez de aplicá-lo ao destino. E SEQUENCE BY define apenas a ordem lógica dos eventos, não o tipo de operação.",
+        topic: "AUTO CDC - APPLY AS DELETE WHEN",
+        options: [
+            ["Usar STORED AS SCD TYPE 1, que remove automaticamente registros antigos do destino", false],
+            ["Adicionar a cláusula APPLY AS DELETE WHEN operation = 'DELETE' ao AUTO CDC INTO", true],
+            ["Criar uma expectation que descarta a linha sempre que operation for igual a 'DELETE'", false],
+            ["Usar SEQUENCE BY operation, para priorizar exclusões sobre as demais operações", false],
+        ],
+    },
+    {
+        statement:
+            "Uma tabela bronze de cliques recebeu o mesmo arquivo processado duas vezes por engano, gerando linhas idênticas em todas as colunas. Antes de gravar na camada silver, o time precisa remover essas duplicatas exatas com o mínimo de código possível. Qual abordagem resolve o problema de forma mais direta?",
+        explanation:
+            "Quando as linhas duplicadas são idênticas em todas as colunas, SELECT DISTINCT, equivalente a dropDuplicates() sem argumentos no PySpark, é a forma mais direta de eliminar as cópias, sem precisar definir chave de negócio nem ordenação. Uma window function com ROW_NUMBER() é útil quando linhas com a mesma chave não são idênticas e é preciso escolher qual versão manter, exigindo mais código do que o necessário aqui. AUTO CDC serve para aplicar mudanças de um feed de CDC com chaves, não para remover duplicatas exatas de um mesmo arquivo. E uma expectation com LAG() não removeria duplicatas, apenas sinalizaria ou descartaria linhas conforme uma condição.",
+        topic: "Deduplicacao (SQL e PySpark)",
+        options: [
+            ["Aplicar uma window function com ROW_NUMBER() particionada por um identificador de negócio", false],
+            ["Adicionar uma CONSTRAINT EXPECT que compara cada linha com a anterior usando a função LAG()", false],
+            ["Usar SELECT DISTINCT, ou dropDuplicates() sem argumentos, sobre o conjunto de colunas completo", true],
+            ["Configurar AUTO CDC INTO com STORED AS SCD TYPE 2 sobre a própria tabela bronze de cliques", false],
+        ],
+    },
+    {
+        statement:
+            "Uma streaming table silver define CONSTRAINT valid_email EXPECT (email RLIKE '@') sem nenhuma cláusula ON VIOLATION adicional. Um lote novo chega com algumas linhas cujo campo email não contém '@'. O que acontece com essas linhas e com a execução do pipeline?",
+        explanation:
+            "Sem uma cláusula ON VIOLATION, o comportamento padrão de uma expectation é warn: a linha é mantida no resultado, mas a violação passa a ser contabilizada nas métricas de qualidade e no log de eventos do pipeline. O descarte automático da linha exige ON VIOLATION DROP ROW, e a falha do pipeline exige ON VIOLATION FAIL UPDATE, nenhuma das duas presente no exemplo. E o Lakeflow Spark Declarative Pipelines não cria uma tabela de quarentena automaticamente para linhas inválidas; isso precisaria ser modelado explicitamente pelo engenheiro.",
+        topic: "Expectations - comportamento warn",
+        options: [
+            ["As linhas são descartadas antes de chegar à tabela de destino, e o restante do lote é gravado normalmente", false],
+            ["O pipeline inteiro falha de imediato, interrompendo a atualização daquela tabela", false],
+            ["As linhas ficam em quarentena, em uma tabela separada criada automaticamente pelo pipeline", false],
+            ["As linhas são gravadas na tabela, e a violação fica registrada nas métricas do pipeline", true],
+        ],
+    },
+    {
+        statement:
+            "Uma tabela silver de vendas não pode conter linhas com valor negativo na coluna amount, mas o time quer que o pipeline continue rodando normalmente, apenas descartando essas linhas inválidas antes de gravar a tabela. Qual configuração de expectation atende esse requisito?",
+        explanation:
+            "ON VIOLATION DROP ROW faz com que apenas as linhas que violam a condição sejam removidas antes da gravação, enquanto o restante do lote segue processado normalmente, que é exatamente o pedido. ON VIOLATION FAIL UPDATE interromperia a atualização inteira da tabela ao encontrar qualquer violação. Sem cláusula de ON VIOLATION, a linha inválida seria mantida na tabela, apenas registrada nas métricas. E um filtro aplicado somente na camada gold deixaria a linha inválida presente na silver, não atendendo ao requisito naquele ponto do pipeline.",
+        topic: "Expectations - ON VIOLATION DROP ROW",
+        options: [
+            ["CONSTRAINT valid_amount EXPECT (amount >= 0) ON VIOLATION DROP ROW", true],
+            ["CONSTRAINT valid_amount EXPECT (amount >= 0) ON VIOLATION FAIL UPDATE", false],
+            ["CONSTRAINT valid_amount EXPECT (amount >= 0), sem nenhuma cláusula ON VIOLATION", false],
+            ["Um filtro WHERE amount >= 0 aplicado somente na consulta de leitura da tabela gold", false],
+        ],
+    },
+    {
+        statement:
+            "Um engenheiro está definindo expectations em uma streaming table e quer saber, além do comportamento padrão de manter a linha e apenas registrar a violação nas métricas, quais outras reações existem para um dado inválido. Quais DUAS cláusulas ON VIOLATION estão disponíveis em uma CONSTRAINT EXPECT do Lakeflow Spark Declarative Pipelines? (Selecione DUAS opções.)",
+        explanation:
+            "As únicas duas cláusulas válidas de ON VIOLATION no Lakeflow Spark Declarative Pipelines são DROP ROW, que descarta somente a linha inválida antes da gravação, e FAIL UPDATE, que interrompe a atualização da tabela ao encontrar a violação. QUARANTINE ROW, RETRY UPDATE e IGNORE COLUMN não são cláusulas existentes no recurso de expectations.",
+        topic: "Expectations - clausulas ON VIOLATION",
+        options: [
+            ["ON VIOLATION QUARANTINE ROW, que move a linha para uma tabela de erro automática", false],
+            ["ON VIOLATION RETRY UPDATE, que tenta novamente a leitura da origem antes de gravar", false],
+            ["ON VIOLATION DROP ROW, que remove somente a linha inválida antes da gravação", true],
+            ["ON VIOLATION IGNORE COLUMN, que grava a linha substituindo o valor inválido por nulo", false],
+            ["ON VIOLATION FAIL UPDATE, que interrompe a atualização da tabela ao encontrar a violação", true],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe de engenharia está desenhando as camadas de um pipeline de pedidos vindos de um sistema transacional. Uma das camadas deve conter os dados o mais próximo possível do formato original da origem, com metadados de ingestão, sem nenhuma limpeza ou regra de negócio aplicada. Qual é a FUNÇÃO dessa camada na arquitetura medallion?",
+        explanation:
+            "A descrição, dados o mais próximos possível do formato original, com metadados de ingestão, sem limpeza, corresponde exatamente ao papel da camada bronze na arquitetura medallion. A opção de silver descreve corretamente essa outra camada, focada em dados conformados e deduplicados, o que não é o caso aqui. A opção de gold descreve a camada de agregados de negócio para consumo final, também não aplicável. E a arquitetura medallion não define uma camada de sandbox exploratória como parte do fluxo bronze, silver e gold.",
+        topic: "Arquitetura Medallion - Bronze",
+        options: [
+            ["Camada silver: dados conformados, deduplicados e enriquecidos, prontos para consumo por outras equipes", false],
+            ["Camada bronze: cópia fiel dos dados brutos, com metadados de ingestão, para auditoria e reprocessamento", true],
+            ["Camada gold: conjunto agregado e modelado, pronto para consumo direto por dashboards e relatórios", false],
+            ["Camada de sandbox, usada apenas para testes exploratórios e descartada após a validação do pipeline", false],
+        ],
+    },
+    {
+        statement:
+            "Depois de ingerir pedidos brutos na camada bronze, o time precisa de uma camada intermediária com dados limpos, com tipos corretos, deduplicados e enriquecidos com a dimensão de clientes, mas ainda sem as agregações de negócio finais usadas nos dashboards executivos. Qual é a FUNÇÃO dessa camada na arquitetura medallion?",
+        explanation:
+            "Dados limpos, com tipos corretos, deduplicados, enriquecidos com dimensões, mas ainda sem as agregações finais de negócio, é exatamente o papel da camada silver na arquitetura medallion. A opção de bronze descreve corretamente essa outra camada, mas bronze preserva os dados brutos, sem limpeza nem deduplicação. A opção de gold descreve a camada de métricas já agregadas para consumo final, que o enunciado explicitamente exclui. E a arquitetura medallion não inclui uma camada de staging volátil descartada a cada execução do pipeline.",
+        topic: "Arquitetura Medallion - Silver",
+        options: [
+            ["Camada bronze: cópia fiel dos dados brutos da origem, preservada para auditoria e reprocessamento", false],
+            ["Camada de staging volátil, descartada após cada execução do pipeline, nunca persistida em Delta Lake", false],
+            ["Camada silver: dados conformados e deduplicados, prontos para consumo, antes das agregações finais", true],
+            ["Camada gold: conjunto final agregado e modelado, pronto para consumo direto por dashboards e relatórios", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe de BI precisa de uma camada final, com métricas já agregadas e modeladas, como receita total por dia e por região, pronta para ser consumida diretamente por dashboards executivos, sem exigir joins ou agregações adicionais na ferramenta de BI. Qual é a FUNÇÃO dessa camada na arquitetura medallion?",
+        explanation:
+            "Métricas já agregadas e modeladas, prontas para consumo direto por dashboards sem joins ou agregações adicionais, é exatamente a definição da camada gold. A opção de silver descreve dados conformados e deduplicados, mas ainda sem as agregações finais, o que não atende ao enunciado. A opção de bronze descreve a cópia bruta da origem, bem distante do requisito. E o catálogo de metadados do Unity Catalog serve para governança e linhagem, não é uma camada de dados de negócio da arquitetura medallion.",
+        topic: "Arquitetura Medallion - Gold",
+        options: [
+            ["Camada silver: dados conformados e deduplicados, mas ainda antes das agregações finais de negócio", false],
+            ["Camada bronze: cópia fiel dos dados brutos da origem, preservada para auditoria e reprocessamento", false],
+            ["Camada de metadados do Unity Catalog, usada para governança e linhagem, não para consumo em BI", false],
+            ["Camada gold: dados agregados e modelados, prontos para consumo direto por dashboards e relatórios", true],
+        ],
+    },
+    {
+        statement:
+            "Uma tabela silver de clientes recebe diariamente um arquivo com clientes novos e clientes existentes que mudaram de endereço. O time quer inserir os clientes novos e atualizar o endereço dos existentes em uma única operação atômica sobre a tabela Delta, usando a chave customer_id. Qual comando resolve isso diretamente?",
+        explanation:
+            "MERGE INTO permite combinar inserção e atualização em uma única instrução atômica sobre uma tabela Delta, usando a chave de correspondência para decidir se atualiza, WHEN MATCHED, ou insere, WHEN NOT MATCHED, que é exatamente o requisito. Um DELETE seguido de INSERT não é atômico como um MERGE e perde a distinção entre quem foi realmente atualizado. Um CREATE OR REPLACE TABLE diário substituiria a tabela inteira, descartando clientes que não estão no arquivo do dia. E um AUTO CDC sem KEYS nem STORED AS SCD TYPE não é uma configuração válida para aplicar upserts.",
+        topic: "Delta Lake - MERGE INTO",
+        options: [
+            ["Um MERGE INTO na tabela clientes_silver, usando ON customer_id, com WHEN MATCHED UPDATE e WHEN NOT MATCHED INSERT", true],
+            ["Um DELETE de todos os clientes que aparecem no arquivo, seguido de um INSERT INTO com o conteúdo completo do arquivo", false],
+            ["Um CREATE OR REPLACE TABLE clientes_silver AS SELECT * FROM atualizacoes, substituindo a tabela inteira todos os dias", false],
+            ["Um AUTO CDC INTO clientes_silver, sem definir KEYS nem STORED AS SCD TYPE, aplicando somente as inserções do arquivo", false],
+        ],
+    },
+    {
+        statement:
+            "Um job com um bug sobrescreveu por engano a tabela Delta vendas_gold com dados incorretos. A equipe confirmou, pelo DESCRIBE HISTORY da tabela, que a versão 41, executada uma hora antes do job com bug, ainda está correta e dentro do período de retenção do log. Qual comando restaura a tabela para o estado da versão 41 da forma mais direta?",
+        explanation:
+            "RESTORE TABLE reverte uma tabela Delta diretamente para uma versão ou timestamp anterior, usando o próprio log de transações, sem exigir reescrita manual. Um SELECT com VERSION AS OF seguido de um INSERT OVERWRITE manual chega a um resultado parecido, mas com mais passos e mais risco de erro do que o comando dedicado. VACUUM remove arquivos de dados antigos que não são mais referenciados pelo log, o oposto do que se quer aqui, podendo até inviabilizar o time travel se aplicado de forma agressiva. E recriar a tabela apontando para os arquivos físicos da versão antiga ignora o gerenciamento transacional do Delta Lake.",
+        topic: "Delta Lake - Time Travel",
+        options: [
+            ["Fazer SELECT * FROM vendas_gold VERSION AS OF 41 e depois um INSERT OVERWRITE manual na mesma tabela", false],
+            ["Executar RESTORE TABLE vendas_gold TO VERSION AS OF 41, revertendo a tabela diretamente para essa versão", true],
+            ["Executar VACUUM vendas_gold RETAIN 41 HOURS, para remover os arquivos gravados após a versão correta", false],
+            ["Recriar a tabela vendas_gold apontando diretamente para os arquivos físicos gravados na versão 41", false],
+        ],
+    },
+    {
+        statement:
+            "Uma tabela bronze de cadastros de clientes recebe múltiplas atualizações para o mesmo customer_id ao longo do dia, cada uma com um updated_at diferente. Para a camada silver, o time precisa manter apenas a versão mais recente de cada cliente, com todas as suas colunas. Qual abordagem em PySpark resolve isso corretamente?",
+        explanation:
+            "Uma Window particionada por customer_id e ordenada por updated_at decrescente, combinada com row_number() e um filtro rn = 1, mantém exatamente a linha mais recente e completa de cada cliente. dropDuplicates() sem colunas remove apenas linhas totalmente idênticas, o que não resolve múltiplas versões diferentes do mesmo cliente. groupBy com max(updated_at) devolve somente a data mais recente, não a linha inteira com as demais colunas daquela versão. E ordenar o DataFrame inteiro e aplicar limit(1) manteria uma única linha no total, não uma por cliente.",
+        topic: "PySpark - Window Functions",
+        options: [
+            ["Aplicar dropDuplicates() sobre o DataFrame inteiro, sem especificar nenhuma coluna de referência para a chave do cliente", false],
+            ["Ordenar o DataFrame inteiro por updated_at com orderBy() e aplicar limit(1) sobre o resultado final obtido", false],
+            ["Aplicar row_number() em uma Window por customer_id, ordenada por updated_at decrescente, e filtrar rn = 1", true],
+            ["Aplicar groupBy('customer_id').max('updated_at') e gravar o resultado dessa agregação direto na silver", false],
+        ],
+    },
+    {
+        statement:
+            "Um job em PySpark une uma tabela de fatos de vendas com centenas de milhões de linhas a uma tabela de dimensão de lojas com apenas algumas centenas de linhas. O join está lento devido a um shuffle grande envolvendo a tabela de fatos. Qual técnica reduz esse custo ao evitar o shuffle da tabela pequena?",
+        explanation:
+            "broadcast() instrui o Spark a enviar uma cópia inteira da tabela pequena para todos os executores, eliminando o shuffle da tabela grande de fatos e acelerando o join. Aumentar o número de partições com repartition() ainda mantém um shuffle completo da tabela de fatos. Converter a tabela de fatos em uma view temporária não muda a estratégia física de execução do join. E substituir o join por um UNION seguido de filtro produz um resultado logicamente diferente, sem combinar colunas das duas tabelas por chave, e não resolve o custo.",
+        topic: "PySpark - Joins (broadcast)",
+        options: [
+            ["Usar repartition() na tabela de fatos para aumentar o número de partições antes do join", false],
+            ["Converter a tabela de fatos em uma view temporária antes de executar o mesmo join", false],
+            ["Trocar o join por um UNION entre as duas tabelas, filtrando o resultado depois", false],
+            ["Usar broadcast(df_lojas) no join, para replicar a tabela pequena em todos os executores", true],
+        ],
+    },
+    {
+        statement:
+            "A camada silver tem uma linha por item de pedido, então um mesmo pedido pode aparecer em várias linhas. Para a camada gold, o time precisa de uma tabela com o total de receita e a quantidade de PEDIDOS distintos por regiao e por mes. Qual consulta SQL produz corretamente essa granularidade?",
+        explanation:
+            "GROUP BY regiao, mes com SUM(valor) e COUNT(DISTINCT pedido_id) produz uma linha por regiao e mes, com receita total e quantidade de pedidos distintos, contando cada pedido uma única vez mesmo com várias linhas de item. Agrupar somente por regiao, sem mes, gera uma granularidade mais grosseira do que a pedida. Selecionar as colunas originais sem nenhuma função de agregação apenas reordena os dados linha a linha, sem consolidar nada. E uma window function com SUM(valor) OVER (PARTITION BY regiao) mantém uma linha por item de pedido, sem reduzir a granularidade, além de não agrupar por mes.",
+        topic: "SQL - Agregacoes (GROUP BY)",
+        options: [
+            ["SELECT regiao, mes, SUM(valor) AS receita, COUNT(DISTINCT pedido_id) AS pedidos FROM silver GROUP BY regiao, mes", true],
+            ["SELECT regiao, mes, SUM(valor) AS receita, COUNT(pedido_id) AS pedidos FROM silver GROUP BY regiao", false],
+            ["SELECT regiao, mes, valor AS receita, pedido_id AS pedidos FROM silver ORDER BY regiao, mes LIMIT 1000", false],
+            ["SELECT regiao, mes, SUM(valor) OVER (PARTITION BY regiao ORDER BY mes) AS receita, pedido_id AS pedidos FROM silver", false],
+        ],
+    },
+];
+
+async function seed() {
+    let [simulado] = await db.select().from(simulados).where(eq(simulados.slug, SLUG));
+    if (!simulado) {
+        [simulado] = await db
+            .insert(simulados)
+            .values({
+                slug: SLUG,
+                name: "Databricks Certified Data Engineer Associate",
+                provider: "databricks",
+                code: "Databricks DE Associate",
+                level: "Associate",
+                description: "Simulado no formato do exame Databricks Certified Data Engineer Associate: 90 minutos, 45 questoes por tentativa, corte de 70%. Cobre a Data Intelligence Platform, ingestao (Lakeflow Connect, Auto Loader), transformacao (Lakeflow Spark Declarative Pipelines), Lakeflow Jobs, CI/CD, otimizacao e governanca com Unity Catalog. Nomenclatura Lakeflow atual.",
+                durationMinutes: 90,
+                questionCount: 45,
+                passPercent: 70,
+                published: true,
+            })
+            .returning();
+        console.log(`Simulado criado: ${simulado.slug}`);
+    }
+    await db
+        .update(simulados)
+        .set({ provider: "databricks", code: "Databricks DE Associate", level: "Associate" })
+        .where(eq(simulados.id, simulado.id));
+
+    const [{ n }] = await db
+        .select({ n: count() })
+        .from(simuladoQuestions)
+        .where(eq(simuladoQuestions.simuladoId, simulado.id));
+    if (Number(n) > 0) { console.log(`Simulado ja tem ${n} questoes, nada a fazer.`); return; }
+
+    for (let i = 0; i < QUESTOES.length; i++) {
+        const q = QUESTOES[i];
+        const [questao] = await db
+            .insert(simuladoQuestions)
+            .values({ simuladoId: simulado.id, statement: q.statement, explanation: q.explanation, topic: q.topic })
+            .returning();
+        await db.insert(simuladoOptions).values(
+            q.options.map(([text, isCorrect], idx) => ({ questionId: questao.id, text, isCorrect, position: idx + 1 })),
+        );
+    }
+    console.log(`Seed concluido: ${QUESTOES.length} questoes inseridas.`);
+}
+
+seed().then(() => process.exit(0)).catch((e) => { console.error("Falha no seed:", e); process.exit(1); });

--- a/backend/scripts/seed-databricks-de-professional.ts
+++ b/backend/scripts/seed-databricks-de-professional.ts
@@ -1,0 +1,1244 @@
+// Seed do simulado Databricks Certified Data Engineer Professional (databricks-de-professional). Idempotente: se ja tiver questoes, nao faz nada.
+//
+// Rodar em dev:  node --env-file=.env scripts/seed-databricks-de-professional.ts
+// Rodar em prod: docker compose -f docker-compose.prod.yml exec -T backend node scripts/seed-databricks-de-professional.ts
+import { db } from "../db.ts";
+import { simulados, simuladoQuestions, simuladoOptions } from "../schema.ts";
+import { eq, count } from "drizzle-orm";
+
+const SLUG = "databricks-de-professional";
+
+type Questao = { statement: string; explanation: string; topic: string; options: [string, boolean][] };
+
+const QUESTOES: Questao[] = [
+    {
+        statement:
+            "A equipe avalia duas tabelas Delta com colunas de altíssima cardinalidade entre os filtros mais frequentes. A tabela A é particionada por device_id, o que gerou um número enorme de diretórios, muitos com poucos arquivos pequenos cada. A tabela B não é particionada, mas roda OPTIMIZE com ZORDER BY (customer_id) periodicamente, e a eficiência dessa reorganização cai visivelmente entre uma execução e a próxima, à medida que novos dados são anexados. Quais DUAS afirmações justificam migrar ambas as tabelas para Liquid Clustering, usando CLUSTER BY na respectiva coluna de alta cardinalidade? (Selecione DUAS opções.)",
+        explanation:
+            "Liquid Clustering reorganiza os dados por afinidade de chave de forma incremental: a cada escrita, para volumes menores, ou a cada OPTIMIZE, para acúmulos maiores, apenas os dados novos ou fora de lugar precisam ser reclusterizados, o que evita o custo crescente do ZORDER, que reescreve arquivos existentes a cada execução para manter a colocação das chaves. Além disso, por não depender de um diretório físico por valor de partição, Liquid Clustering suporta colunas de alta cardinalidade como chave de organização sem o efeito colateral clássico do particionamento tradicional: excesso de partições pequenas e sobrecarga de metadados no log de transações. As chaves de clustering continuam exigindo estatísticas de data skipping para a poda de arquivos, não as dispensam, uma tabela não pode combinar CLUSTER BY com ZORDER BY ou com particionamento (são estratégias mutuamente exclusivas), e VACUUM continua necessário para remover fisicamente, após o período de retenção, os arquivos que a reclusterização deixou de referenciar.",
+        topic: "Liquid Clustering",
+        options: [
+            ["Liquid Clustering reclusteriza os dados de forma incremental a cada escrita ou OPTIMIZE, sem precisar reescrever o histórico inteiro a cada execução, ao contrário do ZORDER.", true],
+            ["Liquid Clustering dispensa a coleta de estatísticas de data skipping, usando apenas metadados internos de clustering para podar arquivos nas consultas.", false],
+            ["Liquid Clustering organiza os dados por afinidade de chave sem exigir um diretório físico por valor distinto, evitando o excesso de partições pequenas típico de colunas de alta cardinalidade.", true],
+            ["Liquid Clustering pode ser combinado livremente com ZORDER BY na mesma tabela, aplicando as duas estratégias de organização física a cada execução de OPTIMIZE.", false],
+            ["Liquid Clustering elimina a necessidade de VACUUM na tabela, pois os arquivos antigos substituídos durante a reclusterização são removidos automaticamente do armazenamento.", false],
+        ],
+    },
+    {
+        statement:
+            "Uma tabela Delta grande recebe operações frequentes de MERGE que alteram menos de 1% das linhas por execução, e a equipe precisa, periodicamente, comprovar a remoção física e definitiva de registros associados a solicitações de exclusão de dados pessoais. A tabela tem deletion vectors habilitados. Quais DUAS afirmações sobre deletion vectors estão corretas nesse contexto? (Selecione DUAS opções.)",
+        explanation:
+            "Deletion vectors implementam merge-on-read: DELETE, UPDATE e MERGE passam a marcar linhas como inválidas em um arquivo auxiliar leve em vez de reescrever o arquivo Parquet inteiro, o que acelera muito operações que tocam uma fração pequena das linhas. Essa marcação, porém, é lógica: as linhas continuam fisicamente presentes no arquivo original até que REORG TABLE ... APPLY (PURGE) reescreva os arquivos afetados sem os registros invalidados, e só depois disso o VACUUM remove do armazenamento os arquivos antigos que deixaram de ser referenciados. Rodar apenas VACUUM, sem o REORG PURGE antes, não elimina fisicamente os dados marcados, o que é crítico para atender uma exigência de exclusão definitiva. Deletion vectors e Change Data Feed são propriedades independentes da tabela, e a compactação de arquivos pequenos continua sendo responsabilidade do OPTIMIZE, manual, agendado ou via predictive optimization, não dos deletion vectors.",
+        topic: "Deletion Vectors",
+        options: [
+            ["Deletion vectors substituem o OPTIMIZE como estratégia de compactação, unindo automaticamente arquivos pequenos a cada escrita realizada na tabela.", false],
+            ["O MERGE marca as linhas afetadas como inválidas em um arquivo auxiliar associado ao arquivo Parquet original, evitando reescrever integralmente arquivos grandes para alterar poucas linhas.", true],
+            ["Deletion vectors dispensam a execução de VACUUM, pois os arquivos Parquet substituídos são removidos automaticamente do armazenamento assim que o MERGE é confirmado.", false],
+            ["Para remover fisicamente as linhas marcadas pelos deletion vectors, é preciso rodar REORG TABLE ... APPLY (PURGE) antes de um VACUUM, que só então elimina os arquivos antigos do armazenamento.", true],
+            ["Deletion vectors são ativados automaticamente em qualquer tabela no momento em que o Change Data Feed é habilitado, pois ambos compartilham a mesma propriedade da tabela.", false],
+        ],
+    },
+    {
+        statement:
+            "Um time de dados mantém dezenas de jobs agendados só para rodar OPTIMIZE, VACUUM e coleta de estatísticas em centenas de tabelas gerenciadas do Unity Catalog, com uma frequência fixa definida manualmente para cada tabela. Além do esforço operacional, tabelas pouco alteradas são otimizadas sem necessidade, e tabelas muito alteradas ficam com arquivos pequenos entre uma execução e outra. Qual mudança resolve diretamente esses dois problemas?",
+        explanation:
+            "Predictive optimization é um recurso do Unity Catalog que assume a decisão de quando rodar OPTIMIZE, incluindo a manutenção de Liquid Clustering, VACUUM e ANALYZE em tabelas gerenciadas, executando essas operações em compute serverless administrado pela própria Databricks. A frequência não é fixa: o serviço avalia o padrão de leitura e escrita de cada tabela para equilibrar o benefício esperado contra o custo de compute, evitando tanto otimizar tabelas paradas quanto deixar tabelas muito alteradas com excesso de arquivos pequenos entre execuções. Optimized writes e auto compaction reduzem o problema de arquivos pequenos no momento da escrita, mas não cobrem VACUUM nem a coleta de estatísticas do ANALYZE, e Liquid Clustering troca a estratégia de organização física dos dados, mas não elimina a necessidade de VACUUM nem de ANALYZE.",
+        topic: "Predictive Optimization",
+        options: [
+            ["Habilitar predictive optimization nas tabelas, deixando o Databricks decidir quando rodar OPTIMIZE, VACUUM e ANALYZE em compute serverless, conforme o uso real.", true],
+            ["Consolidar todos os jobs em um único pipeline com Lakeflow Jobs, mantendo a mesma frequência fixa, mas centralizando o agendamento e o monitoramento em um só lugar.", false],
+            ["Habilitar optimized writes e auto compaction em todas as tabelas, eliminando por completo a necessidade de qualquer execução agendada de OPTIMIZE.", false],
+            ["Migrar as tabelas para Liquid Clustering, que dispensa VACUUM e ANALYZE por manter as estatísticas de partição sempre atualizadas automaticamente.", false],
+        ],
+    },
+    {
+        statement:
+            "Um pipeline de Structured Streaming grava micro-lotes a cada poucos segundos em uma tabela Delta, e cada micro-lote produz vários arquivos pequenos por executor. Depois de algumas semanas, a tabela acumula um número muito grande de arquivos pequenos, o que aumenta o tempo de listagem e de planejamento das consultas downstream. A equipe quer reduzir esse acúmulo continuamente, sem depender apenas de uma execução manual de OPTIMIZE uma vez por dia. Qual configuração ataca o problema no próprio momento da escrita?",
+        explanation:
+            "As propriedades delta.autoOptimize.optimizeWrite e delta.autoOptimize.autoCompact atacam o problema de arquivos pequenos no momento da escrita: optimized writes usa um shuffle adicional para produzir arquivos de tamanho mais adequado antes de gravá-los, e auto compaction roda uma compactação rápida e seletiva logo após cada commit, unindo arquivos pequenos dentro das partições afetadas sem exigir um OPTIMIZE completo. Reduzir o trigger interval só aumenta a frequência de escrita, e o número de arquivos pequenos junto com ela, aumentar spark.sql.shuffle.partitions eleva o paralelismo mas não junta arquivos pequenos já existentes, e deletion vectors resolvem reescrita em DELETE, UPDATE e MERGE, não a fragmentação gerada por escritas incrementais de streaming.",
+        topic: "OPTIMIZE e Compactação",
+        options: [
+            ["Reduzir o intervalo do trigger do Structured Streaming para gravar micro-lotes ainda mais frequentes, diluindo o volume de dados por arquivo gerado.", false],
+            ["Habilitar optimized writes e auto compaction na tabela, para a escrita gerar arquivos maiores e uma compactação leve rodar logo após cada commit de escrita.", true],
+            ["Aumentar o valor de spark.sql.shuffle.partitions no job de streaming, elevando o paralelismo de gravação em cada micro-lote.", false],
+            ["Ativar deletion vectors na tabela, para que os micro-lotes gravados passem a ser mesclados automaticamente aos arquivos existentes em vez de criar arquivos novos.", false],
+        ],
+    },
+    {
+        statement:
+            "Uma tabela Delta muito larga, com mais de 300 colunas, sofre lentidão perceptível em cada escrita. A equipe descobre que boa parte do tempo é gasto coletando estatísticas de min/max para dezenas de colunas que nunca aparecem em cláusulas WHERE das consultas, enquanto as poucas colunas realmente usadas como filtro estão entre as dez primeiras do schema. Qual ajuste reduz o custo de escrita sem comprometer a poda de arquivos (data skipping) nas consultas existentes?",
+        explanation:
+            "O Delta Lake coleta estatísticas de min/max, contagem de nulos e contagem de linhas para as primeiras colunas do schema, até o limite definido por delta.dataSkippingNumIndexedCols (32 por padrão), e usa esses valores para pular arquivos inteiros no planejamento de uma consulta sem precisar lê-los. Em uma tabela muito larga, coletar estatísticas para colunas que nunca são filtradas só adiciona custo de escrita sem benefício de poda, então reduzir esse limite para cobrir apenas as colunas de schema realmente usadas em filtros, que já estão entre as primeiras no cenário descrito, preserva o data skipping onde importa e corta o custo nas demais. Remover as estatísticas por completo eliminaria a poda também para as colunas de filtro, aumentar o limite só pioraria a lentidão na escrita, e Liquid Clustering organiza fisicamente os arquivos por afinidade de chave, mas continua dependendo de estatísticas de data skipping para a poda, não a substitui.",
+        topic: "Data Skipping",
+        options: [
+            ["Remover completamente as estatísticas de data skipping da tabela, deixando toda a poda de arquivos a cargo do particionamento físico.", false],
+            ["Aumentar o delta.dataSkippingNumIndexedCols para o máximo permitido, garantindo que todas as 300 colunas recebam estatísticas atualizadas a cada escrita.", false],
+            ["Reduzir o delta.dataSkippingNumIndexedCols para cobrir apenas as colunas usadas em filtros, coletadas a partir das primeiras colunas do schema.", true],
+            ["Habilitar Liquid Clustering em todas as colunas usadas como filtro, o que substitui automaticamente a necessidade de estatísticas de data skipping.", false],
+        ],
+    },
+    {
+        statement:
+            "Um time de BI roda, repetidamente, as mesmas consultas ad hoc sobre a mesma fatia recente de uma tabela Delta, em um cluster interativo com tipos de instância com SSD local elegíveis para cache. Sem qualquer alteração no código das consultas, as execuções seguintes ficam sensivelmente mais rápidas que a primeira, mesmo em consultas escritas por analistas diferentes. Qual mecanismo explica essa aceleração automática?",
+        explanation:
+            "O disk cache, antigo Delta cache, copia automaticamente para o SSD local dos workers os blocos de arquivos remotos, Parquet ou Delta, lidos durante uma consulta, em tipos de instância com armazenamento local elegíveis para cache. Leituras seguintes dos mesmos dados, mesmo vindas de consultas ou usuários diferentes, são atendidas a partir dessa cópia local, sem passar de novo pelo armazenamento remoto, e isso acontece de forma transparente, sem exigir .cache() explícito. O cache de resultados do warehouse só reaproveita o resultado final de uma consulta idêntica, o Spark não aplica .cache() automaticamente aos DataFrames lidos de uma tabela, e o Photon acelera a execução vetorizada das operações, mas não é responsável por manter cópias locais dos arquivos lidos.",
+        topic: "Disk Cache",
+        options: [
+            ["O resultado de cada consulta é armazenado no cache de resultados do warehouse e reaproveitado sempre que o texto SQL enviado for idêntico.", false],
+            ["O Spark aplica .cache() automaticamente a qualquer DataFrame lido de uma tabela Delta, persistindo os dados deserializados na memória do cluster.", false],
+            ["O Photon reescreve o plano de execução das consultas seguintes para eliminar estágios de shuffle repetidos entre analistas diferentes.", false],
+            ["O disk cache copia para o SSD local dos workers os arquivos remotos lidos na primeira consulta, e as leituras seguintes usam essa cópia local.", true],
+        ],
+    },
+    {
+        statement:
+            "Um engenheiro desabilitou explicitamente o Adaptive Query Execution, definindo spark.sql.adaptive.enabled como false em um job, por um motivo que não tem relação com joins. Depois dessa mudança, um join entre duas tabelas grandes, que antes terminava em poucos minutos, passou a ter uma única tarefa do estágio de shuffle demorando muito mais que as demais, porque uma chave de join concentra uma fração desproporcional das linhas de ambos os lados. Qual ação resolve esse problema de forma mais direta?",
+        explanation:
+            "A divisão automática de partições enviesadas é um sub-recurso da Adaptive Query Execution, controlado por spark.sql.adaptive.skewJoin.enabled e ligado por padrão, mas ele só atua quando a AQE como um todo está habilitada, em spark.sql.adaptive.enabled. Ao desativar a AQE inteira, o engenheiro perdeu também essa subdivisão automática da partição dominada pela chave enviesada, então reabilitar a AQE restaura o comportamento sem exigir mudança no código do job. Aumentar spark.sql.shuffle.partitions redistribui o hash das chaves entre mais partições, mas todas as linhas de uma mesma chave continuam caindo na mesma partição, então não resolve o desbalanceamento causado por uma única chave dominante. Broadcast é pensado para o lado pequeno do join, então aplicá-lo na tabela maior tende a esgotar a memória dos executores, e um repartition() aleatório, sem as colunas de join, ainda exige um shuffle adicional por chave no momento do join em si.",
+        topic: "Shuffle e Join",
+        options: [
+            ["Reabilitar o Adaptive Query Execution, que volta a dividir em tempo de execução a partição dominada pela chave desproporcional entre tarefas.", true],
+            ["Aumentar o valor de spark.sql.shuffle.partitions, elevando o número total de partições usadas no shuffle gerado pelo join entre as duas tabelas.", false],
+            ["Aplicar um hint de broadcast na tabela maior do join, forçando o Spark a enviá-la inteira para a memória de cada executor do cluster.", false],
+            ["Aplicar repartition() no DataFrame de entrada usando 200 partições aleatórias antes do join, sem informar as colunas usadas na condição de join.", false],
+        ],
+    },
+    {
+        statement:
+            "Uma consulta faz join entre uma tabela de fatos grande e uma tabela de dimensão que, após um filtro bastante seletivo aplicado antes do join, resulta em poucas linhas. O plano estático exibido por EXPLAIN mostra um sort-merge join, pois o otimizador não conhece o tamanho pós-filtro em tempo de compilação. Na prática, porém, o Spark UI mostra que a consulta executou como um broadcast join, bem mais rápido que o plano estático sugeria. O que explica essa diferença entre o plano estático e a execução real?",
+        explanation:
+            "A Adaptive Query Execution reotimiza o plano físico entre estágios de uma consulta, usando estatísticas reais em vez das estimativas do otimizador baseado em custo calculadas antes da execução. Nesse caso, o filtro seletivo só revela seu efeito real depois de executado, então a AQE reavalia o tamanho do lado filtrado após esse estágio e, encontrando-o abaixo do limite de spark.sql.autoBroadcastJoinThreshold, substitui o sort-merge join planejado por um broadcast join na execução. O Photon acelera a execução vetorizada das operações, mas não decide a estratégia de join, o otimizador baseado em custo usa estatísticas do ANALYZE para o plano inicial, não para reotimizar durante a execução, e o cache de resultados do warehouse reaproveita resultados finais de consultas idênticas, não planos de execução de consultas diferentes.",
+        topic: "Shuffle e Join",
+        options: [
+            ["O Photon substitui automaticamente qualquer sort-merge join por um broadcast join sempre que ambas as tabelas de origem são arquivos Delta.", false],
+            ["A Adaptive Query Execution reavalia o plano após o filtro e troca o sort-merge join por um broadcast join, pois o lado filtrado ficou menor que o limite de broadcast.", true],
+            ["O otimizador baseado em custo reexecuta o planejamento do zero antes de cada consulta, usando estatísticas de ANALYZE coletadas na execução anterior da mesma consulta.", false],
+            ["O cache de resultados do warehouse reconheceu uma consulta equivalente executada anteriormente e reaproveitou o plano de execução mais eficiente daquela vez.", false],
+        ],
+    },
+    {
+        statement:
+            "Um time de analistas roda consultas SQL ad hoc em horários imprevisíveis ao longo do dia, com longos intervalos de ociosidade entre elas. Hoje, o warehouse clássico fica ligado o dia inteiro para evitar o tempo de provisionamento de um novo cluster a cada consulta, gerando custo elevado de capacidade ociosa. Qual mudança reduz esse desperdício sem piorar o tempo de resposta percebido pelos analistas?",
+        explanation:
+            "Compute serverless, aqui um SQL warehouse serverless, é gerenciado pela própria Databricks, inicia em segundos, escala automaticamente e cobra por uso efetivo, o que elimina a necessidade de manter um cluster clássico ligado o dia inteiro só para evitar o tempo de provisionamento. Um cluster clássico com mínimo de workers zero ainda enfrenta o tempo de subida de nós na nuvem a cada nova consulta após um período ocioso, o que piora o tempo de resposta percebido, e desligar o auto termination só mantém o custo de capacidade ociosa. Aumentar o mínimo de workers do autoscaling clássico reduz a latência de provisionamento em picos, mas mantém capacidade paga ociosa durante os intervalos sem consultas, e pools de instâncias reduzem o tempo de subida de nós, mas ainda exigem manter instâncias pré-inicializadas reservadas, gerando custo contínuo.",
+        topic: "Serverless vs Classic Compute",
+        options: [
+            ["Reduzir o número mínimo de workers do cluster clássico para zero, mantendo o auto termination desligado para garantir disponibilidade imediata.", false],
+            ["Configurar autoscaling clássico com um número mínimo maior de workers, reduzindo o tempo de provisionamento de novos nós a cada pico de consultas.", false],
+            ["Migrar as consultas para um SQL warehouse serverless, que inicia em segundos e cobra por uso, sem custo de capacidade ligada nos intervalos ociosos.", true],
+            ["Trocar o warehouse clássico por um cluster de job dedicado, reaproveitado entre execuções por meio de pools de instâncias pré-inicializadas.", false],
+        ],
+    },
+    {
+        statement:
+            "Um pipeline de Lakeflow Spark Declarative Pipelines processa um fluxo de streaming cuja vazão varia bastante ao longo do dia, com picos curtos seguidos de longos períodos de baixa atividade. Configurado com o modo clássico de autoscaling do cluster, o pipeline mantém mais workers ativos do que o necessário durante boa parte do dia, elevando o custo sem reduzir a latência de forma perceptível. Qual mudança de configuração reduz o custo nos períodos de baixa atividade, mantendo a latência de processamento sob controle?",
+        explanation:
+            "Enhanced Autoscaling é o modo de autoscaling dos Lakeflow Spark Declarative Pipelines, ativado por padrão para pipelines novos, construído para as cargas de streaming e batch do próprio pipeline: ele reage a métricas de carga do pipeline e reduz a capacidade de forma mais agressiva durante quedas de vazão, sem sacrificar a latência de processamento nos picos. O autoscaling clássico de cluster reage principalmente ao volume de tarefas pendentes e costuma manter workers por mais tempo antes de reduzir, o que explica o excesso de capacidade observado. Fixar um número de workers para o pico histórico garante desempenho no pior caso, mas paga por essa capacidade o tempo todo, mesmo nos períodos ociosos. Reduzir o máximo do autoscaling clássico limita o custo no pico, mas não resolve o desperdício nos períodos de baixa atividade, e o intervalo de checkpoint do Structured Streaming não tem relação com a decisão de quantos workers o autoscaling mantém ativos.",
+        topic: "Autoscaling",
+        options: [
+            ["Fixar um número único de workers, dimensionado para o pico máximo de vazão observado historicamente, eliminando a variabilidade do autoscaling.", false],
+            ["Reduzir o valor máximo de workers do autoscaling clássico, forçando o cluster a operar sempre próximo do limite inferior configurado.", false],
+            ["Aumentar o intervalo de checkpoint do Structured Streaming subjacente ao pipeline, reduzindo a frequência de avaliação da carga pelo autoscaling.", false],
+            ["Usar o modo Enhanced Autoscaling no pipeline, que reage à carga real e reduz workers de forma mais agressiva nos períodos ociosos.", true],
+        ],
+    },
+    {
+        statement:
+            "Um job de ETL em SQL faz grandes leituras, joins e agregações sobre tabelas Delta em um cluster clássico. Ao habilitar Photon nesse cluster, o custo por hora de compute em DBUs aumenta, mas o tempo total de execução do job cai de forma significativa. Depois da mudança, o time discute se o job ficou mais caro ou mais barato. Qual afirmação avalia corretamente o efeito de Photon no custo total desse job?",
+        explanation:
+            "Photon é um mecanismo de execução vetorizado, compatível com as APIs do Spark, que acelera operações de scan, join e agregação, entre outras. O compute com Photon tem uma taxa de DBU por hora mais alta do que o compute equivalente sem Photon, mas o custo total de um job é a taxa horária multiplicada pela duração da execução, então uma redução proporcionalmente maior no tempo de execução pode compensar, e até superar, o aumento da taxa, resultando em um custo total menor apesar da taxa mais alta. Não há garantia automática em nenhuma das duas direções: o resultado depende do quanto aquele workload específico se beneficia da execução vetorizada, então nem sempre mais caro nem sempre mais barato na mesma proporção descrevem o comportamento real, e o Databricks não ajusta a cobrança de DBUs para compensar a mudança de taxa.",
+        topic: "Photon",
+        options: [
+            ["O custo total depende da taxa horária multiplicada pela duração; se o tempo cair mais, proporcionalmente, do que a taxa subiu, o custo total do job diminui.", true],
+            ["O job ficou necessariamente mais caro, porque o custo por hora em DBUs de compute com Photon é sempre maior do que o de compute equivalente sem Photon.", false],
+            ["O custo total não muda, pois o Databricks compensa automaticamente o aumento da taxa horária do Photon reduzindo o número de DBUs cobrados por operação executada.", false],
+            ["O job ficou necessariamente mais barato, porque o Photon sempre reduz o tempo de execução na mesma proporção em que aumenta a taxa horária de DBUs.", false],
+        ],
+    },
+    {
+        statement:
+            "Um job noturno de ETL em lote é totalmente reprocessável: cada tarefa perdida pode ser recalculada a partir das fontes sem afetar o resultado final, e um atraso ocasional de alguns minutos é aceitável. A equipe quer reduzir o custo de compute desse job aproveitando instâncias spot, mas sem arriscar a perda do estado do cluster inteiro caso a nuvem reivindique capacidade spot no meio da execução. Qual configuração atende a esse objetivo?",
+        explanation:
+            "Perder o driver encerra o cluster inteiro, e o job junto com ele, então o driver deve rodar em uma instância on-demand, nunca spot. Os workers, por outro lado, são substituíveis: se um worker spot for reivindicado pela nuvem, o Spark apenas recalcula as tarefas perdidas a partir da linhagem, o que é aceitável para um job tolerante a falhas e reprocessável como esse. Configurar também o driver como spot arrisca perder o cluster inteiro no meio da execução, manter todas as instâncias on-demand abre mão da economia de custo que o spot ofereceria aos workers, e inverter as instâncias, com o driver em spot e apenas o primeiro worker on-demand, é exatamente o oposto da prática recomendada, pois expõe o componente mais crítico do cluster ao risco de reivindicação.",
+        topic: "Spot Instances",
+        options: [
+            ["Configurar o driver e todos os workers como instâncias spot, com fallback para on-demand caso a capacidade spot não esteja disponível no momento da criação do cluster.", false],
+            ["Configurar o driver como on-demand e os workers como spot com fallback para on-demand, para que a perda de um worker só dispare o reprocessamento das tarefas afetadas.", true],
+            ["Configurar o driver e todos os workers como instâncias on-demand, e reduzir o número máximo de workers do autoscaling para diminuir o custo total do job.", false],
+            ["Configurar apenas o primeiro worker como instância on-demand e o driver como spot, garantindo que ao menos uma parte fixa do cluster não seja reivindicada pela nuvem.", false],
+        ],
+    },
+    {
+        statement:
+            "Uma consulta Structured Streaming com agregação por janela grava seu diretório de checkpoint em um volume do Unity Catalog. O cluster que executava a consulta falha de forma inesperada e um novo cluster reinicia a mesma consulta apontando para o mesmo checkpoint. Quais DUAS informações o checkpoint permite que a consulta recupere corretamente ao reiniciar? (Selecione DUAS opções.)",
+        explanation:
+            "O checkpoint de uma consulta Structured Streaming guarda o progresso de leitura da fonte, como os offsets já processados, e o estado necessário para operações stateful, como agregações por janela e joins com watermark, permitindo retomar a consulta do ponto correto após uma falha. Ele não armazena os dados brutos lidos, que continuam apenas na fonte, nem credenciais de acesso, que vêm da configuração do cluster, nem o histórico de versões da tabela Delta de destino, que fica no próprio transaction log da tabela Delta, não no checkpoint da consulta.",
+        topic: "Structured Streaming - checkpoint",
+        options: [
+            ["Os offsets de leitura da fonte, indicando até onde os dados já foram processados", true],
+            ["O estado intermediário das operações stateful, como os agregados parciais de cada janela", true],
+            ["Os arquivos de dados brutos lidos da fonte, copiados para dentro do checkpoint", false],
+            ["As credenciais de acesso ao Unity Catalog usadas pelo cluster anterior", false],
+            ["O histórico completo de versões da tabela Delta de destino, equivalente ao transaction log", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe processa arquivos que chegam em um volume ao longo do dia usando Auto Loader com Structured Streaming. Para reduzir custo, a consulta deve rodar em um job agendado que liga o cluster, processa TODOS os arquivos pendentes, dividindo-os em vários micro-batches de tamanho adequado quando o volume acumulado for grande, e encerra a consulta sozinha ao terminar. Qual trigger atende esse requisito?",
+        explanation:
+            "Trigger.AvailableNow() processa todo o backlog de dados disponível no momento em que a consulta inicia, dividindo-o automaticamente em múltiplos micro-batches de tamanho gerenciável, e encerra a consulta sozinha ao concluir, ideal para jobs agendados que ligam e desligam o cluster. Trigger.Once() também processa todo o backlog e encerra a consulta, mas força tudo em um único micro-batch, o que pode ser ineficiente ou arriscado com um volume grande de dados acumulados. Trigger.ProcessingTime com um intervalo fixo e o trigger padrão mantêm a consulta rodando continuamente entre disparos, sem encerrar sozinhos, exigindo que o cluster permaneça ativo.",
+        topic: "Structured Streaming - triggers",
+        options: [
+            ["Trigger.AvailableNow(), que processa todo o backlog disponível em múltiplos micro-batches e encerra a consulta ao final", true],
+            ["Trigger.Once(), que processa todo o backlog disponível em um único micro-batch e encerra a consulta ao final", false],
+            ["Trigger.ProcessingTime('1 hour'), que dispara um novo micro-batch a cada hora e mantém a consulta em execução contínua", false],
+            ["O trigger padrão, sem argumento, que dispara um novo micro-batch assim que o anterior termina e mantém a consulta em execução contínua", false],
+        ],
+    },
+    {
+        statement:
+            "Uma consulta Structured Streaming calcula a contagem de eventos por janela de 10 minutos sobre uma coluna de tempo de evento, com watermark de 15 minutos definido nessa mesma coluna. Um evento chega com timestamp de evento 40 minutos mais antigo que o watermark atual da consulta. O que acontece com esse evento?",
+        explanation:
+            "Quando o watermark avança além do fim de uma janela mais o limite de atraso configurado, o Spark considera essa janela finalizada e libera o estado associado da memória. Eventos que chegam depois disso, com tempo de evento anterior ao watermark, são descartados silenciosamente, sem erro e sem reabrir o estado já liberado. O Structured Streaming não cria nenhuma tabela de quarentena automática para esses dados; se for necessário capturá-los, isso precisa ser implementado explicitamente pela aplicação.",
+        topic: "Structured Streaming - watermark",
+        options: [
+            ["O evento é descartado silenciosamente, pois sua janela já teve o estado finalizado e removido da memória", true],
+            ["O evento é processado normalmente e reabre o estado da janela correspondente, corrigindo o resultado já emitido", false],
+            ["A consulta falha com erro, pois eventos atrasados além do watermark não são permitidos pelo Structured Streaming", false],
+            ["O evento é gravado em uma tabela de quarentena criada automaticamente pelo Spark para dados fora do watermark", false],
+        ],
+    },
+    {
+        statement:
+            "Uma consulta Structured Streaming agrega o total de vendas por janela de 5 minutos e precisa gravar o resultado em um tópico Kafka, que só aceita gravações em modo append. A consulta já define uma coluna de tempo de evento e um watermark. Como o engenheiro deve configurar a saída para que a agregação seja compatível com o sink Kafka?",
+        explanation:
+            "Quando a agregação tem um watermark definido, o modo de saída append passa a ser permitido: o Spark só emite a linha final de cada janela depois que o watermark garante que ela não vai mais receber atualizações, produzindo um fluxo de inserções puras compatível com sinks que só aceitam append, como o Kafka. O modo update emite atualizações incrementais da linha antes dela ser definitiva, e o modo complete reescreve a tabela inteira de resultados a cada micro-batch; nenhum dos dois é aceito por um sink que só suporta append. Remover o watermark não habilita o modo append para agregações, além de impedir o Spark de limitar o estado mantido em memória.",
+        topic: "Structured Streaming - output modes",
+        options: [
+            ["Usar modo de saída append; com watermark definido, o Spark só emite o total de cada janela depois que ela é finalizada", true],
+            ["Usar modo de saída update, pois agregações com watermark só podem ser emitidas de forma incremental nesse modo", false],
+            ["Usar modo de saída complete, pois agregações exigem que a tabela de resultado inteira seja reescrita a cada micro-batch", false],
+            ["Remover o watermark e usar modo append, já que o watermark só é necessário para agregações em modo complete", false],
+        ],
+    },
+    {
+        statement:
+            "Um pipeline usa foreachBatch para aplicar um MERGE INTO customizado em uma tabela Delta a cada micro-batch de uma consulta Structured Streaming. Após uma falha de task, o Spark reexecuta o micro-batch, e a função passada ao foreachBatch é chamada novamente com o mesmo lote de dados. Qual característica do design do MERGE dentro do foreachBatch evita que essa nova execução duplique ou corrompa os dados na tabela de destino?",
+        explanation:
+            "foreachBatch oferece garantia de pelo menos uma vez para a chamada da função: em caso de falha, o mesmo micro-batch pode ser reprocessado. Por isso, a operação dentro da função precisa ser idempotente por design, tipicamente usando MERGE com uma chave de negócio, de forma que reaplicar o mesmo lote produza o mesmo resultado final, sem duplicar linhas. O foreachBatch não garante exatamente uma vez sozinho, o checkpoint da consulta não bloqueia reexecuções de micro-batches em foreachBatch da forma descrita, e o Delta Lake não possui deduplicação automática de lotes reprocessados por identificador de micro-batch.",
+        topic: "foreachBatch - idempotência",
+        options: [
+            ["O MERGE usa uma chave de negócio para casar as linhas do lote com a tabela de destino, tornando a operação idempotente", true],
+            ["O foreachBatch garante processamento exatamente uma vez por padrão, então nenhum cuidado extra é necessário na lógica do MERGE", false],
+            ["O checkpoint da consulta bloqueia automaticamente a reexecução de um micro-batch que já foi processado por foreachBatch", false],
+            ["O Delta Lake detecta lotes duplicados automaticamente pelo identificador interno do micro-batch e ignora reexecuções", false],
+        ],
+    },
+    {
+        statement:
+            "Uma tabela silver precisa receber, no mesmo micro-batch, upserts de uma tabela de dimensão usando SCD tipo 2 e, adicionalmente, gravar uma cópia filtrada de linhas rejeitadas em uma tabela separada de erros, com uma lógica condicional específica do negócio. A equipe avalia implementar isso em um Lakeflow Spark Declarative Pipeline. Qual abordagem atende esse requisito?",
+        explanation:
+            "AUTO CDC automatiza bem o padrão declarativo de upsert e SCD tipo 1 ou 2, mas não oferece um mecanismo declarativo para, na mesma operação, desviar linhas para uma tabela de erros com lógica condicional arbitrária de negócio. Quando a necessidade é esse tipo de controle imperativo combinando múltiplas escritas customizadas no mesmo micro-batch, foreachBatch em Structured Streaming é a abordagem indicada, pois permite escrever código Python livre dentro da função. AUTO CDC não tem uma opção nativa para gravar rejeitados em outra tabela, e materialized view não se aplica a esse padrão de ingestão incremental com upsert.",
+        topic: "foreachBatch x AUTO CDC",
+        options: [
+            ["Usar foreachBatch em uma consulta Structured Streaming, aplicando o MERGE e a gravação condicional de erros na mesma função", true],
+            ["Usar AUTO CDC com STORED AS SCD TYPE 2, que já permite gravar linhas rejeitadas em uma tabela separada como parte da mesma declaração", false],
+            ["Declarar duas streaming tables independentes com AUTO CDC, uma para o SCD tipo 2 e outra para os erros, sem nenhum código customizado", false],
+            ["Usar uma materialized view com AUTO CDC embutido para calcular o SCD tipo 2 e o desvio de linhas de erro na mesma consulta declarativa", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe está decidindo entre implementar um novo fluxo de ingestão como Lakeflow Spark Declarative Pipelines ou como uma consulta Structured Streaming standalone orquestrada por um Lakeflow Job. O fluxo precisa, a cada micro-batch, chamar uma API REST externa para validar um subconjunto de registros antes de decidir, de forma imperativa, se grava, descarta ou reencaminha cada registro para filas diferentes. Qual opção é mais adequada?",
+        explanation:
+            "Lakeflow Spark Declarative Pipelines foi projetado para declarar datasets, como streaming tables e materialized views, e suas transformações de forma declarativa; ele suporta Python, mas o modelo continua centrado em definir o que cada dataset é, não em controle imperativo fino como chamar uma API externa e decidir o roteamento registro a registro. Para esse padrão, uma consulta Structured Streaming com foreachBatch dá o controle imperativo necessário. A opção que descarta Python do pipeline está incorreta, pois pipelines suportam PySpark, e o event log serve para observabilidade do pipeline, não substitui uma chamada de validação a uma API de negócio.",
+        topic: "Structured Streaming x Declarative Pipelines",
+        options: [
+            ["Structured Streaming standalone, porque a chamada a uma API externa e o roteamento imperativo de registros vão além do modelo declarativo de datasets do pipeline", true],
+            ["Lakeflow Spark Declarative Pipelines, porque toda lógica Python arbitrária, incluindo chamadas de rede a APIs externas, roda nativamente dentro de uma streaming table", false],
+            ["Lakeflow Spark Declarative Pipelines, porque o event log do pipeline substitui a necessidade de qualquer chamada de validação externa durante o processamento", false],
+            ["Structured Streaming standalone, porque Lakeflow Spark Declarative Pipelines não suporta nenhuma transformação com Python, apenas SQL declarativo", false],
+        ],
+    },
+    {
+        statement:
+            "Uma tabela Delta de clientes deve refletir exatamente o estado atual de um sistema de origem: quando um cliente é excluído na origem, o registro correspondente deve ser removido da tabela Delta durante a próxima sincronização via MERGE INTO. Qual cláusula do MERGE implementa essa exclusão?",
+        explanation:
+            "WHEN NOT MATCHED BY SOURCE se aplica a linhas que existem na tabela de destino mas não têm correspondência no lote de origem, e permite DELETE ou UPDATE nelas, o que cobre exatamente o caso de um registro excluído na origem. WHEN NOT MATCHED, sem BY SOURCE, se aplica ao caso oposto, linhas presentes na origem sem correspondência no destino, e só permite INSERT, não DELETE. A cláusula com WHEN MATCHED AND só cobre exclusões explícitas enviadas pela origem com uma flag, não o caso em que o registro simplesmente deixa de aparecer no lote. Inserir uma flag e filtrar na leitura não remove fisicamente a linha nem usa a cláusula do MERGE prevista para esse cenário.",
+        topic: "MERGE INTO - WHEN NOT MATCHED BY SOURCE",
+        options: [
+            ["WHEN NOT MATCHED BY SOURCE THEN DELETE, que remove da tabela de destino as linhas sem correspondência no lote de origem", true],
+            ["WHEN NOT MATCHED THEN DELETE, que remove da tabela de destino as linhas sem correspondência no lote de origem", false],
+            ["WHEN MATCHED AND source.deleted = true THEN DELETE, aplicada mesmo quando a origem não envia mais o registro excluído", false],
+            ["WHEN NOT MATCHED THEN INSERT com uma coluna de flag de exclusão, seguida de um filtro na leitura da tabela", false],
+        ],
+    },
+    {
+        statement:
+            "Um MERGE INTO em uma tabela Delta tem duas cláusulas WHEN MATCHED em sequência: a primeira, com uma condição específica, faz DELETE; a segunda, sem condição adicional, faz UPDATE. Para uma linha do lote de origem que casa com uma linha de destino e satisfaz a condição da primeira cláusula, o que o Delta Lake faz?",
+        explanation:
+            "Quando um MERGE INTO tem múltiplas cláusulas WHEN MATCHED, o Delta Lake avalia na ordem em que foram escritas e aplica apenas a primeira cuja condição seja satisfeita para aquela linha; as demais cláusulas WHEN MATCHED são ignoradas para essa mesma linha. Por isso, a linha é excluída pela primeira cláusula e a segunda, de UPDATE, nunca chega a ser aplicada a ela. Múltiplas cláusulas WHEN MATCHED são permitidas, desde que todas exceto a última tenham uma condição, então a operação não é rejeitada, e não é a última cláusula que casa que prevalece, e sim a primeira.",
+        topic: "MERGE INTO - múltiplas cláusulas WHEN MATCHED",
+        options: [
+            ["Aplica apenas a primeira cláusula que casar, a de DELETE, e ignora a segunda cláusula WHEN MATCHED para essa linha", true],
+            ["Aplica as duas cláusulas em sequência na mesma linha, primeiro fazendo DELETE e depois um UPDATE na linha já excluída", false],
+            ["Rejeita a operação inteira com erro, pois duas cláusulas WHEN MATCHED nunca podem coexistir em um mesmo MERGE INTO", false],
+            ["Aplica a última cláusula que casar, ou seja, a de UPDATE, ignorando a cláusula de DELETE definida antes dela", false],
+        ],
+    },
+    {
+        statement:
+            "Um MERGE INTO passa a falhar com erro de schema depois que a origem ganhou uma nova coluna que ainda não existe na tabela Delta de destino. A equipe quer que o MERGE evolua o schema da tabela automaticamente, adicionando a nova coluna, sem reescrever o pipeline manualmente a cada mudança. Qual configuração habilita esse comportamento para operações de MERGE?",
+        explanation:
+            "A evolução automática de schema em operações de MERGE é controlada pela configuração spark.databricks.delta.schema.autoMerge.enabled, definida como true na sessão Spark ou no cluster; com ela ativa, colunas novas presentes na origem são adicionadas automaticamente à tabela de destino durante o MERGE. A opção mergeSchema no DataFrameWriter se aplica a escritas de dataframe comuns, como append e overwrite, mas não é o mecanismo usado para operações de MERGE. Adicionar colunas manualmente com ALTER TABLE funciona, mas não automatiza nada, contrariando o requisito. Column Mapping permite renomear e remover colunas com mais flexibilidade, mas não é o que habilita a evolução automática de schema durante o MERGE.",
+        topic: "MERGE INTO - evolução de schema",
+        options: [
+            ["Definir spark.databricks.delta.schema.autoMerge.enabled como true na sessão ou no cluster antes de executar o MERGE", true],
+            ["Definir a opção mergeSchema como true no DataFrameWriter usado para o MERGE, do mesmo jeito que em uma escrita append comum", false],
+            ["Executar ALTER TABLE ... ADD COLUMNS manualmente antes de cada MERGE, já que nenhuma configuração automatiza esse passo", false],
+            ["Ativar Column Mapping na tabela de destino, que por si só permite que o MERGE aceite colunas novas vindas da origem", false],
+        ],
+    },
+    {
+        statement:
+            "Uma tabela Delta silver precisa propagar para uma tabela gold, de forma incremental, tanto o valor anterior quanto o valor novo de cada linha que sofrer UPDATE, além de identificar linhas inseridas e excluídas. A equipe habilita Change Data Feed na tabela silver. Quais DUAS afirmações sobre esse cenário estão corretas? (Selecione DUAS opções.)",
+        explanation:
+            "Com Change Data Feed habilitado, cada UPDATE gera duas linhas de saída, uma representando o valor antes da mudança, com _change_type update_preimage, e outra o valor depois, com update_postimage, além de linhas insert e delete para os demais casos; essas mudanças podem ser lidas com a função table_changes em SQL ou com a opção readChangeFeed em leituras batch e streaming. O time travel entrega apenas fotografias completas da tabela em versões específicas, sem separar o que mudou linha a linha nem os valores antes e depois de um UPDATE. O CDF pode sim ser consumido em streaming, não apenas em batch. E habilitar o CDF não reescreve nem recalcula versões anteriores da tabela; ele passa a capturar mudanças a partir do momento em que é habilitado.",
+        topic: "Change Data Feed - fundamentos",
+        options: [
+            ["Cada UPDATE capturado pelo CDF gera duas linhas na saída, uma com _change_type update_preimage e outra com update_postimage", true],
+            ["Para consultar as mudanças, é possível usar a função table_changes ou ler a tabela com a opção readChangeFeed como true", true],
+            ["O time travel por versão já entrega o mesmo nível de detalhe do CDF, incluindo o valor anterior e o novo de cada linha alterada", false],
+            ["O CDF só pode ser lido em modo batch; consultas Structured Streaming não podem usar table_changes nem readChangeFeed", false],
+            ["Habilitar o CDF recalcula e reescreve todo o histórico de versões anteriores da tabela para gerar os registros de mudança retroativamente", false],
+        ],
+    },
+    {
+        statement:
+            "Uma consulta Structured Streaming lê uma tabela Delta bronze como fonte, usando spark.readStream.table, para alimentar uma tabela silver. A tabela bronze passa a receber operações de UPDATE e DELETE feitas por um processo de deduplicação. A consulta silver, que antes rodava sem problemas, passa a falhar com um erro informando que foi detectada uma atualização de dados na fonte, não suportada por padrão. Qual abordagem resolve o problema mantendo a propagação correta dos updates e deletes para a silver?",
+        explanation:
+            "Por padrão, uma consulta Structured Streaming trata a fonte Delta como somente inserção; quando detecta um UPDATE ou DELETE nos arquivos de origem, ela falha para evitar processar dados de forma incorreta. Habilitar o Change Data Feed na tabela bronze e ler com readChangeFeed permite que a consulta receba explicitamente cada tipo de mudança, insert, update_preimage, update_postimage e delete, e trate cada um corretamente na silver. ignoreChanges permite que a consulta continue, mas não identifica o que mudou de forma granular, podendo reprocessar linhas de arquivos reescritos e gerar duplicatas rio abaixo. ignoreDeletes só evita erro quando há remoção de partições inteiras, sem resolver updates. Trocar para leitura batch em loop abandona o modelo de streaming incremental e não é a forma recomendada de resolver o problema.",
+        topic: "CDF em streaming - updates e deletes na origem",
+        options: [
+            ["Habilitar Change Data Feed na tabela bronze e ler com a opção readChangeFeed como true, processando os tipos de mudança na silver", true],
+            ["Adicionar a opção ignoreChanges como true na leitura streaming, que propaga updates e deletes da bronze para a silver automaticamente", false],
+            ["Adicionar a opção ignoreDeletes como true na leitura streaming, que permite que updates e deletes sejam propagados sem gerar erro", false],
+            ["Trocar spark.readStream.table por spark.read.table dentro de um loop agendado, que suporta updates e deletes na fonte nativamente", false],
+        ],
+    },
+    {
+        statement:
+            "Um pipeline consome o Change Data Feed de uma tabela Delta a partir da versão 120, usando startingVersion. A tabela recebe VACUUM regularmente com o período de retenção padrão. Alguns meses depois, o pipeline é reiniciado do zero e tenta reler o CDF novamente a partir da versão 120. O que provavelmente acontece?",
+        explanation:
+            "Os dados necessários para servir o Change Data Feed de versões antigas dependem dos mesmos arquivos que o time travel usa, sujeitos ao período de retenção do log e removidos por VACUUM. Se o VACUUM já limpou os arquivos referentes à versão 120, uma tentativa de reler o CDF a partir dela falha, porque os arquivos correspondentes já não existem. O CDF não tem retenção indefinida própria e independente do VACUUM. O Spark não ajusta silenciosamente a versão pedida para uma disponível; ele retorna erro. E o Delta Lake não bloqueia VACUUM automaticamente só por uma tabela ter CDF habilitado; cabe à equipe configurar a retenção de forma compatível com a janela de consumo do CDF.",
+        topic: "Change Data Feed x VACUUM",
+        options: [
+            ["A leitura falha, pois o VACUUM já removeu os arquivos de dados de versões antigas necessários para reconstruir o CDF a partir da versão 120", true],
+            ["A leitura funciona normalmente, pois os arquivos de change data do CDF são mantidos indefinidamente, independente do período de retenção do VACUUM", false],
+            ["A leitura funciona, mas o Spark ignora silenciosamente a versão inicial pedida e começa a partir da versão mais antiga ainda disponível", false],
+            ["O VACUUM é bloqueado automaticamente pelo Delta Lake em tabelas com CDF habilitado, então os dados da versão 120 sempre continuam disponíveis", false],
+        ],
+    },
+    {
+        statement:
+            "Uma tabela bronze acumula múltiplas versões do mesmo registro, identificado por id, cada uma com um updated_at diferente, incluindo casos em que duas versões do mesmo id têm exatamente o mesmo updated_at. Um job PySpark precisa manter exatamente uma linha por id, a mais recente, mesmo nesses casos de empate. Qual função de janela, usada com particionamento por id e ordenação por updated_at descendente, seguida de um filtro, garante exatamente uma linha por id mesmo com empates?",
+        explanation:
+            "row_number() atribui um número sequencial estritamente único a cada linha dentro da partição, mesmo quando várias linhas empatam nos critérios de ordenação, então filtrar por row_number igual a 1 sempre deixa exatamente uma linha por id. rank() e dense_rank() atribuem a mesma posição a todas as linhas empatadas; se duas linhas do mesmo id empatarem no updated_at mais recente, ambas receberiam a posição 1, e o filtro deixaria as duas linhas, quebrando o requisito de exatamente uma linha por id. percent_rank() calcula uma posição relativa contínua e não serve para selecionar uma única linha por chave dessa forma.",
+        topic: "PySpark - funções de janela para deduplicação",
+        options: [
+            ["row_number(), pois atribui números sequenciais únicos dentro de cada partição, sem repetir valor mesmo quando há empate na ordenação", true],
+            ["rank(), pois atribui a mesma posição a valores empatados, garantindo no máximo uma linha com o valor 1 mesmo com empate no updated_at", false],
+            ["dense_rank(), pois atribui a mesma posição a valores empatados, mas sem pular números para as posições seguintes dentro da partição", false],
+            ["percent_rank(), pois calcula a posição relativa de cada linha dentro da partição, sempre normalizada entre 0 e 1", false],
+        ],
+    },
+    {
+        statement:
+            "Uma tabela tem uma coluna do tipo ARRAY<STRUCT<produto STRING, valor DOUBLE>> por linha. Um job precisa, para cada linha, manter apenas os itens do array com valor acima de um limite, sem alterar a granularidade da tabela, ou seja, cada linha de entrada deve continuar sendo uma única linha de saída, ainda com um array, agora filtrado. Qual abordagem evita o custo de um explode seguido de groupBy e collect_list para voltar à granularidade original?",
+        explanation:
+            "A função de ordem superior filter opera diretamente sobre a coluna do tipo array dentro de cada linha, aplicando a condição elemento a elemento sem precisar explodir a coluna em várias linhas nem reagrupar depois, o que evita o shuffle e o custo do padrão explode mais groupBy mais collect_list. Explodir e reagrupar produz o mesmo resultado lógico, mas com custo adicional de embaralhamento de dados e passos extras. Manipular o array como texto com expressões regulares é frágil e propenso a erro de parsing. Um UDF Python resolve o problema funcionalmente, mas processa item a item fora do motor otimizado do Spark, com serialização mais custosa do que a função de ordem superior nativa.",
+        topic: "PySpark - funções de ordem superior em arrays",
+        options: [
+            ["Usar a função de ordem superior filter do PySpark diretamente sobre a coluna array, aplicando a condição a cada elemento sem sair da linha", true],
+            ["Usar explode para transformar cada item do array em uma linha, aplicar o filtro com WHERE e reagrupar com groupBy e collect_list ao final", false],
+            ["Converter a coluna array para string com concat_ws, aplicar uma expressão regular para remover os itens indesejados e converter de volta para array", false],
+            ["Usar um UDF Python que recebe a lista inteira como parâmetro, itera item a item em código Python puro e retorna a lista já filtrada", false],
+        ],
+    },
+    {
+        statement:
+            "Um job PySpark aplica uma UDF Python tradicional, chamada linha a linha, para calcular um indicador numérico complexo sobre bilhões de linhas, usando apenas operações vetorizáveis com numpy. Essa UDF é o gargalo do job. Um engenheiro propõe reescrevê-la como uma pandas UDF do tipo Series to Series. Quais DUAS afirmações explicam corretamente por que essa mudança tende a melhorar o desempenho? (Selecione DUAS opções.)",
+        explanation:
+            "Pandas UDFs usam Apache Arrow para trocar dados em lotes entre a JVM e o processo Python, evitando a serialização linha a linha das UDFs tradicionais, e recebem os dados como Series do pandas, permitindo aplicar operações vetorizadas de numpy e pandas sobre o lote inteiro de uma vez, bem mais eficientes que um laço por valor. A pandas UDF não adiciona paralelismo com múltiplas threads dentro da mesma task por conta própria; o ganho vem da vetorização e da redução de overhead de serialização. Ela também não elimina a movimentação de dados entre JVM e Python, apenas a torna mais eficiente via Arrow, pois o processo Python continua existindo. E funções nativas do Spark SQL, quando existem para o mesmo cálculo, geralmente ainda superam uma pandas UDF, que só vale a pena quando não há equivalente nativo.",
+        topic: "Pandas UDF x UDF Python",
+        options: [
+            ["A pandas UDF usa Apache Arrow para transferir dados em lote entre a JVM e o processo Python, reduzindo a serialização por linha", true],
+            ["Dentro da pandas UDF, o cálculo pode usar operações vetorizadas do numpy e pandas sobre um lote inteiro, em vez de um valor por chamada", true],
+            ["A pandas UDF executa automaticamente em paralelo dentro de uma única task, usando múltiplas threads Python por partition", false],
+            ["A pandas UDF elimina totalmente a necessidade de mover dados entre a JVM e o processo Python, pois roda inteiramente dentro da JVM", false],
+            ["A pandas UDF sempre supera qualquer função nativa do Spark SQL equivalente, independente do tipo de cálculo realizado", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe de dados precisa aplicar, para cada cliente, um modelo estatístico que exige todas as linhas daquele cliente juntas em um único pandas DataFrame para calcular parâmetros específicos do grupo, retornando um pandas DataFrame de saída com um schema diferente do de entrada. Isso deve rodar distribuído sobre um DataFrame Spark com milhões de clientes. Qual API do PySpark atende esse requisito?",
+        explanation:
+            "groupBy(...).applyInPandas permite definir uma função que recebe todas as linhas de cada grupo, chave por chave, como um único pandas DataFrame, calcula o que for necessário usando todo o contexto do grupo e retorna outro pandas DataFrame, possivelmente com schema diferente do de entrada; o Spark distribui essa execução grupo a grupo entre as tasks. Uma pandas UDF escalar processa lotes de linhas sem garantir que todas as linhas de um mesmo cliente estejam juntas na mesma chamada. mapInPandas entrega uma partition inteira por vez, mas sem a garantia de agrupamento por chave que o cenário exige. Uma UDF tradicional com GROUP BY em SQL não entrega ao código Python o grupo inteiro como uma estrutura tabular de uma vez, apenas valores agregados ou linha a linha conforme a função de agregação usada.",
+        topic: "PySpark - applyInPandas",
+        options: [
+            ["df.groupBy('cliente_id').applyInPandas(func, schema), que entrega todas as linhas de cada grupo como um único pandas DataFrame", true],
+            ["Uma pandas UDF escalar do tipo Series to Series, que recebe lotes de linhas na ordem original, sem garantir agrupamento por cliente", false],
+            ["df.mapInPandas(func, schema), que entrega a cada chamada um pandas DataFrame de uma partition inteira, sem agrupar por cliente", false],
+            ["Uma UDF Python tradicional registrada com spark.udf.register, aplicada em conjunto com uma cláusula GROUP BY em SQL", false],
+        ],
+    },
+    {
+        statement:
+            "Uma consulta SQL usa ROW_NUMBER() OVER (PARTITION BY cliente_id ORDER BY data_pedido DESC) AS rn na lista de SELECT e precisa manter apenas as linhas em que rn é igual a 1, sem envolver a consulta em uma subconsulta ou CTE apenas para poder filtrar por rn. Qual cláusula do Databricks SQL permite esse filtro diretamente, aplicado ao resultado das funções de janela do próprio SELECT?",
+        explanation:
+            "QUALIFY filtra as linhas resultantes com base no valor de funções de janela calculadas na própria consulta, dispensando a necessidade de uma subconsulta ou CTE só para poder aplicar o filtro, de forma parecida com o papel do HAVING sobre funções de agregação. HAVING existe para filtrar depois de um GROUP BY, com base em agregações, não em funções de janela. WHERE é avaliado antes do cálculo das funções de janela na ordem lógica de execução do SQL, então não pode referenciar o alias de uma função de janela da mesma consulta. Não existe uma cláusula FILTER que se aplique dessa forma após OVER no Databricks SQL.",
+        topic: "SQL avançado - QUALIFY",
+        options: [
+            ["QUALIFY, que filtra linhas pelo resultado de funções de janela calculadas na mesma consulta, de forma análoga ao HAVING", true],
+            ["HAVING, que filtra diretamente o resultado de qualquer função de janela definida na lista de SELECT, sem exigir agrupamento", false],
+            ["WHERE, que já é avaliado depois do cálculo das funções de janela na ordem lógica de execução de uma consulta SQL", false],
+            ["FILTER, aplicada após a cláusula OVER de uma função de janela, restringindo quais linhas de saída são mantidas", false],
+        ],
+    },
+    {
+        statement:
+            "Uma tabela Delta representa uma hierarquia organizacional, em que cada funcionário referencia o id do seu gestor direto. Um engenheiro precisa calcular o nível hierárquico de cada funcionário a partir do CEO, sem um limite de profundidade conhecido de antemão. Diferente de alguns bancos relacionais tradicionais, o Databricks SQL não oferece o mesmo suporte consolidado a consultas com CTE recursiva autorreferenciada e profundidade variável em uma única instrução declarativa. Qual abordagem é o padrão recomendado no Spark para esse tipo de travessia hierárquica?",
+        explanation:
+            "Como o mecanismo declarativo padrão do Spark SQL não cobre bem travessias recursivas de profundidade desconhecida da mesma forma que alguns bancos relacionais tradicionais, o padrão usado no Spark é implementar a recursão de forma imperativa: um loop em PySpark que junta a tabela ao resultado acumulado, incrementa o nível a cada iteração e para quando nenhuma linha nova é adicionada, ou seja, quando atinge um ponto fixo. Tratar a sintaxe de CTE recursiva como equivalente total à de bancos relacionais tradicionais não reflete o suporte real da plataforma. Repetir um CROSS JOIN um número fixo de vezes é uma abordagem cara e artificial, que não se adapta corretamente à profundidade real dos dados. E a hierarquia não chega pronta pré-achatada em uma única coluna array para se resolver com uma única função de ordem superior; a própria construção dessa coluna é que exige a travessia recursiva.",
+        topic: "SQL avançado - recursão hierárquica",
+        options: [
+            ["Um loop iterativo em PySpark que faz joins sucessivos entre a tabela e o resultado acumulado, parando quando nenhuma linha nova é adicionada", true],
+            ["Uma única consulta com WITH RECURSIVE, com sintaxe e comportamento idênticos aos de bancos relacionais tradicionais como PostgreSQL", false],
+            ["Um CROSS JOIN da tabela com ela mesma, repetido um número fixo de vezes igual ao número total de linhas, para cobrir qualquer profundidade possível", false],
+            ["Uma única função de ordem superior aggregate aplicada a uma coluna do tipo ARRAY contendo toda a hierarquia pré-achatada em uma linha", false],
+        ],
+    },
+    {
+        statement:
+            "Uma consulta Structured Streaming faz join entre duas streams, pedidos e pagamentos, cada uma com sua própria coluna de tempo de evento e um watermark definido. Após rodar por vários dias em produção, o tamanho do estado mantido pela consulta cresce continuamente, até o cluster ficar sem memória. Pedidos sem pagamento correspondente dentro de uma janela razoável de tempo deveriam ser descartados do estado, mas isso não está acontecendo. Qual ajuste no join resolve o crescimento ilimitado do estado?",
+        explanation:
+            "Em um join stream-stream, além de cada lado ter seu próprio watermark, a condição do join precisa incluir restrições de tempo, como intervalos entre as colunas de tempo de evento das duas streams, para que o Spark saiba quando uma linha em buffer de um dos lados não pode mais encontrar correspondência e possa ser descartada do estado. Sem essas restrições de intervalo na condição do join, o Spark não consegue limitar o estado, mesmo com watermark definido nas duas streams, e o estado cresce indefinidamente. Ter watermark em apenas um dos lados não é suficiente para um join stream-stream, que exige limite de atraso definido dos dois lados. Trocar para stream-static muda a semântica do caso de uso, que envolve duas fontes genuinamente streaming. E apenas aumentar o valor do watermark adia o problema, mas não resolve o crescimento do estado, que precisa de um limite real imposto pela condição de tempo do join.",
+        topic: "Structured Streaming - join stream-stream",
+        options: [
+            ["Adicionar, na condição do join, restrições de intervalo de tempo entre as colunas de tempo de evento das duas streams", true],
+            ["Remover o watermark de uma das duas streams, deixando apenas uma delas com limite de atraso definido, o que já é suficiente para joins stream-stream", false],
+            ["Trocar o join stream-stream por um join stream-static, convertendo pagamentos em uma tabela Delta estática lida a cada micro-batch", false],
+            ["Aumentar o valor do watermark das duas streams para um valor bem alto, garantindo que nenhum pedido tardio seja perdido pelo join", false],
+        ],
+    },
+    {
+        statement:
+            "Uma streaming table bronze usa Auto Loader com cloudFiles.schemaEvolutionMode definido como rescue desde a primeira execução, há vários meses. Novos campos passaram a aparecer nos arquivos JSON de origem ao longo do tempo, mas a equipe percebe que o schema da tabela de destino nunca ganha essas colunas novas: elas continuam caindo em _rescued_data mesmo após vários reinícios do stream. Por que isso acontece?",
+        explanation:
+            "O modo rescue mantém o schema fixo por definição: ele nunca evolui automaticamente para incorporar colunas novas, e qualquer dado que não bate com o schema atual, incluindo colunas nunca vistas antes, é capturado em _rescued_data indefinidamente, sem promoção espontânea ao longo do tempo. Apagar o checkpoint reinicia o progresso da leitura e pode causar reprocessamento, mas não muda o comportamento do modo rescue nem promove colunas automaticamente. Não existe um ciclo automático de reavaliação de schema a cada 24 horas nesse modo. E rodar o pipeline com Full Refresh reprocessa o histórico sob a configuração atual, mas continua respeitando o modo rescue, então as colunas novas seguem indo para _rescued_data.",
+        topic: "Auto Loader - modo rescue nao evolui schema",
+        options: [
+            ["Porque o modo rescue nunca evolui o schema por definição: dados fora do schema fixado ficam em _rescued_data", true],
+            ["Porque o modo rescue só promove colunas novas depois que o checkpoint da leitura é apagado manualmente", false],
+            ["Porque o modo rescue reavalia e evolui o schema automaticamente uma vez por dia, em um ciclo fixo de 24 horas", false],
+            ["Porque a promoção de colunas do _rescued_data só ocorre quando o pipeline roda com Full Refresh ativado", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe liga pela primeira vez um stream de Auto Loader sobre um diretório bronze que já acumulou dois anos de arquivos históricos. A primeira execução tenta processar todo o histórico em um único microbatch enorme, gerando forte pressão de memória no cluster. A equipe quer dividir esse backfill inicial em vários microbatches menores e limitados, sem mudar a lógica de processamento do regime permanente depois que o backlog for absorvido. Qual configuração atende isso diretamente?",
+        explanation:
+            "cloudFiles.maxFilesPerTrigger e cloudFiles.maxBytesPerTrigger limitam quantos arquivos ou bytes entram em cada microbatch do Auto Loader, permitindo que um backlog grande seja absorvido aos poucos, em vários microbatches menores, sem alterar a lógica de processamento normal depois disso. O modo de evolução de schema não tem relação com o tamanho do microbatch, apenas com o tratamento de colunas divergentes. O file notification melhora a descoberta de arquivos novos que chegam depois que o stream já está ativo, mas não acelera nem substitui a necessidade de conter o volume de um backlog histórico já acumulado. E reduzir o processingTime aumenta a frequência dos gatilhos, mas não limita, por si só, quantos arquivos pendentes entram em cada execução.",
+        topic: "Auto Loader - maxFilesPerTrigger no backfill",
+        options: [
+            ["Definir cloudFiles.maxFilesPerTrigger, ou maxBytesPerTrigger, para limitar o que entra em cada microbatch", true],
+            ["Definir cloudFiles.schemaEvolutionMode como rescue, o que reduz o tamanho de cada microbatch ao descartar dados", false],
+            ["Migrar para o modo file notification, que descobre e processa arquivos históricos mais rápido que directory listing", false],
+            ["Reduzir o intervalo de processingTime do trigger para poucos segundos, limitando automaticamente o microbatch", false],
+        ],
+    },
+    {
+        statement:
+            "Uma pipeline usa Auto Loader em modo file notification há anos. A equipe decide desativar essa ingestão definitivamente, migrando a carga para outro sistema, e apaga apenas o diretório de checkpoint para limpar o ambiente. Semanas depois, a fatura da nuvem mostra que a fila e o tópico de notificação continuam ativos e gerando custo, mesmo sem nenhum stream em execução. Qual é a explicação correta?",
+        explanation:
+            "Os recursos de notificação criados para o modo file notification, como fila e tópico de eventos, existem de forma independente do checkpoint e do ciclo de vida do stream: eles continuam ativos e gerando custo até serem removidos explicitamente, o que a equipe precisa fazer ao aposentar de vez uma ingestão nesse modo. A Databricks não exclui esses recursos automaticamente por inatividade do stream. Eles também não são cobrados apenas durante a execução do cluster, pois são recursos gerenciados diretamente pelo provedor de nuvem, independentes do cluster. E a ordem entre apagar o checkpoint e parar o stream não influencia essa limpeza, já que nenhuma das duas ações remove a fila ou o tópico automaticamente.",
+        topic: "Auto Loader - custo de recursos do file notification",
+        options: [
+            ["Apagar o checkpoint não remove os recursos de notificação da nuvem; eles precisam ser removidos à parte", true],
+            ["Esses recursos são removidos automaticamente pela Databricks após 30 dias seguidos de inatividade do stream", false],
+            ["Recursos de notificação só são cobrados pelo provedor de nuvem enquanto o cluster do stream está em execução", false],
+            ["Isso ocorre porque o checkpoint foi apagado antes do stream ser parado de forma graciosa, o que impediria a limpeza", false],
+        ],
+    },
+    {
+        statement:
+            "Um arquivo carregado anteriormente por COPY INTO continha dados incorretos. A equipe corrige o conteúdo e sobrescreve o arquivo de origem exatamente no mesmo caminho e com o mesmo nome. Ao rodar novamente o mesmo comando COPY INTO, a tabela de destino não muda: continua com as linhas antigas erradas, sem nenhuma linha nova. Por que isso acontece e como resolver?",
+        explanation:
+            "Por padrão, o COPY INTO rastreia quais arquivos já foram carregados na tabela de destino e ignora esses arquivos em execuções seguintes, mesmo que o conteúdo tenha mudado no mesmo caminho. A cláusula COPY_OPTIONS ('force' = 'true') força o comando a reprocessar arquivos já carregados, que é exatamente o que resolve esse cenário. O COPY INTO não recalcula hash de conteúdo para decidir reprocessamento sozinho. Trocar para MERGE INTO não resolve a causa raiz, que é o rastreamento de arquivos já carregados, e ignora a opção mais direta disponível. E recriar a tabela é uma medida desproporcional, que descartaria todo o histórico já carregado sem necessidade.",
+        topic: "COPY INTO - reprocessamento forcado",
+        options: [
+            ["O COPY INTO ignora arquivos já carregados por padrão; COPY_OPTIONS ('force' = 'true') força reprocessá-los", true],
+            ["O COPY INTO detecta mudanças de conteúdo pelo hash do arquivo e reprocessa sozinho, sem exigir opção extra", false],
+            ["A correção exige trocar para MERGE INTO, já que o COPY INTO jamais reprocessa um arquivo já visto, em nenhuma hipótese", false],
+            ["É necessário apagar e recriar a tabela de destino antes que o COPY INTO aceite o arquivo corrigido de novo", false],
+        ],
+    },
+    {
+        statement:
+            "Um engenheiro compara como o Auto Loader e o COPY INTO garantem que arquivos já carregados não sejam processados de novo. Qual afirmação descreve corretamente onde cada um mantém esse estado de rastreamento?",
+        explanation:
+            "O Auto Loader é uma leitura de Structured Streaming e, como tal, depende de um checkpointLocation externo para saber o que já foi processado; perder ou apagar esse checkpoint compromete a garantia de não reprocessamento. Já o COPY INTO não usa um checkpoint de streaming: o histórico de arquivos já carregados fica registrado junto à própria tabela de destino, sem exigir um local de checkpoint separado. A primeira opção descreve corretamente os dois mecanismos, a segunda inventa uma exigência que o COPY INTO não tem, a terceira inverte os papéis dos dois comandos, e a quarta descreve um comportamento que o Unity Catalog não oferece: o rastreamento de idempotência é responsabilidade de cada comando, não um serviço central do catálogo.",
+        topic: "Auto Loader x COPY INTO - onde vive o estado de idempotencia",
+        options: [
+            ["O Auto Loader depende de um checkpoint externo; o COPY INTO mantém o histórico de cargas junto à própria tabela", true],
+            ["Os dois comandos exigem um checkpointLocation explícito, e perder esse checkpoint tem a mesma consequência nos dois", false],
+            ["O COPY INTO depende de um checkpoint externo, enquanto o Auto Loader guarda o estado no log de transações da tabela", false],
+            ["Nenhum dos dois precisa manter estado de rastreamento, pois o Unity Catalog rastreia centralmente todo arquivo ingerido", false],
+        ],
+    },
+    {
+        statement:
+            "Sobre a arquitetura do Lakeflow Connect para diferentes tipos de fonte, quais DUAS afirmações a seguir estão corretas? (Selecione DUAS opções.)",
+        explanation:
+            "Para determinados conectores de banco de dados, sobretudo origens on premises ou em redes restritas, o Lakeflow Connect usa um gateway de ingestão implantado próximo à origem, responsável por capturar o snapshot inicial e as mudanças subsequentes antes de aplicá-las no Unity Catalog. Já os conectores gerenciados para aplicações SaaS, como Salesforce, acessam a API do provedor diretamente a partir do plano gerenciado do Lakeflow Connect, sem exigir nenhum componente implantado na rede do cliente. Por isso não é verdade que todo conector exija gateway, nem que os conectores SaaS precisem de um. O gateway também não substitui o Auto Loader: são mecanismos para propósitos diferentes, um para conectores de banco de dados, outro para ingestão incremental de arquivos em object storage.",
+        topic: "Lakeflow Connect - gateway x conectores SaaS",
+        options: [
+            ["Para alguns conectores de banco de dados, um gateway implantado próximo à origem captura o snapshot inicial e as mudanças seguintes", true],
+            ["Conectores gerenciados para aplicações SaaS, como Salesforce, também exigem um gateway implantado na rede do cliente", false],
+            ["Conectores gerenciados para SaaS acessam a API do provedor diretamente a partir do plano gerenciado, sem gateway do lado do cliente", true],
+            ["Todo conector do Lakeflow Connect, seja de banco de dados ou de SaaS, exige a implantação de um gateway próximo à origem", false],
+            ["O gateway de ingestão substitui o Auto Loader como mecanismo padrão para qualquer ingestão de arquivos em object storage", false],
+        ],
+    },
+    {
+        statement:
+            "Uma tabela silver de pedidos é mantida por AUTO CDC INTO com SEQUENCE BY event_time. Por instabilidade no produtor de eventos, um evento de atualização com event_time mais antigo chega depois de outro evento com event_time mais recente para o mesmo pedido, que já foi aplicado ao destino. O que o AUTO CDC faz com esse evento atrasado?",
+        explanation:
+            "O AUTO CDC usa a coluna definida em SEQUENCE BY para conhecer a ordem lógica dos eventos e trata dados fora de ordem automaticamente: um evento com valor de sequência menor do que o já aplicado para a mesma chave é descartado, porque o destino já reflete um estado mais recente. Ele não sobrescreve o valor atual com um evento mais antigo só porque esse evento chegou depois, essa é justamente a confusão que SEQUENCE BY evita. O pipeline também não falha por causa de eventos fora de ordem, esse é um cenário esperado e tratado nativamente. E o evento atrasado não gera uma linha adicional: ele é simplesmente descartado.",
+        topic: "AUTO CDC - descarte automatico de eventos atrasados",
+        options: [
+            ["É automaticamente descartado, pois o AUTO CDC sabe que o valor de SEQUENCE BY já aplicado é mais recente", true],
+            ["Sobrescreve o valor já aplicado, pois o AUTO CDC sempre aplica o último evento recebido, independente da sequência", false],
+            ["Faz o pipeline falhar, pois o AUTO CDC não aceita eventos que cheguem fora da ordem cronológica de chegada", false],
+            ["É gravado como uma nova linha adicional, preservando os dois valores lado a lado na tabela de destino", false],
+        ],
+    },
+    {
+        statement:
+            "Uma tabela silver de assinaturas usa AUTO CDC INTO com STORED AS SCD TYPE 2 e APPLY AS DELETE WHEN operation = 'DELETE'. Um evento de delete chega para um cliente cuja versão atual tem __END_AT nulo. O que o AUTO CDC faz com essa versão vigente ao aplicar o delete?",
+        explanation:
+            "Em uma tabela com STORED AS SCD TYPE 2, um evento tratado por APPLY AS DELETE WHEN não apaga fisicamente o histórico: ele fecha a versão vigente, preenchendo __END_AT com o valor de sequência do evento de delete, preservando intactas todas as versões anteriores. Nenhuma versão histórica anterior é removida fisicamente por esse evento. O delete também não é ignorado, já que APPLY AS DELETE WHEN foi definido explicitamente para tratar essa condição. E o AUTO CDC não cria uma versão adicional com colunas nulas para representar a exclusão, ele apenas encerra a vigência da versão atual.",
+        topic: "AUTO CDC - delete em SCD Type 2",
+        options: [
+            ["Preenche o __END_AT da versão com o valor de sequência do delete, fechando a vigência sem apagar o histórico", true],
+            ["Remove fisicamente todas as versões históricas desse cliente da tabela, inclusive as anteriores ao delete", false],
+            ["Ignora o evento de delete, pois tabelas com SCD Type 2 não processam exclusões vindas do feed de CDC", false],
+            ["Cria uma nova versão com todas as colunas nulas para representar a exclusão, mantendo __END_AT nulo", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe quer implementar um padrão de quarentena no Lakeflow Spark Declarative Pipelines: linhas que violam uma regra de qualidade devem ser gravadas em uma tabela separada para investigação, em vez de simplesmente descartadas ou de derrubar o pipeline. Como esse padrão deve ser implementado?",
+        explanation:
+            "As cláusulas ON VIOLATION do Lakeflow Spark Declarative Pipelines não incluem nenhuma opção que roteie automaticamente a linha para outra tabela: só existem DROP ROW, que descarta a linha, e FAIL UPDATE, que interrompe a atualização. Por isso, um padrão de quarentena precisa ser construído manualmente, com duas queries a partir da mesma origem, uma mantendo apenas as linhas válidas para a tabela principal e outra filtrando exatamente as linhas inválidas para uma tabela separada. Não existe uma cláusula ON VIOLATION QUARANTINE ROW. DROP ROW apenas descarta a linha, sem gravá-la em outro lugar. E repetir a mesma constraint com ações diferentes não redireciona nenhuma linha para uma tabela separada, apenas aplica duas verificações redundantes.",
+        topic: "Expectations - padrao de quarentena manual",
+        options: [
+            ["Definindo duas queries a partir da mesma origem: uma para as linhas válidas e outra para as inválidas", true],
+            ["Usando uma única CONSTRAINT EXPECT com a cláusula ON VIOLATION QUARANTINE ROW apontando para a outra tabela", false],
+            ["Usando ON VIOLATION DROP ROW, que já move automaticamente a linha descartada para uma tabela de quarentena", false],
+            ["Definindo a mesma CONSTRAINT EXPECT duas vezes, uma com DROP ROW e outra com FAIL UPDATE, cobrindo os dois destinos", false],
+        ],
+    },
+    {
+        statement:
+            "Uma streaming table silver define duas constraints: CONSTRAINT valid_email EXPECT (email RLIKE '@') ON VIOLATION DROP ROW e CONSTRAINT valid_id EXPECT (customer_id IS NOT NULL) ON VIOLATION FAIL UPDATE. Um microbatch chega com algumas linhas de email inválido e, separadamente, uma única linha com customer_id nulo. O que acontece com essa atualização do pipeline?",
+        explanation:
+            "Cada CONSTRAINT EXPECT é avaliada de forma independente, mas sua ação de ON VIOLATION vale para o resultado da atualização como um todo: as linhas de email inválido seriam descartadas isoladamente pela constraint com DROP ROW, mas a presença de qualquer linha que viole a constraint com FAIL UPDATE faz a atualização inteira falhar, independente do que aconteceria às outras linhas. A linha de customer_id nulo não é simplesmente gravada, pois FAIL UPDATE interrompe a atualização ao encontrar a violação. O pipeline também não apenas descarta tudo sem falhar, já que FAIL UPDATE provoca uma falha explícita. E as duas constraints são avaliadas dentro do mesmo microbatch, não em execuções separadas.",
+        topic: "Expectations - multiplas constraints independentes",
+        options: [
+            ["A atualização inteira falha por causa da linha com customer_id nulo, mesmo o email inválido sendo só descartável", true],
+            ["Somente as linhas de email inválido são descartadas, e a linha de customer_id nulo é gravada com a violação registrada", false],
+            ["O pipeline descarta todas as linhas do microbatch, tanto as de email inválido quanto a de customer_id nulo, sem falhar", false],
+            ["Cada constraint é avaliada em um microbatch separado, então as duas violações nunca são processadas juntas", false],
+        ],
+    },
+    {
+        statement:
+            "Uma materialized view gold calcula, para cada dia, a quantidade de clientes distintos que compraram, usando COUNT(DISTINCT customer_id) sobre a camada silver. A equipe percebe que essa atualização recalcula o resultado inteiro a cada execução do pipeline, mesmo quando chegam poucas linhas novas na silver, ao contrário de outras materialized views mais simples do mesmo pipeline, que atualizam de forma incremental. Qual é a explicação mais provável?",
+        explanation:
+            "Certos padrões de consulta, entre eles agregações que dependem de contar valores distintos, podem impedir que o motor do pipeline mantenha o resultado de forma incremental, levando a um recálculo completo a cada atualização, mesmo com poucas linhas novas na origem. Isso não é verdade para toda materialized view: consultas mais simples, como somas ou contagens diretas, costumam ser mantidas incrementalmente, o que explica a diferença observada no mesmo pipeline. COUNT(DISTINCT ...) funciona normalmente dentro de materialized views, o problema não é de suporte, é de custo de manutenção incremental. E watermark é um conceito de Structured Streaming ligado ao descarte de estado tardio, não o fator que determina se uma materialized view atualiza de forma incremental.",
+        topic: "Materialized view - agregacao nao incrementalizavel",
+        options: [
+            ["Certos padrões de consulta, como agregações com DISTINCT, podem impedir a manutenção incremental e forçar recálculo completo", true],
+            ["Toda materialized view definida sobre a silver sempre recalcula por completo, independente da consulta usada para defini-la", false],
+            ["COUNT(DISTINCT ...) só funciona corretamente dentro de streaming tables, nunca dentro de materialized views", false],
+            ["O recálculo completo só ocorre porque a materialized view não foi configurada com um watermark sobre a data", false],
+        ],
+    },
+    {
+        statement:
+            "Um bug na lógica de uma materialized view gold fez uma coluna calculada trazer valores errados por vários meses. A equipe já corrigiu a consulta que define a materialized view. Rodar o pipeline normalmente, de forma incremental, processa somente os dados novos a partir de agora. O que a equipe precisa fazer para corrigir também as linhas antigas já materializadas com o valor errado?",
+        explanation:
+            "Uma atualização incremental normal processa apenas dados novos ou alterados na origem, então não corrige, por si só, linhas antigas que já foram materializadas com uma lógica anterior incorreta. Para reprocessar o histórico inteiro sob a consulta corrigida, é preciso disparar um full refresh dessa tabela, recalculando tudo do zero. A correção da consulta não aciona um recálculo automático do histórico já materializado. Apagar linhas manualmente foge do fluxo gerenciado pelo pipeline e não garante que elas sejam recriadas corretamente na próxima atualização incremental. E não é necessário recriar o pipeline inteiro, nem recalcular tabelas que não foram afetadas pelo bug, o full refresh pode ser aplicado somente à tabela específica.",
+        topic: "Materialized view - full refresh para correcao retroativa",
+        options: [
+            ["Disparar um full refresh dessa tabela, reprocessando todo o histórico sob a lógica já corrigida", true],
+            ["Nada além de aguardar: a materialized view detecta sozinha a mudança e recalcula automaticamente o histórico", false],
+            ["Excluir manualmente as linhas antigas com DELETE e deixar a próxima atualização incremental recriá-las", false],
+            ["Recriar o pipeline inteiro do zero, incluindo todas as outras tabelas do mesmo pipeline, não somente essa", false],
+        ],
+    },
+    {
+        statement:
+            "Um stream de eventos usa entrega pelo menos uma vez (at least once) na origem, então o mesmo event_id pode chegar mais de uma vez, cada cópia com um event_time ligeiramente diferente, na casa de milissegundos. Deduplicar com dropDuplicates(['event_id', 'event_time']) falha em juntar essas cópias, pois o event_time não é idêntico entre elas. A equipe quer deduplicar somente pelo event_id, mantendo o estado limitado por um watermark sobre o tempo. Qual abordagem atende isso?",
+        explanation:
+            "dropDuplicatesWithinWatermark permite deduplicar usando apenas as colunas de chave informadas, como event_id, sem exigir que uma coluna de tempo também seja idêntica entre as cópias, ao mesmo tempo em que usa o watermark definido no stream para limitar até quando o estado de deduplicação é mantido. dropDuplicates(['event_id']) sem watermark configurado mantém o estado crescendo indefinidamente, sem limite automático baseado no relógio do sistema. Mudar o particionamento do sink não afeta a lógica de deduplicação, que acontece antes da escrita. E aumentar o watermark controla até quando um evento tardio ainda é aceito, não faz duas colunas de tempo diferentes serem tratadas como iguais na comparação.",
+        topic: "Deduplicacao em streaming - dropDuplicatesWithinWatermark",
+        options: [
+            ["Usar dropDuplicatesWithinWatermark(['event_id']), que deduplica só pela chave informada, sem exigir tempo idêntico", true],
+            ["Usar dropDuplicates(['event_id']) sem watermark configurado, o que já limita o estado pelo relógio do sistema", false],
+            ["Adicionar event_time à chave de particionamento do sink, o que remove as duplicatas na escrita final", false],
+            ["Aumentar bastante o watermark, o que faz dropDuplicates(['event_id', 'event_time']) ignorar pequenas diferenças de tempo", false],
+        ],
+    },
+    {
+        statement:
+            "Uma ingestão lê arquivos CSV nos quais algumas linhas têm um número de colunas diferente do esperado, um problema estrutural, não apenas um campo com tipo divergente. A equipe quer que a leitura falhe imediatamente ao encontrar a primeira linha malformada, para impedir que qualquer dado corrompido chegue à camada bronze. Qual configuração do leitor atende exatamente essa exigência?",
+        explanation:
+            "A opção mode do leitor, definida como FAILFAST, faz a leitura falhar imediatamente ao encontrar a primeira linha que não pode ser interpretada corretamente, o que impede que qualquer dado malformado chegue à camada bronze, exatamente o que a equipe quer. DROPMALFORMED descarta as linhas problemáticas silenciosamente e segue processando o restante, sem falhar a leitura. PERMISSIVE é o modo padrão e faz o oposto de falhar: ele mantém a linha problemática, geralmente com os campos não interpretáveis marcados como nulos. E o rescued data column do Auto Loader existe justamente para capturar dados divergentes sem interromper o stream, o oposto do comportamento de falha imediata pedido no cenário.",
+        topic: "Tratamento de dados corrompidos - modo FAILFAST",
+        options: [
+            ["Definir a opção mode como FAILFAST, que interrompe a leitura assim que uma linha malformada é encontrada", true],
+            ["Definir a opção mode como DROPMALFORMED, que impede linhas corrompidas de chegar à bronze e falha a leitura", false],
+            ["Deixar a opção mode no padrão PERMISSIVE, que já interrompe a leitura ao encontrar uma linha malformada", false],
+            ["Habilitar cloudFiles.rescuedDataColumn, que interrompe a leitura ao capturar uma linha estruturalmente malformada", false],
+        ],
+    },
+    {
+        statement:
+            "Sobre o comportamento fino do AUTO CDC e das expectations no Lakeflow Spark Declarative Pipelines, quais DUAS afirmações a seguir estão corretas? (Selecione DUAS opções.)",
+        explanation:
+            "Expectations não são avaliadas apenas uma vez: elas rodam a cada microbatch processado pela streaming table, continuamente, enquanto o pipeline está ativo. A coluna ou colunas informadas em KEYS no AUTO CDC precisam identificar unicamente cada registro de origem, pois é essa chave que decide qual linha do destino deve ser inserida, atualizada ou removida. Sem uma cláusula ON VIOLATION explícita, o comportamento padrão é manter a linha e apenas registrar a violação nas métricas, não interromper a atualização. Mesmo quando a origem parece chegar ordenada, o AUTO CDC continua exigindo SEQUENCE BY para tratar corretamente eventos fora de ordem, já que a ordem de chegada não garante a ordem lógica dos eventos. E cada CONSTRAINT EXPECT aceita apenas uma cláusula ON VIOLATION; para aplicar duas ações diferentes é preciso declarar duas constraints separadas.",
+        topic: "AUTO CDC e expectations - comportamentos finos",
+        options: [
+            ["Expectations definidas em uma streaming table são avaliadas a cada microbatch processado, não só no início do pipeline", true],
+            ["Uma CONSTRAINT EXPECT sem nenhuma cláusula ON VIOLATION interrompe a atualização na primeira linha que viola a condição", false],
+            ["A coluna informada em KEYS no AUTO CDC precisa identificar unicamente cada registro para aplicar as mudanças de forma correta", true],
+            ["Quando a origem já chega ordenada pela chave primária, o AUTO CDC dispensa a necessidade de declarar SEQUENCE BY", false],
+            ["É possível combinar ON VIOLATION DROP ROW e ON VIOLATION FAIL UPDATE na mesma CONSTRAINT, aplicando as duas ações juntas", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe de FinOps quer descobrir quantos DBUs (Databricks Units) um job específico de Lakeflow Jobs consumiu nos últimos 30 dias, para ratear o custo entre centros de custo diferentes. Qual system table deve ser consultada como fonte primária dessa informação?",
+        explanation:
+            "A system table system.billing.usage registra, em granularidade de evento de uso, o consumo de DBUs por workspace, SKU e recurso, incluindo metadados de uso com o identificador do job, permitindo somar o consumo de um job específico ao longo do período desejado. system.access.audit registra ações administrativas e de acesso, não consumo de DBUs. system.query.history registra execuções de consultas SQL, sem agregação de custo por job. system.compute.clusters é um inventário da configuração dos clusters, não do consumo faturado.",
+        topic: "System Tables - billing",
+        options: [
+            ["system.billing.usage", true],
+            ["system.access.audit", false],
+            ["system.query.history", false],
+            ["system.compute.clusters", false],
+        ],
+    },
+    {
+        statement:
+            "O time de conformidade precisa descobrir qual usuário excluiu uma tabela crítica do Unity Catalog e em que horário exato isso ocorreu, para um relatório de auditoria. Qual system table oferece esse histórico de ações administrativas?",
+        explanation:
+            "system.access.audit registra eventos auditáveis do workspace e do Unity Catalog, incluindo quem executou cada ação administrativa, como excluir uma tabela, e em que momento, sendo a fonte correta para investigações de conformidade. system.billing.usage traz apenas consumo de DBUs. system.access.table_lineage mostra relações de leitura e escrita entre tabelas, não quem excluiu um objeto. system.query.history registra consultas SQL, sem cobrir todas as ações administrativas realizadas fora de uma consulta.",
+        topic: "System Tables - audit",
+        options: [
+            ["system.access.audit", true],
+            ["system.billing.usage", false],
+            ["system.access.table_lineage", false],
+            ["system.query.history", false],
+        ],
+    },
+    {
+        statement:
+            "Um time de plataforma quer identificar, entre todos os SQL warehouses do workspace, as 10 consultas com maior tempo de execução nos últimos 7 dias, junto com o usuário que executou cada uma, para priorizar otimizações. Qual system table fornece esse detalhe por consulta?",
+        explanation:
+            "system.query.history traz uma linha por consulta SQL executada, com duração, usuário, warehouse e texto da consulta, permitindo ordenar pelo tempo de execução e identificar as mais lentas. system.billing.usage agrega consumo de DBUs, sem o detalhe de duração por consulta. system.access.audit registra ações administrativas e de acesso, não métricas de desempenho de consulta. system.compute.warehouses é um inventário da configuração dos warehouses, não das consultas executadas neles.",
+        topic: "System Tables - query history",
+        options: [
+            ["system.query.history", true],
+            ["system.billing.usage", false],
+            ["system.access.audit", false],
+            ["system.compute.warehouses", false],
+        ],
+    },
+    {
+        statement:
+            "Sobre as system tables de lineage do Unity Catalog, system.access.table_lineage e system.access.column_lineage, quais afirmações estão corretas? (Selecione DUAS opções.)",
+        explanation:
+            "O lineage do Unity Catalog é capturado automaticamente para leituras e escritas feitas por meio de compute governado pelo Unity Catalog, sem exigir instrumentação manual, e fica registrado em duas granularidades separadas, uma no nível de tabela e outra no nível de coluna. Ele não é retroativo: consultas executadas antes da ativação do rastreamento não aparecem nessas tabelas. Gravações feitas diretamente no armazenamento em nuvem, sem passar por compute governado pelo Unity Catalog, não são capturadas. O lineage cobre notebooks, jobs, pipelines de Lakeflow Spark Declarative Pipelines e dashboards, não apenas notebooks.",
+        topic: "System Tables - lineage",
+        options: [
+            ["O lineage é capturado automaticamente para leituras e escritas via compute governado pelo Unity Catalog, sem instrumentação manual", true],
+            ["A granularidade de coluna é registrada em uma system table separada da granularidade de tabela", true],
+            ["As tabelas de lineage trazem retroativamente o histórico de consultas anteriores à ativação do rastreamento", false],
+            ["O lineage também cobre gravações feitas direto no armazenamento em nuvem, sem passar pelo Unity Catalog", false],
+            ["O lineage registra apenas relações originadas de notebooks, sem cobrir jobs, pipelines ou dashboards", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe de plataforma quer consultar diretamente com SQL os eventos do event log de uma pipeline Lakeflow Spark Declarative Pipelines, filtrando por tipo de evento e por período, sem configurar entrega externa de logs nem acessar arquivos brutos. Qual é a forma suportada de fazer isso?",
+        explanation:
+            "O event log de uma pipeline Lakeflow Spark Declarative Pipelines pode ser consultado diretamente com SQL por meio de uma table-valued function dedicada, que recebe o identificador da pipeline e retorna os eventos como uma tabela comum, permitindo filtros por tipo de evento e por data. Ativar log verboso do cluster e fazer parsing manual de arquivos é desnecessário e não é a via suportada. system.access.audit não traz as métricas de execução por flow da pipeline. Exportar manualmente a aba SQL da Spark UI não produz um registro estruturado e consultável dos eventos da pipeline.",
+        topic: "Event log - consulta como tabela",
+        options: [
+            ["Usar a table-valued function de event log, passando o id da pipeline, e consultar como tabela", true],
+            ["Ativar o log verboso do cluster da pipeline e fazer parsing manual dos arquivos no driver", false],
+            ["Consultar a system table system.access.audit filtrando pelo nome da pipeline", false],
+            ["Exportar manualmente o conteúdo da aba SQL da Spark UI do cluster da pipeline", false],
+        ],
+    },
+    {
+        statement:
+            "Dentro de uma pipeline Lakeflow Spark Declarative Pipelines, uma streaming table específica está acumulando atraso. O engenheiro quer, pelo event log, saber quantos registros esse flow processou na última atualização e se alguma expectation de qualidade de dados reprovou registros. Qual tipo de evento do event log traz essa informação no nível do flow?",
+        explanation:
+            "Eventos do tipo flow_progress trazem, no campo de detalhes, as métricas de execução de cada flow, incluindo linhas processadas e o resultado das expectations de qualidade de dados aplicadas a esse flow. Eventos do tipo user_action apenas registram interações manuais, como iniciar ou interromper uma atualização pelo console. Eventos do tipo planning_information trazem o plano de execução gerado antes da atualização começar, sem métricas de linhas processadas. Eventos do tipo create_update apenas marcam o início de uma nova atualização da pipeline, identificada por um update id.",
+        topic: "Event log - métricas por flow",
+        options: [
+            ["flow_progress, cujo campo de detalhes traz as métricas do flow, como linhas processadas", true],
+            ["user_action, que registra apenas interações manuais feitas pelo console", false],
+            ["planning_information, que traz o plano de execução gerado antes da atualização começar", false],
+            ["create_update, que apenas marca o início de uma nova atualização da pipeline", false],
+        ],
+    },
+    {
+        statement:
+            "No Query Profiler de uma consulta SQL que ficou muito mais lenta que o esperado, o engenheiro observa grande tempo gasto em shuffle e sinais claros de spill para disco em vários estágios, causados por chaves de join fortemente enviesadas. Quais ações são formas válidas de mitigar esse gargalo? (Selecione DUAS opções.)",
+        explanation:
+            "Aumentar o número de partições de shuffle, ou repartitionar os dados de entrada, reduz o volume de dados processado por partição e tende a diminuir o spill para disco. Aplicar salting nas chaves fortemente enviesadas distribui melhor o trabalho entre as tasks, atacando diretamente o skew que gera o gargalo. Trocar Photon por execução Spark padrão não ajuda, pois o Photon acelera justamente operações de shuffle, join e agregação. Aumentar apenas o tipo de instância do driver não resolve, porque o gargalo de shuffle e spill ocorre nos executores, não no driver. Desativar o Adaptive Query Execution tende a piorar o cenário, já que a AQE inclui otimização específica para join enviesado.",
+        topic: "Spark UI e Query Profiler - gargalo",
+        options: [
+            ["Aumentar o número de partições de shuffle ou repartitionar os dados de entrada, reduzindo o volume por partição", true],
+            ["Aplicar salting nas chaves de join fortemente enviesadas, distribuindo melhor o trabalho entre as tasks", true],
+            ["Trocar Photon por execução Spark padrão, já que o Photon não acelera operações de shuffle", false],
+            ["Aumentar apenas o tipo de instância do driver, mantendo os workers inalterados", false],
+            ["Desativar o Adaptive Query Execution para evitar replanejamento durante a consulta", false],
+        ],
+    },
+    {
+        statement:
+            "Além do que a Spark UI mostra, um engenheiro quer enviar automaticamente, a cada micro-batch concluído, as métricas de uma consulta Structured Streaming, como linhas de entrada, taxa de entrada e taxa de processamento, para um sistema externo de observabilidade, sem inspeção manual. Qual abordagem programática atende esse requisito?",
+        explanation:
+            "Implementar um StreamingQueryListener e registrá-lo com spark.streams.addListener permite tratar o evento onQueryProgress, que traz as métricas de cada micro-batch concluído, incluindo taxa de entrada e de processamento, possibilitando encaminhá-las a um sistema externo automaticamente. Chamar explain() na consulta mostra apenas o plano de execução, sem métricas de runtime. system.billing.usage traz consumo de DBUs, não throughput de micro-batch. Ler os checkpoints da consulta expõe offsets e estado para tolerância a falhas, não uma API amigável de métricas.",
+        topic: "Monitoramento de streaming - StreamingQueryListener",
+        options: [
+            ["Implementar um StreamingQueryListener e tratar onQueryProgress via spark.streams.addListener", true],
+            ["Chamar periodicamente o método explain() da consulta para extrair as métricas de runtime", false],
+            ["Consultar system.billing.usage filtrando pelo cluster que executa a consulta em streaming", false],
+            ["Ler os checkpoints da consulta em um notebook separado para calcular as taxas manualmente", false],
+        ],
+    },
+    {
+        statement:
+            "Uma tarefa de um Lakeflow Job normalmente termina em cerca de 15 minutos. A equipe quer ser notificada por e-mail automaticamente apenas quando essa tarefa específica ultrapassar 45 minutos em execução, sem que isso interrompa a tarefa nem exija monitoramento manual. Qual configuração do job atende isso diretamente?",
+        explanation:
+            "Configurar um limite de duração esperada (duration threshold) para a tarefa, com os destinatários do alerta, dispara uma notificação automática quando esse limite é ultrapassado, sem interromper a execução em andamento. A matrix view é uma visualização para comparar manualmente a duração entre execuções, não um mecanismo automático de alerta. A política de retry só age depois que a tarefa falha, não quando ela apenas demora mais que o esperado. Reduzir o timeout da tarefa para 45 minutos faria o job matar a execução ao atingir o limite, em vez de apenas alertar.",
+        topic: "Lakeflow Jobs - limite de duração",
+        options: [
+            ["Configurar um limite de duração esperada (duration threshold) para a tarefa, com os destinatários do alerta", true],
+            ["Abrir a matrix view do job após cada execução para comparar visualmente a duração entre execuções", false],
+            ["Configurar a política de retry da tarefa para atuar após 45 minutos de execução", false],
+            ["Reduzir o timeout da tarefa para 45 minutos, fazendo o job falhar e disparar a notificação padrão de falha", false],
+        ],
+    },
+    {
+        statement:
+            "Uma organização exige que todo Lakeflow Job em produção rode exatamente o código aprovado em um processo de release, sem risco de um push posterior alterar silenciosamente o que será executado na próxima agenda. Hoje a tarefa do job usa como fonte um repositório Git remoto apontando para a branch main. Qual ajuste elimina esse risco?",
+        explanation:
+            "Apontar a tarefa para uma tag ou um commit específico do release, em vez de uma branch, elimina o risco de alteração silenciosa, já que uma branch como main pode receber novos commits a qualquer momento, enquanto uma tag ou commit é uma referência imutável. Trocar para um Git Folder sincronizado manualmente ainda referenciando main mantém a mesma mutabilidade e adiciona um passo manual. Clonar o repositório a cada execução mantendo main como referência não muda a natureza mutável da branch. Remover a integração Git e mover o código para dentro do job sacrifica o versionamento e a rastreabilidade do release.",
+        topic: "Databricks Git Folders - referência imutável",
+        options: [
+            ["Apontar a tarefa para uma tag ou um commit específico do release, em vez da branch main", true],
+            ["Trocar a fonte da tarefa para um Git Folder sincronizado manualmente, mantendo main como referência", false],
+            ["Configurar o job para clonar o repositório a cada execução, mantendo main como referência", false],
+            ["Mover o código da tarefa para dentro do próprio job, removendo a integração Git", false],
+        ],
+    },
+    {
+        statement:
+            "O databricks.yml de um Automation Bundle declara uma variável catalog sem valor padrão na raiz, usada em resources.pipelines.vendas.catalog. O target prod do mesmo arquivo declara um default para essa variável dentro do bloco variables do target. Ao rodar databricks bundle deploy --target prod sem passar --var, qual catálogo a pipeline implantada usa?",
+        explanation:
+            "Quando uma variável não tem default na declaração raiz, um target pode fornecer o próprio default dentro do seu bloco variables, e esse valor é o que resolve a interpolação ao implantar aquele target, sem exigir --var na linha de comando. A implantação não falha nesse caso, porque o target supre o valor. Não existe a regra de sempre usar o primeiro default do arquivo: o default aplicado é o do target selecionado. A pipeline também não fica sem catálogo definido, já que a interpolação só é resolvida quando há um valor disponível.",
+        topic: "Automation Bundles - variables por target",
+        options: [
+            ["O catálogo definido no default declarado dentro do bloco variables do target prod", true],
+            ["Nenhum, porque uma variável sem default na raiz nunca pode ser resolvida por um target", false],
+            ["O catálogo do primeiro default de variável encontrado no arquivo, na ordem em que aparece", false],
+            ["Nenhum catálogo definido, assumindo o catálogo padrão do metastore", false],
+        ],
+    },
+    {
+        statement:
+            "Antes de compartilhar um Automation Bundle com o restante do time, um engenheiro quer confirmar que o databricks.yml está sintaticamente correto e que as referências a variables e recursos resolvem, sem criar nem atualizar nenhum recurso no workspace. Qual comando do Databricks CLI atende exatamente essa necessidade?",
+        explanation:
+            "databricks bundle validate verifica a sintaxe do databricks.yml e resolve as referências de variables e recursos localmente, sem criar nem atualizar nada no workspace. databricks bundle deploy efetivamente cria ou atualiza os recursos no workspace de destino. databricks bundle run dispara a execução de um job ou pipeline já implantado, exigindo deploy prévio. databricks bundle summary exibe informações sobre os recursos já implantados de um bundle, não substitui a validação prévia da configuração.",
+        topic: "Databricks CLI - bundle validate",
+        options: [
+            ["databricks bundle validate", true],
+            ["databricks bundle deploy", false],
+            ["databricks bundle run", false],
+            ["databricks bundle summary", false],
+        ],
+    },
+    {
+        statement:
+            "Dois engenheiros, cada um com seu próprio usuário, implantam o mesmo Automation Bundle no mesmo workspace usando um target com mode: development, cada um a partir do próprio checkout local, rodando databricks bundle deploy. O que evita que a implantação de um sobrescreva os recursos implantados pelo outro?",
+        explanation:
+            "No modo development, o Databricks prefixa automaticamente o nome dos recursos implantados com um identificador do usuário que fez o deploy, isolando as implantações de desenvolvedores diferentes no mesmo workspace. O Databricks CLI não bloqueia deploys simultâneos de usuários diferentes. O modo development não exige um service principal compartilhado via run_as para unificar recursos de usuários diferentes. Também não existe a restrição de um target só poder ser implantado por um único usuário pré configurado no databricks.yml.",
+        topic: "Automation Bundles - modo development",
+        options: [
+            ["O modo development prefixa o nome dos recursos com um identificador do usuário que fez o deploy", true],
+            ["O Databricks CLI bloqueia o segundo deploy, exigindo que o primeiro engenheiro libere o bundle antes", false],
+            ["O modo development exige que os dois compartilhem o mesmo service principal via run_as", false],
+            ["Cada target só pode ser implantado por um único usuário configurado previamente no databricks.yml", false],
+        ],
+    },
+    {
+        statement:
+            "Uma pipeline Lakeflow Spark Declarative Pipelines foi validada no target dev de um Automation Bundle, gravando na streaming table dev_catalog.vendas.pedidos. Para promovê-la a produção gravando em prod_catalog.vendas.pedidos, sem duplicar a definição da pipeline em dois lugares, qual prática o bundle deve seguir?",
+        explanation:
+            "Definir a pipeline uma única vez em resources, referenciando o catálogo por meio de uma variável que cada target sobrescreve, evita duplicar a definição entre dev e prod. Copiar o bloco da pipeline para dentro do target prod duplica a definição e dificulta a manutenção. Trocar o catálogo direto no notebook da pipeline, com um widget preenchido a mão, introduz um passo manual fora do controle do bundle. Manter dois arquivos databricks.yml completos, um por ambiente, também duplica a definição que a variável evitaria.",
+        topic: "Automation Bundles - promover dev para prod",
+        options: [
+            ["Definir a pipeline uma vez, referenciando o catálogo por uma variável que cada target sobrescreve", true],
+            ["Copiar o bloco da pipeline para dentro do target prod, trocando manualmente o catálogo", false],
+            ["Trocar o catálogo direto no notebook da pipeline, com um widget preenchido a mão antes do deploy", false],
+            ["Manter dois arquivos databricks.yml completos, um para dev e outro para prod", false],
+        ],
+    },
+    {
+        statement:
+            "Um Lakeflow Job com 8 tarefas encadeadas falhou na tarefa 6 por uma instabilidade momentânea em uma API externa. As tarefas 1 a 5 terminaram com sucesso e geraram task values consumidos pelas tarefas 7 e 8. Corrigido o problema externo, o engenheiro quer concluir a execução aproveitando o que já foi processado, sem recomputar as tarefas 1 a 5. Qual ação atende isso diretamente?",
+        explanation:
+            "Repair run, disparado a partir da execução que falhou, reexecuta apenas as tarefas que falharam ou foram puladas, preservando as saídas e os task values das tarefas já concluídas com sucesso. Clonar o job e disparar uma execução completa nova recomputa tudo, desperdiçando o processamento já feito. Marcar a tarefa 6 como opcional deixaria as tarefas 7 e 8 rodarem sem os task values esperados dela, o que é semanticamente incorreto. Esperar a próxima execução agendada também recomputa as 8 tarefas do zero.",
+        topic: "Debugging de job - repair run",
+        options: [
+            ["Usar repair run na execução com falha, reexecutando apenas as tarefas que falharam ou puladas", true],
+            ["Clonar o job e disparar uma nova execução completa, comparando os resultados manualmente", false],
+            ["Editar a tarefa 6 para marcá-la como opcional, permitindo que as tarefas 7 e 8 rodem sem ela", false],
+            ["Aguardar a próxima execução agendada, mantendo a execução com falha registrada no histórico", false],
+        ],
+    },
+    {
+        statement:
+            "Uma tarefa Spark falha com um executor perdido por falta de memória (OutOfMemoryError) em apenas um dos workers. O engenheiro já confirmou, pelo event log do cluster, que não houve remoção de instância spot nem perda de nó por parte do provedor de nuvem. Onde ele deve procurar o stack trace exato e os detalhes de alocação de memória que causaram a falha?",
+        explanation:
+            "Os detalhes finos da falha, como o stack trace exato e a alocação de memória que levou ao OutOfMemoryError, ficam nos logs stderr do executor específico, acessíveis pela aba Executors da Spark UI daquele cluster. O log do driver concentra a orquestração do job e as exceções resumidas propagadas dos executores, sem o mesmo nível de detalhe por executor. A aba Output da execução do job mostra apenas a saída do lado do driver, como prints e resultados de células. system.access.audit registra ações administrativas e de acesso, não stack traces de tarefas Spark.",
+        topic: "Debugging - logs de driver e executor",
+        options: [
+            ["Nos logs stderr do executor específico, pela aba Executors da Spark UI daquele cluster", true],
+            ["No log do driver, que concentra o stack trace completo de qualquer exceção de qualquer executor", false],
+            ["Na aba Output da execução do job, que combina o conteúdo dos logs de driver e executor", false],
+            ["Em system.access.audit, que registra os erros de execução de cada tarefa Spark", false],
+        ],
+    },
+    {
+        statement:
+            "Depois de implantar um Automation Bundle no target prod com databricks bundle deploy --target prod, um engenheiro quer disparar agora mesmo uma execução avulsa do job ingestao_diaria definido nesse bundle, sem esperar a próxima agenda e sem abrir a interface web. Qual comando do Databricks CLI faz isso?",
+        explanation:
+            "databricks bundle run ingestao_diaria --target prod dispara uma execução avulsa do job já implantado naquele target, direto pela linha de comando. databricks bundle deploy apenas publica ou atualiza a definição dos recursos, sem disparar uma execução. databricks bundle validate somente confere a configuração localmente. databricks bundle summary apenas exibe informações sobre os recursos já implantados, sem disparar nada.",
+        topic: "Databricks CLI - bundle run",
+        options: [
+            ["databricks bundle run ingestao_diaria --target prod", true],
+            ["databricks bundle deploy ingestao_diaria --target prod", false],
+            ["databricks bundle validate ingestao_diaria --target prod", false],
+            ["databricks bundle summary ingestao_diaria --target prod", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe quer testar automaticamente, em um pipeline de CI a cada pull request, as funções de transformação PySpark de um projeto de dados, com feedback rápido e sem subir um cluster de job a cada execução dos testes. Quais práticas atendem esse objetivo? (Selecione DUAS opções.)",
+        explanation:
+            "Extrair a lógica de transformação para funções Python puras, que recebem e retornam DataFrames desacopladas do notebook, torna essa lógica testável isoladamente. Usar nos testes uma SparkSession local, criada por um framework como pytest, permite comparar o DataFrame resultante com o esperado sem depender de um cluster de job. Testar apenas manualmente no notebook do workspace não é automatizável em um pipeline de CI. A política de retry da tarefa só ajuda com falhas transitórias, não revela erros de lógica de transformação. Observar métricas de linhas processadas no event log de produção é verificação posterior ao deploy, não um teste unitário anterior ao merge.",
+        topic: "Teste unitário de transformações",
+        options: [
+            ["Extrair a lógica de transformação para funções Python puras, que recebem e retornam DataFrames", true],
+            ["Usar nos testes uma SparkSession local, via um framework como pytest, comparando o DataFrame obtido com o esperado", true],
+            ["Testar apenas manualmente, rodando a tarefa inteira no notebook do workspace antes de cada merge", false],
+            ["Confiar na política de retry automático da tarefa para revelar erros de lógica de transformação", false],
+            ["Validar a transformação apenas observando as métricas de linhas processadas no event log em produção", false],
+        ],
+    },
+    {
+        statement:
+            "A tabela rh.folha.salarios tem as colunas salario e departamento, e cada departamento corresponde a um grupo de mesmo nome no Unity Catalog (financeiro, rh, comercial etc.). A regra deve liberar o salário real apenas para quem pertence ao grupo do MESMO departamento daquela linha, retornando NULL nas demais linhas, mas mantendo a linha sempre visível. Como a function de column mask deve ser escrita e aplicada para atender essa regra, que depende dinamicamente do valor de outra coluna da própria linha?",
+        explanation:
+            "O Unity Catalog permite que uma function de column mask receba, além do valor da coluna mascarada, colunas adicionais da mesma linha como parâmetros, declaradas na cláusula USING COLUMNS do ALTER TABLE ... ALTER COLUMN ... SET MASK. Isso possibilita lógica dinâmica, como chamar is_account_group_member(departamento) usando o próprio valor da linha como nome do grupo a verificar, em vez de um grupo fixo no código da function. Uma function sem esse parâmetro adicional não tem acesso ao departamento da linha e só consegue checar um grupo fixo, o que não atende departamentos diferentes com a mesma lógica. Row filter é um mecanismo distinto, que oculta linhas inteiras em vez de substituir o valor de uma coluna, por isso não atende um requisito que exige a linha sempre visível com o dado apenas mascarado.",
+        topic: "Column masking com parâmetros adicionais",
+        options: [
+            ["A function deve receber apenas o salário como parâmetro, comparando internamente com is_account_group_member('rh'), sem precisar da coluna departamento.", false],
+            ["A function deve ser aplicada com ALTER TABLE ... SET ROW FILTER, verificando is_account_group_member(departamento) para ocultar linhas de outros departamentos.", false],
+            ["A function deve receber departamento como parâmetro adicional e chamar is_account_group_member(departamento) dentro dela, aplicada com SET MASK mascara_salario USING COLUMNS (departamento).", true],
+            ["A function deve ser criada sem parâmetros e aplicada com SET MASK, pois is_account_group_member() já enxerga automaticamente todas as colunas da linha atual sem recebê-las explicitamente.", false],
+        ],
+    },
+    {
+        statement:
+            "A tabela comercial.clientes_globais precisa, ao mesmo tempo, ocultar linhas de clientes de países diferentes do país do usuário logado E mascarar o CPF para qualquer usuário fora da equipe de compliance, sem duplicar a tabela em views. É possível aplicar simultaneamente um row filter e um column mask na mesma tabela do Unity Catalog para atender as duas regras?",
+        explanation:
+            "Row filter e column mask são mecanismos independentes do Unity Catalog e podem ser combinados livremente na mesma tabela: o row filter controla quais linhas cada usuário enxerga, enquanto o column mask controla o valor exibido de uma coluna nas linhas que permanecerem visíveis. Não há limite de um mecanismo por tabela, nem exigência de que a coluna mascarada seja a mesma usada no filtro de linhas. Criar uma view intermediária seria um esforço desnecessário, já que os dois recursos se aplicam diretamente com ALTER TABLE na própria tabela, sem duplicar dados.",
+        topic: "Row filter e column mask combinados",
+        options: [
+            ["Sim, os dois mecanismos são independentes e podem ser combinados na mesma tabela, um controlando linhas e o outro, o valor da coluna.", true],
+            ["Não, o Unity Catalog aceita apenas um dos dois mecanismos por tabela, sendo necessário escolher entre ocultar linhas ou mascarar uma coluna.", false],
+            ["Sim, mas somente se a coluna mascarada pelo column mask for a mesma usada como critério do row filter, caso contrário a combinação é rejeitada.", false],
+            ["Não, é preciso criar uma view sobre a tabela com o row filter aplicado e, só então, um column mask separado sobre essa view.", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe de dados mantém centenas de tabelas com uma coluna regiao, e precisa que cada usuário veja apenas linhas da sua própria região em TODAS elas, atuais e futuras, sem criar uma function de row filter e um ALTER TABLE para cada tabela individualmente. Qual abordagem do Unity Catalog atende essa exigência com o menor esforço operacional contínuo?",
+        explanation:
+            "ABAC (attribute-based access control) permite definir uma policy baseada em um atributo comum, como uma tag aplicada às colunas de regiao, e essa policy passa a ser aplicada automaticamente como row filter em qualquer tabela marcada com a tag, inclusive tabelas criadas depois da policy existir, sem precisar de uma function e um ALTER TABLE por tabela. Repetir manualmente a criação e aplicação de uma function de row filter em cada tabela existente não cobre tabelas futuras e exige manutenção contínua. Não existe um DENY global no metastore condicionado a filtros de consulta, e consolidar tabelas em uma view com UNION ALL não aplica a regra às tabelas originais nem inclui automaticamente tabelas novas.",
+        topic: "ABAC aplicado a row filters em escala",
+        options: [
+            ["Criar uma única function de row filter e aplicá-la manualmente com ALTER TABLE em cada tabela existente, repetindo o processo sempre que uma tabela nova surgir.", false],
+            ["Definir uma policy de ABAC baseada em uma tag comum às colunas de regiao, aplicada automaticamente como row filter em qualquer tabela marcada, presente ou futura.", true],
+            ["Marcar as colunas de regiao com uma tag e configurar um DENY global no metastore para consultas que não filtrem por região explicitamente.", false],
+            ["Criar uma view consolidada com UNION ALL de todas as tabelas e aplicar um único row filter apenas nessa view.", false],
+        ],
+    },
+    {
+        statement:
+            "Uma tabela com deletion vectors habilitados recebe uma solicitação de exclusão definitiva de um titular de dados. O engenheiro já rodou DELETE FROM tabela WHERE id = X e confirma que a linha não aparece mais em nenhum SELECT. A área jurídica exige, porém, remoção FÍSICA dos dados nos arquivos, não apenas ocultação lógica. Quais DUAS ações são necessárias para atender essa exigência? (Selecione DUAS opções.)",
+        explanation:
+            "Com deletion vectors habilitados, um DELETE marca as linhas como removidas em um arquivo auxiliar, sem reescrever imediatamente os arquivos de dados Parquet, então o valor original ainda existe fisicamente nesses arquivos. REORG TABLE ... APPLY (PURGE) reescreve os arquivos afetados removendo de fato as linhas marcadas pelos deletion vectors. Como o REORG gera novas versões de arquivo e as antigas continuam disponíveis para time travel, um VACUUM após o período de retenção é necessário para remover essas versões antigas, que ainda contêm os dados originais. TRUNCATE TABLE apaga a tabela inteira, não só as linhas do titular. Desabilitar a propriedade de deletion vectors não reescreve nem apaga retroativamente dados já marcados como removidos.",
+        topic: "Retenção e purga com deletion vectors",
+        options: [
+            ["Executar REORG TABLE tabela APPLY (PURGE), reescrevendo os arquivos de dados para remover as linhas marcadas pelos deletion vectors.", true],
+            ["Considerar o processo concluído após o DELETE, já que a linha some das consultas correntes assim que o comando termina.", false],
+            ["Executar VACUUM na tabela após o período de retenção, removendo as versões de arquivo antigas que ainda contêm as linhas apagadas.", true],
+            ["Executar TRUNCATE TABLE tabela, que remove apenas as linhas apagadas recentemente, preservando o restante dos dados.", false],
+            ["Desabilitar deletion vectors com ALTER TABLE ... SET TBLPROPERTIES, apagando retroativamente as linhas já marcadas como removidas.", false],
+        ],
+    },
+    {
+        statement:
+            "A tabela comercial.clientes tem Change Data Feed habilitado há meses, alimentando um pipeline downstream. Uma solicitação de exclusão remove um cliente com DELETE FROM comercial.clientes WHERE id = X, e o engenheiro confirma que o cliente some de um SELECT * FROM comercial.clientes. Ele pode considerar o dado desse cliente totalmente eliminado da tabela apenas com esse DELETE?",
+        explanation:
+            "Enquanto o Change Data Feed estiver habilitado, o valor anterior de uma linha apagada ou atualizada fica registrado em arquivos de change data próprios, consultados por table_changes() e por consumidores downstream, e esses arquivos seguem sujeitos à mesma janela de retenção e ao VACUUM que os demais arquivos da tabela. Um DELETE remove a linha da versão corrente da tabela, mas o valor anterior pode continuar acessível via CDF até que esses arquivos de change data envelheçam e sejam removidos por um VACUUM. O Change Data Feed não bloqueia fisicamente operações de escrita, e a presença ou ausência de deletion vectors não é a causa dessa persistência nem faz o CDF reter dados indefinidamente.",
+        topic: "Change Data Feed e retenção de PII",
+        options: [
+            ["Sim, o DELETE remove a linha de todos os arquivos internos da tabela, incluindo os arquivos de change data do Change Data Feed, de forma imediata.", false],
+            ["Não, o Change Data Feed impede fisicamente a execução do DELETE, sendo necessário desabilitar delta.enableChangeDataFeed antes.", false],
+            ["Sim, desde que a tabela não tenha deletion vectors habilitados, caso contrário o Change Data Feed retém a linha indefinidamente.", false],
+            ["Não, o valor anterior da linha pode continuar nos arquivos de change data do CDF até que a janela de retenção expire e um VACUUM os remova.", true],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa multi-tenant isola os dados de cada cliente corporativo em um storage account próprio, registrado como um External Location distinto no Unity Catalog. Ao encerrar o contrato de um desses clientes, a área de segurança precisa garantir que os dados dele se tornem irrecuperáveis de forma imediata, sem depender da janela de retenção do Delta Lake nem de rodar VACUUM tabela por tabela. Qual abordagem atende essa exigência?",
+        explanation:
+            "Configurar uma customer-managed key exclusiva para o storage desse cliente permite que, ao revogar ou destruir essa chave no momento do encerramento do contrato, todo o conteúdo criptografado nesse local se torne irrecuperável de imediato, técnica conhecida como crypto-shredding, sem depender de retenção do Delta Lake nem de VACUUM tabela por tabela. Rodar VACUUM com retenção zero ainda depende de processar cada tabela individualmente e não afeta nenhum arquivo fora do controle do Delta Lake. DROP TABLE remove o registro no metastore, mas em tabelas external não apaga os arquivos, e mesmo em tabelas managed não envolve nenhuma criptografia. Desabilitar a governança do Unity Catalog sobre o external location não altera a criptografia dos arquivos armazenados.",
+        topic: "Criptografia com customer-managed keys",
+        options: [
+            ["Rodar VACUUM RETAIN 0 HOURS em todas as tabelas do cliente, o que remove imediatamente qualquer vestígio dos dados nesse storage.", false],
+            ["Configurar uma customer-managed key exclusiva para o storage do cliente e revogar a chave ao fim do contrato, tornando os dados ilegíveis.", true],
+            ["Aplicar DROP TABLE em cada tabela do cliente, apagando de forma imediata e irreversível os arquivos correspondentes no storage account.", false],
+            ["Desabilitar o Unity Catalog nesse External Location, o que revoga automaticamente a criptografia de todos os arquivos armazenados nele.", false],
+        ],
+    },
+    {
+        statement:
+            "A área de segurança quer que as credenciais usadas por um pipeline no Databricks sejam geridas e rotacionadas centralmente no Azure Key Vault da empresa, sem manter uma cópia separada do valor do segredo dentro do Databricks. Qual configuração de secret scope atende essa exigência?",
+        explanation:
+            "Um secret scope do tipo Azure Key Vault-backed referencia os segredos diretamente no Key Vault configurado pela empresa, então a rotação e a gestão continuam centralizadas lá, sem duplicar o valor dentro do Databricks. Um secret scope Databricks-backed, ao contrário, armazena os segredos no próprio armazenamento criptografado do Databricks e não sincroniza automaticamente com um Key Vault externo. Não existe um tipo de secret scope nativo com backing em AWS Secrets Manager. Uma variável de ambiente de cluster não é um secret scope governado, e colocar um valor de segredo diretamente nela expõe o valor em texto na configuração do cluster.",
+        topic: "Secret scopes: tipos e integração",
+        options: [
+            ["Um Azure Key Vault-backed secret scope, que referencia os segredos diretamente no Key Vault, sem duplicar o valor dentro do Databricks.", true],
+            ["Um Databricks-backed secret scope, que sincroniza automaticamente com o Azure Key Vault a cada rotação de credencial feita na nuvem.", false],
+            ["Um secret scope do tipo AWS Secrets Manager-backed, disponível em qualquer workspace Databricks independentemente da nuvem usada.", false],
+            ["Uma variável de ambiente definida em Environment Variables do cluster, apontando diretamente para o segredo dentro do Key Vault.", false],
+        ],
+    },
+    {
+        statement:
+            "Um engenheiro de segurança avalia se a redação automática de segredos do Databricks, que exibe [REDACTED] na saída de células, é suficiente para impedir que um notebook exponha um valor obtido via dbutils.secrets.get. Ele testa um notebook que aplica base64 no valor do segredo antes de exibi-lo com display(). Considerando como essa redação funciona, o que deve acontecer?",
+        explanation:
+            "A redação automática do Databricks compara a saída da célula com o valor exato do segredo recuperado na sessão e substitui apenas correspondências literais dessa string por [REDACTED]. Assim que o valor passa por uma transformação como base64, a string exibida deixa de coincidir byte a byte com o segredo original, então a saída transformada não é reconhecida nem redigida. Isso significa que a redação de saída não é um controle de segurança suficiente por si só, o controle real continua sendo a ACL do secret scope, que decide quem pode chamar dbutils.secrets.get para aquele segredo. Não existe detecção de encoding reversível nem bloqueio automático de chamadas de encoding após a leitura de um segredo, e dbutils.secrets.get sempre retorna o valor real em texto puro para o código, a máscara se aplica somente à exibição.",
+        topic: "Secrets: limite da redação automática",
+        options: [
+            ["O Databricks decodifica automaticamente transformações reversíveis como base64 antes de comparar, então o resultado também aparece como [REDACTED].", false],
+            ["A célula falha com erro de segurança, pois o Databricks bloqueia qualquer chamada de encoding logo após um dbutils.secrets.get na mesma célula.", false],
+            ["O valor em base64 aparece sem redação, pois a comparação cobre só correspondência exata da string, e a ACL do secret scope é o controle real.", true],
+            ["O valor em base64 aparece sem redação, mas isso é irrelevante, pois dbutils.secrets.get só devolve valores já mascarados ao código, nunca o segredo real.", false],
+        ],
+    },
+    {
+        statement:
+            "Para anonimizar CPFs antes de liberar uma tabela ao time de analytics, um engenheiro aplica sha2(cpf, 256) na coluna e passa a tratar o resultado como dado anonimizado, sem nenhuma restrição de acesso adicional sobre essa coluna. Do ponto de vista de proteção de dados, esse raciocínio está correto?",
+        explanation:
+            "CPF tem um formato conhecido e um espaço de valores enumerável, então qualquer pessoa pode pré-calcular o hash sha2 de todos os CPFs possíveis, ou de uma lista de candidatos plausíveis, e comparar com os valores da coluna, reidentificando os titulares por uma tabela de correspondência, mesmo sem acesso à coluna original de CPF. Isso caracteriza pseudonimização, não anonimização, e o hash sozinho não remove esse risco de reidentificação. O fato de sha2 ser irreversível no sentido criptográfico não implica que a saída seja impossível de associar de volta ao valor original quando o espaço de entradas é pequeno o bastante para ser varrido por força bruta. A função sha2 do Databricks SQL não exige nenhuma chave de secret scope para ser executada, e apagar a coluna original de CPF na tabela fonte não impede alguém de gerar novamente os hashes de CPFs candidatos de forma independente.",
+        topic: "Anonimização de PII versus pseudonimização",
+        options: [
+            ["Sim, porque qualquer saída de uma função de hash criptográfico como sha2 é, por definição, irreversível e por isso totalmente anônima.", false],
+            ["Não, porque o espaço de valores de CPF é enumerável, permitindo recriar os hashes possíveis e reidentificar a coluna por comparação direta.", true],
+            ["Não, porque a função sha2 do Databricks SQL exige uma chave de assinatura cadastrada em um secret scope para poder ser executada.", false],
+            ["Sim, desde que a coluna original de CPF seja apagada da tabela fonte logo em seguida, eliminando qualquer vínculo com o valor original.", false],
+        ],
+    },
+    {
+        statement:
+            "Um engenheiro tem USE CATALOG em vendas, USE SCHEMA em vendas.comercial e CREATE TABLE em vendas.comercial. Ao rodar CREATE TABLE vendas.comercial.pedidos_raw (...) LOCATION 's3://dados-brutos/pedidos/', o comando falha por falta de permissão, mesmo com os privilégios acima já concedidos. O que falta conceder a ele para criar essa tabela external?",
+        explanation:
+            "Criar uma tabela external, isto é, uma tabela com cláusula LOCATION apontando para um caminho fora do armazenamento gerenciado, exige, além de USE CATALOG, USE SCHEMA e CREATE TABLE no schema, o privilégio CREATE EXTERNAL TABLE concedido no external location ou no storage credential que cobre aquele caminho específico. Sem esse privilégio adicional ligado à cadeia de governança do caminho externo, a criação falha mesmo com os privilégios do schema corretos. Não existe exigência de papel de account admin para essa operação, repetir CREATE TABLE no catálogo não supre a falta do privilégio ligado ao external location, e MODIFY controla operações de escrita como INSERT, UPDATE e DELETE em tabelas já existentes, sem relação com a criação de tabelas novas.",
+        topic: "Privilégios para tabelas external",
+        options: [
+            ["Um papel de account admin atribuído a ele, exigido para qualquer CREATE TABLE que use a cláusula LOCATION.", false],
+            ["CREATE TABLE no catálogo vendas, já que o privilégio concedido apenas no schema comercial não é suficiente para nenhum tipo de tabela.", false],
+            ["MODIFY no schema comercial, privilégio que libera a criação de tabelas apontando para um caminho de armazenamento externo.", false],
+            ["CREATE EXTERNAL TABLE no external location, ou no storage credential, que cobre o caminho informado na cláusula LOCATION.", true],
+        ],
+    },
+    {
+        statement:
+            "Uma engenheira de dados, owner individual de dezenas de tabelas no catálogo vendas, vai sair da empresa em breve. A área de governança quer evitar que outros usuários e automações percam acesso a essas tabelas quando a conta dela for desativada. Qual prática evita esse problema, aplicada antes da saída dela?",
+        explanation:
+            "A prática recomendada no Unity Catalog é atribuir a propriedade (ownership) de catálogos, schemas e tabelas a um grupo, em vez de a um usuário individual, assim a saída ou desativação de qualquer integrante do grupo não afeta o ownership dos objetos nem quebra grants e automações associadas. Cada objeto do Unity Catalog tem um único owner por vez, então não existe a possibilidade de dois principals serem owners simultâneos do mesmo objeto. Conceder ALL PRIVILEGES a todos os usuários do catálogo não elimina a necessidade de um owner, que é um papel distinto dos privilégios concedidos via GRANT. Reatribuir o ownership tabela por tabela somente depois do desligamento é reativo, e não evita a janela de risco que a área de governança quer eliminar.",
+        topic: "Ownership: boas práticas",
+        options: [
+            ["Definir um grupo como owner das tabelas, em vez de um usuário individual, para que a saída de um integrante não afete o ownership.", true],
+            ["Reatribuir o ownership de cada tabela individualmente com ALTER TABLE ... OWNER TO somente depois que o desligamento dela for efetivado.", false],
+            ["Conceder ALL PRIVILEGES a todos os usuários do catálogo vendas, o que elimina a necessidade de um owner específico por tabela.", false],
+            ["Adicionar um segundo usuário administrador como owner adicional das tabelas, mantendo os dois como owners simultâneos a partir de agora.", false],
+        ],
+    },
+    {
+        statement:
+            "A área de segurança precisa descobrir quem executou um DROP TABLE em uma tabela crítica do catálogo financas e em qual workspace da conta isso aconteceu, cobrindo todos os workspaces vinculados ao metastore em uma única consulta SQL, sem exportar logs manualmente de cada workspace. Qual recurso do Unity Catalog atende essa necessidade?",
+        explanation:
+            "As System Tables de auditoria, no schema system.access, consolidam eventos de todos os workspaces vinculados ao metastore em tabelas Delta comuns, consultáveis com SQL padrão, incluindo colunas que identificam o usuário responsável e o workspace de origem de cada evento. O histórico de uma tabela Delta (DESCRIBE HISTORY) fica no escopo de uma única tabela e não carrega informação de qual workspace originou cada operação. O event log do Lakeflow Spark Declarative Pipelines cobre apenas as operações de um pipeline específico, não operações DDL de todos os workspaces da conta. A aba Lineage do Catalog Explorer mostra dependências de dados entre objetos, não um registro de quem executou uma ação administrativa como DROP TABLE.",
+        topic: "System Tables de auditoria",
+        options: [
+            ["O DESCRIBE HISTORY da tabela financas, que registra o workspace de origem de cada operação DDL executada nela.", false],
+            ["As System Tables de auditoria (system.access.audit), que consolidam eventos de todos os workspaces do metastore em uma tabela consultável por SQL.", true],
+            ["O event log do Lakeflow Spark Declarative Pipelines associado ao catálogo financas, cobrindo as operações DDL de todos os workspaces da conta.", false],
+            ["A aba Lineage do Catalog Explorer para a tabela financas, mostrando o histórico de exclusão e o workspace responsável.", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa tem um metastore do Unity Catalog compartilhado entre o workspace de produção e o workspace de desenvolvimento. A governança quer que o catálogo financas_prod, com dados sensíveis, só possa ser acessado a partir do workspace de produção, mesmo que um usuário com SELECT concedido tente consultá-lo a partir do workspace de desenvolvimento. Qual recurso do Unity Catalog atende essa exigência sem duplicar o catálogo?",
+        explanation:
+            "Workspace-catalog binding restringe um catálogo a um conjunto específico de workspaces, e essa restrição é avaliada no nível do workspace, antes mesmo dos privilégios do usuário, então mesmo alguém com SELECT válido na tabela não consegue acessá-la a partir de um workspace não vinculado ao catálogo. External location controla o acesso a um caminho de armazenamento por credencial, sem relação com a partir de qual workspace um catálogo pode ser consultado. Revogar USE CATALOG apenas dos grupos hoje associados ao workspace de desenvolvimento depende de manter essa lista de grupos sempre atualizada, e não bloqueia um usuário que futuramente ganhe acesso ao catálogo por outro caminho. Row filter avalia valores de linha ou a identidade do usuário, não existe uma function padrão de row filter que identifique o workspace de origem da consulta.",
+        topic: "Catalog-workspace binding",
+        options: [
+            ["Criar um External Location exclusivo para o workspace de produção e associá-lo ao catálogo financas_prod.", false],
+            ["Revogar USE CATALOG do catálogo financas_prod para todos os grupos hoje associados ao workspace de desenvolvimento.", false],
+            ["Workspace-catalog binding, restringindo o catálogo financas_prod ao workspace de produção, e a nenhum outro.", true],
+            ["Definir um row filter na tabela que verifica o nome do workspace atual antes de liberar qualquer linha.", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe de plataforma quer um painel mostrando, para todas as tabelas do metastore, quais colunas alimentam quais colunas downstream, atualizado automaticamente e sem abrir o Catalog Explorer tabela por tabela. Qual fonte do Unity Catalog permite consultar essa linhagem em escala, via SQL comum?",
+        explanation:
+            "As System Tables system.access.table_lineage e system.access.column_lineage expõem a linhagem capturada automaticamente pelo Unity Catalog como tabelas Delta comuns, consultáveis com SQL padrão e fáceis de agregar em um painel para o metastore inteiro. O information_schema.columns lista metadados de colunas, como nome e tipo, mas não registra relações de origem e destino entre colunas de tabelas diferentes. Agregar o DESCRIBE HISTORY de cada tabela mostra operações de versionamento do Delta Lake, como inserts e merges, não dependências de coluna entre tabelas, além de não escalar tabela por tabela. Não existe um log de auditoria do DBFS que registre leituras de arquivo Parquet como mecanismo de linhagem lógica entre colunas do Unity Catalog.",
+        topic: "Linhagem via System Tables",
+        options: [
+            ["O information_schema.columns, que lista todas as colunas do metastore junto com a tabela de origem calculada em tempo real.", false],
+            ["O DESCRIBE HISTORY de cada tabela, agregado manualmente em uma consulta que percorre todas as tabelas do metastore.", false],
+            ["Os logs de auditoria do DBFS, que registram cada leitura de arquivo Parquet subjacente às tabelas Delta do metastore.", false],
+            ["As System Tables system.access.table_lineage e system.access.column_lineage, que expõem a linhagem capturada automaticamente.", true],
+        ],
+    },
+    {
+        statement:
+            "Quais DUAS afirmações sobre tags de objetos no Unity Catalog estão corretas? (Selecione DUAS opções.)",
+        explanation:
+            "Tags podem ser aplicadas a catálogos, schemas, tabelas, colunas e volumes, e ficam visíveis para consulta via views do information_schema, como table_tags e column_tags, o que viabiliza relatórios de governança por SQL. Tags também podem servir de atributo-base para policies de ABAC, que aplicam automaticamente row filters ou column masks a qualquer objeto marcado com a tag configurada, presente ou futuro. Diferente de privilégios concedidos por GRANT, uma tag aplicada em um catálogo não é herdada automaticamente pelos schemas e tabelas dentro dele, cada objeto carrega suas próprias tags. Tags são metadados de classificação e não substituem o GRANT como mecanismo de controle de acesso, e podem ser aplicadas tanto a uma tabela inteira quanto a uma coluna individual dela.",
+        topic: "Tags e information_schema",
+        options: [
+            ["Uma tag aplicada em um catálogo é herdada automaticamente por todos os schemas e tabelas dentro dele, do mesmo jeito que um GRANT.", false],
+            ["Tags podem ser aplicadas em catálogos, schemas, tabelas e colunas, e ficam consultáveis via views do information_schema, como table_tags e column_tags.", true],
+            ["Tags substituem o GRANT tradicional, controlando diretamente quem tem SELECT concedido em uma tabela.", false],
+            ["Tags podem servir de base para policies de ABAC, aplicando automaticamente row filters ou column masks a qualquer objeto marcado com a tag.", true],
+            ["Tags só podem ser aplicadas no nível de tabela inteira, nunca em uma coluna individual dela.", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe de dados quer disponibilizar uma tabela gold para analistas de um parceiro que não possui workspace Databricks nem Unity Catalog, e que pretendem consumir os dados via pandas e Power BI. Qual abordagem de Delta Sharing atende esse cenário sem exigir que o parceiro adote a plataforma Databricks?",
+        explanation:
+            "O recipient aberto (open, também chamado D2O) é o tipo de Delta Sharing pensado para quem não tem Databricks nem Unity Catalog: o provedor gera um link de ativação que o parceiro usa uma única vez para baixar um arquivo de credencial e consultar o share com qualquer cliente compatível com o protocolo Delta Sharing, como pandas ou o conector do Power BI. Já o recipient Databricks-to-Databricks exige que o parceiro tenha seu próprio metastore do Unity Catalog para montar o share como catálogo, o que não se aplica aqui. Lakehouse Federation resolve o problema inverso, consultar uma fonte externa a partir do Databricks, e conceder acesso direto ao armazenamento em nuvem contorna a governança do Unity Catalog.",
+        topic: "Delta Sharing Open (D2O)",
+        options: [
+            ["Criar um share e adicionar o parceiro como recipient Databricks-to-Databricks, identificado pelo metastore do Unity Catalog dele, para montar o share como catálogo.", false],
+            ["Criar um share e adicionar o parceiro como recipient aberto (open), que recebe um link de ativação para gerar a credencial e conectar via cliente Delta Sharing.", true],
+            ["Configurar uma connection de Lakehouse Federation apontando para o ambiente do parceiro e expor a tabela gold como catálogo externo.", false],
+            ["Conceder acesso direto ao parceiro na conta de armazenamento em nuvem que hospeda os arquivos Delta da tabela gold.", false],
+        ],
+    },
+    {
+        statement:
+            "Uma unidade de negócio irmã, que também usa Databricks com seu próprio metastore do Unity Catalog, precisa de acesso contínuo e governado a uma tabela gold do provedor, incluindo auditoria via Unity Catalog, sem que os dados sejam copiados para o armazenamento da unidade que recebe. Qual configuração de Delta Sharing atende esse requisito?",
+        explanation:
+            "O recipient Databricks-to-Databricks (D2D) é identificado pelo metastore do Unity Catalog do destinatário, que monta o share como um catálogo somente leitura em seu próprio ambiente. As consultas rodam com o compute da unidade que recebe, lendo diretamente do armazenamento do provedor sem copiar os dados, e ficam sujeitas à governança e à auditoria do Unity Catalog dos dois lados. O recipient aberto é para quem não tem Unity Catalog, o que não é o caso aqui. Lakehouse Federation serve para consultar fontes externas ao Databricks, não para consumir um share. E descrever o D2D como replicação contínua para o armazenamento de quem recebe está errado: essa cópia física não acontece nesse modelo.",
+        topic: "Delta Sharing D2D",
+        options: [
+            ["Adicionar a unidade irmã como recipient aberto (open), gerando um link de ativação para baixar a credencial e consultar via cliente Delta Sharing.", false],
+            ["Configurar uma connection de Lakehouse Federation no workspace da unidade irmã apontando para o catálogo Unity Catalog do provedor como fonte externa.", false],
+            ["Adicionar a unidade irmã como recipient Databricks-to-Databricks, montando o share como catálogo somente leitura e consultando com o próprio compute.", true],
+            ["Adicionar a unidade irmã como recipient Databricks-to-Databricks e habilitar replicação contínua da tabela para o armazenamento da unidade irmã.", false],
+        ],
+    },
+    {
+        statement:
+            "Um provedor de dados publica em um share a tabela fato de vendas, um volume com anexos de nota fiscal e um notebook de onboarding para o parceiro. Agora o time de governança quer que o parceiro veja apenas as linhas da região Sul da tabela de vendas, sem duplicar fisicamente os dados nem manter um pipeline paralelo. Qual abordagem resolve isso dentro do próprio Delta Sharing?",
+        explanation:
+            "Delta Sharing permite adicionar views ao share no lugar de tabelas, e uma view pode usar a função current_recipient() para filtrar linhas de acordo com quem está consultando, aplicando a regra uma única vez, de forma centralizada, sem duplicar dados nem manter pipeline paralelo algum. O deep clone resolveria o filtro, mas exige manter uma cópia física sincronizada, o que o enunciado descarta. Confiar que o parceiro filtre no lado do cliente não restringe nada de fato, já que a tabela inteira continua acessível. E o Change Data Feed serve para propagar mudanças incrementais, não para restringir linhas por conteúdo.",
+        topic: "Ativos Compartilháveis no Delta Sharing",
+        options: [
+            ["Substituir a tabela por uma view que filtra as linhas pela região com current_recipient() e adicionar essa view ao share no lugar da tabela.", true],
+            ["Criar um deep clone da tabela somente com as linhas da região Sul e adicionar o clone ao share, mantendo-o sincronizado por um job agendado.", false],
+            ["Adicionar a tabela original ao share e orientar o parceiro a aplicar o filtro de região nas consultas feitas pelo cliente Delta Sharing.", false],
+            ["Ativar o Change Data Feed na tabela e instruir o parceiro a descartar as linhas de outras regiões ao processar o feed incremental.", false],
+        ],
+    },
+    {
+        statement:
+            "Um analista de dados precisa investigar, de forma pontual, inconsistências entre pedidos registrados no Databricks e o status de pagamento armazenado em um banco PostgreSQL operacional, sem construir um pipeline de ingestão só para essa investigação pontual. Qual recurso permite consultar as tabelas do PostgreSQL diretamente a partir de um catálogo do Unity Catalog, sem copiar os dados para o Delta Lake?",
+        explanation:
+            "Lakehouse Federation permite registrar uma connection apontando para um sistema externo, como PostgreSQL, e criar um foreign catalog que expõe as tabelas remotas como objetos consultáveis dentro do Unity Catalog, sem mover ou copiar os dados. Delta Sharing não se aplica aqui porque o PostgreSQL não é um provedor do protocolo Delta Sharing. Auto Loader lê arquivos incrementalmente a partir de armazenamento em nuvem e não tem suporte a conexões JDBC com bancos operacionais. E o Lakeflow Connect é voltado a ingestão, replicando os dados para uma tabela Delta, o que contraria a necessidade de não copiar os dados para uma investigação pontual.",
+        topic: "Lakehouse Federation",
+        options: [
+            ["Delta Sharing D2D, criando um share diretamente no PostgreSQL e adicionando o Databricks como recipient para ler as tabelas remotamente.", false],
+            ["Auto Loader configurado com o formato JDBC para ler incrementalmente as tabelas do PostgreSQL a cada novo arquivo detectado no banco.", false],
+            ["Lakeflow Connect com um conector gerenciado que replica continuamente as tabelas do PostgreSQL para uma tabela Delta dentro do catálogo.", false],
+            ["Lakehouse Federation, com uma connection para o PostgreSQL e um foreign catalog que expõe as tabelas do banco como objetos consultáveis.", true],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe de plataforma está definindo diretrizes internas sobre quando usar Lakehouse Federation e quando construir um pipeline de ingestão para trazer dados de sistemas externos ao Delta Lake. Quais DUAS afirmações devem constar nessa diretriz? (Selecione DUAS opções.)",
+        explanation:
+            "Lakehouse Federation é indicada para acesso exploratório, ad hoc ou de baixo volume a uma fonte externa, evitando o custo de manter um pipeline dedicado só para isso. Quando o volume de consultas é alto ou os mesmos dados são reutilizados com frequência, ingerir para o Delta Lake costuma compensar mais, já que passa a se beneficiar de cache, Liquid Clustering e das demais otimizações do Delta Lake. As consultas federadas continuam dependendo de conectividade com o sistema de origem a cada execução, as tabelas de um foreign catalog permanecem como referências externas, não viram tabelas gerenciadas Delta, e o caminho até a fonte remota costuma deixar a consulta federada mais lenta, não mais rápida, do que consultar dados já ingeridos.",
+        topic: "Federation vs Ingestão",
+        options: [
+            ["A Lakehouse Federation elimina a necessidade de conectividade contínua com o sistema de origem, pois os metadados bastam para responder às consultas.", false],
+            ["Lakehouse Federation é adequada para consultas exploratórias ou de baixo volume, quando não compensa manter um pipeline só para acessar a fonte externa.", true],
+            ["Depois que um foreign catalog é criado, as tabelas que ele expõe passam a ser tabelas gerenciadas Delta dentro do Unity Catalog automaticamente.", false],
+            ["Cargas com alto volume de consultas ou reuso frequente do mesmo dado se beneficiam mais da ingestão para o Delta Lake, com cache e Liquid Clustering.", true],
+            ["Consultas federadas sempre executam mais rápido que consultas em tabelas Delta já ingeridas, pois eliminam a etapa de escrita no Delta Lake.", false],
+        ],
+    },
+    {
+        statement:
+            "Uma pipeline usa Auto Loader para ingerir eventos JSON brutos de um bucket, gravando-os em uma tabela que preserva a estrutura original do payload e adiciona apenas colunas técnicas de auditoria, como o momento da ingestão e a coluna _rescued_data, sem aplicar deduplicação ou regras de negócio. Em qual camada da arquitetura medallion essa tabela se encaixa e por quê?",
+        explanation:
+            "A camada bronze existe justamente para reter os dados brutos com a maior fidelidade possível ao formato de origem, servindo como fonte reprocessável caso as regras de transformação mudem no futuro. Colunas puramente técnicas, como o timestamp de ingestão e a _rescued_data, não configuram limpeza nem padronização de negócio, então a tabela não avança para silver. Ela também não está pronta para consumo direto em BI, o que é papel da gold. E manter tabelas brutas versionadas em Delta Lake é justamente a prática recomendada na camada bronze, não o oposto.",
+        topic: "Arquitetura Medallion",
+        options: [
+            ["Silver, porque a adição de colunas de auditoria já caracteriza uma etapa de padronização aplicada aos dados brutos.", false],
+            ["Bronze, porque preserva a fidelidade dos dados brutos como fonte reprocessável para as camadas seguintes.", true],
+            ["Gold, porque a tabela está pronta para ser consumida diretamente por ferramentas de BI sem processamento adicional.", false],
+            ["Nenhuma camada específica, pois tabelas de ingestão bruta não devem ser persistidas como tabelas Delta no lakehouse.", false],
+        ],
+    },
+    {
+        statement:
+            "Uma pipeline recebe eventos de alteração cadastral de clientes via Kafka, que podem chegar fora de ordem devido a reprocessamentos no producer. A tabela dimensão é mantida com AUTO CDC configurado com stored_as_scd_type igual a 2. Qual coluna deve alimentar o parâmetro sequence_by para garantir que o histórico da SCD tipo 2 reflita a ordem real dos eventos de negócio?",
+        explanation:
+            "O sequence_by do AUTO CDC precisa refletir a ordem real dos eventos de negócio, tipicamente um event time vindo da origem, para que as mudanças sejam aplicadas na sequência correta mesmo quando chegam fora de ordem por causa de reprocessamentos. Usar o timestamp de ingestão captura apenas a ordem de chegada no pipeline, que pode divergir da ordem real quando há reprocessamento. O parâmetro keys identifica a entidade, o cliente, não a ordem das mudanças, e a ordem de execução das tasks de um Lakeflow Job não tem relação com a ordenação de eventos dentro do AUTO CDC.",
+        topic: "SCD Tipo 2 com AUTO CDC",
+        options: [
+            ["O timestamp de ingestão atribuído pelo Auto Loader no momento em que o registro chega ao pipeline.", false],
+            ["A chave primária da dimensão definida no parâmetro keys do AUTO CDC, que já identifica cada cliente de forma única.", false],
+            ["A ordem de execução das tasks configurada no Lakeflow Job que orquestra a pipeline de dimensão.", false],
+            ["Uma coluna com o momento do evento na origem (event time), e não o horário de chegada no pipeline.", true],
+        ],
+    },
+    {
+        statement:
+            "Um objeto na camada gold calcula o valor total histórico por cliente (customer lifetime value), unindo uma tabela fato que cresce continuamente com duas dimensões que mudam ao longo do tempo. O padrão de agregação usado na consulta não pode ser mantido de forma incremental pelo motor do Lakeflow Spark Declarative Pipelines. Que tipo de objeto está sendo usado e qual a implicação operacional disso?",
+        explanation:
+            "Materialized views no Lakeflow Spark Declarative Pipelines são atualizadas de forma incremental sempre que o motor consegue calcular a diferença a partir das mudanças de origem, mas quando o padrão da consulta, como esse cálculo de valor histórico por cliente cruzando fato e dimensões variáveis, não permite manutenção incremental, a atualização pode recomputar a saída inteira. Uma streaming table não serviria bem aqui: joins em streaming table não recalculam quando as dimensões mudam, o que comprometeria a correção do valor histórico por cliente ao longo do tempo. Não existe uma variação de streaming table baseada em foreachBatch que elimine recomputação por definição, e materialized views não garantem atualização incremental para qualquer formato de consulta.",
+        topic: "Streaming Table vs Materialized View",
+        options: [
+            ["É uma materialized view com consulta não incrementalizável, então a atualização pode recomputar integralmente a saída em vez de só as linhas novas.", true],
+            ["É uma streaming table, então apenas as linhas novas da tabela fato são processadas a cada atualização, independente do padrão de agregação usado.", false],
+            ["É uma streaming table baseada em foreachBatch, cujos checkpoints eliminam a necessidade de qualquer recomputação futura.", false],
+            ["É uma materialized view, e o Lakeflow Spark Declarative Pipelines sempre garante atualização incremental independente do formato da consulta.", false],
+        ],
+    },
+    {
+        statement:
+            "Uma tabela de histórico de clientes é mantida por AUTO CDC como SCD tipo 2, com as colunas de controle de vigência geradas automaticamente pelo próprio AUTO CDC. Como identity columns não são suportadas na tabela alvo do AUTO CDC, o time cria uma streaming table separada, que lê essa tabela de histórico e adiciona uma IDENTITY COLUMN só para gerar a chave substituta (surrogate key) usada nos joins com a tabela fato. Qual comportamento das identity columns do Delta Lake a lógica downstream precisa considerar?",
+        explanation:
+            "Identity columns no Delta Lake geram valores únicos e crescentes, mas não garantem uma sequência sem lacunas, já que a geração pode pular valores dependendo do estado da tabela, então nenhuma lógica de negócio deve depender de IDs contíguos. Identity columns não são suportadas em tabelas que são alvo de processamento AUTO CDC, por isso a chave substituta precisa ser gerada numa streaming table separada, como no cenário descrito, e a Databricks recomenda usá-las só em streaming tables dentro de pipelines. Elas funcionam normalmente em tabelas gerenciadas dentro do namespace de três níveis do Unity Catalog, e os valores já atribuídos a uma linha não são recalculados nas atualizações incrementais seguintes.",
+        topic: "Surrogate Keys com Identity Column",
+        options: [
+            ["Os valores gerados garantem sequência sem lacunas, mesmo com gravações concorrentes na streaming table, o que permite tratá-los como um contador denso.", false],
+            ["Identity columns só podem ser definidas em tabelas gerenciadas fora do Unity Catalog, sem namespace de três níveis.", false],
+            ["Os valores gerados são crescentes, mas sem garantia de sequência contínua, e nenhuma lógica deve presumir IDs contíguos.", true],
+            ["Os valores já atribuídos a uma linha são recalculados a cada atualização incremental da streaming table, para manter a sequência compacta.", false],
+        ],
+    },
+    {
+        statement:
+            "O time de modelagem está revisando as diretrizes de design para tabelas fato e dimensão na camada gold de um lakehouse consumido por ferramentas de BI. Quais DUAS afirmações são práticas recomendadas nesse contexto? (Selecione DUAS opções.)",
+        explanation:
+            "Definir a granularidade da tabela fato antes de tudo evita agregações incorretas, já que toda medida e toda chave estrangeira precisam ser consistentes com o que uma linha representa. Na camada gold, um esquema estrela com dimensões mais desnormalizadas reduz o número de joins que as ferramentas de BI precisam executar, o que tende a ajudar o desempenho em Spark e Photon, ao contrário do que a opção sobre snowflake afirma. Substituir chaves estrangeiras por atributos descritivos soltos na fato quebra a reutilização das dimensões conformadas, e mudar a granularidade da fato entre versões invalida as agregações que já existem downstream, então nenhuma das duas é uma prática recomendada.",
+        topic: "Modelagem Dimensional e Desnormalização",
+        options: [
+            ["Preferir dimensões totalmente normalizadas (snowflake) na camada gold, pois Spark e Photon têm melhor desempenho em muitos joins pequenos do que em tabelas largas.", false],
+            ["Armazenar atributos descritivos diretamente na tabela fato no lugar de chaves estrangeiras para as dimensões, eliminando joins por completo na consulta.", false],
+            ["Definir explicitamente a granularidade da tabela fato (o que representa uma linha) antes de adicionar medidas e chaves estrangeiras, evitando agregações incorretas.", true],
+            ["Tratar a granularidade da tabela fato como algo alterável livremente entre versões, sem impacto nas agregações já existentes downstream.", false],
+            ["Favorecer um esquema estrela, com dimensões mais desnormalizadas, reduzindo o número de joins exigidos pelas consultas de BI frente a um esquema normalizado.", true],
+        ],
+    },
+];
+
+async function seed() {
+    let [simulado] = await db.select().from(simulados).where(eq(simulados.slug, SLUG));
+    if (!simulado) {
+        [simulado] = await db
+            .insert(simulados)
+            .values({
+                slug: SLUG,
+                name: "Databricks Certified Data Engineer Professional",
+                provider: "databricks",
+                code: "Databricks DE Professional",
+                level: "Professional",
+                description: "Simulado no formato do exame Databricks Certified Data Engineer Professional: 120 minutos, 59 questoes por tentativa, corte de 70%. Nivel avancado, cobrindo desenvolvimento de codigo (Python/SQL), ingestao, transformacao e qualidade, compartilhamento e federacao, monitoramento e alertas, otimizacao de custo e desempenho, seguranca e conformidade, governanca, debugging e deploy, e modelagem de dados. Delta Lake avancado (CDF, deletion vectors), Structured Streaming e Lakeflow Spark Declarative Pipelines. Nomenclatura Lakeflow atual.",
+                durationMinutes: 120,
+                questionCount: 59,
+                passPercent: 70,
+                published: true,
+            })
+            .returning();
+        console.log(`Simulado criado: ${simulado.slug}`);
+    }
+    await db
+        .update(simulados)
+        .set({ provider: "databricks", code: "Databricks DE Professional", level: "Professional" })
+        .where(eq(simulados.id, simulado.id));
+
+    const [{ n }] = await db
+        .select({ n: count() })
+        .from(simuladoQuestions)
+        .where(eq(simuladoQuestions.simuladoId, simulado.id));
+    if (Number(n) > 0) { console.log(`Simulado ja tem ${n} questoes, nada a fazer.`); return; }
+
+    for (let i = 0; i < QUESTOES.length; i++) {
+        const q = QUESTOES[i];
+        const [questao] = await db
+            .insert(simuladoQuestions)
+            .values({ simuladoId: simulado.id, statement: q.statement, explanation: q.explanation, topic: q.topic })
+            .returning();
+        await db.insert(simuladoOptions).values(
+            q.options.map(([text, isCorrect], idx) => ({ questionId: questao.id, text, isCorrect, position: idx + 1 })),
+        );
+    }
+    console.log(`Seed concluido: ${QUESTOES.length} questoes inseridas.`);
+}
+
+seed().then(() => process.exit(0)).catch((e) => { console.error("Falha no seed:", e); process.exit(1); });


### PR DESCRIPTION
## Simulados Databricks Data Engineer (Associate e Professional)

Dois simulados novos, no formato dos exames de certificação da Databricks, como complemento do roadmap de Engenharia de Dados. Ancorados nos guias oficiais atuais dos dois exames, já com a nomenclatura Lakeflow (a Databricks renomeou a stack de engenharia de dados em 2025-2026): Lakeflow Connect, Lakeflow Spark Declarative Pipelines (antes DLT), Lakeflow Jobs (antes Workflows), Automation Bundles (antes DABs), Databricks Git Folders (antes Repos), AUTO CDC (antes APPLY CHANGES).

### Simulado Associate (iniciante)
`databricks-de-associate`: 90 minutos, 45 questões por tentativa, corte de 70%. Banco de 90 questões cenário distribuídas pelos 7 domínios do exame no peso oficial:
- Data Transformation and Modeling (22%), Data Ingestion and Loading (21%), Working with Lakeflow Jobs (16%), Governance and Security (15%), Implementing CI/CD (10%), Troubleshooting/Monitoring/Optimization (10%), Databricks Intelligence Platform (6%).

### Simulado Professional (intermediário)
`databricks-de-professional`: 120 minutos, 59 questões por tentativa, corte de 70%. Banco de 90 questões cenário de nível avançado pelos 10 domínios:
- Developing Code (22%), Cost & Performance Optimization (13%), Data Transformation/Cleansing/Quality (10%), Monitoring and Alerting (10%), Ensuring Data Security and Compliance (10%), Debugging and Deploying (10%), Data Ingestion (7%), Data Governance (7%), Data Modeling (6%), Data Sharing and Federation (5%).

Cada questão mistura resposta única e múltipla, com explicação de gabarito. Conteúdo em português acentuado, termos técnicos e de produto no original.

### Qualidade das questões
- Vício forte (correta é a mais longa E pelo menos 1.4x a média das erradas): 0% nos dois bancos
- Nenhuma questão com a correta liderando a maior errada por mais de 5 caracteres
- 0 duplicatas de enunciado, 0 travessão, 0 emoji, 0 "todas/nenhuma das anteriores"
- Verificação cega de gabarito: revisores independentes (um por grupo de domínios) responderam todas as questões sem ver a resposta marcada. Associate 90/90 (após corrigir 1 questão de Unity Catalog, a cadeia de privilégios USE CATALOG + USE SCHEMA + SELECT); Professional 90/90. Vários fatos finos foram cruzados com a documentação oficial da Databricks durante a autoria.

### Vigência
Os dois exames estão vigentes (guias de mai/2026 e jul/2026) e o conteúdo usa a nomenclatura Lakeflow atual, para não nascer desatualizado.

### Sem migração
Usa as tabelas de simulado que já existem (`simulados`, `simulado_questions`, `simulado_options`). Nenhuma mudança de schema. `provider: "databricks"`, `level: "Associate"` / `"Professional"`.

### Como testar local
```
docker compose exec -T backend node scripts/seed-databricks-de-associate.ts
docker compose exec -T backend node scripts/seed-databricks-de-professional.ts
```
Confirmado no dev: os dois simulados publicados, 90 questões cada, 0 sem correta. Associate 45/tentativa/90 min/70%; Professional 59/tentativa/120 min/70%.
