### PR TITLE
fix: nomeia os provedores Databricks e ISC2 no filtro de simulados

### DIFF
--- a/frontend/src/pages/Simulados/provedores.ts
+++ b/frontend/src/pages/Simulados/provedores.ts
@@ -7,11 +7,13 @@ export const PROVEDORES: Record<
   aws: { nome: 'Amazon Web Services', label: 'AWS', cor: '#ff9900', sigla: 'aws' },
   azure: { nome: 'Microsoft Azure', label: 'Azure', cor: '#0078d4', sigla: 'Az' },
   gcp: { nome: 'Google Cloud', label: 'Google Cloud', cor: '#1a73e8', sigla: 'GC' },
+  databricks: { nome: 'Databricks', label: 'Databricks', cor: '#ff3621', sigla: 'db' },
+  isc2: { nome: 'ISC2', label: 'ISC2', cor: '#00a4a6', sigla: 'i2' },
 };
 
 const PROV_PADRAO = { nome: 'Certificação', label: 'Outros', cor: '#6b7280', sigla: '•' };
 
-export const ORDEM_PROV = ['aws', 'azure', 'gcp'];
+export const ORDEM_PROV = ['aws', 'azure', 'gcp', 'databricks', 'isc2'];
 
 export function provedorDe(p: string | null) {
   return (p && PROVEDORES[p]) || PROV_PADRAO;


### PR DESCRIPTION
## O problema

A tela de simulados agrupa por provedor, mas o mapa de provedores (`pages/Simulados/provedores.ts`) só conhecia AWS, Azure e Google Cloud. Qualquer provedor fora dessa lista caía no rótulo padrão "Outros". Com ISC2 e Databricks publicados, cada um virava um botão de filtro separado, ambos escritos "Outros", dois filtros idênticos e confusos.

O bug já existia latente com o ISC2; os simulados Databricks (recém-adicionados) só tornaram o "Outros" duplicado visível.

## A correção

Adiciona `databricks` (cor da marca) e `isc2` ao mapa de provedores, cada um com nome, label, cor e sigla próprios, e os inclui na ordem de exibição. Agora saem quatro botões nomeados (AWS, Azure, Databricks, ISC2) e nenhum "Outros".

## Verificação

- `tsc` do frontend: 0 erros.
- Simulei a lógica exata do componente (agrupamento por provider + `provedorDe`) com os quatro provedores reais de produção: resultado é quatro botões nomeados e zero "Outros".
- Confirmado em produção que não há simulado publicado com `provider` null (nenhum cairia legitimamente em "Outros").
- Sem mudança de backend nem de schema; só o mapa de provedores do front.

## Follow-up do PR #193
Esta correção tinha sido commitada na branch do #193 (simulados Databricks), mas o #193 foi mergeado antes desse commit entrar. Este PR a traz de forma isolada a partir da develop atualizada.