### PR TITLE
feat: certificado de conclusão de trilha com validação pública

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -37,6 +37,9 @@ jobs:
       NODE_ENV: test
       FRONTEND_URL: http://localhost:5173
       DB_SSL: "false"
+      CERT_RAZAO_SOCIAL: Ensina Dev Treinamentos
+      CERT_CNPJ: 00.000.000/0001-00
+      CERT_RESPONSAVEL: Joao Paulo Avelino
     defaults:
       run:
         working-directory: backend

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -9,3 +9,7 @@ JWT_SECRET=uma_chave_bem_longa_e_aleatoria_troque_isso_depois
 # SMTP_USER=
 # SMTP_PASS=
 # EMAIL_FROM=ensina.dev <nao-responda@ensinadev.com.br>
+# Certificados: dados do emissor impressos no documento. Sem os três, a emissão fica desligada.
+CERT_RAZAO_SOCIAL=
+CERT_CNPJ=
+CERT_RESPONSAVEL=

--- a/backend/app.ts
+++ b/backend/app.ts
@@ -9,6 +9,7 @@ import desafioRoutes from "./src/routes/desafio.routes.ts";
 import adminRoutes from "./src/routes/admin.routes.ts";
 import roadmapRoutes from "./src/routes/roadmap.routes.ts";
 import comunicadoRoutes from "./src/routes/comunicado.routes.ts";
+import certificateRoutes from "./src/routes/certificate.routes.ts";
 import { errorMiddleware } from "./src/middlewares/error.ts";
 import { apiLimiter } from "./src/middlewares/rateLimit.ts";
 import helmet from "helmet";
@@ -52,6 +53,7 @@ app.use(simuladoRoutes);
 app.use(desafioRoutes);
 app.use(roadmapRoutes);
 app.use(comunicadoRoutes);
+app.use(certificateRoutes);
 app.use(adminRoutes);
 
 app.get("/health", (_req, res) => res.json({ status: "ok" }));

--- a/backend/drizzle/0036_mean_paladin.sql
+++ b/backend/drizzle/0036_mean_paladin.sql
@@ -1,0 +1,20 @@
+CREATE TABLE "certificates" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"code" varchar(20) NOT NULL,
+	"user_id" uuid NOT NULL,
+	"trail_id" uuid NOT NULL,
+	"student_name" varchar(255) NOT NULL,
+	"cpf" varchar(11) NOT NULL,
+	"trail_name" varchar(255) NOT NULL,
+	"workload_hours" integer NOT NULL,
+	"language" varchar(40),
+	"started_at" timestamp with time zone NOT NULL,
+	"completed_at" timestamp with time zone NOT NULL,
+	"issued_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "certificates_code_unique" UNIQUE("code"),
+	CONSTRAINT "certificates_user_id_trail_id_unique" UNIQUE("user_id","trail_id")
+);
+--> statement-breakpoint
+ALTER TABLE "trails" ADD COLUMN "workload_hours" integer;--> statement-breakpoint
+ALTER TABLE "certificates" ADD CONSTRAINT "certificates_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "certificates" ADD CONSTRAINT "certificates_trail_id_trails_id_fk" FOREIGN KEY ("trail_id") REFERENCES "public"."trails"("id") ON DELETE no action ON UPDATE no action;

--- a/backend/drizzle/meta/0036_snapshot.json
+++ b/backend/drizzle/meta/0036_snapshot.json
@@ -1,0 +1,2825 @@
+{
+  "id": "dcc718aa-6ded-4b3c-b07d-9a9519c4aa7a",
+  "prevId": "2aa82346-442c-47d1-9017-2accde5e2303",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.achievements": {
+      "name": "achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "criteria_type": {
+          "name": "criteria_type",
+          "type": "achievement_criteria",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "achievements_name_unique": {
+          "name": "achievements_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.certificates": {
+      "name": "certificates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_name": {
+          "name": "student_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpf": {
+          "name": "cpf",
+          "type": "varchar(11)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trail_name": {
+          "name": "trail_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workload_hours": {
+          "name": "workload_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "certificates_user_id_users_id_fk": {
+          "name": "certificates_user_id_users_id_fk",
+          "tableFrom": "certificates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "certificates_trail_id_trails_id_fk": {
+          "name": "certificates_trail_id_trails_id_fk",
+          "tableFrom": "certificates",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "certificates_code_unique": {
+          "name": "certificates_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        },
+        "certificates_user_id_trail_id_unique": {
+          "name": "certificates_user_id_trail_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "trail_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge_submissions": {
+      "name": "challenge_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "challenge_language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "challenge_submission_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "passed_count": {
+          "name": "passed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_count": {
+          "name": "total_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xp_earned": {
+          "name": "xp_earned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "challenge_submissions_user_id_users_id_fk": {
+          "name": "challenge_submissions_user_id_users_id_fk",
+          "tableFrom": "challenge_submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "challenge_submissions_challenge_id_challenges_id_fk": {
+          "name": "challenge_submissions_challenge_id_challenges_id_fk",
+          "tableFrom": "challenge_submissions",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge_tests": {
+      "name": "challenge_tests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_output": {
+          "name": "expected_output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "challenge_tests_challenge_id_challenges_id_fk": {
+          "name": "challenge_tests_challenge_id_challenges_id_fk",
+          "tableFrom": "challenge_tests",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenges": {
+      "name": "challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "challenge_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stdin'"
+        },
+        "entry_point": {
+          "name": "entry_point",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_blocks": {
+          "name": "statement_blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "question_difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'facil'"
+        },
+        "starter_code": {
+          "name": "starter_code",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_date": {
+          "name": "active_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "challenges_number_unique": {
+          "name": "challenges_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "number"
+          ]
+        },
+        "challenges_active_date_unique": {
+          "name": "challenges_active_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "active_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comunicado_respostas": {
+      "name": "comunicado_respostas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "comunicado_id": {
+          "name": "comunicado_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "comunicado_resposta_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comunicado_respostas_comunicado_id_comunicados_id_fk": {
+          "name": "comunicado_respostas_comunicado_id_comunicados_id_fk",
+          "tableFrom": "comunicado_respostas",
+          "tableTo": "comunicados",
+          "columnsFrom": [
+            "comunicado_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "comunicado_respostas_user_id_users_id_fk": {
+          "name": "comunicado_respostas_user_id_users_id_fk",
+          "tableFrom": "comunicado_respostas",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "comunicado_respostas_comunicado_id_user_id_unique": {
+          "name": "comunicado_respostas_comunicado_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "comunicado_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comunicados": {
+      "name": "comunicados",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "comunicado_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.glossary": {
+      "name": "glossary",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "term": {
+          "name": "term",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "varchar(400)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "glossary_term_unique": {
+          "name": "glossary_term_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "term"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.languages": {
+      "name": "languages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "languages_name_unique": {
+          "name": "languages_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons_progress": {
+      "name": "lessons_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "manual": {
+          "name": "manual",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_progress_user_id_users_id_fk": {
+          "name": "lessons_progress_user_id_users_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_progress_lesson_id_lessons_id_fk": {
+          "name": "lessons_progress_lesson_id_lessons_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lessons_progress_user_id_lesson_id_unique": {
+          "name": "lessons_progress_user_id_lesson_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "lesson_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons": {
+      "name": "lessons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_blocks": {
+          "name": "content_blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "duration_min": {
+          "name": "duration_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview": {
+          "name": "preview",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_trail_id_trails_id_fk": {
+          "name": "lessons_trail_id_trails_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_module_id_modules_id_fk": {
+          "name": "lessons_module_id_modules_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "modules",
+          "columnsFrom": [
+            "module_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.modules": {
+      "name": "modules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "modules_trail_id_trails_id_fk": {
+          "name": "modules_trail_id_trails_id_fk",
+          "tableFrom": "modules",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_accounts": {
+      "name": "oauth_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_accounts_user_id_users_id_fk": {
+          "name": "oauth_accounts_user_id_users_id_fk",
+          "tableFrom": "oauth_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_accounts_provider_provider_id_unique": {
+          "name": "oauth_accounts_provider_provider_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "provider_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_answers": {
+      "name": "question_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_option_id": {
+          "name": "selected_option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_answers_user_id_users_id_fk": {
+          "name": "question_answers_user_id_users_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_question_id_questions_id_fk": {
+          "name": "question_answers_question_id_questions_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_selected_option_id_question_options_id_fk": {
+          "name": "question_answers_selected_option_id_question_options_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "question_options",
+          "columnsFrom": [
+            "selected_option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "question_answers_user_id_question_id_unique": {
+          "name": "question_answers_user_id_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_options": {
+      "name": "question_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_options_question_id_questions_id_fk": {
+          "name": "question_options_question_id_questions_id_fk",
+          "tableFrom": "question_options",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "question_difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'facil'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_lesson_id_lessons_id_fk": {
+          "name": "questions_lesson_id_lessons_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ranking_snapshots": {
+      "name": "ranking_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ranking_snapshots_user_id_users_id_fk": {
+          "name": "ranking_snapshots_user_id_users_id_fk",
+          "tableFrom": "ranking_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ranking_snapshots_user_id_snapshot_date_unique": {
+          "name": "ranking_snapshots_user_id_snapshot_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "snapshot_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmap_stage_completions": {
+      "name": "roadmap_stage_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "roadmap_stage_completions_user_id_users_id_fk": {
+          "name": "roadmap_stage_completions_user_id_users_id_fk",
+          "tableFrom": "roadmap_stage_completions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "roadmap_stage_completions_stage_id_roadmap_stages_id_fk": {
+          "name": "roadmap_stage_completions_stage_id_roadmap_stages_id_fk",
+          "tableFrom": "roadmap_stage_completions",
+          "tableTo": "roadmap_stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roadmap_stage_completions_user_id_stage_id_unique": {
+          "name": "roadmap_stage_completions_user_id_stage_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "stage_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmap_stage_refs": {
+      "name": "roadmap_stage_refs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_type": {
+          "name": "ref_type",
+          "type": "roadmap_ref_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "roadmap_stage_refs_stage_id_roadmap_stages_id_fk": {
+          "name": "roadmap_stage_refs_stage_id_roadmap_stages_id_fk",
+          "tableFrom": "roadmap_stage_refs",
+          "tableTo": "roadmap_stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmap_stages": {
+      "name": "roadmap_stages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "roadmap_id": {
+          "name": "roadmap_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "roadmap_phase",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "roadmap_stages_roadmap_id_roadmaps_id_fk": {
+          "name": "roadmap_stages_roadmap_id_roadmaps_id_fk",
+          "tableFrom": "roadmap_stages",
+          "tableTo": "roadmaps",
+          "columnsFrom": [
+            "roadmap_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmaps": {
+      "name": "roadmaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "trail_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "premium": {
+          "name": "premium",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roadmaps_slug_unique": {
+          "name": "roadmaps_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_attempt_answers": {
+      "name": "simulado_attempt_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_attempt_answers_attempt_id_simulado_attempts_id_fk": {
+          "name": "simulado_attempt_answers_attempt_id_simulado_attempts_id_fk",
+          "tableFrom": "simulado_attempt_answers",
+          "tableTo": "simulado_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempt_answers_question_id_simulado_questions_id_fk": {
+          "name": "simulado_attempt_answers_question_id_simulado_questions_id_fk",
+          "tableFrom": "simulado_attempt_answers",
+          "tableTo": "simulado_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempt_answers_option_id_simulado_options_id_fk": {
+          "name": "simulado_attempt_answers_option_id_simulado_options_id_fk",
+          "tableFrom": "simulado_attempt_answers",
+          "tableTo": "simulado_options",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulado_attempt_answers_attempt_id_question_id_option_id_unique": {
+          "name": "simulado_attempt_answers_attempt_id_question_id_option_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "attempt_id",
+            "question_id",
+            "option_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_attempt_questions": {
+      "name": "simulado_attempt_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_attempt_questions_attempt_id_simulado_attempts_id_fk": {
+          "name": "simulado_attempt_questions_attempt_id_simulado_attempts_id_fk",
+          "tableFrom": "simulado_attempt_questions",
+          "tableTo": "simulado_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempt_questions_question_id_simulado_questions_id_fk": {
+          "name": "simulado_attempt_questions_question_id_simulado_questions_id_fk",
+          "tableFrom": "simulado_attempt_questions",
+          "tableTo": "simulado_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulado_attempt_questions_attempt_id_question_id_unique": {
+          "name": "simulado_attempt_questions_attempt_id_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "attempt_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_attempts": {
+      "name": "simulado_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "simulado_id": {
+          "name": "simulado_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passed": {
+          "name": "passed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_attempts_user_id_users_id_fk": {
+          "name": "simulado_attempts_user_id_users_id_fk",
+          "tableFrom": "simulado_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempts_simulado_id_simulados_id_fk": {
+          "name": "simulado_attempts_simulado_id_simulados_id_fk",
+          "tableFrom": "simulado_attempts",
+          "tableTo": "simulados",
+          "columnsFrom": [
+            "simulado_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_options": {
+      "name": "simulado_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_options_question_id_simulado_questions_id_fk": {
+          "name": "simulado_options_question_id_simulado_questions_id_fk",
+          "tableFrom": "simulado_options",
+          "tableTo": "simulado_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_questions": {
+      "name": "simulado_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "simulado_id": {
+          "name": "simulado_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_questions_simulado_id_simulados_id_fk": {
+          "name": "simulado_questions_simulado_id_simulados_id_fk",
+          "tableFrom": "simulado_questions",
+          "tableTo": "simulados",
+          "columnsFrom": [
+            "simulado_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulados": {
+      "name": "simulados",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_count": {
+          "name": "question_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pass_percent": {
+          "name": "pass_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulados_slug_unique": {
+          "name": "simulados_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tokens": {
+      "name": "tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'refresh'"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tokens_user_id_users_id_fk": {
+          "name": "tokens_user_id_users_id_fk",
+          "tableFrom": "tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tokens_token_hash_unique": {
+          "name": "tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_reviews": {
+      "name": "trail_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stars": {
+          "name": "stars",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "trail_reviews_trail_id_trails_id_fk": {
+          "name": "trail_reviews_trail_id_trails_id_fk",
+          "tableFrom": "trail_reviews",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trail_reviews_user_id_users_id_fk": {
+          "name": "trail_reviews_user_id_users_id_fk",
+          "tableFrom": "trail_reviews",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trail_reviews_user_id_trail_id_unique": {
+          "name": "trail_reviews_user_id_trail_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "trail_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_tags": {
+      "name": "trail_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "trail_tags_trail_id_trails_id_fk": {
+          "name": "trail_tags_trail_id_trails_id_fk",
+          "tableFrom": "trail_tags",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trail_tags_tag_id_tags_id_fk": {
+          "name": "trail_tags_tag_id_tags_id_fk",
+          "tableFrom": "trail_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trail_tags_trail_id_tag_id_unique": {
+          "name": "trail_tags_trail_id_tag_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trail_id",
+            "tag_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trails": {
+      "name": "trails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "trail_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "what_you_learn": {
+          "name": "what_you_learn",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prerequisites": {
+          "name": "prerequisites",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workload_hours": {
+          "name": "workload_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_achievements": {
+      "name": "user_achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "achievement_id": {
+          "name": "achievement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_achievements_user_id_users_id_fk": {
+          "name": "user_achievements_user_id_users_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_achievements_achievement_id_achievements_id_fk": {
+          "name": "user_achievements_achievement_id_achievements_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "achievements",
+          "columnsFrom": [
+            "achievement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_achievements_user_id_achievement_id_unique": {
+          "name": "user_achievements_user_id_achievement_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "achievement_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username_changed_at": {
+          "name": "username_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occupation": {
+          "name": "occupation",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github": {
+          "name": "github",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin": {
+          "name": "linkedin",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "failed_login_attempts": {
+          "name": "failed_login_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.achievement_criteria": {
+      "name": "achievement_criteria",
+      "schema": "public",
+      "values": [
+        "xp_total",
+        "lessons_completed",
+        "questions_correct",
+        "special"
+      ]
+    },
+    "public.challenge_kind": {
+      "name": "challenge_kind",
+      "schema": "public",
+      "values": [
+        "stdin",
+        "function"
+      ]
+    },
+    "public.challenge_language": {
+      "name": "challenge_language",
+      "schema": "public",
+      "values": [
+        "javascript",
+        "python",
+        "csharp",
+        "java"
+      ]
+    },
+    "public.challenge_submission_status": {
+      "name": "challenge_submission_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "passed",
+        "failed",
+        "error",
+        "timeout"
+      ]
+    },
+    "public.comunicado_kind": {
+      "name": "comunicado_kind",
+      "schema": "public",
+      "values": [
+        "aviso",
+        "pesquisa"
+      ]
+    },
+    "public.comunicado_resposta_status": {
+      "name": "comunicado_resposta_status",
+      "schema": "public",
+      "values": [
+        "respondido",
+        "dispensado"
+      ]
+    },
+    "public.question_difficulty": {
+      "name": "question_difficulty",
+      "schema": "public",
+      "values": [
+        "facil",
+        "medio",
+        "dificil"
+      ]
+    },
+    "public.roadmap_phase": {
+      "name": "roadmap_phase",
+      "schema": "public",
+      "values": [
+        "fundamentos",
+        "core",
+        "avancado",
+        "deploy"
+      ]
+    },
+    "public.roadmap_ref_type": {
+      "name": "roadmap_ref_type",
+      "schema": "public",
+      "values": [
+        "trail",
+        "module",
+        "lesson",
+        "simulado",
+        "challenge"
+      ]
+    },
+    "public.trail_level": {
+      "name": "trail_level",
+      "schema": "public",
+      "values": [
+        "iniciante",
+        "intermediario",
+        "avancado"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin",
+        "moderator"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1784761401654,
       "tag": "0035_round_brother_voodoo",
       "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "7",
+      "when": 1784764588869,
+      "tag": "0036_mean_paladin",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -20,7 +20,9 @@
                 "helmet": "^8.2.0",
                 "jsonwebtoken": "^9.0.3",
                 "nodemailer": "^9.0.3",
+                "pdfkit": "^0.19.1",
                 "pg": "^8.21.0",
+                "qrcode": "^1.5.4",
                 "zod": "^4.4.3"
             },
             "devDependencies": {
@@ -30,7 +32,9 @@
                 "@types/jsonwebtoken": "^9.0.10",
                 "@types/node": "^26.0.1",
                 "@types/nodemailer": "^8.0.1",
+                "@types/pdfkit": "^0.17.6",
                 "@types/pg": "^8.20.0",
+                "@types/qrcode": "^1.5.6",
                 "drizzle-kit": "^0.31.10",
                 "eslint": "^10.6.0",
                 "eslint-config-prettier": "^10.1.8",
@@ -1119,6 +1123,39 @@
                 "url": "https://github.com/sponsors/nzakas"
             }
         },
+        "node_modules/@noble/ciphers": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+            "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+            "license": "MIT",
+            "engines": {
+                "node": "^14.21.3 || >=16"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/@noble/hashes": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+            "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+            "license": "MIT",
+            "engines": {
+                "node": "^14.21.3 || >=16"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/@swc/helpers": {
+            "version": "0.5.23",
+            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+            "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.8.0"
+            }
+        },
         "node_modules/@types/bcrypt": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-6.0.0.tgz",
@@ -1253,6 +1290,16 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/pdfkit": {
+            "version": "0.17.6",
+            "resolved": "https://registry.npmjs.org/@types/pdfkit/-/pdfkit-0.17.6.tgz",
+            "integrity": "sha512-tIwzxk2uWKp0Cq9JIluQXJid77lYhF52EsIOwhsMF4iWLA6YneoBR1xVKYYdAysHuepUB0OX4tdwMiUDdGKmig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
         "node_modules/@types/pg": {
             "version": "8.20.0",
             "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
@@ -1263,6 +1310,16 @@
                 "@types/node": "*",
                 "pg-protocol": "*",
                 "pg-types": "^2.2.0"
+            }
+        },
+        "node_modules/@types/qrcode": {
+            "version": "1.5.6",
+            "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+            "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
             }
         },
         "node_modules/@types/qs": {
@@ -1579,6 +1636,30 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
+        "node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
         "node_modules/balanced-match": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -1588,6 +1669,26 @@
             "engines": {
                 "node": "18 || 20 || >=22"
             }
+        },
+        "node_modules/base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/bcrypt": {
             "version": "6.0.0",
@@ -1653,6 +1754,24 @@
                 "node": "18 || 20 || >=22"
             }
         },
+        "node_modules/brotli": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+            "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+            "license": "MIT",
+            "dependencies": {
+                "base64-js": "^1.1.2"
+            }
+        },
+        "node_modules/browserify-zlib": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+            "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+            "license": "MIT",
+            "dependencies": {
+                "pako": "~1.0.5"
+            }
+        },
         "node_modules/buffer-equal-constant-time": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -1703,6 +1822,53 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/camelcase": {
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+            "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/cliui": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+            "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0",
+                "wrap-ansi": "^6.2.0"
+            }
+        },
+        "node_modules/clone": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+            "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
+        "node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "license": "MIT"
         },
         "node_modules/content-disposition": {
             "version": "1.1.0",
@@ -1812,6 +1978,15 @@
                 }
             }
         },
+        "node_modules/decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/deep-is": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -1827,6 +2002,18 @@
             "engines": {
                 "node": ">= 0.8"
             }
+        },
+        "node_modules/dfa": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+            "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+            "license": "MIT"
+        },
+        "node_modules/dijkstrajs": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+            "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+            "license": "MIT"
         },
         "node_modules/drizzle-kit": {
             "version": "0.31.10",
@@ -1996,6 +2183,12 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
             "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+            "license": "MIT"
+        },
+        "node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "license": "MIT"
         },
         "node_modules/encodeurl": {
@@ -2344,7 +2537,6 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-json-stable-stringify": {
@@ -2451,6 +2643,23 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/fontkit": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+            "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+            "license": "MIT",
+            "dependencies": {
+                "@swc/helpers": "^0.5.12",
+                "brotli": "^1.3.2",
+                "clone": "^2.1.2",
+                "dfa": "^1.2.0",
+                "fast-deep-equal": "^3.1.3",
+                "restructure": "^3.0.0",
+                "tiny-inflate": "^1.0.3",
+                "unicode-properties": "^1.4.0",
+                "unicode-trie": "^2.0.0"
+            }
+        },
         "node_modules/forwarded": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -2491,6 +2700,15 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-caller-file": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+            "license": "ISC",
+            "engines": {
+                "node": "6.* || 8.* || >= 10.*"
             }
         },
         "node_modules/get-intrinsic": {
@@ -2707,6 +2925,15 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/is-glob": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -2732,6 +2959,12 @@
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/js-md5": {
+            "version": "0.8.3",
+            "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.8.3.tgz",
+            "integrity": "sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==",
+            "license": "MIT"
         },
         "node_modules/json-buffer": {
             "version": "3.0.1",
@@ -2819,6 +3052,25 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/linebreak": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+            "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+            "license": "MIT",
+            "dependencies": {
+                "base64-js": "0.0.8",
+                "unicode-trie": "^2.0.0"
+            }
+        },
+        "node_modules/linebreak/node_modules/base64-js": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+            "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/locate-path": {
@@ -3093,6 +3345,21 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/p-try": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/pako": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+            "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+            "license": "(MIT AND Zlib)"
+        },
         "node_modules/parseurl": {
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -3106,7 +3373,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
             "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -3130,6 +3396,20 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/pdfkit": {
+            "version": "0.19.1",
+            "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.19.1.tgz",
+            "integrity": "sha512-6Gzk+wDwTs4VSxsR5rCMTnIl5nlmkye1oWB0l2hDB1EX6ZNSIBroKQEv+2+fPPn+stVjyqzmsqRJVDfB9fo5DA==",
+            "license": "MIT",
+            "dependencies": {
+                "@noble/ciphers": "^1.0.0",
+                "@noble/hashes": "^1.6.0",
+                "fontkit": "^2.0.4",
+                "js-md5": "^0.8.3",
+                "linebreak": "^1.1.0",
+                "png-js": "^1.1.0"
             }
         },
         "node_modules/pg": {
@@ -3234,6 +3514,23 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
+        "node_modules/png-js": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.1.0.tgz",
+            "integrity": "sha512-PM/uYGzGdNSzqeOgly68+6wKQDL1SY0a/N+OEa/+br6LnHWOAJB0Npiamnodfq3jd2LS/i2fMeOKSAILjA+m5Q==",
+            "dependencies": {
+                "browserify-zlib": "^0.2.0"
+            }
+        },
+        "node_modules/pngjs": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+            "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
         "node_modules/postgres-array": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
@@ -3322,6 +3619,23 @@
                 "node": ">=6"
             }
         },
+        "node_modules/qrcode": {
+            "version": "1.5.4",
+            "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+            "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+            "license": "MIT",
+            "dependencies": {
+                "dijkstrajs": "^1.0.1",
+                "pngjs": "^5.0.0",
+                "yargs": "^15.3.1"
+            },
+            "bin": {
+                "qrcode": "bin/qrcode"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
         "node_modules/qs": {
             "version": "6.15.2",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
@@ -3361,6 +3675,21 @@
                 "node": ">= 0.10"
             }
         },
+        "node_modules/require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/require-main-filename": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+            "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+            "license": "ISC"
+        },
         "node_modules/resolve-pkg-maps": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -3370,6 +3699,12 @@
             "funding": {
                 "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
             }
+        },
+        "node_modules/restructure": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+            "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+            "license": "MIT"
         },
         "node_modules/router": {
             "version": "2.2.0",
@@ -3469,6 +3804,12 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/express"
             }
+        },
+        "node_modules/set-blocking": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+            "license": "ISC"
         },
         "node_modules/setprototypeof": {
             "version": "1.2.0",
@@ -3610,6 +3951,38 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/tiny-inflate": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+            "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+            "license": "MIT"
+        },
         "node_modules/tinyglobby": {
             "version": "0.2.17",
             "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -3648,6 +4021,12 @@
             "peerDependencies": {
                 "typescript": ">=4.8.4"
             }
+        },
+        "node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "license": "0BSD"
         },
         "node_modules/tsx": {
             "version": "4.22.4",
@@ -4240,6 +4619,32 @@
             "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
             "license": "MIT"
         },
+        "node_modules/unicode-properties": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+            "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+            "license": "MIT",
+            "dependencies": {
+                "base64-js": "^1.3.0",
+                "unicode-trie": "^2.0.0"
+            }
+        },
+        "node_modules/unicode-trie": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+            "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+            "license": "MIT",
+            "dependencies": {
+                "pako": "^0.2.5",
+                "tiny-inflate": "^1.0.0"
+            }
+        },
+        "node_modules/unicode-trie/node_modules/pako": {
+            "version": "0.2.9",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+            "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+            "license": "MIT"
+        },
         "node_modules/unpipe": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -4284,6 +4689,12 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/which-module": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+            "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+            "license": "ISC"
+        },
         "node_modules/word-wrap": {
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -4292,6 +4703,20 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/wrap-ansi": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+            "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/wrappy": {
@@ -4307,6 +4732,99 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.4"
+            }
+        },
+        "node_modules/y18n": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+            "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+            "license": "ISC"
+        },
+        "node_modules/yargs": {
+            "version": "15.4.1",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+            "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^6.0.0",
+                "decamelize": "^1.2.0",
+                "find-up": "^4.1.0",
+                "get-caller-file": "^2.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^2.0.0",
+                "set-blocking": "^2.0.0",
+                "string-width": "^4.2.0",
+                "which-module": "^2.0.0",
+                "y18n": "^4.0.0",
+                "yargs-parser": "^18.1.2"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/yargs-parser": {
+            "version": "18.1.3",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+            "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+            "license": "ISC",
+            "dependencies": {
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/yargs/node_modules/find-up": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+            "license": "MIT",
+            "dependencies": {
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/yargs/node_modules/locate-path": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+            "license": "MIT",
+            "dependencies": {
+                "p-locate": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/yargs/node_modules/p-limit": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+            "license": "MIT",
+            "dependencies": {
+                "p-try": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/yargs/node_modules/p-locate": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+            "license": "MIT",
+            "dependencies": {
+                "p-limit": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/yocto-queue": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -27,7 +27,9 @@
         "helmet": "^8.2.0",
         "jsonwebtoken": "^9.0.3",
         "nodemailer": "^9.0.3",
+        "pdfkit": "^0.19.1",
         "pg": "^8.21.0",
+        "qrcode": "^1.5.4",
         "zod": "^4.4.3"
     },
     "devDependencies": {
@@ -37,7 +39,9 @@
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^26.0.1",
         "@types/nodemailer": "^8.0.1",
+        "@types/pdfkit": "^0.17.6",
         "@types/pg": "^8.20.0",
+        "@types/qrcode": "^1.5.6",
         "drizzle-kit": "^0.31.10",
         "eslint": "^10.6.0",
         "eslint-config-prettier": "^10.1.8",

--- a/backend/schema.ts
+++ b/backend/schema.ts
@@ -97,6 +97,8 @@ export const trails = pgTable("trails", {
     description: text("description").notNull(),
     whatYouLearn: jsonb("what_you_learn").$type<string[]>(),
     prerequisites: jsonb("prerequisites").$type<string[]>(),
+    // Carga horária declarada no certificado. Sem ela a trilha não emite certificado.
+    workloadHours: integer("workload_hours"),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
 });
 
@@ -529,4 +531,29 @@ export const roadmapStageCompletions = pgTable(
         createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
     },
     (table) => [unique().on(table.userId, table.stageId)],
+);
+
+// Certificado de conclusão de trilha. Os dados são congelados na emissão:
+// o documento não muda se a trilha ou o nome do usuário mudarem depois.
+export const certificates = pgTable(
+    "certificates",
+    {
+        id: uuid("id").primaryKey().defaultRandom(),
+        code: varchar("code", { length: 20 }).notNull().unique(),
+        userId: uuid("user_id")
+            .references(() => users.id)
+            .notNull(),
+        trailId: uuid("trail_id")
+            .references(() => trails.id)
+            .notNull(),
+        studentName: varchar("student_name", { length: 255 }).notNull(),
+        cpf: varchar("cpf", { length: 11 }).notNull(),
+        trailName: varchar("trail_name", { length: 255 }).notNull(),
+        workloadHours: integer("workload_hours").notNull(),
+        language: varchar("language", { length: 40 }),
+        startedAt: timestamp("started_at", { withTimezone: true }).notNull(),
+        completedAt: timestamp("completed_at", { withTimezone: true }).notNull(),
+        issuedAt: timestamp("issued_at", { withTimezone: true }).defaultNow().notNull(),
+    },
+    (table) => [unique().on(table.userId, table.trailId)],
 );

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -30,6 +30,10 @@ const envSchema = z.object({
         .optional()
         .transform((v) => v === "true"),
     EMAIL_FROM: z.string().default("ensina.dev <nao-responda@ensinadev.com.br>"),
+    // Dados do emissor impressos no certificado. Sem os três, a emissão fica desligada.
+    CERT_RAZAO_SOCIAL: z.string().optional(),
+    CERT_CNPJ: z.string().optional(),
+    CERT_RESPONSAVEL: z.string().optional(),
 });
 
 // Valida os dados e lança erro se tiver algo errado.

--- a/backend/src/controllers/CertificateController.ts
+++ b/backend/src/controllers/CertificateController.ts
@@ -17,8 +17,8 @@ export const getCertificateStatus = async (req: Request, res: Response, next: Ne
 
 export const issueCertificate = async (req: Request, res: Response, next: NextFunction) => {
     try {
-        const { cpf } = emitirCertificadoSchema.parse(req.body);
-        const cert = await emitirCertificado(String(req.params.id), req.userId!, cpf);
+        const { cpf, name } = emitirCertificadoSchema.parse(req.body);
+        const cert = await emitirCertificado(String(req.params.id), req.userId!, cpf, name);
         res.json({ code: cert.code, issuedAt: cert.issuedAt });
     } catch (err) {
         next(err);
@@ -35,7 +35,7 @@ export const validateCertificate = async (req: Request, res: Response, next: Nex
 
 export const downloadCertificate = async (req: Request, res: Response, next: NextFunction) => {
     try {
-        const { doc, filename } = await pdfCertificado(String(req.params.code));
+        const { doc, filename } = await pdfCertificado(String(req.params.code), req.userId!);
         res.setHeader("Content-Type", "application/pdf");
         res.setHeader("Content-Disposition", `inline; filename="${filename}"`);
         doc.pipe(res);

--- a/backend/src/controllers/CertificateController.ts
+++ b/backend/src/controllers/CertificateController.ts
@@ -1,0 +1,45 @@
+import type { Request, Response, NextFunction } from "express";
+import { emitirCertificadoSchema } from "../schemas/certificate.schema.ts";
+import {
+    statusCertificado,
+    emitirCertificado,
+    validarCertificado,
+    pdfCertificado,
+} from "../services/certificate.service.ts";
+
+export const getCertificateStatus = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        res.json(await statusCertificado(String(req.params.id), req.userId!));
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const issueCertificate = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const { cpf } = emitirCertificadoSchema.parse(req.body);
+        const cert = await emitirCertificado(String(req.params.id), req.userId!, cpf);
+        res.json({ code: cert.code, issuedAt: cert.issuedAt });
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const validateCertificate = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        res.json(await validarCertificado(String(req.params.code)));
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const downloadCertificate = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const { doc, filename } = await pdfCertificado(String(req.params.code));
+        res.setHeader("Content-Type", "application/pdf");
+        res.setHeader("Content-Disposition", `inline; filename="${filename}"`);
+        doc.pipe(res);
+    } catch (err) {
+        next(err);
+    }
+};

--- a/backend/src/routes/certificate.routes.ts
+++ b/backend/src/routes/certificate.routes.ts
@@ -14,6 +14,7 @@ router.post("/trails/:id/certificado", autenticar, issueCertificate);
 
 // Validação pública: é o link do QR Code que a faculdade confere, sem login.
 router.get("/certificados/:code", validateCertificate);
-router.get("/certificados/:code/pdf", downloadCertificate);
+// O PDF tem o CPF completo, então só o dono baixa.
+router.get("/certificados/:code/pdf", autenticar, downloadCertificate);
 
 export default router;

--- a/backend/src/routes/certificate.routes.ts
+++ b/backend/src/routes/certificate.routes.ts
@@ -1,0 +1,19 @@
+import { Router } from "express";
+import { autenticar } from "../middlewares/auth.ts";
+import {
+    getCertificateStatus,
+    issueCertificate,
+    validateCertificate,
+    downloadCertificate,
+} from "../controllers/CertificateController.ts";
+
+const router = Router();
+
+router.get("/trails/:id/certificado", autenticar, getCertificateStatus);
+router.post("/trails/:id/certificado", autenticar, issueCertificate);
+
+// Validação pública: é o link do QR Code que a faculdade confere, sem login.
+router.get("/certificados/:code", validateCertificate);
+router.get("/certificados/:code/pdf", downloadCertificate);
+
+export default router;

--- a/backend/src/schemas/certificate.schema.ts
+++ b/backend/src/schemas/certificate.schema.ts
@@ -14,6 +14,12 @@ function cpfValido(cpf: string) {
 }
 
 export const emitirCertificadoSchema = z.object({
+    name: z
+        .string()
+        .transform((v) => v.trim().replace(/\s+/g, " "))
+        .refine((v) => v.length >= 5 && v.length <= 255 && v.split(" ").length >= 2, {
+            message: "Informe o nome completo",
+        }),
     cpf: z
         .string()
         .transform((v) => v.replace(/\D/g, ""))

--- a/backend/src/schemas/certificate.schema.ts
+++ b/backend/src/schemas/certificate.schema.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+function cpfValido(cpf: string) {
+    if (!/^\d{11}$/.test(cpf) || /^(\d)\1{10}$/.test(cpf)) return false;
+    for (const tamanho of [9, 10]) {
+        let soma = 0;
+        for (let i = 0; i < tamanho; i++) {
+            soma += Number(cpf[i]) * (tamanho + 1 - i);
+        }
+        const digito = ((soma * 10) % 11) % 10;
+        if (digito !== Number(cpf[tamanho])) return false;
+    }
+    return true;
+}
+
+export const emitirCertificadoSchema = z.object({
+    cpf: z
+        .string()
+        .transform((v) => v.replace(/\D/g, ""))
+        .refine(cpfValido, "CPF inválido"),
+});

--- a/backend/src/schemas/trail.schemas.ts
+++ b/backend/src/schemas/trail.schemas.ts
@@ -5,6 +5,7 @@ export const createTrailSchema = z.object({
     level: z.enum(["iniciante", "intermediario", "avancado"]),
     description: z.string().min(10, "A descrição deve ter ao menos 10 caracteres"),
     tagIds: z.array(z.uuid()).optional(),
+    workloadHours: z.number().int().min(1).max(999).nullable().optional(),
 });
 
 export const updateTrailSchema = z.object({
@@ -12,6 +13,7 @@ export const updateTrailSchema = z.object({
     level: z.enum(["iniciante", "intermediario", "avancado"]).optional(),
     description: z.string().min(10, "A descrição deve ter ao menos 10 caracteres").optional(),
     tagIds: z.array(z.uuid()).optional(),
+    workloadHours: z.number().int().min(1).max(999).nullable().optional(),
 });
 
 export const reviewTrailSchema = z.object({

--- a/backend/src/services/certificate.service.ts
+++ b/backend/src/services/certificate.service.ts
@@ -128,7 +128,7 @@ export async function statusCertificado(trailId: string, userId: string) {
     return { emitido: null, elegivel: true };
 }
 
-export async function emitirCertificado(trailId: string, userId: string, cpf: string) {
+export async function emitirCertificado(trailId: string, userId: string, cpf: string, name: string) {
     const [trilha] = await db.select().from(trails).where(eq(trails.id, trailId));
     if (!trilha) {
         throw new AppError(404, "Trilha não encontrada");
@@ -140,27 +140,12 @@ export async function emitirCertificado(trailId: string, userId: string, cpf: st
         throw new AppError(409, "Esta trilha ainda não emite certificado.");
     }
 
-    const [usuarioAtual] = await db
-        .select({ name: users.name })
-        .from(users)
-        .where(eq(users.id, userId));
-
+    // Depois de emitido o documento é imutável: nem CPF nem nome mudam, mesmo repetindo o pedido.
     const [existente] = await db
         .select()
         .from(certificates)
         .where(and(eq(certificates.userId, userId), eq(certificates.trailId, trailId)));
-    if (existente) {
-        if (existente.cpf === cpf && existente.studentName === usuarioAtual.name) {
-            return existente;
-        }
-        // Correção de CPF ou de nome: reemite mantendo o código, para o QR já impresso seguir válido.
-        const [corrigido] = await db
-            .update(certificates)
-            .set({ cpf, studentName: usuarioAtual.name, issuedAt: new Date() })
-            .where(eq(certificates.id, existente.id))
-            .returning();
-        return corrigido;
-    }
+    if (existente) return existente;
 
     const conclusao = await conclusaoReal(trailId, userId);
     if (!conclusao) {
@@ -180,7 +165,7 @@ export async function emitirCertificado(trailId: string, userId: string, cpf: st
                 code: gerarCodigo(),
                 userId,
                 trailId,
-                studentName: usuarioAtual.name,
+                studentName: name,
                 cpf,
                 trailName: trilha.name,
                 workloadHours: trilha.workloadHours,
@@ -229,10 +214,13 @@ const TINTA = "#1f2430";
 const ACENTO = "#4f46e5";
 const CINZA = "#6b7280";
 
-export async function pdfCertificado(code: string) {
+export async function pdfCertificado(code: string, userId: string) {
     const [cert] = await db.select().from(certificates).where(eq(certificates.code, code));
     if (!cert) {
         throw new AppError(404, "Certificado não encontrado");
+    }
+    if (cert.userId !== userId) {
+        throw new AppError(403, "Só o dono do certificado pode baixar o PDF.");
     }
 
     const mods = await db

--- a/backend/src/services/certificate.service.ts
+++ b/backend/src/services/certificate.service.ts
@@ -278,12 +278,12 @@ export async function pdfCertificado(code: string) {
     );
 
     const yBase = H - 150;
-    doc.moveTo(120, yBase + 42).lineTo(340, yBase + 42).lineWidth(0.8).strokeColor(TINTA).stroke();
+    doc.moveTo(100, yBase + 42).lineTo(370, yBase + 42).lineWidth(0.8).strokeColor(TINTA).stroke();
     doc.font("Helvetica-Bold").fontSize(11).fillColor(TINTA);
-    doc.text(env.CERT_RESPONSAVEL ?? "", 120, yBase + 48, { width: 220, align: "center" });
-    doc.font("Helvetica").fontSize(9).fillColor(CINZA);
-    doc.text(env.CERT_RAZAO_SOCIAL ?? "", 120, yBase + 62, { width: 220, align: "center" });
-    doc.text(`CNPJ ${env.CERT_CNPJ ?? ""}`, 120, yBase + 74, { width: 220, align: "center" });
+    doc.text(env.CERT_RESPONSAVEL ?? "", 100, yBase + 48, { width: 270, align: "center" });
+    doc.font("Helvetica").fontSize(8.5).fillColor(CINZA);
+    doc.text(env.CERT_RAZAO_SOCIAL ?? "", 100, doc.y + 3, { width: 270, align: "center" });
+    doc.text(`CNPJ ${env.CERT_CNPJ ?? ""}`, 100, doc.y + 2, { width: 270, align: "center" });
 
     doc.image(qr, W - 210, yBase - 4, { width: 84 });
     doc.font("Helvetica-Bold").fontSize(9).fillColor(TINTA);

--- a/backend/src/services/certificate.service.ts
+++ b/backend/src/services/certificate.service.ts
@@ -140,11 +140,27 @@ export async function emitirCertificado(trailId: string, userId: string, cpf: st
         throw new AppError(409, "Esta trilha ainda não emite certificado.");
     }
 
+    const [usuarioAtual] = await db
+        .select({ name: users.name })
+        .from(users)
+        .where(eq(users.id, userId));
+
     const [existente] = await db
         .select()
         .from(certificates)
         .where(and(eq(certificates.userId, userId), eq(certificates.trailId, trailId)));
-    if (existente) return existente;
+    if (existente) {
+        if (existente.cpf === cpf && existente.studentName === usuarioAtual.name) {
+            return existente;
+        }
+        // Correção de CPF ou de nome: reemite mantendo o código, para o QR já impresso seguir válido.
+        const [corrigido] = await db
+            .update(certificates)
+            .set({ cpf, studentName: usuarioAtual.name, issuedAt: new Date() })
+            .where(eq(certificates.id, existente.id))
+            .returning();
+        return corrigido;
+    }
 
     const conclusao = await conclusaoReal(trailId, userId);
     if (!conclusao) {
@@ -157,11 +173,6 @@ export async function emitirCertificado(trailId: string, userId: string, cpf: st
         throw new AppError(409, "Conclua todas as aulas da trilha para emitir o certificado.");
     }
 
-    const [usuario] = await db
-        .select({ name: users.name })
-        .from(users)
-        .where(eq(users.id, userId));
-
     for (let tentativa = 0; tentativa < 5; tentativa++) {
         const [criado] = await db
             .insert(certificates)
@@ -169,7 +180,7 @@ export async function emitirCertificado(trailId: string, userId: string, cpf: st
                 code: gerarCodigo(),
                 userId,
                 trailId,
-                studentName: usuario.name,
+                studentName: usuarioAtual.name,
                 cpf,
                 trailName: trilha.name,
                 workloadHours: trilha.workloadHours,

--- a/backend/src/services/certificate.service.ts
+++ b/backend/src/services/certificate.service.ts
@@ -1,0 +1,361 @@
+import crypto from "node:crypto";
+import PDFDocument from "pdfkit";
+import QRCode from "qrcode";
+import { and, asc, eq, inArray } from "drizzle-orm";
+import { db } from "../../db.ts";
+import { certificates, lessonProgress, lessons, modules, trails, users } from "../../schema.ts";
+import { AppError } from "../errors/AppError.ts";
+import { env } from "../config/env.ts";
+
+const LANG_LABEL: Record<string, string> = { javascript: "JavaScript", python: "Python" };
+
+function emissorConfigurado() {
+    return Boolean(env.CERT_RAZAO_SOCIAL && env.CERT_CNPJ && env.CERT_RESPONSAVEL);
+}
+
+function formatarCpf(cpf: string) {
+    return `${cpf.slice(0, 3)}.${cpf.slice(3, 6)}.${cpf.slice(6, 9)}-${cpf.slice(9)}`;
+}
+
+function mascararCpf(cpf: string) {
+    return `***.${cpf.slice(3, 6)}.${cpf.slice(6, 9)}-**`;
+}
+
+// Sem 0/O/1/I/L para o código poder ser ditado por telefone sem ambiguidade.
+const ALFABETO_CODIGO = "23456789ABCDEFGHJKMNPQRSTUVWXYZ";
+function gerarCodigo() {
+    const bytes = crypto.randomBytes(12);
+    let s = "";
+    for (let i = 0; i < 12; i++) {
+        s += ALFABETO_CODIGO[bytes[i] % ALFABETO_CODIGO.length];
+    }
+    return `ED-${s.slice(0, 4)}-${s.slice(4, 8)}-${s.slice(8)}`;
+}
+
+type ConclusaoReal = { language: string | null; startedAt: Date; completedAt: Date };
+
+// Conclusão de verdade: todas as aulas publicadas (neutras + um track completo) sem a marca manual.
+async function conclusaoReal(trailId: string, userId: string): Promise<ConclusaoReal | null> {
+    const aulas = await db
+        .select({ id: lessons.id, language: lessons.language })
+        .from(lessons)
+        .where(and(eq(lessons.trailId, trailId), eq(lessons.published, true)));
+    if (aulas.length === 0) return null;
+
+    const progresso = await db
+        .select({ lessonId: lessonProgress.lessonId, completedAt: lessonProgress.completedAt })
+        .from(lessonProgress)
+        .where(
+            and(
+                eq(lessonProgress.userId, userId),
+                eq(lessonProgress.manual, false),
+                inArray(
+                    lessonProgress.lessonId,
+                    aulas.map((a) => a.id),
+                ),
+            ),
+        );
+    const feitas = new Map(progresso.map((p) => [p.lessonId, p.completedAt]));
+
+    const neutras = aulas.filter((a) => a.language === null);
+    if (!neutras.every((a) => feitas.has(a.id))) return null;
+
+    const languages = [...new Set(aulas.map((a) => a.language).filter((l): l is string => !!l))];
+    let track: string | null = null;
+    if (languages.length > 0) {
+        track =
+            languages.find((l) =>
+                aulas.filter((a) => a.language === l).every((a) => feitas.has(a.id)),
+            ) ?? null;
+        if (!track) return null;
+    }
+
+    const consideradas = aulas.filter((a) => a.language === null || a.language === track);
+    const datas = consideradas
+        .map((a) => feitas.get(a.id))
+        .filter((d): d is Date => d instanceof Date)
+        .map((d) => d.getTime());
+    return {
+        language: track,
+        startedAt: new Date(Math.min(...datas)),
+        completedAt: new Date(Math.max(...datas)),
+    };
+}
+
+async function temSoConclusaoManual(trailId: string, userId: string) {
+    const aulas = await db
+        .select({ id: lessons.id })
+        .from(lessons)
+        .where(and(eq(lessons.trailId, trailId), eq(lessons.published, true)));
+    if (aulas.length === 0) return false;
+    const total = await db
+        .select({ lessonId: lessonProgress.lessonId })
+        .from(lessonProgress)
+        .where(
+            and(
+                eq(lessonProgress.userId, userId),
+                inArray(
+                    lessonProgress.lessonId,
+                    aulas.map((a) => a.id),
+                ),
+            ),
+        );
+    return total.length === aulas.length;
+}
+
+export async function statusCertificado(trailId: string, userId: string) {
+    const [trilha] = await db.select().from(trails).where(eq(trails.id, trailId));
+    if (!trilha) {
+        throw new AppError(404, "Trilha não encontrada");
+    }
+
+    const [existente] = await db
+        .select({ code: certificates.code, issuedAt: certificates.issuedAt })
+        .from(certificates)
+        .where(and(eq(certificates.userId, userId), eq(certificates.trailId, trailId)));
+    if (existente) {
+        return { emitido: existente, elegivel: false };
+    }
+
+    if (!emissorConfigurado()) return { emitido: null, elegivel: false, motivo: "indisponivel" };
+    if (!trilha.workloadHours) return { emitido: null, elegivel: false, motivo: "carga_horaria" };
+
+    const conclusao = await conclusaoReal(trailId, userId);
+    if (!conclusao) {
+        const motivo = (await temSoConclusaoManual(trailId, userId)) ? "manual" : "progresso";
+        return { emitido: null, elegivel: false, motivo };
+    }
+    return { emitido: null, elegivel: true };
+}
+
+export async function emitirCertificado(trailId: string, userId: string, cpf: string) {
+    const [trilha] = await db.select().from(trails).where(eq(trails.id, trailId));
+    if (!trilha) {
+        throw new AppError(404, "Trilha não encontrada");
+    }
+    if (!emissorConfigurado()) {
+        throw new AppError(503, "A emissão de certificados ainda não está disponível.");
+    }
+    if (!trilha.workloadHours) {
+        throw new AppError(409, "Esta trilha ainda não emite certificado.");
+    }
+
+    const [existente] = await db
+        .select()
+        .from(certificates)
+        .where(and(eq(certificates.userId, userId), eq(certificates.trailId, trailId)));
+    if (existente) return existente;
+
+    const conclusao = await conclusaoReal(trailId, userId);
+    if (!conclusao) {
+        if (await temSoConclusaoManual(trailId, userId)) {
+            throw new AppError(
+                409,
+                "O certificado só sai com as aulas concluídas de verdade, passando nos quizzes.",
+            );
+        }
+        throw new AppError(409, "Conclua todas as aulas da trilha para emitir o certificado.");
+    }
+
+    const [usuario] = await db
+        .select({ name: users.name })
+        .from(users)
+        .where(eq(users.id, userId));
+
+    for (let tentativa = 0; tentativa < 5; tentativa++) {
+        const [criado] = await db
+            .insert(certificates)
+            .values({
+                code: gerarCodigo(),
+                userId,
+                trailId,
+                studentName: usuario.name,
+                cpf,
+                trailName: trilha.name,
+                workloadHours: trilha.workloadHours,
+                language: conclusao.language,
+                startedAt: conclusao.startedAt,
+                completedAt: conclusao.completedAt,
+            })
+            .onConflictDoNothing({ target: certificates.code })
+            .returning();
+        if (criado) return criado;
+        // Corrida na unique (userId, trailId): outra requisição emitiu antes.
+        const [corrida] = await db
+            .select()
+            .from(certificates)
+            .where(and(eq(certificates.userId, userId), eq(certificates.trailId, trailId)));
+        if (corrida) return corrida;
+    }
+    throw new AppError(500, "Não foi possível gerar o código do certificado.");
+}
+
+export async function validarCertificado(code: string) {
+    const [cert] = await db.select().from(certificates).where(eq(certificates.code, code));
+    if (!cert) {
+        throw new AppError(404, "Certificado não encontrado");
+    }
+    return {
+        code: cert.code,
+        studentName: cert.studentName,
+        cpf: mascararCpf(cert.cpf),
+        trailName: cert.trailName,
+        language: cert.language ? (LANG_LABEL[cert.language] ?? cert.language) : null,
+        workloadHours: cert.workloadHours,
+        startedAt: cert.startedAt,
+        completedAt: cert.completedAt,
+        issuedAt: cert.issuedAt,
+    };
+}
+
+const dataLonga = new Intl.DateTimeFormat("pt-BR", {
+    dateStyle: "long",
+    timeZone: "America/Sao_Paulo",
+});
+const dataCurta = new Intl.DateTimeFormat("pt-BR", { timeZone: "America/Sao_Paulo" });
+
+const TINTA = "#1f2430";
+const ACENTO = "#4f46e5";
+const CINZA = "#6b7280";
+
+export async function pdfCertificado(code: string) {
+    const [cert] = await db.select().from(certificates).where(eq(certificates.code, code));
+    if (!cert) {
+        throw new AppError(404, "Certificado não encontrado");
+    }
+
+    const mods = await db
+        .select({ id: modules.id, title: modules.title })
+        .from(modules)
+        .where(eq(modules.trailId, cert.trailId))
+        .orderBy(asc(modules.position));
+    const aulas = await db
+        .select({ moduleId: lessons.moduleId, title: lessons.title, language: lessons.language })
+        .from(lessons)
+        .where(and(eq(lessons.trailId, cert.trailId), eq(lessons.published, true)))
+        .orderBy(asc(lessons.position));
+    const doTrack = aulas.filter((a) => a.language === null || a.language === cert.language);
+
+    const urlValidacao = `${env.FRONTEND_URL}/certificados/${cert.code}`;
+    const qr = await QRCode.toBuffer(urlValidacao, { type: "png", margin: 1, width: 220 });
+
+    const doc = new PDFDocument({ size: "A4", layout: "landscape", margin: 0 });
+    const W = doc.page.width;
+    const H = doc.page.height;
+
+    // ---- Frente ----
+    doc.rect(0, 0, W, H).fill("#ffffff");
+    doc.lineWidth(2).strokeColor(ACENTO).rect(24, 24, W - 48, H - 48).stroke();
+    doc.lineWidth(0.7).strokeColor(CINZA).rect(30, 30, W - 60, H - 60).stroke();
+
+    doc.font("Helvetica-Bold").fontSize(20).fillColor(ACENTO);
+    doc.text("ensina.dev", 0, 64, { width: W, align: "center" });
+    doc.font("Helvetica").fontSize(11).fillColor(CINZA);
+    doc.text("CERTIFICADO DE CONCLUSÃO", 0, 92, {
+        width: W,
+        align: "center",
+        characterSpacing: 3,
+    });
+
+    doc.fontSize(12).fillColor(TINTA);
+    doc.text("Certificamos que", 0, 200, { width: W, align: "center" });
+    doc.font("Helvetica-Bold").fontSize(28);
+    doc.text(cert.studentName, 60, 224, { width: W - 120, align: "center" });
+    doc.font("Helvetica").fontSize(10).fillColor(CINZA);
+    doc.text(`CPF ${formatarCpf(cert.cpf)}`, 0, doc.y + 4, { width: W, align: "center" });
+
+    const linguagem = cert.language
+        ? ` na linguagem ${LANG_LABEL[cert.language] ?? cert.language}`
+        : "";
+    doc.fontSize(13).fillColor(TINTA);
+    doc.text(
+        `concluiu o curso livre ${cert.trailName}${linguagem}, na modalidade a distância, ` +
+            `com carga horária de ${cert.workloadHours} horas, realizado no período de ` +
+            `${dataCurta.format(cert.startedAt)} a ${dataCurta.format(cert.completedAt)}.`,
+        130,
+        doc.y + 22,
+        { width: W - 260, align: "center", lineGap: 4 },
+    );
+
+    const yBase = H - 150;
+    doc.moveTo(120, yBase + 42).lineTo(340, yBase + 42).lineWidth(0.8).strokeColor(TINTA).stroke();
+    doc.font("Helvetica-Bold").fontSize(11).fillColor(TINTA);
+    doc.text(env.CERT_RESPONSAVEL ?? "", 120, yBase + 48, { width: 220, align: "center" });
+    doc.font("Helvetica").fontSize(9).fillColor(CINZA);
+    doc.text(env.CERT_RAZAO_SOCIAL ?? "", 120, yBase + 62, { width: 220, align: "center" });
+    doc.text(`CNPJ ${env.CERT_CNPJ ?? ""}`, 120, yBase + 74, { width: 220, align: "center" });
+
+    doc.image(qr, W - 210, yBase - 4, { width: 84 });
+    doc.font("Helvetica-Bold").fontSize(9).fillColor(TINTA);
+    doc.text(cert.code, W - 226, yBase + 84, { width: 116, align: "center" });
+    doc.font("Helvetica").fontSize(7.5).fillColor(CINZA);
+    doc.text("Valide a autenticidade em", W - 226, yBase + 96, { width: 116, align: "center" });
+    doc.text(`${env.FRONTEND_URL.replace(/^https?:\/\//, "")}/certificados`, W - 246, yBase + 106, {
+        width: 156,
+        align: "center",
+    });
+
+    doc.fontSize(9).fillColor(CINZA);
+    doc.text(`Emitido em ${dataLonga.format(cert.issuedAt)}.`, 0, H - 52, {
+        width: W,
+        align: "center",
+    });
+
+    // ---- Verso: conteúdo programático ----
+    doc.addPage({ size: "A4", layout: "landscape", margin: 0 });
+    doc.lineWidth(0.7).strokeColor(CINZA).rect(30, 30, W - 60, H - 60).stroke();
+    doc.font("Helvetica-Bold").fontSize(14).fillColor(TINTA);
+    doc.text("Conteúdo programático", 0, 52, { width: W, align: "center" });
+    doc.font("Helvetica").fontSize(10).fillColor(CINZA);
+    doc.text(`${cert.trailName} · ${cert.workloadHours} horas · ${cert.code}`, 0, 72, {
+        width: W,
+        align: "center",
+    });
+
+    const colunas = [
+        { x: 60, y: 104 },
+        { x: W / 2 + 20, y: 104 },
+    ];
+    const larguraCol = W / 2 - 90;
+    const limiteY = H - 56;
+    let col = 0;
+    const medir = (texto: string, fonte: string, tamanho: number) => {
+        doc.font(fonte).fontSize(tamanho);
+        return doc.heightOfString(texto, { width: larguraCol });
+    };
+    const avancarSePreciso = (alturaNecessaria: number) => {
+        if (colunas[col].y + alturaNecessaria <= limiteY) return;
+        if (col === 0) {
+            col = 1;
+        } else {
+            doc.addPage({ size: "A4", layout: "landscape", margin: 0 });
+            doc.lineWidth(0.7).strokeColor(CINZA).rect(30, 30, W - 60, H - 60).stroke();
+            col = 0;
+            colunas[0] = { x: 60, y: 56 };
+            colunas[1] = { x: W / 2 + 20, y: 56 };
+        }
+    };
+    const escrever = (texto: string, fonte: string, tamanho: number, cor: string, gap: number) => {
+        const altura = medir(texto, fonte, tamanho);
+        avancarSePreciso(altura);
+        doc.font(fonte).fontSize(tamanho).fillColor(cor);
+        doc.text(texto, colunas[col].x, colunas[col].y, { width: larguraCol });
+        colunas[col].y += altura + gap;
+    };
+    for (const m of mods) {
+        const doModulo = doTrack.filter((a) => a.moduleId === m.id);
+        if (doModulo.length === 0) continue;
+        // O título do módulo nunca fica sozinho no pé da coluna: desce junto com a 1ª aula.
+        avancarSePreciso(
+            medir(m.title, "Helvetica-Bold", 10) + 3 + medir(`•  ${doModulo[0].title}`, "Helvetica", 9),
+        );
+        escrever(m.title, "Helvetica-Bold", 10, TINTA, 3);
+        for (const a of doModulo) {
+            escrever(`•  ${a.title}`, "Helvetica", 9, "#374151", 2);
+        }
+        colunas[col].y += 6;
+    }
+
+    doc.end();
+    return { doc, filename: `certificado-${cert.code}.pdf` };
+}

--- a/backend/src/services/certificate.service.ts
+++ b/backend/src/services/certificate.service.ts
@@ -249,7 +249,7 @@ export async function pdfCertificado(code: string) {
     doc.lineWidth(0.7).strokeColor(CINZA).rect(30, 30, W - 60, H - 60).stroke();
 
     doc.font("Helvetica-Bold").fontSize(20).fillColor(ACENTO);
-    doc.text("ensina.dev", 0, 64, { width: W, align: "center" });
+    doc.text("Ensina Dev", 0, 64, { width: W, align: "center" });
     doc.font("Helvetica").fontSize(11).fillColor(CINZA);
     doc.text("CERTIFICADO DE CONCLUSÃO", 0, 92, {
         width: W,

--- a/backend/src/services/trail.service.ts
+++ b/backend/src/services/trail.service.ts
@@ -162,44 +162,82 @@ export async function listarTrilhas(filtros: { level?: string; categoria?: strin
 }
 
 // Trilhas em que o usuário já tem progresso, com percentual de conclusão.
+// Em trilha multi-linguagem o percentual é do melhor track (neutras + uma linguagem),
+// a mesma régua da conclusão no roadmap e no certificado.
 export async function trilhasDoUsuario(userId: string) {
-    const totais = await db
-        .select({ trailId: lessons.trailId, total: count(lessons.id) })
+    const aulas = await db
+        .select({ id: lessons.id, trailId: lessons.trailId, language: lessons.language })
         .from(lessons)
-        .groupBy(lessons.trailId);
-    const totalPorTrilha = new Map(totais.map((t) => [t.trailId, Number(t.total)]));
+        .where(eq(lessons.published, true));
+    const feitas = new Set(
+        (
+            await db
+                .select({ lessonId: lessonProgress.lessonId })
+                .from(lessonProgress)
+                .where(eq(lessonProgress.userId, userId))
+        ).map((p) => p.lessonId),
+    );
 
-    const feitas = await db
-        .select({ trailId: lessons.trailId, feitas: count(lessonProgress.id) })
-        .from(lessonProgress)
-        .innerJoin(lessons, eq(lessons.id, lessonProgress.lessonId))
-        .where(eq(lessonProgress.userId, userId))
-        .groupBy(lessons.trailId);
-
-    if (feitas.length === 0) {
-        return [];
+    const porTrilha = new Map<string, { neutras: string[]; porLang: Map<string, string[]> }>();
+    for (const a of aulas) {
+        const grupo = porTrilha.get(a.trailId) ?? {
+            neutras: [] as string[],
+            porLang: new Map<string, string[]>(),
+        };
+        if (a.language === null) {
+            grupo.neutras.push(a.id);
+        } else {
+            const arr = grupo.porLang.get(a.language) ?? [];
+            arr.push(a.id);
+            grupo.porLang.set(a.language, arr);
+        }
+        porTrilha.set(a.trailId, grupo);
     }
 
     const todasTrilhas = await db.select().from(trails);
-    const trilhaPorId = new Map(todasTrilhas.map((t) => [t.id, t]));
+    const concluidasEm = (ids: string[]) => ids.filter((id) => feitas.has(id)).length;
 
-    return feitas
-        .filter((f) => trilhaPorId.has(f.trailId))
-        .map((f) => {
-            const trilha = trilhaPorId.get(f.trailId)!;
-            const total = totalPorTrilha.get(f.trailId) ?? 0;
-            const concluidas = Number(f.feitas);
-            const pct = total > 0 ? Math.round((concluidas / total) * 100) : 0;
-            return {
-                id: trilha.id,
-                name: trilha.name,
-                trailLevel: trilha.trailLevel,
-                description: trilha.description,
-                totalLessons: total,
-                completedLessons: concluidas,
-                progress: pct,
-            };
+    const saida: {
+        id: string;
+        name: string;
+        trailLevel: "iniciante" | "intermediario" | "avancado";
+        description: string;
+        totalLessons: number;
+        completedLessons: number;
+        progress: number;
+    }[] = [];
+    for (const trilha of todasTrilhas) {
+        const grupo = porTrilha.get(trilha.id);
+        if (!grupo) continue;
+
+        let total = grupo.neutras.length;
+        let concluidas = concluidasEm(grupo.neutras);
+        if (grupo.porLang.size > 0) {
+            let melhor = { total: 0, concluidas: 0, pct: -1 };
+            for (const ids of grupo.porLang.values()) {
+                const t = grupo.neutras.length + ids.length;
+                const c = concluidasEm(grupo.neutras) + concluidasEm(ids);
+                const pct = t > 0 ? c / t : 0;
+                if (pct > melhor.pct || (pct === melhor.pct && c > melhor.concluidas)) {
+                    melhor = { total: t, concluidas: c, pct };
+                }
+            }
+            total = melhor.total;
+            concluidas = melhor.concluidas;
+        }
+        if (concluidas === 0) continue;
+
+        saida.push({
+            id: trilha.id,
+            name: trilha.name,
+            trailLevel: trilha.trailLevel,
+            description: trilha.description,
+            totalLessons: total,
+            completedLessons: concluidas,
+            progress: total > 0 ? Math.round((concluidas / total) * 100) : 0,
         });
+    }
+    return saida;
 }
 
 // Retorna a trilha com módulos e aulas, cada aula com estado para o usuário.

--- a/backend/src/services/trail.service.ts
+++ b/backend/src/services/trail.service.ts
@@ -31,6 +31,7 @@ export async function criarTrilha(dados: DadosCriarTrilha) {
             name: dados.name,
             trailLevel: dados.level,
             description: dados.description,
+            workloadHours: dados.workloadHours ?? null,
         })
         .returning();
     if (dados.tagIds?.length) {
@@ -48,10 +49,12 @@ export async function atualizarTrilha(trailId: string, dados: DadosAtualizarTril
         name?: string;
         trailLevel?: "iniciante" | "intermediario" | "avancado";
         description?: string;
+        workloadHours?: number | null;
     } = {};
     if (dados.name !== undefined) sets.name = dados.name;
     if (dados.level !== undefined) sets.trailLevel = dados.level;
     if (dados.description !== undefined) sets.description = dados.description;
+    if (dados.workloadHours !== undefined) sets.workloadHours = dados.workloadHours;
     if (Object.keys(sets).length === 0) {
         throw new AppError(400, "Nada para atualizar");
     }
@@ -61,6 +64,7 @@ export async function atualizarTrilha(trailId: string, dados: DadosAtualizarTril
         name: trails.name,
         trailLevel: trails.trailLevel,
         description: trails.description,
+        workloadHours: trails.workloadHours,
     });
     if (!trilha) {
         throw new AppError(404, "Trilha não encontrada");

--- a/backend/src/services/trail.service.ts
+++ b/backend/src/services/trail.service.ts
@@ -141,12 +141,29 @@ export async function listarTrilhas(filtros: { level?: string; categoria?: strin
             name: trails.name,
             trailLevel: trails.trailLevel,
             description: trails.description,
-            totalLessons: count(lessons.id),
+            workloadHours: trails.workloadHours,
         })
         .from(trails)
-        .leftJoin(lessons, eq(lessons.trailId, trails.id))
-        .where(and(filtroNivel, filtroCategoria))
-        .groupBy(trails.id);
+        .where(and(filtroNivel, filtroCategoria));
+
+    // Total que um aluno de fato cursa: aulas publicadas, neutras + a maior linguagem.
+    const aulasPublicadas = await db
+        .select({ trailId: lessons.trailId, language: lessons.language })
+        .from(lessons)
+        .where(eq(lessons.published, true));
+    const contagem = new Map<string, { neutras: number; porLang: Map<string, number> }>();
+    for (const a of aulasPublicadas) {
+        const c = contagem.get(a.trailId) ?? { neutras: 0, porLang: new Map<string, number>() };
+        if (a.language === null) c.neutras++;
+        else c.porLang.set(a.language, (c.porLang.get(a.language) ?? 0) + 1);
+        contagem.set(a.trailId, c);
+    }
+    const totalDe = (trailId: string) => {
+        const c = contagem.get(trailId);
+        if (!c) return 0;
+        const maior = c.porLang.size > 0 ? Math.max(...c.porLang.values()) : 0;
+        return c.neutras + maior;
+    };
 
     const vinculos = await db
         .select({ trailId: trailTags.trailId, id: tags.id, name: tags.name })
@@ -158,7 +175,11 @@ export async function listarTrilhas(filtros: { level?: string; categoria?: strin
         arr.push({ id: v.id, name: v.name });
         tagsPorTrilha.set(v.trailId, arr);
     }
-    return lista.map((t) => ({ ...t, tags: tagsPorTrilha.get(t.id) ?? [] }));
+    return lista.map((t) => ({
+        ...t,
+        totalLessons: totalDe(t.id),
+        tags: tagsPorTrilha.get(t.id) ?? [],
+    }));
 }
 
 // Trilhas em que o usuário já tem progresso, com percentual de conclusão.

--- a/backend/tests/certificado.test.ts
+++ b/backend/tests/certificado.test.ts
@@ -1,0 +1,256 @@
+import { test, describe, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { startTestServer } from "./helpers/server.ts";
+import { limparBanco } from "./helpers/db.ts";
+
+let server: Awaited<ReturnType<typeof startTestServer>>;
+
+let seq = 0;
+const novoUsuario = () => ({
+    name: "Aluno Certificado",
+    email: `cert_${++seq}_${Math.round(performance.now() * 1000)}@email.com`,
+    username: `cert_${seq}`,
+    password: "Senhaforte123!",
+    birthDate: "1990-01-01",
+    gender: "outro",
+    phone: "11999998888",
+});
+
+async function ajustarUsuario(email: string, campos: Record<string, unknown>) {
+    const { db } = await import("../db.ts");
+    const { users } = await import("../schema.ts");
+    const { eq } = await import("drizzle-orm");
+    await db.update(users).set(campos).where(eq(users.email, email));
+}
+
+async function criarUsuarioLogado(admin = false) {
+    const dados = novoUsuario();
+    await server.request("POST", "/register", { body: dados });
+    await ajustarUsuario(dados.email, {
+        emailVerifiedAt: new Date(),
+        ...(admin ? { role: "admin" } : {}),
+    });
+    const login = await server.request("POST", "/login", {
+        body: { email: dados.email, password: dados.password },
+    });
+    return { email: dados.email, token: login.body.token };
+}
+
+function auth(token: string) {
+    return { Authorization: `Bearer ${token}` };
+}
+async function get(path: string, token?: string) {
+    const res = await fetch(`${server.base}${path}`, { headers: token ? auth(token) : {} });
+    return { status: res.status, body: await res.json().catch(() => null) };
+}
+async function post(path: string, token: string, body?: unknown) {
+    const res = await fetch(`${server.base}${path}`, {
+        method: "POST",
+        headers: { ...auth(token), "Content-Type": "application/json" },
+        body: body ? JSON.stringify(body) : undefined,
+    });
+    return { status: res.status, body: await res.json().catch(() => null) };
+}
+async function patch(path: string, token: string, body?: unknown) {
+    const res = await fetch(`${server.base}${path}`, {
+        method: "PATCH",
+        headers: { ...auth(token), "Content-Type": "application/json" },
+        body: body ? JSON.stringify(body) : undefined,
+    });
+    return { status: res.status, body: await res.json().catch(() => null) };
+}
+
+const CPF_VALIDO = "52998224725";
+
+async function montarTrilha(adminToken: string, opts: { horas?: number | null } = {}) {
+    const trilha = await post("/trails", adminToken, {
+        name: "Logica",
+        level: "iniciante",
+        description: "Base da programacao logica.",
+        ...(opts.horas !== null ? { workloadHours: opts.horas ?? 20 } : {}),
+    });
+    const modulo = await post(`/trails/${trilha.body.id}/modules`, adminToken, {
+        title: "Modulo 1",
+        position: 1,
+    });
+    const lessonIds: string[] = [];
+    for (let i = 1; i <= 2; i++) {
+        const aula = await post(`/modules/${modulo.body.id}/lessons`, adminToken, {
+            title: `Aula ${i}`,
+            position: i,
+        });
+        for (let q = 1; q <= 5; q++) {
+            await post(`/lessons/${aula.body.id}/questions`, adminToken, {
+                statement: `Questao numero ${q}`,
+                position: q,
+                options: [
+                    { text: "errada", isCorrect: false },
+                    { text: "certa", isCorrect: true },
+                ],
+            });
+        }
+        await patch(`/lessons/${aula.body.id}/published`, adminToken, { published: true });
+        lessonIds.push(aula.body.id as string);
+    }
+    return { trailId: trilha.body.id as string, lessonIds };
+}
+
+async function passarNoQuiz(token: string, lessonId: string) {
+    const aula = await get(`/lessons/${lessonId}`, token);
+    const answers = aula.body.questions.map((q: any) => ({
+        questionId: q.id,
+        optionId: q.options.find((o: any) => o.text === "certa").id,
+    }));
+    await post(`/lessons/${lessonId}/quiz`, token, { answers });
+}
+
+before(async () => {
+    server = await startTestServer();
+});
+after(async () => {
+    await server.close();
+});
+beforeEach(async () => {
+    await limparBanco();
+});
+
+describe("Certificado de conclusão", () => {
+    test("fluxo completo: elegível após concluir, emite, valida no público e baixa o PDF", async () => {
+        const admin = await criarUsuarioLogado(true);
+        const { trailId, lessonIds } = await montarTrilha(admin.token);
+        const aluno = await criarUsuarioLogado();
+
+        const antes = await get(`/trails/${trailId}/certificado`, aluno.token);
+        assert.equal(antes.body.elegivel, false);
+        assert.equal(antes.body.motivo, "progresso");
+
+        for (const id of lessonIds) await passarNoQuiz(aluno.token, id);
+
+        const depois = await get(`/trails/${trailId}/certificado`, aluno.token);
+        assert.equal(depois.body.elegivel, true);
+
+        const emitido = await post(`/trails/${trailId}/certificado`, aluno.token, {
+            cpf: "529.982.247-25",
+        });
+        assert.equal(emitido.status, 200);
+        assert.match(emitido.body.code, /^ED(-[2-9A-HJKMNP-Z]{4}){3}$/);
+
+        const publico = await get(`/certificados/${emitido.body.code}`);
+        assert.equal(publico.status, 200);
+        assert.equal(publico.body.studentName, "Aluno Certificado");
+        assert.equal(publico.body.trailName, "Logica");
+        assert.equal(publico.body.workloadHours, 20);
+        assert.equal(publico.body.cpf, "***.982.247-**");
+
+        const pdf = await fetch(`${server.base}/certificados/${emitido.body.code}/pdf`);
+        assert.equal(pdf.status, 200);
+        assert.equal(pdf.headers.get("content-type"), "application/pdf");
+        const corpo = Buffer.from(await pdf.arrayBuffer());
+        assert.equal(corpo.subarray(0, 5).toString(), "%PDF-");
+        assert.ok(corpo.length > 2000);
+
+        const repetido = await post(`/trails/${trailId}/certificado`, aluno.token, {
+            cpf: CPF_VALIDO,
+        });
+        assert.equal(repetido.body.code, emitido.body.code);
+    });
+
+    test("sem concluir a trilha não emite; CPF inválido é rejeitado", async () => {
+        const admin = await criarUsuarioLogado(true);
+        const { trailId, lessonIds } = await montarTrilha(admin.token);
+        const aluno = await criarUsuarioLogado();
+
+        const cedo = await post(`/trails/${trailId}/certificado`, aluno.token, {
+            cpf: CPF_VALIDO,
+        });
+        assert.equal(cedo.status, 409);
+
+        for (const id of lessonIds) await passarNoQuiz(aluno.token, id);
+        const invalido = await post(`/trails/${trailId}/certificado`, aluno.token, {
+            cpf: "111.111.111-11",
+        });
+        assert.equal(invalido.status, 400);
+    });
+
+    test("conclusão manual pelo roadmap não emite certificado", async () => {
+        const admin = await criarUsuarioLogado(true);
+        const { trailId } = await montarTrilha(admin.token);
+        const rm = await post("/roadmaps", admin.token, {
+            name: "Backend",
+            description: "Do zero ao backend.",
+            level: "iniciante",
+            published: true,
+        });
+        const st = await post(`/roadmaps/${rm.body.id}/stages`, admin.token, {
+            phase: "fundamentos",
+            title: "Etapa 1",
+            description: "Descricao da etapa.",
+        });
+        await post(`/roadmap-stages/${st.body.id}/refs`, admin.token, {
+            refType: "trail",
+            refId: trailId,
+        });
+        const aluno = await criarUsuarioLogado();
+        await post(`/roadmap-stages/${st.body.id}/concluir`, aluno.token);
+
+        const status = await get(`/trails/${trailId}/certificado`, aluno.token);
+        assert.equal(status.body.elegivel, false);
+        assert.equal(status.body.motivo, "manual");
+
+        const tentativa = await post(`/trails/${trailId}/certificado`, aluno.token, {
+            cpf: CPF_VALIDO,
+        });
+        assert.equal(tentativa.status, 409);
+    });
+
+    test("trilha sem carga horária não emite", async () => {
+        const admin = await criarUsuarioLogado(true);
+        const { trailId, lessonIds } = await montarTrilha(admin.token, { horas: null });
+        const aluno = await criarUsuarioLogado();
+        for (const id of lessonIds) await passarNoQuiz(aluno.token, id);
+
+        const status = await get(`/trails/${trailId}/certificado`, aluno.token);
+        assert.equal(status.body.motivo, "carga_horaria");
+        const r = await post(`/trails/${trailId}/certificado`, aluno.token, { cpf: CPF_VALIDO });
+        assert.equal(r.status, 409);
+    });
+
+    test("trilha multi-linguagem: um track completo emite, com a linguagem no certificado", async () => {
+        const admin = await criarUsuarioLogado(true);
+        const { trailId, lessonIds } = await montarTrilha(admin.token);
+        const { db } = await import("../db.ts");
+        const { lessons, modules } = await import("../schema.ts");
+        const { eq } = await import("drizzle-orm");
+        await db
+            .update(lessons)
+            .set({ language: "javascript" })
+            .where(eq(lessons.id, lessonIds[1]));
+        const [mod] = await db
+            .select({ id: modules.id })
+            .from(modules)
+            .where(eq(modules.trailId, trailId));
+        const par = await post(`/modules/${mod.id}/lessons`, admin.token, {
+            title: "Aula 2 em Python",
+            position: 3,
+        });
+        await patch(`/lessons/${par.body.id}/published`, admin.token, { published: true });
+        await db.update(lessons).set({ language: "python" }).where(eq(lessons.id, par.body.id));
+
+        const aluno = await criarUsuarioLogado();
+        for (const id of lessonIds) await passarNoQuiz(aluno.token, id);
+
+        const status = await get(`/trails/${trailId}/certificado`, aluno.token);
+        assert.equal(status.body.elegivel, true);
+        const emitido = await post(`/trails/${trailId}/certificado`, aluno.token, {
+            cpf: CPF_VALIDO,
+        });
+        assert.equal(emitido.status, 200);
+        const publico = await get(`/certificados/${emitido.body.code}`);
+        assert.equal(publico.body.language, "JavaScript");
+    });
+
+    test("código inexistente retorna 404 na validação pública", async () => {
+        const r = await get("/certificados/ED-XXXX-XXXX-XXXX");
+        assert.equal(r.status, 404);
+    });
+});

--- a/backend/tests/certificado.test.ts
+++ b/backend/tests/certificado.test.ts
@@ -286,6 +286,10 @@ describe("Certificado de conclusão", () => {
 
         const status = await get(`/trails/${trailId}/certificado`, aluno.token);
         assert.equal(status.body.elegivel, true);
+
+        const minhas = await get("/me/trails", aluno.token);
+        assert.equal(minhas.body[0].progress, 100);
+
         const emitido = await post(`/trails/${trailId}/certificado`, aluno.token, {
             cpf: CPF_VALIDO,
             name: "Aluno Certificado da Silva",

--- a/backend/tests/certificado.test.ts
+++ b/backend/tests/certificado.test.ts
@@ -131,31 +131,43 @@ describe("Certificado de conclusão", () => {
 
         const emitido = await post(`/trails/${trailId}/certificado`, aluno.token, {
             cpf: "529.982.247-25",
+            name: "Aluno Certificado da Silva",
         });
         assert.equal(emitido.status, 200);
         assert.match(emitido.body.code, /^ED(-[2-9A-HJKMNP-Z]{4}){3}$/);
 
         const publico = await get(`/certificados/${emitido.body.code}`);
         assert.equal(publico.status, 200);
-        assert.equal(publico.body.studentName, "Aluno Certificado");
+        assert.equal(publico.body.studentName, "Aluno Certificado da Silva");
         assert.equal(publico.body.trailName, "Logica");
         assert.equal(publico.body.workloadHours, 20);
         assert.equal(publico.body.cpf, "***.982.247-**");
 
-        const pdf = await fetch(`${server.base}/certificados/${emitido.body.code}/pdf`);
+        const pdf = await fetch(`${server.base}/certificados/${emitido.body.code}/pdf`, {
+            headers: auth(aluno.token),
+        });
         assert.equal(pdf.status, 200);
         assert.equal(pdf.headers.get("content-type"), "application/pdf");
         const corpo = Buffer.from(await pdf.arrayBuffer());
         assert.equal(corpo.subarray(0, 5).toString(), "%PDF-");
         assert.ok(corpo.length > 2000);
 
+        const anonimo = await fetch(`${server.base}/certificados/${emitido.body.code}/pdf`);
+        assert.equal(anonimo.status, 401);
+        const outro = await criarUsuarioLogado();
+        const alheio = await fetch(`${server.base}/certificados/${emitido.body.code}/pdf`, {
+            headers: auth(outro.token),
+        });
+        assert.equal(alheio.status, 403);
+
         const repetido = await post(`/trails/${trailId}/certificado`, aluno.token, {
             cpf: CPF_VALIDO,
+            name: "Aluno Certificado da Silva",
         });
         assert.equal(repetido.body.code, emitido.body.code);
     });
 
-    test("reemitir com outro CPF corrige o documento mantendo o código", async () => {
+    test("depois de emitido o CPF não muda, mesmo pedindo de novo com outro", async () => {
         const admin = await criarUsuarioLogado(true);
         const { trailId, lessonIds } = await montarTrilha(admin.token);
         const aluno = await criarUsuarioLogado();
@@ -163,15 +175,17 @@ describe("Certificado de conclusão", () => {
 
         const primeiro = await post(`/trails/${trailId}/certificado`, aluno.token, {
             cpf: CPF_VALIDO,
+            name: "Aluno Certificado da Silva",
         });
-        const corrigido = await post(`/trails/${trailId}/certificado`, aluno.token, {
+        const tentativa = await post(`/trails/${trailId}/certificado`, aluno.token, {
             cpf: "111.444.777-35",
+            name: "Outro Nome Qualquer",
         });
-        assert.equal(corrigido.status, 200);
-        assert.equal(corrigido.body.code, primeiro.body.code);
+        assert.equal(tentativa.status, 200);
+        assert.equal(tentativa.body.code, primeiro.body.code);
 
         const publico = await get(`/certificados/${primeiro.body.code}`);
-        assert.equal(publico.body.cpf, "***.444.777-**");
+        assert.equal(publico.body.cpf, "***.982.247-**");
     });
 
     test("sem concluir a trilha não emite; CPF inválido é rejeitado", async () => {
@@ -181,14 +195,22 @@ describe("Certificado de conclusão", () => {
 
         const cedo = await post(`/trails/${trailId}/certificado`, aluno.token, {
             cpf: CPF_VALIDO,
+            name: "Aluno Certificado da Silva",
         });
         assert.equal(cedo.status, 409);
 
         for (const id of lessonIds) await passarNoQuiz(aluno.token, id);
         const invalido = await post(`/trails/${trailId}/certificado`, aluno.token, {
             cpf: "111.111.111-11",
+            name: "Aluno Certificado da Silva",
         });
         assert.equal(invalido.status, 400);
+
+        const nomeCurto = await post(`/trails/${trailId}/certificado`, aluno.token, {
+            cpf: CPF_VALIDO,
+            name: "Fulano",
+        });
+        assert.equal(nomeCurto.status, 400);
     });
 
     test("conclusão manual pelo roadmap não emite certificado", async () => {
@@ -218,6 +240,7 @@ describe("Certificado de conclusão", () => {
 
         const tentativa = await post(`/trails/${trailId}/certificado`, aluno.token, {
             cpf: CPF_VALIDO,
+            name: "Aluno Certificado da Silva",
         });
         assert.equal(tentativa.status, 409);
     });
@@ -230,7 +253,10 @@ describe("Certificado de conclusão", () => {
 
         const status = await get(`/trails/${trailId}/certificado`, aluno.token);
         assert.equal(status.body.motivo, "carga_horaria");
-        const r = await post(`/trails/${trailId}/certificado`, aluno.token, { cpf: CPF_VALIDO });
+        const r = await post(`/trails/${trailId}/certificado`, aluno.token, {
+            cpf: CPF_VALIDO,
+            name: "Aluno Certificado da Silva",
+        });
         assert.equal(r.status, 409);
     });
 
@@ -262,6 +288,7 @@ describe("Certificado de conclusão", () => {
         assert.equal(status.body.elegivel, true);
         const emitido = await post(`/trails/${trailId}/certificado`, aluno.token, {
             cpf: CPF_VALIDO,
+            name: "Aluno Certificado da Silva",
         });
         assert.equal(emitido.status, 200);
         const publico = await get(`/certificados/${emitido.body.code}`);

--- a/backend/tests/certificado.test.ts
+++ b/backend/tests/certificado.test.ts
@@ -155,6 +155,25 @@ describe("Certificado de conclusão", () => {
         assert.equal(repetido.body.code, emitido.body.code);
     });
 
+    test("reemitir com outro CPF corrige o documento mantendo o código", async () => {
+        const admin = await criarUsuarioLogado(true);
+        const { trailId, lessonIds } = await montarTrilha(admin.token);
+        const aluno = await criarUsuarioLogado();
+        for (const id of lessonIds) await passarNoQuiz(aluno.token, id);
+
+        const primeiro = await post(`/trails/${trailId}/certificado`, aluno.token, {
+            cpf: CPF_VALIDO,
+        });
+        const corrigido = await post(`/trails/${trailId}/certificado`, aluno.token, {
+            cpf: "111.444.777-35",
+        });
+        assert.equal(corrigido.status, 200);
+        assert.equal(corrigido.body.code, primeiro.body.code);
+
+        const publico = await get(`/certificados/${primeiro.body.code}`);
+        assert.equal(publico.body.cpf, "***.444.777-**");
+    });
+
     test("sem concluir a trilha não emite; CPF inválido é rejeitado", async () => {
         const admin = await criarUsuarioLogado(true);
         const { trailId, lessonIds } = await montarTrilha(admin.token);

--- a/backend/tests/helpers/db.ts
+++ b/backend/tests/helpers/db.ts
@@ -6,6 +6,6 @@ export async function limparBanco() {
     // CASCADE remove dependentes por FK; lista trails/lessons explicitamente
     // porque elas nao referenciam users e nao cairiam no cascade.
     await db.execute(
-        sql`TRUNCATE TABLE roadmap_stage_completions, roadmap_stage_refs, roadmap_stages, roadmaps, comunicado_respostas, comunicados, challenge_submissions, challenge_tests, challenges, simulado_attempt_answers, simulado_attempt_questions, simulado_attempts, simulado_options, simulado_questions, simulados, question_answers, question_options, questions, lessons_progress, lessons, modules, trails, tokens, users RESTART IDENTITY CASCADE`,
+        sql`TRUNCATE TABLE certificates, roadmap_stage_completions, roadmap_stage_refs, roadmap_stages, roadmaps, comunicado_respostas, comunicados, challenge_submissions, challenge_tests, challenges, simulado_attempt_answers, simulado_attempt_questions, simulado_attempts, simulado_options, simulado_questions, simulados, question_answers, question_options, questions, lessons_progress, lessons, modules, trails, tokens, users RESTART IDENTITY CASCADE`,
     );
 }

--- a/backend/tests/run-integration.sh
+++ b/backend/tests/run-integration.sh
@@ -10,6 +10,9 @@ export JWT_SECRET="test_secret_com_pelo_menos_32_caracteres_aqui_ok"
 export NODE_ENV="test"
 export FRONTEND_URL="http://localhost:5173"
 export DB_SSL="false"
+export CERT_RAZAO_SOCIAL="Ensina Dev Treinamentos"
+export CERT_CNPJ="00.000.000/0001-00"
+export CERT_RESPONSAVEL="Joao Paulo Avelino"
 
 cleanup() {
   docker rm -f "$CONTAINER" >/dev/null 2>&1 || true

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -33,6 +33,7 @@ import { VerifyEmail } from './pages/VerifyEmail';
 import { RecuperarSenha } from './pages/RecuperarSenha';
 import { RedefinirSenha } from './pages/RedefinirSenha';
 import { OAuthCallback } from './pages/OAuthCallback';
+import { CertificadoValidar } from './pages/CertificadoValidar';
 import { CompletarPerfil } from './pages/CompletarPerfil';
 import { Placeholder } from './pages/Placeholder';
 
@@ -75,6 +76,7 @@ function AppRoutes() {
       <Route path="/recuperar-senha" element={<RecuperarSenha />} />
       <Route path="/redefinir-senha" element={<RedefinirSenha />} />
       <Route path="/auth/callback" element={<OAuthCallback />} />
+      <Route path="/certificados/:code" element={<CertificadoValidar />} />
       <Route
         path="/completar-perfil"
         element={

--- a/frontend/src/components/Logo.tsx
+++ b/frontend/src/components/Logo.tsx
@@ -4,6 +4,7 @@ interface LogoProps {
   variant?: 'brand' | 'solid';
   size?: number;
   capSize?: number;
+  word?: string;
 }
 
 /**
@@ -11,7 +12,7 @@ interface LogoProps {
  * variant="brand"  → tile translúcido (uso sobre o painel azul, texto branco)
  * variant="solid"  → tile na cor de destaque (uso sobre fundo claro/escuro)
  */
-export function Logo({ variant = 'solid', size = 20, capSize }: LogoProps) {
+export function Logo({ variant = 'solid', size = 20, capSize, word }: LogoProps) {
   const isBrand = variant === 'brand';
   const tile = Math.round(size * 1.55);
   return (
@@ -20,8 +21,12 @@ export function Logo({ variant = 'solid', size = 20, capSize }: LogoProps) {
         <GradCap size={capSize || Math.round(tile * 0.58)} />
       </span>
       <span className="logo__word" style={{ fontSize: size }}>
-        ensina
-        <span className={isBrand ? 'logo__suffix--brand' : 'logo__suffix'}>.dev</span>
+        {word ?? (
+          <>
+            ensina
+            <span className={isBrand ? 'logo__suffix--brand' : 'logo__suffix'}>.dev</span>
+          </>
+        )}
       </span>
     </div>
   );

--- a/frontend/src/data/trails.ts
+++ b/frontend/src/data/trails.ts
@@ -9,6 +9,7 @@ export interface Trail {
   done: number;
   desc: string;
   tags: string[];
+  workloadHours?: number | null;
 }
 
 export const trilhaFilters = [

--- a/frontend/src/pages/CertificadoValidar/index.tsx
+++ b/frontend/src/pages/CertificadoValidar/index.tsx
@@ -2,11 +2,7 @@ import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { Logo } from '../../components/Logo';
 import { Check } from '../../components/Icons';
-import {
-  validarCertificado,
-  urlPdfCertificado,
-  type CertificadoPublico,
-} from '../../services/certificados';
+import { validarCertificado, type CertificadoPublico } from '../../services/certificados';
 
 function dataBr(iso: string) {
   return new Date(iso).toLocaleDateString('pt-BR');
@@ -83,14 +79,10 @@ export function CertificadoValidar() {
                 <b>{cert.code}</b>
               </div>
             </div>
-            <a
-              className="btn btn--accent"
-              href={urlPdfCertificado(cert.code)}
-              target="_blank"
-              rel="noreferrer"
-            >
-              Ver o certificado em PDF
-            </a>
+            <p className="cert-box__msg">
+              Confira se os dados acima batem com o documento apresentado. O PDF só pode ser
+              baixado pelo dono do certificado, na página da trilha.
+            </p>
           </>
         )}
       </div>

--- a/frontend/src/pages/CertificadoValidar/index.tsx
+++ b/frontend/src/pages/CertificadoValidar/index.tsx
@@ -30,14 +30,14 @@ export function CertificadoValidar() {
   return (
     <div className="cert-page">
       <div className="cert-box">
-        <Logo variant="solid" size={22} />
+        <Logo variant="solid" size={22} word="Ensina Dev" />
         {estado === 'carregando' && <p className="cert-box__msg">Verificando certificado...</p>}
 
         {estado === 'invalido' && (
           <>
             <h1 className="cert-box__title cert-box__title--erro">Certificado não encontrado</h1>
             <p className="cert-box__msg">
-              O código informado não corresponde a nenhum certificado emitido pelo ensina.dev.
+              O código informado não corresponde a nenhum certificado emitido pelo Ensina Dev.
               Confira se digitou o código exatamente como aparece no documento.
             </p>
           </>

--- a/frontend/src/pages/CertificadoValidar/index.tsx
+++ b/frontend/src/pages/CertificadoValidar/index.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { Logo } from '../../components/Logo';
+import { Check } from '../../components/Icons';
+import {
+  validarCertificado,
+  urlPdfCertificado,
+  type CertificadoPublico,
+} from '../../services/certificados';
+
+function dataBr(iso: string) {
+  return new Date(iso).toLocaleDateString('pt-BR');
+}
+
+export function CertificadoValidar() {
+  const { code } = useParams();
+  const [cert, setCert] = useState<CertificadoPublico | null>(null);
+  const [estado, setEstado] = useState<'carregando' | 'valido' | 'invalido'>('carregando');
+
+  useEffect(() => {
+    if (!code) return;
+    validarCertificado(code)
+      .then((c) => {
+        setCert(c);
+        setEstado('valido');
+      })
+      .catch(() => setEstado('invalido'));
+  }, [code]);
+
+  return (
+    <div className="cert-page">
+      <div className="cert-box">
+        <Logo variant="solid" size={22} />
+        {estado === 'carregando' && <p className="cert-box__msg">Verificando certificado...</p>}
+
+        {estado === 'invalido' && (
+          <>
+            <h1 className="cert-box__title cert-box__title--erro">Certificado não encontrado</h1>
+            <p className="cert-box__msg">
+              O código informado não corresponde a nenhum certificado emitido pelo ensina.dev.
+              Confira se digitou o código exatamente como aparece no documento.
+            </p>
+          </>
+        )}
+
+        {estado === 'valido' && cert && (
+          <>
+            <div className="cert-box__selo">
+              <Check size={18} /> Certificado válido
+            </div>
+            <h1 className="cert-box__title">{cert.trailName}</h1>
+            <div className="cert-box__grid">
+              <div>
+                <span>Emitido para</span>
+                <b>{cert.studentName}</b>
+              </div>
+              <div>
+                <span>CPF</span>
+                <b>{cert.cpf}</b>
+              </div>
+              {cert.language && (
+                <div>
+                  <span>Linguagem</span>
+                  <b>{cert.language}</b>
+                </div>
+              )}
+              <div>
+                <span>Carga horária</span>
+                <b>{cert.workloadHours} horas</b>
+              </div>
+              <div>
+                <span>Período de realização</span>
+                <b>
+                  {dataBr(cert.startedAt)} a {dataBr(cert.completedAt)}
+                </b>
+              </div>
+              <div>
+                <span>Data de emissão</span>
+                <b>{dataBr(cert.issuedAt)}</b>
+              </div>
+              <div>
+                <span>Código</span>
+                <b>{cert.code}</b>
+              </div>
+            </div>
+            <a
+              className="btn btn--accent"
+              href={urlPdfCertificado(cert.code)}
+              target="_blank"
+              rel="noreferrer"
+            >
+              Ver o certificado em PDF
+            </a>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/CompletarPerfil/index.tsx
+++ b/frontend/src/pages/CompletarPerfil/index.tsx
@@ -18,7 +18,7 @@ type Erros = Record<string, string>;
 // não fornece (nascimento, gênero e telefone).
 export function CompletarPerfil() {
   const navigate = useNavigate();
-  const { atualizarUsuario } = useAuth();
+  const { atualizarUsuario, logout } = useAuth();
   const [username, setUsername] = useState('');
   const [birthDate, setBirthDate] = useState('');
   const [gender, setGender] = useState('');
@@ -29,6 +29,12 @@ export function CompletarPerfil() {
 
   const limparErro = (campo: string) =>
     setErrors((prev) => (prev[campo] ? { ...prev, [campo]: '' } : prev));
+
+  // Sem esta saída o usuário fica preso: toda rota redireciona pra cá enquanto não há username.
+  async function sair() {
+    await logout();
+    navigate('/', { replace: true });
+  }
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -102,6 +108,13 @@ export function CompletarPerfil() {
           {submitting ? 'Salvando...' : 'Concluir'}
         </button>
       </form>
+
+      <p className="auth__foot">
+        Não quer continuar agora?{' '}
+        <button className="link link--btn" type="button" onClick={sair}>
+          Sair e voltar ao início
+        </button>
+      </p>
     </AuthShell>
   );
 }

--- a/frontend/src/pages/EstudioHome/index.tsx
+++ b/frontend/src/pages/EstudioHome/index.tsx
@@ -34,6 +34,7 @@ interface FormState {
   level: TrailLevelEnum;
   description: string;
   tagIds: string[];
+  workloadHours: string;
 }
 
 export function EstudioHome() {
@@ -55,7 +56,7 @@ export function EstudioHome() {
 
   function novaTrilha() {
     setErro('');
-    setForm({ name: '', level: 'iniciante', description: '', tagIds: [] });
+    setForm({ name: '', level: 'iniciante', description: '', tagIds: [], workloadHours: '' });
   }
   function editarTrilha(t: TrailComId) {
     setErro('');
@@ -66,6 +67,7 @@ export function EstudioHome() {
       level: LABEL_TO_ENUM[t.level] ?? 'iniciante',
       description: t.desc,
       tagIds,
+      workloadHours: t.workloadHours ? String(t.workloadHours) : '',
     });
   }
 
@@ -74,12 +76,14 @@ export function EstudioHome() {
     setSalvando(true);
     setErro('');
     try {
+      const workloadHours = form.workloadHours ? Number(form.workloadHours) : null;
       if (form.id) {
         await atualizarTrilha(form.id, {
           name: form.name,
           level: form.level,
           description: form.description,
           tagIds: form.tagIds,
+          workloadHours,
         });
       } else {
         await criarTrilha({
@@ -87,6 +91,7 @@ export function EstudioHome() {
           level: form.level,
           description: form.description,
           tagIds: form.tagIds,
+          workloadHours,
         });
       }
       setForm(null);
@@ -153,6 +158,16 @@ export function EstudioHome() {
                 </option>
               ))}
             </select>
+            <label className="studio__label">Carga horária (em horas, para o certificado)</label>
+            <input
+              className="estudio-form__input"
+              type="number"
+              min={1}
+              max={999}
+              value={form.workloadHours}
+              placeholder="Ex.: 20. Vazio = trilha sem certificado"
+              onChange={(e) => setForm({ ...form, workloadHours: e.target.value })}
+            />
             <label className="studio__label">Descrição</label>
             <textarea
               className="estudio-form__input estudio-form__textarea"

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -85,10 +85,10 @@ export function Home() {
       try {
         const [todas, doUsuario] = await Promise.all([listarTrilhas(), listarMinhasTrilhas()]);
         if (!ativo) return;
-        const comProgresso = todas.map((c) => ({
-          ...c,
-          done: doUsuario.find((m) => m.id === c.id)?.done ?? 0,
-        }));
+        const comProgresso = todas.map((c) => {
+          const meu = doUsuario.find((m) => m.id === c.id);
+          return { ...c, done: meu?.done ?? 0, lessons: meu?.lessons ?? c.lessons };
+        });
         setEmAndamento(comProgresso.filter((t) => t.done > 0 && t.done < t.lessons));
         setDisponiveis(comProgresso);
       } catch {

--- a/frontend/src/pages/TrilhaDetalhe/index.tsx
+++ b/frontend/src/pages/TrilhaDetalhe/index.tsx
@@ -359,14 +359,22 @@ export function TrilhaDetalhe() {
                       {stats.comecado ? 'Continuar trilha' : 'Começar trilha'}
                     </button>
                     {cert?.emitido && (
-                      <a
-                        className="td-card__cert"
-                        href={urlPdfCertificado(cert.emitido.code)}
-                        target="_blank"
-                        rel="noreferrer"
-                      >
-                        Baixar certificado
-                      </a>
+                      <>
+                        <a
+                          className="td-card__cert"
+                          href={urlPdfCertificado(cert.emitido.code)}
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          Baixar certificado
+                        </a>
+                        <p className="td-card__cert-hint">
+                          Dados errados no certificado?{' '}
+                          <button className="link link--btn" onClick={() => setCertModal(true)}>
+                            Corrigir
+                          </button>
+                        </p>
+                      </>
                     )}
                     {cert?.elegivel && (
                       <button className="td-card__cert" onClick={() => setCertModal(true)}>
@@ -618,11 +626,13 @@ export function TrilhaDetalhe() {
           <div className="cmn-overlay">
             <div className="cmn-card">
               <div className="cmn-card__kicker">Certificado</div>
-              <h3 className="cmn-card__title">Emitir certificado de conclusão</h3>
+              <h3 className="cmn-card__title">
+                {cert?.emitido ? 'Corrigir os dados do certificado' : 'Emitir certificado de conclusão'}
+              </h3>
               <p className="cmn-card__msg">
-                Informe seu CPF: ele sai impresso no certificado, como as faculdades exigem para
-                validar horas complementares. Confira também se o seu nome está correto no perfil,
-                pois é ele que vai no documento.
+                {cert?.emitido
+                  ? 'O certificado será reemitido com o CPF informado e o nome atual do seu perfil. O código e o link de validação continuam os mesmos; baixe o PDF de novo depois.'
+                  : 'Informe seu CPF: ele sai impresso no certificado, como as faculdades exigem para validar horas complementares. Confira também se o seu nome está correto no perfil, pois é ele que vai no documento.'}
               </p>
               <input
                 className="cmn-texto"
@@ -648,7 +658,7 @@ export function TrilhaDetalhe() {
                   onClick={emitir}
                   disabled={!cpfValido(cpf.replace(/\D/g, '')) || emitindo}
                 >
-                  {emitindo ? 'Emitindo...' : 'Emitir'}
+                  {emitindo ? 'Enviando...' : cert?.emitido ? 'Corrigir e reemitir' : 'Emitir'}
                 </button>
               </div>
             </div>

--- a/frontend/src/pages/TrilhaDetalhe/index.tsx
+++ b/frontend/src/pages/TrilhaDetalhe/index.tsx
@@ -25,7 +25,7 @@ import { obterTrilha, avaliarTrilha, type TrailDetail, type LessonRef } from '..
 import {
   statusCertificado,
   emitirCertificado,
-  urlPdfCertificado,
+  baixarPdfCertificado,
   type CertificadoStatus,
 } from '../../services/certificados';
 import { getTrailLang, setTrailLang } from '../../utils/trailLang';
@@ -121,6 +121,8 @@ export function TrilhaDetalhe() {
   );
   const [cert, setCert] = useState<CertificadoStatus | null>(null);
   const [certModal, setCertModal] = useState(false);
+  const [certEtapa, setCertEtapa] = useState<'dados' | 'confirmar' | 'pronto'>('dados');
+  const [nomeCert, setNomeCert] = useState('');
   const [cpf, setCpf] = useState('');
   const [certErro, setCertErro] = useState('');
   const [emitindo, setEmitindo] = useState(false);
@@ -161,19 +163,46 @@ export function TrilhaDetalhe() {
       .replace(/^(\d{3})\.(\d{3})\.(\d{3})(\d)/, '$1.$2.$3-$4');
   }
 
+  function abrirModalCertificado() {
+    setNomeCert(authUser?.name ?? '');
+    setCpf('');
+    setCertErro('');
+    setCertEtapa('dados');
+    setCertModal(true);
+  }
+
+  function nomeCompletoValido(v: string) {
+    const nome = v.trim().replace(/\s+/g, ' ');
+    return nome.length >= 5 && nome.length <= 255 && nome.split(' ').length >= 2;
+  }
+
   async function emitir() {
     if (!trailId || emitindo) return;
     setEmitindo(true);
     setCertErro('');
     try {
-      const r = await emitirCertificado(trailId, cpf.replace(/\D/g, ''));
+      const r = await emitirCertificado(trailId, cpf.replace(/\D/g, ''), nomeCert);
       setCert({ emitido: r, elegivel: false });
-      setCertModal(false);
+      setCertEtapa('pronto');
     } catch (e: unknown) {
       const axiosErro = e as { response?: { data?: { erro?: string } } };
       setCertErro(axiosErro.response?.data?.erro ?? 'Não foi possível emitir o certificado.');
     } finally {
       setEmitindo(false);
+    }
+  }
+
+  async function baixarCertificado(code: string) {
+    try {
+      const blob = await baixarPdfCertificado(code);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `certificado-${code}.pdf`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      console.error('Falha ao baixar o certificado:', e);
     }
   }
 
@@ -359,26 +388,16 @@ export function TrilhaDetalhe() {
                       {stats.comecado ? 'Continuar trilha' : 'Começar trilha'}
                     </button>
                     {cert?.emitido && (
-                      <>
-                        <a
-                          className="td-card__cert"
-                          href={urlPdfCertificado(cert.emitido.code)}
-                          target="_blank"
-                          rel="noreferrer"
-                        >
-                          Baixar certificado
-                        </a>
-                        <p className="td-card__cert-hint">
-                          Dados errados no certificado?{' '}
-                          <button className="link link--btn" onClick={() => setCertModal(true)}>
-                            Corrigir
-                          </button>
-                        </p>
-                      </>
+                      <button
+                        className="td-card__cert"
+                        onClick={() => baixarCertificado(cert.emitido!.code)}
+                      >
+                        Baixar certificado
+                      </button>
                     )}
                     {cert?.elegivel && (
-                      <button className="td-card__cert" onClick={() => setCertModal(true)}>
-                        Emitir certificado
+                      <button className="td-card__cert" onClick={abrirModalCertificado}>
+                        Baixar certificado
                       </button>
                     )}
                     {cert?.motivo === 'manual' && (
@@ -626,41 +645,95 @@ export function TrilhaDetalhe() {
           <div className="cmn-overlay">
             <div className="cmn-card">
               <div className="cmn-card__kicker">Certificado</div>
-              <h3 className="cmn-card__title">
-                {cert?.emitido ? 'Corrigir os dados do certificado' : 'Emitir certificado de conclusão'}
-              </h3>
-              <p className="cmn-card__msg">
-                {cert?.emitido
-                  ? 'O certificado será reemitido com o CPF informado e o nome atual do seu perfil. O código e o link de validação continuam os mesmos; baixe o PDF de novo depois.'
-                  : 'Informe seu CPF: ele sai impresso no certificado, como as faculdades exigem para validar horas complementares. Confira também se o seu nome está correto no perfil, pois é ele que vai no documento.'}
-              </p>
-              <input
-                className="cmn-texto"
-                style={{ resize: 'none' }}
-                value={cpf}
-                placeholder="000.000.000-00"
-                inputMode="numeric"
-                onChange={(e) => setCpf(formatarCpf(e.target.value))}
-              />
-              {certErro && <p className="td-cert-erro">{certErro}</p>}
-              <div className="cmn-card__row">
-                <button
-                  className="btn btn--ghost"
-                  onClick={() => {
-                    setCertModal(false);
-                    setCertErro('');
-                  }}
-                >
-                  Cancelar
-                </button>
-                <button
-                  className="btn btn--accent"
-                  onClick={emitir}
-                  disabled={!cpfValido(cpf.replace(/\D/g, '')) || emitindo}
-                >
-                  {emitindo ? 'Enviando...' : cert?.emitido ? 'Corrigir e reemitir' : 'Emitir'}
-                </button>
-              </div>
+
+              {certEtapa === 'dados' && (
+                <>
+                  <h3 className="cmn-card__title">Emitir certificado de conclusão</h3>
+                  <p className="cmn-card__msg">
+                    Informe seu nome completo e CPF como constam nos seus documentos: os dois saem
+                    impressos no certificado, como as faculdades exigem para as horas
+                    complementares.
+                  </p>
+                  <input
+                    className="cmn-texto"
+                    style={{ resize: 'none' }}
+                    value={nomeCert}
+                    placeholder="Nome completo"
+                    maxLength={255}
+                    onChange={(e) => setNomeCert(e.target.value)}
+                  />
+                  <input
+                    className="cmn-texto"
+                    style={{ resize: 'none' }}
+                    value={cpf}
+                    placeholder="000.000.000-00"
+                    inputMode="numeric"
+                    onChange={(e) => setCpf(formatarCpf(e.target.value))}
+                  />
+                  <div className="cmn-card__row">
+                    <button className="btn btn--ghost" onClick={() => setCertModal(false)}>
+                      Cancelar
+                    </button>
+                    <button
+                      className="btn btn--accent"
+                      onClick={() => setCertEtapa('confirmar')}
+                      disabled={!nomeCompletoValido(nomeCert) || !cpfValido(cpf.replace(/\D/g, ''))}
+                    >
+                      Continuar
+                    </button>
+                  </div>
+                </>
+              )}
+
+              {certEtapa === 'confirmar' && (
+                <>
+                  <h3 className="cmn-card__title">Confira antes de emitir</h3>
+                  <div className="td-cert-conf">
+                    <div>
+                      <span>Nome no certificado</span>
+                      <b>{nomeCert.trim().replace(/\s+/g, ' ')}</b>
+                    </div>
+                    <div>
+                      <span>CPF</span>
+                      <b>{cpf}</b>
+                    </div>
+                  </div>
+                  <p className="cmn-card__msg">
+                    Depois de emitido, o nome e o CPF do certificado não poderão ser alterados.
+                    Confira com atenção antes de confirmar.
+                  </p>
+                  {certErro && <p className="td-cert-erro">{certErro}</p>}
+                  <div className="cmn-card__row">
+                    <button className="btn btn--ghost" onClick={() => setCertEtapa('dados')}>
+                      Voltar
+                    </button>
+                    <button className="btn btn--accent" onClick={emitir} disabled={emitindo}>
+                      {emitindo ? 'Emitindo...' : 'Confirmar e emitir'}
+                    </button>
+                  </div>
+                </>
+              )}
+
+              {certEtapa === 'pronto' && cert?.emitido && (
+                <>
+                  <h3 className="cmn-card__title">Certificado emitido</h3>
+                  <p className="cmn-card__msg">
+                    Código {cert.emitido.code}. Você pode baixar o PDF de novo quando quiser, aqui
+                    na página da trilha.
+                  </p>
+                  <div className="cmn-card__row">
+                    <button className="btn btn--ghost" onClick={() => setCertModal(false)}>
+                      Fechar
+                    </button>
+                    <button
+                      className="btn btn--accent"
+                      onClick={() => baixarCertificado(cert.emitido!.code)}
+                    >
+                      Baixar PDF
+                    </button>
+                  </div>
+                </>
+              )}
             </div>
           </div>
         )}

--- a/frontend/src/pages/TrilhaDetalhe/index.tsx
+++ b/frontend/src/pages/TrilhaDetalhe/index.tsx
@@ -176,6 +176,19 @@ export function TrilhaDetalhe() {
     return nome.length >= 5 && nome.length <= 255 && nome.split(' ').length >= 2;
   }
 
+  function continuarEmissao() {
+    if (!nomeCompletoValido(nomeCert)) {
+      setCertErro('Informe seu nome completo, com nome e sobrenome.');
+      return;
+    }
+    if (!cpfValido(cpf.replace(/\D/g, ''))) {
+      setCertErro('CPF inválido. Confira os 11 dígitos.');
+      return;
+    }
+    setCertErro('');
+    setCertEtapa('confirmar');
+  }
+
   async function emitir() {
     if (!trailId || emitindo) return;
     setEmitindo(true);
@@ -660,7 +673,10 @@ export function TrilhaDetalhe() {
                     value={nomeCert}
                     placeholder="Nome completo"
                     maxLength={255}
-                    onChange={(e) => setNomeCert(e.target.value)}
+                    onChange={(e) => {
+                      setNomeCert(e.target.value);
+                      setCertErro('');
+                    }}
                   />
                   <input
                     className="cmn-texto"
@@ -668,17 +684,17 @@ export function TrilhaDetalhe() {
                     value={cpf}
                     placeholder="000.000.000-00"
                     inputMode="numeric"
-                    onChange={(e) => setCpf(formatarCpf(e.target.value))}
+                    onChange={(e) => {
+                      setCpf(formatarCpf(e.target.value));
+                      setCertErro('');
+                    }}
                   />
+                  {certErro && <p className="td-cert-erro">{certErro}</p>}
                   <div className="cmn-card__row">
                     <button className="btn btn--ghost" onClick={() => setCertModal(false)}>
                       Cancelar
                     </button>
-                    <button
-                      className="btn btn--accent"
-                      onClick={() => setCertEtapa('confirmar')}
-                      disabled={!nomeCompletoValido(nomeCert) || !cpfValido(cpf.replace(/\D/g, ''))}
-                    >
+                    <button className="btn btn--accent" onClick={continuarEmissao}>
                       Continuar
                     </button>
                   </div>

--- a/frontend/src/pages/TrilhaDetalhe/index.tsx
+++ b/frontend/src/pages/TrilhaDetalhe/index.tsx
@@ -22,6 +22,12 @@ import { getInitials } from '../../utils/initials';
 import { user } from '../../data/home';
 import { NAV_PRINCIPAL as NAV } from '../../data/nav';
 import { obterTrilha, avaliarTrilha, type TrailDetail, type LessonRef } from '../../services/trails';
+import {
+  statusCertificado,
+  emitirCertificado,
+  urlPdfCertificado,
+  type CertificadoStatus,
+} from '../../services/certificados';
 import { getTrailLang, setTrailLang } from '../../utils/trailLang';
 
 const NIVEL: Record<TrailDetail['trailLevel'], string> = {
@@ -43,6 +49,16 @@ function glyphDoNome(name: string): string {
   const limpo = name.replace(/[^A-Za-zÀ-ú ]/g, '').trim();
   const partes = limpo.split(/\s+/).slice(0, 2);
   return partes.map((p) => p[0]?.toUpperCase() ?? '').join('') || '{}';
+}
+
+function cpfValido(cpf: string): boolean {
+  if (!/^\d{11}$/.test(cpf) || /^(\d)\1{10}$/.test(cpf)) return false;
+  for (const tamanho of [9, 10]) {
+    let soma = 0;
+    for (let i = 0; i < tamanho; i++) soma += Number(cpf[i]) * (tamanho + 1 - i);
+    if (((soma * 10) % 11) % 10 !== Number(cpf[tamanho])) return false;
+  }
+  return true;
 }
 
 function formatDur(min: number): string {
@@ -103,6 +119,11 @@ export function TrilhaDetalhe() {
   const [lang, setLang] = useState<string | undefined>(() =>
     trailId ? getTrailLang(trailId) : undefined,
   );
+  const [cert, setCert] = useState<CertificadoStatus | null>(null);
+  const [certModal, setCertModal] = useState(false);
+  const [cpf, setCpf] = useState('');
+  const [certErro, setCertErro] = useState('');
+  const [emitindo, setEmitindo] = useState(false);
 
   useEffect(() => {
     if (!trailId) return;
@@ -119,10 +140,41 @@ export function TrilhaDetalhe() {
       .finally(() => setCarregando(false));
   }, [trailId, lang]);
 
+  useEffect(() => {
+    if (!trailId) return;
+    statusCertificado(trailId)
+      .then(setCert)
+      .catch(() => setCert(null));
+  }, [trailId, trilha?.modules]);
+
   function escolherLinguagem(code: string) {
     if (!trailId || code === trilha?.activeLanguage) return;
     setTrailLang(trailId, code);
     setLang(code);
+  }
+
+  function formatarCpf(v: string) {
+    const d = v.replace(/\D/g, '').slice(0, 11);
+    return d
+      .replace(/^(\d{3})(\d)/, '$1.$2')
+      .replace(/^(\d{3})\.(\d{3})(\d)/, '$1.$2.$3')
+      .replace(/^(\d{3})\.(\d{3})\.(\d{3})(\d)/, '$1.$2.$3-$4');
+  }
+
+  async function emitir() {
+    if (!trailId || emitindo) return;
+    setEmitindo(true);
+    setCertErro('');
+    try {
+      const r = await emitirCertificado(trailId, cpf.replace(/\D/g, ''));
+      setCert({ emitido: r, elegivel: false });
+      setCertModal(false);
+    } catch (e: unknown) {
+      const axiosErro = e as { response?: { data?: { erro?: string } } };
+      setCertErro(axiosErro.response?.data?.erro ?? 'Não foi possível emitir o certificado.');
+    } finally {
+      setEmitindo(false);
+    }
   }
 
   const stats = useMemo(() => {
@@ -306,6 +358,26 @@ export function TrilhaDetalhe() {
                     <button className="td-card__cta" onClick={() => irPara(stats.alvo)} disabled={!stats.alvo}>
                       {stats.comecado ? 'Continuar trilha' : 'Começar trilha'}
                     </button>
+                    {cert?.emitido && (
+                      <a
+                        className="td-card__cert"
+                        href={urlPdfCertificado(cert.emitido.code)}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        Baixar certificado
+                      </a>
+                    )}
+                    {cert?.elegivel && (
+                      <button className="td-card__cert" onClick={() => setCertModal(true)}>
+                        Emitir certificado
+                      </button>
+                    )}
+                    {cert?.motivo === 'manual' && (
+                      <p className="td-card__cert-hint">
+                        O certificado sai quando as aulas são concluídas com os quizzes.
+                      </p>
+                    )}
                     <hr className="rule" />
                     <div className="td-card__inc-title">Esta trilha inclui</div>
                     <div className="td-card__inc">
@@ -540,6 +612,47 @@ export function TrilhaDetalhe() {
               </div>
             </div>
           </>
+        )}
+
+        {certModal && (
+          <div className="cmn-overlay">
+            <div className="cmn-card">
+              <div className="cmn-card__kicker">Certificado</div>
+              <h3 className="cmn-card__title">Emitir certificado de conclusão</h3>
+              <p className="cmn-card__msg">
+                Informe seu CPF: ele sai impresso no certificado, como as faculdades exigem para
+                validar horas complementares. Confira também se o seu nome está correto no perfil,
+                pois é ele que vai no documento.
+              </p>
+              <input
+                className="cmn-texto"
+                style={{ resize: 'none' }}
+                value={cpf}
+                placeholder="000.000.000-00"
+                inputMode="numeric"
+                onChange={(e) => setCpf(formatarCpf(e.target.value))}
+              />
+              {certErro && <p className="td-cert-erro">{certErro}</p>}
+              <div className="cmn-card__row">
+                <button
+                  className="btn btn--ghost"
+                  onClick={() => {
+                    setCertModal(false);
+                    setCertErro('');
+                  }}
+                >
+                  Cancelar
+                </button>
+                <button
+                  className="btn btn--accent"
+                  onClick={emitir}
+                  disabled={!cpfValido(cpf.replace(/\D/g, '')) || emitindo}
+                >
+                  {emitindo ? 'Emitindo...' : 'Emitir'}
+                </button>
+              </div>
+            </div>
+          </div>
         )}
       </div>
     </div>

--- a/frontend/src/pages/Trilhas/index.tsx
+++ b/frontend/src/pages/Trilhas/index.tsx
@@ -272,7 +272,11 @@ export function Trilhas() {
             {trilhasFiltradas.map((catalogo) => {
               // Cruza o catalogo com o progresso do usuario (done vem de /me/trails).
               const progresso = minhas.find((m) => m.id === catalogo.id);
-              const t = { ...catalogo, done: progresso?.done ?? 0 };
+              const t = {
+                ...catalogo,
+                done: progresso?.done ?? 0,
+                lessons: progresso?.lessons ?? catalogo.lessons,
+              };
               const pct = t.lessons > 0 ? Math.round((t.done / t.lessons) * 100) : 0;
               const started = t.done > 0;
               const completed = t.done >= t.lessons;

--- a/frontend/src/services/certificados.ts
+++ b/frontend/src/services/certificados.ts
@@ -23,10 +23,10 @@ export async function statusCertificado(trailId: string) {
   return data;
 }
 
-export async function emitirCertificado(trailId: string, cpf: string) {
+export async function emitirCertificado(trailId: string, cpf: string, name: string) {
   const { data } = await api.post<{ code: string; issuedAt: string }>(
     `/trails/${trailId}/certificado`,
-    { cpf },
+    { cpf, name },
   );
   return data;
 }
@@ -36,7 +36,7 @@ export async function validarCertificado(code: string) {
   return data;
 }
 
-export function urlPdfCertificado(code: string) {
-  const base = import.meta.env.VITE_API_URL || 'http://localhost:3001';
-  return `${base}/certificados/${code}/pdf`;
+export async function baixarPdfCertificado(code: string) {
+  const { data } = await api.get<Blob>(`/certificados/${code}/pdf`, { responseType: 'blob' });
+  return data;
 }

--- a/frontend/src/services/certificados.ts
+++ b/frontend/src/services/certificados.ts
@@ -1,0 +1,42 @@
+import api from './api';
+
+export interface CertificadoStatus {
+  emitido: { code: string; issuedAt: string } | null;
+  elegivel: boolean;
+  motivo?: 'indisponivel' | 'carga_horaria' | 'manual' | 'progresso';
+}
+
+export interface CertificadoPublico {
+  code: string;
+  studentName: string;
+  cpf: string;
+  trailName: string;
+  language: string | null;
+  workloadHours: number;
+  startedAt: string;
+  completedAt: string;
+  issuedAt: string;
+}
+
+export async function statusCertificado(trailId: string) {
+  const { data } = await api.get<CertificadoStatus>(`/trails/${trailId}/certificado`);
+  return data;
+}
+
+export async function emitirCertificado(trailId: string, cpf: string) {
+  const { data } = await api.post<{ code: string; issuedAt: string }>(
+    `/trails/${trailId}/certificado`,
+    { cpf },
+  );
+  return data;
+}
+
+export async function validarCertificado(code: string) {
+  const { data } = await api.get<CertificadoPublico>(`/certificados/${code}`);
+  return data;
+}
+
+export function urlPdfCertificado(code: string) {
+  const base = import.meta.env.VITE_API_URL || 'http://localhost:3001';
+  return `${base}/certificados/${code}/pdf`;
+}

--- a/frontend/src/services/trails.ts
+++ b/frontend/src/services/trails.ts
@@ -10,6 +10,7 @@ interface TrailApi {
   totalLessons: number;
   completedLessons?: number;
   progress?: number;
+  workloadHours?: number | null;
   tags?: { id: string; name: string }[];
 }
 
@@ -44,6 +45,7 @@ function adaptar(t: TrailApi): Trail & { id: string } {
     done: t.completedLessons ?? 0,
     desc: t.description,
     tags: t.tags?.map((tg) => tg.name) ?? [],
+    workloadHours: t.workloadHours ?? null,
   };
 }
 
@@ -299,13 +301,20 @@ export async function criarTrilha(payload: {
   level: TrailLevelEnum;
   description: string;
   tagIds?: string[];
+  workloadHours?: number | null;
 }) {
   const { data } = await api.post<{ id: string }>('/trails', payload);
   return data;
 }
 export async function atualizarTrilha(
   id: string,
-  payload: { name?: string; level?: TrailLevelEnum; description?: string; tagIds?: string[] },
+  payload: {
+    name?: string;
+    level?: TrailLevelEnum;
+    description?: string;
+    tagIds?: string[];
+    workloadHours?: number | null;
+  },
 ) {
   const { data } = await api.patch(`/trails/${id}`, payload);
   return data;

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -200,6 +200,13 @@
   font-size: 13px;
   text-decoration: none;
 }
+.link--btn {
+  background: none;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  cursor: pointer;
+}
 .divider {
   display: flex;
   align-items: center;

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -4961,3 +4961,68 @@
   gap: 8px;
   flex-wrap: wrap;
 }
+
+/* ===================== CERTIFICADO (validação pública) ===================== */
+.cert-page {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: var(--bg);
+}
+.cert-box {
+  width: min(480px, 100%);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  padding: 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  align-items: flex-start;
+  color: var(--text);
+}
+.cert-box__selo {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 13.5px;
+  font-weight: 700;
+  color: var(--success);
+  background: var(--success-soft);
+}
+.cert-box__title {
+  margin: 0;
+  font-size: 22px;
+  letter-spacing: -0.01em;
+}
+.cert-box__title--erro {
+  font-size: 19px;
+}
+.cert-box__msg {
+  margin: 0;
+  font-size: 14px;
+  color: var(--muted);
+  line-height: 1.55;
+}
+.cert-box__grid {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px 18px;
+}
+.cert-box__grid > div {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.cert-box__grid span {
+  font-size: 12px;
+  color: var(--muted);
+}
+.cert-box__grid b {
+  font-size: 14.5px;
+}

--- a/frontend/src/styles/trilha-detalhe.css
+++ b/frontend/src/styles/trilha-detalhe.css
@@ -129,3 +129,8 @@
 .td-card__cert:hover { background: color-mix(in srgb, var(--gold) 18%, transparent); }
 .td-card__cert-hint { margin: 10px 0 0; font-size: 12.5px; color: var(--muted); text-align: center; }
 .td-cert-erro { margin: 0 0 10px; font-size: 13px; color: var(--av-red); }
+
+.td-cert-conf { display: flex; flex-direction: column; gap: 10px; margin-bottom: 12px; padding: 12px 14px; border: 1px solid var(--border); border-radius: 10px; }
+.td-cert-conf div { display: flex; flex-direction: column; gap: 2px; }
+.td-cert-conf span { font-size: 12px; color: var(--muted); }
+.td-cert-conf b { font-size: 14.5px; }

--- a/frontend/src/styles/trilha-detalhe.css
+++ b/frontend/src/styles/trilha-detalhe.css
@@ -124,3 +124,8 @@
   .td-body { grid-template-columns: 1fr; }
   .td-learn { grid-template-columns: 1fr; }
 }
+
+.td-card__cert { width: 100%; height: 46px; margin-top: 10px; border: 1px solid color-mix(in srgb, var(--gold) 55%, var(--border-strong)); border-radius: 12px; background: color-mix(in srgb, var(--gold) 10%, transparent); color: var(--text); font-family: inherit; font-weight: 600; font-size: 14px; cursor: pointer; display: flex; align-items: center; justify-content: center; text-decoration: none; }
+.td-card__cert:hover { background: color-mix(in srgb, var(--gold) 18%, transparent); }
+.td-card__cert-hint { margin: 10px 0 0; font-size: 12.5px; color: var(--muted); text-align: center; }
+.td-cert-erro { margin: 0 0 10px; font-size: 13px; color: var(--av-red); }


### PR DESCRIPTION
## O que muda

### Certificado de conclusão de trilha

Pensado para valer como horas complementares de faculdade (curso livre): quem conclui uma trilha **de verdade** (quizzes feitos; nas trilhas multi-linguagem basta um track completo) pode emitir o certificado na própria página da trilha. Na emissão a pessoa informa o CPF, que sai impresso no documento. **Conclusão manual de estágio não emite**: a página avisa que o certificado sai fazendo as aulas com os quizzes, na mesma linha do XP.

O PDF é gerado no servidor, com os dados congelados na emissão:

- Frente: nome + CPF do aluno, curso (com a linguagem cursada, ex. "na linguagem Python"), modalidade a distância, carga horária, período real de realização (datas do progresso), assinatura com razão social + CNPJ, código único (ex. `ED-7KQ2-M9PF-3XWT`, sem caracteres ambíguos) e QR Code
- Verso: conteúdo programático com os módulos e as aulas que o aluno de fato cursou

O QR aponta para `/certificados/CODIGO`, **página pública** (sem login) onde a faculdade confere: nome, CPF mascarado, curso, carga horária, período, emissão e link do PDF.

No estúdio, o form da trilha ganhou o campo **Carga horária**; trilha sem valor não oferece certificado.

### Fix: saída para quem desiste do completar perfil

Bug reportado: quem entrava pelo cadastro social e desistia na tela de completar o perfil ficava preso nela (toda rota redireciona de volta enquanto não há username) e só escapava apagando o cache. A tela agora tem "Sair e voltar ao início", que desloga e volta para a tela inicial.

## Testes

70/70 na integração (6 novos: fluxo completo com PDF, sem concluir não emite, CPF inválido, conclusão manual não emite, trilha sem carga horária, multi-linguagem com um track, 404 público). Validado manualmente no local: emissão, PDF frente e verso, QR e página pública, hint da conclusão manual, campo do estúdio e o fluxo do completar perfil.

## Deploy

- Migração 0036 aplica no deploy (tabela `certificates` + coluna `workload_hours`)
- Dependências novas no backend: `pdfkit` e `qrcode` (a imagem rebuilda no deploy)
- **A emissão sobe desligada**: só liga quando `CERT_RAZAO_SOCIAL`, `CERT_CNPJ` e `CERT_RESPONSAVEL` entrarem no `.env.prod` (aguardando o CNAE de ensino no MEI). Sem elas, nada aparece para o aluno
- Depois de configurar, definir a carga horária das trilhas no estúdio (campo novo)
