### PR TITLE
feat: perfil público em /username, certificado no LinkedIn e marca Ensina Dev

### DIFF
--- a/backend/src/controllers/UserController.ts
+++ b/backend/src/controllers/UserController.ts
@@ -9,6 +9,7 @@ import { updateMeSchema, completarPerfilSchema } from "../schemas/auth.schema.ts
 import { UPLOADS_DIR, AVATARS_DIR, COVERS_DIR } from "../config/paths.ts";
 import { streakDoUsuario } from "../services/streak.ts";
 import { calcularEstatisticas } from "../services/stats.service.ts";
+import { perfilPublico } from "../services/perfil-publico.service.ts";
 
 const publicUserColumns = {
     id: users.id,
@@ -311,4 +312,12 @@ export const listUsers = async (_req: Request, res: Response) => {
     const allUsers = await db.select(publicUserColumns).from(users);
 
     res.json(allUsers);
+};
+
+export const getPublicProfile = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        res.json(await perfilPublico(String(req.params.username)));
+    } catch (err) {
+        next(err);
+    }
 };

--- a/backend/src/routes/user.routes.ts
+++ b/backend/src/routes/user.routes.ts
@@ -9,6 +9,7 @@ import {
     removerAvatar,
     removerCover,
     listUsers,
+    getPublicProfile,
 } from "../controllers/UserController.ts";
 const router = Router();
 
@@ -20,5 +21,8 @@ router.post("/me/cover", autenticar, uploadCover);
 router.delete("/me/avatar", autenticar, removerAvatar);
 router.delete("/me/cover", autenticar, removerCover);
 router.get("/users", autenticar, exigirAdmin, listUsers);
+
+// Perfil público compartilhável: qualquer pessoa vê, sem login.
+router.get("/perfis/:username", getPublicProfile);
 
 export default router;

--- a/backend/src/services/certificate.service.ts
+++ b/backend/src/services/certificate.service.ts
@@ -24,10 +24,9 @@ function mascararCpf(cpf: string) {
 // Sem 0/O/1/I/L para o código poder ser ditado por telefone sem ambiguidade.
 const ALFABETO_CODIGO = "23456789ABCDEFGHJKMNPQRSTUVWXYZ";
 function gerarCodigo() {
-    const bytes = crypto.randomBytes(12);
     let s = "";
     for (let i = 0; i < 12; i++) {
-        s += ALFABETO_CODIGO[bytes[i] % ALFABETO_CODIGO.length];
+        s += ALFABETO_CODIGO[crypto.randomInt(ALFABETO_CODIGO.length)];
     }
     return `ED-${s.slice(0, 4)}-${s.slice(4, 8)}-${s.slice(8)}`;
 }

--- a/backend/src/services/perfil-publico.service.ts
+++ b/backend/src/services/perfil-publico.service.ts
@@ -1,0 +1,72 @@
+import { db } from "../../db.ts";
+import { certificates, users } from "../../schema.ts";
+import { desc, eq } from "drizzle-orm";
+import { AppError } from "../errors/AppError.ts";
+import { calcularEstatisticas } from "./stats.service.ts";
+import { streakDoUsuario } from "./streak.ts";
+import { conquistasDoUsuario } from "./achievement.service.ts";
+import { trilhasDoUsuario } from "./trail.service.ts";
+
+// Só o que pode ser visto por qualquer pessoa: nada de email, telefone ou nascimento.
+export async function perfilPublico(username: string) {
+    const [usuario] = await db.select().from(users).where(eq(users.username, username));
+    if (!usuario || !usuario.username) {
+        throw new AppError(404, "Perfil não encontrado");
+    }
+
+    const [stats, streak, conquistas, trilhas, certs] = await Promise.all([
+        calcularEstatisticas(usuario.id),
+        streakDoUsuario(usuario.id),
+        conquistasDoUsuario(usuario.id),
+        trilhasDoUsuario(usuario.id),
+        db
+            .select({
+                code: certificates.code,
+                trailName: certificates.trailName,
+                language: certificates.language,
+                workloadHours: certificates.workloadHours,
+                issuedAt: certificates.issuedAt,
+            })
+            .from(certificates)
+            .where(eq(certificates.userId, usuario.id))
+            .orderBy(desc(certificates.issuedAt)),
+    ]);
+
+    return {
+        name: usuario.name,
+        username: usuario.username,
+        bio: usuario.bio,
+        location: usuario.location,
+        occupation: usuario.occupation,
+        languages: usuario.languages ?? [],
+        github: usuario.github,
+        linkedin: usuario.linkedin,
+        x: usuario.x,
+        avatarUrl: usuario.avatarUrl,
+        coverUrl: usuario.coverUrl,
+        memberSince: usuario.createdAt,
+        xp: stats.xp,
+        level: stats.level,
+        lessonsCompleted: stats.lessonsCompleted,
+        questionsCorrect: stats.questionsCorrect,
+        challengesCompleted: stats.challengesCompleted,
+        streak,
+        conquistas: conquistas
+            .filter((c) => c.earned)
+            .map((c) => ({
+                id: c.id,
+                name: c.name,
+                description: c.description,
+                icon: c.icon,
+                earnedAt: c.earnedAt,
+            })),
+        trilhas: trilhas.map((t) => ({
+            name: t.name,
+            trailLevel: t.trailLevel,
+            totalLessons: t.totalLessons,
+            completedLessons: t.completedLessons,
+            progress: t.progress,
+        })),
+        certificados: certs,
+    };
+}

--- a/backend/tests/perfil-publico.test.ts
+++ b/backend/tests/perfil-publico.test.ts
@@ -1,0 +1,150 @@
+import { test, describe, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { startTestServer } from "./helpers/server.ts";
+import { limparBanco } from "./helpers/db.ts";
+
+let server: Awaited<ReturnType<typeof startTestServer>>;
+
+let seq = 0;
+const novoUsuario = () => ({
+    name: "Aluno Publico",
+    email: `pub_${++seq}_${Math.round(performance.now() * 1000)}@email.com`,
+    username: `pub_${seq}`,
+    password: "Senhaforte123!",
+    birthDate: "1990-01-01",
+    gender: "outro",
+    phone: "11999998888",
+});
+
+async function ajustarUsuario(email: string, campos: Record<string, unknown>) {
+    const { db } = await import("../db.ts");
+    const { users } = await import("../schema.ts");
+    const { eq } = await import("drizzle-orm");
+    await db.update(users).set(campos).where(eq(users.email, email));
+}
+
+async function criarUsuarioLogado(admin = false) {
+    const dados = novoUsuario();
+    await server.request("POST", "/register", { body: dados });
+    await ajustarUsuario(dados.email, {
+        emailVerifiedAt: new Date(),
+        ...(admin ? { role: "admin" } : {}),
+    });
+    const login = await server.request("POST", "/login", {
+        body: { email: dados.email, password: dados.password },
+    });
+    return { email: dados.email, username: dados.username, token: login.body.token };
+}
+
+function auth(token: string) {
+    return { Authorization: `Bearer ${token}` };
+}
+async function get(path: string, token?: string) {
+    const res = await fetch(`${server.base}${path}`, { headers: token ? auth(token) : {} });
+    return { status: res.status, body: await res.json().catch(() => null) };
+}
+async function post(path: string, token: string, body?: unknown) {
+    const res = await fetch(`${server.base}${path}`, {
+        method: "POST",
+        headers: { ...auth(token), "Content-Type": "application/json" },
+        body: body ? JSON.stringify(body) : undefined,
+    });
+    return { status: res.status, body: await res.json().catch(() => null) };
+}
+async function patch(path: string, token: string, body?: unknown) {
+    const res = await fetch(`${server.base}${path}`, {
+        method: "PATCH",
+        headers: { ...auth(token), "Content-Type": "application/json" },
+        body: body ? JSON.stringify(body) : undefined,
+    });
+    return { status: res.status, body: await res.json().catch(() => null) };
+}
+
+async function montarTrilhaConcluida(adminToken: string, alunoToken: string) {
+    const trilha = await post("/trails", adminToken, {
+        name: "Logica",
+        level: "iniciante",
+        description: "Base da programacao logica.",
+        workloadHours: 20,
+    });
+    const modulo = await post(`/trails/${trilha.body.id}/modules`, adminToken, {
+        title: "Modulo 1",
+        position: 1,
+    });
+    for (let i = 1; i <= 2; i++) {
+        const aula = await post(`/modules/${modulo.body.id}/lessons`, adminToken, {
+            title: `Aula ${i}`,
+            position: i,
+        });
+        for (let q = 1; q <= 5; q++) {
+            await post(`/lessons/${aula.body.id}/questions`, adminToken, {
+                statement: `Questao numero ${q}`,
+                position: q,
+                options: [
+                    { text: "errada", isCorrect: false },
+                    { text: "certa", isCorrect: true },
+                ],
+            });
+        }
+        await patch(`/lessons/${aula.body.id}/published`, adminToken, { published: true });
+        const detalhe = await get(`/lessons/${aula.body.id}`, alunoToken);
+        const answers = detalhe.body.questions.map((q: any) => ({
+            questionId: q.id,
+            optionId: q.options.find((o: any) => o.text === "certa").id,
+        }));
+        await post(`/lessons/${aula.body.id}/quiz`, alunoToken, { answers });
+    }
+    return trilha.body.id as string;
+}
+
+before(async () => {
+    server = await startTestServer();
+});
+after(async () => {
+    await server.close();
+});
+beforeEach(async () => {
+    await limparBanco();
+});
+
+describe("Perfil público", () => {
+    test("qualquer pessoa vê o perfil sem login, sem dados sensíveis", async () => {
+        const aluno = await criarUsuarioLogado();
+        await patch("/me", aluno.token, { bio: "Estudando programacao todo dia." });
+
+        const r = await get(`/perfis/${aluno.username}`);
+        assert.equal(r.status, 200);
+        assert.equal(r.body.username, aluno.username);
+        assert.equal(r.body.name, "Aluno Publico");
+        assert.equal(r.body.bio, "Estudando programacao todo dia.");
+        assert.equal(r.body.email, undefined);
+        assert.equal(r.body.phone, undefined);
+        assert.equal(r.body.birthDate, undefined);
+    });
+
+    test("mostra progresso, trilha e certificado emitido", async () => {
+        const admin = await criarUsuarioLogado(true);
+        const aluno = await criarUsuarioLogado();
+        const trailId = await montarTrilhaConcluida(admin.token, aluno.token);
+        await post(`/trails/${trailId}/certificado`, aluno.token, {
+            cpf: "529.982.247-25",
+            name: "Aluno Publico da Silva",
+        });
+
+        const r = await get(`/perfis/${aluno.username}`);
+        assert.equal(r.status, 200);
+        assert.equal(r.body.lessonsCompleted, 2);
+        assert.equal(r.body.xp, 200);
+        assert.equal(r.body.trilhas.length, 1);
+        assert.equal(r.body.trilhas[0].progress, 100);
+        assert.equal(r.body.certificados.length, 1);
+        assert.equal(r.body.certificados[0].trailName, "Logica");
+        assert.match(r.body.certificados[0].code, /^ED-/);
+        assert.equal(r.body.certificados[0].cpf, undefined);
+    });
+
+    test("username inexistente retorna 404", async () => {
+        const r = await get("/perfis/nao_existe_esse");
+        assert.equal(r.status, 404);
+    });
+});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ensina.dev</title>
+    <title>Ensina Dev</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Navigate, useParams } from 'react-router-dom';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
 import { ToastProvider } from './contexts/ToastContext';
 import { Login } from './pages/Login';
@@ -34,6 +34,7 @@ import { RecuperarSenha } from './pages/RecuperarSenha';
 import { RedefinirSenha } from './pages/RedefinirSenha';
 import { OAuthCallback } from './pages/OAuthCallback';
 import { CertificadoValidar } from './pages/CertificadoValidar';
+import { PerfilPublico } from './pages/PerfilPublico';
 import { CompletarPerfil } from './pages/CompletarPerfil';
 import { Placeholder } from './pages/Placeholder';
 
@@ -61,6 +62,20 @@ function AdminRoute({ children }: { children: React.JSX.Element }) {
   if (!isAuthenticated) return <Navigate to="/" />;
   if (!user?.username) return <Navigate to="/completar-perfil" replace />;
   return user?.role === 'admin' ? children : <Navigate to="/home" />;
+}
+
+// A URL canônica do perfil é /username: o dono vê a versão editável, os demais a pública.
+function PerfilPorUsername() {
+  const { user, isAuthenticated } = useAuth();
+  const { username } = useParams();
+  if (isAuthenticated && user?.username && user.username === username) return <Perfil />;
+  return <PerfilPublico />;
+}
+
+// /perfil segue funcionando (links antigos), mas redireciona para a URL canônica.
+function MeuPerfil() {
+  const { user } = useAuth();
+  return user?.username ? <Navigate to={`/${user.username}`} replace /> : <Perfil />;
 }
 
 function AppRoutes() {
@@ -293,7 +308,7 @@ function AppRoutes() {
         path="/perfil"
         element={
           <PrivateRoute>
-            <Perfil />
+            <MeuPerfil />
           </PrivateRoute>
         }
       />
@@ -308,6 +323,8 @@ function AppRoutes() {
           </PrivateRoute>
         }
       />
+      {/* Perfil compartilhável: /username. Fica por último; rotas fixas têm prioridade. */}
+      <Route path="/:username" element={<PerfilPorUsername />} />
     </Routes>
     </>
   );

--- a/frontend/src/components/EstudioTopbar.tsx
+++ b/frontend/src/components/EstudioTopbar.tsx
@@ -23,7 +23,7 @@ export function EstudioTopbar({ crumb, actions, badge = 'Estúdio', nav = true }
     <header className="topbar studio__bar">
       <MobileMenu items={NAV_ESTUDIO} />
       <div className="studio__brand">
-        <Logo variant="solid" size={19} />
+        <Logo variant="solid" size={19} to="/home" />
         <span className="studio__badge">{badge}</span>
       </div>
       {crumb && (

--- a/frontend/src/components/Logo.tsx
+++ b/frontend/src/components/Logo.tsx
@@ -1,33 +1,38 @@
+import { Link } from 'react-router-dom';
 import { GradCap } from './Icons';
 
 interface LogoProps {
   variant?: 'brand' | 'solid';
   size?: number;
   capSize?: number;
-  word?: string;
+  to?: string;
 }
 
 /**
- * Logo — capelo + wordmark "ensina.dev".
+ * Logo: capelo + wordmark "Ensina Dev".
  * variant="brand"  → tile translúcido (uso sobre o painel azul, texto branco)
  * variant="solid"  → tile na cor de destaque (uso sobre fundo claro/escuro)
  */
-export function Logo({ variant = 'solid', size = 20, capSize, word }: LogoProps) {
+export function Logo({ variant = 'solid', size = 20, capSize, to }: LogoProps) {
   const isBrand = variant === 'brand';
   const tile = Math.round(size * 1.55);
-  return (
-    <div className="logo">
+  const conteudo = (
+    <>
       <span className={`logo__mark logo__mark--${variant}`} style={{ width: tile, height: tile }}>
         <GradCap size={capSize || Math.round(tile * 0.58)} />
       </span>
       <span className="logo__word" style={{ fontSize: size }}>
-        {word ?? (
-          <>
-            ensina
-            <span className={isBrand ? 'logo__suffix--brand' : 'logo__suffix'}>.dev</span>
-          </>
-        )}
+        Ensina
+        <span className={isBrand ? 'logo__suffix--brand' : 'logo__suffix'}> Dev</span>
       </span>
-    </div>
+    </>
   );
+  if (to) {
+    return (
+      <Link className="logo" to={to} aria-label="Ir para o início">
+        {conteudo}
+      </Link>
+    );
+  }
+  return <div className="logo">{conteudo}</div>;
 }

--- a/frontend/src/components/MobileMenu.tsx
+++ b/frontend/src/components/MobileMenu.tsx
@@ -38,7 +38,7 @@ export function MobileMenu({ items = NAV }: { items?: { to: string; label: strin
           <div className="drawer-scrim" onClick={fechar} />
           <nav className="drawer">
             <div className="drawer__head">
-              <Logo variant="solid" size={18} />
+              <Logo variant="solid" size={18} to="/home" />
               <button className="drawer__close" aria-label="Fechar menu" onClick={fechar}>
                 <X size={20} />
               </button>

--- a/frontend/src/components/UserMenu.tsx
+++ b/frontend/src/components/UserMenu.tsx
@@ -74,7 +74,7 @@ export function UserMenu({ initials, level, name, email }: UserMenuProps) {
             type="button"
             role="menuitem"
             className="user-menu__item"
-            onClick={() => go('/perfil')}
+            onClick={() => go(user?.username ? `/${user.username}` : '/perfil')}
           >
             Perfil
           </button>

--- a/frontend/src/pages/Aula/index.tsx
+++ b/frontend/src/pages/Aula/index.tsx
@@ -65,7 +65,7 @@ export function Aula() {
       <div className="home">
         <header className="topbar">
           <MobileMenu />
-          <Logo variant="solid" size={20} />
+          <Logo variant="solid" size={20} to="/home" />
           <nav className="nav">
             {NAV.map((item) => (
               <Link

--- a/frontend/src/pages/CertificadoValidar/index.tsx
+++ b/frontend/src/pages/CertificadoValidar/index.tsx
@@ -26,7 +26,7 @@ export function CertificadoValidar() {
   return (
     <div className="cert-page">
       <div className="cert-box">
-        <Logo variant="solid" size={22} word="Ensina Dev" />
+        <Logo variant="solid" size={22} />
         {estado === 'carregando' && <p className="cert-box__msg">Verificando certificado...</p>}
 
         {estado === 'invalido' && (

--- a/frontend/src/pages/Desafios/DesTopbar.tsx
+++ b/frontend/src/pages/Desafios/DesTopbar.tsx
@@ -17,7 +17,7 @@ export function DesTopbar() {
   return (
     <header className="topbar">
       <MobileMenu />
-      <Logo variant="solid" size={20} />
+      <Logo variant="solid" size={20} to="/home" />
       <nav className="nav">
         {NAV.map((item) => (
           <Link

--- a/frontend/src/pages/Desafios/ResolverDesafio.tsx
+++ b/frontend/src/pages/Desafios/ResolverDesafio.tsx
@@ -215,7 +215,7 @@ export function ResolverDesafio({ desafio }: { desafio: DesafioDetalhe }) {
   return (
     <div className="solve">
       <header className="solve-bar">
-        <Logo variant="solid" size={19} />
+        <Logo variant="solid" size={19} to="/home" />
         <button className="solve-bar__back" onClick={() => navigate('/desafios')}>
           <ChevronLeft size={16} /> {desafio.isToday ? 'Desafio do dia' : 'Desafios'}
         </button>

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -140,7 +140,7 @@ export function Home() {
         {/* Topbar */}
         <header className="topbar">
           <MobileMenu />
-          <Logo variant="solid" size={20} />
+          <Logo variant="solid" size={20} to="/home" />
           <nav className="nav">
             {NAV.map((item, i) => (
               <Link

--- a/frontend/src/pages/Perfil/index.tsx
+++ b/frontend/src/pages/Perfil/index.tsx
@@ -7,7 +7,7 @@ import {
   type ChangeEvent,
   type ReactNode,
 } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import api from '../../services/api';
 import { useAuth } from '../../contexts/AuthContext';
 import { Logo } from '../../components/Logo';
@@ -103,6 +103,7 @@ function lerArquivo(file: File): Promise<string> {
 
 export function Perfil() {
   const { user: authUser, atualizarUsuario } = useAuth();
+  const navigate = useNavigate();
   const [perfil, setPerfil] = useState<PerfilData | null>(null);
   const [xp, setXp] = useState({ xp: 0, level: 1, lessonsCompleted: 0, questionsCorrect: 0 });
   const [carregando, setCarregando] = useState(true);
@@ -127,6 +128,7 @@ export function Perfil() {
   const [erro, setErro] = useState('');
   const [enviandoFoto, setEnviandoFoto] = useState(false);
   const [enviandoCapa, setEnviandoCapa] = useState(false);
+  const [linkCopiado, setLinkCopiado] = useState(false);
   const [cropper, setCropper] = useState<{ image: string; tipo: 'avatar' | 'cover' } | null>(null);
   const inputFoto = useRef<HTMLInputElement>(null);
   const inputCapa = useRef<HTMLInputElement>(null);
@@ -162,6 +164,17 @@ export function Perfil() {
     };
   }, []);
 
+  async function copiarLinkPublico() {
+    if (!perfil?.username) return;
+    try {
+      await navigator.clipboard.writeText(`${window.location.origin}/${perfil.username}`);
+      setLinkCopiado(true);
+      setTimeout(() => setLinkCopiado(false), 2000);
+    } catch (e) {
+      console.error('Falha ao copiar o link:', e);
+    }
+  }
+
   function editar() {
     if (!perfil) return;
     setErro('');
@@ -192,8 +205,10 @@ export function Perfil() {
       const { data } = await api.patch<PerfilData>('/me', draft);
       // Preserva campos derivados (streak) que o PATCH não retorna.
       setPerfil((prev) => (prev ? { ...prev, ...data } : data));
-      atualizarUsuario({ name: data.name });
+      atualizarUsuario({ name: data.name, username: data.username });
       setEditando(false);
+      // A URL canônica do perfil carrega o username; se ele mudou, acompanha.
+      if (data.username) navigate(`/${data.username}`, { replace: true });
     } catch (e) {
       const msg = (e as { response?: { data?: { erro?: string } } })?.response?.data?.erro;
       setErro(msg ?? 'Não foi possível salvar as alterações.');
@@ -308,7 +323,7 @@ export function Perfil() {
       <div className="home">
         <header className="topbar">
           <MobileMenu />
-          <Logo variant="solid" size={20} />
+          <Logo variant="solid" size={20} to="/home" />
           <nav className="nav">
             {NAV.map((item) => (
               <Link key={item.to} to={item.to} className="nav__item">
@@ -449,6 +464,20 @@ export function Perfil() {
                 </div>
                 {!editando ? (
                   <div className="pf-actions">
+                    {perfil.username && (
+                      <button
+                        className="btn btn--ghost pf-actions__btn"
+                        onClick={copiarLinkPublico}
+                      >
+                        {linkCopiado ? (
+                          <>
+                            <Check size={14} /> Copiado!
+                          </>
+                        ) : (
+                          'Compartilhar'
+                        )}
+                      </button>
+                    )}
                     <button className="btn btn--accent pf-actions__btn" onClick={editar}>
                       <Pencil size={14} /> Editar perfil
                     </button>

--- a/frontend/src/pages/PerfilPublico/index.tsx
+++ b/frontend/src/pages/PerfilPublico/index.tsx
@@ -1,0 +1,350 @@
+import { useEffect, useState, type ReactNode } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { useAuth } from '../../contexts/AuthContext';
+import { Logo } from '../../components/Logo';
+import { ThemeToggle } from '../../components/ThemeToggle';
+import {
+  Flame,
+  AtSign,
+  MapPin,
+  Briefcase,
+  Calendar,
+  Github,
+  Linkedin,
+  XSocial,
+  Check,
+  IconeConquista,
+} from '../../components/Icons';
+import { getInitials } from '../../utils/initials';
+import { urlImagem } from '../../utils/urlImagem';
+import { obterPerfilPublico, type PerfilPublicoData } from '../../services/perfis';
+
+const NIVEL: Record<string, string> = {
+  iniciante: 'Iniciante',
+  intermediario: 'Intermediário',
+  avancado: 'Avançado',
+};
+
+function membroDesde(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '—';
+  const s = d.toLocaleDateString('pt-BR', { month: 'long', year: 'numeric' });
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function urlSocial(valor: string, prefixo: string): string {
+  const v = valor.trim();
+  if (/^https?:\/\//i.test(v)) return v;
+  if (v.includes('.')) return `https://${v.replace(/^\/+/, '')}`;
+  return `${prefixo}${v.replace(/^@/, '')}`;
+}
+
+export function PerfilPublico() {
+  const { username } = useParams();
+  const { isAuthenticated } = useAuth();
+  const [perfil, setPerfil] = useState<PerfilPublicoData | null>(null);
+  const [estado, setEstado] = useState<'carregando' | 'ok' | 'nao_encontrado'>('carregando');
+  const [copiado, setCopiado] = useState(false);
+
+  useEffect(() => {
+    if (!username) return;
+    setEstado('carregando');
+    obterPerfilPublico(username)
+      .then((p) => {
+        setPerfil(p);
+        setEstado('ok');
+      })
+      .catch(() => setEstado('nao_encontrado'));
+  }, [username]);
+
+  async function copiarLink() {
+    try {
+      await navigator.clipboard.writeText(`${window.location.origin}/${username}`);
+      setCopiado(true);
+      setTimeout(() => setCopiado(false), 2000);
+    } catch (e) {
+      console.error('Falha ao copiar o link:', e);
+    }
+  }
+
+  const fotoUrl = urlImagem(perfil?.avatarUrl);
+  const capaUrl = urlImagem(perfil?.coverUrl);
+
+  return (
+    <div className="home-shell">
+      <div className="home">
+        <header className="topbar">
+          <Logo variant="solid" size={20} to={isAuthenticated ? '/home' : '/'} />
+          <div className="topbar__spacer" />
+          <ThemeToggle inline />
+          <Link className="btn btn--ghost" to={isAuthenticated ? '/home' : '/'}>
+            {isAuthenticated ? 'Ir para o início' : 'Entrar'}
+          </Link>
+        </header>
+
+        {estado === 'carregando' && (
+          <p className="track__desc" style={{ padding: '40px 26px' }}>
+            Carregando perfil...
+          </p>
+        )}
+
+        {estado === 'nao_encontrado' && (
+          <p className="track__desc" style={{ padding: '40px 26px' }}>
+            Perfil não encontrado. Confira o endereço.
+          </p>
+        )}
+
+        {estado === 'ok' && perfil && (
+          <div className="pf">
+            <div className="pf-card">
+              <div
+                className="pf-banner"
+                style={
+                  capaUrl
+                    ? {
+                        backgroundImage: `url(${capaUrl})`,
+                        backgroundSize: 'cover',
+                        backgroundPosition: 'center',
+                      }
+                    : undefined
+                }
+              >
+                {!capaUrl && (
+                  <>
+                    <span className="pf-banner__glow pf-banner__glow--a" />
+                    <span className="pf-banner__glow pf-banner__glow--b" />
+                  </>
+                )}
+              </div>
+              <div className="pf-head">
+                <div className="pf-avatar-wrap">
+                  <div
+                    className="pf-avatar"
+                    style={{
+                      width: 104,
+                      height: 104,
+                      fontSize: 38,
+                      border: '4px solid var(--surface)',
+                    }}
+                  >
+                    {fotoUrl ? <img src={fotoUrl} alt={perfil.name} /> : getInitials(perfil.name)}
+                  </div>
+                </div>
+                <div className="pf-id">
+                  <div className="pf-id__row">
+                    <span className="pf-id__name">{perfil.name}</span>
+                    <span className="pf-id__level">Nível {perfil.level}</span>
+                  </div>
+                  <div className="pf-id__user">@{perfil.username}</div>
+                </div>
+                <div className="pf-actions">
+                  <button className="btn btn--ghost pf-actions__btn" onClick={copiarLink}>
+                    {copiado ? (
+                      <>
+                        <Check size={14} /> Copiado!
+                      </>
+                    ) : (
+                      'Copiar link'
+                    )}
+                  </button>
+                </div>
+              </div>
+              <div className="pf-stats">
+                <Stat
+                  value={String(perfil.streak)}
+                  label="dias de streak"
+                  icon={<Flame size={18} />}
+                />
+                <Stat value={perfil.xp.toLocaleString('pt-BR')} label="XP total" />
+                <Stat value={String(perfil.lessonsCompleted)} label="aulas concluídas" />
+                <Stat value={String(perfil.questionsCorrect)} label="exercícios resolvidos" />
+                <Stat value={String(perfil.challengesCompleted)} label="desafios resolvidos" />
+              </div>
+            </div>
+
+            <div className="pf-grid">
+              <div className="pf-col">
+                <div className="card">
+                  <h3 className="card__title card__title--mb">Sobre</h3>
+                  <p className="pf-bio">{perfil.bio || 'Sem descrição ainda.'}</p>
+                </div>
+
+                <div className="card">
+                  <h3 className="card__title card__title--mb">Informações</h3>
+                  <div className="pf-fields">
+                    <Campo
+                      icon={<AtSign size={14} />}
+                      label="Usuário"
+                      value={`@${perfil.username}`}
+                    />
+                    <Campo
+                      icon={<MapPin size={14} />}
+                      label="Localização"
+                      value={perfil.location || '—'}
+                    />
+                    <Campo
+                      icon={<Briefcase size={14} />}
+                      label="Função"
+                      value={perfil.occupation || '—'}
+                    />
+                    <Campo
+                      icon={<Calendar size={14} />}
+                      label="Membro desde"
+                      value={membroDesde(perfil.memberSince)}
+                    />
+
+                    <div>
+                      <div className="pf-field__label">Linguagens</div>
+                      <div className="pf-langs">
+                        {perfil.languages.map((l, i) => (
+                          <span key={l + i} className="pf-lang">
+                            {l}
+                          </span>
+                        ))}
+                        {perfil.languages.length === 0 && (
+                          <span className="pf-field__value" style={{ color: 'var(--muted)' }}>
+                            —
+                          </span>
+                        )}
+                      </div>
+                    </div>
+
+                    <div>
+                      <div className="pf-field__label">Links</div>
+                      <div className="pf-links">
+                        <LinkSocial
+                          icon={<Github size={15} />}
+                          value={perfil.github}
+                          prefixo="https://github.com/"
+                        />
+                        <LinkSocial
+                          icon={<Linkedin size={15} />}
+                          value={perfil.linkedin}
+                          prefixo="https://www.linkedin.com/in/"
+                        />
+                        <LinkSocial
+                          icon={<XSocial size={15} />}
+                          value={perfil.x}
+                          prefixo="https://x.com/"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div className="pf-col">
+                {perfil.certificados.length > 0 && (
+                  <div className="card">
+                    <h3 className="card__title card__title--mb">Certificados</h3>
+                    <div className="pf-certs">
+                      {perfil.certificados.map((c) => (
+                        <Link key={c.code} className="pf-cert" to={`/certificados/${c.code}`}>
+                          <div className="pf-cert__name">{c.trailName}</div>
+                          <div className="pf-cert__meta">
+                            {c.workloadHours} horas
+                            {c.language ? ` · ${c.language}` : ''} ·{' '}
+                            {new Date(c.issuedAt).toLocaleDateString('pt-BR')} · código {c.code}
+                          </div>
+                        </Link>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                <div className="card">
+                  <h3 className="card__title card__title--mb">Conquistas</h3>
+                  {perfil.conquistas.length === 0 ? (
+                    <p className="track__desc">Nenhuma conquista desbloqueada.</p>
+                  ) : (
+                    <div className="pf-badges">
+                      {perfil.conquistas.slice(0, 6).map((c) => (
+                        <div key={c.id} className="pf-badge">
+                          <span className="pf-badge__icon">
+                            <IconeConquista chave={c.icon} size={24} />
+                          </span>
+                          <div className="pf-badge__name">{c.name}</div>
+                          <div className="pf-badge__sub">{c.description}</div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+
+                {perfil.trilhas.length > 0 && (
+                  <div className="card">
+                    <h3 className="card__title card__title--mb">Trilhas</h3>
+                    <div className="pf-certs">
+                      {perfil.trilhas.map((t) => (
+                        <div key={t.name} className="pf-cert pf-cert--flat">
+                          <div className="pf-cert__name">{t.name}</div>
+                          <div className="pf-cert__meta">
+                            {NIVEL[t.trailLevel]} · {t.completedLessons}/{t.totalLessons} aulas ·{' '}
+                            {t.progress}%
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Stat({ value, label, icon }: { value: string; label: string; icon?: ReactNode }) {
+  return (
+    <div className="pf-stat">
+      <div className="pf-stat__value">
+        {icon && <span className="pf-stat__icon">{icon}</span>}
+        {value}
+      </div>
+      <div className="pf-stat__label">{label}</div>
+    </div>
+  );
+}
+
+function Campo({ icon, label, value }: { icon: ReactNode; label: string; value: string }) {
+  return (
+    <div>
+      <div className="pf-field__label">
+        <span className="pf-field__icon">{icon}</span>
+        {label}
+      </div>
+      <div className="pf-field__value">{value}</div>
+    </div>
+  );
+}
+
+function LinkSocial({
+  icon,
+  value,
+  prefixo,
+}: {
+  icon: ReactNode;
+  value: string | null;
+  prefixo: string;
+}) {
+  if (!value) {
+    return (
+      <div className="pf-link">
+        <span className="pf-link__icon">{icon}</span>—
+      </div>
+    );
+  }
+  return (
+    <a
+      className="pf-link pf-link--click"
+      href={urlSocial(value, prefixo)}
+      target="_blank"
+      rel="noreferrer noopener"
+    >
+      <span className="pf-link__icon">{icon}</span>
+      {value}
+    </a>
+  );
+}

--- a/frontend/src/pages/Ranking/index.tsx
+++ b/frontend/src/pages/Ranking/index.tsx
@@ -77,7 +77,7 @@ export function Ranking() {
       <div className="home">
         <header className="topbar">
           <MobileMenu />
-          <Logo variant="solid" size={20} />
+          <Logo variant="solid" size={20} to="/home" />
           <nav className="nav">
             {NAV.map((item) => (
               <Link

--- a/frontend/src/pages/Roadmaps/Detalhe.tsx
+++ b/frontend/src/pages/Roadmaps/Detalhe.tsx
@@ -115,7 +115,7 @@ export function RoadmapDetalhe() {
       <div className="home">
         <header className="topbar">
           <MobileMenu />
-          <Logo variant="solid" size={20} />
+          <Logo variant="solid" size={20} to="/home" />
           <nav className="nav">
             {NAV.map((item) => (
               <Link

--- a/frontend/src/pages/Roadmaps/index.tsx
+++ b/frontend/src/pages/Roadmaps/index.tsx
@@ -70,7 +70,7 @@ export function Roadmaps() {
       <div className="home">
         <header className="topbar">
           <MobileMenu />
-          <Logo variant="solid" size={20} />
+          <Logo variant="solid" size={20} to="/home" />
           <nav className="nav">
             {NAV.map((item) => (
               <Link

--- a/frontend/src/pages/Simulados/SimTopbar.tsx
+++ b/frontend/src/pages/Simulados/SimTopbar.tsx
@@ -17,7 +17,7 @@ export function SimTopbar({ active = '/simulados' }: { active?: string }) {
   return (
     <header className="topbar">
       <MobileMenu />
-      <Logo variant="solid" size={20} />
+      <Logo variant="solid" size={20} to="/home" />
       <nav className="nav">
         {NAV.map((item) => (
           <Link

--- a/frontend/src/pages/TrilhaDetalhe/index.tsx
+++ b/frontend/src/pages/TrilhaDetalhe/index.tsx
@@ -205,6 +205,32 @@ export function TrilhaDetalhe() {
     }
   }
 
+  function urlValidacao(code: string) {
+    return `${window.location.origin}/certificados/${code}`;
+  }
+
+  function linkedinCertUrl(code: string, issuedAt: string) {
+    const d = new Date(issuedAt);
+    const q = new URLSearchParams({
+      startTask: 'CERTIFICATION_NAME',
+      name: trilha?.name ?? 'Trilha',
+      organizationName: 'Ensina Dev',
+      issueYear: String(d.getFullYear()),
+      issueMonth: String(d.getMonth() + 1),
+      certUrl: urlValidacao(code),
+      certId: code,
+    });
+    return `https://www.linkedin.com/profile/add?${q.toString()}`;
+  }
+
+  function xCertUrl(code: string) {
+    const q = new URLSearchParams({
+      text: `Concluí a trilha ${trilha?.name ?? ''} no Ensina Dev!`,
+      url: urlValidacao(code),
+    });
+    return `https://twitter.com/intent/tweet?${q.toString()}`;
+  }
+
   async function baixarCertificado(code: string) {
     try {
       const blob = await baixarPdfCertificado(code);
@@ -274,7 +300,7 @@ export function TrilhaDetalhe() {
       <div className="home">
         <header className="topbar">
           <MobileMenu />
-          <Logo variant="solid" size={20} />
+          <Logo variant="solid" size={20} to="/home" />
           <nav className="nav">
             {NAV.map((item) => (
               <Link
@@ -401,12 +427,32 @@ export function TrilhaDetalhe() {
                       {stats.comecado ? 'Continuar trilha' : 'Começar trilha'}
                     </button>
                     {cert?.emitido && (
-                      <button
-                        className="td-card__cert"
-                        onClick={() => baixarCertificado(cert.emitido!.code)}
-                      >
-                        Baixar certificado
-                      </button>
+                      <>
+                        <button
+                          className="td-card__cert"
+                          onClick={() => baixarCertificado(cert.emitido!.code)}
+                        >
+                          Baixar certificado
+                        </button>
+                        <div className="td-cert-share">
+                          <a
+                            className="td-cert-share__btn"
+                            href={linkedinCertUrl(cert.emitido.code, cert.emitido.issuedAt)}
+                            target="_blank"
+                            rel="noreferrer noopener"
+                          >
+                            Adicionar ao LinkedIn
+                          </a>
+                          <a
+                            className="td-cert-share__btn"
+                            href={xCertUrl(cert.emitido.code)}
+                            target="_blank"
+                            rel="noreferrer noopener"
+                          >
+                            Compartilhar no X
+                          </a>
+                        </div>
+                      </>
                     )}
                     {cert?.elegivel && (
                       <button className="td-card__cert" onClick={abrirModalCertificado}>
@@ -737,6 +783,24 @@ export function TrilhaDetalhe() {
                     Código {cert.emitido.code}. Você pode baixar o PDF de novo quando quiser, aqui
                     na página da trilha.
                   </p>
+                  <div className="td-cert-share" style={{ marginBottom: 12 }}>
+                    <a
+                      className="td-cert-share__btn"
+                      href={linkedinCertUrl(cert.emitido.code, cert.emitido.issuedAt)}
+                      target="_blank"
+                      rel="noreferrer noopener"
+                    >
+                      Adicionar ao LinkedIn
+                    </a>
+                    <a
+                      className="td-cert-share__btn"
+                      href={xCertUrl(cert.emitido.code)}
+                      target="_blank"
+                      rel="noreferrer noopener"
+                    >
+                      Compartilhar no X
+                    </a>
+                  </div>
                   <div className="cmn-card__row">
                     <button className="btn btn--ghost" onClick={() => setCertModal(false)}>
                       Fechar

--- a/frontend/src/pages/Trilhas/index.tsx
+++ b/frontend/src/pages/Trilhas/index.tsx
@@ -140,7 +140,7 @@ export function Trilhas() {
         {/* Topbar */}
         <header className="topbar">
           <MobileMenu />
-          <Logo variant="solid" size={20} />
+          <Logo variant="solid" size={20} to="/home" />
           <nav className="nav">
             {NAV.map((item) => (
               <Link

--- a/frontend/src/services/perfis.ts
+++ b/frontend/src/services/perfis.ts
@@ -1,0 +1,48 @@
+import api from './api';
+
+export interface PerfilPublicoData {
+  name: string;
+  username: string;
+  bio: string | null;
+  location: string | null;
+  occupation: string | null;
+  languages: string[];
+  github: string | null;
+  linkedin: string | null;
+  x: string | null;
+  avatarUrl: string | null;
+  coverUrl: string | null;
+  memberSince: string;
+  xp: number;
+  level: number;
+  lessonsCompleted: number;
+  questionsCorrect: number;
+  challengesCompleted: number;
+  streak: number;
+  conquistas: {
+    id: string;
+    name: string;
+    description: string;
+    icon: string;
+    earnedAt: string | null;
+  }[];
+  trilhas: {
+    name: string;
+    trailLevel: 'iniciante' | 'intermediario' | 'avancado';
+    totalLessons: number;
+    completedLessons: number;
+    progress: number;
+  }[];
+  certificados: {
+    code: string;
+    trailName: string;
+    language: string | null;
+    workloadHours: number;
+    issuedAt: string;
+  }[];
+}
+
+export async function obterPerfilPublico(username: string) {
+  const { data } = await api.get<PerfilPublicoData>(`/perfis/${username}`);
+  return data;
+}

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -5060,3 +5060,8 @@
   font-size: 12.5px;
   color: var(--muted);
 }
+
+a.logo {
+  color: inherit;
+  text-decoration: none;
+}

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -5033,3 +5033,30 @@
 .cert-box__grid b {
   font-size: 14.5px;
 }
+
+/* ===================== PERFIL PÚBLICO ===================== */
+.pf-certs {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.pf-cert {
+  display: block;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  text-decoration: none;
+  color: var(--text);
+}
+.pf-cert:not(.pf-cert--flat):hover {
+  border-color: var(--accent);
+}
+.pf-cert__name {
+  font-weight: 700;
+  font-size: 14.5px;
+}
+.pf-cert__meta {
+  margin-top: 3px;
+  font-size: 12.5px;
+  color: var(--muted);
+}

--- a/frontend/src/styles/trilha-detalhe.css
+++ b/frontend/src/styles/trilha-detalhe.css
@@ -134,3 +134,7 @@
 .td-cert-conf div { display: flex; flex-direction: column; gap: 2px; }
 .td-cert-conf span { font-size: 12px; color: var(--muted); }
 .td-cert-conf b { font-size: 14.5px; }
+
+.td-cert-share { display: flex; gap: 8px; margin-top: 8px; }
+.td-cert-share__btn { flex: 1; height: 38px; display: flex; align-items: center; justify-content: center; border: 1px solid var(--border-strong); border-radius: 10px; background: transparent; color: var(--text); font-size: 13px; font-weight: 600; text-decoration: none; }
+.td-cert-share__btn:hover { border-color: var(--accent); }


### PR DESCRIPTION
## O que muda

### Perfil público em /username

Cada pessoa ganha uma URL própria e compartilhável (`ensinadev.com.br/username`), aberta sem login: capa, avatar, nível, streak, XP, aulas, exercícios, desafios, sobre, informações, linguagens, links sociais, conquistas desbloqueadas, trilhas com progresso e certificados (cada um linkando para a validação pública). Email, telefone e nascimento ficam de fora.

A URL vira a canônica do perfil: o menu leva para `/username` (o dono vê a versão editável ali mesmo), `/perfil` redireciona para ela, e trocar o username atualiza URL e menu na hora. O perfil ganhou o botão **Compartilhar**, que copia o link. Rotas fixas têm prioridade sobre `/username`, então `/home`, `/trilhas` etc. seguem intactas.

### Compartilhar certificado

Com certificado emitido, aparecem **Adicionar ao LinkedIn** (abre o formulário oficial de licenças e certificados do LinkedIn já preenchido: curso, emissor, mês/ano, código e URL de validação) e **Compartilhar no X** (composer com texto e link prontos), no card da trilha e no passo final da emissão.

### Marca Ensina Dev

Título da aba e wordmark do logo passam de "ensina.dev" para "Ensina Dev" (Dev na cor de destaque). O logo das topbars vira link para a home em todas as telas.

### Segurança

Fecha o alerta do CodeQL na geração do código do certificado: `crypto.randomInt` no lugar de `randomBytes % 31`, que enviesava de leve os primeiros caracteres do alfabeto.

## Testes

3 testes novos de integração (perfil público sem dados sensíveis, progresso + trilha + certificado no perfil, 404 para username inexistente). Suíte completa: **74/74**. `tsc` e build limpos. Validado manualmente no local.

## Deploy

Sem migração e sem variável nova; nenhum passo extra.
