### PR TITLE
feat: comunicados aos usuários e conclusão manual de estágios do roadmap

### DIFF
--- a/backend/app.ts
+++ b/backend/app.ts
@@ -8,6 +8,7 @@ import simuladoRoutes from "./src/routes/simulado.routes.ts";
 import desafioRoutes from "./src/routes/desafio.routes.ts";
 import adminRoutes from "./src/routes/admin.routes.ts";
 import roadmapRoutes from "./src/routes/roadmap.routes.ts";
+import comunicadoRoutes from "./src/routes/comunicado.routes.ts";
 import { errorMiddleware } from "./src/middlewares/error.ts";
 import { apiLimiter } from "./src/middlewares/rateLimit.ts";
 import helmet from "helmet";
@@ -50,6 +51,7 @@ app.use(trailRoutes);
 app.use(simuladoRoutes);
 app.use(desafioRoutes);
 app.use(roadmapRoutes);
+app.use(comunicadoRoutes);
 app.use(adminRoutes);
 
 app.get("/health", (_req, res) => res.json({ status: "ok" }));

--- a/backend/drizzle/0033_unique_magneto.sql
+++ b/backend/drizzle/0033_unique_magneto.sql
@@ -1,0 +1,24 @@
+CREATE TYPE "public"."comunicado_kind" AS ENUM('aviso', 'pesquisa');--> statement-breakpoint
+CREATE TYPE "public"."comunicado_resposta_status" AS ENUM('respondido', 'dispensado');--> statement-breakpoint
+CREATE TABLE "comunicado_respostas" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"comunicado_id" uuid NOT NULL,
+	"user_id" uuid NOT NULL,
+	"status" "comunicado_resposta_status" NOT NULL,
+	"rating" integer,
+	"comment" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "comunicado_respostas_comunicado_id_user_id_unique" UNIQUE("comunicado_id","user_id")
+);
+--> statement-breakpoint
+CREATE TABLE "comunicados" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"kind" "comunicado_kind" NOT NULL,
+	"title" varchar(200) NOT NULL,
+	"message" text NOT NULL,
+	"published" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "comunicado_respostas" ADD CONSTRAINT "comunicado_respostas_comunicado_id_comunicados_id_fk" FOREIGN KEY ("comunicado_id") REFERENCES "public"."comunicados"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "comunicado_respostas" ADD CONSTRAINT "comunicado_respostas_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;

--- a/backend/drizzle/0034_slimy_nico_minoru.sql
+++ b/backend/drizzle/0034_slimy_nico_minoru.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "roadmap_stage_completions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"stage_id" uuid NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "roadmap_stage_completions_user_id_stage_id_unique" UNIQUE("user_id","stage_id")
+);
+--> statement-breakpoint
+ALTER TABLE "roadmap_stage_completions" ADD CONSTRAINT "roadmap_stage_completions_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "roadmap_stage_completions" ADD CONSTRAINT "roadmap_stage_completions_stage_id_roadmap_stages_id_fk" FOREIGN KEY ("stage_id") REFERENCES "public"."roadmap_stages"("id") ON DELETE no action ON UPDATE no action;

--- a/backend/drizzle/0035_round_brother_voodoo.sql
+++ b/backend/drizzle/0035_round_brother_voodoo.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "lessons_progress" ADD COLUMN "manual" boolean DEFAULT false NOT NULL;

--- a/backend/drizzle/meta/0033_snapshot.json
+++ b/backend/drizzle/meta/0033_snapshot.json
@@ -1,0 +1,2607 @@
+{
+  "id": "0eebdeff-f0db-47de-8a5b-f51ccbc57330",
+  "prevId": "e1515cd2-1283-40ad-abaf-e32620f95361",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.achievements": {
+      "name": "achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "criteria_type": {
+          "name": "criteria_type",
+          "type": "achievement_criteria",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "achievements_name_unique": {
+          "name": "achievements_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge_submissions": {
+      "name": "challenge_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "challenge_language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "challenge_submission_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "passed_count": {
+          "name": "passed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_count": {
+          "name": "total_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xp_earned": {
+          "name": "xp_earned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "challenge_submissions_user_id_users_id_fk": {
+          "name": "challenge_submissions_user_id_users_id_fk",
+          "tableFrom": "challenge_submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "challenge_submissions_challenge_id_challenges_id_fk": {
+          "name": "challenge_submissions_challenge_id_challenges_id_fk",
+          "tableFrom": "challenge_submissions",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge_tests": {
+      "name": "challenge_tests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_output": {
+          "name": "expected_output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "challenge_tests_challenge_id_challenges_id_fk": {
+          "name": "challenge_tests_challenge_id_challenges_id_fk",
+          "tableFrom": "challenge_tests",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenges": {
+      "name": "challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "challenge_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stdin'"
+        },
+        "entry_point": {
+          "name": "entry_point",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_blocks": {
+          "name": "statement_blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "question_difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'facil'"
+        },
+        "starter_code": {
+          "name": "starter_code",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_date": {
+          "name": "active_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "challenges_number_unique": {
+          "name": "challenges_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "number"
+          ]
+        },
+        "challenges_active_date_unique": {
+          "name": "challenges_active_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "active_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comunicado_respostas": {
+      "name": "comunicado_respostas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "comunicado_id": {
+          "name": "comunicado_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "comunicado_resposta_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comunicado_respostas_comunicado_id_comunicados_id_fk": {
+          "name": "comunicado_respostas_comunicado_id_comunicados_id_fk",
+          "tableFrom": "comunicado_respostas",
+          "tableTo": "comunicados",
+          "columnsFrom": [
+            "comunicado_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "comunicado_respostas_user_id_users_id_fk": {
+          "name": "comunicado_respostas_user_id_users_id_fk",
+          "tableFrom": "comunicado_respostas",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "comunicado_respostas_comunicado_id_user_id_unique": {
+          "name": "comunicado_respostas_comunicado_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "comunicado_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comunicados": {
+      "name": "comunicados",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "comunicado_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.glossary": {
+      "name": "glossary",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "term": {
+          "name": "term",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "varchar(400)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "glossary_term_unique": {
+          "name": "glossary_term_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "term"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.languages": {
+      "name": "languages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "languages_name_unique": {
+          "name": "languages_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons_progress": {
+      "name": "lessons_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_progress_user_id_users_id_fk": {
+          "name": "lessons_progress_user_id_users_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_progress_lesson_id_lessons_id_fk": {
+          "name": "lessons_progress_lesson_id_lessons_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lessons_progress_user_id_lesson_id_unique": {
+          "name": "lessons_progress_user_id_lesson_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "lesson_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons": {
+      "name": "lessons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_blocks": {
+          "name": "content_blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "duration_min": {
+          "name": "duration_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview": {
+          "name": "preview",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_trail_id_trails_id_fk": {
+          "name": "lessons_trail_id_trails_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_module_id_modules_id_fk": {
+          "name": "lessons_module_id_modules_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "modules",
+          "columnsFrom": [
+            "module_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.modules": {
+      "name": "modules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "modules_trail_id_trails_id_fk": {
+          "name": "modules_trail_id_trails_id_fk",
+          "tableFrom": "modules",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_accounts": {
+      "name": "oauth_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_accounts_user_id_users_id_fk": {
+          "name": "oauth_accounts_user_id_users_id_fk",
+          "tableFrom": "oauth_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_accounts_provider_provider_id_unique": {
+          "name": "oauth_accounts_provider_provider_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "provider_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_answers": {
+      "name": "question_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_option_id": {
+          "name": "selected_option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_answers_user_id_users_id_fk": {
+          "name": "question_answers_user_id_users_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_question_id_questions_id_fk": {
+          "name": "question_answers_question_id_questions_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_selected_option_id_question_options_id_fk": {
+          "name": "question_answers_selected_option_id_question_options_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "question_options",
+          "columnsFrom": [
+            "selected_option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "question_answers_user_id_question_id_unique": {
+          "name": "question_answers_user_id_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_options": {
+      "name": "question_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_options_question_id_questions_id_fk": {
+          "name": "question_options_question_id_questions_id_fk",
+          "tableFrom": "question_options",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "question_difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'facil'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_lesson_id_lessons_id_fk": {
+          "name": "questions_lesson_id_lessons_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ranking_snapshots": {
+      "name": "ranking_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ranking_snapshots_user_id_users_id_fk": {
+          "name": "ranking_snapshots_user_id_users_id_fk",
+          "tableFrom": "ranking_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ranking_snapshots_user_id_snapshot_date_unique": {
+          "name": "ranking_snapshots_user_id_snapshot_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "snapshot_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmap_stage_refs": {
+      "name": "roadmap_stage_refs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_type": {
+          "name": "ref_type",
+          "type": "roadmap_ref_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "roadmap_stage_refs_stage_id_roadmap_stages_id_fk": {
+          "name": "roadmap_stage_refs_stage_id_roadmap_stages_id_fk",
+          "tableFrom": "roadmap_stage_refs",
+          "tableTo": "roadmap_stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmap_stages": {
+      "name": "roadmap_stages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "roadmap_id": {
+          "name": "roadmap_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "roadmap_phase",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "roadmap_stages_roadmap_id_roadmaps_id_fk": {
+          "name": "roadmap_stages_roadmap_id_roadmaps_id_fk",
+          "tableFrom": "roadmap_stages",
+          "tableTo": "roadmaps",
+          "columnsFrom": [
+            "roadmap_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmaps": {
+      "name": "roadmaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "trail_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "premium": {
+          "name": "premium",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roadmaps_slug_unique": {
+          "name": "roadmaps_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_attempt_answers": {
+      "name": "simulado_attempt_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_attempt_answers_attempt_id_simulado_attempts_id_fk": {
+          "name": "simulado_attempt_answers_attempt_id_simulado_attempts_id_fk",
+          "tableFrom": "simulado_attempt_answers",
+          "tableTo": "simulado_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempt_answers_question_id_simulado_questions_id_fk": {
+          "name": "simulado_attempt_answers_question_id_simulado_questions_id_fk",
+          "tableFrom": "simulado_attempt_answers",
+          "tableTo": "simulado_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempt_answers_option_id_simulado_options_id_fk": {
+          "name": "simulado_attempt_answers_option_id_simulado_options_id_fk",
+          "tableFrom": "simulado_attempt_answers",
+          "tableTo": "simulado_options",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulado_attempt_answers_attempt_id_question_id_option_id_unique": {
+          "name": "simulado_attempt_answers_attempt_id_question_id_option_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "attempt_id",
+            "question_id",
+            "option_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_attempt_questions": {
+      "name": "simulado_attempt_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_attempt_questions_attempt_id_simulado_attempts_id_fk": {
+          "name": "simulado_attempt_questions_attempt_id_simulado_attempts_id_fk",
+          "tableFrom": "simulado_attempt_questions",
+          "tableTo": "simulado_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempt_questions_question_id_simulado_questions_id_fk": {
+          "name": "simulado_attempt_questions_question_id_simulado_questions_id_fk",
+          "tableFrom": "simulado_attempt_questions",
+          "tableTo": "simulado_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulado_attempt_questions_attempt_id_question_id_unique": {
+          "name": "simulado_attempt_questions_attempt_id_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "attempt_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_attempts": {
+      "name": "simulado_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "simulado_id": {
+          "name": "simulado_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passed": {
+          "name": "passed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_attempts_user_id_users_id_fk": {
+          "name": "simulado_attempts_user_id_users_id_fk",
+          "tableFrom": "simulado_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempts_simulado_id_simulados_id_fk": {
+          "name": "simulado_attempts_simulado_id_simulados_id_fk",
+          "tableFrom": "simulado_attempts",
+          "tableTo": "simulados",
+          "columnsFrom": [
+            "simulado_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_options": {
+      "name": "simulado_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_options_question_id_simulado_questions_id_fk": {
+          "name": "simulado_options_question_id_simulado_questions_id_fk",
+          "tableFrom": "simulado_options",
+          "tableTo": "simulado_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_questions": {
+      "name": "simulado_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "simulado_id": {
+          "name": "simulado_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_questions_simulado_id_simulados_id_fk": {
+          "name": "simulado_questions_simulado_id_simulados_id_fk",
+          "tableFrom": "simulado_questions",
+          "tableTo": "simulados",
+          "columnsFrom": [
+            "simulado_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulados": {
+      "name": "simulados",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_count": {
+          "name": "question_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pass_percent": {
+          "name": "pass_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulados_slug_unique": {
+          "name": "simulados_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tokens": {
+      "name": "tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'refresh'"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tokens_user_id_users_id_fk": {
+          "name": "tokens_user_id_users_id_fk",
+          "tableFrom": "tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tokens_token_hash_unique": {
+          "name": "tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_reviews": {
+      "name": "trail_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stars": {
+          "name": "stars",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "trail_reviews_trail_id_trails_id_fk": {
+          "name": "trail_reviews_trail_id_trails_id_fk",
+          "tableFrom": "trail_reviews",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trail_reviews_user_id_users_id_fk": {
+          "name": "trail_reviews_user_id_users_id_fk",
+          "tableFrom": "trail_reviews",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trail_reviews_user_id_trail_id_unique": {
+          "name": "trail_reviews_user_id_trail_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "trail_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_tags": {
+      "name": "trail_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "trail_tags_trail_id_trails_id_fk": {
+          "name": "trail_tags_trail_id_trails_id_fk",
+          "tableFrom": "trail_tags",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trail_tags_tag_id_tags_id_fk": {
+          "name": "trail_tags_tag_id_tags_id_fk",
+          "tableFrom": "trail_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trail_tags_trail_id_tag_id_unique": {
+          "name": "trail_tags_trail_id_tag_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trail_id",
+            "tag_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trails": {
+      "name": "trails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "trail_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "what_you_learn": {
+          "name": "what_you_learn",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prerequisites": {
+          "name": "prerequisites",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_achievements": {
+      "name": "user_achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "achievement_id": {
+          "name": "achievement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_achievements_user_id_users_id_fk": {
+          "name": "user_achievements_user_id_users_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_achievements_achievement_id_achievements_id_fk": {
+          "name": "user_achievements_achievement_id_achievements_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "achievements",
+          "columnsFrom": [
+            "achievement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_achievements_user_id_achievement_id_unique": {
+          "name": "user_achievements_user_id_achievement_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "achievement_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username_changed_at": {
+          "name": "username_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occupation": {
+          "name": "occupation",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github": {
+          "name": "github",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin": {
+          "name": "linkedin",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "failed_login_attempts": {
+          "name": "failed_login_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.achievement_criteria": {
+      "name": "achievement_criteria",
+      "schema": "public",
+      "values": [
+        "xp_total",
+        "lessons_completed",
+        "questions_correct",
+        "special"
+      ]
+    },
+    "public.challenge_kind": {
+      "name": "challenge_kind",
+      "schema": "public",
+      "values": [
+        "stdin",
+        "function"
+      ]
+    },
+    "public.challenge_language": {
+      "name": "challenge_language",
+      "schema": "public",
+      "values": [
+        "javascript",
+        "python",
+        "csharp",
+        "java"
+      ]
+    },
+    "public.challenge_submission_status": {
+      "name": "challenge_submission_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "passed",
+        "failed",
+        "error",
+        "timeout"
+      ]
+    },
+    "public.comunicado_kind": {
+      "name": "comunicado_kind",
+      "schema": "public",
+      "values": [
+        "aviso",
+        "pesquisa"
+      ]
+    },
+    "public.comunicado_resposta_status": {
+      "name": "comunicado_resposta_status",
+      "schema": "public",
+      "values": [
+        "respondido",
+        "dispensado"
+      ]
+    },
+    "public.question_difficulty": {
+      "name": "question_difficulty",
+      "schema": "public",
+      "values": [
+        "facil",
+        "medio",
+        "dificil"
+      ]
+    },
+    "public.roadmap_phase": {
+      "name": "roadmap_phase",
+      "schema": "public",
+      "values": [
+        "fundamentos",
+        "core",
+        "avancado",
+        "deploy"
+      ]
+    },
+    "public.roadmap_ref_type": {
+      "name": "roadmap_ref_type",
+      "schema": "public",
+      "values": [
+        "trail",
+        "module",
+        "lesson",
+        "simulado",
+        "challenge"
+      ]
+    },
+    "public.trail_level": {
+      "name": "trail_level",
+      "schema": "public",
+      "values": [
+        "iniciante",
+        "intermediario",
+        "avancado"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin",
+        "moderator"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/0034_snapshot.json
+++ b/backend/drizzle/meta/0034_snapshot.json
@@ -1,0 +1,2682 @@
+{
+  "id": "3518152c-5da7-46ff-8379-f75c2a616950",
+  "prevId": "0eebdeff-f0db-47de-8a5b-f51ccbc57330",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.achievements": {
+      "name": "achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "criteria_type": {
+          "name": "criteria_type",
+          "type": "achievement_criteria",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "achievements_name_unique": {
+          "name": "achievements_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge_submissions": {
+      "name": "challenge_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "challenge_language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "challenge_submission_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "passed_count": {
+          "name": "passed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_count": {
+          "name": "total_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xp_earned": {
+          "name": "xp_earned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "challenge_submissions_user_id_users_id_fk": {
+          "name": "challenge_submissions_user_id_users_id_fk",
+          "tableFrom": "challenge_submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "challenge_submissions_challenge_id_challenges_id_fk": {
+          "name": "challenge_submissions_challenge_id_challenges_id_fk",
+          "tableFrom": "challenge_submissions",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge_tests": {
+      "name": "challenge_tests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_output": {
+          "name": "expected_output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "challenge_tests_challenge_id_challenges_id_fk": {
+          "name": "challenge_tests_challenge_id_challenges_id_fk",
+          "tableFrom": "challenge_tests",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenges": {
+      "name": "challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "challenge_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stdin'"
+        },
+        "entry_point": {
+          "name": "entry_point",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_blocks": {
+          "name": "statement_blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "question_difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'facil'"
+        },
+        "starter_code": {
+          "name": "starter_code",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_date": {
+          "name": "active_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "challenges_number_unique": {
+          "name": "challenges_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "number"
+          ]
+        },
+        "challenges_active_date_unique": {
+          "name": "challenges_active_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "active_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comunicado_respostas": {
+      "name": "comunicado_respostas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "comunicado_id": {
+          "name": "comunicado_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "comunicado_resposta_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comunicado_respostas_comunicado_id_comunicados_id_fk": {
+          "name": "comunicado_respostas_comunicado_id_comunicados_id_fk",
+          "tableFrom": "comunicado_respostas",
+          "tableTo": "comunicados",
+          "columnsFrom": [
+            "comunicado_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "comunicado_respostas_user_id_users_id_fk": {
+          "name": "comunicado_respostas_user_id_users_id_fk",
+          "tableFrom": "comunicado_respostas",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "comunicado_respostas_comunicado_id_user_id_unique": {
+          "name": "comunicado_respostas_comunicado_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "comunicado_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comunicados": {
+      "name": "comunicados",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "comunicado_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.glossary": {
+      "name": "glossary",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "term": {
+          "name": "term",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "varchar(400)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "glossary_term_unique": {
+          "name": "glossary_term_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "term"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.languages": {
+      "name": "languages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "languages_name_unique": {
+          "name": "languages_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons_progress": {
+      "name": "lessons_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_progress_user_id_users_id_fk": {
+          "name": "lessons_progress_user_id_users_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_progress_lesson_id_lessons_id_fk": {
+          "name": "lessons_progress_lesson_id_lessons_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lessons_progress_user_id_lesson_id_unique": {
+          "name": "lessons_progress_user_id_lesson_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "lesson_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons": {
+      "name": "lessons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_blocks": {
+          "name": "content_blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "duration_min": {
+          "name": "duration_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview": {
+          "name": "preview",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_trail_id_trails_id_fk": {
+          "name": "lessons_trail_id_trails_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_module_id_modules_id_fk": {
+          "name": "lessons_module_id_modules_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "modules",
+          "columnsFrom": [
+            "module_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.modules": {
+      "name": "modules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "modules_trail_id_trails_id_fk": {
+          "name": "modules_trail_id_trails_id_fk",
+          "tableFrom": "modules",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_accounts": {
+      "name": "oauth_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_accounts_user_id_users_id_fk": {
+          "name": "oauth_accounts_user_id_users_id_fk",
+          "tableFrom": "oauth_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_accounts_provider_provider_id_unique": {
+          "name": "oauth_accounts_provider_provider_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "provider_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_answers": {
+      "name": "question_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_option_id": {
+          "name": "selected_option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_answers_user_id_users_id_fk": {
+          "name": "question_answers_user_id_users_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_question_id_questions_id_fk": {
+          "name": "question_answers_question_id_questions_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_selected_option_id_question_options_id_fk": {
+          "name": "question_answers_selected_option_id_question_options_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "question_options",
+          "columnsFrom": [
+            "selected_option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "question_answers_user_id_question_id_unique": {
+          "name": "question_answers_user_id_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_options": {
+      "name": "question_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_options_question_id_questions_id_fk": {
+          "name": "question_options_question_id_questions_id_fk",
+          "tableFrom": "question_options",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "question_difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'facil'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_lesson_id_lessons_id_fk": {
+          "name": "questions_lesson_id_lessons_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ranking_snapshots": {
+      "name": "ranking_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ranking_snapshots_user_id_users_id_fk": {
+          "name": "ranking_snapshots_user_id_users_id_fk",
+          "tableFrom": "ranking_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ranking_snapshots_user_id_snapshot_date_unique": {
+          "name": "ranking_snapshots_user_id_snapshot_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "snapshot_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmap_stage_completions": {
+      "name": "roadmap_stage_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "roadmap_stage_completions_user_id_users_id_fk": {
+          "name": "roadmap_stage_completions_user_id_users_id_fk",
+          "tableFrom": "roadmap_stage_completions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "roadmap_stage_completions_stage_id_roadmap_stages_id_fk": {
+          "name": "roadmap_stage_completions_stage_id_roadmap_stages_id_fk",
+          "tableFrom": "roadmap_stage_completions",
+          "tableTo": "roadmap_stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roadmap_stage_completions_user_id_stage_id_unique": {
+          "name": "roadmap_stage_completions_user_id_stage_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "stage_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmap_stage_refs": {
+      "name": "roadmap_stage_refs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_type": {
+          "name": "ref_type",
+          "type": "roadmap_ref_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "roadmap_stage_refs_stage_id_roadmap_stages_id_fk": {
+          "name": "roadmap_stage_refs_stage_id_roadmap_stages_id_fk",
+          "tableFrom": "roadmap_stage_refs",
+          "tableTo": "roadmap_stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmap_stages": {
+      "name": "roadmap_stages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "roadmap_id": {
+          "name": "roadmap_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "roadmap_phase",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "roadmap_stages_roadmap_id_roadmaps_id_fk": {
+          "name": "roadmap_stages_roadmap_id_roadmaps_id_fk",
+          "tableFrom": "roadmap_stages",
+          "tableTo": "roadmaps",
+          "columnsFrom": [
+            "roadmap_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmaps": {
+      "name": "roadmaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "trail_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "premium": {
+          "name": "premium",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roadmaps_slug_unique": {
+          "name": "roadmaps_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_attempt_answers": {
+      "name": "simulado_attempt_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_attempt_answers_attempt_id_simulado_attempts_id_fk": {
+          "name": "simulado_attempt_answers_attempt_id_simulado_attempts_id_fk",
+          "tableFrom": "simulado_attempt_answers",
+          "tableTo": "simulado_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempt_answers_question_id_simulado_questions_id_fk": {
+          "name": "simulado_attempt_answers_question_id_simulado_questions_id_fk",
+          "tableFrom": "simulado_attempt_answers",
+          "tableTo": "simulado_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempt_answers_option_id_simulado_options_id_fk": {
+          "name": "simulado_attempt_answers_option_id_simulado_options_id_fk",
+          "tableFrom": "simulado_attempt_answers",
+          "tableTo": "simulado_options",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulado_attempt_answers_attempt_id_question_id_option_id_unique": {
+          "name": "simulado_attempt_answers_attempt_id_question_id_option_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "attempt_id",
+            "question_id",
+            "option_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_attempt_questions": {
+      "name": "simulado_attempt_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_attempt_questions_attempt_id_simulado_attempts_id_fk": {
+          "name": "simulado_attempt_questions_attempt_id_simulado_attempts_id_fk",
+          "tableFrom": "simulado_attempt_questions",
+          "tableTo": "simulado_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempt_questions_question_id_simulado_questions_id_fk": {
+          "name": "simulado_attempt_questions_question_id_simulado_questions_id_fk",
+          "tableFrom": "simulado_attempt_questions",
+          "tableTo": "simulado_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulado_attempt_questions_attempt_id_question_id_unique": {
+          "name": "simulado_attempt_questions_attempt_id_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "attempt_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_attempts": {
+      "name": "simulado_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "simulado_id": {
+          "name": "simulado_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passed": {
+          "name": "passed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_attempts_user_id_users_id_fk": {
+          "name": "simulado_attempts_user_id_users_id_fk",
+          "tableFrom": "simulado_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempts_simulado_id_simulados_id_fk": {
+          "name": "simulado_attempts_simulado_id_simulados_id_fk",
+          "tableFrom": "simulado_attempts",
+          "tableTo": "simulados",
+          "columnsFrom": [
+            "simulado_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_options": {
+      "name": "simulado_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_options_question_id_simulado_questions_id_fk": {
+          "name": "simulado_options_question_id_simulado_questions_id_fk",
+          "tableFrom": "simulado_options",
+          "tableTo": "simulado_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_questions": {
+      "name": "simulado_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "simulado_id": {
+          "name": "simulado_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_questions_simulado_id_simulados_id_fk": {
+          "name": "simulado_questions_simulado_id_simulados_id_fk",
+          "tableFrom": "simulado_questions",
+          "tableTo": "simulados",
+          "columnsFrom": [
+            "simulado_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulados": {
+      "name": "simulados",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_count": {
+          "name": "question_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pass_percent": {
+          "name": "pass_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulados_slug_unique": {
+          "name": "simulados_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tokens": {
+      "name": "tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'refresh'"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tokens_user_id_users_id_fk": {
+          "name": "tokens_user_id_users_id_fk",
+          "tableFrom": "tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tokens_token_hash_unique": {
+          "name": "tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_reviews": {
+      "name": "trail_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stars": {
+          "name": "stars",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "trail_reviews_trail_id_trails_id_fk": {
+          "name": "trail_reviews_trail_id_trails_id_fk",
+          "tableFrom": "trail_reviews",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trail_reviews_user_id_users_id_fk": {
+          "name": "trail_reviews_user_id_users_id_fk",
+          "tableFrom": "trail_reviews",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trail_reviews_user_id_trail_id_unique": {
+          "name": "trail_reviews_user_id_trail_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "trail_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_tags": {
+      "name": "trail_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "trail_tags_trail_id_trails_id_fk": {
+          "name": "trail_tags_trail_id_trails_id_fk",
+          "tableFrom": "trail_tags",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trail_tags_tag_id_tags_id_fk": {
+          "name": "trail_tags_tag_id_tags_id_fk",
+          "tableFrom": "trail_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trail_tags_trail_id_tag_id_unique": {
+          "name": "trail_tags_trail_id_tag_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trail_id",
+            "tag_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trails": {
+      "name": "trails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "trail_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "what_you_learn": {
+          "name": "what_you_learn",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prerequisites": {
+          "name": "prerequisites",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_achievements": {
+      "name": "user_achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "achievement_id": {
+          "name": "achievement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_achievements_user_id_users_id_fk": {
+          "name": "user_achievements_user_id_users_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_achievements_achievement_id_achievements_id_fk": {
+          "name": "user_achievements_achievement_id_achievements_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "achievements",
+          "columnsFrom": [
+            "achievement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_achievements_user_id_achievement_id_unique": {
+          "name": "user_achievements_user_id_achievement_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "achievement_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username_changed_at": {
+          "name": "username_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occupation": {
+          "name": "occupation",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github": {
+          "name": "github",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin": {
+          "name": "linkedin",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "failed_login_attempts": {
+          "name": "failed_login_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.achievement_criteria": {
+      "name": "achievement_criteria",
+      "schema": "public",
+      "values": [
+        "xp_total",
+        "lessons_completed",
+        "questions_correct",
+        "special"
+      ]
+    },
+    "public.challenge_kind": {
+      "name": "challenge_kind",
+      "schema": "public",
+      "values": [
+        "stdin",
+        "function"
+      ]
+    },
+    "public.challenge_language": {
+      "name": "challenge_language",
+      "schema": "public",
+      "values": [
+        "javascript",
+        "python",
+        "csharp",
+        "java"
+      ]
+    },
+    "public.challenge_submission_status": {
+      "name": "challenge_submission_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "passed",
+        "failed",
+        "error",
+        "timeout"
+      ]
+    },
+    "public.comunicado_kind": {
+      "name": "comunicado_kind",
+      "schema": "public",
+      "values": [
+        "aviso",
+        "pesquisa"
+      ]
+    },
+    "public.comunicado_resposta_status": {
+      "name": "comunicado_resposta_status",
+      "schema": "public",
+      "values": [
+        "respondido",
+        "dispensado"
+      ]
+    },
+    "public.question_difficulty": {
+      "name": "question_difficulty",
+      "schema": "public",
+      "values": [
+        "facil",
+        "medio",
+        "dificil"
+      ]
+    },
+    "public.roadmap_phase": {
+      "name": "roadmap_phase",
+      "schema": "public",
+      "values": [
+        "fundamentos",
+        "core",
+        "avancado",
+        "deploy"
+      ]
+    },
+    "public.roadmap_ref_type": {
+      "name": "roadmap_ref_type",
+      "schema": "public",
+      "values": [
+        "trail",
+        "module",
+        "lesson",
+        "simulado",
+        "challenge"
+      ]
+    },
+    "public.trail_level": {
+      "name": "trail_level",
+      "schema": "public",
+      "values": [
+        "iniciante",
+        "intermediario",
+        "avancado"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin",
+        "moderator"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/0035_snapshot.json
+++ b/backend/drizzle/meta/0035_snapshot.json
@@ -1,0 +1,2689 @@
+{
+  "id": "2aa82346-442c-47d1-9017-2accde5e2303",
+  "prevId": "3518152c-5da7-46ff-8379-f75c2a616950",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.achievements": {
+      "name": "achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "criteria_type": {
+          "name": "criteria_type",
+          "type": "achievement_criteria",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "achievements_name_unique": {
+          "name": "achievements_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge_submissions": {
+      "name": "challenge_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "challenge_language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "challenge_submission_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "passed_count": {
+          "name": "passed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_count": {
+          "name": "total_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xp_earned": {
+          "name": "xp_earned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "challenge_submissions_user_id_users_id_fk": {
+          "name": "challenge_submissions_user_id_users_id_fk",
+          "tableFrom": "challenge_submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "challenge_submissions_challenge_id_challenges_id_fk": {
+          "name": "challenge_submissions_challenge_id_challenges_id_fk",
+          "tableFrom": "challenge_submissions",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge_tests": {
+      "name": "challenge_tests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_output": {
+          "name": "expected_output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "challenge_tests_challenge_id_challenges_id_fk": {
+          "name": "challenge_tests_challenge_id_challenges_id_fk",
+          "tableFrom": "challenge_tests",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenges": {
+      "name": "challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "challenge_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stdin'"
+        },
+        "entry_point": {
+          "name": "entry_point",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_blocks": {
+          "name": "statement_blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "question_difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'facil'"
+        },
+        "starter_code": {
+          "name": "starter_code",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_date": {
+          "name": "active_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "challenges_number_unique": {
+          "name": "challenges_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "number"
+          ]
+        },
+        "challenges_active_date_unique": {
+          "name": "challenges_active_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "active_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comunicado_respostas": {
+      "name": "comunicado_respostas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "comunicado_id": {
+          "name": "comunicado_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "comunicado_resposta_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comunicado_respostas_comunicado_id_comunicados_id_fk": {
+          "name": "comunicado_respostas_comunicado_id_comunicados_id_fk",
+          "tableFrom": "comunicado_respostas",
+          "tableTo": "comunicados",
+          "columnsFrom": [
+            "comunicado_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "comunicado_respostas_user_id_users_id_fk": {
+          "name": "comunicado_respostas_user_id_users_id_fk",
+          "tableFrom": "comunicado_respostas",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "comunicado_respostas_comunicado_id_user_id_unique": {
+          "name": "comunicado_respostas_comunicado_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "comunicado_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comunicados": {
+      "name": "comunicados",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "comunicado_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.glossary": {
+      "name": "glossary",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "term": {
+          "name": "term",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "varchar(400)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "glossary_term_unique": {
+          "name": "glossary_term_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "term"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.languages": {
+      "name": "languages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "languages_name_unique": {
+          "name": "languages_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons_progress": {
+      "name": "lessons_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "manual": {
+          "name": "manual",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_progress_user_id_users_id_fk": {
+          "name": "lessons_progress_user_id_users_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_progress_lesson_id_lessons_id_fk": {
+          "name": "lessons_progress_lesson_id_lessons_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lessons_progress_user_id_lesson_id_unique": {
+          "name": "lessons_progress_user_id_lesson_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "lesson_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons": {
+      "name": "lessons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_blocks": {
+          "name": "content_blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "duration_min": {
+          "name": "duration_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview": {
+          "name": "preview",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_trail_id_trails_id_fk": {
+          "name": "lessons_trail_id_trails_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_module_id_modules_id_fk": {
+          "name": "lessons_module_id_modules_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "modules",
+          "columnsFrom": [
+            "module_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.modules": {
+      "name": "modules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "modules_trail_id_trails_id_fk": {
+          "name": "modules_trail_id_trails_id_fk",
+          "tableFrom": "modules",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_accounts": {
+      "name": "oauth_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_accounts_user_id_users_id_fk": {
+          "name": "oauth_accounts_user_id_users_id_fk",
+          "tableFrom": "oauth_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_accounts_provider_provider_id_unique": {
+          "name": "oauth_accounts_provider_provider_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "provider_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_answers": {
+      "name": "question_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_option_id": {
+          "name": "selected_option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_answers_user_id_users_id_fk": {
+          "name": "question_answers_user_id_users_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_question_id_questions_id_fk": {
+          "name": "question_answers_question_id_questions_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_selected_option_id_question_options_id_fk": {
+          "name": "question_answers_selected_option_id_question_options_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "question_options",
+          "columnsFrom": [
+            "selected_option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "question_answers_user_id_question_id_unique": {
+          "name": "question_answers_user_id_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_options": {
+      "name": "question_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_options_question_id_questions_id_fk": {
+          "name": "question_options_question_id_questions_id_fk",
+          "tableFrom": "question_options",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "question_difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'facil'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_lesson_id_lessons_id_fk": {
+          "name": "questions_lesson_id_lessons_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ranking_snapshots": {
+      "name": "ranking_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ranking_snapshots_user_id_users_id_fk": {
+          "name": "ranking_snapshots_user_id_users_id_fk",
+          "tableFrom": "ranking_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ranking_snapshots_user_id_snapshot_date_unique": {
+          "name": "ranking_snapshots_user_id_snapshot_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "snapshot_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmap_stage_completions": {
+      "name": "roadmap_stage_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "roadmap_stage_completions_user_id_users_id_fk": {
+          "name": "roadmap_stage_completions_user_id_users_id_fk",
+          "tableFrom": "roadmap_stage_completions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "roadmap_stage_completions_stage_id_roadmap_stages_id_fk": {
+          "name": "roadmap_stage_completions_stage_id_roadmap_stages_id_fk",
+          "tableFrom": "roadmap_stage_completions",
+          "tableTo": "roadmap_stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roadmap_stage_completions_user_id_stage_id_unique": {
+          "name": "roadmap_stage_completions_user_id_stage_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "stage_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmap_stage_refs": {
+      "name": "roadmap_stage_refs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_type": {
+          "name": "ref_type",
+          "type": "roadmap_ref_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "roadmap_stage_refs_stage_id_roadmap_stages_id_fk": {
+          "name": "roadmap_stage_refs_stage_id_roadmap_stages_id_fk",
+          "tableFrom": "roadmap_stage_refs",
+          "tableTo": "roadmap_stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmap_stages": {
+      "name": "roadmap_stages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "roadmap_id": {
+          "name": "roadmap_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "roadmap_phase",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "roadmap_stages_roadmap_id_roadmaps_id_fk": {
+          "name": "roadmap_stages_roadmap_id_roadmaps_id_fk",
+          "tableFrom": "roadmap_stages",
+          "tableTo": "roadmaps",
+          "columnsFrom": [
+            "roadmap_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmaps": {
+      "name": "roadmaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "trail_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "premium": {
+          "name": "premium",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roadmaps_slug_unique": {
+          "name": "roadmaps_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_attempt_answers": {
+      "name": "simulado_attempt_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_attempt_answers_attempt_id_simulado_attempts_id_fk": {
+          "name": "simulado_attempt_answers_attempt_id_simulado_attempts_id_fk",
+          "tableFrom": "simulado_attempt_answers",
+          "tableTo": "simulado_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempt_answers_question_id_simulado_questions_id_fk": {
+          "name": "simulado_attempt_answers_question_id_simulado_questions_id_fk",
+          "tableFrom": "simulado_attempt_answers",
+          "tableTo": "simulado_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempt_answers_option_id_simulado_options_id_fk": {
+          "name": "simulado_attempt_answers_option_id_simulado_options_id_fk",
+          "tableFrom": "simulado_attempt_answers",
+          "tableTo": "simulado_options",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulado_attempt_answers_attempt_id_question_id_option_id_unique": {
+          "name": "simulado_attempt_answers_attempt_id_question_id_option_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "attempt_id",
+            "question_id",
+            "option_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_attempt_questions": {
+      "name": "simulado_attempt_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_attempt_questions_attempt_id_simulado_attempts_id_fk": {
+          "name": "simulado_attempt_questions_attempt_id_simulado_attempts_id_fk",
+          "tableFrom": "simulado_attempt_questions",
+          "tableTo": "simulado_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempt_questions_question_id_simulado_questions_id_fk": {
+          "name": "simulado_attempt_questions_question_id_simulado_questions_id_fk",
+          "tableFrom": "simulado_attempt_questions",
+          "tableTo": "simulado_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulado_attempt_questions_attempt_id_question_id_unique": {
+          "name": "simulado_attempt_questions_attempt_id_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "attempt_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_attempts": {
+      "name": "simulado_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "simulado_id": {
+          "name": "simulado_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passed": {
+          "name": "passed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_attempts_user_id_users_id_fk": {
+          "name": "simulado_attempts_user_id_users_id_fk",
+          "tableFrom": "simulado_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempts_simulado_id_simulados_id_fk": {
+          "name": "simulado_attempts_simulado_id_simulados_id_fk",
+          "tableFrom": "simulado_attempts",
+          "tableTo": "simulados",
+          "columnsFrom": [
+            "simulado_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_options": {
+      "name": "simulado_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_options_question_id_simulado_questions_id_fk": {
+          "name": "simulado_options_question_id_simulado_questions_id_fk",
+          "tableFrom": "simulado_options",
+          "tableTo": "simulado_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_questions": {
+      "name": "simulado_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "simulado_id": {
+          "name": "simulado_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_questions_simulado_id_simulados_id_fk": {
+          "name": "simulado_questions_simulado_id_simulados_id_fk",
+          "tableFrom": "simulado_questions",
+          "tableTo": "simulados",
+          "columnsFrom": [
+            "simulado_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulados": {
+      "name": "simulados",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_count": {
+          "name": "question_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pass_percent": {
+          "name": "pass_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulados_slug_unique": {
+          "name": "simulados_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tokens": {
+      "name": "tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'refresh'"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tokens_user_id_users_id_fk": {
+          "name": "tokens_user_id_users_id_fk",
+          "tableFrom": "tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tokens_token_hash_unique": {
+          "name": "tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_reviews": {
+      "name": "trail_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stars": {
+          "name": "stars",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "trail_reviews_trail_id_trails_id_fk": {
+          "name": "trail_reviews_trail_id_trails_id_fk",
+          "tableFrom": "trail_reviews",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trail_reviews_user_id_users_id_fk": {
+          "name": "trail_reviews_user_id_users_id_fk",
+          "tableFrom": "trail_reviews",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trail_reviews_user_id_trail_id_unique": {
+          "name": "trail_reviews_user_id_trail_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "trail_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_tags": {
+      "name": "trail_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "trail_tags_trail_id_trails_id_fk": {
+          "name": "trail_tags_trail_id_trails_id_fk",
+          "tableFrom": "trail_tags",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trail_tags_tag_id_tags_id_fk": {
+          "name": "trail_tags_tag_id_tags_id_fk",
+          "tableFrom": "trail_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trail_tags_trail_id_tag_id_unique": {
+          "name": "trail_tags_trail_id_tag_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trail_id",
+            "tag_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trails": {
+      "name": "trails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "trail_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "what_you_learn": {
+          "name": "what_you_learn",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prerequisites": {
+          "name": "prerequisites",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_achievements": {
+      "name": "user_achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "achievement_id": {
+          "name": "achievement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_achievements_user_id_users_id_fk": {
+          "name": "user_achievements_user_id_users_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_achievements_achievement_id_achievements_id_fk": {
+          "name": "user_achievements_achievement_id_achievements_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "achievements",
+          "columnsFrom": [
+            "achievement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_achievements_user_id_achievement_id_unique": {
+          "name": "user_achievements_user_id_achievement_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "achievement_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username_changed_at": {
+          "name": "username_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occupation": {
+          "name": "occupation",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github": {
+          "name": "github",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin": {
+          "name": "linkedin",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "failed_login_attempts": {
+          "name": "failed_login_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.achievement_criteria": {
+      "name": "achievement_criteria",
+      "schema": "public",
+      "values": [
+        "xp_total",
+        "lessons_completed",
+        "questions_correct",
+        "special"
+      ]
+    },
+    "public.challenge_kind": {
+      "name": "challenge_kind",
+      "schema": "public",
+      "values": [
+        "stdin",
+        "function"
+      ]
+    },
+    "public.challenge_language": {
+      "name": "challenge_language",
+      "schema": "public",
+      "values": [
+        "javascript",
+        "python",
+        "csharp",
+        "java"
+      ]
+    },
+    "public.challenge_submission_status": {
+      "name": "challenge_submission_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "passed",
+        "failed",
+        "error",
+        "timeout"
+      ]
+    },
+    "public.comunicado_kind": {
+      "name": "comunicado_kind",
+      "schema": "public",
+      "values": [
+        "aviso",
+        "pesquisa"
+      ]
+    },
+    "public.comunicado_resposta_status": {
+      "name": "comunicado_resposta_status",
+      "schema": "public",
+      "values": [
+        "respondido",
+        "dispensado"
+      ]
+    },
+    "public.question_difficulty": {
+      "name": "question_difficulty",
+      "schema": "public",
+      "values": [
+        "facil",
+        "medio",
+        "dificil"
+      ]
+    },
+    "public.roadmap_phase": {
+      "name": "roadmap_phase",
+      "schema": "public",
+      "values": [
+        "fundamentos",
+        "core",
+        "avancado",
+        "deploy"
+      ]
+    },
+    "public.roadmap_ref_type": {
+      "name": "roadmap_ref_type",
+      "schema": "public",
+      "values": [
+        "trail",
+        "module",
+        "lesson",
+        "simulado",
+        "challenge"
+      ]
+    },
+    "public.trail_level": {
+      "name": "trail_level",
+      "schema": "public",
+      "values": [
+        "iniciante",
+        "intermediario",
+        "avancado"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin",
+        "moderator"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1784547603259,
       "tag": "0032_regular_rick_jones",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1784758734668,
+      "tag": "0033_unique_magneto",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -239,6 +239,20 @@
       "when": 1784758734668,
       "tag": "0033_unique_magneto",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1784760834426,
+      "tag": "0034_slimy_nico_minoru",
+      "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "7",
+      "when": 1784761401654,
+      "tag": "0035_round_brother_voodoo",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/schema.ts
+++ b/backend/schema.ts
@@ -160,6 +160,8 @@ export const lessonProgress = pgTable(
             .references(() => lessons.id)
             .notNull(),
         completedAt: timestamp("completed_at", { withTimezone: true }).defaultNow().notNull(),
+        // Conclusão manual (estágio de roadmap marcado como concluído): conta como progresso, mas não dá XP.
+        manual: boolean("manual").default(false).notNull(),
     },
     (table) => [unique().on(table.userId, table.lessonId)],
 );
@@ -511,4 +513,20 @@ export const comunicadoRespostas = pgTable(
         createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
     },
     (table) => [unique().on(table.comunicadoId, table.userId)],
+);
+
+// Conclusão manual de estágio ("já sei isso"): conta como concluído, sem conceder XP.
+export const roadmapStageCompletions = pgTable(
+    "roadmap_stage_completions",
+    {
+        id: uuid("id").primaryKey().defaultRandom(),
+        userId: uuid("user_id")
+            .references(() => users.id)
+            .notNull(),
+        stageId: uuid("stage_id")
+            .references(() => roadmapStages.id)
+            .notNull(),
+        createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    },
+    (table) => [unique().on(table.userId, table.stageId)],
 );

--- a/backend/schema.ts
+++ b/backend/schema.ts
@@ -478,3 +478,37 @@ export const roadmapStageRefs = pgTable("roadmap_stage_refs", {
     refId: uuid("ref_id").notNull(),
     position: integer("position").default(0).notNull(),
 });
+
+export const comunicadoKind = pgEnum("comunicado_kind", ["aviso", "pesquisa"]);
+export const comunicadoRespostaStatus = pgEnum("comunicado_resposta_status", [
+    "respondido",
+    "dispensado",
+]);
+
+// Comunicado lançado pelo admin: aviso (só mensagem) ou pesquisa (nota 1-5 + comentário opcional).
+export const comunicados = pgTable("comunicados", {
+    id: uuid("id").primaryKey().defaultRandom(),
+    kind: comunicadoKind("kind").notNull(),
+    title: varchar("title", { length: 200 }).notNull(),
+    message: text("message").notNull(),
+    published: boolean("published").default(false).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+});
+
+export const comunicadoRespostas = pgTable(
+    "comunicado_respostas",
+    {
+        id: uuid("id").primaryKey().defaultRandom(),
+        comunicadoId: uuid("comunicado_id")
+            .references(() => comunicados.id)
+            .notNull(),
+        userId: uuid("user_id")
+            .references(() => users.id)
+            .notNull(),
+        status: comunicadoRespostaStatus("status").notNull(),
+        rating: integer("rating"),
+        comment: text("comment"),
+        createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    },
+    (table) => [unique().on(table.comunicadoId, table.userId)],
+);

--- a/backend/src/controllers/ComunicadoController.ts
+++ b/backend/src/controllers/ComunicadoController.ts
@@ -1,0 +1,84 @@
+import type { Request, Response, NextFunction } from "express";
+import {
+    createComunicadoSchema,
+    updateComunicadoSchema,
+    responderComunicadoSchema,
+} from "../schemas/comunicado.schema.ts";
+import {
+    comunicadoAtivo,
+    responderComunicado,
+    dispensarComunicado,
+    criarComunicado,
+    atualizarComunicado,
+    excluirComunicado,
+    listarComunicadosAdmin,
+    resultadosComunicado,
+} from "../services/comunicado.service.ts";
+
+export const getComunicadoAtivo = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        res.json(await comunicadoAtivo(req.userId!));
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const respondComunicado = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const dados = responderComunicadoSchema.parse(req.body);
+        res.json(await responderComunicado(String(req.params.id), req.userId!, dados));
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const dismissComunicado = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        res.json(await dispensarComunicado(String(req.params.id), req.userId!));
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const createComunicado = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const dados = createComunicadoSchema.parse(req.body);
+        res.status(201).json(await criarComunicado(dados));
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const updateComunicado = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const dados = updateComunicadoSchema.parse(req.body);
+        res.json(await atualizarComunicado(String(req.params.id), dados));
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const deleteComunicado = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        await excluirComunicado(String(req.params.id));
+        res.json({ ok: true });
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const listComunicadosStudio = async (_req: Request, res: Response, next: NextFunction) => {
+    try {
+        res.json(await listarComunicadosAdmin());
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const getComunicadoStudio = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        res.json(await resultadosComunicado(String(req.params.id)));
+    } catch (err) {
+        next(err);
+    }
+};

--- a/backend/src/controllers/RoadmapController.ts
+++ b/backend/src/controllers/RoadmapController.ts
@@ -1,5 +1,6 @@
 import type { Request, Response, NextFunction } from "express";
 import {
+    concluirEstagio,
     listarRoadmaps,
     obterRoadmap,
     listarRoadmapsAdmin,
@@ -127,6 +128,14 @@ export const deleteStageRef = async (req: Request, res: Response, next: NextFunc
     try {
         await removerRef(String(req.params.id));
         res.json({ ok: true });
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const completeStage = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        res.json(await concluirEstagio(String(req.params.id), req.userId!));
     } catch (err) {
         next(err);
     }

--- a/backend/src/routes/comunicado.routes.ts
+++ b/backend/src/routes/comunicado.routes.ts
@@ -1,0 +1,26 @@
+import { Router } from "express";
+import { autenticar, exigirAdmin } from "../middlewares/auth.ts";
+import {
+    getComunicadoAtivo,
+    respondComunicado,
+    dismissComunicado,
+    createComunicado,
+    updateComunicado,
+    deleteComunicado,
+    listComunicadosStudio,
+    getComunicadoStudio,
+} from "../controllers/ComunicadoController.ts";
+
+const router = Router();
+
+router.get("/comunicados/ativo", autenticar, getComunicadoAtivo);
+router.post("/comunicados/:id/responder", autenticar, respondComunicado);
+router.post("/comunicados/:id/dispensar", autenticar, dismissComunicado);
+
+router.get("/studio/comunicados", autenticar, exigirAdmin, listComunicadosStudio);
+router.get("/studio/comunicados/:id", autenticar, exigirAdmin, getComunicadoStudio);
+router.post("/comunicados", autenticar, exigirAdmin, createComunicado);
+router.patch("/comunicados/:id", autenticar, exigirAdmin, updateComunicado);
+router.delete("/comunicados/:id", autenticar, exigirAdmin, deleteComunicado);
+
+export default router;

--- a/backend/src/routes/roadmap.routes.ts
+++ b/backend/src/routes/roadmap.routes.ts
@@ -13,6 +13,7 @@ import {
     deleteStage,
     createStageRef,
     deleteStageRef,
+    completeStage,
 } from "../controllers/RoadmapController.ts";
 
 const router = Router();
@@ -30,6 +31,7 @@ router.delete("/roadmaps/:id", autenticar, exigirAdmin, deleteRoadmap);
 router.post("/roadmaps/:id/stages", autenticar, exigirAdmin, createStage);
 router.patch("/roadmap-stages/:id", autenticar, exigirAdmin, updateStage);
 router.delete("/roadmap-stages/:id", autenticar, exigirAdmin, deleteStage);
+router.post("/roadmap-stages/:id/concluir", autenticar, completeStage);
 router.post("/roadmap-stages/:id/refs", autenticar, exigirAdmin, createStageRef);
 router.delete("/roadmap-stage-refs/:id", autenticar, exigirAdmin, deleteStageRef);
 

--- a/backend/src/schemas/comunicado.schema.ts
+++ b/backend/src/schemas/comunicado.schema.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export const createComunicadoSchema = z.object({
+    kind: z.enum(["aviso", "pesquisa"]),
+    title: z.string().trim().min(2, "Título deve ter ao menos 2 caracteres").max(200, "Título muito longo"),
+    message: z.string().trim().min(2, "Mensagem obrigatória").max(2000, "Mensagem muito longa"),
+    published: z.boolean().optional(),
+});
+
+export const updateComunicadoSchema = createComunicadoSchema.partial();
+
+export const responderComunicadoSchema = z.object({
+    rating: z.int("Nota inválida").min(1, "A nota vai de 1 a 5").max(5, "A nota vai de 1 a 5"),
+    comment: z.string().trim().max(2000, "Comentário muito longo").optional(),
+});

--- a/backend/src/services/activity.service.ts
+++ b/backend/src/services/activity.service.ts
@@ -1,6 +1,6 @@
 import { db } from "../../db.ts";
 import { lessonProgress, lessons, userAchievements, achievements } from "../../schema.ts";
-import { eq, desc } from "drizzle-orm";
+import { eq, and, desc } from "drizzle-orm";
 
 // Atividades recentes derivadas: aulas concluídas + conquistas desbloqueadas.
 export async function atividadeRecente(userId: string) {
@@ -8,7 +8,7 @@ export async function atividadeRecente(userId: string) {
         .select({ at: lessonProgress.completedAt, title: lessons.title })
         .from(lessonProgress)
         .innerJoin(lessons, eq(lessons.id, lessonProgress.lessonId))
-        .where(eq(lessonProgress.userId, userId))
+        .where(and(eq(lessonProgress.userId, userId), eq(lessonProgress.manual, false)))
         .orderBy(desc(lessonProgress.completedAt))
         .limit(15);
     const conquistas = await db

--- a/backend/src/services/comunicado.service.ts
+++ b/backend/src/services/comunicado.service.ts
@@ -1,0 +1,163 @@
+import { db } from "../../db.ts";
+import { comunicados, comunicadoRespostas, users } from "../../schema.ts";
+import { and, desc, eq, notExists } from "drizzle-orm";
+import type { z } from "zod";
+import type { createComunicadoSchema, updateComunicadoSchema } from "../schemas/comunicado.schema.ts";
+import { AppError } from "../errors/AppError.ts";
+
+type DadosCriar = z.infer<typeof createComunicadoSchema>;
+type DadosAtualizar = z.infer<typeof updateComunicadoSchema>;
+
+// O comunicado publicado mais recente com o qual o usuário ainda não interagiu.
+export async function comunicadoAtivo(userId: string) {
+    const [c] = await db
+        .select({
+            id: comunicados.id,
+            kind: comunicados.kind,
+            title: comunicados.title,
+            message: comunicados.message,
+        })
+        .from(comunicados)
+        .where(
+            and(
+                eq(comunicados.published, true),
+                notExists(
+                    db
+                        .select()
+                        .from(comunicadoRespostas)
+                        .where(
+                            and(
+                                eq(comunicadoRespostas.comunicadoId, comunicados.id),
+                                eq(comunicadoRespostas.userId, userId),
+                            ),
+                        ),
+                ),
+            ),
+        )
+        .orderBy(desc(comunicados.createdAt))
+        .limit(1);
+    return c ?? null;
+}
+
+async function publicadoOu404(id: string) {
+    const [c] = await db.select().from(comunicados).where(eq(comunicados.id, id));
+    if (!c || !c.published) throw new AppError(404, "Comunicado não encontrado");
+    return c;
+}
+
+export async function responderComunicado(
+    comunicadoId: string,
+    userId: string,
+    dados: { rating: number; comment?: string },
+) {
+    const c = await publicadoOu404(comunicadoId);
+    if (c.kind !== "pesquisa") throw new AppError(400, "Este comunicado não aceita resposta");
+    const [existe] = await db
+        .select({ id: comunicadoRespostas.id })
+        .from(comunicadoRespostas)
+        .where(
+            and(
+                eq(comunicadoRespostas.comunicadoId, comunicadoId),
+                eq(comunicadoRespostas.userId, userId),
+            ),
+        );
+    if (existe) throw new AppError(409, "Você já respondeu este comunicado");
+    await db.insert(comunicadoRespostas).values({
+        comunicadoId,
+        userId,
+        status: "respondido",
+        rating: dados.rating,
+        comment: dados.comment?.trim() || null,
+    });
+    return { ok: true };
+}
+
+export async function dispensarComunicado(comunicadoId: string, userId: string) {
+    await publicadoOu404(comunicadoId);
+    await db
+        .insert(comunicadoRespostas)
+        .values({ comunicadoId, userId, status: "dispensado" })
+        .onConflictDoNothing();
+    return { ok: true };
+}
+
+export async function criarComunicado(dados: DadosCriar) {
+    const [c] = await db.insert(comunicados).values(dados).returning();
+    return c;
+}
+
+export async function atualizarComunicado(id: string, dados: DadosAtualizar) {
+    const [c] = await db.update(comunicados).set(dados).where(eq(comunicados.id, id)).returning();
+    if (!c) throw new AppError(404, "Comunicado não encontrado");
+    return c;
+}
+
+export async function excluirComunicado(id: string) {
+    await db.transaction(async (tx) => {
+        await tx.delete(comunicadoRespostas).where(eq(comunicadoRespostas.comunicadoId, id));
+        await tx.delete(comunicados).where(eq(comunicados.id, id));
+    });
+}
+
+function media(notas: number[]) {
+    return notas.length
+        ? Math.round((notas.reduce((s, n) => s + n, 0) / notas.length) * 10) / 10
+        : null;
+}
+
+export async function listarComunicadosAdmin() {
+    const cs = await db.select().from(comunicados).orderBy(desc(comunicados.createdAt));
+    const rs = await db
+        .select({
+            comunicadoId: comunicadoRespostas.comunicadoId,
+            status: comunicadoRespostas.status,
+            rating: comunicadoRespostas.rating,
+        })
+        .from(comunicadoRespostas);
+    return cs.map((c) => {
+        const deste = rs.filter((r) => r.comunicadoId === c.id);
+        const respondidos = deste.filter((r) => r.status === "respondido");
+        const notas = respondidos.map((r) => r.rating).filter((n): n is number => n != null);
+        return {
+            ...c,
+            respondidos: respondidos.length,
+            dispensados: deste.length - respondidos.length,
+            media: media(notas),
+        };
+    });
+}
+
+export async function resultadosComunicado(id: string) {
+    const [c] = await db.select().from(comunicados).where(eq(comunicados.id, id));
+    if (!c) throw new AppError(404, "Comunicado não encontrado");
+    const rows = await db
+        .select({
+            status: comunicadoRespostas.status,
+            rating: comunicadoRespostas.rating,
+            comment: comunicadoRespostas.comment,
+            createdAt: comunicadoRespostas.createdAt,
+            name: users.name,
+        })
+        .from(comunicadoRespostas)
+        .innerJoin(users, eq(users.id, comunicadoRespostas.userId))
+        .where(eq(comunicadoRespostas.comunicadoId, id))
+        .orderBy(desc(comunicadoRespostas.createdAt));
+    const respondidas = rows.filter((r) => r.status === "respondido");
+    const notas = respondidas.map((r) => r.rating).filter((n): n is number => n != null);
+    return {
+        ...c,
+        respondidos: respondidas.length,
+        dispensados: rows.length - respondidas.length,
+        media: media(notas),
+        distribuicao: [1, 2, 3, 4, 5].map((n) => ({
+            rating: n,
+            count: notas.filter((x) => x === n).length,
+        })),
+        respostas: respondidas.map((r) => ({
+            name: r.name,
+            rating: r.rating,
+            comment: r.comment,
+            createdAt: r.createdAt,
+        })),
+    };
+}

--- a/backend/src/services/quiz.service.ts
+++ b/backend/src/services/quiz.service.ts
@@ -81,11 +81,16 @@ export async function corrigirQuiz(userId: string, lessonId: string, dados: Resp
     let aulaConcluida = false;
     if (passou) {
         const [existe] = await db
-            .select({ id: lessonProgress.id })
+            .select({ id: lessonProgress.id, manual: lessonProgress.manual })
             .from(lessonProgress)
             .where(and(eq(lessonProgress.userId, userId), eq(lessonProgress.lessonId, lessonId)));
         if (!existe) {
             await db.insert(lessonProgress).values({ userId, lessonId });
+        } else if (existe.manual) {
+            await db
+                .update(lessonProgress)
+                .set({ manual: false, completedAt: new Date() })
+                .where(eq(lessonProgress.id, existe.id));
         }
         aulaConcluida = true;
     }

--- a/backend/src/services/ranking.ts
+++ b/backend/src/services/ranking.ts
@@ -84,6 +84,7 @@ export async function rankingGlobal(periodo: string, currentUserId: string | und
         db
             .select({ userId: lessonProgress.userId, n: count() })
             .from(lessonProgress)
+            .where(eq(lessonProgress.manual, false))
             .groupBy(lessonProgress.userId),
         db
             .select({ userId: questionAnswers.userId, n: count() })

--- a/backend/src/services/roadmap.service.ts
+++ b/backend/src/services/roadmap.service.ts
@@ -1,5 +1,6 @@
 import { db } from "../../db.ts";
 import {
+    roadmapStageCompletions,
     roadmaps,
     roadmapStages,
     roadmapStageRefs,
@@ -159,6 +160,15 @@ async function resolverRefs(refs: { refType: RefType; refId: string }[]) {
     return info;
 }
 
+
+async function estagiosConcluidosManualmente(userId: string) {
+    const rows = await db
+        .select({ stageId: roadmapStageCompletions.stageId })
+        .from(roadmapStageCompletions)
+        .where(eq(roadmapStageCompletions.userId, userId));
+    return new Set(rows.map((r) => r.stageId));
+}
+
 export async function listarRoadmaps(userId?: string) {
     const lista = await db
         .select()
@@ -179,9 +189,11 @@ export async function listarRoadmaps(userId?: string) {
         : [];
 
     let conclusao = SEM_CONCLUSAO;
+    let manuais = new Set<string>();
     let aulas = { porTrail: new Map<string, string[]>(), porModule: new Map<string, string[]>() };
     if (userId) {
         conclusao = await carregarConclusao(userId);
+        manuais = await estagiosConcluidosManualmente(userId);
         aulas = await carregarAulasPorContainer(
             refs.filter((r) => r.refType === "trail").map((r) => r.refId),
             refs.filter((r) => r.refType === "module").map((r) => r.refId),
@@ -195,6 +207,7 @@ export async function listarRoadmaps(userId?: string) {
         refsPorEtapa.set(r.stageId, arr);
     }
     const etapaConcluida = (stageId: string) => {
+        if (manuais.has(stageId)) return true;
         const rs = refsPorEtapa.get(stageId) ?? [];
         return rs.length > 0 && rs.every((r) => refConcluido(r.refType as RefType, r.refId, conclusao, aulas));
     };
@@ -243,9 +256,11 @@ export async function obterRoadmap(slug: string, userId?: string) {
         : [];
 
     let conclusao = SEM_CONCLUSAO;
+    let manuais = new Set<string>();
     let aulas = { porTrail: new Map<string, string[]>(), porModule: new Map<string, string[]>() };
     if (userId) {
         conclusao = await carregarConclusao(userId);
+        manuais = await estagiosConcluidosManualmente(userId);
         aulas = await carregarAulasPorContainer(
             refs.filter((r) => r.refType === "trail").map((r) => r.refId),
             refs.filter((r) => r.refType === "module").map((r) => r.refId),
@@ -263,7 +278,8 @@ export async function obterRoadmap(slug: string, userId?: string) {
     const etapasSaida = etapas.map((e) => {
         const rs = refsPorEtapa.get(e.id) ?? [];
         const completed =
-            userId && rs.length > 0 && rs.every((r) => refConcluido(r.refType as RefType, r.refId, conclusao, aulas));
+            (userId && manuais.has(e.id)) ||
+            (userId && rs.length > 0 && rs.every((r) => refConcluido(r.refType as RefType, r.refId, conclusao, aulas)));
         return {
             id: e.id,
             phase: e.phase,
@@ -330,6 +346,47 @@ function gerarSlug(nome: string): string {
 }
 
 // Lista para o admin: todos os roadmaps (inclusive rascunhos), com contagem de estágios.
+export async function concluirEstagio(stageId: string, userId: string) {
+    const [etapa] = await db
+        .select({ id: roadmapStages.id })
+        .from(roadmapStages)
+        .where(eq(roadmapStages.id, stageId));
+    if (!etapa) throw new AppError(404, "Estágio não encontrado");
+    await db
+        .insert(roadmapStageCompletions)
+        .values({ stageId, userId })
+        .onConflictDoNothing();
+
+    // As trilhas e módulos do estágio também ficam concluídos: progresso manual, sem XP.
+    const refs = await db
+        .select()
+        .from(roadmapStageRefs)
+        .where(eq(roadmapStageRefs.stageId, stageId));
+    const trailIds = refs.filter((r) => r.refType === "trail").map((r) => r.refId);
+    const moduleIds = refs.filter((r) => r.refType === "module").map((r) => r.refId);
+    const aulasAlvo = [
+        ...(trailIds.length
+            ? await db
+                  .select({ id: lessons.id })
+                  .from(lessons)
+                  .where(and(inArray(lessons.trailId, trailIds), eq(lessons.published, true)))
+            : []),
+        ...(moduleIds.length
+            ? await db
+                  .select({ id: lessons.id })
+                  .from(lessons)
+                  .where(and(inArray(lessons.moduleId, moduleIds), eq(lessons.published, true)))
+            : []),
+    ];
+    if (aulasAlvo.length) {
+        await db
+            .insert(lessonProgress)
+            .values(aulasAlvo.map((a) => ({ userId, lessonId: a.id, manual: true })))
+            .onConflictDoNothing();
+    }
+    return { ok: true };
+}
+
 export async function listarRoadmapsAdmin() {
     const lista = await db.select().from(roadmaps).orderBy(asc(roadmaps.position));
     const contagens = await db

--- a/backend/src/services/stats.service.ts
+++ b/backend/src/services/stats.service.ts
@@ -8,7 +8,7 @@ export async function calcularEstatisticas(userId: string) {
     const [aulas] = await db
         .select({ n: count() })
         .from(lessonProgress)
-        .where(eq(lessonProgress.userId, userId));
+        .where(and(eq(lessonProgress.userId, userId), eq(lessonProgress.manual, false)));
     const [acertos] = await db
         .select({ n: count() })
         .from(questionAnswers)

--- a/backend/tests/comunicado.test.ts
+++ b/backend/tests/comunicado.test.ts
@@ -1,0 +1,188 @@
+import { test, describe, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { startTestServer } from "./helpers/server.ts";
+import { limparBanco } from "./helpers/db.ts";
+
+let server: Awaited<ReturnType<typeof startTestServer>>;
+
+let seq = 0;
+const novoUsuario = () => ({
+    name: "Aluno Teste",
+    email: `aluno_${++seq}_${Math.round(performance.now() * 1000)}@email.com`,
+    username: `aluno_${seq}`,
+    password: "Senhaforte123!",
+    birthDate: "1990-01-01",
+    gender: "outro",
+    phone: "11999998888",
+});
+
+async function ajustarUsuario(email: string, campos: Record<string, unknown>) {
+    const { db } = await import("../db.ts");
+    const { users } = await import("../schema.ts");
+    const { eq } = await import("drizzle-orm");
+    await db.update(users).set(campos).where(eq(users.email, email));
+}
+
+async function criarUsuarioLogado(admin = false) {
+    const dados = novoUsuario();
+    await server.request("POST", "/register", { body: dados });
+    await ajustarUsuario(dados.email, {
+        emailVerifiedAt: new Date(),
+        ...(admin ? { role: "admin" } : {}),
+    });
+    const login = await server.request("POST", "/login", {
+        body: { email: dados.email, password: dados.password },
+    });
+    return { email: dados.email, token: login.body.token };
+}
+
+function auth(token: string) {
+    return { Authorization: `Bearer ${token}` };
+}
+async function get(path: string, token: string) {
+    const res = await fetch(`${server.base}${path}`, { headers: auth(token) });
+    return { status: res.status, body: await res.json().catch(() => null) };
+}
+async function post(path: string, token: string, body?: unknown) {
+    const res = await fetch(`${server.base}${path}`, {
+        method: "POST",
+        headers: { ...auth(token), "Content-Type": "application/json" },
+        body: body ? JSON.stringify(body) : undefined,
+    });
+    return { status: res.status, body: await res.json().catch(() => null) };
+}
+
+async function criarPesquisa(adminToken: string, over: Record<string, unknown> = {}) {
+    return post("/comunicados", adminToken, {
+        kind: "pesquisa",
+        title: "Ajude a melhorar o site",
+        message: "De 1 a 5, como está sendo sua experiência?",
+        published: true,
+        ...over,
+    });
+}
+
+before(async () => {
+    server = await startTestServer();
+});
+after(async () => {
+    await server.close();
+});
+beforeEach(async () => {
+    await limparBanco();
+});
+
+describe("Comunicados", () => {
+    test("admin cria; usuário comum recebe 403", async () => {
+        const admin = await criarUsuarioLogado(true);
+        const criado = await criarPesquisa(admin.token);
+        assert.equal(criado.status, 201);
+        assert.equal(criado.body.kind, "pesquisa");
+
+        const comum = await criarUsuarioLogado();
+        const negado = await criarPesquisa(comum.token);
+        assert.equal(negado.status, 403);
+    });
+
+    test("ativo traz o publicado mais recente; rascunho não aparece", async () => {
+        const admin = await criarUsuarioLogado(true);
+        await criarPesquisa(admin.token, { title: "Antiga" });
+        await criarPesquisa(admin.token, { title: "Recente" });
+        await criarPesquisa(admin.token, { title: "Rascunho", published: false });
+
+        const aluno = await criarUsuarioLogado();
+        const ativo = await get("/comunicados/ativo", aluno.token);
+        assert.equal(ativo.status, 200);
+        assert.equal(ativo.body.title, "Recente");
+    });
+
+    test("responder registra nota e comentário e não reaparece; repetir dá 409", async () => {
+        const admin = await criarUsuarioLogado(true);
+        const pesquisa = await criarPesquisa(admin.token);
+        const aluno = await criarUsuarioLogado();
+
+        const ok = await post(`/comunicados/${pesquisa.body.id}/responder`, aluno.token, {
+            rating: 4,
+            comment: "Muito bom, faltam mais desafios",
+        });
+        assert.equal(ok.status, 200);
+
+        const ativo = await get("/comunicados/ativo", aluno.token);
+        assert.equal(ativo.body, null);
+
+        const repetida = await post(`/comunicados/${pesquisa.body.id}/responder`, aluno.token, {
+            rating: 5,
+        });
+        assert.equal(repetida.status, 409);
+    });
+
+    test("nota fora de 1 a 5 é rejeitada", async () => {
+        const admin = await criarUsuarioLogado(true);
+        const pesquisa = await criarPesquisa(admin.token);
+        const aluno = await criarUsuarioLogado();
+
+        for (const rating of [0, 6]) {
+            const r = await post(`/comunicados/${pesquisa.body.id}/responder`, aluno.token, {
+                rating,
+            });
+            assert.equal(r.status, 400);
+        }
+    });
+
+    test("dispensar esconde o comunicado e é idempotente", async () => {
+        const admin = await criarUsuarioLogado(true);
+        const pesquisa = await criarPesquisa(admin.token);
+        const aluno = await criarUsuarioLogado();
+
+        assert.equal(
+            (await post(`/comunicados/${pesquisa.body.id}/dispensar`, aluno.token)).status,
+            200,
+        );
+        assert.equal(
+            (await post(`/comunicados/${pesquisa.body.id}/dispensar`, aluno.token)).status,
+            200,
+        );
+        const ativo = await get("/comunicados/ativo", aluno.token);
+        assert.equal(ativo.body, null);
+    });
+
+    test("aviso não aceita resposta, só dispensa", async () => {
+        const admin = await criarUsuarioLogado(true);
+        const aviso = await criarPesquisa(admin.token, { kind: "aviso", title: "Manutenção" });
+        const aluno = await criarUsuarioLogado();
+
+        const r = await post(`/comunicados/${aviso.body.id}/responder`, aluno.token, { rating: 5 });
+        assert.equal(r.status, 400);
+        assert.equal(
+            (await post(`/comunicados/${aviso.body.id}/dispensar`, aluno.token)).status,
+            200,
+        );
+    });
+
+    test("resultados agregam distribuição, média e comentários (só admin)", async () => {
+        const admin = await criarUsuarioLogado(true);
+        const pesquisa = await criarPesquisa(admin.token);
+
+        const a = await criarUsuarioLogado();
+        const b = await criarUsuarioLogado();
+        const c = await criarUsuarioLogado();
+        await post(`/comunicados/${pesquisa.body.id}/responder`, a.token, {
+            rating: 5,
+            comment: "Excelente",
+        });
+        await post(`/comunicados/${pesquisa.body.id}/responder`, b.token, { rating: 3 });
+        await post(`/comunicados/${pesquisa.body.id}/dispensar`, c.token);
+
+        const res = await get(`/studio/comunicados/${pesquisa.body.id}`, admin.token);
+        assert.equal(res.status, 200);
+        assert.equal(res.body.respondidos, 2);
+        assert.equal(res.body.dispensados, 1);
+        assert.equal(res.body.media, 4);
+        assert.equal(res.body.distribuicao.find((d: any) => d.rating === 5).count, 1);
+        assert.equal(res.body.distribuicao.find((d: any) => d.rating === 3).count, 1);
+        assert.equal(res.body.respostas.some((r: any) => r.comment === "Excelente"), true);
+
+        const negado = await get(`/studio/comunicados/${pesquisa.body.id}`, a.token);
+        assert.equal(negado.status, 403);
+    });
+});

--- a/backend/tests/helpers/db.ts
+++ b/backend/tests/helpers/db.ts
@@ -6,6 +6,6 @@ export async function limparBanco() {
     // CASCADE remove dependentes por FK; lista trails/lessons explicitamente
     // porque elas nao referenciam users e nao cairiam no cascade.
     await db.execute(
-        sql`TRUNCATE TABLE challenge_submissions, challenge_tests, challenges, simulado_attempt_answers, simulado_attempt_questions, simulado_attempts, simulado_options, simulado_questions, simulados, question_answers, question_options, questions, lessons_progress, lessons, modules, trails, tokens, users RESTART IDENTITY CASCADE`,
+        sql`TRUNCATE TABLE comunicado_respostas, comunicados, challenge_submissions, challenge_tests, challenges, simulado_attempt_answers, simulado_attempt_questions, simulado_attempts, simulado_options, simulado_questions, simulados, question_answers, question_options, questions, lessons_progress, lessons, modules, trails, tokens, users RESTART IDENTITY CASCADE`,
     );
 }

--- a/backend/tests/helpers/db.ts
+++ b/backend/tests/helpers/db.ts
@@ -6,6 +6,6 @@ export async function limparBanco() {
     // CASCADE remove dependentes por FK; lista trails/lessons explicitamente
     // porque elas nao referenciam users e nao cairiam no cascade.
     await db.execute(
-        sql`TRUNCATE TABLE comunicado_respostas, comunicados, challenge_submissions, challenge_tests, challenges, simulado_attempt_answers, simulado_attempt_questions, simulado_attempts, simulado_options, simulado_questions, simulados, question_answers, question_options, questions, lessons_progress, lessons, modules, trails, tokens, users RESTART IDENTITY CASCADE`,
+        sql`TRUNCATE TABLE roadmap_stage_completions, roadmap_stage_refs, roadmap_stages, roadmaps, comunicado_respostas, comunicados, challenge_submissions, challenge_tests, challenges, simulado_attempt_answers, simulado_attempt_questions, simulado_attempts, simulado_options, simulado_questions, simulados, question_answers, question_options, questions, lessons_progress, lessons, modules, trails, tokens, users RESTART IDENTITY CASCADE`,
     );
 }

--- a/backend/tests/roadmap.test.ts
+++ b/backend/tests/roadmap.test.ts
@@ -1,0 +1,190 @@
+import { test, describe, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { startTestServer } from "./helpers/server.ts";
+import { limparBanco } from "./helpers/db.ts";
+
+let server: Awaited<ReturnType<typeof startTestServer>>;
+
+let seq = 0;
+const novoUsuario = () => ({
+    name: "Aluno Teste",
+    email: `rmap_${++seq}_${Math.round(performance.now() * 1000)}@email.com`,
+    username: `rmap_${seq}`,
+    password: "Senhaforte123!",
+    birthDate: "1990-01-01",
+    gender: "outro",
+    phone: "11999998888",
+});
+
+async function ajustarUsuario(email: string, campos: Record<string, unknown>) {
+    const { db } = await import("../db.ts");
+    const { users } = await import("../schema.ts");
+    const { eq } = await import("drizzle-orm");
+    await db.update(users).set(campos).where(eq(users.email, email));
+}
+
+async function criarUsuarioLogado(admin = false) {
+    const dados = novoUsuario();
+    await server.request("POST", "/register", { body: dados });
+    await ajustarUsuario(dados.email, {
+        emailVerifiedAt: new Date(),
+        ...(admin ? { role: "admin" } : {}),
+    });
+    const login = await server.request("POST", "/login", {
+        body: { email: dados.email, password: dados.password },
+    });
+    return { email: dados.email, token: login.body.token };
+}
+
+function auth(token: string) {
+    return { Authorization: `Bearer ${token}` };
+}
+async function get(path: string, token: string) {
+    const res = await fetch(`${server.base}${path}`, { headers: auth(token) });
+    return { status: res.status, body: await res.json().catch(() => null) };
+}
+async function post(path: string, token: string, body?: unknown) {
+    const res = await fetch(`${server.base}${path}`, {
+        method: "POST",
+        headers: { ...auth(token), "Content-Type": "application/json" },
+        body: body ? JSON.stringify(body) : undefined,
+    });
+    return { status: res.status, body: await res.json().catch(() => null) };
+}
+
+async function patch(path: string, token: string, body?: unknown) {
+    const res = await fetch(`${server.base}${path}`, {
+        method: "PATCH",
+        headers: { ...auth(token), "Content-Type": "application/json" },
+        body: body ? JSON.stringify(body) : undefined,
+    });
+    return { status: res.status, body: await res.json().catch(() => null) };
+}
+
+async function montarRoadmap(adminToken: string) {
+    const trilha = await post("/trails", adminToken, {
+        name: "Logica",
+        level: "iniciante",
+        description: "Base da programacao logica.",
+    });
+    const modulo = await post(`/trails/${trilha.body.id}/modules`, adminToken, {
+        title: "Modulo 1",
+        position: 1,
+    });
+    const lessonIds: string[] = [];
+    for (let i = 1; i <= 2; i++) {
+        const aula = await post(`/modules/${modulo.body.id}/lessons`, adminToken, {
+            title: `Aula ${i}`,
+            position: i,
+        });
+        for (let q = 1; q <= 5; q++) {
+            await post(`/lessons/${aula.body.id}/questions`, adminToken, {
+                statement: `Questao numero ${q}`,
+                position: q,
+                options: [
+                    { text: "errada", isCorrect: false },
+                    { text: "certa", isCorrect: true },
+                ],
+            });
+        }
+        await patch(`/lessons/${aula.body.id}/published`, adminToken, { published: true });
+        lessonIds.push(aula.body.id as string);
+    }
+    const trilha2 = await post("/trails", adminToken, {
+        name: "Logica 2",
+        level: "iniciante",
+        description: "Continuacao da programacao logica.",
+    });
+    const rm = await post("/roadmaps", adminToken, {
+        name: "Backend",
+        description: "Do zero ao backend.",
+        level: "iniciante",
+        published: true,
+    });
+    const stageIds: string[] = [];
+    for (const trailId of [trilha.body.id, trilha2.body.id]) {
+        const st = await post(`/roadmaps/${rm.body.id}/stages`, adminToken, {
+            phase: "fundamentos",
+            title: `Etapa ${stageIds.length + 1}`,
+            description: "Descricao da etapa.",
+        });
+        await post(`/roadmap-stages/${st.body.id}/refs`, adminToken, {
+            refType: "trail",
+            refId: trailId,
+        });
+        stageIds.push(st.body.id as string);
+    }
+    return { slug: rm.body.slug as string, stageIds, lessonIds };
+}
+
+before(async () => {
+    server = await startTestServer();
+});
+after(async () => {
+    await server.close();
+});
+beforeEach(async () => {
+    await limparBanco();
+});
+
+describe("Roadmap: conclusão manual de estágio", () => {
+    test("concluir marca o estágio, destrava o próximo e é idempotente", async () => {
+        const admin = await criarUsuarioLogado(true);
+        const { slug, stageIds } = await montarRoadmap(admin.token);
+        const aluno = await criarUsuarioLogado();
+
+        const antes = await get(`/roadmaps/${slug}`, aluno.token);
+        assert.equal(antes.body.stages[0].completed, false);
+        assert.equal(antes.body.stages[1].locked, true);
+
+        assert.equal(
+            (await post(`/roadmap-stages/${stageIds[0]}/concluir`, aluno.token)).status,
+            200,
+        );
+        assert.equal(
+            (await post(`/roadmap-stages/${stageIds[0]}/concluir`, aluno.token)).status,
+            200,
+        );
+
+        const depois = await get(`/roadmaps/${slug}`, aluno.token);
+        assert.equal(depois.body.stages[0].completed, true);
+        assert.equal(depois.body.stages[1].locked, false);
+        assert.equal(depois.body.progress.stagesDone, 1);
+    });
+
+    test("concluir marca as trilhas do estágio sem dar XP; fazer de verdade recupera o XP", async () => {
+        const admin = await criarUsuarioLogado(true);
+        const { stageIds, lessonIds } = await montarRoadmap(admin.token);
+        const aluno = await criarUsuarioLogado();
+
+        await post(`/roadmap-stages/${stageIds[0]}/concluir`, aluno.token);
+
+        const minhas = await get("/me/trails", aluno.token);
+        assert.equal(minhas.body.length, 1);
+        assert.equal(minhas.body[0].progress, 100);
+
+        const xpAntes = await get("/me/xp", aluno.token);
+        assert.equal(xpAntes.body.xp, 0);
+        assert.equal(xpAntes.body.lessonsCompleted, 0);
+
+        const aula = await get(`/lessons/${lessonIds[0]}`, aluno.token);
+        const answers = aula.body.questions.map((q: any) => ({
+            questionId: q.id,
+            optionId: q.options.find((o: any) => o.text === "certa").id,
+        }));
+        await post(`/lessons/${lessonIds[0]}/quiz`, aluno.token, { answers });
+
+        const xpDepois = await get("/me/xp", aluno.token);
+        assert.equal(xpDepois.body.lessonsCompleted, 1);
+        assert.equal(xpDepois.body.xp, 100);
+    });
+
+    test("estágio inexistente retorna 404", async () => {
+        const aluno = await criarUsuarioLogado();
+        const r = await post(
+            "/roadmap-stages/00000000-0000-0000-0000-000000000000/concluir",
+            aluno.token,
+        );
+        assert.equal(r.status, 404);
+    });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -26,6 +26,8 @@ import { RoadmapEditor } from './pages/RoadmapsAdmin/Editor';
 import { Desafios } from './pages/Desafios';
 import { Desafio } from './pages/Desafios/Desafio';
 import { DesafiosAdmin } from './pages/DesafiosAdmin';
+import { ComunicadosAdmin } from './pages/ComunicadosAdmin';
+import { ComunicadoPrompt } from './components/ComunicadoPrompt';
 import { DesafioEditor } from './pages/DesafiosAdmin/Editor';
 import { VerifyEmail } from './pages/VerifyEmail';
 import { RecuperarSenha } from './pages/RecuperarSenha';
@@ -64,6 +66,8 @@ function AppRoutes() {
   const { isAuthenticated } = useAuth();
 
   return (
+    <>
+    <ComunicadoPrompt />
     <Routes>
       <Route path="/" element={isAuthenticated ? <Navigate to="/home" /> : <Login />} />
       <Route path="/cadastro" element={isAuthenticated ? <Navigate to="/home" /> : <Register />} />
@@ -185,6 +189,14 @@ function AppRoutes() {
         }
       />
       <Route
+        path="/estudio/comunicados"
+        element={
+          <AdminRoute>
+            <ComunicadosAdmin />
+          </AdminRoute>
+        }
+      />
+      <Route
         path="/estudio/desafios"
         element={
           <AdminRoute>
@@ -295,6 +307,7 @@ function AppRoutes() {
         }
       />
     </Routes>
+    </>
   );
 }
 

--- a/frontend/src/components/ComunicadoPrompt.tsx
+++ b/frontend/src/components/ComunicadoPrompt.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+import {
+  obterComunicadoAtivo,
+  responderComunicado,
+  dispensarComunicado,
+  type ComunicadoAtivo,
+} from '../services/comunicados';
+
+// Não interrompe quem está no meio de uma aula, simulado ou desafio.
+const ROTAS_SEM_PROMPT = [/\/aula\//, /\/tentativa/, /^\/desafios\/./];
+
+export function ComunicadoPrompt() {
+  const { isAuthenticated, user } = useAuth();
+  const { pathname } = useLocation();
+  const [comunicado, setComunicado] = useState<ComunicadoAtivo | null>(null);
+  const [etapa, setEtapa] = useState<'convite' | 'pesquisa' | 'obrigado'>('convite');
+  const [nota, setNota] = useState(0);
+  const [comentario, setComentario] = useState('');
+  const [enviando, setEnviando] = useState(false);
+
+  const logado = isAuthenticated && !!user?.username;
+
+  useEffect(() => {
+    if (!logado) return;
+    obterComunicadoAtivo()
+      .then(setComunicado)
+      .catch(() => {});
+  }, [logado]);
+
+  if (!logado || !comunicado || ROTAS_SEM_PROMPT.some((r) => r.test(pathname))) return null;
+
+  async function dispensar() {
+    const id = comunicado!.id;
+    setComunicado(null);
+    try {
+      await dispensarComunicado(id);
+    } catch (e) {
+      console.error('Falha ao dispensar comunicado:', e);
+    }
+  }
+
+  async function enviar() {
+    if (nota < 1 || enviando) return;
+    setEnviando(true);
+    try {
+      await responderComunicado(comunicado!.id, nota, comentario.trim() || undefined);
+      setEtapa('obrigado');
+    } catch (e) {
+      console.error('Falha ao responder comunicado:', e);
+      setComunicado(null);
+    } finally {
+      setEnviando(false);
+    }
+  }
+
+  if (comunicado.kind === 'aviso') {
+    return (
+      <div className="cmn-card">
+        <div className="cmn-card__kicker">Aviso</div>
+        <h3 className="cmn-card__title">{comunicado.title}</h3>
+        <p className="cmn-card__msg">{comunicado.message}</p>
+        <div className="cmn-card__row">
+          <button className="btn btn--accent" onClick={dispensar}>
+            Entendi
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (etapa === 'convite') {
+    return (
+      <div className="cmn-card">
+        <div className="cmn-card__kicker">Sua opinião</div>
+        <h3 className="cmn-card__title">Topa responder um questionário rápido?</h3>
+        <p className="cmn-card__msg">
+          É uma pergunta só e ajuda a melhorar o site para todo mundo.
+        </p>
+        <div className="cmn-card__row">
+          <button className="btn btn--ghost" onClick={dispensar}>
+            Agora não
+          </button>
+          <button className="btn btn--accent" onClick={() => setEtapa('pesquisa')}>
+            Responder
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (etapa === 'pesquisa') {
+    return (
+      <div className="cmn-card">
+        <div className="cmn-card__kicker">Questionário</div>
+        <h3 className="cmn-card__title">{comunicado.title}</h3>
+        <p className="cmn-card__msg">{comunicado.message}</p>
+        <div className="cmn-notas">
+          {[1, 2, 3, 4, 5].map((n) => (
+            <button
+              key={n}
+              type="button"
+              className={`cmn-nota${nota === n ? ' cmn-nota--on' : ''}`}
+              onClick={() => setNota(n)}
+            >
+              {n}
+            </button>
+          ))}
+        </div>
+        <textarea
+          className="cmn-texto"
+          value={comentario}
+          onChange={(e) => setComentario(e.target.value)}
+          placeholder="Quer contar mais? (opcional)"
+          maxLength={2000}
+          rows={3}
+        />
+        <div className="cmn-card__row">
+          <button className="btn btn--ghost" onClick={dispensar}>
+            Cancelar
+          </button>
+          <button className="btn btn--accent" onClick={enviar} disabled={nota < 1 || enviando}>
+            {enviando ? 'Enviando...' : 'Enviar'}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="cmn-card">
+      <div className="cmn-card__kicker">Valeu!</div>
+      <h3 className="cmn-card__title">Resposta enviada</h3>
+      <p className="cmn-card__msg">Obrigado por ajudar a melhorar o site.</p>
+      <div className="cmn-card__row">
+        <button className="btn btn--accent" onClick={() => setComunicado(null)}>
+          Fechar
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ComunicadoPrompt.tsx
+++ b/frontend/src/components/ComunicadoPrompt.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import {
@@ -55,9 +55,10 @@ export function ComunicadoPrompt() {
     }
   }
 
+  let conteudo: ReactNode;
   if (comunicado.kind === 'aviso') {
-    return (
-      <div className="cmn-card">
+    conteudo = (
+      <>
         <div className="cmn-card__kicker">Aviso</div>
         <h3 className="cmn-card__title">{comunicado.title}</h3>
         <p className="cmn-card__msg">{comunicado.message}</p>
@@ -66,13 +67,11 @@ export function ComunicadoPrompt() {
             Entendi
           </button>
         </div>
-      </div>
+      </>
     );
-  }
-
-  if (etapa === 'convite') {
-    return (
-      <div className="cmn-card">
+  } else if (etapa === 'convite') {
+    conteudo = (
+      <>
         <div className="cmn-card__kicker">Sua opinião</div>
         <h3 className="cmn-card__title">Topa responder um questionário rápido?</h3>
         <p className="cmn-card__msg">
@@ -86,13 +85,11 @@ export function ComunicadoPrompt() {
             Responder
           </button>
         </div>
-      </div>
+      </>
     );
-  }
-
-  if (etapa === 'pesquisa') {
-    return (
-      <div className="cmn-card">
+  } else if (etapa === 'pesquisa') {
+    conteudo = (
+      <>
         <div className="cmn-card__kicker">Questionário</div>
         <h3 className="cmn-card__title">{comunicado.title}</h3>
         <p className="cmn-card__msg">{comunicado.message}</p>
@@ -124,20 +121,26 @@ export function ComunicadoPrompt() {
             {enviando ? 'Enviando...' : 'Enviar'}
           </button>
         </div>
-      </div>
+      </>
+    );
+  } else {
+    conteudo = (
+      <>
+        <div className="cmn-card__kicker">Valeu!</div>
+        <h3 className="cmn-card__title">Resposta enviada</h3>
+        <p className="cmn-card__msg">Obrigado por ajudar a melhorar o site.</p>
+        <div className="cmn-card__row">
+          <button className="btn btn--accent" onClick={() => setComunicado(null)}>
+            Fechar
+          </button>
+        </div>
+      </>
     );
   }
 
   return (
-    <div className="cmn-card">
-      <div className="cmn-card__kicker">Valeu!</div>
-      <h3 className="cmn-card__title">Resposta enviada</h3>
-      <p className="cmn-card__msg">Obrigado por ajudar a melhorar o site.</p>
-      <div className="cmn-card__row">
-        <button className="btn btn--accent" onClick={() => setComunicado(null)}>
-          Fechar
-        </button>
-      </div>
+    <div className="cmn-overlay">
+      <div className="cmn-card">{conteudo}</div>
     </div>
   );
 }

--- a/frontend/src/data/nav.ts
+++ b/frontend/src/data/nav.ts
@@ -16,5 +16,6 @@ export const NAV_ESTUDIO = [
   { label: 'Usuários', to: '/estudio/usuarios' },
   { label: 'Simulados', to: '/estudio/simulados' },
   { label: 'Desafios', to: '/estudio/desafios' },
+  { label: 'Comunicados', to: '/estudio/comunicados' },
   { label: 'Voltar ao app', to: '/home' },
 ];

--- a/frontend/src/pages/ComunicadosAdmin/index.tsx
+++ b/frontend/src/pages/ComunicadosAdmin/index.tsx
@@ -1,0 +1,229 @@
+import { useEffect, useState } from 'react';
+import { EstudioTopbar } from '../../components/EstudioTopbar';
+import { Plus, Trash, ChevronDown } from '../../components/Icons';
+import { useToast } from '../../contexts/ToastContext';
+import {
+  adminListarComunicados,
+  adminResultadosComunicado,
+  adminCriarComunicado,
+  adminAtualizarComunicado,
+  adminExcluirComunicado,
+  type ComunicadoResumo,
+  type ComunicadoResultados,
+  type ComunicadoKind,
+} from '../../services/comunicados';
+
+const KIND_LABEL: Record<ComunicadoKind, string> = { aviso: 'Aviso', pesquisa: 'Pesquisa' };
+
+export function ComunicadosAdmin() {
+  const { mostrar } = useToast();
+  const [itens, setItens] = useState<ComunicadoResumo[]>([]);
+  const [carregando, setCarregando] = useState(true);
+  const [formAberto, setFormAberto] = useState(false);
+  const [form, setForm] = useState({ kind: 'pesquisa' as ComunicadoKind, title: '', message: '' });
+  const [salvando, setSalvando] = useState(false);
+  const [abertoId, setAbertoId] = useState<string | null>(null);
+  const [resultados, setResultados] = useState<Record<string, ComunicadoResultados>>({});
+
+  async function carregar() {
+    try {
+      setItens(await adminListarComunicados());
+    } catch {
+      mostrar('Não foi possível carregar os comunicados.', 'erro');
+    } finally {
+      setCarregando(false);
+    }
+  }
+  useEffect(() => {
+    carregar();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  async function criar() {
+    if (salvando) return;
+    setSalvando(true);
+    try {
+      await adminCriarComunicado({ ...form, published: true });
+      mostrar('Comunicado publicado.');
+      setForm({ kind: 'pesquisa', title: '', message: '' });
+      setFormAberto(false);
+      carregar();
+    } catch {
+      mostrar('Não foi possível criar o comunicado.', 'erro');
+    } finally {
+      setSalvando(false);
+    }
+  }
+
+  async function alternarPublicacao(item: ComunicadoResumo) {
+    try {
+      await adminAtualizarComunicado(item.id, { published: !item.published });
+      carregar();
+    } catch {
+      mostrar('Não foi possível atualizar.', 'erro');
+    }
+  }
+
+  async function excluir(item: ComunicadoResumo) {
+    if (!window.confirm(`Excluir "${item.title}" e todas as respostas?`)) return;
+    try {
+      await adminExcluirComunicado(item.id);
+      mostrar('Comunicado excluído.');
+      carregar();
+    } catch {
+      mostrar('Não foi possível excluir.', 'erro');
+    }
+  }
+
+  async function alternarResultados(item: ComunicadoResumo) {
+    if (abertoId === item.id) {
+      setAbertoId(null);
+      return;
+    }
+    setAbertoId(item.id);
+    if (!resultados[item.id]) {
+      try {
+        const r = await adminResultadosComunicado(item.id);
+        setResultados((prev) => ({ ...prev, [item.id]: r }));
+      } catch {
+        mostrar('Não foi possível carregar os resultados.', 'erro');
+      }
+    }
+  }
+
+  return (
+    <div className="home">
+      <EstudioTopbar crumb={<b>Comunicados</b>} />
+
+      <div className="estudio-home">
+        <div className="estudio-home__head">
+          <div>
+            <h1 className="estudio-home__title">Comunicados</h1>
+            <p className="estudio-home__sub">
+              Lance avisos ou pesquisas (nota de 1 a 5 com comentário opcional) para os usuários.
+            </p>
+          </div>
+          <button className="btn btn--accent" onClick={() => setFormAberto((v) => !v)}>
+            <Plus size={14} /> Novo comunicado
+          </button>
+        </div>
+
+        {formAberto && (
+          <div className="card" style={{ marginBottom: 18 }}>
+            <div className="estudio-form__title">Novo comunicado</div>
+            <div style={{ display: 'grid', gap: 10 }}>
+              <select
+                className="cmn-texto"
+                style={{ resize: 'none', marginBottom: 0 }}
+                value={form.kind}
+                onChange={(e) => setForm({ ...form, kind: e.target.value as ComunicadoKind })}
+              >
+                <option value="pesquisa">Pesquisa (nota 1 a 5 + comentário)</option>
+                <option value="aviso">Aviso (só mensagem)</option>
+              </select>
+              <input
+                className="cmn-texto"
+                style={{ resize: 'none', marginBottom: 0 }}
+                placeholder="Título"
+                value={form.title}
+                maxLength={200}
+                onChange={(e) => setForm({ ...form, title: e.target.value })}
+              />
+              <textarea
+                className="cmn-texto"
+                style={{ marginBottom: 0 }}
+                placeholder={
+                  form.kind === 'pesquisa'
+                    ? 'A pergunta da pesquisa (ex.: De 1 a 5, como está sendo sua experiência?)'
+                    : 'A mensagem do aviso'
+                }
+                rows={3}
+                maxLength={2000}
+                value={form.message}
+                onChange={(e) => setForm({ ...form, message: e.target.value })}
+              />
+              <div className="cmn-card__row">
+                <button className="btn btn--ghost" onClick={() => setFormAberto(false)}>
+                  Cancelar
+                </button>
+                <button
+                  className="btn btn--accent"
+                  onClick={criar}
+                  disabled={form.title.trim().length < 2 || form.message.trim().length < 2 || salvando}
+                >
+                  {salvando ? 'Publicando...' : 'Publicar'}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {carregando && <p className="track__desc">Carregando...</p>}
+        {!carregando && itens.length === 0 && (
+          <p className="track__desc">Nenhum comunicado ainda. Lance o primeiro.</p>
+        )}
+
+        {itens.map((item) => {
+          const res = resultados[item.id];
+          const aberto = abertoId === item.id;
+          const maxDist = res ? Math.max(1, ...res.distribuicao.map((d) => d.count)) : 1;
+          return (
+            <div key={item.id} className="card" style={{ marginBottom: 12 }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
+                <span className="studio__badge">{KIND_LABEL[item.kind]}</span>
+                <b style={{ flex: 1, minWidth: 180 }}>{item.title}</b>
+                <span className="td-lesson__dur">
+                  {item.respondidos} respostas · {item.dispensados} dispensas
+                  {item.media != null ? ` · média ${item.media}` : ''}
+                </span>
+                <button className="btn btn--ghost" onClick={() => alternarPublicacao(item)}>
+                  {item.published ? 'Despublicar' : 'Publicar'}
+                </button>
+                {item.kind === 'pesquisa' && (
+                  <button className="btn btn--ghost" onClick={() => alternarResultados(item)}>
+                    <ChevronDown size={14} /> Resultados
+                  </button>
+                )}
+                <button className="btn btn--ghost" onClick={() => excluir(item)}>
+                  <Trash size={14} />
+                </button>
+              </div>
+              <p className="cmn-card__msg" style={{ margin: '8px 0 0' }}>
+                {item.message}
+              </p>
+
+              {aberto && res && (
+                <div style={{ marginTop: 10 }}>
+                  <div className="cmn-dist">
+                    {[...res.distribuicao].reverse().map((d) => (
+                      <div key={d.rating} className="cmn-dist__row">
+                        <span style={{ width: 12 }}>{d.rating}</span>
+                        <div className="cmn-dist__track">
+                          <span style={{ width: `${(d.count / maxDist) * 100}%` }} />
+                        </div>
+                        <span style={{ width: 24, textAlign: 'right' }}>{d.count}</span>
+                      </div>
+                    ))}
+                  </div>
+                  {res.respostas.filter((r) => r.comment).map((r, i) => (
+                    <div key={i} className="cmn-resposta">
+                      <div className="cmn-resposta__meta">
+                        <b>{r.name}</b>
+                        <span>nota {r.rating}</span>
+                        <span>{new Date(r.createdAt).toLocaleDateString('pt-BR')}</span>
+                      </div>
+                      {r.comment}
+                    </div>
+                  ))}
+                  {res.respostas.every((r) => !r.comment) && (
+                    <p className="track__desc">Nenhum comentário escrito ainda.</p>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Roadmaps/Detalhe.tsx
+++ b/frontend/src/pages/Roadmaps/Detalhe.tsx
@@ -5,11 +5,11 @@ import { Logo } from '../../components/Logo';
 import { MobileMenu } from '../../components/MobileMenu';
 import { UserMenu } from '../../components/UserMenu';
 import { ThemeToggle } from '../../components/ThemeToggle';
-import { Flame, Check, Lock, ChevronRight, ChevronLeft, Play } from '../../components/Icons';
+import { Flame, Check, ChevronRight, ChevronLeft, Play } from '../../components/Icons';
 import { getInitials } from '../../utils/initials';
 import { user } from '../../data/home';
 import { NAV_PRINCIPAL as NAV } from '../../data/nav';
-import { obterRoadmap, type RoadmapDetalhe, type RoadmapStage, type RoadmapRef, type RoadmapPhase } from '../../services/roadmaps';
+import { concluirEstagio, obterRoadmap, type RoadmapDetalhe, type RoadmapStage, type RoadmapRef, type RoadmapPhase } from '../../services/roadmaps';
 import { obterTrilha } from '../../services/trails';
 
 const PHASE_LABEL: Record<RoadmapPhase, string> = {
@@ -54,6 +54,8 @@ export function RoadmapDetalhe() {
   const initials = getInitials(displayName);
 
   const [rm, setRm] = useState<RoadmapDetalhe | null>(null);
+  const [confirmando, setConfirmando] = useState<RoadmapStage | null>(null);
+  const [concluindo, setConcluindo] = useState(false);
   const [carregando, setCarregando] = useState(true);
   const [erro, setErro] = useState('');
 
@@ -83,6 +85,20 @@ export function RoadmapDetalhe() {
       } catch {
         return navigate('/trilhas');
       }
+    }
+  }
+
+  async function confirmarConclusao() {
+    if (!confirmando || !slug || concluindo) return;
+    setConcluindo(true);
+    try {
+      await concluirEstagio(confirmando.id);
+      setRm(await obterRoadmap(slug));
+      setConfirmando(null);
+    } catch (e) {
+      console.error('Falha ao concluir estágio:', e);
+    } finally {
+      setConcluindo(false);
     }
   }
 
@@ -152,13 +168,7 @@ export function RoadmapDetalhe() {
                     <div key={s.id} className={`rmd-stage rmd-stage--${estado}`}>
                       <div className="rmd-stage__rail">
                         <span className="rmd-stage__dot">
-                          {estado === 'done' ? (
-                            <Check size={16} />
-                          ) : estado === 'locked' ? (
-                            <Lock size={14} />
-                          ) : (
-                            i + 1
-                          )}
+                          {estado === 'done' ? <Check size={16} /> : i + 1}
                         </span>
                       </div>
                       <div className="rmd-stage__card">
@@ -169,7 +179,7 @@ export function RoadmapDetalhe() {
                             {estado === 'done'
                               ? 'Concluído'
                               : estado === 'locked'
-                                ? 'Bloqueado'
+                                ? 'A seguir'
                                 : estado === 'current'
                                   ? 'Em andamento'
                                   : 'Disponível'}
@@ -183,11 +193,19 @@ export function RoadmapDetalhe() {
                             </span>
                           ))}
                         </div>
-                        {estado !== 'locked' && estado !== 'done' && (
-                          <button className="rmd-stage__btn" onClick={() => irParaRef(s.refs[0])}>
-                            <Play size={13} />{' '}
-                            {estado === 'current' ? 'Continuar estágio' : 'Começar estágio'}
-                          </button>
+                        {estado !== 'done' && (
+                          <div className="rmd-stage__acoes">
+                            <button className="rmd-stage__btn" onClick={() => irParaRef(s.refs[0])}>
+                              <Play size={13} />{' '}
+                              {estado === 'current' ? 'Continuar estágio' : 'Começar estágio'}
+                            </button>
+                            <button
+                              className="rmd-stage__btn rmd-stage__btn--ghost"
+                              onClick={() => setConfirmando(s)}
+                            >
+                              <Check size={14} /> Concluído
+                            </button>
+                          </div>
                         )}
                         {estado === 'done' && s.refs[0] && (
                           <button
@@ -206,6 +224,27 @@ export function RoadmapDetalhe() {
           )}
         </div>
       </div>
+
+      {confirmando && (
+        <div className="cmn-overlay">
+          <div className="cmn-card">
+            <div className="cmn-card__kicker">Concluir estágio</div>
+            <h3 className="cmn-card__title">{confirmando.title}</h3>
+            <p className="cmn-card__msg">
+              O estágio e as trilhas dele ficam marcados como concluídos, mas você não ganha o XP
+              das aulas. Se fizer as aulas de verdade depois, o XP delas volta a contar.
+            </p>
+            <div className="cmn-card__row">
+              <button className="btn btn--ghost" onClick={() => setConfirmando(null)}>
+                Cancelar
+              </button>
+              <button className="btn btn--accent" onClick={confirmarConclusao} disabled={concluindo}>
+                {concluindo ? 'Concluindo...' : 'Concluir mesmo assim'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/services/comunicados.ts
+++ b/frontend/src/services/comunicados.ts
@@ -1,0 +1,76 @@
+import api from './api';
+
+export type ComunicadoKind = 'aviso' | 'pesquisa';
+
+export interface ComunicadoAtivo {
+  id: string;
+  kind: ComunicadoKind;
+  title: string;
+  message: string;
+}
+
+export async function obterComunicadoAtivo() {
+  const { data } = await api.get<ComunicadoAtivo | null>('/comunicados/ativo');
+  return data;
+}
+
+export async function responderComunicado(id: string, rating: number, comment?: string) {
+  const { data } = await api.post(`/comunicados/${id}/responder`, {
+    rating,
+    comment: comment || undefined,
+  });
+  return data;
+}
+
+export async function dispensarComunicado(id: string) {
+  const { data } = await api.post(`/comunicados/${id}/dispensar`);
+  return data;
+}
+
+export interface ComunicadoResumo {
+  id: string;
+  kind: ComunicadoKind;
+  title: string;
+  message: string;
+  published: boolean;
+  createdAt: string;
+  respondidos: number;
+  dispensados: number;
+  media: number | null;
+}
+
+export interface ComunicadoResultados extends ComunicadoResumo {
+  distribuicao: { rating: number; count: number }[];
+  respostas: { name: string; rating: number | null; comment: string | null; createdAt: string }[];
+}
+
+export interface ComunicadoPayload {
+  kind: ComunicadoKind;
+  title: string;
+  message: string;
+  published?: boolean;
+}
+
+export async function adminListarComunicados() {
+  const { data } = await api.get<ComunicadoResumo[]>('/studio/comunicados');
+  return data;
+}
+
+export async function adminResultadosComunicado(id: string) {
+  const { data } = await api.get<ComunicadoResultados>(`/studio/comunicados/${id}`);
+  return data;
+}
+
+export async function adminCriarComunicado(payload: ComunicadoPayload) {
+  const { data } = await api.post('/comunicados', payload);
+  return data;
+}
+
+export async function adminAtualizarComunicado(id: string, payload: Partial<ComunicadoPayload>) {
+  const { data } = await api.patch(`/comunicados/${id}`, payload);
+  return data;
+}
+
+export async function adminExcluirComunicado(id: string) {
+  await api.delete(`/comunicados/${id}`);
+}

--- a/frontend/src/services/roadmaps.ts
+++ b/frontend/src/services/roadmaps.ts
@@ -66,6 +66,11 @@ export async function obterRoadmap(slug: string) {
 
 // ===================== ADMIN (estúdio) =====================
 
+export async function concluirEstagio(stageId: string) {
+  const { data } = await api.post(`/roadmap-stages/${stageId}/concluir`);
+  return data;
+}
+
 export type RefType = RoadmapRef['refType'];
 
 export interface RoadmapAdminItem {

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -4841,17 +4841,23 @@
 }
 
 /* ===== Comunicados (prompt flutuante e admin) ===== */
-.cmn-card {
+.cmn-overlay {
   position: fixed;
-  right: 20px;
-  bottom: 20px;
+  inset: 0;
   z-index: 300;
-  width: min(372px, calc(100vw - 32px));
+  background: rgba(8, 12, 24, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+}
+.cmn-card {
+  width: min(430px, 100%);
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 16px;
-  padding: 18px;
-  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.3);
+  padding: 22px;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.35);
 }
 .cmn-card__kicker {
   font-size: 11.5px;
@@ -4948,4 +4954,10 @@
   color: var(--muted);
   font-size: 12px;
   margin-bottom: 3px;
+}
+
+.rmd-stage__acoes {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
 }

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -4839,3 +4839,113 @@
 .rmadm-refadd select {
   flex: 1;
 }
+
+/* ===== Comunicados (prompt flutuante e admin) ===== */
+.cmn-card {
+  position: fixed;
+  right: 20px;
+  bottom: 20px;
+  z-index: 300;
+  width: min(372px, calc(100vw - 32px));
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 18px;
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.3);
+}
+.cmn-card__kicker {
+  font-size: 11.5px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 6px;
+}
+.cmn-card__title {
+  font-size: 15.5px;
+  font-weight: 700;
+  margin: 0 0 6px;
+}
+.cmn-card__msg {
+  font-size: 13.5px;
+  color: var(--muted);
+  line-height: 1.5;
+  margin: 0 0 12px;
+  white-space: pre-wrap;
+}
+.cmn-card__row {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+.cmn-notas {
+  display: flex;
+  gap: 8px;
+  margin: 2px 0 12px;
+}
+.cmn-nota {
+  width: 42px;
+  height: 42px;
+  border-radius: 10px;
+  border: 1.5px solid var(--border-strong);
+  background: var(--surface-2);
+  color: var(--text);
+  font-family: inherit;
+  font-size: 15px;
+  font-weight: 700;
+  cursor: pointer;
+}
+.cmn-nota--on {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+.cmn-texto {
+  width: 100%;
+  border: 1px solid var(--border-strong);
+  border-radius: 10px;
+  background: var(--surface-2);
+  color: var(--text);
+  font-family: inherit;
+  font-size: 13.5px;
+  padding: 10px 12px;
+  resize: vertical;
+  margin-bottom: 12px;
+}
+.cmn-dist {
+  display: grid;
+  gap: 5px;
+  margin: 10px 0;
+}
+.cmn-dist__row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12.5px;
+}
+.cmn-dist__track {
+  flex: 1;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--surface-2);
+  overflow: hidden;
+}
+.cmn-dist__track span {
+  display: block;
+  height: 100%;
+  background: var(--accent);
+  border-radius: 999px;
+}
+.cmn-resposta {
+  border-top: 1px solid var(--border);
+  padding: 10px 0;
+  font-size: 13px;
+}
+.cmn-resposta__meta {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  color: var(--muted);
+  font-size: 12px;
+  margin-bottom: 3px;
+}


### PR DESCRIPTION
## O que muda

Duas frentes, testadas juntas no local.

### 1. Comunicados do admin para os usuários

O admin lança comunicados pelo estúdio (aba nova **Comunicados**): **aviso** (mensagem com botão "Entendi") ou **pesquisa** (nota de 1 a 5 + comentário opcional). O usuário vê um **modal central** com fundo escurecido assim que entra, começando pelo convite ("Topa responder um questionário rápido?"); quem dispensa não é perguntado de novo naquele comunicado, e o modal não aparece no meio de aula, simulado ou desafio. O estúdio mostra os resultados: respostas, dispensas, média, distribuição das notas e comentários com nome e data.

- Tabelas `comunicados` e `comunicado_respostas` (migração 0033, resposta única por usuário/comunicado)
- Rotas de aluno (`ativo`, `responder`, `dispensar`) e de admin (CRUD + resultados)
- Card global `ComunicadoPrompt` + página `ComunicadosAdmin`

### 2. Roadmap: estágios destravados e conclusão manual sem XP

Os estágios à frente deixam de bloquear: aparecem como **"A seguir"**, clicáveis, com **"Começar estágio"** e **"Concluído"** (mesma filosofia da navegação livre das aulas). O "Concluído" abre um modal avisando que concluir sem fazer as aulas **não dá o XP** delas.

Ao confirmar: o estágio é marcado e **as trilhas/módulos do estágio ficam concluídos nas outras telas também** (card a 100%, aulas com check, roadmap derivando) via progresso com marca `manual`, que conta para o progresso mas fica **fora do XP, do ranking e do feed de atividades**. Se a pessoa depois passar no quiz de uma aula marcada, a marca vira progresso real e o XP daquela aula passa a contar.

- Migrações 0034 (`roadmap_stage_completions`) e 0035 (coluna `manual` em `lessons_progress`)
- `POST /roadmap-stages/:id/concluir`

## Testes

9 testes de integração novos (7 de comunicados + 2 de roadmap, incluindo: trilha a 100% com XP zero após concluir, e XP recuperado ao fazer a aula de verdade). Suíte completa: **61/61**. `tsc` e build do front limpos. Validado manualmente no ambiente local (fluxo completo de pesquisa nas duas contas e conclusão manual com destravamento).

## Deploy

As migrações 0033-0035 aplicam no deploy. Sem seed: o primeiro comunicado é criado pelo próprio estúdio (Estúdio > Comunicados).
