### PR TITLE
fix: preserva quebras de linha e indentação nas questões do quiz

### DIFF
--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -2192,6 +2192,8 @@
   font-weight: 600;
   line-height: 1.45;
   padding-top: 1px;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
 }
 .quiz__options {
   display: flex;
@@ -2234,6 +2236,8 @@
   font-size: 15px;
   font-weight: 500;
   color: var(--text);
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
 }
 .quiz-opt--selected {
   border-color: var(--accent);


### PR DESCRIPTION
## Problema

Na trilha de Python, questões que mostram código no enunciado ficavam impossíveis de responder: o código é escrito com quebras de linha e indentação (que em Python decidem a resposta), mas o enunciado era renderizado num `<div>` comum, onde o HTML colapsa `\n` e espaços. O `if x > 5:` e os dois `print` viravam uma linha só, sem dar pra ver o que está dentro ou fora do bloco.

O conteúdo já estava correto (a indentação estava lá, byte a byte). O bug era só de renderização.

## Correção

`white-space: pre-wrap` (mais `overflow-wrap: break-word`) em `.quiz__q-text` e `.quiz-opt__label`, as duas superfícies onde o aluno vê enunciado e alternativa. Preserva as quebras e a indentação que o autor já escreveu.

Efeito, sem tocar em conteúdo:
- 70 questões da trilha Python (56 com indentação de verdade) passam a renderizar certo.
- +164 enunciados com código nas outras trilhas.
- 6 alternativas que mostram código.
- Todas as questões futuras.

Questões só de texto não mudam (não têm quebras nem espaços a preservar).

## Teste

`tsc -b` limpo e `vite build` verde. Falta a conferência visual (o ambiente local estava derrubado); dá pra validar subindo o front ou na preview do deploy.
