### PR TITLE
fix: continuar a trilha respeita a linguagem escolhida

### DIFF
--- a/backend/src/services/quiz.service.ts
+++ b/backend/src/services/quiz.service.ts
@@ -10,7 +10,6 @@ import { eq, and, inArray } from "drizzle-orm";
 import type { z } from "zod";
 import type { submitQuizSchema } from "../schemas/trail.schemas.ts";
 import { AppError } from "../errors/AppError.ts";
-import { estadoDaAula } from "./lesson.service.ts";
 import { ehAdmin } from "./usuario.service.ts";
 import { verificarConquistas } from "./achievement.service.ts";
 
@@ -28,11 +27,6 @@ export async function corrigirQuiz(userId: string, lessonId: string, dados: Resp
 
     if (!aula.published) {
         throw new AppError(404, "Aula não encontrada");
-    }
-
-    const estado = await estadoDaAula(userId, aula);
-    if (estado === "locked") {
-        throw new AppError(403, "Aula bloqueada. Conclua a aula anterior.");
     }
 
     const qs = await db
@@ -109,11 +103,6 @@ export async function conferirResposta(
     }
     if (!aula.published && !(await ehAdmin(userId))) {
         throw new AppError(404, "Aula não encontrada");
-    }
-
-    const estado = await estadoDaAula(userId, aula);
-    if (estado === "locked") {
-        throw new AppError(403, "Aula bloqueada. Conclua a aula anterior.");
     }
 
     // A questão precisa pertencer a esta aula.

--- a/backend/src/services/roadmap.service.ts
+++ b/backend/src/services/roadmap.service.ts
@@ -59,40 +59,53 @@ async function carregarConclusao(userId: string): Promise<Conclusao> {
     };
 }
 
+type AulaContainer = { id: string; language: string | null };
+
 // Aulas publicadas por trilha e por módulo referenciados (pra derivar conclusão de container).
 async function carregarAulasPorContainer(trailIds: string[], moduleIds: string[]) {
-    const porTrail = new Map<string, string[]>();
-    const porModule = new Map<string, string[]>();
+    const porTrail = new Map<string, AulaContainer[]>();
+    const porModule = new Map<string, AulaContainer[]>();
     if (trailIds.length) {
         const rows = await db
-            .select({ trailId: lessons.trailId, id: lessons.id })
+            .select({ trailId: lessons.trailId, id: lessons.id, language: lessons.language })
             .from(lessons)
             .where(and(inArray(lessons.trailId, trailIds), eq(lessons.published, true)));
         for (const r of rows) {
             const arr = porTrail.get(r.trailId) ?? [];
-            arr.push(r.id);
+            arr.push({ id: r.id, language: r.language });
             porTrail.set(r.trailId, arr);
         }
     }
     if (moduleIds.length) {
         const rows = await db
-            .select({ moduleId: lessons.moduleId, id: lessons.id })
+            .select({ moduleId: lessons.moduleId, id: lessons.id, language: lessons.language })
             .from(lessons)
             .where(and(inArray(lessons.moduleId, moduleIds), eq(lessons.published, true)));
         for (const r of rows) {
             const arr = porModule.get(r.moduleId) ?? [];
-            arr.push(r.id);
+            arr.push({ id: r.id, language: r.language });
             porModule.set(r.moduleId, arr);
         }
     }
     return { porTrail, porModule };
 }
 
+// Multi-linguagem: concluído = todas as neutras + todas as aulas de alguma linguagem.
+function containerConcluido(ls: AulaContainer[], c: Conclusao): boolean {
+    if (!ls.length) return false;
+    const linguagens = [...new Set(ls.map((l) => l.language).filter((x): x is string => !!x))];
+    if (!linguagens.length) return ls.every((l) => c.lessons.has(l.id));
+    if (!ls.filter((l) => l.language === null).every((l) => c.lessons.has(l.id))) return false;
+    return linguagens.some((lg) =>
+        ls.filter((l) => l.language === lg).every((l) => c.lessons.has(l.id)),
+    );
+}
+
 function refConcluido(
     refType: RefType,
     refId: string,
     c: Conclusao,
-    aulas: { porTrail: Map<string, string[]>; porModule: Map<string, string[]> },
+    aulas: { porTrail: Map<string, AulaContainer[]>; porModule: Map<string, AulaContainer[]> },
 ): boolean {
     switch (refType) {
         case "lesson":
@@ -101,14 +114,10 @@ function refConcluido(
             return c.simulados.has(refId);
         case "challenge":
             return c.desafios.has(refId);
-        case "trail": {
-            const ls = aulas.porTrail.get(refId) ?? [];
-            return ls.length > 0 && ls.every((id) => c.lessons.has(id));
-        }
-        case "module": {
-            const ls = aulas.porModule.get(refId) ?? [];
-            return ls.length > 0 && ls.every((id) => c.lessons.has(id));
-        }
+        case "trail":
+            return containerConcluido(aulas.porTrail.get(refId) ?? [], c);
+        case "module":
+            return containerConcluido(aulas.porModule.get(refId) ?? [], c);
     }
 }
 
@@ -179,7 +188,7 @@ export async function listarRoadmaps(userId?: string) {
         : [];
 
     let conclusao = SEM_CONCLUSAO;
-    let aulas = { porTrail: new Map<string, string[]>(), porModule: new Map<string, string[]>() };
+    let aulas = { porTrail: new Map<string, AulaContainer[]>(), porModule: new Map<string, AulaContainer[]>() };
     if (userId) {
         conclusao = await carregarConclusao(userId);
         aulas = await carregarAulasPorContainer(
@@ -243,7 +252,7 @@ export async function obterRoadmap(slug: string, userId?: string) {
         : [];
 
     let conclusao = SEM_CONCLUSAO;
-    let aulas = { porTrail: new Map<string, string[]>(), porModule: new Map<string, string[]>() };
+    let aulas = { porTrail: new Map<string, AulaContainer[]>(), porModule: new Map<string, AulaContainer[]>() };
     if (userId) {
         conclusao = await carregarConclusao(userId);
         aulas = await carregarAulasPorContainer(

--- a/backend/src/services/trail.service.ts
+++ b/backend/src/services/trail.service.ts
@@ -15,7 +15,7 @@ import {
     trailReviews,
     users,
 } from "../../schema.ts";
-import { eq, asc, desc, count, countDistinct, inArray, and } from "drizzle-orm";
+import { eq, asc, desc, count, countDistinct, inArray, and, isNotNull } from "drizzle-orm";
 import type { z } from "zod";
 import type { createTrailSchema, updateTrailSchema } from "../schemas/trail.schemas.ts";
 import { AppError } from "../errors/AppError.ts";
@@ -225,7 +225,29 @@ export async function detalheDaTrilha(trailId: string, userId: string, lang?: st
         ...new Set(aulasBrutas.map((a) => a.language).filter((l): l is string => !!l)),
     ].sort();
     const multi = languages.length > 0;
-    const langAtiva = multi ? (lang && languages.includes(lang) ? lang : languages[0]) : null;
+    let langAtiva: string | null = null;
+    if (multi) {
+        if (lang && languages.includes(lang)) {
+            langAtiva = lang;
+        } else {
+            // Sem lang explícito, o default é o track da última aula concluída, não o primeiro idioma.
+            const [ult] = await db
+                .select({ language: lessons.language })
+                .from(lessonProgress)
+                .innerJoin(lessons, eq(lessons.id, lessonProgress.lessonId))
+                .where(
+                    and(
+                        eq(lessonProgress.userId, userId),
+                        eq(lessons.trailId, trailId),
+                        isNotNull(lessons.language),
+                    ),
+                )
+                .orderBy(desc(lessonProgress.completedAt))
+                .limit(1);
+            langAtiva =
+                ult?.language && languages.includes(ult.language) ? ult.language : languages[0];
+        }
+    }
 
     const todasAulas = multi
         ? aulasBrutas.filter((a) => a.language === null || a.language === langAtiva)

--- a/backend/tests/trail.test.ts
+++ b/backend/tests/trail.test.ts
@@ -279,3 +279,36 @@ describe("Quiz e estado das aulas", () => {
         assert.deepEqual(estadosB, ["current", "locked"]);
     });
 });
+
+describe("Trilha multi-linguagem", () => {
+    test("sem lang explicito, continua no track da ultima aula concluida", async () => {
+        const admin = await criarUsuarioLogado(true);
+        const { trailId, lessonIds } = await montarTrilha(admin.token, 4);
+
+        const { db } = await import("../db.ts");
+        const { lessons } = await import("../schema.ts");
+        const { eq } = await import("drizzle-orm");
+        const definir = (id: string, language: string, position: number) =>
+            db.update(lessons).set({ language, position }).where(eq(lessons.id, id));
+        await definir(lessonIds[0], "javascript", 1);
+        await definir(lessonIds[1], "javascript", 2);
+        await definir(lessonIds[2], "python", 1);
+        await definir(lessonIds[3], "python", 2);
+
+        const aluno = await criarUsuarioLogado();
+
+        const antes = await get(`/trails/${trailId}`, aluno.token);
+        assert.equal(antes.body.activeLanguage, "javascript");
+
+        const quiz = await responderQuiz(aluno.token, lessonIds[2], 5);
+        assert.equal(quiz.body.lessonCompleted, true);
+
+        const depois = await get(`/trails/${trailId}`, aluno.token);
+        assert.equal(depois.body.activeLanguage, "python");
+        const aulas = depois.body.modules.flatMap((m: any) => m.lessons);
+        assert.equal(aulas.find((l: any) => l.state === "current")?.id, lessonIds[3]);
+
+        const js = await get(`/trails/${trailId}?lang=javascript`, aluno.token);
+        assert.equal(js.body.activeLanguage, "javascript");
+    });
+});

--- a/backend/tests/trail.test.ts
+++ b/backend/tests/trail.test.ts
@@ -216,6 +216,20 @@ describe("Quiz e estado das aulas", () => {
         assert.deepEqual(estados, ["done", "current"]);
     });
 
+    test("quiz pode ser concluido fora de ordem", async () => {
+        const admin = await criarUsuarioLogado(true);
+        const { trailId, lessonIds } = await montarTrilha(admin.token, 2);
+        const aluno = await criarUsuarioLogado();
+
+        const quiz = await responderQuiz(aluno.token, lessonIds[1], 5);
+        assert.equal(quiz.status, 200);
+        assert.equal(quiz.body.lessonCompleted, true);
+
+        const trilha = await get(`/trails/${trailId}`, aluno.token);
+        const estados = trilha.body.modules.flatMap((m: any) => m.lessons.map((l: any) => l.state));
+        assert.deepEqual(estados, ["current", "done"]);
+    });
+
     test("menos de 4 acertos nao conclui a aula", async () => {
         const admin = await criarUsuarioLogado(true);
         const { lessonIds } = await montarTrilha(admin.token, 1);
@@ -310,5 +324,44 @@ describe("Trilha multi-linguagem", () => {
 
         const js = await get(`/trails/${trailId}?lang=javascript`, aluno.token);
         assert.equal(js.body.activeLanguage, "javascript");
+    });
+
+    test("estagio de roadmap conclui com um unico track completo", async () => {
+        const admin = await criarUsuarioLogado(true);
+        const { trailId, lessonIds } = await montarTrilha(admin.token, 4);
+
+        const { db } = await import("../db.ts");
+        const { lessons } = await import("../schema.ts");
+        const { eq } = await import("drizzle-orm");
+        const definir = (id: string, language: string, position: number) =>
+            db.update(lessons).set({ language, position }).where(eq(lessons.id, id));
+        await definir(lessonIds[0], "javascript", 1);
+        await definir(lessonIds[1], "javascript", 2);
+        await definir(lessonIds[2], "python", 1);
+        await definir(lessonIds[3], "python", 2);
+
+        const rm = await post("/roadmaps", admin.token, {
+            name: "Backend",
+            description: "Do zero ao backend.",
+            level: "iniciante",
+            published: true,
+        });
+        const st = await post(`/roadmaps/${rm.body.id}/stages`, admin.token, {
+            phase: "fundamentos",
+            title: "Logica",
+            description: "Base de logica.",
+        });
+        await post(`/roadmap-stages/${st.body.id}/refs`, admin.token, {
+            refType: "trail",
+            refId: trailId,
+        });
+
+        const aluno = await criarUsuarioLogado();
+        await responderQuiz(aluno.token, lessonIds[2], 5);
+        await responderQuiz(aluno.token, lessonIds[3], 5);
+
+        const det = await get(`/roadmaps/${rm.body.slug}`, aluno.token);
+        assert.equal(det.status, 200);
+        assert.equal(det.body.stages[0].completed, true);
     });
 });

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -21,6 +21,7 @@ import {
   type RankingRow,
   type StreakInfo,
 } from '../../services/trails';
+import { getTrailLang } from '../../utils/trailLang';
 import { getDesafioDoDia, type DesafioDetalhe } from '../../services/desafios';
 import type { Trail } from '../../data/trails';
 import { NAV_PRINCIPAL as NAV } from '../../data/nav';
@@ -120,7 +121,7 @@ export function Home() {
   // Abre a trilha na primeira aula disponivel (a atual, ou a primeira).
   async function abrirTrilha(trailId: string) {
     try {
-      const detalhe = await obterTrilha(trailId);
+      const detalhe = await obterTrilha(trailId, getTrailLang(trailId));
       const aulas = detalhe.modules.flatMap((m) => m.lessons);
       const alvo =
         aulas.find((l) => l.state === 'current') ?? aulas.find((l) => l.state !== 'locked');

--- a/frontend/src/pages/Roadmaps/Detalhe.tsx
+++ b/frontend/src/pages/Roadmaps/Detalhe.tsx
@@ -11,6 +11,7 @@ import { user } from '../../data/home';
 import { NAV_PRINCIPAL as NAV } from '../../data/nav';
 import { obterRoadmap, type RoadmapDetalhe, type RoadmapStage, type RoadmapRef, type RoadmapPhase } from '../../services/roadmaps';
 import { obterTrilha } from '../../services/trails';
+import { getTrailLang } from '../../utils/trailLang';
 
 const PHASE_LABEL: Record<RoadmapPhase, string> = {
   fundamentos: 'Fundamentos',
@@ -75,7 +76,7 @@ export function RoadmapDetalhe() {
     if (ref.refType === 'challenge') return navigate(`/desafios/${ref.refId}`);
     if ((ref.refType === 'trail' || ref.refType === 'module') && ref.trailId) {
       try {
-        const detalhe = await obterTrilha(ref.trailId);
+        const detalhe = await obterTrilha(ref.trailId, getTrailLang(ref.trailId));
         const aulas = detalhe.modules.flatMap((m) => m.lessons);
         const alvo =
           aulas.find((l) => l.state === 'current') ?? aulas.find((l) => l.state !== 'locked') ?? aulas[0];

--- a/frontend/src/pages/Trilhas/index.tsx
+++ b/frontend/src/pages/Trilhas/index.tsx
@@ -18,6 +18,7 @@ import {
   listarTags,
   type Tag,
 } from '../../services/trails';
+import { getTrailLang } from '../../utils/trailLang';
 
 type TrailComId = Trail & { id: string };
 
@@ -65,7 +66,7 @@ export function Trilhas() {
   // Abre a trilha indo para a primeira aula disponivel (current, ou a primeira).
   async function abrirTrilha(trailId: string) {
     try {
-      const detalhe = await obterTrilha(trailId);
+      const detalhe = await obterTrilha(trailId, getTrailLang(trailId));
       const aulas = detalhe.modules.flatMap((m) => m.lessons);
       // nunca manda para uma aula bloqueada: prefere a atual, senao a primeira liberada.
       const alvo =


### PR DESCRIPTION
## Bug reportado

Quem fazia a Lógica em JavaScript, trocava para Python e continuava por lá, ao clicar em "continuar" era levado de volta ao ponto do track de **JavaScript**, não ao mais recente de Python.

## Causa e correções (3 da mesma família)

**1. Continuar respeita a linguagem.** O card da Home, o "Continuar de onde parou" da lista de trilhas e o abrir-estágio do roadmap buscavam o detalhe da trilha sem `lang`, e o backend caía no primeiro idioma em ordem alfabética (`javascript`). Agora os três enviam a linguagem guardada, e o backend, sem escolha explícita, continua no **track da última aula concluída** (cobre navegador novo e localStorage limpo). Prioridade: escolha explícita > última atividade > primeiro idioma.

**2. Quiz sem trava sequencial.** A navegação livre tinha deixado um resto: o envio do quiz (e o check de resposta) ainda respondia 403 para aula "locked" — dava pra abrir uma aula à frente, mas não concluí-la. As travas saem, completando a feature.

**3. Roadmap conclui com um track.** A conclusão de trilha/módulo no roadmap exigia TODAS as aulas publicadas; numa trilha bilíngue isso pedia os dois tracks (70 aulas na Lógica). Agora: todas as neutras + todas as aulas de **uma** linguagem.

## Testes

3 novos em `tests/trail.test.ts`: inferência do track pela última atividade (com `?lang=` explícito mandando), quiz concluído fora de ordem, e estágio de roadmap concluído com um único track. Suíte completa: **54/54**. `tsc` e build do front limpos.
