### PR TITLE
feat: aba Meu progresso com dados reais

### DIFF
--- a/backend/drizzle/0037_lazy_thor_girl.sql
+++ b/backend/drizzle/0037_lazy_thor_girl.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "users" ADD COLUMN "weekly_goal_kind" varchar(10);--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "weekly_goal_target" integer;

--- a/backend/drizzle/meta/0037_snapshot.json
+++ b/backend/drizzle/meta/0037_snapshot.json
@@ -1,0 +1,2837 @@
+{
+  "id": "bd0a56ea-d759-4883-ae3b-47ae4544b33f",
+  "prevId": "dcc718aa-6ded-4b3c-b07d-9a9519c4aa7a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.achievements": {
+      "name": "achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "criteria_type": {
+          "name": "criteria_type",
+          "type": "achievement_criteria",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "achievements_name_unique": {
+          "name": "achievements_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.certificates": {
+      "name": "certificates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_name": {
+          "name": "student_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpf": {
+          "name": "cpf",
+          "type": "varchar(11)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trail_name": {
+          "name": "trail_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workload_hours": {
+          "name": "workload_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "certificates_user_id_users_id_fk": {
+          "name": "certificates_user_id_users_id_fk",
+          "tableFrom": "certificates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "certificates_trail_id_trails_id_fk": {
+          "name": "certificates_trail_id_trails_id_fk",
+          "tableFrom": "certificates",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "certificates_code_unique": {
+          "name": "certificates_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        },
+        "certificates_user_id_trail_id_unique": {
+          "name": "certificates_user_id_trail_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "trail_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge_submissions": {
+      "name": "challenge_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "challenge_language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "challenge_submission_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "passed_count": {
+          "name": "passed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_count": {
+          "name": "total_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xp_earned": {
+          "name": "xp_earned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "challenge_submissions_user_id_users_id_fk": {
+          "name": "challenge_submissions_user_id_users_id_fk",
+          "tableFrom": "challenge_submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "challenge_submissions_challenge_id_challenges_id_fk": {
+          "name": "challenge_submissions_challenge_id_challenges_id_fk",
+          "tableFrom": "challenge_submissions",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge_tests": {
+      "name": "challenge_tests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_output": {
+          "name": "expected_output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "challenge_tests_challenge_id_challenges_id_fk": {
+          "name": "challenge_tests_challenge_id_challenges_id_fk",
+          "tableFrom": "challenge_tests",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenges": {
+      "name": "challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "challenge_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stdin'"
+        },
+        "entry_point": {
+          "name": "entry_point",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_blocks": {
+          "name": "statement_blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "question_difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'facil'"
+        },
+        "starter_code": {
+          "name": "starter_code",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_date": {
+          "name": "active_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "challenges_number_unique": {
+          "name": "challenges_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "number"
+          ]
+        },
+        "challenges_active_date_unique": {
+          "name": "challenges_active_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "active_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comunicado_respostas": {
+      "name": "comunicado_respostas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "comunicado_id": {
+          "name": "comunicado_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "comunicado_resposta_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comunicado_respostas_comunicado_id_comunicados_id_fk": {
+          "name": "comunicado_respostas_comunicado_id_comunicados_id_fk",
+          "tableFrom": "comunicado_respostas",
+          "tableTo": "comunicados",
+          "columnsFrom": [
+            "comunicado_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "comunicado_respostas_user_id_users_id_fk": {
+          "name": "comunicado_respostas_user_id_users_id_fk",
+          "tableFrom": "comunicado_respostas",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "comunicado_respostas_comunicado_id_user_id_unique": {
+          "name": "comunicado_respostas_comunicado_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "comunicado_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comunicados": {
+      "name": "comunicados",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "comunicado_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.glossary": {
+      "name": "glossary",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "term": {
+          "name": "term",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "varchar(400)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "glossary_term_unique": {
+          "name": "glossary_term_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "term"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.languages": {
+      "name": "languages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "languages_name_unique": {
+          "name": "languages_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons_progress": {
+      "name": "lessons_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "manual": {
+          "name": "manual",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_progress_user_id_users_id_fk": {
+          "name": "lessons_progress_user_id_users_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_progress_lesson_id_lessons_id_fk": {
+          "name": "lessons_progress_lesson_id_lessons_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lessons_progress_user_id_lesson_id_unique": {
+          "name": "lessons_progress_user_id_lesson_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "lesson_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons": {
+      "name": "lessons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_blocks": {
+          "name": "content_blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "duration_min": {
+          "name": "duration_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview": {
+          "name": "preview",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_trail_id_trails_id_fk": {
+          "name": "lessons_trail_id_trails_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_module_id_modules_id_fk": {
+          "name": "lessons_module_id_modules_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "modules",
+          "columnsFrom": [
+            "module_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.modules": {
+      "name": "modules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "modules_trail_id_trails_id_fk": {
+          "name": "modules_trail_id_trails_id_fk",
+          "tableFrom": "modules",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_accounts": {
+      "name": "oauth_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_accounts_user_id_users_id_fk": {
+          "name": "oauth_accounts_user_id_users_id_fk",
+          "tableFrom": "oauth_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_accounts_provider_provider_id_unique": {
+          "name": "oauth_accounts_provider_provider_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "provider_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_answers": {
+      "name": "question_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_option_id": {
+          "name": "selected_option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_answers_user_id_users_id_fk": {
+          "name": "question_answers_user_id_users_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_question_id_questions_id_fk": {
+          "name": "question_answers_question_id_questions_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_selected_option_id_question_options_id_fk": {
+          "name": "question_answers_selected_option_id_question_options_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "question_options",
+          "columnsFrom": [
+            "selected_option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "question_answers_user_id_question_id_unique": {
+          "name": "question_answers_user_id_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_options": {
+      "name": "question_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_options_question_id_questions_id_fk": {
+          "name": "question_options_question_id_questions_id_fk",
+          "tableFrom": "question_options",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "question_difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'facil'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_lesson_id_lessons_id_fk": {
+          "name": "questions_lesson_id_lessons_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ranking_snapshots": {
+      "name": "ranking_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ranking_snapshots_user_id_users_id_fk": {
+          "name": "ranking_snapshots_user_id_users_id_fk",
+          "tableFrom": "ranking_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ranking_snapshots_user_id_snapshot_date_unique": {
+          "name": "ranking_snapshots_user_id_snapshot_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "snapshot_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmap_stage_completions": {
+      "name": "roadmap_stage_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "roadmap_stage_completions_user_id_users_id_fk": {
+          "name": "roadmap_stage_completions_user_id_users_id_fk",
+          "tableFrom": "roadmap_stage_completions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "roadmap_stage_completions_stage_id_roadmap_stages_id_fk": {
+          "name": "roadmap_stage_completions_stage_id_roadmap_stages_id_fk",
+          "tableFrom": "roadmap_stage_completions",
+          "tableTo": "roadmap_stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roadmap_stage_completions_user_id_stage_id_unique": {
+          "name": "roadmap_stage_completions_user_id_stage_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "stage_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmap_stage_refs": {
+      "name": "roadmap_stage_refs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_type": {
+          "name": "ref_type",
+          "type": "roadmap_ref_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "roadmap_stage_refs_stage_id_roadmap_stages_id_fk": {
+          "name": "roadmap_stage_refs_stage_id_roadmap_stages_id_fk",
+          "tableFrom": "roadmap_stage_refs",
+          "tableTo": "roadmap_stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmap_stages": {
+      "name": "roadmap_stages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "roadmap_id": {
+          "name": "roadmap_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "roadmap_phase",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "roadmap_stages_roadmap_id_roadmaps_id_fk": {
+          "name": "roadmap_stages_roadmap_id_roadmaps_id_fk",
+          "tableFrom": "roadmap_stages",
+          "tableTo": "roadmaps",
+          "columnsFrom": [
+            "roadmap_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmaps": {
+      "name": "roadmaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "trail_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "premium": {
+          "name": "premium",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roadmaps_slug_unique": {
+          "name": "roadmaps_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_attempt_answers": {
+      "name": "simulado_attempt_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_attempt_answers_attempt_id_simulado_attempts_id_fk": {
+          "name": "simulado_attempt_answers_attempt_id_simulado_attempts_id_fk",
+          "tableFrom": "simulado_attempt_answers",
+          "tableTo": "simulado_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempt_answers_question_id_simulado_questions_id_fk": {
+          "name": "simulado_attempt_answers_question_id_simulado_questions_id_fk",
+          "tableFrom": "simulado_attempt_answers",
+          "tableTo": "simulado_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempt_answers_option_id_simulado_options_id_fk": {
+          "name": "simulado_attempt_answers_option_id_simulado_options_id_fk",
+          "tableFrom": "simulado_attempt_answers",
+          "tableTo": "simulado_options",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulado_attempt_answers_attempt_id_question_id_option_id_unique": {
+          "name": "simulado_attempt_answers_attempt_id_question_id_option_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "attempt_id",
+            "question_id",
+            "option_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_attempt_questions": {
+      "name": "simulado_attempt_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_attempt_questions_attempt_id_simulado_attempts_id_fk": {
+          "name": "simulado_attempt_questions_attempt_id_simulado_attempts_id_fk",
+          "tableFrom": "simulado_attempt_questions",
+          "tableTo": "simulado_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempt_questions_question_id_simulado_questions_id_fk": {
+          "name": "simulado_attempt_questions_question_id_simulado_questions_id_fk",
+          "tableFrom": "simulado_attempt_questions",
+          "tableTo": "simulado_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulado_attempt_questions_attempt_id_question_id_unique": {
+          "name": "simulado_attempt_questions_attempt_id_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "attempt_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_attempts": {
+      "name": "simulado_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "simulado_id": {
+          "name": "simulado_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passed": {
+          "name": "passed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_attempts_user_id_users_id_fk": {
+          "name": "simulado_attempts_user_id_users_id_fk",
+          "tableFrom": "simulado_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempts_simulado_id_simulados_id_fk": {
+          "name": "simulado_attempts_simulado_id_simulados_id_fk",
+          "tableFrom": "simulado_attempts",
+          "tableTo": "simulados",
+          "columnsFrom": [
+            "simulado_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_options": {
+      "name": "simulado_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_options_question_id_simulado_questions_id_fk": {
+          "name": "simulado_options_question_id_simulado_questions_id_fk",
+          "tableFrom": "simulado_options",
+          "tableTo": "simulado_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_questions": {
+      "name": "simulado_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "simulado_id": {
+          "name": "simulado_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_questions_simulado_id_simulados_id_fk": {
+          "name": "simulado_questions_simulado_id_simulados_id_fk",
+          "tableFrom": "simulado_questions",
+          "tableTo": "simulados",
+          "columnsFrom": [
+            "simulado_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulados": {
+      "name": "simulados",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_count": {
+          "name": "question_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pass_percent": {
+          "name": "pass_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulados_slug_unique": {
+          "name": "simulados_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tokens": {
+      "name": "tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'refresh'"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tokens_user_id_users_id_fk": {
+          "name": "tokens_user_id_users_id_fk",
+          "tableFrom": "tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tokens_token_hash_unique": {
+          "name": "tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_reviews": {
+      "name": "trail_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stars": {
+          "name": "stars",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "trail_reviews_trail_id_trails_id_fk": {
+          "name": "trail_reviews_trail_id_trails_id_fk",
+          "tableFrom": "trail_reviews",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trail_reviews_user_id_users_id_fk": {
+          "name": "trail_reviews_user_id_users_id_fk",
+          "tableFrom": "trail_reviews",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trail_reviews_user_id_trail_id_unique": {
+          "name": "trail_reviews_user_id_trail_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "trail_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_tags": {
+      "name": "trail_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "trail_tags_trail_id_trails_id_fk": {
+          "name": "trail_tags_trail_id_trails_id_fk",
+          "tableFrom": "trail_tags",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trail_tags_tag_id_tags_id_fk": {
+          "name": "trail_tags_tag_id_tags_id_fk",
+          "tableFrom": "trail_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trail_tags_trail_id_tag_id_unique": {
+          "name": "trail_tags_trail_id_tag_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trail_id",
+            "tag_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trails": {
+      "name": "trails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "trail_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "what_you_learn": {
+          "name": "what_you_learn",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prerequisites": {
+          "name": "prerequisites",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workload_hours": {
+          "name": "workload_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_achievements": {
+      "name": "user_achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "achievement_id": {
+          "name": "achievement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_achievements_user_id_users_id_fk": {
+          "name": "user_achievements_user_id_users_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_achievements_achievement_id_achievements_id_fk": {
+          "name": "user_achievements_achievement_id_achievements_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "achievements",
+          "columnsFrom": [
+            "achievement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_achievements_user_id_achievement_id_unique": {
+          "name": "user_achievements_user_id_achievement_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "achievement_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username_changed_at": {
+          "name": "username_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occupation": {
+          "name": "occupation",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github": {
+          "name": "github",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin": {
+          "name": "linkedin",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "failed_login_attempts": {
+          "name": "failed_login_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_goal_kind": {
+          "name": "weekly_goal_kind",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_goal_target": {
+          "name": "weekly_goal_target",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.achievement_criteria": {
+      "name": "achievement_criteria",
+      "schema": "public",
+      "values": [
+        "xp_total",
+        "lessons_completed",
+        "questions_correct",
+        "special"
+      ]
+    },
+    "public.challenge_kind": {
+      "name": "challenge_kind",
+      "schema": "public",
+      "values": [
+        "stdin",
+        "function"
+      ]
+    },
+    "public.challenge_language": {
+      "name": "challenge_language",
+      "schema": "public",
+      "values": [
+        "javascript",
+        "python",
+        "csharp",
+        "java"
+      ]
+    },
+    "public.challenge_submission_status": {
+      "name": "challenge_submission_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "passed",
+        "failed",
+        "error",
+        "timeout"
+      ]
+    },
+    "public.comunicado_kind": {
+      "name": "comunicado_kind",
+      "schema": "public",
+      "values": [
+        "aviso",
+        "pesquisa"
+      ]
+    },
+    "public.comunicado_resposta_status": {
+      "name": "comunicado_resposta_status",
+      "schema": "public",
+      "values": [
+        "respondido",
+        "dispensado"
+      ]
+    },
+    "public.question_difficulty": {
+      "name": "question_difficulty",
+      "schema": "public",
+      "values": [
+        "facil",
+        "medio",
+        "dificil"
+      ]
+    },
+    "public.roadmap_phase": {
+      "name": "roadmap_phase",
+      "schema": "public",
+      "values": [
+        "fundamentos",
+        "core",
+        "avancado",
+        "deploy"
+      ]
+    },
+    "public.roadmap_ref_type": {
+      "name": "roadmap_ref_type",
+      "schema": "public",
+      "values": [
+        "trail",
+        "module",
+        "lesson",
+        "simulado",
+        "challenge"
+      ]
+    },
+    "public.trail_level": {
+      "name": "trail_level",
+      "schema": "public",
+      "values": [
+        "iniciante",
+        "intermediario",
+        "avancado"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin",
+        "moderator"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -260,6 +260,13 @@
       "when": 1784764588869,
       "tag": "0036_mean_paladin",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1784813493307,
+      "tag": "0037_lazy_thor_girl",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/schema.ts
+++ b/backend/schema.ts
@@ -61,6 +61,10 @@ export const users = pgTable("users", {
     role: userRole("role").default("user").notNull(),
     failedLoginAttempts: integer("failed_login_attempts").default(0).notNull(),
     lockedUntil: timestamp("locked_until", { withTimezone: true }),
+    // Meta semanal escolhida pelo usuário: "aulas" (X aulas por dia) ou "dias"
+    // (streak de X dias). Nulo = meta padrão de 7 dias ativos na semana.
+    weeklyGoalKind: varchar("weekly_goal_kind", { length: 10 }),
+    weeklyGoalTarget: integer("weekly_goal_target"),
 });
 
 // Identidades de login social vinculadas a um usuário. Um usuário pode ter mais de

--- a/backend/src/controllers/UserController.ts
+++ b/backend/src/controllers/UserController.ts
@@ -5,11 +5,12 @@ import { writeFile, mkdir, unlink } from "node:fs/promises";
 import { db } from "../../db.ts";
 import { users, languages as languagesTable } from "../../schema.ts";
 import { eq } from "drizzle-orm";
-import { updateMeSchema, completarPerfilSchema } from "../schemas/auth.schema.ts";
+import { updateMeSchema, completarPerfilSchema, metaSemanalSchema } from "../schemas/auth.schema.ts";
 import { UPLOADS_DIR, AVATARS_DIR, COVERS_DIR } from "../config/paths.ts";
 import { streakDoUsuario } from "../services/streak.ts";
 import { calcularEstatisticas } from "../services/stats.service.ts";
 import { perfilPublico } from "../services/perfil-publico.service.ts";
+import { progressoDoUsuario, definirMetaSemanal, limparMetaSemanal } from "../services/progresso.service.ts";
 
 const publicUserColumns = {
     id: users.id,
@@ -317,6 +318,35 @@ export const listUsers = async (_req: Request, res: Response) => {
 export const getPublicProfile = async (req: Request, res: Response, next: NextFunction) => {
     try {
         res.json(await perfilPublico(String(req.params.username)));
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const getMyProgress = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const bruto = String(req.query.periodo ?? "30");
+        const periodo = bruto === "7" ? 7 : bruto === "tudo" ? null : 30;
+        res.json(await progressoDoUsuario(req.userId!, periodo));
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const setWeeklyGoal = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const { kind, target } = metaSemanalSchema.parse(req.body);
+        await definirMetaSemanal(req.userId!, kind, target);
+        res.json({ ok: true });
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const clearWeeklyGoal = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        await limparMetaSemanal(req.userId!);
+        res.json({ ok: true });
     } catch (err) {
         next(err);
     }

--- a/backend/src/routes/user.routes.ts
+++ b/backend/src/routes/user.routes.ts
@@ -10,6 +10,9 @@ import {
     removerCover,
     listUsers,
     getPublicProfile,
+    getMyProgress,
+    setWeeklyGoal,
+    clearWeeklyGoal,
 } from "../controllers/UserController.ts";
 const router = Router();
 
@@ -20,6 +23,9 @@ router.post("/me/avatar", autenticar, uploadAvatar);
 router.post("/me/cover", autenticar, uploadCover);
 router.delete("/me/avatar", autenticar, removerAvatar);
 router.delete("/me/cover", autenticar, removerCover);
+router.get("/me/progresso", autenticar, getMyProgress);
+router.put("/me/meta-semanal", autenticar, setWeeklyGoal);
+router.delete("/me/meta-semanal", autenticar, clearWeeklyGoal);
 router.get("/users", autenticar, exigirAdmin, listUsers);
 
 // Perfil público compartilhável: qualquer pessoa vê, sem login.

--- a/backend/src/schemas/auth.schema.ts
+++ b/backend/src/schemas/auth.schema.ts
@@ -73,3 +73,12 @@ export const completarPerfilSchema = z.object({
     gender: z.string().min(1, "Selecione o gênero"),
     phone: z.string().trim().min(1, "Informe o telefone").max(20, "Telefone muito longo"),
 });
+
+export const metaSemanalSchema = z
+    .object({
+        kind: z.enum(["aulas", "dias"]),
+        target: z.number().int().min(1).max(60),
+    })
+    .refine((v) => (v.kind === "aulas" ? v.target <= 20 : v.target >= 2), {
+        message: "Meta fora do intervalo permitido",
+    });

--- a/backend/src/services/progresso.service.ts
+++ b/backend/src/services/progresso.service.ts
@@ -1,0 +1,251 @@
+import { eq, sql } from "drizzle-orm";
+import { db } from "../../db.ts";
+import { trails, users } from "../../schema.ts";
+import { diasAtivosDoUsuario, hojeSaoPaulo } from "./streak.ts";
+import { calcularStreak, diaAnterior, semanaAtividade } from "../domain/streak.ts";
+import { calcularEstatisticas } from "./stats.service.ts";
+
+const TZ = "America/Sao_Paulo";
+const DIAS_GRAFICO = 14;
+const SEMANAS_HEATMAP = 52;
+
+type DiaAtividade = { xp: number; exercicios: number; minutos: number; aulas: number };
+
+// XP, exercícios corretos e minutos estimados (duração das aulas concluídas),
+// agregados por dia no fuso de SP, unindo as três fontes de atividade.
+async function atividadePorDia(userId: string) {
+    const res = await db.execute(sql`
+        SELECT d,
+               SUM(xp)::int AS xp,
+               SUM(exercicios)::int AS exercicios,
+               SUM(minutos)::int AS minutos,
+               SUM(aulas)::int AS aulas
+        FROM (
+            SELECT to_char(answered_at AT TIME ZONE ${TZ}, 'YYYY-MM-DD') AS d,
+                   CASE WHEN is_correct THEN 10 ELSE 0 END AS xp,
+                   CASE WHEN is_correct THEN 1 ELSE 0 END AS exercicios,
+                   0 AS minutos, 0 AS aulas
+            FROM question_answers WHERE user_id = ${userId}
+            UNION ALL
+            SELECT to_char(lp.completed_at AT TIME ZONE ${TZ}, 'YYYY-MM-DD') AS d,
+                   50 AS xp, 0 AS exercicios, COALESCE(l.duration_min, 12) AS minutos, 1 AS aulas
+            FROM lessons_progress lp
+            JOIN lessons l ON l.id = lp.lesson_id
+            WHERE lp.user_id = ${userId} AND lp.manual = false
+            UNION ALL
+            SELECT to_char(created_at AT TIME ZONE ${TZ}, 'YYYY-MM-DD') AS d,
+                   xp_earned AS xp, 0 AS exercicios, 0 AS minutos, 0 AS aulas
+            FROM challenge_submissions WHERE user_id = ${userId} AND xp_earned > 0
+        ) t
+        GROUP BY d
+    `);
+    return new Map<string, DiaAtividade>(
+        (
+            res.rows as { d: string; xp: number; exercicios: number; minutos: number; aulas: number }[]
+        ).map((r) => [
+            r.d,
+            {
+                xp: Number(r.xp),
+                exercicios: Number(r.exercicios),
+                minutos: Number(r.minutos),
+                aulas: Number(r.aulas),
+            },
+        ]),
+    );
+}
+
+// Domínio = questões distintas acertadas sobre o total de questões da trilha
+// (aulas publicadas; em trilha multi-linguagem, neutras + o melhor track).
+async function dominioPorTrilha(userId: string) {
+    const questoes = await db.execute(sql`
+        SELECT l.trail_id AS tid, l.language AS lang, q.id AS qid
+        FROM questions q
+        JOIN lessons l ON l.id = q.lesson_id
+        WHERE l.published = true
+    `);
+    const acertos = await db.execute(sql`
+        SELECT DISTINCT question_id AS qid FROM question_answers
+        WHERE user_id = ${userId} AND is_correct = true
+    `);
+    const certas = new Set((acertos.rows as { qid: string }[]).map((r) => r.qid));
+
+    type Grupo = { neutras: string[]; porLang: Map<string, string[]> };
+    const porTrilha = new Map<string, Grupo>();
+    for (const r of questoes.rows as { tid: string; lang: string | null; qid: string }[]) {
+        const grupo = porTrilha.get(r.tid) ?? {
+            neutras: [] as string[],
+            porLang: new Map<string, string[]>(),
+        };
+        if (r.lang === null) {
+            grupo.neutras.push(r.qid);
+        } else {
+            const arr = grupo.porLang.get(r.lang) ?? [];
+            arr.push(r.qid);
+            grupo.porLang.set(r.lang, arr);
+        }
+        porTrilha.set(r.tid, grupo);
+    }
+
+    const todas = await db
+        .select({ id: trails.id, name: trails.name, trailLevel: trails.trailLevel })
+        .from(trails);
+    const contar = (ids: string[]) => ids.filter((id) => certas.has(id)).length;
+
+    const saida = [];
+    for (const t of todas) {
+        const grupo = porTrilha.get(t.id);
+        if (!grupo) continue;
+        let total = grupo.neutras.length;
+        let feitas = contar(grupo.neutras);
+        if (grupo.porLang.size > 0) {
+            let melhor = { total: 0, feitas: 0, pct: -1 };
+            for (const ids of grupo.porLang.values()) {
+                const tt = grupo.neutras.length + ids.length;
+                const ff = contar(grupo.neutras) + contar(ids);
+                const pct = tt > 0 ? ff / tt : 0;
+                if (pct > melhor.pct || (pct === melhor.pct && ff > melhor.feitas)) {
+                    melhor = { total: tt, feitas: ff, pct };
+                }
+            }
+            total = melhor.total;
+            feitas = melhor.feitas;
+        }
+        if (feitas === 0 || total === 0) continue;
+        saida.push({
+            trailId: t.id,
+            name: t.name,
+            trailLevel: t.trailLevel,
+            acertos: feitas,
+            total,
+            pct: Math.round((feitas / total) * 100),
+        });
+    }
+    return saida.sort((a, b) => b.pct - a.pct);
+}
+
+// Maior sequência de dias consecutivos com atividade, em qualquer época.
+function recordeStreak(dias: Set<string>): number {
+    let recorde = 0;
+    for (const d of dias) {
+        if (dias.has(diaAnterior(d))) continue;
+        let n = 0;
+        let cursor = d;
+        while (dias.has(cursor)) {
+            n++;
+            cursor = new Date(Date.parse(cursor + "T00:00:00Z") + 86400000)
+                .toISOString()
+                .slice(0, 10);
+        }
+        recorde = Math.max(recorde, n);
+    }
+    return recorde;
+}
+
+export type MetaSemanal =
+    | { tipo: "padrao"; valor: number; alvo: number }
+    | { tipo: "aulas"; valor: number; alvo: number; alvoDiario: number }
+    | { tipo: "dias"; valor: number; alvo: number };
+
+export async function definirMetaSemanal(userId: string, kind: "aulas" | "dias", target: number) {
+    await db
+        .update(users)
+        .set({ weeklyGoalKind: kind, weeklyGoalTarget: target })
+        .where(eq(users.id, userId));
+}
+
+export async function limparMetaSemanal(userId: string) {
+    await db
+        .update(users)
+        .set({ weeklyGoalKind: null, weeklyGoalTarget: null })
+        .where(eq(users.id, userId));
+}
+
+export async function progressoDoUsuario(userId: string, periodoDias: 7 | 30 | null) {
+    const [porDia, diasAtivos, stats, [meta], dominio] = await Promise.all([
+        atividadePorDia(userId),
+        diasAtivosDoUsuario(userId),
+        calcularEstatisticas(userId),
+        db
+            .select({ kind: users.weeklyGoalKind, target: users.weeklyGoalTarget })
+            .from(users)
+            .where(eq(users.id, userId)),
+        dominioPorTrilha(userId),
+    ]);
+    const hoje = hojeSaoPaulo();
+
+    const dataAtras = (offset: number) =>
+        new Date(Date.parse(hoje + "T00:00:00Z") - offset * 86400000).toISOString().slice(0, 10);
+
+    const somaJanela = (inicio: number, fim: number): DiaAtividade => {
+        const total = { xp: 0, exercicios: 0, minutos: 0, aulas: 0 };
+        for (let o = inicio; o <= fim; o++) {
+            const v = porDia.get(dataAtras(o));
+            if (v) {
+                total.xp += v.xp;
+                total.exercicios += v.exercicios;
+                total.minutos += v.minutos;
+                total.aulas += v.aulas;
+            }
+        }
+        return total;
+    };
+    const somaTudo = (): DiaAtividade => {
+        const total = { xp: 0, exercicios: 0, minutos: 0, aulas: 0 };
+        for (const v of porDia.values()) {
+            total.xp += v.xp;
+            total.exercicios += v.exercicios;
+            total.minutos += v.minutos;
+            total.aulas += v.aulas;
+        }
+        return total;
+    };
+
+    const atual = periodoDias ? somaJanela(0, periodoDias - 1) : somaTudo();
+    const anterior = periodoDias ? somaJanela(periodoDias, periodoDias * 2 - 1) : null;
+
+    const xpPorDia = Array.from({ length: DIAS_GRAFICO }, (_, i) => {
+        const d = dataAtras(DIAS_GRAFICO - 1 - i);
+        return { d, xp: porDia.get(d)?.xp ?? 0 };
+    });
+
+    // O heatmap mede aulas concluídas por dia; dias só com exercícios ficam vazios.
+    const heatmap: { d: string; n: number }[] = [];
+    let aulasAno = 0;
+    for (let o = 0; o < SEMANAS_HEATMAP * 7; o++) {
+        const d = dataAtras(o);
+        const v = porDia.get(d);
+        if (!v) continue;
+        aulasAno += v.aulas;
+        if (v.aulas > 0) heatmap.push({ d, n: v.aulas });
+    }
+
+    const semana = semanaAtividade(diasAtivos, hoje);
+    const streakAtual = calcularStreak(diasAtivos, hoje);
+
+    let metaSemana: MetaSemanal;
+    if (meta?.kind === "aulas" && meta.target) {
+        let cumpridos = 0;
+        for (let o = 0; o < 7; o++) {
+            if ((porDia.get(dataAtras(o))?.aulas ?? 0) >= meta.target) cumpridos++;
+        }
+        metaSemana = { tipo: "aulas", valor: cumpridos, alvo: 7, alvoDiario: meta.target };
+    } else if (meta?.kind === "dias" && meta.target) {
+        metaSemana = { tipo: "dias", valor: Math.min(streakAtual, meta.target), alvo: meta.target };
+    } else {
+        metaSemana = { tipo: "padrao", valor: semana.filter((s) => s.active).length, alvo: 7 };
+    }
+
+    return {
+        hoje,
+        xpTotal: stats.xp,
+        level: stats.level,
+        streakAtual,
+        streakRecorde: recordeStreak(diasAtivos),
+        periodo: { dias: periodoDias, atual, anterior },
+        xpPorDia,
+        metaSemana,
+        heatmap,
+        aulasAno,
+        dominio,
+    };
+}

--- a/backend/tests/progresso.test.ts
+++ b/backend/tests/progresso.test.ts
@@ -1,0 +1,210 @@
+import { test, describe, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { startTestServer } from "./helpers/server.ts";
+import { limparBanco } from "./helpers/db.ts";
+
+let server: Awaited<ReturnType<typeof startTestServer>>;
+
+let seq = 0;
+const novoUsuario = () => ({
+    name: "Aluno Progresso",
+    email: `prg_${++seq}_${Math.round(performance.now() * 1000)}@email.com`,
+    username: `prg_${seq}`,
+    password: "Senhaforte123!",
+    birthDate: "1990-01-01",
+    gender: "outro",
+    phone: "11999998888",
+});
+
+async function ajustarUsuario(email: string, campos: Record<string, unknown>) {
+    const { db } = await import("../db.ts");
+    const { users } = await import("../schema.ts");
+    const { eq } = await import("drizzle-orm");
+    await db.update(users).set(campos).where(eq(users.email, email));
+}
+
+async function criarUsuarioLogado(admin = false) {
+    const dados = novoUsuario();
+    await server.request("POST", "/register", { body: dados });
+    await ajustarUsuario(dados.email, {
+        emailVerifiedAt: new Date(),
+        ...(admin ? { role: "admin" } : {}),
+    });
+    const login = await server.request("POST", "/login", {
+        body: { email: dados.email, password: dados.password },
+    });
+    return { email: dados.email, token: login.body.token };
+}
+
+function auth(token: string) {
+    return { Authorization: `Bearer ${token}` };
+}
+async function get(path: string, token: string) {
+    const res = await fetch(`${server.base}${path}`, { headers: auth(token) });
+    return { status: res.status, body: await res.json().catch(() => null) };
+}
+async function post(path: string, token: string, body?: unknown) {
+    const res = await fetch(`${server.base}${path}`, {
+        method: "POST",
+        headers: { ...auth(token), "Content-Type": "application/json" },
+        body: body ? JSON.stringify(body) : undefined,
+    });
+    return { status: res.status, body: await res.json().catch(() => null) };
+}
+async function patch(path: string, token: string, body?: unknown) {
+    const res = await fetch(`${server.base}${path}`, {
+        method: "PATCH",
+        headers: { ...auth(token), "Content-Type": "application/json" },
+        body: body ? JSON.stringify(body) : undefined,
+    });
+    return { status: res.status, body: await res.json().catch(() => null) };
+}
+
+before(async () => {
+    server = await startTestServer();
+});
+after(async () => {
+    await server.close();
+});
+beforeEach(async () => {
+    await limparBanco();
+});
+
+describe("Meu progresso", () => {
+    test("agrega XP, exercícios, tempo estimado, meta da semana e heatmap", async () => {
+        const admin = await criarUsuarioLogado(true);
+        const trilha = await post("/trails", admin.token, {
+            name: "Logica",
+            level: "iniciante",
+            description: "Base da programacao logica.",
+        });
+        const modulo = await post(`/trails/${trilha.body.id}/modules`, admin.token, {
+            title: "Modulo 1",
+            position: 1,
+        });
+        const aluno = await criarUsuarioLogado();
+        for (let i = 1; i <= 2; i++) {
+            const aula = await post(`/modules/${modulo.body.id}/lessons`, admin.token, {
+                title: `Aula ${i}`,
+                position: i,
+            });
+            for (let q = 1; q <= 5; q++) {
+                await post(`/lessons/${aula.body.id}/questions`, admin.token, {
+                    statement: `Questao numero ${q}`,
+                    position: q,
+                    options: [
+                        { text: "errada", isCorrect: false },
+                        { text: "certa", isCorrect: true },
+                    ],
+                });
+            }
+            await patch(`/lessons/${aula.body.id}/published`, admin.token, { published: true });
+            const detalhe = await get(`/lessons/${aula.body.id}`, aluno.token);
+            const answers = detalhe.body.questions.map((q: any) => ({
+                questionId: q.id,
+                optionId: q.options.find((o: any) => o.text === "certa").id,
+            }));
+            await post(`/lessons/${aula.body.id}/quiz`, aluno.token, { answers });
+        }
+
+        const r = await get("/me/progresso?periodo=30", aluno.token);
+        assert.equal(r.status, 200);
+        assert.equal(r.body.xpTotal, 200);
+        assert.equal(r.body.streakAtual, 1);
+        assert.equal(r.body.streakRecorde, 1);
+        assert.equal(r.body.periodo.atual.xp, 200);
+        assert.equal(r.body.periodo.atual.exercicios, 10);
+        assert.equal(r.body.periodo.atual.minutos, 24);
+        assert.equal(r.body.metaSemana.tipo, "padrao");
+        assert.equal(r.body.metaSemana.valor, 1);
+        assert.equal(r.body.metaSemana.alvo, 7);
+        assert.equal(r.body.xpPorDia.length, 14);
+        assert.equal(r.body.xpPorDia.at(-1).xp, 200);
+        assert.equal(r.body.heatmap.length, 1);
+        assert.equal(r.body.heatmap[0].n, 2);
+        assert.equal(r.body.aulasAno, 2);
+        assert.equal(r.body.dominio.length, 1);
+        assert.equal(r.body.dominio[0].name, "Logica");
+        assert.equal(r.body.dominio[0].acertos, 10);
+        assert.equal(r.body.dominio[0].total, 10);
+        assert.equal(r.body.dominio[0].pct, 100);
+    });
+
+    test("meta semanal personalizada muda o anel e pode voltar ao padrão", async () => {
+        const admin = await criarUsuarioLogado(true);
+        const trilha = await post("/trails", admin.token, {
+            name: "Logica",
+            level: "iniciante",
+            description: "Base da programacao logica.",
+        });
+        const modulo = await post(`/trails/${trilha.body.id}/modules`, admin.token, {
+            title: "Modulo 1",
+            position: 1,
+        });
+        const aluno = await criarUsuarioLogado();
+        for (let i = 1; i <= 2; i++) {
+            const aula = await post(`/modules/${modulo.body.id}/lessons`, admin.token, {
+                title: `Aula ${i}`,
+                position: i,
+            });
+            for (let q = 1; q <= 5; q++) {
+                await post(`/lessons/${aula.body.id}/questions`, admin.token, {
+                    statement: `Questao numero ${q}`,
+                    position: q,
+                    options: [
+                        { text: "errada", isCorrect: false },
+                        { text: "certa", isCorrect: true },
+                    ],
+                });
+            }
+            await patch(`/lessons/${aula.body.id}/published`, admin.token, { published: true });
+            const detalhe = await get(`/lessons/${aula.body.id}`, aluno.token);
+            const answers = detalhe.body.questions.map((q: any) => ({
+                questionId: q.id,
+                optionId: q.options.find((o: any) => o.text === "certa").id,
+            }));
+            await post(`/lessons/${aula.body.id}/quiz`, aluno.token, { answers });
+        }
+
+        const put = await fetch(`${server.base}/me/meta-semanal`, {
+            method: "PUT",
+            headers: { ...auth(aluno.token), "Content-Type": "application/json" },
+            body: JSON.stringify({ kind: "aulas", target: 2 }),
+        });
+        assert.equal(put.status, 200);
+        let r = await get("/me/progresso?periodo=30", aluno.token);
+        assert.deepEqual(r.body.metaSemana, { tipo: "aulas", valor: 1, alvo: 7, alvoDiario: 2 });
+
+        await fetch(`${server.base}/me/meta-semanal`, {
+            method: "PUT",
+            headers: { ...auth(aluno.token), "Content-Type": "application/json" },
+            body: JSON.stringify({ kind: "dias", target: 5 }),
+        });
+        r = await get("/me/progresso?periodo=30", aluno.token);
+        assert.deepEqual(r.body.metaSemana, { tipo: "dias", valor: 1, alvo: 5 });
+
+        const del = await fetch(`${server.base}/me/meta-semanal`, {
+            method: "DELETE",
+            headers: auth(aluno.token),
+        });
+        assert.equal(del.status, 200);
+        r = await get("/me/progresso?periodo=30", aluno.token);
+        assert.equal(r.body.metaSemana.tipo, "padrao");
+
+        const invalida = await fetch(`${server.base}/me/meta-semanal`, {
+            method: "PUT",
+            headers: { ...auth(aluno.token), "Content-Type": "application/json" },
+            body: JSON.stringify({ kind: "dias", target: 1 }),
+        });
+        assert.equal(invalida.status, 400);
+    });
+
+    test("período tudo não traz comparação com anterior", async () => {
+        const aluno = await criarUsuarioLogado();
+        const r = await get("/me/progresso?periodo=tudo", aluno.token);
+        assert.equal(r.status, 200);
+        assert.equal(r.body.periodo.dias, null);
+        assert.equal(r.body.periodo.anterior, null);
+        assert.equal(r.body.xpTotal, 0);
+    });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,6 +35,7 @@ import { RedefinirSenha } from './pages/RedefinirSenha';
 import { OAuthCallback } from './pages/OAuthCallback';
 import { CertificadoValidar } from './pages/CertificadoValidar';
 import { PerfilPublico } from './pages/PerfilPublico';
+import { Progresso } from './pages/Progresso';
 import { CompletarPerfil } from './pages/CompletarPerfil';
 import { Placeholder } from './pages/Placeholder';
 
@@ -316,10 +317,7 @@ function AppRoutes() {
         path="/progresso"
         element={
           <PrivateRoute>
-            <Placeholder
-              title="Meu progresso"
-              description="Em breve seu progresso por trilhas e conquistas aparecerá aqui."
-            />
+            <Progresso />
           </PrivateRoute>
         }
       />

--- a/frontend/src/components/Icons.tsx
+++ b/frontend/src/components/Icons.tsx
@@ -514,3 +514,15 @@ export const Grid4 = ({ size = 17 }: IconProps) => (
     <rect x="14" y="14" width="7" height="7" rx="1" />
   </svg>
 );
+
+export const Zap = ({ size = 16 }: IconProps) => (
+  <svg
+    {...base(size)}
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M13 2L3 14h8l-1 8 10-12h-8z" />
+  </svg>
+);

--- a/frontend/src/pages/Progresso/index.tsx
+++ b/frontend/src/pages/Progresso/index.tsx
@@ -1,0 +1,628 @@
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+import { useAuth } from '../../contexts/AuthContext';
+import { Logo } from '../../components/Logo';
+import { MobileMenu } from '../../components/MobileMenu';
+import { UserMenu } from '../../components/UserMenu';
+import { ThemeToggle } from '../../components/ThemeToggle';
+import {
+  Flame,
+  Zap,
+  Check,
+  ClockExam,
+  ChevronUp,
+  Plus,
+  IconeConquista,
+} from '../../components/Icons';
+import { getInitials } from '../../utils/initials';
+import { tempoRelativo } from '../../utils/tempo';
+import { NAV_PRINCIPAL as NAV } from '../../data/nav';
+import {
+  obterProgresso,
+  definirMetaSemanal,
+  limparMetaSemanal,
+  type PeriodoProgresso,
+  type ProgressoData,
+} from '../../services/progresso';
+import { obterMinhasConquistas, type MinhaConquista } from '../../services/trails';
+
+const PERIODOS: { valor: PeriodoProgresso; label: string }[] = [
+  { valor: '7', label: '7 dias' },
+  { valor: '30', label: '30 dias' },
+  { valor: 'tudo', label: 'Tudo' },
+];
+
+const DIA_LETRA = ['D', 'S', 'T', 'Q', 'Q', 'S', 'S'];
+
+const LEVEL_HUE: Record<string, string> = {
+  iniciante: '#2D6BF5',
+  intermediario: '#2E9E6B',
+  avancado: '#D9536B',
+};
+
+function glyphDoNome(name: string): string {
+  const limpo = name.replace(/[^A-Za-zÀ-ú ]/g, '').trim();
+  const partes = limpo.split(/\s+/).slice(0, 2);
+  return partes.map((p) => p[0]?.toUpperCase() ?? '').join('') || '{}';
+}
+
+function formatHoras(min: number): string {
+  if (min < 60) return `${min}min`;
+  return `${Math.round(min / 60)}h`;
+}
+
+// Diferença entre o período atual e o anterior, com sinal (ex.: "+120", "-2h").
+function deltaTexto(atual: number, anterior: number | null, horas = false): string | null {
+  if (anterior === null) return null;
+  const dif = atual - anterior;
+  if (dif === 0) return null;
+  const valor = horas ? formatHoras(Math.abs(dif)) : String(Math.abs(dif));
+  return `${dif > 0 ? '+' : '-'}${valor}`;
+}
+
+// Variação percentual (ex.: "+18%"); com base zero cai no valor absoluto.
+function deltaPercentual(atual: number, anterior: number | null): string | null {
+  if (anterior === null) return null;
+  if (anterior === 0) return deltaTexto(atual, anterior);
+  const pct = Math.round(((atual - anterior) / anterior) * 100);
+  if (pct === 0) return null;
+  return `${pct > 0 ? '+' : '-'}${Math.abs(pct)}%`;
+}
+
+export function Progresso() {
+  const { user: authUser } = useAuth();
+  const [periodo, setPeriodo] = useState<PeriodoProgresso>('30');
+  const [dados, setDados] = useState<ProgressoData | null>(null);
+  const [conquistas, setConquistas] = useState<MinhaConquista[]>([]);
+  const [carregando, setCarregando] = useState(true);
+  const [erro, setErro] = useState('');
+  const [metaModal, setMetaModal] = useState(false);
+  const [metaKind, setMetaKind] = useState<'aulas' | 'dias'>('aulas');
+  const [metaTarget, setMetaTarget] = useState('2');
+  const [salvandoMeta, setSalvandoMeta] = useState(false);
+
+  useEffect(() => {
+    obterMinhasConquistas()
+      .then(setConquistas)
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    let ativo = true;
+    setCarregando(true);
+    obterProgresso(periodo)
+      .then((d) => {
+        if (ativo) setDados(d);
+      })
+      .catch(() => {
+        if (ativo) setErro('Não foi possível carregar seu progresso.');
+      })
+      .finally(() => {
+        if (ativo) setCarregando(false);
+      });
+    return () => {
+      ativo = false;
+    };
+  }, [periodo]);
+
+  const displayName = authUser?.name ?? '';
+  const initials = getInitials(displayName || 'A');
+
+  const ganhas = useMemo(
+    () =>
+      conquistas
+        .filter((c) => c.earned && c.earnedAt)
+        .sort((a, b) => new Date(b.earnedAt!).getTime() - new Date(a.earnedAt!).getTime())
+        .slice(0, 4),
+    [conquistas],
+  );
+
+  // Grade do heatmap: 52 semanas terminando hoje, colunas de domingo a sábado.
+  const heat = useMemo(() => {
+    if (!dados) return null;
+    const porDia = new Map(dados.heatmap.map((h) => [h.d, h.n]));
+    const hoje = new Date(dados.hoje + 'T00:00:00Z');
+    const fim = new Date(hoje);
+    fim.setUTCDate(fim.getUTCDate() + (6 - fim.getUTCDay()));
+    const colunas: { d: string; n: number; futuro: boolean }[][] = [];
+    const mesPorColuna: string[] = [];
+    const MESES = ['jan', 'fev', 'mar', 'abr', 'mai', 'jun', 'jul', 'ago', 'set', 'out', 'nov', 'dez'];
+    let mesAnterior = -1;
+    for (let s = 51; s >= 0; s--) {
+      const celulas: { d: string; n: number; futuro: boolean }[] = [];
+      for (let dia = 0; dia < 7; dia++) {
+        const dt = new Date(fim);
+        dt.setUTCDate(dt.getUTCDate() - s * 7 - (6 - dia));
+        const iso = dt.toISOString().slice(0, 10);
+        celulas.push({ d: iso, n: porDia.get(iso) ?? 0, futuro: iso > dados.hoje });
+      }
+      const mes = new Date(celulas[0].d + 'T00:00:00Z').getUTCMonth();
+      mesPorColuna.push(mes !== mesAnterior ? MESES[mes] : '');
+      mesAnterior = mes;
+      colunas.push(celulas);
+    }
+    return { colunas, mesPorColuna };
+  }, [dados]);
+
+  const maxXpDia = dados ? Math.max(1, ...dados.xpPorDia.map((b) => b.xp)) : 1;
+  const meta = dados?.metaSemana ?? { tipo: 'padrao' as const, valor: 0, alvo: 7 };
+  const metaPct = Math.round((meta.valor / meta.alvo) * 100);
+  const anelPerimetro = 2 * Math.PI * 64;
+  const faltamMeta = meta.alvo - meta.valor;
+
+  async function recarregarProgresso() {
+    try {
+      setDados(await obterProgresso(periodo));
+    } catch (e) {
+      console.error('Falha ao recarregar o progresso:', e);
+    }
+  }
+
+  function abrirMetaModal() {
+    if (dados?.metaSemana.tipo === 'aulas') {
+      setMetaKind('aulas');
+      setMetaTarget(String(dados.metaSemana.alvoDiario));
+    } else if (dados?.metaSemana.tipo === 'dias') {
+      setMetaKind('dias');
+      setMetaTarget(String(dados.metaSemana.alvo));
+    } else {
+      setMetaKind('aulas');
+      setMetaTarget('2');
+    }
+    setMetaModal(true);
+  }
+
+  async function salvarMeta() {
+    const alvo = Number(metaTarget);
+    if (!alvo || salvandoMeta) return;
+    setSalvandoMeta(true);
+    try {
+      await definirMetaSemanal(metaKind, alvo);
+      setMetaModal(false);
+      await recarregarProgresso();
+    } catch (e) {
+      console.error('Falha ao salvar a meta:', e);
+    } finally {
+      setSalvandoMeta(false);
+    }
+  }
+
+  async function removerMeta() {
+    if (salvandoMeta) return;
+    setSalvandoMeta(true);
+    try {
+      await limparMetaSemanal();
+      setMetaModal(false);
+      await recarregarProgresso();
+    } catch (e) {
+      console.error('Falha ao remover a meta:', e);
+    } finally {
+      setSalvandoMeta(false);
+    }
+  }
+
+  const nivelHeat = (n: number): number => (n === 0 ? 0 : n === 1 ? 1 : n === 2 ? 2 : 3);
+
+  function dataBr(iso: string) {
+    const [, m, d] = iso.split('-');
+    return `${d}/${m}`;
+  }
+
+  return (
+    <div className="home-shell">
+      <div className="home">
+        <header className="topbar">
+          <MobileMenu />
+          <Logo variant="solid" size={20} to="/home" />
+          <nav className="nav">
+            {NAV.map((item) => (
+              <Link key={item.to} to={item.to} className="nav__item">
+                {item.label}
+              </Link>
+            ))}
+          </nav>
+          <div className="topbar__spacer" />
+          <div className="streak-pill">
+            <Flame size={16} /> {authUser?.streak ?? 0}
+          </div>
+          <ThemeToggle inline />
+          <UserMenu
+            initials={initials}
+            level={authUser?.level ?? 1}
+            name={displayName}
+            email={authUser?.email}
+          />
+        </header>
+
+        <div className="prg">
+          <div className="prg-head">
+            <div>
+              <h1 className="prg-head__title">Meu progresso</h1>
+              <p className="prg-head__sub">
+                Acompanhe sua evolução, constância e domínio em cada trilha.
+              </p>
+            </div>
+            <div className="prg-periodos">
+              {PERIODOS.map((p) => (
+                <button
+                  key={p.valor}
+                  className={`prg-periodo${p.valor === periodo ? ' prg-periodo--on' : ''}`}
+                  onClick={() => setPeriodo(p.valor)}
+                >
+                  {p.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {erro && <div className="auth__alert">{erro}</div>}
+          {carregando && !dados && <p className="track__desc">Carregando progresso...</p>}
+
+          {dados && (
+            <>
+              <div className="prg-stats">
+                <StatCard
+                  icon={<Zap size={19} />}
+                  valor={dados.xpTotal.toLocaleString('pt-BR')}
+                  label="XP total"
+                  delta={deltaPercentual(dados.periodo.atual.xp, dados.periodo.anterior?.xp ?? null)}
+                />
+                <StatCard
+                  icon={<Flame size={19} />}
+                  valor={`${dados.streakAtual} ${dados.streakAtual === 1 ? 'dia' : 'dias'}`}
+                  label="Streak atual"
+                  extra={`recorde ${dados.streakRecorde}d`}
+                />
+                <StatCard
+                  icon={<Check size={17} />}
+                  valor={String(dados.periodo.atual.exercicios)}
+                  label={
+                    dados.periodo.dias ? `Exercícios em ${dados.periodo.dias} dias` : 'Exercícios'
+                  }
+                  delta={
+                    dados.periodo.anterior
+                      ? deltaTexto(
+                          dados.periodo.atual.exercicios,
+                          dados.periodo.anterior.exercicios,
+                        )
+                      : null
+                  }
+                />
+                <StatCard
+                  icon={<ClockExam size={19} />}
+                  valor={formatHoras(dados.periodo.atual.minutos)}
+                  label={
+                    dados.periodo.dias
+                      ? `Estudo em ${dados.periodo.dias} dias`
+                      : 'Tempo de estudo'
+                  }
+                  delta={
+                    dados.periodo.anterior
+                      ? deltaTexto(dados.periodo.atual.minutos, dados.periodo.anterior.minutos, true)
+                      : null
+                  }
+                />
+              </div>
+
+              <div className="prg-linha1">
+                <div className="card prg-chart">
+                  <div className="prg-chart__head">
+                    <div>
+                      <div className="prg-card__title">XP conquistado</div>
+                      <div className="prg-card__sub">Últimas 2 semanas</div>
+                    </div>
+                    <div className="prg-chart__total">
+                      <div className="prg-chart__num">
+                        {dados.xpPorDia.reduce((s, b) => s + b.xp, 0).toLocaleString('pt-BR')}
+                      </div>
+                      <div className="prg-card__sub">XP no período</div>
+                    </div>
+                  </div>
+                  <div className="prg-bars">
+                    {dados.xpPorDia.map((b, i) => (
+                      <div key={b.d} className="prg-bar" title={`${b.xp} XP em ${dataBr(b.d)}`}>
+                        <div
+                          className={`prg-bar__fill${i >= dados.xpPorDia.length - 3 ? ' prg-bar__fill--on' : ''}`}
+                          style={{ height: `${Math.round((b.xp / maxXpDia) * 100)}%` }}
+                        />
+                        <span className="prg-bar__label">
+                          {DIA_LETRA[new Date(b.d + 'T00:00:00Z').getUTCDay()]}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="card prg-meta">
+                  <div className="prg-meta__topo">
+                    <div>
+                      <div className="prg-card__title">Meta semanal</div>
+                      {meta.tipo !== 'padrao' && (
+                        <div className="prg-card__sub">
+                          {meta.tipo === 'aulas'
+                            ? `${meta.alvoDiario} ${meta.alvoDiario === 1 ? 'aula' : 'aulas'} por dia`
+                            : `${meta.alvo} dias seguidos`}
+                        </div>
+                      )}
+                    </div>
+                    <button
+                      className="prg-plus"
+                      onClick={abrirMetaModal}
+                      aria-label="Definir meta semanal"
+                    >
+                      <Plus size={14} />
+                    </button>
+                  </div>
+                  <div className="prg-meta__anel">
+                    <svg width="150" height="150" viewBox="0 0 150 150" style={{ transform: 'rotate(-90deg)' }}>
+                      <circle cx="75" cy="75" r="64" fill="none" stroke="var(--surface-2)" strokeWidth="14" />
+                      <circle
+                        cx="75"
+                        cy="75"
+                        r="64"
+                        fill="none"
+                        stroke="var(--accent)"
+                        strokeWidth="14"
+                        strokeLinecap="round"
+                        strokeDasharray={anelPerimetro}
+                        strokeDashoffset={anelPerimetro * (1 - Math.min(1, meta.valor / meta.alvo))}
+                      />
+                    </svg>
+                    <div className="prg-meta__centro">
+                      <div className="prg-meta__pct">{metaPct}%</div>
+                      <div className="prg-card__sub">
+                        {meta.valor} de {meta.alvo} dias
+                      </div>
+                    </div>
+                  </div>
+                  <p className="prg-meta__msg">
+                    {meta.valor >= meta.alvo ? (
+                      <>
+                        Meta batida! <b>{meta.alvo} de {meta.alvo} dias</b>. Continue assim!
+                      </>
+                    ) : (
+                      <>
+                        {faltamMeta === 1 ? 'Falta' : 'Faltam'}{' '}
+                        <b>
+                          {faltamMeta} {faltamMeta === 1 ? 'dia' : 'dias'}
+                          {meta.tipo === 'dias' ? ' seguidos' : ''}
+                        </b>{' '}
+                        para bater sua meta. Você consegue!
+                      </>
+                    )}
+                  </p>
+                </div>
+              </div>
+
+              {heat && (
+                <div className="card prg-heat">
+                  <div className="prg-heat__head">
+                    <div className="prg-card__title">
+                      {dados.aulasAno.toLocaleString('pt-BR')}{' '}
+                      {dados.aulasAno === 1 ? 'aula concluída' : 'aulas concluídas'} no último ano
+                    </div>
+                  </div>
+                  <div className="prg-heat__corpo">
+                    <div className="prg-heat__dias">
+                      {['', 'Seg', '', 'Qua', '', 'Sex', ''].map((d, i) => (
+                        <div key={i} className="prg-heat__dia">
+                          {d}
+                        </div>
+                      ))}
+                    </div>
+                    <div className="prg-heat__grade-wrap">
+                      <div className="prg-heat__meses">
+                        {heat.mesPorColuna.map((m, i) => (
+                          <div key={i} className="prg-heat__mes">
+                            {m}
+                          </div>
+                        ))}
+                      </div>
+                      <div className="prg-heat__grade">
+                        {heat.colunas.map((col, i) => (
+                          <div key={i} className="prg-heat__col">
+                            {col.map((c) => (
+                              <span
+                                key={c.d}
+                                className={`prg-cel prg-cel--${nivelHeat(c.n)}${c.futuro ? ' prg-cel--futuro' : ''}`}
+                                title={
+                                  c.futuro
+                                    ? undefined
+                                    : c.n === 0
+                                      ? `Nenhuma aula em ${dataBr(c.d)}`
+                                      : `${c.n} ${c.n === 1 ? 'aula' : 'aulas'} em ${dataBr(c.d)}`
+                                }
+                              />
+                            ))}
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+                  <div className="prg-heat__foot">
+                    <span>Cada quadrado é um dia: quanto mais aulas concluídas, mais forte o tom.</span>
+                    <div className="prg-heat__legenda">
+                      menos
+                      <span className="prg-cel prg-cel--0" />
+                      <span className="prg-cel prg-cel--1" />
+                      <span className="prg-cel prg-cel--2" />
+                      <span className="prg-cel prg-cel--3" />
+                      mais
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              <div className="prg-linha3">
+                <div className="card">
+                  <div className="prg-card__title prg-card__title--mb">Domínio por trilha</div>
+                  {dados.dominio.length === 0 ? (
+                    <p className="track__desc">
+                      Responda os quizzes de uma trilha para acompanhar seu domínio aqui.
+                    </p>
+                  ) : (
+                    <div className="prg-skills">
+                      {dados.dominio.map((t) => {
+                        const hue = LEVEL_HUE[t.trailLevel] ?? 'var(--accent)';
+                        return (
+                          <Link
+                            key={t.trailId}
+                            to={`/trilhas/${t.trailId}`}
+                            className="prg-skill"
+                            title={`${t.acertos} de ${t.total} questões acertadas`}
+                          >
+                            <div className="prg-skill__head">
+                              <span
+                                className="prg-skill__glyph"
+                                style={{
+                                  color: hue,
+                                  background: `color-mix(in srgb, ${hue} 16%, transparent)`,
+                                }}
+                              >
+                                {glyphDoNome(t.name)}
+                              </span>
+                              <span className="prg-skill__nome">{t.name}</span>
+                              <span className="prg-skill__pct" style={{ color: hue }}>
+                                {t.pct}%
+                              </span>
+                            </div>
+                            <div className="prg-skill__track">
+                              <div
+                                className="prg-skill__fill"
+                                style={{ background: hue, width: `${t.pct}%` }}
+                              />
+                            </div>
+                          </Link>
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
+
+                <div className="card">
+                  <div className="prg-conq__head">
+                    <div className="prg-card__title">Conquistas recentes</div>
+                    <Link className="link" to="/conquistas">
+                      Ver todas
+                    </Link>
+                  </div>
+                  {ganhas.length === 0 ? (
+                    <p className="track__desc">Nenhuma conquista desbloqueada ainda.</p>
+                  ) : (
+                    <div className="prg-conqs">
+                      {ganhas.map((c) => (
+                        <div key={c.id} className="prg-conq">
+                          <span className="prg-conq__icone">
+                            <IconeConquista chave={c.icon} size={20} />
+                          </span>
+                          <div className="prg-conq__corpo">
+                            <div className="prg-conq__nome">{c.name}</div>
+                            <div className="prg-card__sub">{c.description}</div>
+                          </div>
+                          <span className="prg-conq__quando">{tempoRelativo(c.earnedAt!)}</span>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+
+        {metaModal && (
+          <div className="cmn-overlay">
+            <div className="cmn-card">
+              <div className="cmn-card__kicker">Meta semanal</div>
+              <h3 className="cmn-card__title">Definir sua meta</h3>
+              <div className="prg-meta-tipos">
+                <button
+                  className={`prg-meta-tipo${metaKind === 'aulas' ? ' prg-meta-tipo--on' : ''}`}
+                  onClick={() => {
+                    setMetaKind('aulas');
+                    setMetaTarget('2');
+                  }}
+                >
+                  Aulas por dia
+                </button>
+                <button
+                  className={`prg-meta-tipo${metaKind === 'dias' ? ' prg-meta-tipo--on' : ''}`}
+                  onClick={() => {
+                    setMetaKind('dias');
+                    setMetaTarget('7');
+                  }}
+                >
+                  Dias seguidos
+                </button>
+              </div>
+              <p className="cmn-card__msg">
+                {metaKind === 'aulas'
+                  ? 'Quantas aulas você quer concluir por dia? O anel mostra em quantos dos últimos 7 dias você cumpriu.'
+                  : 'Quantos dias seguidos de atividade você quer manter? O anel acompanha seu streak até a meta.'}
+              </p>
+              <input
+                className="cmn-texto"
+                style={{ resize: 'none' }}
+                type="number"
+                min={metaKind === 'aulas' ? 1 : 2}
+                max={metaKind === 'aulas' ? 20 : 60}
+                value={metaTarget}
+                onChange={(e) => setMetaTarget(e.target.value)}
+              />
+              <div className="cmn-card__row">
+                <button className="btn btn--ghost" onClick={() => setMetaModal(false)}>
+                  Cancelar
+                </button>
+                <button
+                  className="btn btn--accent"
+                  onClick={salvarMeta}
+                  disabled={!Number(metaTarget) || salvandoMeta}
+                >
+                  {salvandoMeta ? 'Salvando...' : 'Salvar meta'}
+                </button>
+              </div>
+              {dados?.metaSemana.tipo !== 'padrao' && (
+                <p className="prg-meta__reset">
+                  <button className="link link--btn" onClick={removerMeta}>
+                    Voltar à meta padrão (7 dias ativos)
+                  </button>
+                </p>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function StatCard({
+  icon,
+  valor,
+  label,
+  delta,
+  extra,
+}: {
+  icon: ReactNode;
+  valor: string;
+  label: string;
+  delta?: string | null;
+  extra?: string;
+}) {
+  return (
+    <div className="card prg-stat">
+      <div className="prg-stat__topo">
+        <span className="prg-stat__icone">{icon}</span>
+        {delta && (
+          <span className={`prg-stat__delta${delta.startsWith('-') ? ' prg-stat__delta--down' : ''}`}>
+            <ChevronUp size={12} />
+            {delta.replace('-', '')}
+          </span>
+        )}
+        {!delta && extra && <span className="prg-stat__extra">{extra}</span>}
+      </div>
+      <div className="prg-stat__valor">{valor}</div>
+      <div className="prg-stat__label">{label}</div>
+    </div>
+  );
+}

--- a/frontend/src/services/progresso.ts
+++ b/frontend/src/services/progresso.ts
@@ -1,0 +1,46 @@
+import api from './api';
+
+export type PeriodoProgresso = '7' | '30' | 'tudo';
+
+export type MetaSemana =
+  | { tipo: 'padrao'; valor: number; alvo: number }
+  | { tipo: 'aulas'; valor: number; alvo: number; alvoDiario: number }
+  | { tipo: 'dias'; valor: number; alvo: number };
+
+export interface ProgressoData {
+  hoje: string;
+  xpTotal: number;
+  level: number;
+  streakAtual: number;
+  streakRecorde: number;
+  periodo: {
+    dias: number | null;
+    atual: { xp: number; exercicios: number; minutos: number };
+    anterior: { xp: number; exercicios: number; minutos: number } | null;
+  };
+  xpPorDia: { d: string; xp: number }[];
+  metaSemana: MetaSemana;
+  heatmap: { d: string; n: number }[];
+  aulasAno: number;
+  dominio: {
+    trailId: string;
+    name: string;
+    trailLevel: 'iniciante' | 'intermediario' | 'avancado';
+    acertos: number;
+    total: number;
+    pct: number;
+  }[];
+}
+
+export async function obterProgresso(periodo: PeriodoProgresso) {
+  const { data } = await api.get<ProgressoData>('/me/progresso', { params: { periodo } });
+  return data;
+}
+
+export async function definirMetaSemanal(kind: 'aulas' | 'dias', target: number) {
+  await api.put('/me/meta-semanal', { kind, target });
+}
+
+export async function limparMetaSemanal() {
+  await api.delete('/me/meta-semanal');
+}

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -5065,3 +5065,459 @@ a.logo {
   color: inherit;
   text-decoration: none;
 }
+
+/* ===================== MEU PROGRESSO ===================== */
+.prg {
+  padding: 26px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  color: var(--text);
+}
+.prg-head {
+  display: flex;
+  align-items: flex-end;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+.prg-head__title {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+.prg-head__sub {
+  margin: 4px 0 0;
+  font-size: 14px;
+  color: var(--muted);
+}
+.prg-periodos {
+  margin-left: auto;
+  display: flex;
+  gap: 3px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 11px;
+  padding: 3px;
+}
+.prg-periodo {
+  padding: 7px 15px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--muted);
+  cursor: pointer;
+}
+.prg-periodo--on {
+  background: var(--accent);
+  color: #fff;
+}
+.prg-stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+}
+.prg-stat__topo {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.prg-stat__icone {
+  width: 38px;
+  height: 38px;
+  border-radius: 11px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 13%, transparent);
+}
+.prg-stat__delta {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 12.5px;
+  font-weight: 700;
+  color: var(--success);
+}
+.prg-stat__delta--down {
+  color: var(--av-red);
+}
+.prg-stat__delta--down svg {
+  transform: rotate(180deg);
+}
+.prg-stat__extra {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--muted);
+}
+.prg-stat__valor {
+  margin-top: 14px;
+  font-size: 27px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+.prg-stat__label {
+  margin-top: 1px;
+  font-size: 13px;
+  color: var(--muted);
+}
+.prg-card__title {
+  font-size: 15px;
+  font-weight: 700;
+}
+.prg-card__title--mb {
+  margin-bottom: 16px;
+}
+.prg-card__sub {
+  font-size: 12.5px;
+  color: var(--muted);
+  margin-top: 1px;
+}
+.prg-linha1 {
+  display: grid;
+  grid-template-columns: 1fr 320px;
+  gap: 18px;
+  align-items: start;
+}
+.prg-chart__head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 6px;
+}
+.prg-chart__total {
+  text-align: right;
+}
+.prg-chart__num {
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--accent);
+}
+.prg-bars {
+  display: flex;
+  align-items: flex-end;
+  gap: 10px;
+  height: 160px;
+  margin-top: 18px;
+}
+.prg-bar {
+  flex: 1;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+.prg-bar__fill {
+  width: 100%;
+  min-height: 4px;
+  border-radius: 6px 6px 0 0;
+  background: color-mix(in srgb, var(--accent) 38%, transparent);
+  transition: background 0.15s;
+}
+.prg-bar__fill--on {
+  background: var(--accent);
+}
+.prg-bar:hover .prg-bar__fill {
+  background: color-mix(in srgb, var(--accent) 70%, transparent);
+}
+.prg-bar:hover .prg-bar__fill--on {
+  background: color-mix(in srgb, var(--accent) 82%, #000);
+}
+.prg-bar__label {
+  font-size: 10px;
+  color: var(--muted);
+}
+.prg-meta {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.prg-meta .prg-card__title {
+  align-self: flex-start;
+}
+.prg-meta__anel {
+  position: relative;
+  width: 150px;
+  height: 150px;
+  margin: 14px 0 4px;
+}
+.prg-meta__centro {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+.prg-meta__pct {
+  font-size: 30px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1;
+}
+.prg-meta__msg {
+  margin: 6px 0 0;
+  font-size: 13px;
+  color: var(--muted);
+  text-align: center;
+  line-height: 1.45;
+}
+.prg-meta__msg b {
+  color: var(--text);
+}
+.card.prg-heat {
+  padding: 18px 22px;
+}
+.prg-heat__head {
+  margin-bottom: 12px;
+}
+.prg-heat__legenda {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 11.5px;
+  color: var(--muted);
+}
+.prg-heat__corpo {
+  display: flex;
+  gap: 9px;
+}
+.prg-heat__dias {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding-top: 19px;
+}
+.prg-heat__dia {
+  height: 14px;
+  width: 26px;
+  font-size: 10.5px;
+  line-height: 14px;
+  color: var(--muted);
+  text-align: right;
+}
+.prg-heat__grade-wrap {
+  flex: 1;
+  overflow-x: auto;
+}
+.prg-heat__meses {
+  display: flex;
+  gap: 3px;
+  margin-bottom: 5px;
+}
+.prg-heat__mes {
+  width: 14px;
+  min-width: 14px;
+  font-size: 10.5px;
+  line-height: 1;
+  color: var(--muted);
+  white-space: nowrap;
+}
+.prg-heat__grade {
+  display: flex;
+  gap: 3px;
+}
+.prg-heat__col {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.prg-cel {
+  width: 14px;
+  height: 14px;
+  min-width: 14px;
+  border-radius: 3px;
+  display: inline-block;
+}
+.prg-heat__grade .prg-cel:hover {
+  outline: 1px solid color-mix(in srgb, var(--accent) 55%, var(--border-strong));
+  outline-offset: -1px;
+}
+.prg-heat__foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-top: 10px;
+  font-size: 11.5px;
+  color: var(--muted);
+}
+.prg-heat__foot .prg-cel {
+  width: 11px;
+  height: 11px;
+  min-width: 11px;
+}
+.prg-cel--0 {
+  background: var(--surface-2);
+}
+.prg-cel--1 {
+  background: color-mix(in srgb, var(--accent) 28%, transparent);
+}
+.prg-cel--2 {
+  background: color-mix(in srgb, var(--accent) 55%, transparent);
+}
+.prg-cel--3 {
+  background: var(--accent);
+}
+.prg-cel--futuro {
+  opacity: 0.35;
+}
+.prg-linha3 {
+  display: grid;
+  grid-template-columns: 1fr 360px;
+  gap: 18px;
+  align-items: start;
+}
+.prg-skills {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.prg-skill {
+  display: block;
+  text-decoration: none;
+  color: var(--text);
+}
+.prg-skill__head {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  margin-bottom: 8px;
+}
+.prg-skill__glyph {
+  width: 32px;
+  height: 32px;
+  border-radius: 9px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'JetBrains Mono', monospace;
+  font-weight: 700;
+  font-size: 13px;
+}
+.prg-skill__nome {
+  font-size: 14px;
+  font-weight: 600;
+  flex: 1;
+}
+.prg-skill__pct {
+  font-size: 13px;
+  font-weight: 700;
+}
+.prg-skill__track {
+  height: 8px;
+  border-radius: 99px;
+  background: var(--surface-2);
+  overflow: hidden;
+}
+.prg-skill__fill {
+  height: 100%;
+  border-radius: 99px;
+}
+.prg-conq__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+.prg-conqs {
+  display: flex;
+  flex-direction: column;
+  gap: 13px;
+}
+.prg-conq {
+  display: flex;
+  align-items: center;
+  gap: 13px;
+}
+.prg-conq__icone {
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 13%, transparent);
+}
+.prg-conq__corpo {
+  flex: 1;
+  min-width: 0;
+}
+.prg-conq__nome {
+  font-size: 14px;
+  font-weight: 700;
+}
+.prg-conq__quando {
+  font-size: 11.5px;
+  color: var(--muted);
+  flex-shrink: 0;
+}
+@media (max-width: 980px) {
+  .prg-stats {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .prg-linha1,
+  .prg-linha3 {
+    grid-template-columns: 1fr;
+  }
+}
+
+.prg-meta__topo {
+  width: 100%;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+.prg-plus {
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  border: 1px solid var(--border-strong);
+  background: transparent;
+  color: var(--muted);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+.prg-plus:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.prg-meta-tipos {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+.prg-meta-tipo {
+  flex: 1;
+  padding: 9px 0;
+  border: 1px solid var(--border-strong);
+  border-radius: 10px;
+  background: transparent;
+  color: var(--muted);
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.prg-meta-tipo--on {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+}
+.prg-meta__reset {
+  margin: 10px 0 0;
+  text-align: center;
+}


### PR DESCRIPTION
## O que muda

A aba **Meu progresso** (`/progresso`) deixa de ser placeholder e vira o painel completo do design, com dados reais:

- **Cards com período** (7 dias / 30 dias / Tudo): XP total com variação percentual contra o período anterior, streak atual com recorde, exercícios e tempo de estudo no período (estimado pela duração das aulas concluídas; 12 min por aula quando não preenchida)
- **XP conquistado**: barras dos últimos 14 dias, hover escurecendo e tooltip por dia
- **Meta semanal personalizável**: o botão de mais no card abre o modal para escolher entre **X aulas por dia** (o anel conta em quantos dos últimos 7 dias a meta diária foi cumprida) ou **X dias seguidos** (o anel acompanha o streak até o alvo), com opção de voltar à meta padrão (7 dias ativos na semana)
- **Atividade no formato do GitHub**: 52 semanas de aulas concluídas por dia, tom mais forte com mais aulas, tooltip com a contagem ("2 aulas em 18/07"), meses no topo, legenda e rodapé explicativo
- **Domínio por trilha**: questões distintas acertadas sobre o total de questões da trilha (aulas publicadas; nas multi-linguagem, neutras + o melhor track), com hover mostrando o detalhe e clique levando à trilha
- **Conquistas recentes** com tempo relativo e link para ver todas

## Backend

- `GET /me/progresso?periodo=7|30|tudo`: agrega questões, aulas e desafios por dia no fuso de São Paulo (XP, exercícios, minutos e aulas), monta os cards, o gráfico, o heatmap, a meta e o domínio numa chamada
- `PUT/DELETE /me/meta-semanal` com validação (aulas 1 a 20, dias 2 a 60)
- Migração **0037**: colunas `weekly_goal_kind` e `weekly_goal_target` em `users`

## Testes

3 testes novos de integração com asserts determinísticos (agregação completa, meta personalizada nos dois tipos + reset + alvo inválido, período tudo sem comparação). Suíte completa: **77/77**. `tsc` e build limpos. Validado manualmente no local.

## Deploy

Migração 0037 aplica no deploy; sem variável nova e sem seed.
