### PR TITLE
feat: certificação AWS AI Practitioner (AIF-C01)

### DIFF
--- a/backend/scripts/seed-aif-c01.ts
+++ b/backend/scripts/seed-aif-c01.ts
@@ -1,0 +1,978 @@
+// Seed do simulado AWS Certified AI Practitioner (AIF-C01). Questões autorais,
+// escritas para ensinar os conceitos dos 5 domínios do exame (não reproduzem a prova real).
+// Idempotente: se o simulado já tiver questões, não faz nada.
+//
+// Rodar em dev:  node --env-file=.env scripts/seed-aif-c01.ts
+// Rodar em prod: docker compose -f docker-compose.prod.yml exec -T backend \
+//                  node --env-file=.env.prod scripts/seed-aif-c01.ts
+import { db } from "../db.ts";
+import { simulados, simuladoQuestions, simuladoOptions } from "../schema.ts";
+import { eq, count } from "drizzle-orm";
+
+const SLUG = "aws-ai-practitioner";
+
+type Questao = {
+    statement: string;
+    explanation: string;
+    topic: string;
+    options: [string, boolean][];
+};
+
+const QUESTOES: Questao[] = [
+    // ===================== Domínio 1: Fundamentos de IA e ML =====================
+    {
+        statement:
+            "Uma equipe apresenta machine learning para a liderança. Qual afirmação define corretamente a relação entre inteligência artificial (IA), machine learning (ML) e deep learning?",
+        explanation:
+            "IA é o campo mais amplo; ML é um subconjunto da IA que aprende padrões a partir de dados; deep learning é um subconjunto do ML baseado em redes neurais profundas. A hierarquia é IA contém ML, que contém deep learning.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            [
+                "Machine learning é um subcampo da IA, e deep learning é um subcampo do machine learning que usa redes neurais",
+                true,
+            ],
+            [
+                "Deep learning e machine learning são sinônimos, e ambos englobam a inteligência artificial como caso particular",
+                false,
+            ],
+            [
+                "Inteligência artificial é um subcampo do machine learning voltado apenas a redes neurais profundas",
+                false,
+            ],
+            [
+                "Machine learning e inteligência artificial são áreas independentes, sem qualquer sobreposição de técnicas",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Um banco quer treinar um modelo para prever se uma transação é fraudulenta usando um histórico já rotulado como 'fraude' ou 'legítima'. Que tipo de aprendizado esse cenário representa?",
+        explanation:
+            "Rótulos conhecidos ('fraude'/'legítima') caracterizam aprendizado supervisionado. Sem rótulos seria não supervisionado; recompensas por tentativa e erro seriam aprendizado por reforço.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            [
+                "Aprendizado supervisionado, porque o modelo treina com exemplos que já possuem o rótulo correto",
+                true,
+            ],
+            [
+                "Aprendizado não supervisionado, porque o modelo agrupa as transações sem usar nenhum rótulo",
+                false,
+            ],
+            [
+                "Aprendizado por reforço, porque o modelo recebe recompensas a cada acerto durante a produção",
+                false,
+            ],
+            [
+                "Aprendizado auto-supervisionado, porque o modelo cria os próprios rótulos a partir do texto",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma varejista tem milhões de clientes sem categoria definida e quer descobrir grupos de perfis de compra semelhantes para campanhas. Qual abordagem de ML se encaixa melhor?",
+        explanation:
+            "Descobrir grupos sem categorias pré-definidas é clustering (não supervisionado). Regressão prevê números; classificação exige classes conhecidas; detecção de anomalias foca em outliers, não em segmentar toda a base.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            [
+                "Clustering, uma técnica não supervisionada que agrupa dados por semelhança sem rótulos prévios",
+                true,
+            ],
+            [
+                "Regressão linear, que prevê um valor numérico contínuo a partir das variáveis de entrada",
+                false,
+            ],
+            [
+                "Classificação binária, que atribui cada cliente a uma de duas classes já conhecidas",
+                false,
+            ],
+            [
+                "Detecção de anomalias, que sinaliza apenas os registros muito fora do padrão esperado",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Uma imobiliária quer estimar o preço de venda de um imóvel (um valor em reais) a partir de área, localização e número de quartos. Que tipo de problema de ML é esse?",
+        explanation:
+            "Prever um valor contínuo (preço) é regressão. Classificação produz categorias; clustering agrupa; redução de dimensionalidade comprime variáveis, não gera a previsão de preço.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Regressão, pois a saída desejada é um valor numérico contínuo", true],
+            ["Classificação, pois o modelo escolhe entre categorias discretas de preço", false],
+            ["Clustering, pois agrupa imóveis parecidos sem prever um valor", false],
+            ["Redução de dimensionalidade, pois resume as variáveis em menos colunas", false],
+        ],
+    },
+    {
+        statement: "Em qual situação usar machine learning é a opção MENOS apropriada?",
+        explanation:
+            "Regras fixas e determinísticas (cálculo de imposto) devem ser resolvidas com lógica programada, não ML. Machine learning brilha quando os padrões são complexos, mudam com os dados ou são difíceis de descrever em regras.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            [
+                "Um cálculo de imposto que segue regras fixas, determinísticas e bem documentadas em lei",
+                true,
+            ],
+            [
+                "Prever a demanda de produtos com base em padrões históricos de vendas sazonais",
+                false,
+            ],
+            [
+                "Recomendar conteúdos personalizados a partir do comportamento de cada usuário",
+                false,
+            ],
+            [
+                "Classificar automaticamente e-mails recebidos entre spam e não spam em grande volume",
+                false,
+            ],
+        ],
+    },
+    {
+        statement:
+            "Durante o treino, um modelo atinge 99% de acurácia nos dados de treino, mas apenas 62% em dados novos de teste. Qual é o diagnóstico mais provável?",
+        explanation:
+            "Alta acurácia no treino e baixa no teste é a assinatura clássica de overfitting: o modelo memorizou o treino e não generaliza. Underfitting daria desempenho ruim nos dois conjuntos.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Overfitting: o modelo memorizou o treino e não generaliza para dados novos", true],
+            ["Underfitting: o modelo é simples demais para capturar os padrões dos dados", false],
+            ["Vazamento de rótulos, que aumentou a acurácia de teste acima da de treino", false],
+            ["Falta de dados de treino, já que o modelo não aprendeu nada no conjunto original", false],
+        ],
+    },
+    {
+        statement:
+            "Uma cientista de dados quer treinar e implantar um modelo customizado de ML com controle sobre o algoritmo e a infraestrutura. Quais recursos do Amazon SageMaker apoiam DIRETAMENTE esse fluxo? (Selecione DUAS opções.)",
+        explanation:
+            "Treinar e implantar modelos customizados são funções de SageMaker Training e SageMaker Endpoints. Polly (voz), Connect (contact center) e Shield (proteção DDoS) não fazem parte desse fluxo de ML.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["SageMaker Training, para treinar modelos em infraestrutura gerenciada e escalável", true],
+            ["SageMaker Endpoints, para hospedar o modelo e servir inferências em tempo real", true],
+            ["Amazon Polly, para converter os resultados do modelo em áudio de voz natural", false],
+            ["Amazon Connect, para distribuir chamadas telefônicas em uma central de atendimento", false],
+            ["AWS Shield, para proteger a aplicação contra ataques de negação de serviço", false],
+        ],
+    },
+    {
+        statement:
+            "Um analista de negócios sem experiência em programação quer construir modelos de ML por uma interface visual, sem escrever código. Qual serviço atende melhor?",
+        explanation:
+            "SageMaker Canvas é a ferramenta no-code para usuários de negócio criarem previsões visualmente. Studio é para quem programa; Lambda executa funções; EMR é big data com Spark.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Amazon SageMaker Canvas, que oferece ML visual sem necessidade de código", true],
+            ["Amazon SageMaker Studio, um ambiente de desenvolvimento voltado a cientistas de dados", false],
+            ["AWS Lambda, um serviço para executar funções de código sob demanda", false],
+            ["Amazon EMR, uma plataforma de big data baseada em frameworks como Apache Spark", false],
+        ],
+    },
+    {
+        statement:
+            "No contexto de um conjunto de dados de treino supervisionado, o que é um 'rótulo' (label)?",
+        explanation:
+            "O rótulo é o alvo/resposta que o modelo aprende a prever. As colunas de entrada são features; parâmetros são ajustados no treino; métricas avaliam o desempenho.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["A resposta correta que se deseja prever, associada a cada exemplo de treino", true],
+            ["Cada uma das colunas de entrada usadas pelo modelo para fazer as previsões", false],
+            ["O parâmetro interno ajustado pelo algoritmo durante o processo de treino", false],
+            ["A métrica que mede o quão bem o modelo se saiu no conjunto de teste", false],
+        ],
+    },
+    {
+        statement:
+            "Depois de treinado, um modelo é usado para gerar previsões sobre dados novos em produção. Como esse processo é chamado?",
+        explanation:
+            "Usar o modelo treinado para prever sobre dados novos é inferência. Treino ajusta parâmetros; rotulagem prepara os dados; engenharia de atributos cria features.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Inferência, quando o modelo já treinado produz previsões para novas entradas", true],
+            ["Treinamento, quando o modelo ajusta seus parâmetros a partir dos dados", false],
+            ["Rotulagem, quando pessoas atribuem as respostas corretas aos exemplos", false],
+            ["Engenharia de atributos, quando novas variáveis de entrada são criadas", false],
+        ],
+    },
+    {
+        statement:
+            "Um modelo de triagem médica deve evitar ao máximo classificar um paciente doente como saudável (falso negativo). Qual métrica a equipe deve priorizar para reduzir esse erro?",
+        explanation:
+            "Reduzir falsos negativos (doente classificado como saudável) significa aumentar o recall. Precisão foca em falsos positivos; taxa de aprendizado é um hiperparâmetro de treino, não uma métrica de erro.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Recall (sensibilidade), que mede a fração de casos positivos que o modelo captura", true],
+            ["Precisão, que mede a fração de alertas positivos que estavam realmente corretos", false],
+            ["Especificidade, que mede a fração de casos negativos identificados corretamente", false],
+            ["Taxa de aprendizado, que controla o tamanho do passo durante o treino do modelo", false],
+        ],
+    },
+    {
+        statement:
+            "Uma startup precisa transcrever áudios de reuniões para texto rapidamente, sem treinar nenhum modelo. Qual serviço da AWS resolve isso com um modelo pré-treinado?",
+        explanation:
+            "Amazon Transcribe faz speech-to-text pronto para uso. Polly é o inverso (text-to-speech); Comprehend analisa texto escrito; SageMaker exigiria treinar um modelo próprio.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Amazon Transcribe, que converte fala em texto com um modelo já pronto", true],
+            ["Amazon SageMaker, no qual seria preciso treinar e implantar um modelo próprio", false],
+            ["Amazon Polly, que faz o caminho inverso, gerando voz a partir de texto", false],
+            ["Amazon Comprehend, que extrai entidades e sentimentos de textos já escritos", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe obteve resultados ruins com um modelo e descobriu que os dados de treino continham muitos valores errados e faltantes. Qual princípio isso reforça?",
+        explanation:
+            "Dados ruins levam a modelos ruins ('garbage in, garbage out'). Nem modelos grandes nem grande volume compensam dados de baixa qualidade; a limpeza e a curadoria dos dados são essenciais.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["A qualidade dos dados de treino determina fortemente a qualidade do modelo", true],
+            ["Modelos maiores compensam automaticamente quaisquer problemas nos dados", false],
+            ["A escolha do algoritmo é irrelevante quando há um grande volume de dados", false],
+            ["Os dados de teste têm mais impacto no desempenho do que os dados de treino", false],
+        ],
+    },
+
+    // ===================== Domínio 2: Fundamentos de IA generativa =====================
+    {
+        statement:
+            "O que caracteriza um 'foundation model' (modelo de fundação) no contexto de IA generativa?",
+        explanation:
+            "Foundation models são grandes, pré-treinados em dados massivos e adaptáveis a muitas tarefas (texto, imagem e outros). Não são modelos de tarefa única nem bancos de dados vetoriais.",
+        topic: "IA generativa",
+        options: [
+            ["Um modelo grande, pré-treinado em vastos dados, que serve de base para muitas tarefas", true],
+            ["Um modelo pequeno treinado do zero para uma única tarefa muito específica", false],
+            ["Um banco de dados vetorial usado apenas para armazenar embeddings de texto", false],
+            ["Uma regra de negócio determinística que não depende de dados para funcionar", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço da AWS permite acessar foundation models de diversos provedores por uma única API gerenciada, sem administrar infraestrutura?",
+        explanation:
+            "Amazon Bedrock dá acesso serverless a foundation models de vários provedores por uma API única. EC2 exigiria operar tudo; S3 apenas armazena; Glue faz ETL de dados.",
+        topic: "IA generativa",
+        options: [
+            ["Amazon Bedrock, que oferece foundation models por API totalmente gerenciada", true],
+            ["Amazon EC2, no qual seria preciso instalar e operar os modelos manualmente", false],
+            ["Amazon S3, um serviço de armazenamento de objetos sem capacidade de inferência", false],
+            ["AWS Glue, um serviço de ETL para preparar e integrar dados entre fontes", false],
+        ],
+    },
+    {
+        statement: "Ao trabalhar com um grande modelo de linguagem (LLM), o que é um 'token'?",
+        explanation:
+            "Em LLMs, token é a unidade de texto (palavra ou subpalavra) processada por vez. Não confundir com token de autenticação, parâmetro interno do modelo ou registro de log.",
+        topic: "IA generativa",
+        options: [
+            ["Uma unidade de texto (palavra ou parte dela) que o modelo processa por vez", true],
+            ["Uma credencial de segurança que autoriza o acesso à API do modelo", false],
+            ["O parâmetro interno que o modelo ajusta durante o pré-treinamento", false],
+            ["Um registro de log gerado a cada requisição feita ao modelo", false],
+        ],
+    },
+    {
+        statement: "O que é um 'embedding' no contexto de IA generativa e busca semântica?",
+        explanation:
+            "Embeddings são vetores numéricos que capturam o significado semântico do texto, permitindo comparar conteúdos por proximidade. Não são resumos, cópias criptografadas nem índices de palavra-chave.",
+        topic: "IA generativa",
+        options: [
+            ["Uma representação numérica em vetores que captura o significado de um texto", true],
+            ["Um resumo em linguagem natural gerado automaticamente a partir do texto", false],
+            ["Uma cópia criptografada do documento original armazenada em disco", false],
+            ["Um índice tradicional de palavras-chave usado em bancos relacionais", false],
+        ],
+    },
+    {
+        statement:
+            "Um LLM respondeu a uma pergunta citando um artigo científico que não existe, com autores e datas inventados. Como esse comportamento é chamado?",
+        explanation:
+            "Gerar conteúdo plausível mas falso (referências inventadas) é alucinação. Overfitting é sobre generalização; viés é sobre desequilíbrio dos dados; latência é o tempo de resposta.",
+        topic: "IA generativa",
+        options: [
+            ["Alucinação, quando o modelo gera informação plausível, porém falsa", true],
+            ["Overfitting, quando o modelo memoriza os dados de treino em excesso", false],
+            ["Viés de dados, quando o modelo reflete desequilíbrios do conjunto de treino", false],
+            ["Latência, quando o modelo demora demais para produzir a resposta", false],
+        ],
+    },
+    {
+        statement: "Qual é um caso de uso típico de IA generativa?",
+        explanation:
+            "IA generativa cria conteúdo novo (texto, código, resumos) a partir de prompts. Somar planilhas, rotear rede e aplicar políticas de permissão são tarefas determinísticas, não de geração.",
+        topic: "IA generativa",
+        options: [
+            ["Gerar rascunhos de texto, resumos e código a partir de instruções em linguagem natural", true],
+            ["Somar valores de uma planilha seguindo uma fórmula fixa e determinística", false],
+            ["Rotear pacotes de rede entre sub-redes com base em tabelas de roteamento", false],
+            ["Controlar o acesso a recursos por meio de políticas de permissão explícitas", false],
+        ],
+    },
+    {
+        statement:
+            "Qual é uma vantagem central de usar foundation models em vez de treinar um modelo do zero para cada tarefa?",
+        explanation:
+            "A grande vantagem é reaproveitar um modelo pré-treinado e adaptá-lo a muitas tarefas, poupando tempo e dados. Eles não eliminam erros, não dispensam dados nem têm custo de inferência zero.",
+        topic: "IA generativa",
+        options: [
+            ["Eles já vêm pré-treinados e podem ser adaptados a várias tarefas com pouco esforço", true],
+            ["Eles eliminam por completo qualquer risco de gerar respostas incorretas", false],
+            ["Eles dispensam totalmente o uso de dados ao serem aplicados a novos casos", false],
+            ["Eles garantem custo zero de inferência independentemente do volume de uso", false],
+        ],
+    },
+    {
+        statement: "Qual é um desafio conhecido ao adotar IA generativa em produção?",
+        explanation:
+            "IA generativa pode gerar saídas variáveis e imprecisas (inclusive alucinações), exigindo verificação e guardrails. Ela é acessível por API, permite restrições de tema e é multilíngue.",
+        topic: "IA generativa",
+        options: [
+            ["As respostas podem variar e conter imprecisões, exigindo verificação e controles", true],
+            ["Os modelos só funcionam offline, sem qualquer possibilidade de uso via API", false],
+            ["É impossível restringir os temas sobre os quais o modelo pode responder", false],
+            ["Eles não conseguem processar texto em mais de um idioma simultaneamente", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer um assistente de IA generativa que responda perguntas dos funcionários com base nos documentos internos, respeitando as permissões de acesso. Qual serviço da AWS é voltado a isso?",
+        explanation:
+            "Amazon Q Business é o assistente generativo que responde com base nos dados corporativos e respeita as permissões. Rekognition é visão; Athena é consulta SQL; Polly gera voz.",
+        topic: "IA generativa",
+        options: [
+            ["Amazon Q Business, um assistente generativo conectado aos dados corporativos", true],
+            ["Amazon Rekognition, um serviço de análise de imagens e vídeos", false],
+            ["Amazon Athena, um serviço de consultas SQL sobre dados no Amazon S3", false],
+            ["Amazon Polly, um serviço que converte texto em voz de forma natural", false],
+        ],
+    },
+    {
+        statement:
+            "Uma agência quer gerar imagens originais a partir de descrições em texto. Que categoria de modelo generativo é a mais indicada?",
+        explanation:
+            "Gerar imagens a partir de texto usa modelos generativos de imagem (por exemplo, de difusão). Regressão e clustering não geram imagens; detecção de objetos analisa imagens existentes, não cria novas.",
+        topic: "IA generativa",
+        options: [
+            ["Modelos de geração de imagem a partir de texto, como os de difusão", true],
+            ["Modelos de regressão linear, voltados a prever valores numéricos contínuos", false],
+            ["Modelos de clustering, voltados a agrupar dados sem rótulos prévios", false],
+            ["Modelos de detecção de objetos, que apenas localizam itens em fotos existentes", false],
+        ],
+    },
+    {
+        statement: "O que representa a 'janela de contexto' (context window) de um LLM?",
+        explanation:
+            "A janela de contexto é o limite de tokens (entrada mais saída) que o modelo processa em uma interação. Não tem relação com concorrência de usuários, cache de resposta ou região de nuvem.",
+        topic: "IA generativa",
+        options: [
+            ["A quantidade máxima de tokens que o modelo considera em uma única interação", true],
+            ["O número de usuários que podem chamar o modelo ao mesmo tempo", false],
+            ["O período em que a resposta do modelo fica em cache antes de expirar", false],
+            ["A região de nuvem onde o modelo está fisicamente hospedado", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe pequena quer experimentar vários foundation models sem provisionar servidores nem gerenciar GPUs. Qual característica do Amazon Bedrock ajuda nisso?",
+        explanation:
+            "Bedrock é serverless: a AWS opera a infraestrutura e você consome os modelos por API. Não é preciso criar cluster de GPU, baixar os pesos nem treinar os modelos do zero.",
+        topic: "IA generativa",
+        options: [
+            ["É um serviço serverless, no qual a AWS gerencia a infraestrutura dos modelos", true],
+            ["Exige a criação de um cluster dedicado de GPUs para cada modelo testado", false],
+            ["Requer baixar os pesos dos modelos e hospedá-los em instâncias próprias", false],
+            ["Só funciona se os modelos forem treinados do zero pela própria equipe", false],
+        ],
+    },
+    {
+        statement:
+            "Quais são casos de uso apropriados para IA generativa? (Selecione DUAS opções.)",
+        explanation:
+            "Resumir textos e gerar respostas em linguagem natural são fortes da IA generativa. Somas exatas, regras fiscais fixas e ordenação determinística devem usar lógica tradicional, não geração.",
+        topic: "IA generativa",
+        options: [
+            ["Resumir automaticamente longos relatórios em poucos parágrafos", true],
+            ["Gerar respostas de atendimento a partir de perguntas em linguagem natural", true],
+            ["Garantir a soma exata de uma coluna financeira com precisão contábil", false],
+            ["Aplicar regras fiscais fixas para calcular impostos de forma determinística", false],
+            ["Ordenar uma lista de números de forma perfeitamente reproduzível", false],
+        ],
+    },
+    {
+        statement: "No uso de LLMs, o que é um 'prompt'?",
+        explanation:
+            "O prompt é a instrução ou entrada em linguagem natural que orienta a resposta do modelo. Pesos são internos do treino; o banco vetorial guarda embeddings; métricas avaliam a saída.",
+        topic: "IA generativa",
+        options: [
+            ["A instrução ou entrada em linguagem natural que orienta a resposta do modelo", true],
+            ["O conjunto de pesos internos que o modelo ajusta durante o treinamento", false],
+            ["O banco de dados vetorial que armazena os embeddings dos documentos", false],
+            ["A métrica que mede a qualidade final da resposta gerada pelo modelo", false],
+        ],
+    },
+    {
+        statement:
+            "Por que LLMs são especialmente úteis para tarefas com linguagem natural, como responder perguntas e redigir textos?",
+        explanation:
+            "LLMs foram pré-treinados em enormes volumes de texto e capturam padrões da linguagem, o que os torna bons em tarefas de linguagem natural. Não são calculadoras, não usam regras manuais nem exigem dados tabulares.",
+        topic: "IA generativa",
+        options: [
+            ["Foram pré-treinados em grandes volumes de texto e capturam padrões da linguagem", true],
+            ["Executam apenas operações aritméticas exatas sobre números estruturados", false],
+            ["Dependem de regras gramaticais escritas manualmente para cada idioma", false],
+            ["Funcionam somente com dados tabulares organizados em linhas e colunas", false],
+        ],
+    },
+
+    // ============ Domínio 3: Aplicações de foundation models ============
+    {
+        statement: "O que é 'engenharia de prompt' (prompt engineering)?",
+        explanation:
+            "Engenharia de prompt é elaborar instruções eficazes para guiar o LLM a respostas melhores. Não envolve treinar o modelo do zero, comprimir pesos nem configurar a rede da VPC.",
+        topic: "Prompt engineering",
+        options: [
+            ["A prática de estruturar instruções para obter respostas melhores de um LLM", true],
+            ["O processo de treinar um foundation model do zero com dados próprios", false],
+            ["A técnica de comprimir os pesos do modelo para reduzir o custo de memória", false],
+            ["O ajuste dos parâmetros de rede da VPC onde o modelo está hospedado", false],
+        ],
+    },
+    {
+        statement:
+            "Um desenvolvedor inclui no prompt três exemplos de perguntas com as respostas desejadas antes de fazer a pergunta real, para orientar o formato da saída. Que técnica é essa?",
+        explanation:
+            "Fornecer alguns exemplos dentro do prompt é few-shot (aprendizado em contexto). Fine-tuning e pré-treinamento alteram os pesos do modelo; destilação cria um modelo menor a partir de outro.",
+        topic: "Prompt engineering",
+        options: [
+            ["Prompt few-shot, que fornece alguns exemplos no próprio prompt", true],
+            ["Fine-tuning, que reajusta os pesos do modelo com um novo conjunto de dados", false],
+            ["Pré-treinamento, que ensina o modelo do zero em grandes volumes de dados", false],
+            ["Destilação, que transfere conhecimento de um modelo grande para um menor", false],
+        ],
+    },
+    {
+        statement:
+            "Pedir a um LLM para classificar o sentimento de uma frase sem fornecer nenhum exemplo no prompt é um caso de:",
+        explanation:
+            "Pedir a tarefa sem exemplos é zero-shot. Few-shot inclui exemplos no prompt; fine-tuning treina com dados rotulados; RAG recupera documentos externos antes de responder.",
+        topic: "Prompt engineering",
+        options: [
+            ["Prompt zero-shot, no qual a tarefa é pedida sem exemplos", true],
+            ["Prompt few-shot, no qual vários exemplos guiam a resposta", false],
+            ["Fine-tuning supervisionado, que usa milhares de exemplos rotulados", false],
+            ["RAG, que recupera documentos externos antes de responder", false],
+        ],
+    },
+    {
+        statement:
+            "Ao chamar um LLM, aumentar o parâmetro de 'temperatura' tende a produzir respostas:",
+        explanation:
+            "Temperatura alta aumenta a aleatoriedade e a criatividade; baixa deixa as respostas mais determinísticas. Ela não controla diretamente o tamanho, a velocidade nem o custo da resposta.",
+        topic: "Prompt engineering",
+        options: [
+            ["Mais aleatórias e criativas, com maior variação entre as execuções", true],
+            ["Mais curtas, limitando automaticamente o número de tokens de saída", false],
+            ["Mais rápidas, reduzindo o tempo de processamento de cada requisição", false],
+            ["Mais baratas, diminuindo o custo cobrado por token processado", false],
+        ],
+    },
+    {
+        statement: "O que é Retrieval Augmented Generation (RAG)?",
+        explanation:
+            "RAG busca dados relevantes em uma fonte externa (por exemplo, uma base vetorial) e os inclui no prompt, embasando a resposta em informação atual e específica, sem alterar os pesos do modelo.",
+        topic: "RAG e customização",
+        options: [
+            ["Buscar dados em uma fonte externa e incluí-los no contexto do prompt", true],
+            ["Reajustar os pesos do modelo com um novo conjunto de dados rotulados", false],
+            ["Treinar um foundation model do zero usando apenas os dados da empresa", false],
+            ["Comprimir o modelo para que ele caiba em dispositivos com pouca memória", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer que um assistente responda com base nos seus manuais internos e reduza respostas inventadas, sem treinar um modelo próprio. Qual abordagem é a mais indicada?",
+        explanation:
+            "RAG embasa as respostas nos documentos internos, reduzindo alucinações sem custo de treino. Aumentar a temperatura piora; treinar do zero é caro e desnecessário; remover guardrails aumenta o risco.",
+        topic: "RAG e customização",
+        options: [
+            ["RAG, recuperando trechos dos manuais e incluindo-os no contexto do prompt", true],
+            ["Aumentar a temperatura do modelo para torná-lo mais criativo nas respostas", false],
+            ["Treinar um foundation model do zero somente com os manuais da empresa", false],
+            ["Remover todos os guardrails para o modelo responder a qualquer pergunta", false],
+        ],
+    },
+    {
+        statement:
+            "Qual recurso do Amazon Bedrock facilita implementar RAG conectando foundation models às fontes de dados da empresa?",
+        explanation:
+            "Knowledge Bases for Amazon Bedrock cuida da ingestão, dos embeddings e da recuperação para RAG. Guardrails filtra conteúdo; CloudWatch monitora; CloudFormation provisiona infraestrutura.",
+        topic: "RAG e customização",
+        options: [
+            ["Knowledge Bases for Amazon Bedrock, que gerencia a recuperação de dados para RAG", true],
+            ["Amazon Bedrock Guardrails, voltado a filtrar conteúdo indesejado nas respostas", false],
+            ["Amazon CloudWatch, voltado ao monitoramento de métricas e logs de aplicações", false],
+            ["AWS CloudFormation, voltado a provisionar infraestrutura como código", false],
+        ],
+    },
+    {
+        statement: "O que é 'fine-tuning' de um foundation model?",
+        explanation:
+            "Fine-tuning continua o treino do modelo com dados específicos, ajustando os pesos e especializando-o em uma tarefa. Melhorar o prompt é engenharia de prompt; recuperar documentos é RAG.",
+        topic: "RAG e customização",
+        options: [
+            ["Continuar o treino do modelo com dados específicos, ajustando seus pesos", true],
+            ["Escrever instruções mais detalhadas no prompt sem alterar o modelo", false],
+            ["Recuperar documentos externos e incluí-los no contexto da pergunta", false],
+            ["Reduzir o número de tokens da resposta apenas para diminuir o custo", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa precisa que o assistente use informações que mudam toda semana. Por que RAG costuma ser preferível a fine-tuning nesse caso?",
+        explanation:
+            "Com RAG basta atualizar a base de dados recuperada, ideal para informações que mudam sempre. Fine-tuning fixa o conhecimento nos pesos e exigiria retreinar o modelo a cada mudança.",
+        topic: "RAG e customização",
+        options: [
+            ["Com RAG basta atualizar a base de dados, sem retreinar o modelo a cada mudança", true],
+            ["Fine-tuning atualiza o modelo automaticamente sempre que os dados mudam", false],
+            ["RAG altera os pesos do modelo mais rápido do que o fine-tuning consegue", false],
+            ["Fine-tuning dispensa qualquer fonte de dados para responder perguntas novas", false],
+        ],
+    },
+    {
+        statement:
+            "Qual recurso do Amazon Bedrock permite que um foundation model execute tarefas em várias etapas, chamando APIs e sistemas para concluir uma solicitação do usuário?",
+        explanation:
+            "Agents for Amazon Bedrock orquestram tarefas de múltiplas etapas, invocando APIs e fontes de dados. Guardrails filtra conteúdo; Textract extrai de documentos; Macie protege dados sensíveis.",
+        topic: "RAG e customização",
+        options: [
+            ["Agents for Amazon Bedrock, que orquestram ações e chamadas a sistemas", true],
+            ["Amazon Bedrock Guardrails, que restringem os temas e conteúdos das respostas", false],
+            ["Amazon Textract, que extrai texto e dados de documentos digitalizados", false],
+            ["Amazon Macie, que descobre e protege dados sensíveis armazenados no S3", false],
+        ],
+    },
+    {
+        statement:
+            "Ao escolher um foundation model para um chatbot de alto volume e baixo custo, qual tradeoff a equipe deve considerar?",
+        explanation:
+            "Modelos menores tendem a custar menos e responder mais rápido, com menos capacidade; os maiores custam e demoram mais, mas resolvem tarefas complexas. A escolha equilibra custo, latência e qualidade.",
+        topic: "RAG e customização",
+        options: [
+            ["Modelos menores tendem a custar menos e responder mais rápido, com menos capacidade", true],
+            ["Modelos maiores são sempre mais baratos e mais rápidos que os menores", false],
+            ["O tamanho do modelo não influencia custo, latência nem capacidade", false],
+            ["Modelos menores sempre superam os maiores em qualquer tarefa de linguagem", false],
+        ],
+    },
+    {
+        statement:
+            "Qual é o efeito de definir um limite de 'máximo de tokens' (max tokens) na chamada de um LLM?",
+        explanation:
+            "Max tokens limita o comprimento da resposta, cortando-a ao atingir o teto. A criatividade é governada pela temperatura e top-p; a correção não é garantida por esse limite; cotas de chamada são outra coisa.",
+        topic: "Prompt engineering",
+        options: [
+            ["Limita o tamanho da resposta gerada, cortando-a ao atingir o teto de tokens", true],
+            ["Aumenta a criatividade da resposta ao permitir mais variação de palavras", false],
+            ["Garante que a resposta esteja sempre factualmente correta e sem erros", false],
+            ["Define quantas vezes o modelo pode ser chamado por minuto na conta", false],
+        ],
+    },
+    {
+        statement: "Em uma solução de RAG, qual é o papel de um banco de dados vetorial?",
+        explanation:
+            "O banco vetorial guarda embeddings e faz busca por similaridade para recuperar os trechos mais relevantes ao prompt. Ele não treina modelos, não gera imagens nem cuida da autorização de acesso.",
+        topic: "RAG e customização",
+        options: [
+            ["Armazenar embeddings e recuperar os trechos mais semelhantes à consulta", true],
+            ["Executar o treino do foundation model a partir de dados rotulados", false],
+            ["Gerar as imagens de saída solicitadas pelo usuário no prompt", false],
+            ["Aplicar as políticas de IAM que autorizam o acesso ao modelo", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe quer comparar a qualidade de diferentes foundation models para a sua tarefa antes de escolher um. Qual recurso do Amazon Bedrock apoia isso?",
+        explanation:
+            "A avaliação de modelos (model evaluation) do Bedrock compara modelos por métricas automáticas ou por avaliação humana. Guardrails filtra; Trusted Advisor e Inspector são de conta e segurança.",
+        topic: "RAG e customização",
+        options: [
+            ["A avaliação de modelos (model evaluation) do Amazon Bedrock", true],
+            ["O Amazon Bedrock Guardrails, focado em bloquear conteúdo indesejado", false],
+            ["O AWS Trusted Advisor, focado em recomendações de custo e segurança da conta", false],
+            ["O Amazon Inspector, focado em avaliar vulnerabilidades de segurança", false],
+        ],
+    },
+    {
+        statement:
+            "Uma forma de melhorar respostas de um LLM em problemas de raciocínio é pedir que ele explique o passo a passo antes de dar a resposta final. Essa técnica de prompt é conhecida como:",
+        explanation:
+            "Pedir o raciocínio passo a passo é a cadeia de raciocínio (chain-of-thought), que costuma melhorar tarefas de lógica. As demais opções são conceitos de ML ou de infraestrutura, não técnicas de prompt.",
+        topic: "Prompt engineering",
+        options: [
+            ["Cadeia de raciocínio (chain-of-thought), pedindo o passo a passo antes da resposta", true],
+            ["Redução de dimensionalidade, que resume as variáveis de entrada em menos colunas", false],
+            ["Quantização, que reduz a precisão numérica dos pesos do modelo", false],
+            ["Balanceamento de carga, que distribui as requisições entre vários servidores", false],
+        ],
+    },
+    {
+        statement: "Qual é um risco de segurança específico ao expor um LLM a entradas de usuários?",
+        explanation:
+            "Injeção de prompt tenta fazer o modelo ignorar as instruções originais e seguir as do atacante. Os outros itens são problemas genéricos de infraestrutura, não específicos de LLMs.",
+        topic: "Prompt engineering",
+        options: [
+            ["Injeção de prompt, na qual a entrada tenta subverter as instruções do sistema", true],
+            ["Estouro de buffer causado por excesso de memória alocada pelo modelo", false],
+            ["Perda de pacotes na rede entre o cliente e o endpoint do modelo", false],
+            ["Fragmentação de disco no armazenamento onde o modelo está hospedado", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa quer impedir que seu assistente generativo responda sobre temas proibidos e evite linguagem tóxica. Qual recurso do Amazon Bedrock atende a isso?",
+        explanation:
+            "Guardrails aplica filtros de conteúdo, tópicos negados e proteção de PII nas respostas. Knowledge Bases é para RAG; Ground Truth rotula dados; DataBrew prepara dados de forma visual.",
+        topic: "RAG e customização",
+        options: [
+            ["Amazon Bedrock Guardrails, que aplica filtros de conteúdo e tópicos negados", true],
+            ["Amazon Bedrock Knowledge Bases, que conecta o modelo a fontes de dados", false],
+            ["Amazon SageMaker Ground Truth, que rotula dados para treino supervisionado", false],
+            ["AWS Glue DataBrew, que limpa e prepara dados de forma visual", false],
+        ],
+    },
+    {
+        statement:
+            "Além de reduzir alucinações, incluir no prompt trechos recuperados de documentos confiáveis permite que a resposta:",
+        explanation:
+            "Ao embasar a resposta em trechos recuperados, é possível citar as fontes e aumentar a confiança. Isso não garante correção absoluta, não zera o custo de inferência nem fixa a latência.",
+        topic: "RAG e customização",
+        options: [
+            ["Cite as fontes usadas, aumentando a rastreabilidade e a confiança na resposta", true],
+            ["Dispense qualquer revisão humana, por estar sempre 100% correta", false],
+            ["Elimine o custo de inferência cobrado por token processado", false],
+            ["Garanta tempo de resposta constante independentemente do modelo escolhido", false],
+        ],
+    },
+
+    // ===================== Domínio 4: IA responsável =====================
+    {
+        statement:
+            "No contexto de IA responsável, o que é 'viés' (bias) em um modelo de ML?",
+        explanation:
+            "Viés é o erro sistemático que favorece ou prejudica certos grupos de forma injusta, muitas vezes refletindo desequilíbrios nos dados. Não é a diferença treino/teste, a latência nem o tamanho do modelo.",
+        topic: "IA responsável",
+        options: [
+            ["Erros sistemáticos que favorecem ou prejudicam certos grupos de forma injusta", true],
+            ["A diferença entre a acurácia de treino e a acurácia de teste do modelo", false],
+            ["O tempo que o modelo leva para produzir cada resposta em produção", false],
+            ["A quantidade de parâmetros ajustados durante o treino do modelo", false],
+        ],
+    },
+    {
+        statement:
+            "Qual serviço da AWS ajuda a detectar viés nos dados e no modelo e a explicar as previsões?",
+        explanation:
+            "Amazon SageMaker Clarify detecta viés e fornece explicabilidade das previsões. Ground Truth rotula dados; CloudFront é uma CDN; AWS Backup cria e gerencia cópias de segurança.",
+        topic: "IA responsável",
+        options: [
+            ["Amazon SageMaker Clarify, voltado à detecção de viés e à explicabilidade", true],
+            ["Amazon SageMaker Ground Truth, voltado à rotulagem de dados de treino", false],
+            ["Amazon CloudFront, voltado à entrega de conteúdo com baixa latência", false],
+            ["AWS Backup, voltado à criação e à gestão de cópias de segurança", false],
+        ],
+    },
+    {
+        statement:
+            "Por que a 'explicabilidade' (explainability) de um modelo é importante em aplicações sensíveis, como concessão de crédito?",
+        explanation:
+            "Explicabilidade ajuda a entender e justificar as decisões, essencial em contextos regulados e sensíveis. Ela não garante ausência de erros, não reduz o custo de inferência nem acelera o treino.",
+        topic: "IA responsável",
+        options: [
+            ["Permite entender por que o modelo decidiu e justificar isso a quem for afetado", true],
+            ["Garante que o modelo nunca cometa erros em nenhuma previsão futura", false],
+            ["Reduz automaticamente o custo de inferência do modelo em produção", false],
+            ["Aumenta a velocidade de treino ao simplificar o algoritmo utilizado", false],
+        ],
+    },
+    {
+        statement: "Qual das opções é uma dimensão central da IA responsável?",
+        explanation:
+            "Justiça (fairness) é um pilar da IA responsável, ao lado de transparência, explicabilidade, robustez e privacidade. Aumentar parâmetros, limitar idiomas ou ocultar o funcionamento não são princípios de IA responsável.",
+        topic: "IA responsável",
+        options: [
+            ["Justiça (fairness), buscando tratar diferentes grupos de forma equânime", true],
+            ["Maximizar o número de parâmetros do modelo a qualquer custo", false],
+            ["Reduzir o número de idiomas suportados para simplificar o sistema", false],
+            ["Ocultar totalmente de todos os envolvidos como o sistema funciona", false],
+        ],
+    },
+    {
+        statement:
+            "Um modelo de recrutamento passou a favorecer um perfil específico de candidato. A investigação apontou que os dados históricos de contratação já eram desequilibrados. Que problema isso ilustra?",
+        explanation:
+            "Dados históricos desequilibrados geram viés que o modelo aprende e reproduz (ou amplifica). Overfitting é sobre generalização; alucinação é de modelos generativos; latência é desempenho, não justiça.",
+        topic: "IA responsável",
+        options: [
+            ["Viés herdado dos dados de treino, que o modelo aprendeu e reproduziu", true],
+            ["Overfitting causado por um modelo grande demais para os dados disponíveis", false],
+            ["Alucinação, típica de modelos generativos que inventam informações", false],
+            ["Latência alta provocada por um endpoint mal dimensionado", false],
+        ],
+    },
+    {
+        statement:
+            "A AWS publica documentos que descrevem casos de uso pretendidos, limitações e escolhas de design de seus serviços de IA, apoiando o uso responsável. Como esses documentos são chamados?",
+        explanation:
+            "As AWS AI Service Cards trazem transparência sobre uso pretendido, limitações e design responsável dos serviços de IA. As demais opções são recursos de rede, IAM e computação.",
+        topic: "IA responsável",
+        options: [
+            ["AI Service Cards, que documentam o uso pretendido e as limitações dos serviços de IA", true],
+            ["Security Groups, que controlam o tráfego de rede de instâncias EC2", false],
+            ["Trust Policies, que definem quem pode assumir uma função do IAM", false],
+            ["Launch Templates, que padronizam a criação de instâncias de computação", false],
+        ],
+    },
+    {
+        statement:
+            "Em decisões de alto impacto apoiadas por IA, qual prática de IA responsável ajuda a evitar erros graves do modelo?",
+        explanation:
+            "Manter revisão humana (human in the loop) sobre decisões críticas é uma salvaguarda central da IA responsável. Remover supervisão, elevar a temperatura ou ocultar decisões aumentam o risco.",
+        topic: "IA responsável",
+        options: [
+            ["Manter revisão humana (human in the loop) sobre as decisões do modelo", true],
+            ["Remover qualquer supervisão para acelerar as decisões automatizadas", false],
+            ["Aumentar a temperatura do modelo para gerar respostas mais variadas", false],
+            ["Ocultar as decisões do modelo dos usuários afetados por elas", false],
+        ],
+    },
+    {
+        statement:
+            "Aplicar filtros que impedem um assistente de gerar conteúdo tóxico ou perigoso está mais associado a qual princípio de IA responsável?",
+        explanation:
+            "Filtrar conteúdo tóxico ou perigoso é uma medida de segurança e mitigação de danos, um pilar da IA responsável. As outras opções tratam de custo, desempenho e dados, não da segurança do conteúdo.",
+        topic: "IA responsável",
+        options: [
+            ["Segurança e mitigação de danos ao usuário e à sociedade", true],
+            ["Redução do custo de armazenamento dos dados de treino", false],
+            ["Aumento da taxa de tokens processados por segundo", false],
+            ["Simplificação do pipeline de ETL que alimenta o modelo", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe quer documentar, para cada modelo, a finalidade, os dados usados, as métricas e as limitações conhecidas, apoiando a governança. Que artefato atende a isso?",
+        explanation:
+            "Os cartões de modelo (model cards) documentam finalidade, dados, métricas e limitações de um modelo, apoiando governança e transparência. As demais opções são recursos de rede, armazenamento e mensageria.",
+        topic: "IA responsável",
+        options: [
+            ["Cartões de modelo (model cards), que documentam finalidade, dados e limitações", true],
+            ["Grupos de segurança, que controlam o tráfego de rede das instâncias", false],
+            ["Buckets do S3, que apenas armazenam objetos sem descrever modelos", false],
+            ["Filas SQS, que desacoplam componentes por meio de mensagens", false],
+        ],
+    },
+
+    // ============ Domínio 5: Segurança, conformidade e governança ============
+    {
+        statement:
+            "Ao dar acesso a um serviço de IA na AWS, qual prática de segurança concede apenas as permissões estritamente necessárias?",
+        explanation:
+            "O princípio do menor privilégio, aplicado via AWS IAM, concede só o necessário e reduz a superfície de ataque. Dar admin a todos, compartilhar a chave raiz ou desativar a autenticação são práticas inseguras.",
+        topic: "Segurança e governança",
+        options: [
+            ["Aplicar o princípio do menor privilégio com políticas do AWS IAM", true],
+            ["Conceder permissões de administrador a todos para agilizar o trabalho", false],
+            ["Compartilhar uma única chave de acesso raiz entre toda a equipe", false],
+            ["Desativar a autenticação para simplificar o acesso aos serviços", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa precisa descobrir e proteger dados pessoais (PII) presentes em grandes volumes de documentos armazenados no Amazon S3. Qual serviço é voltado a isso?",
+        explanation:
+            "Amazon Macie usa ML para descobrir e proteger PII e outros dados sensíveis no S3. Polly gera voz, Lex constrói chatbots e AWS Batch executa cargas de processamento em lote.",
+        topic: "Segurança e governança",
+        options: [
+            ["Amazon Macie, que descobre e protege dados sensíveis armazenados no S3", true],
+            ["Amazon Polly, que converte texto em voz de forma natural", false],
+            ["Amazon Lex, que constrói interfaces conversacionais e chatbots", false],
+            ["AWS Batch, que executa cargas de processamento em lote", false],
+        ],
+    },
+    {
+        statement:
+            "Para proteger os dados usados por uma solução de IA na AWS, qual medida de segurança é recomendada?",
+        explanation:
+            "Criptografar os dados em repouso e em trânsito (por exemplo, com o AWS KMS) é uma prática básica de proteção. Texto puro, buckets públicos e desativar logs enfraquecem a segurança.",
+        topic: "Segurança e governança",
+        options: [
+            ["Criptografar os dados em repouso e em trânsito, por exemplo com o AWS KMS", true],
+            ["Manter os dados sempre em texto puro para facilitar a depuração", false],
+            ["Publicar os dados em um bucket S3 aberto para acesso público", false],
+            ["Desabilitar o registro de logs para reduzir o volume de dados guardado", false],
+        ],
+    },
+    {
+        statement:
+            "No modelo de responsabilidade compartilhada da AWS aplicado a um serviço gerenciado de IA, qual item normalmente é responsabilidade do CLIENTE?",
+        explanation:
+            "O cliente é responsável pelo controle de acesso (IAM) e pela governança dos próprios dados. A AWS cuida da infraestrutura física, dos patches da plataforma gerenciada e da operação dos data centers.",
+        topic: "Segurança e governança",
+        options: [
+            ["Definir quem pode acessar o serviço e como os dados de entrada são usados", true],
+            ["Manter o hardware físico dos data centers que hospedam o serviço", false],
+            ["Aplicar patches no sistema operacional da infraestrutura gerenciada", false],
+            ["Operar a rede física e a energia elétrica das instalações da AWS", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa teme que seus prompts e dados enviados ao Amazon Bedrock sejam usados para treinar os modelos base de terceiros. Qual afirmação reflete a postura de privacidade do Bedrock?",
+        explanation:
+            "No Bedrock, os dados do cliente não são usados para treinar os foundation models base nem compartilhados com os provedores dos modelos. As demais afirmações contrariam a privacidade do serviço.",
+        topic: "Segurança e governança",
+        options: [
+            ["Os dados do cliente não são usados para treinar os foundation models base", true],
+            ["Todos os prompts enviados passam a treinar publicamente os modelos base", false],
+            ["Os dados ficam visíveis para todos os outros clientes do serviço", false],
+            ["Os dados são compartilhados automaticamente com os provedores dos modelos", false],
+        ],
+    },
+    {
+        statement:
+            "Uma equipe de governança precisa auditar quem chamou as APIs dos serviços de IA e quando, para fins de conformidade. Qual serviço registra essas chamadas de API na conta?",
+        explanation:
+            "AWS CloudTrail registra as chamadas de API feitas na conta, apoiando auditoria e conformidade. Rekognition analisa imagens, Translate traduz textos e Amplify acelera o desenvolvimento de apps.",
+        topic: "Segurança e governança",
+        options: [
+            ["AWS CloudTrail, que registra as chamadas de API feitas na conta", true],
+            ["Amazon Rekognition, que analisa imagens e vídeos com visão computacional", false],
+            ["Amazon Translate, que traduz textos entre diferentes idiomas", false],
+            ["AWS Amplify, que acelera o desenvolvimento de aplicações web e mobile", false],
+        ],
+    },
+    {
+        statement:
+            "Depois de implantar um modelo em produção, quais recursos ajudam a monitorar a operação e a qualidade ao longo do tempo? (Selecione DUAS opções.)",
+        explanation:
+            "Amazon CloudWatch acompanha métricas e logs operacionais, e o SageMaker Model Monitor detecta desvios (drift) na qualidade do modelo. Polly gera voz, AWS Budgets controla gastos e Lex faz chatbots.",
+        topic: "Segurança e governança",
+        options: [
+            ["Amazon CloudWatch, para acompanhar métricas e logs operacionais", true],
+            ["Amazon SageMaker Model Monitor, para detectar desvios na qualidade do modelo", true],
+            ["Amazon Polly, para converter as previsões do modelo em áudio", false],
+            ["AWS Budgets, para definir alertas de gasto financeiro na conta", false],
+            ["Amazon Lex, para criar fluxos de conversa em chatbots", false],
+        ],
+    },
+    {
+        statement:
+            "Para que as chamadas a um serviço de IA não trafeguem pela internet pública, mantendo o tráfego dentro da rede da AWS, qual recurso pode ser usado?",
+        explanation:
+            "AWS PrivateLink conecta a VPC ao serviço sem expor o tráfego à internet pública. Route 53 é DNS, SNS é mensageria por publicação e assinatura e Cost Explorer analisa custos da conta.",
+        topic: "Segurança e governança",
+        options: [
+            ["AWS PrivateLink, que conecta a VPC ao serviço sem expor o tráfego à internet", true],
+            ["Amazon Route 53, um serviço de DNS para resolução de nomes de domínio", false],
+            ["Amazon SNS, um serviço de notificações por publicação e assinatura", false],
+            ["AWS Cost Explorer, uma ferramenta de análise de custos da conta", false],
+        ],
+    },
+    {
+        statement:
+            "Uma empresa regulada precisa obter relatórios de conformidade e certificações da AWS (como ISO e SOC) para uma auditoria. Onde esses documentos ficam disponíveis?",
+        explanation:
+            "AWS Artifact é o portal de relatórios de conformidade e certificações (ISO, SOC e outros). QuickSight é BI, Kinesis é ingestão em streaming e Step Functions orquestra fluxos de trabalho.",
+        topic: "Segurança e governança",
+        options: [
+            ["AWS Artifact, o portal de relatórios de conformidade e certificações da AWS", true],
+            ["Amazon QuickSight, uma ferramenta de business intelligence e dashboards", false],
+            ["Amazon Kinesis, um serviço de ingestão de dados em streaming", false],
+            ["AWS Step Functions, um orquestrador de fluxos de trabalho serverless", false],
+        ],
+    },
+    {
+        statement:
+            "No contexto de governança de dados para IA, por que rastrear a origem e as transformações dos dados (linhagem) é importante?",
+        explanation:
+            "A linhagem de dados apoia auditoria, conformidade e reprodutibilidade, mostrando de onde os dados vieram e como foram tratados. Ela não substitui controle de acesso, não elimina viés por si só nem substitui a criptografia.",
+        topic: "Segurança e governança",
+        options: [
+            ["Permite auditar de onde vieram os dados e como foram tratados antes do treino", true],
+            ["Elimina a necessidade de qualquer controle de acesso aos conjuntos de dados", false],
+            ["Garante que o modelo nunca apresentará viés em suas previsões", false],
+            ["Substitui a criptografia dos dados em repouso e em trânsito", false],
+        ],
+    },
+];
+
+async function seed() {
+    let [simulado] = await db.select().from(simulados).where(eq(simulados.slug, SLUG));
+    if (!simulado) {
+        [simulado] = await db
+            .insert(simulados)
+            .values({
+                slug: SLUG,
+                name: "AWS Certified AI Practitioner (AIF-C01)",
+                provider: "aws",
+                code: "AIF-C01",
+                level: "Fundamental",
+                description:
+                    "Simulado no formato da prova AIF-C01: 90 minutos, corte de 70%. Cobre os 5 domínios: fundamentos de IA e ML, IA generativa, aplicações de foundation models, IA responsável e segurança e governança.",
+                durationMinutes: 90,
+                questionCount: 65,
+                passPercent: 70,
+                published: true,
+            })
+            .returning();
+        console.log(`Simulado criado: ${simulado.slug}`);
+    }
+    await db
+        .update(simulados)
+        .set({ provider: "aws", code: "AIF-C01", level: "Fundamental" })
+        .where(eq(simulados.id, simulado.id));
+
+    const [{ n }] = await db
+        .select({ n: count() })
+        .from(simuladoQuestions)
+        .where(eq(simuladoQuestions.simuladoId, simulado.id));
+    if (Number(n) > 0) {
+        console.log(`Simulado já tem ${n} questões, nada a fazer.`);
+        return;
+    }
+
+    for (const q of QUESTOES) {
+        const [questao] = await db
+            .insert(simuladoQuestions)
+            .values({
+                simuladoId: simulado.id,
+                statement: q.statement,
+                explanation: q.explanation,
+                topic: q.topic,
+            })
+            .returning();
+        await db.insert(simuladoOptions).values(
+            q.options.map(([text, isCorrect], idx) => ({
+                questionId: questao.id,
+                text,
+                isCorrect,
+                position: idx + 1,
+            })),
+        );
+    }
+    console.log(`Seed concluído: ${QUESTOES.length} questões inseridas.`);
+}
+
+seed()
+    .then(() => process.exit(0))
+    .catch((e) => {
+        console.error("Falha no seed:", e);
+        process.exit(1);
+    });

--- a/backend/scripts/seed-trilha-aif-c01.ts
+++ b/backend/scripts/seed-trilha-aif-c01.ts
@@ -1,0 +1,1512 @@
+// Seed da trilha AWS Certified AI Practitioner (AIF-C01). Conteúdo autoral,
+// escrito para ensinar os 5 domínios do exame. Idempotente e não destrutivo:
+// se a trilha já tiver aulas, não faz nada.
+//
+// Rodar em prod: docker compose -f docker-compose.prod.yml exec -T backend node scripts/seed-trilha-aif-c01.ts
+import { db } from "../db.ts";
+import { trails, modules, lessons, questions, questionOptions } from "../schema.ts";
+import { eq } from "drizzle-orm";
+
+const NOME = "AWS AI Practitioner";
+const DESCRICAO =
+    "Trilha de fundamentos de inteligência artificial na AWS para a certificação AI Practitioner (AIF-C01): conceitos de IA e machine learning, IA generativa e foundation models, engenharia de prompt e RAG, IA responsável e segurança, conformidade e governança de soluções de IA.";
+
+type Bloco = { type: "text" | "code" | "quote" | "table"; value: string };
+type Questao = {
+    statement: string;
+    difficulty: "facil" | "medio" | "dificil";
+    options: { text: string; isCorrect: boolean }[];
+};
+type Aula = { titulo: string; blocks: Bloco[]; questions: Questao[] };
+type Modulo = { titulo: string; aulas: Aula[] };
+
+const MODULO_1: Modulo = {
+    titulo: "Módulo 1 - Fundamentos de IA e machine learning",
+    aulas: [
+        {
+            titulo: "IA, machine learning e deep learning",
+            blocks: [
+                {
+                    type: "text",
+                    value: "## Três termos que se encaixam\nO exame AIF-C01 começa exigindo clareza sobre três palavras que muita gente usa como sinônimo, mas que têm uma relação de encaixe.\n\n**Inteligência artificial (IA)** é o campo mais amplo: qualquer técnica que faça um computador imitar capacidades associadas à inteligência humana, como entender linguagem, reconhecer imagens ou tomar decisões. Um sistema de regras escritas à mão já pode ser considerado IA.\n\n**Machine learning (ML)** é um subconjunto da IA no qual o sistema aprende padrões a partir de dados, em vez de seguir apenas regras fixas. Você não programa a resposta; você mostra exemplos e o algoritmo descobre a regra.\n\n**Deep learning** é um subconjunto do ML baseado em redes neurais com muitas camadas. É o que sustenta avanços recentes em visão, linguagem e IA generativa.",
+                },
+                {
+                    type: "quote",
+                    value: "A hierarquia cai direto na prova: IA contém machine learning, que por sua vez contém deep learning.",
+                },
+                {
+                    type: "text",
+                    value: "## Por que a distinção importa\nSaber quem contém quem evita as pegadinhas mais comuns do exame, do tipo \"deep learning engloba a IA\" (falso) ou \"IA é um caso particular de ML\" (falso). O caminho é sempre do mais geral para o mais específico: IA, depois ML, depois deep learning.\n\nNa prática, quando um cenário fala em aprender a partir de dados, você está no território do machine learning. Quando fala especificamente em redes neurais profundas para imagem, som ou texto livre, é deep learning.",
+                },
+            ],
+            questions: [
+                {
+                    statement:
+                        "Qual afirmação descreve corretamente a relação entre inteligência artificial, machine learning e deep learning?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "ML é um subconjunto da IA, e deep learning é um subconjunto do ML", isCorrect: true },
+                        { text: "Deep learning contém o machine learning, que contém a IA", isCorrect: false },
+                        { text: "IA e machine learning são áreas separadas, sem sobreposição", isCorrect: false },
+                        { text: "Machine learning é mais amplo do que a inteligência artificial", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Um sistema aprende a identificar gatos em fotos a partir de milhares de exemplos rotulados, sem regras escritas à mão. Esse sistema é melhor descrito como:",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Machine learning, pois aprende padrões a partir de dados", isCorrect: true },
+                        { text: "Um sistema de regras fixas escritas manualmente", isCorrect: false },
+                        { text: "Uma planilha com fórmulas determinísticas", isCorrect: false },
+                        { text: "Um banco de dados relacional consultado por SQL", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Deep learning se distingue de outras técnicas de machine learning principalmente por:",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Usar redes neurais com muitas camadas para aprender padrões complexos", isCorrect: true },
+                        { text: "Dispensar completamente qualquer tipo de dado de treino", isCorrect: false },
+                        { text: "Funcionar apenas com regras lógicas escritas por especialistas", isCorrect: false },
+                        { text: "Ser incapaz de lidar com imagens, áudio ou texto livre", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Tipos de aprendizado: supervisionado, não supervisionado e por reforço",
+            blocks: [
+                {
+                    type: "text",
+                    value: "## Três formas de aprender\nO machine learning se organiza em famílias, e o AIF-C01 cobra que você reconheça qual se aplica a um cenário.\n\n**Aprendizado supervisionado** treina com dados que já têm a resposta certa (o rótulo). O modelo aprende a mapear entradas para saídas conhecidas. Exemplo: prever se um e-mail é spam usando milhares de e-mails já marcados como spam ou não.\n\n**Aprendizado não supervisionado** trabalha com dados sem rótulos e busca estrutura escondida, como agrupar itens parecidos. Exemplo: segmentar clientes em grupos de comportamento sem categorias pré-definidas.\n\n**Aprendizado por reforço** aprende por tentativa e erro: um agente toma ações, recebe recompensas ou penalidades e ajusta a estratégia para maximizar a recompensa ao longo do tempo. Exemplo: um sistema que aprende a jogar ou a controlar um robô.",
+                },
+                {
+                    type: "table",
+                    value: "[[\"Tipo\", \"Usa rótulos?\", \"O que busca\", \"Exemplo\"], [\"Supervisionado\", \"Sim\", \"Prever uma saída conhecida\", \"Detectar fraude com transações rotuladas\"], [\"Não supervisionado\", \"Não\", \"Achar grupos ou padrões\", \"Segmentar clientes por comportamento\"], [\"Por reforço\", \"Não (usa recompensas)\", \"Maximizar recompensa por tentativa e erro\", \"Controlar um robô ou jogar\"]]",
+                },
+                {
+                    type: "text",
+                    value: "## Como decidir no cenário\nProcure a palavra-chave. Se o enunciado menciona dados já rotulados ou uma resposta certa conhecida, é supervisionado. Se fala em descobrir grupos ou padrões sem categorias prontas, é não supervisionado. Se descreve um agente que age, recebe recompensa e melhora com o tempo, é por reforço.",
+                },
+            ],
+            questions: [
+                {
+                    statement:
+                        "Uma operadora quer prever cancelamento de clientes usando um histórico em que cada cliente já está marcado como 'cancelou' ou 'permaneceu'. Que tipo de aprendizado é esse?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Supervisionado, porque os dados já têm o rótulo a prever", isCorrect: true },
+                        { text: "Não supervisionado, porque agrupa clientes sem rótulos", isCorrect: false },
+                        { text: "Por reforço, porque recebe recompensas a cada acerto", isCorrect: false },
+                        { text: "Nenhum, porque previsão não usa machine learning", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Uma equipe tem um grande conjunto de artigos sem categorias e quer que o sistema descubra sozinho grupos de temas semelhantes. Que abordagem se aplica?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Aprendizado não supervisionado, que encontra grupos sem rótulos", isCorrect: true },
+                        { text: "Aprendizado supervisionado, que exige rótulos definidos antes", isCorrect: false },
+                        { text: "Aprendizado por reforço, que depende de um sistema de recompensas", isCorrect: false },
+                        { text: "Programação de regras fixas para cada tema possível", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Qual cenário caracteriza aprendizado por reforço?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um agente que age, recebe recompensas e ajusta a estratégia ao longo do tempo", isCorrect: true },
+                        { text: "Um modelo treinado uma única vez com exemplos já rotulados de antemão", isCorrect: false },
+                        { text: "Um algoritmo que apenas agrupa dados semelhantes entre si, sem rótulos", isCorrect: false },
+                        { text: "Uma consulta que retorna registros já prontos de um banco de dados", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Classificação, regressão e clustering",
+            blocks: [
+                {
+                    type: "text",
+                    value: "## O tipo de saída define o tipo de problema\nAlém de como o modelo aprende, o exame cobra que tipo de problema ele resolve. A pista é sempre o que se quer na saída.\n\n**Classificação** prevê uma categoria discreta: spam ou não spam, fraude ou legítima, aprovado ou reprovado. As classes são conhecidas de antemão.\n\n**Regressão** prevê um valor numérico contínuo: o preço de um imóvel, a temperatura de amanhã, a demanda da próxima semana.\n\n**Clustering** (agrupamento) não prevê nada dado de antemão: ele descobre grupos naturais nos dados. É a técnica não supervisionada mais cobrada.",
+                },
+                {
+                    type: "quote",
+                    value: "Saída é categoria conhecida, é classificação; saída é número contínuo, é regressão; achar grupos sem rótulo, é clustering.",
+                },
+                {
+                    type: "text",
+                    value: "## Quando ML não é a resposta\nUm ponto sutil que a prova adora: nem todo problema pede machine learning. Se as regras são fixas, determinísticas e bem definidas (calcular um imposto pela lei, aplicar um desconto de tabela), o certo é programar a lógica, não treinar um modelo. Machine learning vale a pena quando os padrões são complexos, mudam com o tempo ou são difíceis de descrever em regras explícitas.",
+                },
+            ],
+            questions: [
+                {
+                    statement:
+                        "Uma loja quer prever quantas unidades de um produto venderá na próxima semana (um número). Que tipo de problema de ML é esse?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Regressão, pois a saída é um valor numérico contínuo", isCorrect: true },
+                        { text: "Classificação, pois a saída é uma categoria discreta", isCorrect: false },
+                        { text: "Clustering, pois agrupa produtos semelhantes", isCorrect: false },
+                        { text: "Reforço, pois aprende por recompensa e punição", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Decidir se um e-mail recebido é 'spam' ou 'não spam' é um exemplo de qual tipo de problema?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Classificação, pois prevê uma categoria conhecida", isCorrect: true },
+                        { text: "Regressão, pois prevê um número contínuo", isCorrect: false },
+                        { text: "Clustering, pois descobre grupos sem rótulos", isCorrect: false },
+                        { text: "Redução de dimensionalidade, pois resume variáveis", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Em qual situação usar machine learning é a escolha MENOS apropriada?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Calcular um imposto por regras fixas e determinísticas da lei", isCorrect: true },
+                        { text: "Prever a demanda de produtos a partir de padrões históricos", isCorrect: false },
+                        { text: "Recomendar conteúdos com base no comportamento do usuário", isCorrect: false },
+                        { text: "Classificar avaliações de clientes entre positivas e negativas", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "O ciclo de vida de ML e a importância dos dados",
+            blocks: [
+                {
+                    type: "text",
+                    value: "## Do problema ao modelo em produção\nUm projeto de machine learning segue um ciclo que o AIF-C01 espera que você reconheça em alto nível:\n\n1. **Enquadrar o problema**: definir o que se quer prever e como o sucesso será medido.\n2. **Coletar e preparar os dados**: reunir, limpar e transformar os dados; criar variáveis (features).\n3. **Treinar o modelo**: o algoritmo ajusta seus parâmetros a partir dos dados de treino.\n4. **Avaliar**: medir o desempenho em dados que o modelo não viu no treino.\n5. **Implantar (deploy)**: colocar o modelo para servir previsões (inferência) em produção.\n6. **Monitorar**: acompanhar a qualidade ao longo do tempo e retreinar quando necessário.",
+                },
+                {
+                    type: "text",
+                    value: "## Vocabulário essencial\n**Feature (atributo)** é cada variável de entrada usada para prever, como área e localização de um imóvel. **Rótulo (label)** é a resposta que se quer prever, como o preço. **Treino** é o ajuste dos parâmetros com os dados; **inferência** é usar o modelo já treinado para prever sobre dados novos.\n\nGuarde a diferença entre treino e inferência: treinar acontece uma vez (ou periodicamente) e é custoso; inferir acontece o tempo todo em produção, a cada previsão pedida.",
+                },
+                {
+                    type: "quote",
+                    value: "Dados ruins geram modelos ruins. Nem um modelo maior nem mais dados compensam informação errada ou enviesada: qualidade de dados é decisiva.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "No vocabulário de ML supervisionado, o que é um 'rótulo' (label)?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "A resposta que se deseja prever, associada a cada exemplo", isCorrect: true },
+                        { text: "Cada variável de entrada usada para fazer a previsão", isCorrect: false },
+                        { text: "O parâmetro interno ajustado durante o treino", isCorrect: false },
+                        { text: "A métrica que avalia o modelo no conjunto de teste", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Usar um modelo já treinado para gerar previsões sobre dados novos em produção é chamado de:",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Inferência", isCorrect: true },
+                        { text: "Treinamento", isCorrect: false },
+                        { text: "Rotulagem", isCorrect: false },
+                        { text: "Coleta de dados", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Uma equipe teve um modelo com desempenho fraco e descobriu muitos valores errados e faltantes no conjunto de treino. Que princípio isso reforça?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A qualidade dos dados influencia fortemente a qualidade do modelo", isCorrect: true },
+                        { text: "Um modelo maior compensa automaticamente dados ruins", isCorrect: false },
+                        { text: "O algoritmo escolhido não afeta o resultado com muitos dados", isCorrect: false },
+                        { text: "Os dados de teste importam mais do que os de treino", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Avaliando modelos: acurácia, precisão, recall e overfitting",
+            blocks: [
+                {
+                    type: "text",
+                    value: "## Métricas para saber se o modelo é bom\nAvaliar é comparar as previsões do modelo com as respostas reais em dados que ele não viu no treino. Para classificação, algumas métricas caem no exame:\n\n**Acurácia** é a fração de previsões corretas no total. Simples, mas enganosa quando as classes são desbalanceadas.\n\n**Precisão** responde: dos casos que o modelo marcou como positivos, quantos eram mesmo positivos? Alta precisão significa poucos falsos positivos.\n\n**Recall (sensibilidade)** responde: dos casos que eram realmente positivos, quantos o modelo capturou? Alto recall significa poucos falsos negativos.",
+                },
+                {
+                    type: "text",
+                    value: "## Precisão x recall: o trade-off\nQual priorizar depende do custo do erro. Numa triagem médica, deixar passar um doente (falso negativo) é grave, então prioriza-se o recall. Num filtro que bloqueia e-mails, marcar um e-mail legítimo como spam (falso positivo) incomoda o usuário, então a precisão pesa mais. Raramente se maximiza as duas ao mesmo tempo.",
+                },
+                {
+                    type: "text",
+                    value: "## Overfitting e underfitting\n**Overfitting** acontece quando o modelo vai muito bem no treino e mal em dados novos: ele memorizou em vez de generalizar. A assinatura é acurácia alta no treino e baixa no teste. **Underfitting** é o oposto: o modelo é simples demais e vai mal nos dois conjuntos. O objetivo é o meio-termo, um modelo que generaliza para dados que nunca viu.",
+                },
+                {
+                    type: "quote",
+                    value: "Foi bem no treino e mal no teste? Overfitting. Foi mal nos dois? Underfitting.",
+                },
+            ],
+            questions: [
+                {
+                    statement:
+                        "Um modelo tem 99% de acurácia no treino e 60% no teste. Qual é o diagnóstico mais provável?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Overfitting: o modelo memorizou o treino e não generaliza", isCorrect: true },
+                        { text: "Underfitting: o modelo é simples demais para os dados", isCorrect: false },
+                        { text: "O modelo está perfeito e pronto para produção", isCorrect: false },
+                        { text: "Falta de dados, pois o modelo não aprendeu no treino", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Uma triagem médica deve evitar ao máximo classificar um paciente doente como saudável. Qual métrica priorizar?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Recall, para reduzir os falsos negativos", isCorrect: true },
+                        { text: "Precisão, para reduzir os falsos positivos", isCorrect: false },
+                        { text: "Tempo de treino, para acelerar o modelo", isCorrect: false },
+                        { text: "Tamanho do modelo, para caber em memória", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que a acurácia pode enganar em um conjunto de dados muito desbalanceado?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Prever sempre a classe majoritária dá acurácia alta sem prever a rara", isCorrect: true },
+                        { text: "A acurácia é impossível de calcular quando há desbalanceamento", isCorrect: false },
+                        { text: "A acurácia sempre fica igual ao recall nesses casos", isCorrect: false },
+                        { text: "Dados desbalanceados aumentam a acurácia de forma proporcional e justa", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Os serviços de IA e ML da AWS",
+            blocks: [
+                {
+                    type: "text",
+                    value: "## Três camadas de serviços\nA AWS organiza a IA em camadas, e reconhecer a camada certa para cada cenário é um dos temas mais cobrados no AIF-C01.\n\n**Serviços de IA pré-treinados** entregam capacidades prontas por API, sem treinar nada. Você chama e usa. Exemplos: Amazon Rekognition (imagens e vídeo), Amazon Transcribe (fala para texto), Amazon Polly (texto para voz), Amazon Translate (tradução), Amazon Comprehend (análise de texto e PII), Amazon Textract (extração de documentos) e Amazon Lex (chatbots).\n\n**Amazon SageMaker** é a plataforma para quem quer construir, treinar e implantar modelos próprios, com controle total. Inclui o SageMaker Canvas (ML visual, sem código) para usuários de negócio.\n\n**Serviços de IA generativa**, como o Amazon Bedrock e o Amazon Q, são vistos nos próximos módulos.",
+                },
+                {
+                    type: "table",
+                    value: "[[\"Preciso...\", \"Serviço da AWS\"], [\"Transcrever áudio em texto\", \"Amazon Transcribe\"], [\"Converter texto em voz\", \"Amazon Polly\"], [\"Analisar imagens e vídeos\", \"Amazon Rekognition\"], [\"Extrair sentimento e entidades de texto\", \"Amazon Comprehend\"], [\"Ler campos de documentos e formulários\", \"Amazon Textract\"], [\"Traduzir entre idiomas\", \"Amazon Translate\"], [\"Construir um chatbot\", \"Amazon Lex\"], [\"Treinar um modelo próprio\", \"Amazon SageMaker\"], [\"Criar ML sem escrever código\", \"Amazon SageMaker Canvas\"]]",
+                },
+                {
+                    type: "text",
+                    value: "## Pré-treinado ou construir do zero?\nA regra prática: se um serviço pronto já resolve (transcrever, traduzir, analisar texto), use-o, é mais rápido e barato. Só parta para o SageMaker quando precisar de um modelo customizado para um problema específico da empresa, com dados próprios e controle sobre o algoritmo.",
+                },
+            ],
+            questions: [
+                {
+                    statement:
+                        "Uma startup precisa transcrever áudios de reuniões em texto rapidamente, sem treinar nenhum modelo. Qual serviço usar?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Amazon Transcribe, um serviço pronto de fala para texto", isCorrect: true },
+                        { text: "Amazon SageMaker, treinando um modelo próprio", isCorrect: false },
+                        { text: "Amazon Polly, que gera voz a partir de texto", isCorrect: false },
+                        { text: "Amazon Comprehend, que analisa texto já escrito", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Um analista de negócios sem experiência em código quer criar modelos de ML por uma interface visual. Qual ferramenta é a mais indicada?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Amazon SageMaker Canvas, que oferece ML sem código", isCorrect: true },
+                        { text: "AWS Lambda, para executar funções sob demanda", isCorrect: false },
+                        { text: "Amazon EMR, uma plataforma de big data com Spark", isCorrect: false },
+                        { text: "Amazon Athena, para consultas SQL no S3", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Uma empresa quer extrair automaticamente o valor e a data de vencimento de milhares de faturas em PDF. Qual serviço é o mais adequado?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Amazon Textract, que extrai texto e campos de documentos", isCorrect: true },
+                        { text: "Amazon Polly, que converte texto em voz", isCorrect: false },
+                        { text: "Amazon Translate, que traduz entre idiomas", isCorrect: false },
+                        { text: "Amazon Rekognition, voltado a imagens e vídeos", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_2: Modulo = {
+    titulo: "Módulo 2 - IA generativa e foundation models",
+    aulas: [
+        {
+            titulo: "O que é IA generativa e o que são foundation models",
+            blocks: [
+                {
+                    type: "text",
+                    value: "## Da previsão à criação\nO machine learning tradicional prevê ou classifica: dado um e-mail, é spam ou não? A **IA generativa** faz algo diferente: cria conteúdo novo e original, como texto, imagem, código ou áudio, a partir de uma instrução em linguagem natural.\n\nO motor por trás disso é o **foundation model (modelo de fundação)**: um modelo grande, pré-treinado em volumes enormes de dados, que serve de base para muitas tarefas diferentes. Em vez de treinar um modelo por tarefa, você parte de um foundation model já pronto e o adapta.",
+                },
+                {
+                    type: "text",
+                    value: "## O que torna um foundation model especial\nDuas características definem um foundation model:\n\n**Escala e pré-treinamento**: ele aprendeu padrões gerais a partir de uma quantidade massiva de dados, o que lhe dá conhecimento amplo sem ter sido treinado para uma tarefa específica.\n\n**Adaptabilidade**: o mesmo modelo consegue resumir, traduzir, responder perguntas, escrever código e classificar, dependendo de como você o instrui. Um **large language model (LLM)** é um foundation model especializado em linguagem.",
+                },
+                {
+                    type: "quote",
+                    value: "Foundation model é grande, pré-treinado em vastos dados e adaptável a muitas tarefas. Não é um modelo de tarefa única nem um banco de dados.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que melhor caracteriza um foundation model?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Um modelo grande, pré-treinado, que serve de base para muitas tarefas", isCorrect: true },
+                        { text: "Um modelo pequeno treinado do zero para uma única tarefa", isCorrect: false },
+                        { text: "Um banco de dados vetorial que guarda embeddings", isCorrect: false },
+                        { text: "Uma regra determinística que não depende de dados", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual tarefa é um caso de uso típico de IA generativa?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Gerar o rascunho de um texto a partir de uma instrução", isCorrect: true },
+                        { text: "Somar uma coluna de uma planilha com precisão exata", isCorrect: false },
+                        { text: "Rotear pacotes de rede entre sub-redes", isCorrect: false },
+                        { text: "Aplicar políticas de permissão de acesso", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Um large language model (LLM) é melhor descrito como:",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um foundation model especializado em linguagem", isCorrect: true },
+                        { text: "Um banco de dados relacional otimizado para texto", isCorrect: false },
+                        { text: "Um serviço de tradução baseado em regras manuais", isCorrect: false },
+                        { text: "Um algoritmo de clustering para agrupar documentos", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Como um LLM funciona: tokens, embeddings e janela de contexto",
+            blocks: [
+                {
+                    type: "text",
+                    value: "## Tokens: a unidade que o modelo processa\nUm LLM não lê letras nem palavras inteiras diretamente; ele processa **tokens**, unidades de texto que podem ser uma palavra ou parte dela. Uma frase vira uma sequência de tokens, e o modelo prevê o próximo token a cada passo. O custo e os limites de uso costumam ser medidos em tokens, então vale ter o conceito claro.",
+                },
+                {
+                    type: "text",
+                    value: "## Embeddings: significado virou número\nPara comparar textos por significado, converte-se cada trecho em um **embedding**: uma representação numérica em forma de vetor que captura o sentido do conteúdo. Textos com significado parecido ficam próximos nesse espaço vetorial. Embeddings são a base da busca semântica e do RAG, que veremos no próximo módulo.",
+                },
+                {
+                    type: "text",
+                    value: "## Janela de contexto: o quanto o modelo enxerga\nA **janela de contexto (context window)** é a quantidade máxima de tokens que o modelo considera de uma vez, somando a entrada e a saída. Se a conversa ou o documento excede a janela, o excesso precisa ser resumido ou recuperado sob demanda. Janelas maiores permitem processar mais texto por interação, geralmente a um custo maior.",
+                },
+                {
+                    type: "quote",
+                    value: "Token é a unidade de texto processada; embedding é o significado em forma de vetor; janela de contexto é o limite de tokens por interação.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "No contexto de um LLM, o que é um token?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Uma unidade de texto (palavra ou parte dela) que o modelo processa", isCorrect: true },
+                        { text: "Uma credencial de segurança que autoriza o acesso à API", isCorrect: false },
+                        { text: "Um parâmetro interno que o modelo ajusta durante o treino", isCorrect: false },
+                        { text: "Um registro de log gerado a cada requisição ao modelo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual é o papel de um embedding?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Representar o significado de um texto como um vetor numérico", isCorrect: true },
+                        { text: "Gerar um resumo em linguagem natural do texto", isCorrect: false },
+                        { text: "Criptografar o documento antes de armazená-lo", isCorrect: false },
+                        { text: "Indexar palavras-chave em um banco relacional", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que a 'janela de contexto' de um LLM representa?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O máximo de tokens que o modelo considera em uma interação", isCorrect: true },
+                        { text: "O número de usuários simultâneos permitidos", isCorrect: false },
+                        { text: "O tempo em que a resposta fica em cache", isCorrect: false },
+                        { text: "A região de nuvem onde o modelo roda", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Amazon Bedrock: foundation models por API",
+            blocks: [
+                {
+                    type: "text",
+                    value: "## Um só ponto de acesso a vários modelos\nO **Amazon Bedrock** é o serviço da AWS para IA generativa. Ele dá acesso a foundation models de diversos provedores por uma única API totalmente gerenciada. Você escolhe o modelo, envia um prompt e recebe a resposta, sem provisionar servidores nem gerenciar GPUs.\n\nPor ser **serverless**, o Bedrock deixa a AWS cuidar da infraestrutura. Isso permite que uma equipe pequena experimente e compare modelos rapidamente e leve uma aplicação generativa à produção sem operar a parte pesada.",
+                },
+                {
+                    type: "table",
+                    value: "[[\"Quero...\", \"Como o Bedrock ajuda\"], [\"Usar vários foundation models\", \"Uma API única para modelos de diferentes provedores\"], [\"Não gerenciar servidores\", \"Serviço serverless, infraestrutura gerenciada pela AWS\"], [\"Embasar respostas em dados meus\", \"Knowledge Bases (RAG gerenciado)\"], [\"Executar tarefas em várias etapas\", \"Agents (orquestração de ações)\"], [\"Filtrar conteúdo indesejado\", \"Guardrails\"], [\"Comparar a qualidade de modelos\", \"Avaliação de modelos (model evaluation)\"]]",
+                },
+                {
+                    type: "text",
+                    value: "## O que o Bedrock NÃO exige\nUm ponto que a prova reforça: no Bedrock você não precisa baixar os pesos dos modelos, não precisa manter um cluster de GPUs próprio e não precisa treinar nada do zero para começar. O foco é consumir os modelos por API e, quando necessário, customizá-los com recursos gerenciados.",
+                },
+            ],
+            questions: [
+                {
+                    statement:
+                        "Qual serviço permite acessar foundation models de vários provedores por uma única API gerenciada, sem administrar infraestrutura?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Amazon Bedrock", isCorrect: true },
+                        { text: "Amazon EC2", isCorrect: false },
+                        { text: "Amazon S3", isCorrect: false },
+                        { text: "AWS Glue", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Uma equipe pequena quer testar vários foundation models sem provisionar GPUs. Que característica do Bedrock ajuda?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "É serverless: a AWS gerencia a infraestrutura dos modelos", isCorrect: true },
+                        { text: "Exige um cluster de GPUs dedicado por modelo testado", isCorrect: false },
+                        { text: "Requer baixar os pesos e hospedá-los por conta própria", isCorrect: false },
+                        { text: "Só funciona com modelos treinados do zero pela equipe", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Para usar o Amazon Bedrock em uma aplicação generativa básica, o que NÃO é necessário?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Manter um cluster de GPUs próprio para hospedar os modelos", isCorrect: true },
+                        { text: "Escolher um foundation model disponível no serviço", isCorrect: false },
+                        { text: "Enviar um prompt para o modelo pela API", isCorrect: false },
+                        { text: "Ter permissões adequadas de acesso ao serviço", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Casos de uso, vantagens e desafios da IA generativa",
+            blocks: [
+                {
+                    type: "text",
+                    value: "## Onde a IA generativa brilha\nBons casos de uso envolvem criar ou transformar conteúdo em linguagem natural: gerar rascunhos de texto, resumir documentos longos, responder perguntas, escrever e explicar código, traduzir com nuance e criar imagens a partir de descrições. O ponto comum é lidar com conteúdo aberto e não estruturado.",
+                },
+                {
+                    type: "text",
+                    value: "## Vantagens sobre treinar do zero\nUsar foundation models poupa tempo e dados: você aproveita um modelo já pré-treinado e o adapta a muitas tarefas com pouco esforço, em vez de coletar dados e treinar um modelo por problema. Isso acelera protótipos e reduz a barreira de entrada.",
+                },
+                {
+                    type: "text",
+                    value: "## Desafios que a prova cobra\nA IA generativa também traz desafios que precisam de controles:\n\n- **Respostas variáveis e imprecisas**: a mesma pergunta pode gerar respostas diferentes, e algumas podem conter erros. Isso exige verificação.\n- **Alucinações**: o modelo pode inventar informação plausível, porém falsa.\n- **Custo e latência**: modelos maiores custam e demoram mais.\n- **Segurança do conteúdo**: sem controles, o modelo pode gerar conteúdo indesejado.\n\nO que a IA generativa NÃO deve fazer: cálculos exatos, regras determinísticas ou operações que exigem reprodutibilidade perfeita. Para isso, use lógica tradicional.",
+                },
+                {
+                    type: "quote",
+                    value: "Conteúdo aberto (texto, código, imagem, resumo) combina com IA generativa; cálculo exato e regra fixa combinam com lógica tradicional.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual é uma vantagem central de usar foundation models em vez de treinar do zero?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Já vêm pré-treinados e se adaptam a várias tarefas com pouco esforço", isCorrect: true },
+                        { text: "Eliminam qualquer risco de gerar respostas incorretas", isCorrect: false },
+                        { text: "Dispensam totalmente o uso de dados em novos casos", isCorrect: false },
+                        { text: "Garantem custo zero de inferência em qualquer volume", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual é um desafio conhecido ao adotar IA generativa em produção?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "As respostas podem variar e conter imprecisões, exigindo verificação", isCorrect: true },
+                        { text: "Os modelos só funcionam offline, sem qualquer acesso por API", isCorrect: false },
+                        { text: "É impossível restringir os temas sobre os quais o modelo responde", isCorrect: false },
+                        { text: "Eles não conseguem processar mais de um idioma de cada vez", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Para qual tarefa a IA generativa é a MENOS indicada?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Calcular impostos por regras fiscais fixas e exatas", isCorrect: true },
+                        { text: "Resumir um relatório longo em poucos parágrafos", isCorrect: false },
+                        { text: "Redigir o rascunho de uma resposta de atendimento", isCorrect: false },
+                        { text: "Explicar um trecho de código em linguagem simples", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Amazon Q e assistentes generativos gerenciados",
+            blocks: [
+                {
+                    type: "text",
+                    value: "## Assistentes prontos para o trabalho\nAlém do Bedrock (a plataforma para construir), a AWS oferece assistentes generativos prontos sob a marca **Amazon Q**.\n\n**Amazon Q Business** é um assistente que responde perguntas dos funcionários com base nos dados internos da empresa (documentos, wikis, sistemas), respeitando as permissões de cada pessoa. É a opção quando o objetivo é dar respostas fundamentadas no conhecimento corporativo.\n\n**Amazon Q Developer** ajuda times de tecnologia com geração e explicação de código e apoio a tarefas de desenvolvimento na AWS.",
+                },
+                {
+                    type: "text",
+                    value: "## Como escolher no cenário\nSe o enunciado pede um assistente que responde com base nos documentos internos e respeita acesso, pense em **Amazon Q Business**. Se pede construir uma aplicação generativa customizada, com escolha de modelo e integração própria, pense em **Amazon Bedrock**. Serviços como Rekognition (imagens), Athena (consulta SQL) e Polly (voz) não são assistentes generativos corporativos.",
+                },
+            ],
+            questions: [
+                {
+                    statement:
+                        "Uma empresa quer um assistente que responda perguntas dos funcionários com base nos documentos internos, respeitando permissões. Qual serviço é voltado a isso?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Amazon Q Business", isCorrect: true },
+                        { text: "Amazon Rekognition", isCorrect: false },
+                        { text: "Amazon Athena", isCorrect: false },
+                        { text: "Amazon Polly", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Uma equipe quer construir uma aplicação generativa customizada, escolhendo o foundation model e integrando com seus sistemas. Qual serviço é a base?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Amazon Bedrock, plataforma para construir com foundation models", isCorrect: true },
+                        { text: "Amazon Q Business, um assistente pronto para uso interno", isCorrect: false },
+                        { text: "Amazon Comprehend, para análise de texto pré-treinada", isCorrect: false },
+                        { text: "Amazon Translate, para tradução entre idiomas", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Qual serviço apoia equipes de desenvolvimento com geração e explicação de código na AWS?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Amazon Q Developer", isCorrect: true },
+                        { text: "Amazon Macie", isCorrect: false },
+                        { text: "Amazon Kinesis", isCorrect: false },
+                        { text: "AWS Backup", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Alucinações e os limites da IA generativa",
+            blocks: [
+                {
+                    type: "text",
+                    value: "## Quando o modelo inventa\nUma **alucinação** ocorre quando o modelo gera informação plausível, mas falsa: uma citação inexistente, um dado inventado, uma referência com autores e datas fabricados. O modelo não mente de propósito; ele prevê o texto mais provável, e às vezes o mais provável não é verdadeiro.\n\nPor isso, saídas de IA generativa em contextos que exigem precisão precisam de verificação. Não confunda alucinação com viés (que vem de desequilíbrio nos dados) nem com overfitting (que é sobre generalização em ML tradicional).",
+                },
+                {
+                    type: "text",
+                    value: "## Como reduzir o risco\nAlgumas práticas ajudam a mitigar alucinações e limites:\n\n- **Embasar as respostas em dados confiáveis** (RAG), em vez de confiar só na memória do modelo.\n- **Aplicar guardrails** para bloquear conteúdo indesejado.\n- **Manter revisão humana** em decisões de alto impacto.\n- **Pedir que o modelo cite as fontes** quando possível.\n\nEsses temas aparecem em detalhe nos módulos de aplicações e de IA responsável.",
+                },
+                {
+                    type: "quote",
+                    value: "Alucinação é conteúdo plausível, porém falso. IA generativa poderosa ainda exige verificação, guardrails e supervisão humana.",
+                },
+            ],
+            questions: [
+                {
+                    statement:
+                        "Um LLM respondeu citando um artigo que não existe, com autores inventados. Como esse comportamento é chamado?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Alucinação, quando o modelo gera algo plausível, porém falso", isCorrect: true },
+                        { text: "Overfitting, quando o modelo memoriza o treino", isCorrect: false },
+                        { text: "Viés, quando o modelo reflete desequilíbrio dos dados", isCorrect: false },
+                        { text: "Latência, quando o modelo demora a responder", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual prática ajuda a reduzir alucinações em uma aplicação generativa?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Embasar as respostas em dados confiáveis recuperados (RAG)", isCorrect: true },
+                        { text: "Aumentar a temperatura para respostas mais criativas", isCorrect: false },
+                        { text: "Remover toda verificação para acelerar as respostas", isCorrect: false },
+                        { text: "Desligar quaisquer guardrails de conteúdo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Por que saídas de IA generativa exigem verificação em contextos que pedem precisão?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O modelo prevê o texto mais provável, que nem sempre é verdadeiro", isCorrect: true },
+                        { text: "O modelo sempre se recusa a responder perguntas factuais", isCorrect: false },
+                        { text: "As respostas são idênticas a cada execução, sem variação", isCorrect: false },
+                        { text: "A verificação elimina o custo de inferência do modelo", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_3: Modulo = {
+    titulo: "Módulo 3 - Aplicando foundation models: prompt, RAG e customização",
+    aulas: [
+        {
+            titulo: "Engenharia de prompt: zero-shot, few-shot e chain-of-thought",
+            blocks: [
+                {
+                    type: "text",
+                    value: "## A instrução molda a resposta\n**Engenharia de prompt** é a prática de estruturar a instrução para obter respostas melhores de um LLM, sem alterar o modelo. É a forma mais rápida e barata de melhorar resultados: você muda o texto que envia, não os pesos do modelo.\n\nUm bom prompt costuma deixar claros a tarefa, o formato esperado da resposta, o tom e eventuais restrições. Pequenas mudanças de redação podem ter grande efeito na qualidade da saída.",
+                },
+                {
+                    type: "text",
+                    value: "## Três técnicas que caem na prova\n**Zero-shot**: você pede a tarefa sem dar exemplos. Ex.: \"Classifique o sentimento desta frase\". Funciona bem em tarefas comuns.\n\n**Few-shot**: você inclui alguns exemplos de entrada e saída desejada dentro do próprio prompt, para orientar o formato e o estilo. Também chamado de aprendizado em contexto, porque o modelo aprende com os exemplos ali, sem treino.\n\n**Chain-of-thought (cadeia de raciocínio)**: você pede que o modelo explique o passo a passo antes de dar a resposta final. Isso costuma melhorar tarefas de lógica e cálculo.",
+                },
+                {
+                    type: "table",
+                    value: "[[\"Técnica\", \"Como é\", \"Bom para\"], [\"Zero-shot\", \"Pede a tarefa sem exemplos\", \"Tarefas comuns e diretas\"], [\"Few-shot\", \"Inclui alguns exemplos no prompt\", \"Fixar formato e estilo da saída\"], [\"Chain-of-thought\", \"Pede o raciocínio passo a passo\", \"Problemas de lógica e cálculo\"]]",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que é engenharia de prompt?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Estruturar instruções para obter respostas melhores de um LLM", isCorrect: true },
+                        { text: "Treinar um foundation model do zero com dados próprios", isCorrect: false },
+                        { text: "Comprimir os pesos do modelo para poupar memória", isCorrect: false },
+                        { text: "Configurar a rede da VPC onde o modelo roda", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Um desenvolvedor inclui três exemplos de pergunta e resposta no prompt antes da pergunta real. Que técnica é essa?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Prompt few-shot, que fornece exemplos no próprio prompt", isCorrect: true },
+                        { text: "Fine-tuning, que reajusta os pesos do modelo", isCorrect: false },
+                        { text: "Pré-treinamento, que ensina o modelo do zero", isCorrect: false },
+                        { text: "RAG, que recupera documentos externos", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Pedir que o modelo explique o raciocínio passo a passo antes da resposta final é a técnica de:",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Cadeia de raciocínio (chain-of-thought)", isCorrect: true },
+                        { text: "Redução de dimensionalidade", isCorrect: false },
+                        { text: "Quantização dos pesos", isCorrect: false },
+                        { text: "Balanceamento de carga", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Parâmetros de inferência: temperatura, top-p e máximo de tokens",
+            blocks: [
+                {
+                    type: "text",
+                    value: "## Controlando o comportamento da resposta\nAo chamar um LLM, além do prompt você ajusta parâmetros de inferência que mudam o estilo da saída, sem alterar o modelo.\n\n**Temperatura** controla a aleatoriedade. Temperatura baixa deixa as respostas mais previsíveis e focadas; temperatura alta as deixa mais variadas e criativas. Para tarefas factuais, prefira temperatura baixa; para brainstorming, mais alta.\n\n**Top-p (nucleus sampling)** limita a escolha às palavras mais prováveis que somam certa probabilidade. Junto com a temperatura, governa o quanto a resposta é diversa.",
+                },
+                {
+                    type: "text",
+                    value: "## Máximo de tokens e o que ele NÃO faz\nO **máximo de tokens (max tokens)** limita o tamanho da resposta: ao atingir o teto, a geração para. É útil para controlar custo e evitar respostas longas demais.\n\nCuidado com pegadinhas: o max tokens não aumenta a criatividade (isso é temperatura/top-p), não garante que a resposta esteja correta e não define quantas vezes você pode chamar a API (isso são cotas do serviço).",
+                },
+                {
+                    type: "quote",
+                    value: "Temperatura e top-p controlam a diversidade da resposta; máximo de tokens controla o tamanho. Nenhum deles garante que a resposta é verdadeira.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Aumentar a temperatura na chamada de um LLM tende a produzir respostas:",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Mais aleatórias e criativas, com maior variação", isCorrect: true },
+                        { text: "Mais curtas, limitando os tokens de saída", isCorrect: false },
+                        { text: "Mais rápidas, reduzindo o tempo de processamento", isCorrect: false },
+                        { text: "Mais baratas, diminuindo o custo por token", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual é o efeito de definir o 'máximo de tokens' em uma chamada de LLM?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Limita o tamanho da resposta, cortando-a ao atingir o teto", isCorrect: true },
+                        { text: "Aumenta a criatividade ao permitir mais variação", isCorrect: false },
+                        { text: "Garante que a resposta esteja sempre correta", isCorrect: false },
+                        { text: "Define quantas chamadas por minuto são permitidas", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Para uma tarefa que exige respostas factuais e consistentes, qual ajuste é o mais indicado?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Usar temperatura baixa, para respostas mais previsíveis", isCorrect: true },
+                        { text: "Usar temperatura alta, para respostas mais variadas", isCorrect: false },
+                        { text: "Remover o limite de tokens para respostas maiores", isCorrect: false },
+                        { text: "Aumentar o top-p ao máximo para mais diversidade", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "RAG: embasar respostas em dados confiáveis",
+            blocks: [
+                {
+                    type: "text",
+                    value: "## O problema que o RAG resolve\nUm foundation model só sabe o que estava nos dados de pré-treino, e não conhece os documentos internos da sua empresa nem informações que mudaram depois. Pedir a ele que responda sobre isso convida a alucinações.\n\n**Retrieval Augmented Generation (RAG)** resolve isso: antes de responder, o sistema recupera trechos relevantes de uma base de dados externa e os inclui no prompt, embasando a resposta em informação real e específica. O modelo não é alterado; o que muda é o contexto que ele recebe.",
+                },
+                {
+                    type: "text",
+                    value: "## O papel do banco de dados vetorial\nPara recuperar por significado, os documentos são convertidos em embeddings e guardados em um **banco de dados vetorial**. Na hora da pergunta, ela também vira embedding, e o banco retorna os trechos mais semelhantes, que entram no prompt. Assim, a busca é semântica, não apenas por palavra-chave.\n\nBenefícios do RAG: reduz alucinações, usa dados atualizados sem retreinar e permite citar as fontes, aumentando a confiança.",
+                },
+                {
+                    type: "quote",
+                    value: "RAG recupera dados externos e os injeta no prompt. Reduz alucinações, usa dados atuais sem retreino e permite citar fontes.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que é Retrieval Augmented Generation (RAG)?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Recuperar dados de uma base externa e incluí-los no prompt", isCorrect: true },
+                        { text: "Reajustar os pesos do modelo com novos dados rotulados", isCorrect: false },
+                        { text: "Treinar um foundation model do zero com dados da empresa", isCorrect: false },
+                        { text: "Comprimir o modelo para caber em pouca memória", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Uma empresa quer um assistente que responda com base nos manuais internos e reduza respostas inventadas, sem treinar um modelo. Qual abordagem indicar?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "RAG, recuperando trechos dos manuais para o contexto", isCorrect: true },
+                        { text: "Aumentar a temperatura para respostas mais criativas", isCorrect: false },
+                        { text: "Treinar um foundation model do zero com os manuais", isCorrect: false },
+                        { text: "Remover os guardrails para responder qualquer coisa", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual é o papel de um banco de dados vetorial em uma solução de RAG?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Guardar embeddings e recuperar os trechos mais semelhantes", isCorrect: true },
+                        { text: "Treinar o foundation model com dados rotulados", isCorrect: false },
+                        { text: "Gerar as imagens pedidas pelo usuário", isCorrect: false },
+                        { text: "Aplicar as políticas de IAM de acesso ao modelo", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Knowledge Bases e Agents for Amazon Bedrock",
+            blocks: [
+                {
+                    type: "text",
+                    value: "## RAG gerenciado com Knowledge Bases\nMontar um RAG do zero envolve gerar embeddings, manter um banco vetorial e orquestrar a recuperação. O **Knowledge Bases for Amazon Bedrock** cuida disso de forma gerenciada: você aponta suas fontes de dados e o serviço trata a ingestão, os embeddings e a recuperação, conectando o foundation model aos seus documentos.",
+                },
+                {
+                    type: "text",
+                    value: "## Ações em várias etapas com Agents\nÀs vezes responder não basta; é preciso agir. O **Agents for Amazon Bedrock** permite que um foundation model execute tarefas em várias etapas, chamando APIs e sistemas para concluir uma solicitação. Um agente pode, por exemplo, consultar um estoque, criar um pedido e confirmar o prazo, orquestrando as chamadas necessárias.\n\nNão confunda os recursos do Bedrock: Knowledge Bases é para RAG; Agents é para orquestrar ações; Guardrails é para filtrar conteúdo; a avaliação de modelos é para comparar modelos.",
+                },
+                {
+                    type: "table",
+                    value: "[[\"Recurso do Bedrock\", \"Para que serve\"], [\"Knowledge Bases\", \"RAG gerenciado: conecta o modelo aos seus dados\"], [\"Agents\", \"Executa tarefas em várias etapas, chamando APIs\"], [\"Guardrails\", \"Filtra conteúdo e bloqueia temas indesejados\"], [\"Model evaluation\", \"Compara a qualidade de modelos para a sua tarefa\"]]",
+                },
+            ],
+            questions: [
+                {
+                    statement:
+                        "Qual recurso do Amazon Bedrock facilita implementar RAG conectando o modelo às fontes de dados da empresa?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Knowledge Bases for Amazon Bedrock", isCorrect: true },
+                        { text: "Amazon Bedrock Guardrails", isCorrect: false },
+                        { text: "Amazon CloudWatch", isCorrect: false },
+                        { text: "AWS CloudFormation", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Qual recurso permite que um foundation model execute tarefas em várias etapas, chamando APIs e sistemas?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Agents for Amazon Bedrock", isCorrect: true },
+                        { text: "Amazon Bedrock Guardrails", isCorrect: false },
+                        { text: "Amazon Textract", isCorrect: false },
+                        { text: "Amazon Macie", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Uma equipe quer comparar a qualidade de vários foundation models antes de escolher um. Que recurso do Bedrock usar?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A avaliação de modelos (model evaluation) do Bedrock", isCorrect: true },
+                        { text: "O Guardrails, para filtrar conteúdo indesejado", isCorrect: false },
+                        { text: "O AWS Trusted Advisor, para custo e segurança da conta", isCorrect: false },
+                        { text: "O Amazon Inspector, para vulnerabilidades de segurança", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Fine-tuning, RAG ou prompt: como escolher",
+            blocks: [
+                {
+                    type: "text",
+                    value: "## Três formas de adaptar um modelo\nQuando um foundation model pronto não basta, há três caminhos, do mais leve ao mais pesado:\n\n**Engenharia de prompt**: mudar só a instrução. Rápido, barato, sem alterar o modelo. Comece sempre por aqui.\n\n**RAG**: dar ao modelo acesso a dados externos no momento da resposta. Ideal quando a informação é específica da empresa ou muda com frequência, pois basta atualizar a base, sem retreinar.\n\n**Fine-tuning**: continuar o treino do modelo com dados próprios, ajustando os pesos para especializá-lo em uma tarefa ou estilo. É mais custoso e o conhecimento fica fixado nos pesos.",
+                },
+                {
+                    type: "text",
+                    value: "## A pergunta que decide\nSe a informação muda toda semana, RAG costuma vencer o fine-tuning: você atualiza a base de dados e pronto, sem retreinar o modelo a cada mudança. O fine-tuning brilha quando você quer especializar o comportamento ou o estilo do modelo de forma estável, não quando o conteúdo é volátil.\n\nUm bom raciocínio: prompt para ajustar a instrução, RAG para trazer conhecimento atual e específico, fine-tuning para especializar o comportamento.",
+                },
+                {
+                    type: "table",
+                    value: "[[\"Abordagem\", \"Altera os pesos?\", \"Melhor quando\"], [\"Engenharia de prompt\", \"Não\", \"Ajustar instrução e formato rapidamente\"], [\"RAG\", \"Não\", \"Usar dados específicos ou que mudam sempre\"], [\"Fine-tuning\", \"Sim\", \"Especializar o comportamento ou estilo de forma estável\"]]",
+                },
+                {
+                    type: "quote",
+                    value: "Dados que mudam sempre pedem RAG (atualize a base, sem retreinar). Especializar o comportamento pede fine-tuning.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que é fine-tuning de um foundation model?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Continuar o treino com dados específicos, ajustando os pesos", isCorrect: true },
+                        { text: "Escrever instruções mais detalhadas no prompt", isCorrect: false },
+                        { text: "Recuperar documentos externos para o contexto", isCorrect: false },
+                        { text: "Reduzir o número de tokens da resposta", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "A informação que o assistente precisa usar muda toda semana. Por que RAG costuma ser preferível a fine-tuning?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Basta atualizar a base de dados, sem retreinar o modelo", isCorrect: true },
+                        { text: "O fine-tuning se atualiza sozinho quando os dados mudam", isCorrect: false },
+                        { text: "O RAG altera os pesos mais rápido que o fine-tuning", isCorrect: false },
+                        { text: "O fine-tuning dispensa qualquer fonte de dados", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Uma empresa quer que o modelo adote um estilo de escrita próprio e estável em todas as respostas. Qual abordagem é a mais adequada?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Fine-tuning, para especializar o comportamento nos pesos", isCorrect: true },
+                        { text: "RAG, para recuperar exemplos de estilo a cada pergunta", isCorrect: false },
+                        { text: "Aumentar a temperatura para variar o estilo", isCorrect: false },
+                        { text: "Reduzir o máximo de tokens da resposta", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Escolha de modelos e segurança do prompt",
+            blocks: [
+                {
+                    type: "text",
+                    value: "## Nem sempre o maior modelo é o certo\nFoundation models variam em tamanho, custo, latência e capacidade. Modelos menores tendem a custar menos e responder mais rápido, com menos capacidade; os maiores resolvem tarefas mais complexas, porém custam e demoram mais. A escolha equilibra esses fatores para o caso de uso.\n\nPara um chatbot de alto volume e respostas simples, um modelo menor pode ser ideal. Para raciocínio complexo, vale um modelo maior. Testar e comparar (com a avaliação de modelos do Bedrock) ajuda a decidir com dados.",
+                },
+                {
+                    type: "text",
+                    value: "## Injeção de prompt: um risco específico de LLMs\nQuando um LLM recebe entradas de usuários, surge a **injeção de prompt**: uma entrada maliciosa que tenta subverter as instruções originais do sistema, fazendo o modelo ignorar as regras e seguir as do atacante. É um risco próprio de aplicações com LLM, diferente de problemas genéricos de infraestrutura.\n\nMitigações incluem guardrails, separar claramente instruções de dados do usuário e validar as saídas. Cuidados de segurança de conteúdo aparecem em detalhe no módulo de IA responsável.",
+                },
+                {
+                    type: "quote",
+                    value: "Modelo menor: mais barato e rápido, menos capaz. Injeção de prompt: entrada que tenta subverter as instruções do sistema.",
+                },
+            ],
+            questions: [
+                {
+                    statement:
+                        "Ao escolher um foundation model para um chatbot de alto volume e baixo custo, qual trade-off considerar?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Modelos menores custam menos e respondem mais rápido, com menos capacidade", isCorrect: true },
+                        { text: "Modelos maiores são sempre mais baratos e mais rápidos que os menores", isCorrect: false },
+                        { text: "O tamanho do modelo não afeta o custo, a latência nem a capacidade", isCorrect: false },
+                        { text: "Modelos menores sempre superam os maiores em qualquer tarefa", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual é um risco de segurança específico ao expor um LLM a entradas de usuários?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Injeção de prompt, que tenta subverter as instruções do sistema", isCorrect: true },
+                        { text: "Estouro de buffer por excesso de memória do modelo", isCorrect: false },
+                        { text: "Perda de pacotes na rede até o endpoint", isCorrect: false },
+                        { text: "Fragmentação de disco onde o modelo está hospedado", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Para decidir entre dois foundation models candidatos com base em métricas para a sua tarefa, a melhor prática é:",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Compará-los com a avaliação de modelos antes de escolher", isCorrect: true },
+                        { text: "Escolher sempre o maior, independentemente do custo", isCorrect: false },
+                        { text: "Escolher sempre o menor, independentemente da tarefa", isCorrect: false },
+                        { text: "Decidir por sorteio, já que todos são equivalentes", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_4: Modulo = {
+    titulo: "Módulo 4 - IA responsável",
+    aulas: [
+        {
+            titulo: "O que é IA responsável e suas dimensões",
+            blocks: [
+                {
+                    type: "text",
+                    value: "## Construir IA com responsabilidade\n**IA responsável** é o conjunto de princípios e práticas para desenvolver e usar sistemas de IA de forma justa, segura, transparente e confiável. Não é um recurso opcional: é uma dimensão que atravessa todo o ciclo de vida, dos dados ao monitoramento.\n\nO AIF-C01 espera que você reconheça as dimensões centrais e associe cada uma a práticas e serviços da AWS.",
+                },
+                {
+                    type: "table",
+                    value: "[[\"Dimensão\", \"O que significa\"], [\"Justiça (fairness)\", \"Tratar diferentes grupos de forma equânime\"], [\"Explicabilidade\", \"Entender por que o modelo decidiu\"], [\"Transparência\", \"Deixar claro como o sistema funciona e seus limites\"], [\"Robustez e segurança\", \"Funcionar de forma confiável e evitar danos\"], [\"Privacidade\", \"Proteger os dados das pessoas\"], [\"Governança\", \"Definir responsabilidades, controles e supervisão\"]]",
+                },
+                {
+                    type: "text",
+                    value: "## Por que isso cai na prova\nSoluções de IA afetam pessoas: crédito, contratação, saúde, moderação de conteúdo. Sem cuidado, podem reproduzir injustiças, tomar decisões inexplicáveis ou gerar conteúdo prejudicial. Reconhecer que justiça, explicabilidade, transparência, segurança e privacidade são pilares (e não \"aumentar parâmetros\" ou \"esconder o funcionamento\") é o que a prova quer.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual das opções é uma dimensão central da IA responsável?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Justiça (fairness), tratando os grupos de forma equânime", isCorrect: true },
+                        { text: "Maximizar o número de parâmetros a qualquer custo", isCorrect: false },
+                        { text: "Reduzir os idiomas suportados para simplificar", isCorrect: false },
+                        { text: "Ocultar de todos como o sistema funciona", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "IA responsável é melhor descrita como:",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Princípios e práticas para uma IA justa, segura e transparente", isCorrect: true },
+                        { text: "Uma técnica para aumentar a acurácia do modelo", isCorrect: false },
+                        { text: "Um serviço específico que substitui o SageMaker", isCorrect: false },
+                        { text: "Uma forma de reduzir o custo de inferência", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Deixar claro como um sistema de IA funciona e quais são seus limites está mais ligado a qual dimensão?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Transparência", isCorrect: true },
+                        { text: "Latência", isCorrect: false },
+                        { text: "Escalabilidade", isCorrect: false },
+                        { text: "Compressão do modelo", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Viés e justiça em modelos de IA",
+            blocks: [
+                {
+                    type: "text",
+                    value: "## O que é viés\n**Viés (bias)** em IA é um erro sistemático que favorece ou prejudica certos grupos de forma injusta. Ele costuma vir dos dados: se o histórico usado no treino já é desequilibrado, o modelo aprende e reproduz (ou até amplifica) esse desequilíbrio.\n\nUm exemplo clássico: um modelo de recrutamento treinado com contratações passadas enviesadas passa a favorecer o mesmo perfil, perpetuando a injustiça. O problema não é o algoritmo inventar; é ele aprender o viés que já estava nos dados.",
+                },
+                {
+                    type: "text",
+                    value: "## Detectar e reduzir com o SageMaker Clarify\nO **Amazon SageMaker Clarify** ajuda a detectar viés nos dados e no modelo e a explicar as previsões. Ele mede, por exemplo, se um grupo está sub-representado ou se recebe resultados sistematicamente diferentes, ajudando a equipe a identificar e mitigar o problema antes e depois do treino.\n\nReduzir viés envolve dados mais representativos, verificação com métricas de justiça e, muitas vezes, supervisão humana nas decisões sensíveis.",
+                },
+                {
+                    type: "quote",
+                    value: "Viés é erro sistemático que trata grupos de forma injusta, muitas vezes herdado de dados desequilibrados. O SageMaker Clarify ajuda a detectá-lo.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "No contexto de IA responsável, o que é viés (bias) em um modelo?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Erros sistemáticos que favorecem ou prejudicam grupos injustamente", isCorrect: true },
+                        { text: "A diferença entre a acurácia de treino e a de teste", isCorrect: false },
+                        { text: "O tempo que o modelo leva para responder", isCorrect: false },
+                        { text: "A quantidade de parâmetros ajustados no treino", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Um modelo de recrutamento passou a favorecer um perfil específico, pois os dados históricos eram desequilibrados. Que problema é esse?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Viés herdado dos dados, que o modelo aprendeu e reproduziu", isCorrect: true },
+                        { text: "Overfitting por um modelo grande demais", isCorrect: false },
+                        { text: "Alucinação típica de modelos generativos", isCorrect: false },
+                        { text: "Latência alta por um endpoint mal dimensionado", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual serviço da AWS ajuda a detectar viés nos dados e no modelo e a explicar previsões?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Amazon SageMaker Clarify", isCorrect: true },
+                        { text: "Amazon SageMaker Ground Truth", isCorrect: false },
+                        { text: "Amazon CloudFront", isCorrect: false },
+                        { text: "AWS Backup", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Explicabilidade, transparência e documentação",
+            blocks: [
+                {
+                    type: "text",
+                    value: "## Explicar decisões\n**Explicabilidade** é a capacidade de entender por que um modelo tomou determinada decisão. Em aplicações sensíveis, como concessão de crédito, isso é essencial: permite justificar a decisão a quem foi afetado e atender a exigências regulatórias. Explicar não elimina erros nem acelera o treino; ela dá visibilidade sobre o raciocínio do modelo.",
+                },
+                {
+                    type: "text",
+                    value: "## Documentar para governar\nDuas ferramentas de transparência caem na prova:\n\n**Cartões de modelo (model cards)** documentam, para cada modelo, a finalidade, os dados usados, as métricas e as limitações conhecidas. Servem para governança e para que quem usa o modelo saiba o que esperar.\n\n**AWS AI Service Cards** são documentos publicados pela AWS que descrevem casos de uso pretendidos, limitações e escolhas de design de seus serviços de IA, promovendo uso responsável e transparência.",
+                },
+                {
+                    type: "table",
+                    value: "[[\"Artefato\", \"Quem produz\", \"O que documenta\"], [\"Model card\", \"Quem cria o modelo\", \"Finalidade, dados, métricas e limitações do modelo\"], [\"AI Service Card\", \"A AWS\", \"Uso pretendido e limitações de um serviço de IA da AWS\"]]",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Por que a explicabilidade é importante em aplicações sensíveis, como crédito?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Permite entender e justificar a decisão a quem foi afetado", isCorrect: true },
+                        { text: "Garante que o modelo nunca cometerá erros", isCorrect: false },
+                        { text: "Reduz o custo de inferência em produção", isCorrect: false },
+                        { text: "Acelera o treino ao simplificar o algoritmo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Uma equipe quer documentar finalidade, dados, métricas e limitações de cada modelo para apoiar a governança. Que artefato usar?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Cartões de modelo (model cards)", isCorrect: true },
+                        { text: "Grupos de segurança de rede", isCorrect: false },
+                        { text: "Buckets do Amazon S3", isCorrect: false },
+                        { text: "Filas do Amazon SQS", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Os documentos da AWS que descrevem uso pretendido e limitações de seus serviços de IA, promovendo transparência, são chamados de:",
+                    difficulty: "medio",
+                    options: [
+                        { text: "AI Service Cards", isCorrect: true },
+                        { text: "Security Groups", isCorrect: false },
+                        { text: "Trust Policies", isCorrect: false },
+                        { text: "Launch Templates", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Segurança do conteúdo e supervisão humana",
+            blocks: [
+                {
+                    type: "text",
+                    value: "## Guardrails: barreiras de conteúdo\nEm aplicações generativas, é preciso impedir respostas tóxicas, perigosas ou fora de escopo. Os **Amazon Bedrock Guardrails** aplicam filtros de conteúdo, bloqueiam tópicos negados e ajudam a proteger dados sensíveis nas respostas. É a forma gerenciada de manter o assistente dentro dos limites definidos pela empresa, uma medida de segurança e mitigação de danos.",
+                },
+                {
+                    type: "text",
+                    value: "## Manter o humano no circuito\nEm decisões de alto impacto, manter **revisão humana (human in the loop)** é uma salvaguarda central da IA responsável: uma pessoa revisa ou aprova as decisões do modelo, evitando que erros graves passem direto. Remover a supervisão para \"ganhar velocidade\", ocultar decisões dos afetados ou elevar a criatividade do modelo vão na direção oposta do uso responsável.\n\nJuntos, guardrails (limitam o conteúdo) e supervisão humana (revisam as decisões) reduzem os principais riscos de operar IA em produção.",
+                },
+                {
+                    type: "quote",
+                    value: "Guardrails limitam o conteúdo gerado; supervisão humana revisa decisões de alto impacto. Ambos são pilares da IA responsável.",
+                },
+            ],
+            questions: [
+                {
+                    statement:
+                        "Uma empresa quer impedir que seu assistente responda sobre temas proibidos e evite linguagem tóxica. Qual recurso do Bedrock atende a isso?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Amazon Bedrock Guardrails", isCorrect: true },
+                        { text: "Amazon Bedrock Knowledge Bases", isCorrect: false },
+                        { text: "Amazon SageMaker Ground Truth", isCorrect: false },
+                        { text: "AWS Glue DataBrew", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Em decisões de alto impacto apoiadas por IA, qual prática ajuda a evitar erros graves do modelo?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Manter revisão humana (human in the loop) sobre as decisões", isCorrect: true },
+                        { text: "Remover a supervisão para acelerar as decisões", isCorrect: false },
+                        { text: "Aumentar a temperatura para respostas variadas", isCorrect: false },
+                        { text: "Ocultar as decisões dos usuários afetados", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Aplicar filtros que impedem um assistente de gerar conteúdo tóxico está mais associado a qual princípio?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Segurança e mitigação de danos ao usuário e à sociedade", isCorrect: true },
+                        { text: "Redução do custo de armazenamento dos dados", isCorrect: false },
+                        { text: "Aumento da taxa de tokens por segundo", isCorrect: false },
+                        { text: "Simplificação do pipeline de ETL", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_5: Modulo = {
+    titulo: "Módulo 5 - Segurança, conformidade e governança",
+    aulas: [
+        {
+            titulo: "Responsabilidade compartilhada e controle de acesso",
+            blocks: [
+                {
+                    type: "text",
+                    value: "## Quem cuida do quê\nNa nuvem, a segurança é uma **responsabilidade compartilhada**. A AWS cuida da segurança **da** nuvem: infraestrutura física, hardware, rede e a operação dos serviços gerenciados. O cliente cuida da segurança **na** nuvem: quem acessa o quê, como os dados são configurados e usados, e as permissões da aplicação.\n\nEm um serviço de IA gerenciado, isso significa que a AWS mantém a plataforma e os patches, enquanto você define o controle de acesso e a governança dos seus dados de entrada e saída.",
+                },
+                {
+                    type: "text",
+                    value: "## Menor privilégio com o IAM\nO controle de acesso na AWS é feito com o **AWS IAM (Identity and Access Management)**. A boa prática é o **princípio do menor privilégio**: conceder apenas as permissões estritamente necessárias para cada usuário ou serviço, e nada além disso. Isso reduz a superfície de ataque.\n\nPráticas inseguras que a prova rejeita: dar permissão de administrador a todos, compartilhar a chave da conta raiz ou desativar a autenticação para \"facilitar\".",
+                },
+                {
+                    type: "quote",
+                    value: "A AWS cuida da segurança da nuvem; o cliente cuida da segurança na nuvem, incluindo acesso e dados. Use IAM com menor privilégio.",
+                },
+            ],
+            questions: [
+                {
+                    statement:
+                        "No modelo de responsabilidade compartilhada aplicado a um serviço gerenciado de IA, o que normalmente cabe ao CLIENTE?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Definir quem acessa o serviço e como os dados são usados", isCorrect: true },
+                        { text: "Manter o hardware físico dos data centers", isCorrect: false },
+                        { text: "Aplicar patches na infraestrutura gerenciada", isCorrect: false },
+                        { text: "Operar a rede física e a energia das instalações", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Ao dar acesso a um serviço de IA, qual prática concede apenas as permissões necessárias?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Aplicar o princípio do menor privilégio com o AWS IAM", isCorrect: true },
+                        { text: "Conceder permissão de administrador a todos", isCorrect: false },
+                        { text: "Compartilhar a chave da conta raiz com a equipe", isCorrect: false },
+                        { text: "Desativar a autenticação para simplificar o acesso", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O AWS IAM é o serviço usado para:",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Gerenciar identidades e permissões de acesso na conta", isCorrect: true },
+                        { text: "Transcrever áudio em texto automaticamente", isCorrect: false },
+                        { text: "Armazenar objetos de dados em larga escala", isCorrect: false },
+                        { text: "Traduzir textos entre diferentes idiomas", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Proteção de dados: criptografia, Macie e PII",
+            blocks: [
+                {
+                    type: "text",
+                    value: "## Criptografar em repouso e em trânsito\nProteger os dados de uma solução de IA começa pela **criptografia**: em repouso (dados armazenados) e em trânsito (dados que trafegam pela rede). O **AWS KMS (Key Management Service)** gerencia as chaves de criptografia. Manter dados em texto puro, em buckets abertos ou sem logs enfraquece a segurança e é o oposto do recomendado.",
+                },
+                {
+                    type: "text",
+                    value: "## Descobrir e proteger dados sensíveis\nDados pessoais (PII) e outros dados sensíveis precisam ser identificados e protegidos. O **Amazon Macie** usa machine learning para descobrir e proteger dados sensíveis, como PII, armazenados no Amazon S3. É a resposta típica quando o cenário fala em achar e proteger dados pessoais em grandes volumes de arquivos.\n\nOutros serviços têm papéis diferentes: Comprehend também detecta PII em texto, mas o Macie é o especialista em varrer o S3 em escala.",
+                },
+                {
+                    type: "quote",
+                    value: "Criptografe em repouso e em trânsito (KMS). Para descobrir e proteger PII no S3 em escala, use o Amazon Macie.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Para proteger dados de uma solução de IA na AWS, qual medida é recomendada?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Criptografar os dados em repouso e em trânsito, por exemplo com o KMS", isCorrect: true },
+                        { text: "Manter os dados em texto puro para facilitar a depuração", isCorrect: false },
+                        { text: "Publicar os dados em um bucket S3 aberto ao público", isCorrect: false },
+                        { text: "Desabilitar os logs para reduzir o volume guardado", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Uma empresa precisa descobrir e proteger PII em grandes volumes de documentos no Amazon S3. Qual serviço é voltado a isso?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Amazon Macie", isCorrect: true },
+                        { text: "Amazon Polly", isCorrect: false },
+                        { text: "Amazon Lex", isCorrect: false },
+                        { text: "AWS Batch", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual serviço da AWS gerencia as chaves usadas para criptografar dados?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "AWS KMS (Key Management Service)", isCorrect: true },
+                        { text: "Amazon Rekognition", isCorrect: false },
+                        { text: "Amazon Athena", isCorrect: false },
+                        { text: "AWS Amplify", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Privacidade no Bedrock e conectividade privada",
+            blocks: [
+                {
+                    type: "text",
+                    value: "## O que acontece com os seus dados no Bedrock\nUma dúvida comum: os prompts e dados que envio ao Amazon Bedrock são usados para treinar os modelos base de terceiros? A postura de privacidade do Bedrock é que os **dados do cliente não são usados para treinar os foundation models base** nem compartilhados com os provedores dos modelos. Isso dá às empresas a confiança de usar o serviço com dados próprios.",
+                },
+                {
+                    type: "text",
+                    value: "## Tráfego sem passar pela internet\nPara que as chamadas a um serviço de IA não trafeguem pela internet pública, mantendo o tráfego dentro da rede da AWS, usa-se o **AWS PrivateLink**. Ele conecta a sua VPC ao serviço de forma privada, reduzindo a exposição. Serviços como Route 53 (DNS), SNS (mensageria) e Cost Explorer (custos) não têm essa função de conectividade privada.",
+                },
+                {
+                    type: "quote",
+                    value: "No Bedrock, os dados do cliente não treinam os modelos base. Para conectividade privada à rede da AWS, use o AWS PrivateLink.",
+                },
+            ],
+            questions: [
+                {
+                    statement:
+                        "Qual afirmação reflete a postura de privacidade do Amazon Bedrock quanto aos dados do cliente?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Não são usados para treinar os foundation models base", isCorrect: true },
+                        { text: "Todos os prompts passam a treinar publicamente os modelos", isCorrect: false },
+                        { text: "Ficam visíveis para todos os outros clientes do serviço", isCorrect: false },
+                        { text: "São compartilhados automaticamente com os provedores", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Para que as chamadas a um serviço de IA não passem pela internet pública, mantendo o tráfego na rede da AWS, qual recurso usar?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "AWS PrivateLink, que conecta a VPC ao serviço de forma privada", isCorrect: true },
+                        { text: "Amazon Route 53, um serviço de DNS para resolver nomes", isCorrect: false },
+                        { text: "Amazon SNS, um serviço de notificações por mensagens", isCorrect: false },
+                        { text: "AWS Cost Explorer, uma ferramenta de análise de custos", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Uma empresa hesita em usar IA generativa por medo de expor dados. Como a privacidade do Bedrock ajuda a mitigar isso?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Garante que os dados não treinam os modelos base nem vão aos provedores", isCorrect: true },
+                        { text: "Publica todos os prompts em um repositório aberto", isCorrect: false },
+                        { text: "Compartilha os dados com outros clientes para comparação", isCorrect: false },
+                        { text: "Exige que os dados fiquem em texto puro e sem controle", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Monitoramento, auditoria e conformidade",
+            blocks: [
+                {
+                    type: "text",
+                    value: "## Acompanhar em produção\nDepois de implantar, é preciso monitorar a operação e a qualidade ao longo do tempo. O **Amazon CloudWatch** acompanha métricas e logs operacionais (latência, erros, uso). O **Amazon SageMaker Model Monitor** detecta desvios (drift) na qualidade do modelo, avisando quando o desempenho cai e vale retreinar.",
+                },
+                {
+                    type: "text",
+                    value: "## Auditar e comprovar conformidade\nPara governança, dois serviços aparecem:\n\n**AWS CloudTrail** registra as chamadas de API feitas na conta, permitindo auditar quem fez o quê e quando, um requisito comum de conformidade.\n\n**AWS Artifact** é o portal onde ficam os relatórios de conformidade e as certificações da AWS (ISO, SOC e outros), úteis em auditorias.\n\nA **governança de dados** completa o quadro: rastrear a origem e as transformações dos dados (linhagem) apoia auditoria, conformidade e reprodutibilidade, mostrando de onde os dados vieram e como foram tratados.",
+                },
+                {
+                    type: "table",
+                    value: "[[\"Preciso...\", \"Serviço\"], [\"Métricas e logs operacionais\", \"Amazon CloudWatch\"], [\"Detectar queda de qualidade do modelo\", \"SageMaker Model Monitor\"], [\"Auditar chamadas de API\", \"AWS CloudTrail\"], [\"Obter relatórios de conformidade\", \"AWS Artifact\"]]",
+                },
+            ],
+            questions: [
+                {
+                    statement:
+                        "Qual serviço registra as chamadas de API na conta, apoiando auditoria e conformidade?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "AWS CloudTrail", isCorrect: true },
+                        { text: "Amazon Rekognition", isCorrect: false },
+                        { text: "Amazon Translate", isCorrect: false },
+                        { text: "AWS Amplify", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Depois de implantar um modelo, qual serviço detecta desvios (drift) na qualidade ao longo do tempo?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Amazon SageMaker Model Monitor, que detecta desvios", isCorrect: true },
+                        { text: "Amazon Polly, que converte texto em voz", isCorrect: false },
+                        { text: "AWS Budgets, que acompanha os gastos da conta", isCorrect: false },
+                        { text: "Amazon Lex, que cria fluxos de conversa em chatbots", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Uma empresa regulada precisa obter relatórios de conformidade e certificações da AWS para uma auditoria. Onde encontrá-los?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "AWS Artifact", isCorrect: true },
+                        { text: "Amazon QuickSight", isCorrect: false },
+                        { text: "Amazon Kinesis", isCorrect: false },
+                        { text: "AWS Step Functions", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Fechamento: revisão e próximos passos",
+            blocks: [
+                {
+                    type: "text",
+                    value: "## O que você percorreu\nVocê cobriu os cinco domínios do AIF-C01:\n\n- **Fundamentos de IA e ML**: a hierarquia IA, ML e deep learning; tipos de aprendizado; classificação, regressão e clustering; o ciclo de vida; métricas; e os serviços de IA e ML da AWS.\n- **IA generativa e foundation models**: o que são, tokens, embeddings, janela de contexto, o Amazon Bedrock, o Amazon Q e as alucinações.\n- **Aplicando foundation models**: engenharia de prompt, parâmetros de inferência, RAG, Knowledge Bases e Agents, e a escolha entre prompt, RAG e fine-tuning.\n- **IA responsável**: justiça, viés, explicabilidade, transparência, guardrails e supervisão humana.\n- **Segurança, conformidade e governança**: responsabilidade compartilhada, IAM, criptografia, Macie, privacidade no Bedrock, PrivateLink, monitoramento, auditoria e conformidade.",
+                },
+                {
+                    type: "text",
+                    value: "## Como fixar\nAo revisar, treine dois reflexos que o exame cobra: associar um cenário ao serviço certo da AWS (por exemplo, \"achar PII no S3\" leva ao Macie; \"conectar o modelo aos meus dados\" leva ao Knowledge Bases) e distinguir conceitos próximos (generativa x agêntica, RAG x fine-tuning, precisão x recall, viés x alucinação).\n\nO melhor termômetro é praticar com questões no formato da prova, revisando cada explicação. Faça o simulado do AWS AI Practitioner na aba de Simulados para medir onde você está e reforçar os pontos fracos.",
+                },
+                {
+                    type: "quote",
+                    value: "Dois reflexos para a prova: ligar o cenário ao serviço certo e separar conceitos parecidos. Pratique com o simulado e revise as explicações.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual é uma boa estratégia final de preparação para o AIF-C01?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Praticar questões no formato da prova e revisar cada explicação", isCorrect: true },
+                        { text: "Decorar apenas os nomes dos serviços, sem entender o uso", isCorrect: false },
+                        { text: "Ignorar a IA responsável, por ser um tema secundário", isCorrect: false },
+                        { text: "Focar só em um domínio e pular os demais", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Um cenário pede achar e proteger dados pessoais (PII) em arquivos no Amazon S3. Qual serviço você associa?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Amazon Macie", isCorrect: true },
+                        { text: "Amazon Bedrock Knowledge Bases", isCorrect: false },
+                        { text: "Amazon SageMaker Model Monitor", isCorrect: false },
+                        { text: "AWS PrivateLink", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Distinguir 'RAG' de 'fine-tuning' é importante porque:",
+                    difficulty: "medio",
+                    options: [
+                        { text: "RAG usa dados externos sem mudar o modelo; fine-tuning muda os pesos", isCorrect: true },
+                        { text: "São exatamente a mesma técnica, apenas com nomes diferentes", isCorrect: false },
+                        { text: "Ambos exigem treinar um foundation model inteiro do zero", isCorrect: false },
+                        { text: "Nenhum dos dois tem qualquer relação com foundation models", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULOS: Modulo[] = [MODULO_1, MODULO_2, MODULO_3, MODULO_4, MODULO_5];
+
+async function seed() {
+    let [trilha] = await db.select().from(trails).where(eq(trails.name, NOME));
+    if (!trilha) {
+        [trilha] = await db
+            .insert(trails)
+            .values({ name: NOME, trailLevel: "iniciante", description: DESCRICAO })
+            .returning();
+        console.log("Trilha criada: " + trilha.name);
+    }
+
+    const existentes = await db.select().from(lessons).where(eq(lessons.trailId, trilha.id));
+    if (existentes.length > 0) {
+        console.log("Trilha " + NOME + " já tem " + existentes.length + " aulas. Nada a fazer.");
+        return;
+    }
+
+    let totalAulas = 0;
+    let totalQuestoes = 0;
+    for (let mi = 0; mi < MODULOS.length; mi++) {
+        const m = MODULOS[mi];
+        const [mod] = await db
+            .insert(modules)
+            .values({ trailId: trilha.id, title: m.titulo, position: mi + 1 })
+            .returning();
+        for (let li = 0; li < m.aulas.length; li++) {
+            const a = m.aulas[li];
+            const [lesson] = await db
+                .insert(lessons)
+                .values({
+                    trailId: trilha.id,
+                    moduleId: mod.id,
+                    title: a.titulo,
+                    content: null,
+                    contentBlocks: a.blocks,
+                    position: li + 1,
+                    published: true,
+                })
+                .returning();
+            for (let qi = 0; qi < a.questions.length; qi++) {
+                const q = a.questions[qi];
+                const [questao] = await db
+                    .insert(questions)
+                    .values({
+                        lessonId: lesson.id,
+                        statement: q.statement,
+                        difficulty: q.difficulty,
+                        position: qi + 1,
+                    })
+                    .returning();
+                await db.insert(questionOptions).values(
+                    q.options.map((o, k) => ({
+                        questionId: questao.id,
+                        text: o.text,
+                        isCorrect: o.isCorrect,
+                        position: k + 1,
+                    })),
+                );
+            }
+            totalAulas++;
+            totalQuestoes += a.questions.length;
+        }
+    }
+    console.log(
+        "Seed concluído: " + MODULOS.length + " módulos, " + totalAulas + " aulas, " + totalQuestoes + " questões.",
+    );
+}
+
+seed()
+    .then(() => process.exit(0))
+    .catch((e) => {
+        console.error("Falha no seed:", e);
+        process.exit(1);
+    });


### PR DESCRIPTION
## O que muda

Adiciona a certificação **AWS Certified AI Practitioner (AIF-C01)** ao catálogo, com simulado e trilha, cobrindo os cinco domínios do exame.

### Simulado (aba Simulados)
65 questões autorais no formato da prova: 90 minutos, corte de 70%, mistura de resposta única e múltipla (3 questões de "Selecione DUAS"). Distribuição proporcional aos pesos dos domínios, com aplicações de foundation models como o maior bloco.

### Trilha (aba Trilhas)
5 módulos, 27 aulas e 81 questões de quiz:

- Fundamentos de IA e machine learning
- IA generativa e foundation models
- Aplicando foundation models: prompt, RAG e customização
- IA responsável
- Segurança, conformidade e governança (com o fechamento)

As aulas usam blocos de texto, tabelas e destaques. O fechamento é neutro por roadmap: revisa os domínios e aponta para o simulado, sem cravar próxima trilha ou roadmap.

## Verificação

Gabaritos conferidos por SQL, não presumidos:
- Simulado: 62 single + 3 multi, todo "DUAS" casando com 2 corretas, 0 questões desbalanceadas por tamanho, 0 duplicatas.
- Trilha: 81 questões single-answer com 4 opções, 0 desbalanceadas por tamanho, 0 duplicatas, 9 tabelas com JSON válido.

Conteúdo autoral (explicações próprias dos conceitos e serviços da AWS). `tsc` limpo. Os dois seeds foram rodados e validados no ambiente local.

## Deploy

Os seeds são idempotentes e não entram no fluxo automático de deploy. Depois do merge, rodar uma vez em produção:

```
docker compose -f docker-compose.prod.yml exec -T backend node --env-file=.env.prod scripts/seed-aif-c01.ts
docker compose -f docker-compose.prod.yml exec -T backend node scripts/seed-trilha-aif-c01.ts
```
