### PR TITLE
feat: comunidade com feed, dúvidas, soluções e conquistas

### DIFF
--- a/backend/app.ts
+++ b/backend/app.ts
@@ -11,6 +11,7 @@ import roadmapRoutes from "./src/routes/roadmap.routes.ts";
 import comunicadoRoutes from "./src/routes/comunicado.routes.ts";
 import certificateRoutes from "./src/routes/certificate.routes.ts";
 import apoioRoutes from "./src/routes/apoio.routes.ts";
+import comunidadeRoutes from "./src/routes/comunidade.routes.ts";
 import { errorMiddleware } from "./src/middlewares/error.ts";
 import { apiLimiter } from "./src/middlewares/rateLimit.ts";
 import helmet from "helmet";
@@ -27,6 +28,7 @@ app.use(cookieParser());
 app.use("/me/avatar", express.json({ limit: "6mb" }));
 app.use("/me/cover", express.json({ limit: "6mb" }));
 app.use("/me/fundo", express.json({ limit: "14mb" }));
+app.use("/comunidade/imagem", express.json({ limit: "6mb" }));
 app.use(express.json());
 app.use(helmet({ frameguard: { action: "deny" } }));
 app.use(
@@ -57,6 +59,7 @@ app.use(roadmapRoutes);
 app.use(comunicadoRoutes);
 app.use(certificateRoutes);
 app.use(apoioRoutes);
+app.use(comunidadeRoutes);
 app.use(adminRoutes);
 
 app.get("/health", (_req, res) => res.json({ status: "ok" }));

--- a/backend/drizzle/0041_magical_nomad.sql
+++ b/backend/drizzle/0041_magical_nomad.sql
@@ -1,0 +1,51 @@
+CREATE TYPE "public"."community_post_kind" AS ENUM('duvida', 'solucao', 'conquista', 'post');--> statement-breakpoint
+CREATE TABLE "community_comments" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"post_id" uuid NOT NULL,
+	"user_id" uuid NOT NULL,
+	"content" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "community_likes" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"post_id" uuid NOT NULL,
+	"user_id" uuid NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "community_likes_post_id_user_id_unique" UNIQUE("post_id","user_id")
+);
+--> statement-breakpoint
+CREATE TABLE "community_post_tags" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"post_id" uuid NOT NULL,
+	"tag" varchar(40) NOT NULL,
+	CONSTRAINT "community_post_tags_post_id_tag_unique" UNIQUE("post_id","tag")
+);
+--> statement-breakpoint
+CREATE TABLE "community_posts" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"kind" "community_post_kind" DEFAULT 'post' NOT NULL,
+	"content" text NOT NULL,
+	"code" text,
+	"code_language" varchar(30),
+	"image_url" varchar(300),
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "user_follows" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"follower_id" uuid NOT NULL,
+	"following_id" uuid NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "user_follows_follower_id_following_id_unique" UNIQUE("follower_id","following_id")
+);
+--> statement-breakpoint
+ALTER TABLE "community_comments" ADD CONSTRAINT "community_comments_post_id_community_posts_id_fk" FOREIGN KEY ("post_id") REFERENCES "public"."community_posts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "community_comments" ADD CONSTRAINT "community_comments_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "community_likes" ADD CONSTRAINT "community_likes_post_id_community_posts_id_fk" FOREIGN KEY ("post_id") REFERENCES "public"."community_posts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "community_likes" ADD CONSTRAINT "community_likes_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "community_post_tags" ADD CONSTRAINT "community_post_tags_post_id_community_posts_id_fk" FOREIGN KEY ("post_id") REFERENCES "public"."community_posts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "community_posts" ADD CONSTRAINT "community_posts_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_follows" ADD CONSTRAINT "user_follows_follower_id_users_id_fk" FOREIGN KEY ("follower_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_follows" ADD CONSTRAINT "user_follows_following_id_users_id_fk" FOREIGN KEY ("following_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;

--- a/backend/drizzle/meta/0041_snapshot.json
+++ b/backend/drizzle/meta/0041_snapshot.json
@@ -1,0 +1,3332 @@
+{
+  "id": "0d624c7e-c346-4728-b57b-b15234a3fe17",
+  "prevId": "9371c4af-7fc3-4198-ab11-ac7843285032",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.achievements": {
+      "name": "achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "criteria_type": {
+          "name": "criteria_type",
+          "type": "achievement_criteria",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "achievements_name_unique": {
+          "name": "achievements_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.certificates": {
+      "name": "certificates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_name": {
+          "name": "student_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpf": {
+          "name": "cpf",
+          "type": "varchar(11)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trail_name": {
+          "name": "trail_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workload_hours": {
+          "name": "workload_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "certificates_user_id_users_id_fk": {
+          "name": "certificates_user_id_users_id_fk",
+          "tableFrom": "certificates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "certificates_trail_id_trails_id_fk": {
+          "name": "certificates_trail_id_trails_id_fk",
+          "tableFrom": "certificates",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "certificates_code_unique": {
+          "name": "certificates_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        },
+        "certificates_user_id_trail_id_unique": {
+          "name": "certificates_user_id_trail_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "trail_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge_submissions": {
+      "name": "challenge_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "challenge_language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "challenge_submission_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "passed_count": {
+          "name": "passed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_count": {
+          "name": "total_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xp_earned": {
+          "name": "xp_earned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "challenge_submissions_user_id_users_id_fk": {
+          "name": "challenge_submissions_user_id_users_id_fk",
+          "tableFrom": "challenge_submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "challenge_submissions_challenge_id_challenges_id_fk": {
+          "name": "challenge_submissions_challenge_id_challenges_id_fk",
+          "tableFrom": "challenge_submissions",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge_tests": {
+      "name": "challenge_tests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_output": {
+          "name": "expected_output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "challenge_tests_challenge_id_challenges_id_fk": {
+          "name": "challenge_tests_challenge_id_challenges_id_fk",
+          "tableFrom": "challenge_tests",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenges": {
+      "name": "challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "challenge_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stdin'"
+        },
+        "entry_point": {
+          "name": "entry_point",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_blocks": {
+          "name": "statement_blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "question_difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'facil'"
+        },
+        "starter_code": {
+          "name": "starter_code",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_date": {
+          "name": "active_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "challenges_number_unique": {
+          "name": "challenges_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "number"
+          ]
+        },
+        "challenges_active_date_unique": {
+          "name": "challenges_active_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "active_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_comments": {
+      "name": "community_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_comments_post_id_community_posts_id_fk": {
+          "name": "community_comments_post_id_community_posts_id_fk",
+          "tableFrom": "community_comments",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_comments_user_id_users_id_fk": {
+          "name": "community_comments_user_id_users_id_fk",
+          "tableFrom": "community_comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_likes": {
+      "name": "community_likes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_likes_post_id_community_posts_id_fk": {
+          "name": "community_likes_post_id_community_posts_id_fk",
+          "tableFrom": "community_likes",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_likes_user_id_users_id_fk": {
+          "name": "community_likes_user_id_users_id_fk",
+          "tableFrom": "community_likes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "community_likes_post_id_user_id_unique": {
+          "name": "community_likes_post_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_post_tags": {
+      "name": "community_post_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_post_tags_post_id_community_posts_id_fk": {
+          "name": "community_post_tags_post_id_community_posts_id_fk",
+          "tableFrom": "community_post_tags",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "community_post_tags_post_id_tag_unique": {
+          "name": "community_post_tags_post_id_tag_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_id",
+            "tag"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_posts": {
+      "name": "community_posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "community_post_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'post'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_language": {
+          "name": "code_language",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_posts_user_id_users_id_fk": {
+          "name": "community_posts_user_id_users_id_fk",
+          "tableFrom": "community_posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comunicado_respostas": {
+      "name": "comunicado_respostas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "comunicado_id": {
+          "name": "comunicado_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "comunicado_resposta_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comunicado_respostas_comunicado_id_comunicados_id_fk": {
+          "name": "comunicado_respostas_comunicado_id_comunicados_id_fk",
+          "tableFrom": "comunicado_respostas",
+          "tableTo": "comunicados",
+          "columnsFrom": [
+            "comunicado_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "comunicado_respostas_user_id_users_id_fk": {
+          "name": "comunicado_respostas_user_id_users_id_fk",
+          "tableFrom": "comunicado_respostas",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "comunicado_respostas_comunicado_id_user_id_unique": {
+          "name": "comunicado_respostas_comunicado_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "comunicado_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comunicados": {
+      "name": "comunicados",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "comunicado_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.glossary": {
+      "name": "glossary",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "term": {
+          "name": "term",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "varchar(400)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "glossary_term_unique": {
+          "name": "glossary_term_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "term"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.languages": {
+      "name": "languages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "languages_name_unique": {
+          "name": "languages_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons_progress": {
+      "name": "lessons_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "manual": {
+          "name": "manual",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_progress_user_id_users_id_fk": {
+          "name": "lessons_progress_user_id_users_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_progress_lesson_id_lessons_id_fk": {
+          "name": "lessons_progress_lesson_id_lessons_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lessons_progress_user_id_lesson_id_unique": {
+          "name": "lessons_progress_user_id_lesson_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "lesson_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons": {
+      "name": "lessons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_blocks": {
+          "name": "content_blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "duration_min": {
+          "name": "duration_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview": {
+          "name": "preview",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_trail_id_trails_id_fk": {
+          "name": "lessons_trail_id_trails_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_module_id_modules_id_fk": {
+          "name": "lessons_module_id_modules_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "modules",
+          "columnsFrom": [
+            "module_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.modules": {
+      "name": "modules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "modules_trail_id_trails_id_fk": {
+          "name": "modules_trail_id_trails_id_fk",
+          "tableFrom": "modules",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_accounts": {
+      "name": "oauth_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_accounts_user_id_users_id_fk": {
+          "name": "oauth_accounts_user_id_users_id_fk",
+          "tableFrom": "oauth_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_accounts_provider_provider_id_unique": {
+          "name": "oauth_accounts_provider_provider_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "provider_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_answers": {
+      "name": "question_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_option_id": {
+          "name": "selected_option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_answers_user_id_users_id_fk": {
+          "name": "question_answers_user_id_users_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_question_id_questions_id_fk": {
+          "name": "question_answers_question_id_questions_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_selected_option_id_question_options_id_fk": {
+          "name": "question_answers_selected_option_id_question_options_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "question_options",
+          "columnsFrom": [
+            "selected_option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "question_answers_user_id_question_id_unique": {
+          "name": "question_answers_user_id_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_options": {
+      "name": "question_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_options_question_id_questions_id_fk": {
+          "name": "question_options_question_id_questions_id_fk",
+          "tableFrom": "question_options",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "question_difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'facil'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_lesson_id_lessons_id_fk": {
+          "name": "questions_lesson_id_lessons_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ranking_snapshots": {
+      "name": "ranking_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ranking_snapshots_user_id_users_id_fk": {
+          "name": "ranking_snapshots_user_id_users_id_fk",
+          "tableFrom": "ranking_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ranking_snapshots_user_id_snapshot_date_unique": {
+          "name": "ranking_snapshots_user_id_snapshot_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "snapshot_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmap_stage_completions": {
+      "name": "roadmap_stage_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "roadmap_stage_completions_user_id_users_id_fk": {
+          "name": "roadmap_stage_completions_user_id_users_id_fk",
+          "tableFrom": "roadmap_stage_completions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "roadmap_stage_completions_stage_id_roadmap_stages_id_fk": {
+          "name": "roadmap_stage_completions_stage_id_roadmap_stages_id_fk",
+          "tableFrom": "roadmap_stage_completions",
+          "tableTo": "roadmap_stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roadmap_stage_completions_user_id_stage_id_unique": {
+          "name": "roadmap_stage_completions_user_id_stage_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "stage_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmap_stage_refs": {
+      "name": "roadmap_stage_refs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_type": {
+          "name": "ref_type",
+          "type": "roadmap_ref_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "roadmap_stage_refs_stage_id_roadmap_stages_id_fk": {
+          "name": "roadmap_stage_refs_stage_id_roadmap_stages_id_fk",
+          "tableFrom": "roadmap_stage_refs",
+          "tableTo": "roadmap_stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmap_stages": {
+      "name": "roadmap_stages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "roadmap_id": {
+          "name": "roadmap_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "roadmap_phase",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "roadmap_stages_roadmap_id_roadmaps_id_fk": {
+          "name": "roadmap_stages_roadmap_id_roadmaps_id_fk",
+          "tableFrom": "roadmap_stages",
+          "tableTo": "roadmaps",
+          "columnsFrom": [
+            "roadmap_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmaps": {
+      "name": "roadmaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "trail_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "premium": {
+          "name": "premium",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roadmaps_slug_unique": {
+          "name": "roadmaps_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_attempt_answers": {
+      "name": "simulado_attempt_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_attempt_answers_attempt_id_simulado_attempts_id_fk": {
+          "name": "simulado_attempt_answers_attempt_id_simulado_attempts_id_fk",
+          "tableFrom": "simulado_attempt_answers",
+          "tableTo": "simulado_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempt_answers_question_id_simulado_questions_id_fk": {
+          "name": "simulado_attempt_answers_question_id_simulado_questions_id_fk",
+          "tableFrom": "simulado_attempt_answers",
+          "tableTo": "simulado_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempt_answers_option_id_simulado_options_id_fk": {
+          "name": "simulado_attempt_answers_option_id_simulado_options_id_fk",
+          "tableFrom": "simulado_attempt_answers",
+          "tableTo": "simulado_options",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulado_attempt_answers_attempt_id_question_id_option_id_unique": {
+          "name": "simulado_attempt_answers_attempt_id_question_id_option_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "attempt_id",
+            "question_id",
+            "option_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_attempt_questions": {
+      "name": "simulado_attempt_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_attempt_questions_attempt_id_simulado_attempts_id_fk": {
+          "name": "simulado_attempt_questions_attempt_id_simulado_attempts_id_fk",
+          "tableFrom": "simulado_attempt_questions",
+          "tableTo": "simulado_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempt_questions_question_id_simulado_questions_id_fk": {
+          "name": "simulado_attempt_questions_question_id_simulado_questions_id_fk",
+          "tableFrom": "simulado_attempt_questions",
+          "tableTo": "simulado_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulado_attempt_questions_attempt_id_question_id_unique": {
+          "name": "simulado_attempt_questions_attempt_id_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "attempt_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_attempts": {
+      "name": "simulado_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "simulado_id": {
+          "name": "simulado_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passed": {
+          "name": "passed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_attempts_user_id_users_id_fk": {
+          "name": "simulado_attempts_user_id_users_id_fk",
+          "tableFrom": "simulado_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempts_simulado_id_simulados_id_fk": {
+          "name": "simulado_attempts_simulado_id_simulados_id_fk",
+          "tableFrom": "simulado_attempts",
+          "tableTo": "simulados",
+          "columnsFrom": [
+            "simulado_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_options": {
+      "name": "simulado_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_options_question_id_simulado_questions_id_fk": {
+          "name": "simulado_options_question_id_simulado_questions_id_fk",
+          "tableFrom": "simulado_options",
+          "tableTo": "simulado_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_questions": {
+      "name": "simulado_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "simulado_id": {
+          "name": "simulado_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "simulado_questions_simulado_id_simulados_id_fk": {
+          "name": "simulado_questions_simulado_id_simulados_id_fk",
+          "tableFrom": "simulado_questions",
+          "tableTo": "simulados",
+          "columnsFrom": [
+            "simulado_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulados": {
+      "name": "simulados",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_count": {
+          "name": "question_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pass_percent": {
+          "name": "pass_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulados_slug_unique": {
+          "name": "simulados_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "subscription_plan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "subscription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pendente'"
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gateway": {
+          "name": "gateway",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'abacatepay'"
+        },
+        "gateway_id": {
+          "name": "gateway_id",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subscriptions_user_id_users_id_fk": {
+          "name": "subscriptions_user_id_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tokens": {
+      "name": "tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'refresh'"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tokens_user_id_users_id_fk": {
+          "name": "tokens_user_id_users_id_fk",
+          "tableFrom": "tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tokens_token_hash_unique": {
+          "name": "tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_reviews": {
+      "name": "trail_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stars": {
+          "name": "stars",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "trail_reviews_trail_id_trails_id_fk": {
+          "name": "trail_reviews_trail_id_trails_id_fk",
+          "tableFrom": "trail_reviews",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trail_reviews_user_id_users_id_fk": {
+          "name": "trail_reviews_user_id_users_id_fk",
+          "tableFrom": "trail_reviews",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trail_reviews_user_id_trail_id_unique": {
+          "name": "trail_reviews_user_id_trail_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "trail_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_tags": {
+      "name": "trail_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "trail_tags_trail_id_trails_id_fk": {
+          "name": "trail_tags_trail_id_trails_id_fk",
+          "tableFrom": "trail_tags",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trail_tags_tag_id_tags_id_fk": {
+          "name": "trail_tags_tag_id_tags_id_fk",
+          "tableFrom": "trail_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trail_tags_trail_id_tag_id_unique": {
+          "name": "trail_tags_trail_id_tag_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trail_id",
+            "tag_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trails": {
+      "name": "trails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "trail_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "what_you_learn": {
+          "name": "what_you_learn",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prerequisites": {
+          "name": "prerequisites",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workload_hours": {
+          "name": "workload_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_achievements": {
+      "name": "user_achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "achievement_id": {
+          "name": "achievement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_achievements_user_id_users_id_fk": {
+          "name": "user_achievements_user_id_users_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_achievements_achievement_id_achievements_id_fk": {
+          "name": "user_achievements_achievement_id_achievements_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "achievements",
+          "columnsFrom": [
+            "achievement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_achievements_user_id_achievement_id_unique": {
+          "name": "user_achievements_user_id_achievement_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "achievement_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_follows": {
+      "name": "user_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "following_id": {
+          "name": "following_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_follows_follower_id_users_id_fk": {
+          "name": "user_follows_follower_id_users_id_fk",
+          "tableFrom": "user_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_follows_following_id_users_id_fk": {
+          "name": "user_follows_following_id_users_id_fk",
+          "tableFrom": "user_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "following_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_follows_follower_id_following_id_unique": {
+          "name": "user_follows_follower_id_following_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "follower_id",
+            "following_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username_changed_at": {
+          "name": "username_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occupation": {
+          "name": "occupation",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github": {
+          "name": "github",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin": {
+          "name": "linkedin",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "failed_login_attempts": {
+          "name": "failed_login_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_goal_kind": {
+          "name": "weekly_goal_kind",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_goal_target": {
+          "name": "weekly_goal_target",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accent": {
+          "name": "accent",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "background_url": {
+          "name": "background_url",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "background_dim": {
+          "name": "background_dim",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.achievement_criteria": {
+      "name": "achievement_criteria",
+      "schema": "public",
+      "values": [
+        "xp_total",
+        "lessons_completed",
+        "questions_correct",
+        "special"
+      ]
+    },
+    "public.challenge_kind": {
+      "name": "challenge_kind",
+      "schema": "public",
+      "values": [
+        "stdin",
+        "function"
+      ]
+    },
+    "public.challenge_language": {
+      "name": "challenge_language",
+      "schema": "public",
+      "values": [
+        "javascript",
+        "python",
+        "csharp",
+        "java"
+      ]
+    },
+    "public.challenge_submission_status": {
+      "name": "challenge_submission_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "passed",
+        "failed",
+        "error",
+        "timeout"
+      ]
+    },
+    "public.community_post_kind": {
+      "name": "community_post_kind",
+      "schema": "public",
+      "values": [
+        "duvida",
+        "solucao",
+        "conquista",
+        "post"
+      ]
+    },
+    "public.comunicado_kind": {
+      "name": "comunicado_kind",
+      "schema": "public",
+      "values": [
+        "aviso",
+        "pesquisa"
+      ]
+    },
+    "public.comunicado_resposta_status": {
+      "name": "comunicado_resposta_status",
+      "schema": "public",
+      "values": [
+        "respondido",
+        "dispensado"
+      ]
+    },
+    "public.question_difficulty": {
+      "name": "question_difficulty",
+      "schema": "public",
+      "values": [
+        "facil",
+        "medio",
+        "dificil"
+      ]
+    },
+    "public.roadmap_phase": {
+      "name": "roadmap_phase",
+      "schema": "public",
+      "values": [
+        "fundamentos",
+        "core",
+        "avancado",
+        "deploy"
+      ]
+    },
+    "public.roadmap_ref_type": {
+      "name": "roadmap_ref_type",
+      "schema": "public",
+      "values": [
+        "trail",
+        "module",
+        "lesson",
+        "simulado",
+        "challenge"
+      ]
+    },
+    "public.subscription_plan": {
+      "name": "subscription_plan",
+      "schema": "public",
+      "values": [
+        "mensal",
+        "anual",
+        "pix_auto"
+      ]
+    },
+    "public.subscription_status": {
+      "name": "subscription_status",
+      "schema": "public",
+      "values": [
+        "pendente",
+        "ativa",
+        "cancelada"
+      ]
+    },
+    "public.trail_level": {
+      "name": "trail_level",
+      "schema": "public",
+      "values": [
+        "iniciante",
+        "intermediario",
+        "avancado"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin",
+        "moderator"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -288,6 +288,13 @@
       "when": 1784818895484,
       "tag": "0040_exotic_bloodstrike",
       "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "7",
+      "when": 1784898127219,
+      "tag": "0041_magical_nomad",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/schema.ts
+++ b/backend/schema.ts
@@ -588,3 +588,80 @@ export const subscriptions = pgTable("subscriptions", {
     expiresAt: timestamp("expires_at", { withTimezone: true }),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
 });
+
+export const communityPostKind = pgEnum("community_post_kind", [
+    "duvida",
+    "solucao",
+    "conquista",
+    "post",
+]);
+
+// Publicação na comunidade. code/codeLanguage e imageUrl são opcionais.
+export const communityPosts = pgTable("community_posts", {
+    id: uuid("id").primaryKey().defaultRandom(),
+    userId: uuid("user_id")
+        .references(() => users.id)
+        .notNull(),
+    kind: communityPostKind("kind").default("post").notNull(),
+    content: text("content").notNull(),
+    code: text("code"),
+    codeLanguage: varchar("code_language", { length: 30 }),
+    imageUrl: varchar("image_url", { length: 300 }),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+});
+
+// Tags de um post (hashtags). Denormalizado para contar os tópicos populares.
+export const communityPostTags = pgTable(
+    "community_post_tags",
+    {
+        id: uuid("id").primaryKey().defaultRandom(),
+        postId: uuid("post_id")
+            .references(() => communityPosts.id)
+            .notNull(),
+        tag: varchar("tag", { length: 40 }).notNull(),
+    },
+    (table) => [unique().on(table.postId, table.tag)],
+);
+
+export const communityLikes = pgTable(
+    "community_likes",
+    {
+        id: uuid("id").primaryKey().defaultRandom(),
+        postId: uuid("post_id")
+            .references(() => communityPosts.id)
+            .notNull(),
+        userId: uuid("user_id")
+            .references(() => users.id)
+            .notNull(),
+        createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    },
+    (table) => [unique().on(table.postId, table.userId)],
+);
+
+export const communityComments = pgTable("community_comments", {
+    id: uuid("id").primaryKey().defaultRandom(),
+    postId: uuid("post_id")
+        .references(() => communityPosts.id)
+        .notNull(),
+    userId: uuid("user_id")
+        .references(() => users.id)
+        .notNull(),
+    content: text("content").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+});
+
+// Quem segue quem. followerId segue followingId.
+export const userFollows = pgTable(
+    "user_follows",
+    {
+        id: uuid("id").primaryKey().defaultRandom(),
+        followerId: uuid("follower_id")
+            .references(() => users.id)
+            .notNull(),
+        followingId: uuid("following_id")
+            .references(() => users.id)
+            .notNull(),
+        createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    },
+    (table) => [unique().on(table.followerId, table.followingId)],
+);

--- a/backend/scripts/seed-comunidade-demo.ts
+++ b/backend/scripts/seed-comunidade-demo.ts
@@ -1,0 +1,275 @@
+// Seed de DEMONSTRAÇÃO da comunidade (apenas para desenvolvimento local).
+// Cria alguns usuários fictícios, publicações, curtidas, comentários e follows
+// para visualizar o feed. Idempotente: se os usuários demo já existem, não repete.
+// NÃO deve ser rodado em produção; lá a comunidade começa vazia e é preenchida
+// pelos usuários reais.
+//
+// Rodar local: docker compose exec -T backend node scripts/seed-comunidade-demo.ts
+import { db } from "../db.ts";
+import {
+    users,
+    lessons,
+    lessonProgress,
+    communityPosts,
+    communityPostTags,
+    communityLikes,
+    communityComments,
+    userFollows,
+} from "../schema.ts";
+import { eq, inArray } from "drizzle-orm";
+
+type DemoUser = {
+    chave: string;
+    name: string;
+    username: string;
+    email: string;
+    nivelAulas: number; // quantas aulas concluídas (define o nível exibido)
+};
+
+const DEMO: DemoUser[] = [
+    { chave: "camila", name: "Camila Rocha", username: "mila_dev", email: "camila.demo@ensinadev.local", nivelAulas: 28 },
+    { chave: "lucas", name: "Lucas Pereira", username: "lucaspereira", email: "lucas.demo@ensinadev.local", nivelAulas: 40 },
+    { chave: "aisha", name: "Aisha Santos", username: "aisha", email: "aisha.demo@ensinadev.local", nivelAulas: 33 },
+    { chave: "diego", name: "Diego Ramos", username: "diegoramos", email: "diego.demo@ensinadev.local", nivelAulas: 46 },
+    { chave: "marina", name: "Marina Alves", username: "marinaalves", email: "marina.demo@ensinadev.local", nivelAulas: 52 },
+    { chave: "elena", name: "Elena Souza", username: "elenasouza", email: "elena.demo@ensinadev.local", nivelAulas: 36 },
+    { chave: "bruno", name: "Bruno Costa", username: "brunocosta", email: "bruno.demo@ensinadev.local", nivelAulas: 18 },
+];
+
+const CODE_WHILE = `let i = 0;
+while (i < 5) {
+  console.log(i);
+  // i++  <- esqueci disto
+}`;
+
+const CODE_HASH = `function soma(nums, alvo) {
+  const mapa = {};
+  for (let i = 0; i < nums.length; i++) {
+    const falta = alvo - nums[i];
+    if (falta in mapa) return [mapa[falta], i];
+    mapa[nums[i]] = i;
+  }
+}`;
+
+const CODE_RECURSAO = `// iterativo: sem risco de estourar a pilha
+function fatorial(n) {
+  let r = 1;
+  for (let i = 2; i <= n; i++) r *= i;
+  return r;
+}`;
+
+type DemoPost = {
+    autor: string;
+    kind: "duvida" | "solucao" | "conquista" | "post";
+    content: string;
+    code?: string;
+    codeLanguage?: string;
+    tags: string[];
+    horasAtras: number;
+    curtidasDe: string[];
+    comentarios: { autor: string; texto: string; horasAtras: number }[];
+};
+
+const POSTS: DemoPost[] = [
+    {
+        autor: "camila",
+        kind: "duvida",
+        content:
+            "Alguém consegue explicar por que meu while não para de rodar? Acho que esqueci de incrementar o contador, mas não tô achando o erro.",
+        code: CODE_WHILE,
+        codeLanguage: "javascript",
+        tags: ["logica", "while"],
+        horasAtras: 2,
+        curtidasDe: ["lucas", "aisha", "diego", "marina"],
+        comentarios: [
+            { autor: "diego", texto: "Faltou o i++ dentro do while. Do jeito que está, i nunca muda e a condição i < 5 é sempre verdadeira.", horasAtras: 1 },
+            { autor: "aisha", texto: "Isso, descomenta o i++ que resolve. Loop infinito clássico. :)", horasAtras: 1 },
+        ],
+    },
+    {
+        autor: "lucas",
+        kind: "conquista",
+        content:
+            "Finalmente concluí a trilha de JavaScript Essencial, foram 30 aulas! Três semanas de prática diária. Agora bora pros algoritmos.",
+        tags: ["javascript", "conquista"],
+        horasAtras: 4,
+        curtidasDe: ["camila", "aisha", "marina", "elena", "bruno"],
+        comentarios: [{ autor: "marina", texto: "Parabéns! A parte de algoritmos é onde tudo faz sentido, vai gostar.", horasAtras: 3 }],
+    },
+    {
+        autor: "aisha",
+        kind: "solucao",
+        content:
+            "Resolvi o desafio de hoje (Soma de Dois Números) com hash table, O(n) em vez de O(n²). Compartilhando a ideia:",
+        code: CODE_HASH,
+        codeLanguage: "javascript",
+        tags: ["array", "hashtable"],
+        horasAtras: 6,
+        curtidasDe: ["camila", "lucas", "diego"],
+        comentarios: [{ autor: "elena", texto: "Boa! Sempre esqueço de usar mapa pra evitar o loop dobrado. Obrigada por compartilhar.", horasAtras: 5 }],
+    },
+    {
+        autor: "marina",
+        kind: "duvida",
+        content: "Qual a diferença real entre let, const e var? Sei que const não deixa reatribuir, mas e o escopo?",
+        tags: ["javascript"],
+        horasAtras: 9,
+        curtidasDe: ["camila", "bruno"],
+        comentarios: [],
+    },
+    {
+        autor: "bruno",
+        kind: "duvida",
+        content: "Alguém tem um bom material sobre Big O? Entendo a ideia, mas travo na hora de calcular a complexidade.",
+        tags: ["algoritmos"],
+        horasAtras: 11,
+        curtidasDe: ["aisha"],
+        comentarios: [],
+    },
+    {
+        autor: "elena",
+        kind: "solucao",
+        content: "Recursão vs iteração: quando usar cada um? Fiz um resumo do que aprendi na trilha de algoritmos.",
+        code: CODE_RECURSAO,
+        codeLanguage: "javascript",
+        tags: ["algoritmos", "recursao"],
+        horasAtras: 14,
+        curtidasDe: ["aisha", "marina"],
+        comentarios: [],
+    },
+    {
+        autor: "diego",
+        kind: "post",
+        content:
+            "Dica rápida: leiam a mensagem de erro inteira antes de sair mudando o código. Na maioria das vezes ela já diz a linha e o motivo.",
+        tags: ["carreira", "dicas"],
+        horasAtras: 20,
+        curtidasDe: ["camila", "lucas", "aisha", "marina", "elena", "bruno"],
+        comentarios: [{ autor: "bruno", texto: "Demorei pra aprender isso. Stack trace é amigo, não inimigo.", horasAtras: 19 }],
+    },
+    {
+        autor: "bruno",
+        kind: "post",
+        content:
+            "Dicas para destravar em lógica de programação: resolvam 1 exercício fácil por dia sem pular. A consistência vence o talento.",
+        tags: ["logica", "carreira"],
+        horasAtras: 28,
+        curtidasDe: ["camila", "marina"],
+        comentarios: [],
+    },
+];
+
+// followerChave -> [seguidos]
+const FOLLOWS: Record<string, string[]> = {
+    camila: ["aisha", "diego", "marina"],
+    lucas: ["marina", "diego"],
+    aisha: ["camila", "elena"],
+    bruno: ["diego", "bruno"],
+};
+
+function horas(n: number): Date {
+    return new Date(Date.now() - n * 3600_000);
+}
+
+async function main() {
+    const emails = DEMO.map((d) => d.email);
+    const existentes = await db.select({ email: users.email }).from(users).where(inArray(users.email, emails));
+    if (existentes.length > 0) {
+        console.log("Usuários demo já existem. Nada a fazer (idempotente).");
+        return;
+    }
+
+    // Pool de lições reais para atribuir progresso (e, com ele, nível).
+    const poolLicoes = await db.select({ id: lessons.id }).from(lessons).limit(60);
+    if (poolLicoes.length === 0) {
+        console.log("Sem lições no banco; rode os seeds de trilha antes. Abortando.");
+        return;
+    }
+
+    const idPorChave = new Map<string, string>();
+    for (const d of DEMO) {
+        const [u] = await db
+            .insert(users)
+            .values({
+                name: d.name,
+                username: d.username,
+                email: d.email,
+                emailVerifiedAt: new Date(),
+            })
+            .returning({ id: users.id });
+        idPorChave.set(d.chave, u.id);
+
+        const qtd = Math.min(d.nivelAulas, poolLicoes.length);
+        if (qtd > 0) {
+            await db
+                .insert(lessonProgress)
+                .values(poolLicoes.slice(0, qtd).map((l) => ({ userId: u.id, lessonId: l.id, manual: false })))
+                .onConflictDoNothing();
+        }
+    }
+
+    let nPosts = 0;
+    let nComent = 0;
+    let nLikes = 0;
+    for (const p of POSTS) {
+        const autorId = idPorChave.get(p.autor)!;
+        const [post] = await db
+            .insert(communityPosts)
+            .values({
+                userId: autorId,
+                kind: p.kind,
+                content: p.content,
+                code: p.code ?? null,
+                codeLanguage: p.code ? (p.codeLanguage ?? null) : null,
+                createdAt: horas(p.horasAtras),
+            })
+            .returning({ id: communityPosts.id });
+        nPosts++;
+
+        if (p.tags.length) {
+            await db
+                .insert(communityPostTags)
+                .values(p.tags.map((tag) => ({ postId: post.id, tag })))
+                .onConflictDoNothing();
+        }
+        for (const chave of p.curtidasDe) {
+            await db
+                .insert(communityLikes)
+                .values({ postId: post.id, userId: idPorChave.get(chave)!, createdAt: horas(p.horasAtras - 0.2) })
+                .onConflictDoNothing();
+            nLikes++;
+        }
+        for (const c of p.comentarios) {
+            await db.insert(communityComments).values({
+                postId: post.id,
+                userId: idPorChave.get(c.autor)!,
+                content: c.texto,
+                createdAt: horas(c.horasAtras),
+            });
+            nComent++;
+        }
+    }
+
+    let nFollows = 0;
+    for (const [seguidor, seguidos] of Object.entries(FOLLOWS)) {
+        for (const alvo of seguidos) {
+            if (seguidor === alvo) continue;
+            await db
+                .insert(userFollows)
+                .values({ followerId: idPorChave.get(seguidor)!, followingId: idPorChave.get(alvo)! })
+                .onConflictDoNothing();
+            nFollows++;
+        }
+    }
+
+    console.log(
+        `Comunidade demo criada: ${DEMO.length} usuários, ${nPosts} posts, ${nComent} comentários, ${nLikes} curtidas, ${nFollows} follows.`,
+    );
+}
+
+main()
+    .then(() => process.exit(0))
+    .catch((err) => {
+        console.error(err);
+        process.exit(1);
+    });

--- a/backend/src/config/paths.ts
+++ b/backend/src/config/paths.ts
@@ -6,3 +6,4 @@ export const UPLOADS_DIR = path.join(process.cwd(), "uploads");
 export const AVATARS_DIR = path.join(UPLOADS_DIR, "avatars");
 export const COVERS_DIR = path.join(UPLOADS_DIR, "covers");
 export const FUNDOS_DIR = path.join(UPLOADS_DIR, "fundos");
+export const COMUNIDADE_DIR = path.join(UPLOADS_DIR, "comunidade");

--- a/backend/src/controllers/ComunidadeController.ts
+++ b/backend/src/controllers/ComunidadeController.ts
@@ -1,0 +1,128 @@
+import type { Request, Response, NextFunction } from "express";
+import { criarPostSchema, comentarSchema } from "../schemas/comunidade.schema.ts";
+import { salvarImagem } from "../services/imagens.ts";
+import { apoiadorAtivo } from "../services/apoiador.service.ts";
+import { COMUNIDADE_DIR } from "../config/paths.ts";
+import {
+    feed,
+    criarPost,
+    alternarCurtida,
+    detalhePost,
+    comentar,
+    tagsPopulares,
+    discussoesEmAlta,
+    sugestoesParaSeguir,
+    duvidasAbertas,
+    estadoSeguir,
+    seguir,
+    deixarDeSeguir,
+} from "../services/comunidade.service.ts";
+
+const FILTROS = [
+    "para-voce",
+    "recentes",
+    "em-alta",
+    "sem-resposta",
+    "seguindo",
+    "duvida",
+    "solucao",
+    "conquista",
+] as const;
+
+export const getFeed = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const filtroBruto = String(req.query.filtro ?? "para-voce");
+        const filtro = (FILTROS as readonly string[]).includes(filtroBruto)
+            ? (filtroBruto as (typeof FILTROS)[number])
+            : "para-voce";
+        const tag = req.query.tag ? String(req.query.tag).toLowerCase() : null;
+        res.json(await feed(req.userId!, filtro, tag));
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const postar = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const dados = criarPostSchema.parse(req.body);
+        res.status(201).json(await criarPost(req.userId!, dados));
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const enviarImagem = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        if (!(await apoiadorAtivo(req.userId!))) {
+            return res.status(403).json({ erro: "Enviar imagens na comunidade é um benefício de apoiador." });
+        }
+        const r = await salvarImagem(req.body?.image, COMUNIDADE_DIR, "/uploads/comunidade");
+        if (!r.ok) return res.status(400).json({ erro: r.erro });
+        res.json({ url: r.url });
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const curtir = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        res.json(await alternarCurtida(req.userId!, String(req.params.id)));
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const getPost = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        res.json(await detalhePost(req.userId!, String(req.params.id)));
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const comentarPost = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const dados = comentarSchema.parse(req.body);
+        res.status(201).json(await comentar(req.userId!, String(req.params.id), dados));
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const getBarraLateral = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const [topicos, discussoes, sugestoes, duvidas] = await Promise.all([
+            tagsPopulares(),
+            discussoesEmAlta(),
+            sugestoesParaSeguir(req.userId!),
+            duvidasAbertas(),
+        ]);
+        res.json({ topicos, discussoes, sugestoes, duvidasAbertas: duvidas });
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const estadoSeguirUsuario = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        res.json(await estadoSeguir(req.userId!, String(req.params.username)));
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const seguirUsuario = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        res.json(await seguir(req.userId!, String(req.params.username)));
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const deixarDeSeguirUsuario = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        res.json(await deixarDeSeguir(req.userId!, String(req.params.username)));
+    } catch (err) {
+        next(err);
+    }
+};

--- a/backend/src/controllers/UserController.ts
+++ b/backend/src/controllers/UserController.ts
@@ -1,12 +1,10 @@
 import type { Request, Response, NextFunction } from "express";
-import { randomUUID } from "node:crypto";
-import path from "node:path";
-import { writeFile, mkdir, unlink } from "node:fs/promises";
 import { db } from "../../db.ts";
 import { users, languages as languagesTable } from "../../schema.ts";
 import { eq } from "drizzle-orm";
 import { updateMeSchema, completarPerfilSchema, metaSemanalSchema } from "../schemas/auth.schema.ts";
-import { UPLOADS_DIR, AVATARS_DIR, COVERS_DIR, FUNDOS_DIR } from "../config/paths.ts";
+import { AVATARS_DIR, COVERS_DIR, FUNDOS_DIR } from "../config/paths.ts";
+import { salvarImagem, removerArquivoLocal } from "../services/imagens.ts";
 import { streakDoUsuario } from "../services/streak.ts";
 import { calcularEstatisticas } from "../services/stats.service.ts";
 import { perfilPublico } from "../services/perfil-publico.service.ts";
@@ -193,49 +191,6 @@ export const completarPerfil = async (req: Request, res: Response, next: NextFun
         next(err);
     }
 };
-
-const MIME_EXT: Record<string, string> = {
-    "image/png": "png",
-    "image/jpeg": "jpg",
-    "image/jpg": "jpg",
-    "image/webp": "webp",
-};
-const MAX_IMG_BYTES = 4 * 1024 * 1024; // 4MB
-
-type ResultadoImagem = { ok: true; url: string } | { ok: false; erro: string };
-
-// Decodifica uma data URL (base64) e grava em disco com nome aleatorio. O nome
-// nunca vem do cliente, entao nao ha risco de path traversal nem sobrescrita.
-async function salvarImagem(
-    dataUrl: unknown,
-    destDir: string,
-    urlBase: string,
-    maxBytes = MAX_IMG_BYTES,
-): Promise<ResultadoImagem> {
-    if (typeof dataUrl !== "string") return { ok: false, erro: "Imagem ausente" };
-    const m = /^data:([^;]+);base64,(.+)$/s.exec(dataUrl);
-    if (!m) return { ok: false, erro: "Formato de imagem invalido" };
-    const ext = MIME_EXT[m[1].toLowerCase()];
-    if (!ext) return { ok: false, erro: "Use uma imagem PNG, JPG ou WEBP" };
-    const buffer = Buffer.from(m[2], "base64");
-    if (buffer.length === 0) return { ok: false, erro: "Imagem vazia" };
-    if (buffer.length > maxBytes)
-        return { ok: false, erro: `Imagem muito grande (maximo ${Math.round(maxBytes / 1024 / 1024)}MB)` };
-    await mkdir(destDir, { recursive: true });
-    const nome = `${randomUUID()}.${ext}`;
-    await writeFile(path.join(destDir, nome), buffer);
-    return { ok: true, url: `${urlBase}/${nome}` };
-}
-
-// Remove (best-effort) o arquivo local antigo ao trocar a imagem, evitando orfaos.
-async function removerArquivoLocal(url: string | null) {
-    if (!url || !url.startsWith("/uploads/")) return;
-    try {
-        await unlink(path.join(UPLOADS_DIR, url.slice("/uploads/".length)));
-    } catch {
-        // arquivo ja removido ou inexistente: ignora
-    }
-}
 
 export const uploadAvatar = async (req: Request, res: Response, next: NextFunction) => {
     const userId = req.userId;

--- a/backend/src/middlewares/rateLimit.ts
+++ b/backend/src/middlewares/rateLimit.ts
@@ -66,3 +66,10 @@ export const uploadLimiter = criarLimiter(
     30,
     "Muitos envios de imagem. Aguarde alguns minutos.",
 );
+
+// Publicar na comunidade (post ou comentário) é escrita de conteúdo; teto por
+// janela para conter spam/flood sem atrapalhar quem participa normalmente.
+export const comunidadeEscritaLimiter = criarLimiter(
+    40,
+    "Você está publicando rápido demais. Aguarde alguns minutos.",
+);

--- a/backend/src/routes/comunidade.routes.ts
+++ b/backend/src/routes/comunidade.routes.ts
@@ -1,0 +1,30 @@
+import { Router } from "express";
+import { autenticar } from "../middlewares/auth.ts";
+import { comunidadeEscritaLimiter, uploadLimiter } from "../middlewares/rateLimit.ts";
+import {
+    getFeed,
+    postar,
+    enviarImagem,
+    curtir,
+    getPost,
+    comentarPost,
+    getBarraLateral,
+    estadoSeguirUsuario,
+    seguirUsuario,
+    deixarDeSeguirUsuario,
+} from "../controllers/ComunidadeController.ts";
+
+const router = Router();
+
+router.get("/comunidade/feed", autenticar, getFeed);
+router.get("/comunidade/lateral", autenticar, getBarraLateral);
+router.post("/comunidade/imagem", autenticar, uploadLimiter, enviarImagem);
+router.post("/comunidade/posts", autenticar, comunidadeEscritaLimiter, postar);
+router.get("/comunidade/posts/:id", autenticar, getPost);
+router.post("/comunidade/posts/:id/curtir", autenticar, curtir);
+router.post("/comunidade/posts/:id/comentarios", autenticar, comunidadeEscritaLimiter, comentarPost);
+router.get("/comunidade/seguir/:username", autenticar, estadoSeguirUsuario);
+router.post("/comunidade/seguir/:username", autenticar, seguirUsuario);
+router.delete("/comunidade/seguir/:username", autenticar, deixarDeSeguirUsuario);
+
+export default router;

--- a/backend/src/schemas/comunidade.schema.ts
+++ b/backend/src/schemas/comunidade.schema.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+export const criarPostSchema = z.object({
+    kind: z.enum(["duvida", "solucao", "conquista", "post"]).default("post"),
+    content: z
+        .string()
+        .transform((v) => v.trim())
+        .refine((v) => v.length >= 1 && v.length <= 2000, "A publicação deve ter entre 1 e 2000 caracteres."),
+    code: z.string().max(6000).optional(),
+    codeLanguage: z.string().max(30).optional(),
+    tags: z.array(z.string().max(40)).max(5).optional(),
+    // Só aceita caminhos já gravados pelo nosso upload; nunca uma URL arbitrária.
+    imageUrl: z
+        .string()
+        .regex(/^\/uploads\/comunidade\/[\w.-]+$/)
+        .optional(),
+});
+
+export const comentarSchema = z.object({
+    content: z
+        .string()
+        .transform((v) => v.trim())
+        .refine((v) => v.length >= 1 && v.length <= 1000, "O comentário deve ter entre 1 e 1000 caracteres."),
+});

--- a/backend/src/services/comunidade.service.ts
+++ b/backend/src/services/comunidade.service.ts
@@ -1,0 +1,442 @@
+import { and, count, desc, eq, gt, inArray, notInArray, sql, sum, isNotNull } from "drizzle-orm";
+import { db } from "../../db.ts";
+import {
+    communityPosts,
+    communityPostTags,
+    communityLikes,
+    communityComments,
+    userFollows,
+    users,
+    lessonProgress,
+    questionAnswers,
+    challengeSubmissions,
+} from "../../schema.ts";
+import { calcularXp, nivelPorXp } from "../domain/xp.ts";
+import { apoiadoresAtivos, apoiadorAtivo } from "./apoiador.service.ts";
+import { AppError } from "../errors/AppError.ts";
+import type { z } from "zod";
+import type { criarPostSchema, comentarSchema } from "../schemas/comunidade.schema.ts";
+
+type DadosPost = z.infer<typeof criarPostSchema>;
+
+// Nível de cada usuário da lista, em 3 queries agrupadas (não uma por autor).
+async function niveisDeUsuarios(userIds: string[]): Promise<Map<string, number>> {
+    const niveis = new Map<string, number>();
+    if (userIds.length === 0) return niveis;
+    const [aulas, acertos, desafios] = await Promise.all([
+        db
+            .select({ userId: lessonProgress.userId, n: count() })
+            .from(lessonProgress)
+            .where(and(inArray(lessonProgress.userId, userIds), eq(lessonProgress.manual, false)))
+            .groupBy(lessonProgress.userId),
+        db
+            .select({ userId: questionAnswers.userId, n: count() })
+            .from(questionAnswers)
+            .where(and(inArray(questionAnswers.userId, userIds), eq(questionAnswers.isCorrect, true)))
+            .groupBy(questionAnswers.userId),
+        db
+            .select({ userId: challengeSubmissions.userId, xp: sum(challengeSubmissions.xpEarned) })
+            .from(challengeSubmissions)
+            .where(and(inArray(challengeSubmissions.userId, userIds), gt(challengeSubmissions.xpEarned, 0)))
+            .groupBy(challengeSubmissions.userId),
+    ]);
+    const paraMapa = (arr: { userId: string; n?: number | string; xp?: number | string | null }[]) =>
+        new Map(arr.map((a) => [a.userId, Number(a.n ?? a.xp ?? 0)]));
+    const a = paraMapa(aulas);
+    const q = paraMapa(acertos);
+    const d = paraMapa(desafios);
+    for (const id of userIds) {
+        const xp = calcularXp({ aulas: a.get(id) ?? 0, questoes: q.get(id) ?? 0, desafiosXp: d.get(id) ?? 0 });
+        niveis.set(id, nivelPorXp(xp));
+    }
+    return niveis;
+}
+
+type LinhaPost = {
+    id: string;
+    userId: string;
+    kind: string;
+    content: string;
+    code: string | null;
+    codeLanguage: string | null;
+    imageUrl: string | null;
+    createdAt: Date;
+    authorName: string;
+    authorUsername: string | null;
+    authorAvatar: string | null;
+};
+
+// Contagem de curtidas e comentários por post, em duas queries agrupadas.
+async function contagens(ids: string[]) {
+    if (ids.length === 0) return { likes: new Map<string, number>(), comentarios: new Map<string, number>() };
+    const [likes, comentarios] = await Promise.all([
+        db
+            .select({ postId: communityLikes.postId, n: count() })
+            .from(communityLikes)
+            .where(inArray(communityLikes.postId, ids))
+            .groupBy(communityLikes.postId),
+        db
+            .select({ postId: communityComments.postId, n: count() })
+            .from(communityComments)
+            .where(inArray(communityComments.postId, ids))
+            .groupBy(communityComments.postId),
+    ]);
+    return {
+        likes: new Map(likes.map((l) => [l.postId, Number(l.n)])),
+        comentarios: new Map(comentarios.map((c) => [c.postId, Number(c.n)])),
+    };
+}
+
+// Enriquece linhas cruas de post com tags, contagens, curtida do usuário,
+// nível do autor e selo de apoiador. Preserva a ordem recebida.
+async function montarPosts(userId: string, linhas: LinhaPost[]) {
+    const ids = linhas.map((l) => l.id);
+    if (ids.length === 0) return [];
+    const autores = [...new Set(linhas.map((l) => l.userId))];
+
+    const [{ likes, comentarios }, tags, curtidos, niveis, apoiadores] = await Promise.all([
+        contagens(ids),
+        db
+            .select({ postId: communityPostTags.postId, tag: communityPostTags.tag })
+            .from(communityPostTags)
+            .where(inArray(communityPostTags.postId, ids)),
+        db
+            .select({ postId: communityLikes.postId })
+            .from(communityLikes)
+            .where(and(eq(communityLikes.userId, userId), inArray(communityLikes.postId, ids))),
+        niveisDeUsuarios(autores),
+        apoiadoresAtivos(),
+    ]);
+
+    const tagsPorPost = new Map<string, string[]>();
+    for (const t of tags) {
+        const arr = tagsPorPost.get(t.postId) ?? [];
+        arr.push(t.tag);
+        tagsPorPost.set(t.postId, arr);
+    }
+    const curtidosSet = new Set(curtidos.map((c) => c.postId));
+
+    return linhas.map((l) => ({
+        id: l.id,
+        kind: l.kind,
+        content: l.content,
+        code: l.code,
+        codeLanguage: l.codeLanguage,
+        imageUrl: l.imageUrl,
+        createdAt: l.createdAt,
+        tags: tagsPorPost.get(l.id) ?? [],
+        likes: likes.get(l.id) ?? 0,
+        comentarios: comentarios.get(l.id) ?? 0,
+        curtido: curtidosSet.has(l.id),
+        autor: {
+            name: l.authorName,
+            username: l.authorUsername,
+            avatarUrl: l.authorAvatar,
+            level: niveis.get(l.userId) ?? 1,
+            apoiador: apoiadores.has(l.userId),
+        },
+    }));
+}
+
+const COLUNAS_POST = {
+    id: communityPosts.id,
+    userId: communityPosts.userId,
+    kind: communityPosts.kind,
+    content: communityPosts.content,
+    code: communityPosts.code,
+    codeLanguage: communityPosts.codeLanguage,
+    imageUrl: communityPosts.imageUrl,
+    createdAt: communityPosts.createdAt,
+    authorName: users.name,
+    authorUsername: users.username,
+    authorAvatar: users.avatarUrl,
+} as const;
+
+type FiltroFeed =
+    | "para-voce"
+    | "recentes"
+    | "em-alta"
+    | "sem-resposta"
+    | "seguindo"
+    | "duvida"
+    | "solucao"
+    | "conquista";
+
+export async function feed(userId: string, filtro: FiltroFeed, tag: string | null) {
+    const cond = [];
+    if (filtro === "duvida" || filtro === "solucao" || filtro === "conquista") {
+        cond.push(eq(communityPosts.kind, filtro));
+    }
+    if (filtro === "seguindo") {
+        const seguidos = await db
+            .select({ id: userFollows.followingId })
+            .from(userFollows)
+            .where(eq(userFollows.followerId, userId));
+        const idsSeguidos = seguidos.map((s) => s.id);
+        cond.push(idsSeguidos.length > 0 ? inArray(communityPosts.userId, idsSeguidos) : sql`false`);
+    }
+    if (filtro === "em-alta") {
+        cond.push(gt(communityPosts.createdAt, new Date(Date.now() - 14 * 86400000)));
+    }
+    if (tag) {
+        const comTag = db
+            .select({ postId: communityPostTags.postId })
+            .from(communityPostTags)
+            .where(eq(communityPostTags.tag, tag.toLowerCase()));
+        cond.push(inArray(communityPosts.id, comTag));
+    }
+
+    // "Em alta" e "sem resposta" ordenam/filtram por contagem, feita em JS sobre
+    // uma janela maior; os demais filtros já saem prontos por data.
+    const precisaJanela = filtro === "em-alta" || filtro === "sem-resposta";
+    const linhas = (await db
+        .select(COLUNAS_POST)
+        .from(communityPosts)
+        .innerJoin(users, eq(users.id, communityPosts.userId))
+        .where(cond.length ? and(...cond) : undefined)
+        .orderBy(desc(communityPosts.createdAt))
+        .limit(precisaJanela ? 80 : 30)) as LinhaPost[];
+
+    let posts = await montarPosts(userId, linhas);
+    if (filtro === "sem-resposta") {
+        posts = posts.filter((p) => p.comentarios === 0).slice(0, 30);
+    } else if (filtro === "em-alta") {
+        posts = posts
+            .sort(
+                (x, y) =>
+                    y.likes + y.comentarios * 2 - (x.likes + x.comentarios * 2) ||
+                    y.createdAt.getTime() - x.createdAt.getTime(),
+            )
+            .slice(0, 30);
+    }
+    return posts;
+}
+
+const TAG_RE = /^[a-z0-9-]{2,40}$/;
+
+export async function criarPost(userId: string, dados: DadosPost) {
+    // Anexar imagem é benefício de apoiador; barra aqui também (não só no upload)
+    // para que uma URL reaproveitada de outro post não fure a regra.
+    if (dados.imageUrl && !(await apoiadorAtivo(userId))) {
+        throw new AppError(403, "Enviar imagens na comunidade é um benefício de apoiador.");
+    }
+    const tagsLimpa = [
+        ...new Set((dados.tags ?? []).map((t) => t.trim().toLowerCase()).filter((t) => TAG_RE.test(t))),
+    ].slice(0, 5);
+
+    const [post] = await db
+        .insert(communityPosts)
+        .values({
+            userId,
+            kind: dados.kind,
+            content: dados.content.trim(),
+            code: dados.code?.trim() || null,
+            codeLanguage: dados.code?.trim() ? (dados.codeLanguage ?? null) : null,
+            imageUrl: dados.imageUrl ?? null,
+        })
+        .returning();
+    if (tagsLimpa.length) {
+        await db
+            .insert(communityPostTags)
+            .values(tagsLimpa.map((tag) => ({ postId: post.id, tag })))
+            .onConflictDoNothing();
+    }
+    return { id: post.id };
+}
+
+export async function alternarCurtida(userId: string, postId: string) {
+    const [post] = await db
+        .select({ id: communityPosts.id })
+        .from(communityPosts)
+        .where(eq(communityPosts.id, postId));
+    if (!post) throw new AppError(404, "Publicação não encontrada");
+
+    const removidas = await db
+        .delete(communityLikes)
+        .where(and(eq(communityLikes.postId, postId), eq(communityLikes.userId, userId)))
+        .returning({ id: communityLikes.id });
+    if (removidas.length === 0) {
+        await db.insert(communityLikes).values({ postId, userId }).onConflictDoNothing();
+    }
+    const [{ n }] = await db
+        .select({ n: count() })
+        .from(communityLikes)
+        .where(eq(communityLikes.postId, postId));
+    return { curtido: removidas.length === 0, likes: Number(n) };
+}
+
+export async function detalhePost(userId: string, postId: string) {
+    const linhas = (await db
+        .select(COLUNAS_POST)
+        .from(communityPosts)
+        .innerJoin(users, eq(users.id, communityPosts.userId))
+        .where(eq(communityPosts.id, postId))) as LinhaPost[];
+    const [post] = await montarPosts(userId, linhas);
+    if (!post) throw new AppError(404, "Publicação não encontrada");
+
+    const comentariosBrutos = await db
+        .select({
+            id: communityComments.id,
+            userId: communityComments.userId,
+            content: communityComments.content,
+            createdAt: communityComments.createdAt,
+            authorName: users.name,
+            authorUsername: users.username,
+            authorAvatar: users.avatarUrl,
+        })
+        .from(communityComments)
+        .innerJoin(users, eq(users.id, communityComments.userId))
+        .where(eq(communityComments.postId, postId))
+        .orderBy(communityComments.createdAt);
+    const niveis = await niveisDeUsuarios([...new Set(comentariosBrutos.map((c) => c.userId))]);
+
+    return {
+        ...post,
+        comentariosLista: comentariosBrutos.map((c) => ({
+            id: c.id,
+            content: c.content,
+            createdAt: c.createdAt,
+            autor: {
+                name: c.authorName,
+                username: c.authorUsername,
+                avatarUrl: c.authorAvatar,
+                level: niveis.get(c.userId) ?? 1,
+            },
+        })),
+    };
+}
+
+export async function comentar(userId: string, postId: string, dados: z.infer<typeof comentarSchema>) {
+    const [post] = await db
+        .select({ id: communityPosts.id })
+        .from(communityPosts)
+        .where(eq(communityPosts.id, postId));
+    if (!post) throw new AppError(404, "Publicação não encontrada");
+    const [c] = await db
+        .insert(communityComments)
+        .values({ postId, userId, content: dados.content.trim() })
+        .returning({ id: communityComments.id });
+    return { id: c.id };
+}
+
+// Dúvidas em aberto: posts do tipo dúvida que ainda não têm nenhum comentário.
+export async function duvidasAbertas(): Promise<number> {
+    const semResposta = db
+        .select({ postId: communityComments.postId })
+        .from(communityComments);
+    const [linha] = await db
+        .select({ n: count() })
+        .from(communityPosts)
+        .where(and(eq(communityPosts.kind, "duvida"), notInArray(communityPosts.id, semResposta)));
+    return Number(linha?.n ?? 0);
+}
+
+export async function tagsPopulares() {
+    const linhas = await db
+        .select({ tag: communityPostTags.tag, n: count() })
+        .from(communityPostTags)
+        .groupBy(communityPostTags.tag)
+        .orderBy(desc(count()))
+        .limit(6);
+    return linhas.map((l) => ({ tag: l.tag, count: Number(l.n) }));
+}
+
+// Discussões em alta: posts recentes com mais respostas.
+export async function discussoesEmAlta() {
+    const linhas = await db
+        .select({
+            id: communityPosts.id,
+            content: communityPosts.content,
+            comentarios: count(communityComments.id),
+            tag: sql<string | null>`(
+                SELECT ${communityPostTags.tag} FROM ${communityPostTags}
+                WHERE ${communityPostTags.postId} = ${communityPosts.id} LIMIT 1
+            )`,
+        })
+        .from(communityPosts)
+        .leftJoin(communityComments, eq(communityComments.postId, communityPosts.id))
+        .where(gt(communityPosts.createdAt, new Date(Date.now() - 30 * 86400000)))
+        .groupBy(communityPosts.id)
+        .orderBy(desc(count(communityComments.id)), desc(communityPosts.createdAt))
+        .limit(4);
+    return linhas
+        .filter((l) => Number(l.comentarios) > 0)
+        .map((l) => ({
+            id: l.id,
+            titulo: l.content.length > 70 ? l.content.slice(0, 70) + "..." : l.content,
+            comentarios: Number(l.comentarios),
+            tag: l.tag,
+        }));
+}
+
+// Sugestões para seguir: usuários com perfil público que o usuário ainda não segue.
+export async function sugestoesParaSeguir(userId: string) {
+    const seguidos = await db
+        .select({ id: userFollows.followingId })
+        .from(userFollows)
+        .where(eq(userFollows.followerId, userId));
+    const excluir = [...seguidos.map((s) => s.id), userId];
+
+    const candidatos = await db
+        .select({
+            id: users.id,
+            name: users.name,
+            username: users.username,
+            avatarUrl: users.avatarUrl,
+        })
+        .from(users)
+        .where(and(notInArray(users.id, excluir), isNotNull(users.username)))
+        .orderBy(desc(users.createdAt))
+        .limit(30);
+    if (candidatos.length === 0) return [];
+
+    const ids = candidatos.map((c) => c.id);
+    const [niveis, respostas] = await Promise.all([
+        niveisDeUsuarios(ids),
+        db
+            .select({ userId: communityComments.userId, n: count() })
+            .from(communityComments)
+            .where(inArray(communityComments.userId, ids))
+            .groupBy(communityComments.userId),
+    ]);
+    const respostasMap = new Map(respostas.map((r) => [r.userId, Number(r.n)]));
+
+    return candidatos
+        .map((c) => ({
+            username: c.username,
+            name: c.name,
+            avatarUrl: c.avatarUrl,
+            level: niveis.get(c.id) ?? 1,
+            respostas: respostasMap.get(c.id) ?? 0,
+        }))
+        .sort((a, b) => b.level - a.level || b.respostas - a.respostas)
+        .slice(0, 3);
+}
+
+export async function estadoSeguir(followerId: string, username: string): Promise<{ seguindo: boolean }> {
+    const [alvo] = await db.select({ id: users.id }).from(users).where(eq(users.username, username));
+    if (!alvo) throw new AppError(404, "Usuário não encontrado");
+    if (alvo.id === followerId) return { seguindo: false };
+    const [rel] = await db
+        .select({ id: userFollows.id })
+        .from(userFollows)
+        .where(and(eq(userFollows.followerId, followerId), eq(userFollows.followingId, alvo.id)));
+    return { seguindo: Boolean(rel) };
+}
+
+export async function seguir(followerId: string, username: string) {
+    const [alvo] = await db.select({ id: users.id }).from(users).where(eq(users.username, username));
+    if (!alvo) throw new AppError(404, "Usuário não encontrado");
+    if (alvo.id === followerId) throw new AppError(400, "Você não pode seguir a si mesmo.");
+    await db.insert(userFollows).values({ followerId, followingId: alvo.id }).onConflictDoNothing();
+    return { seguindo: true };
+}
+
+export async function deixarDeSeguir(followerId: string, username: string) {
+    const [alvo] = await db.select({ id: users.id }).from(users).where(eq(users.username, username));
+    if (!alvo) throw new AppError(404, "Usuário não encontrado");
+    await db
+        .delete(userFollows)
+        .where(and(eq(userFollows.followerId, followerId), eq(userFollows.followingId, alvo.id)));
+    return { seguindo: false };
+}

--- a/backend/src/services/imagens.ts
+++ b/backend/src/services/imagens.ts
@@ -1,0 +1,47 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import { writeFile, mkdir, unlink } from "node:fs/promises";
+import { UPLOADS_DIR } from "../config/paths.ts";
+
+const MIME_EXT: Record<string, string> = {
+    "image/png": "png",
+    "image/jpeg": "jpg",
+    "image/jpg": "jpg",
+    "image/webp": "webp",
+};
+export const MAX_IMG_BYTES = 4 * 1024 * 1024; // 4MB
+
+export type ResultadoImagem = { ok: true; url: string } | { ok: false; erro: string };
+
+// Decodifica uma data URL (base64) e grava em disco com nome aleatorio. O nome
+// nunca vem do cliente, entao nao ha risco de path traversal nem sobrescrita.
+export async function salvarImagem(
+    dataUrl: unknown,
+    destDir: string,
+    urlBase: string,
+    maxBytes = MAX_IMG_BYTES,
+): Promise<ResultadoImagem> {
+    if (typeof dataUrl !== "string") return { ok: false, erro: "Imagem ausente" };
+    const m = /^data:([^;]+);base64,(.+)$/s.exec(dataUrl);
+    if (!m) return { ok: false, erro: "Formato de imagem invalido" };
+    const ext = MIME_EXT[m[1].toLowerCase()];
+    if (!ext) return { ok: false, erro: "Use uma imagem PNG, JPG ou WEBP" };
+    const buffer = Buffer.from(m[2], "base64");
+    if (buffer.length === 0) return { ok: false, erro: "Imagem vazia" };
+    if (buffer.length > maxBytes)
+        return { ok: false, erro: `Imagem muito grande (maximo ${Math.round(maxBytes / 1024 / 1024)}MB)` };
+    await mkdir(destDir, { recursive: true });
+    const nome = `${randomUUID()}.${ext}`;
+    await writeFile(path.join(destDir, nome), buffer);
+    return { ok: true, url: `${urlBase}/${nome}` };
+}
+
+// Remove (best-effort) o arquivo local antigo ao trocar a imagem, evitando orfaos.
+export async function removerArquivoLocal(url: string | null) {
+    if (!url || !url.startsWith("/uploads/")) return;
+    try {
+        await unlink(path.join(UPLOADS_DIR, url.slice("/uploads/".length)));
+    } catch {
+        // arquivo ja removido ou inexistente: ignora
+    }
+}

--- a/backend/tests/comunidade.test.ts
+++ b/backend/tests/comunidade.test.ts
@@ -1,0 +1,269 @@
+import { test, describe, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { startTestServer } from "./helpers/server.ts";
+import { limparBanco } from "./helpers/db.ts";
+
+let server: Awaited<ReturnType<typeof startTestServer>>;
+
+let seq = 0;
+const novoUsuario = () => ({
+    name: "Membro Comunidade",
+    email: `com_${++seq}_${Math.round(performance.now() * 1000)}@email.com`,
+    username: `com_${seq}_${Math.round(performance.now())}`.slice(0, 20),
+    password: "Senhaforte123!",
+    birthDate: "1990-01-01",
+    gender: "outro",
+    phone: "11999998888",
+});
+
+async function verificarEmail(email: string) {
+    const { db } = await import("../db.ts");
+    const { users } = await import("../schema.ts");
+    const { eq } = await import("drizzle-orm");
+    await db.update(users).set({ emailVerifiedAt: new Date() }).where(eq(users.email, email));
+}
+
+async function tornarApoiador(email: string) {
+    const { db } = await import("../db.ts");
+    const { users, subscriptions } = await import("../schema.ts");
+    const { eq } = await import("drizzle-orm");
+    const [u] = await db.select({ id: users.id }).from(users).where(eq(users.email, email));
+    await db.insert(subscriptions).values({
+        userId: u.id,
+        plan: "mensal",
+        status: "ativa",
+        amountCents: 500,
+        paidAt: new Date(),
+        expiresAt: new Date(Date.now() + 30 * 86400000),
+    });
+}
+
+async function criarUsuarioLogado() {
+    const dados = novoUsuario();
+    await server.request("POST", "/register", { body: dados });
+    await verificarEmail(dados.email);
+    const login = await server.request("POST", "/login", {
+        body: { email: dados.email, password: dados.password },
+    });
+    return { ...dados, token: login.body.token as string };
+}
+
+function auth(token: string) {
+    return { Authorization: `Bearer ${token}` };
+}
+async function get(path: string, token: string) {
+    const res = await fetch(`${server.base}${path}`, { headers: auth(token) });
+    return { status: res.status, body: await res.json().catch(() => null) };
+}
+async function post(path: string, token: string, body?: unknown) {
+    const res = await fetch(`${server.base}${path}`, {
+        method: "POST",
+        headers: { ...auth(token), "Content-Type": "application/json" },
+        body: body ? JSON.stringify(body) : undefined,
+    });
+    return { status: res.status, body: await res.json().catch(() => null) };
+}
+async function del(path: string, token: string) {
+    const res = await fetch(`${server.base}${path}`, { method: "DELETE", headers: auth(token) });
+    return { status: res.status, body: await res.json().catch(() => null) };
+}
+
+before(async () => {
+    server = await startTestServer();
+});
+after(async () => {
+    await server.close();
+});
+beforeEach(async () => {
+    await limparBanco();
+});
+
+describe("Comunidade", () => {
+    test("cria publicação com tags e ela aparece no feed com o autor", async () => {
+        const u = await criarUsuarioLogado();
+        const criado = await post("/comunidade/posts", u.token, {
+            kind: "duvida",
+            content: "Por que meu while não para?",
+            code: "while(true){}",
+            codeLanguage: "javascript",
+            tags: ["logica", "While", "logica"],
+        });
+        assert.equal(criado.status, 201);
+        assert.ok(criado.body.id);
+
+        const feed = await get("/comunidade/feed?filtro=recentes", u.token);
+        assert.equal(feed.status, 200);
+        assert.equal(feed.body.length, 1);
+        const p = feed.body[0];
+        assert.equal(p.content, "Por que meu while não para?");
+        assert.equal(p.kind, "duvida");
+        assert.equal(p.code, "while(true){}");
+        assert.equal(p.likes, 0);
+        assert.equal(p.comentarios, 0);
+        assert.equal(p.curtido, false);
+        assert.equal(p.autor.name, u.name);
+        assert.equal(p.autor.username, u.username);
+        assert.equal(p.autor.level, 1);
+        // Tags normalizadas (minúsculas) e sem duplicata.
+        assert.deepEqual([...p.tags].sort(), ["logica", "while"]);
+    });
+
+    test("rejeita publicação sem conteúdo", async () => {
+        const u = await criarUsuarioLogado();
+        const r = await post("/comunidade/posts", u.token, { kind: "post", content: "   " });
+        assert.equal(r.status, 400);
+    });
+
+    test("exige autenticação no feed", async () => {
+        const res = await fetch(`${server.base}/comunidade/feed`);
+        assert.equal(res.status, 401);
+    });
+
+    test("curtir alterna o estado e a contagem", async () => {
+        const autor = await criarUsuarioLogado();
+        const outro = await criarUsuarioLogado();
+        const criado = await post("/comunidade/posts", autor.token, { kind: "post", content: "Olá comunidade" });
+        const id = criado.body.id;
+
+        const curtir = await post(`/comunidade/posts/${id}/curtir`, outro.token);
+        assert.equal(curtir.status, 200);
+        assert.equal(curtir.body.curtido, true);
+        assert.equal(curtir.body.likes, 1);
+
+        const feedOutro = await get("/comunidade/feed?filtro=recentes", outro.token);
+        assert.equal(feedOutro.body[0].curtido, true);
+        assert.equal(feedOutro.body[0].likes, 1);
+
+        // O autor não curtiu: vê o like, mas curtido=false.
+        const feedAutor = await get("/comunidade/feed?filtro=recentes", autor.token);
+        assert.equal(feedAutor.body[0].curtido, false);
+        assert.equal(feedAutor.body[0].likes, 1);
+
+        const descurtir = await post(`/comunidade/posts/${id}/curtir`, outro.token);
+        assert.equal(descurtir.body.curtido, false);
+        assert.equal(descurtir.body.likes, 0);
+    });
+
+    test("comentar aparece na contagem e no detalhe do post", async () => {
+        const autor = await criarUsuarioLogado();
+        const criado = await post("/comunidade/posts", autor.token, {
+            kind: "duvida",
+            content: "Como resolver?",
+        });
+        const id = criado.body.id;
+
+        const c = await post(`/comunidade/posts/${id}/comentarios`, autor.token, { content: "Tente assim" });
+        assert.equal(c.status, 201);
+
+        const detalhe = await get(`/comunidade/posts/${id}`, autor.token);
+        assert.equal(detalhe.status, 200);
+        assert.equal(detalhe.body.comentarios, 1);
+        assert.equal(detalhe.body.comentariosLista.length, 1);
+        assert.equal(detalhe.body.comentariosLista[0].content, "Tente assim");
+    });
+
+    test("filtro por tipo e por 'sem resposta'", async () => {
+        const u = await criarUsuarioLogado();
+        const duvida = await post("/comunidade/posts", u.token, { kind: "duvida", content: "Uma dúvida" });
+        await post("/comunidade/posts", u.token, { kind: "conquista", content: "Uma conquista" });
+
+        const soDuvidas = await get("/comunidade/feed?filtro=duvida", u.token);
+        assert.equal(soDuvidas.body.length, 1);
+        assert.equal(soDuvidas.body[0].kind, "duvida");
+
+        // Comenta na dúvida: deixa de aparecer em "sem resposta".
+        await post(`/comunidade/posts/${duvida.body.id}/comentarios`, u.token, { content: "resposta" });
+        const semResposta = await get("/comunidade/feed?filtro=sem-resposta", u.token);
+        assert.equal(semResposta.body.length, 1);
+        assert.equal(semResposta.body[0].kind, "conquista");
+    });
+
+    test("seguir habilita o filtro 'seguindo' e depois deixar de seguir o esvazia", async () => {
+        const a = await criarUsuarioLogado();
+        const b = await criarUsuarioLogado();
+        await post("/comunidade/posts", b.token, { kind: "post", content: "Post do B" });
+
+        // Antes de seguir, o feed 'seguindo' de A está vazio.
+        const antes = await get("/comunidade/feed?filtro=seguindo", a.token);
+        assert.equal(antes.body.length, 0);
+
+        const seguir = await post(`/comunidade/seguir/${b.username}`, a.token);
+        assert.equal(seguir.status, 200);
+        assert.equal(seguir.body.seguindo, true);
+
+        const depois = await get("/comunidade/feed?filtro=seguindo", a.token);
+        assert.equal(depois.body.length, 1);
+        assert.equal(depois.body[0].content, "Post do B");
+
+        const parar = await del(`/comunidade/seguir/${b.username}`, a.token);
+        assert.equal(parar.body.seguindo, false);
+        const vazio = await get("/comunidade/feed?filtro=seguindo", a.token);
+        assert.equal(vazio.body.length, 0);
+    });
+
+    test("não permite seguir a si mesmo", async () => {
+        const a = await criarUsuarioLogado();
+        const r = await post(`/comunidade/seguir/${a.username}`, a.token);
+        assert.equal(r.status, 400);
+    });
+
+    test("barra lateral traz tópicos e a contagem de dúvidas em aberto", async () => {
+        const u = await criarUsuarioLogado();
+        await post("/comunidade/posts", u.token, { kind: "duvida", content: "Dúvida aberta", tags: ["logica"] });
+        const respondida = await post("/comunidade/posts", u.token, {
+            kind: "duvida",
+            content: "Dúvida respondida",
+            tags: ["logica", "javascript"],
+        });
+        await post(`/comunidade/posts/${respondida.body.id}/comentarios`, u.token, { content: "aqui está" });
+
+        const lateral = await get("/comunidade/lateral", u.token);
+        assert.equal(lateral.status, 200);
+        // Apenas a dúvida sem comentário conta como aberta.
+        assert.equal(lateral.body.duvidasAbertas, 1);
+        const logica = lateral.body.topicos.find((t: { tag: string }) => t.tag === "logica");
+        assert.equal(logica.count, 2);
+    });
+
+    test("filtrar o feed por tag", async () => {
+        const u = await criarUsuarioLogado();
+        await post("/comunidade/posts", u.token, { kind: "post", content: "Sobre arrays", tags: ["array"] });
+        await post("/comunidade/posts", u.token, { kind: "post", content: "Sobre loops", tags: ["logica"] });
+
+        const soArray = await get("/comunidade/feed?tag=array", u.token);
+        assert.equal(soArray.body.length, 1);
+        assert.equal(soArray.body[0].content, "Sobre arrays");
+    });
+
+    test("enviar imagem é bloqueado para quem não é apoiador", async () => {
+        const u = await criarUsuarioLogado();
+        const r = await post("/comunidade/imagem", u.token, {
+            image: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+        });
+        assert.equal(r.status, 403);
+    });
+
+    test("publicar com imagem é bloqueado para quem não é apoiador", async () => {
+        const u = await criarUsuarioLogado();
+        const r = await post("/comunidade/posts", u.token, {
+            kind: "post",
+            content: "olha essa imagem",
+            imageUrl: "/uploads/comunidade/x.jpg",
+        });
+        assert.equal(r.status, 403);
+    });
+
+    test("apoiador consegue publicar com imagem", async () => {
+        const u = await criarUsuarioLogado();
+        await tornarApoiador(u.email);
+        const r = await post("/comunidade/posts", u.token, {
+            kind: "post",
+            content: "olha essa imagem",
+            imageUrl: "/uploads/comunidade/x.jpg",
+        });
+        assert.equal(r.status, 201);
+        const feed = await get("/comunidade/feed?filtro=recentes", u.token);
+        assert.equal(feed.body[0].imageUrl, "/uploads/comunidade/x.jpg");
+        assert.equal(feed.body[0].autor.apoiador, true);
+    });
+});

--- a/backend/tests/helpers/db.ts
+++ b/backend/tests/helpers/db.ts
@@ -6,6 +6,6 @@ export async function limparBanco() {
     // CASCADE remove dependentes por FK; lista trails/lessons explicitamente
     // porque elas nao referenciam users e nao cairiam no cascade.
     await db.execute(
-        sql`TRUNCATE TABLE subscriptions, certificates, roadmap_stage_completions, roadmap_stage_refs, roadmap_stages, roadmaps, comunicado_respostas, comunicados, challenge_submissions, challenge_tests, challenges, simulado_attempt_answers, simulado_attempt_questions, simulado_attempts, simulado_options, simulado_questions, simulados, question_answers, question_options, questions, lessons_progress, lessons, modules, trails, tokens, users RESTART IDENTITY CASCADE`,
+        sql`TRUNCATE TABLE community_comments, community_likes, community_post_tags, community_posts, user_follows, subscriptions, certificates, roadmap_stage_completions, roadmap_stage_refs, roadmap_stages, roadmaps, comunicado_respostas, comunicados, challenge_submissions, challenge_tests, challenges, simulado_attempt_answers, simulado_attempt_questions, simulado_attempts, simulado_options, simulado_questions, simulados, question_answers, question_options, questions, lessons_progress, lessons, modules, trails, tokens, users RESTART IDENTITY CASCADE`,
     );
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -37,9 +37,9 @@ import { OAuthCallback } from './pages/OAuthCallback';
 import { CertificadoValidar } from './pages/CertificadoValidar';
 import { PerfilPublico } from './pages/PerfilPublico';
 import { Progresso } from './pages/Progresso';
+import { Comunidade } from './pages/Comunidade';
 import { Apoie } from './pages/Apoie';
 import { CompletarPerfil } from './pages/CompletarPerfil';
-import { Placeholder } from './pages/Placeholder';
 
 function AuthRoute({ children }: { children: React.JSX.Element }) {
   const { isAuthenticated, loading } = useAuth();
@@ -308,10 +308,7 @@ function AppRoutes() {
         path="/comunidade"
         element={
           <PrivateRoute>
-            <Placeholder
-              title="Comunidade"
-              description="Em breve a atividade da comunidade aparecerá aqui."
-            />
+            <Comunidade />
           </PrivateRoute>
         }
       />

--- a/frontend/src/components/Icons.tsx
+++ b/frontend/src/components/Icons.tsx
@@ -538,3 +538,55 @@ export const Heart = ({ size = 16 }: IconProps) => (
     <path d="M12 21C7 16.5 3 13.2 3 9a5 5 0 0 1 9-3.2A5 5 0 0 1 21 9c0 4.2-4 7.5-9 12z" />
   </svg>
 );
+
+export const House = ({ size = 18 }: IconProps) => (
+  <svg
+    {...base(size)}
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M4 11.5 12 4l8 7.5" />
+    <path d="M6 10.5V20h12v-9.5" />
+  </svg>
+);
+
+export const Code = ({ size = 16 }: IconProps) => (
+  <svg
+    {...base(size)}
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <polyline points="8 8 4 12 8 16" />
+    <polyline points="16 8 20 12 16 16" />
+  </svg>
+);
+
+export const ChatBubble = ({ size = 16 }: IconProps) => (
+  <svg
+    {...base(size)}
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M21 11.5a8.5 8.5 0 0 1-12.3 7.6L3 21l1.9-5.7A8.5 8.5 0 1 1 21 11.5z" />
+  </svg>
+);
+
+export const Share = ({ size = 16 }: IconProps) => (
+  <svg
+    {...base(size)}
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M12 15V4" />
+    <path d="m8 8 4-4 4 4" />
+    <path d="M5 12v7a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-7" />
+  </svg>
+);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5,3 +5,4 @@
 @import './styles/conquistas.css';
 @import './styles/desafio.css';
 @import './styles/trilha-detalhe.css';
+@import './styles/comunidade.css';

--- a/frontend/src/pages/Comunidade/index.tsx
+++ b/frontend/src/pages/Comunidade/index.tsx
@@ -1,0 +1,818 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { useAuth } from '../../contexts/AuthContext';
+import { Logo } from '../../components/Logo';
+import { MobileMenu } from '../../components/MobileMenu';
+import { UserMenu } from '../../components/UserMenu';
+import { ThemeToggle } from '../../components/ThemeToggle';
+import {
+  Flame,
+  Search,
+  House,
+  Users,
+  Help,
+  Check,
+  Trophy,
+  Code,
+  Camera,
+  Heart,
+  ChatBubble,
+  Share,
+  Zap,
+  X,
+} from '../../components/Icons';
+import { getInitials } from '../../utils/initials';
+import { tempoRelativo } from '../../utils/tempo';
+import { urlImagem } from '../../utils/urlImagem';
+import { comprimirImagem, lerArquivoComoDataUrl } from '../../utils/comprimirImagem';
+import { NAV_PRINCIPAL as NAV } from '../../data/nav';
+import { getDesafioDoDia, type DesafioDetalhe } from '../../services/desafios';
+import {
+  obterFeed,
+  obterLateral,
+  publicarPost,
+  alternarCurtida,
+  obterPost,
+  comentarPost,
+  seguir,
+  enviarImagem,
+  type FeedPost,
+  type FiltroFeed,
+  type PostKind,
+  type BarraLateral,
+  type Comentario,
+} from '../../services/comunidade';
+
+const PALETA_AVATAR = ['#5b8def', '#2e9e6b', '#d9536b', '#9b6cd6', '#e0a82e', '#2d6bf5', '#e0653b'];
+
+function corDoNome(chave: string): string {
+  let h = 0;
+  for (let i = 0; i < chave.length; i++) h = (h * 31 + chave.charCodeAt(i)) >>> 0;
+  return PALETA_AVATAR[h % PALETA_AVATAR.length];
+}
+
+const KIND_META: Record<Exclude<PostKind, 'post'>, { label: string; cls: string; Icon: typeof Help }> = {
+  duvida: { label: 'Dúvida', cls: 'ct--duvida', Icon: Help },
+  solucao: { label: 'Solução', cls: 'ct--solucao', Icon: Check },
+  conquista: { label: 'Conquista', cls: 'ct--conquista', Icon: Trophy },
+};
+
+const MENU_ESQUERDO: { key: FiltroFeed; label: string; Icon: typeof House }[] = [
+  { key: 'para-voce', label: 'Para você', Icon: House },
+  { key: 'seguindo', label: 'Seguindo', Icon: Users },
+  { key: 'duvida', label: 'Dúvidas', Icon: Help },
+  { key: 'solucao', label: 'Soluções', Icon: Check },
+  { key: 'conquista', label: 'Conquistas', Icon: Trophy },
+];
+
+const TABS: { key: FiltroFeed; label: string }[] = [
+  { key: 'recentes', label: 'Recentes' },
+  { key: 'em-alta', label: 'Em alta' },
+  { key: 'sem-resposta', label: 'Sem resposta' },
+];
+
+const FILTRO_PRINCIPAL: FiltroFeed[] = ['para-voce', 'recentes', 'em-alta', 'sem-resposta'];
+
+const KINDS_COMPOR: { key: PostKind; label: string }[] = [
+  { key: 'post', label: 'Post' },
+  { key: 'duvida', label: 'Dúvida' },
+  { key: 'solucao', label: 'Solução' },
+  { key: 'conquista', label: 'Conquista' },
+];
+
+function AvatarPessoa({
+  name,
+  avatarUrl,
+  chave,
+  className = '',
+}: {
+  name: string;
+  avatarUrl: string | null;
+  chave: string;
+  className?: string;
+}) {
+  const url = urlImagem(avatarUrl);
+  if (url) return <img src={url} alt={name} className={`com-av ${className}`} />;
+  return (
+    <span className={`com-av com-av--txt ${className}`} style={{ background: corDoNome(chave) }}>
+      {getInitials(name || '?')}
+    </span>
+  );
+}
+
+export function Comunidade() {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  const [params, setParams] = useSearchParams();
+
+  const [filtro, setFiltro] = useState<FiltroFeed>('para-voce');
+  const [tag, setTag] = useState<string | null>(params.get('tag'));
+  const [posts, setPosts] = useState<FeedPost[]>([]);
+  const [lateral, setLateral] = useState<BarraLateral | null>(null);
+  const [desafio, setDesafio] = useState<DesafioDetalhe | null>(null);
+  const [carregando, setCarregando] = useState(true);
+  const [erro, setErro] = useState('');
+  const [busca, setBusca] = useState('');
+  const [copiado, setCopiado] = useState<string | null>(null);
+  const [seguindo, setSeguindo] = useState<Set<string>>(new Set());
+
+  const displayName = user?.name ?? '';
+  const initials = getInitials(displayName || 'A');
+
+  async function carregarFeed(f: FiltroFeed, t: string | null) {
+    setCarregando(true);
+    setErro('');
+    try {
+      setPosts(await obterFeed(f, t));
+    } catch {
+      setErro('Não foi possível carregar o feed. Tente novamente.');
+    } finally {
+      setCarregando(false);
+    }
+  }
+
+  useEffect(() => {
+    carregarFeed(filtro, tag);
+  }, [filtro, tag]);
+
+  useEffect(() => {
+    obterLateral().then(setLateral).catch(() => setLateral(null));
+    getDesafioDoDia().then(setDesafio).catch(() => setDesafio(null));
+  }, []);
+
+  function abrirTag(t: string) {
+    setTag(t);
+    setFiltro('para-voce');
+    setParams(t ? { tag: t } : {});
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }
+
+  function limparTag() {
+    setTag(null);
+    setParams({});
+  }
+
+  function selecionarFiltro(f: FiltroFeed) {
+    setTag(null);
+    setParams({});
+    setFiltro(f);
+  }
+
+  async function toggleCurtida(post: FeedPost) {
+    const eraCurtido = post.curtido;
+    setPosts((prev) =>
+      prev.map((p) =>
+        p.id === post.id ? { ...p, curtido: !eraCurtido, likes: p.likes + (eraCurtido ? -1 : 1) } : p,
+      ),
+    );
+    try {
+      const r = await alternarCurtida(post.id);
+      setPosts((prev) => prev.map((p) => (p.id === post.id ? { ...p, curtido: r.curtido, likes: r.likes } : p)));
+    } catch {
+      setPosts((prev) =>
+        prev.map((p) => (p.id === post.id ? { ...p, curtido: eraCurtido, likes: post.likes } : p)),
+      );
+    }
+  }
+
+  function compartilhar(post: FeedPost) {
+    const link = `${window.location.origin}/comunidade?post=${post.id}`;
+    navigator.clipboard?.writeText(link).catch(() => {});
+    setCopiado(post.id);
+    setTimeout(() => setCopiado((c) => (c === post.id ? null : c)), 1600);
+  }
+
+  async function seguirSugestao(username: string) {
+    setSeguindo((prev) => new Set(prev).add(username));
+    try {
+      await seguir(username);
+    } catch {
+      setSeguindo((prev) => {
+        const n = new Set(prev);
+        n.delete(username);
+        return n;
+      });
+    }
+  }
+
+  const postsFiltrados = useMemo(() => {
+    const termo = busca.trim().toLowerCase();
+    if (!termo) return posts;
+    return posts.filter(
+      (p) =>
+        p.content.toLowerCase().includes(termo) ||
+        p.autor.name.toLowerCase().includes(termo) ||
+        (p.autor.username ?? '').toLowerCase().includes(termo) ||
+        p.tags.some((t) => t.includes(termo)),
+    );
+  }, [posts, busca]);
+
+  const postDestaque = params.get('post');
+
+  return (
+    <div className="home-shell">
+      <div className="home">
+        <header className="topbar">
+          <MobileMenu />
+          <Logo variant="solid" size={20} to="/home" />
+          <nav className="nav">
+            {NAV.map((item) => (
+              <Link
+                key={item.to}
+                to={item.to}
+                className={`nav__item${item.to === '/comunidade' ? ' nav__item--active' : ''}`}
+              >
+                {item.label}
+              </Link>
+            ))}
+          </nav>
+          <div className="topbar__spacer" />
+          <label className="searchbar com-search">
+            <Search size={16} />
+            <input
+              value={busca}
+              onChange={(e) => setBusca(e.target.value)}
+              placeholder="Buscar na comunidade…"
+            />
+          </label>
+          <div className="streak-pill">
+            <Flame size={16} /> {user?.streak ?? 0}
+          </div>
+          <ThemeToggle inline />
+          <UserMenu
+            initials={initials}
+            level={user?.level ?? 1}
+            name={displayName}
+            email={user?.email}
+          />
+        </header>
+
+        <div className="com">
+          <aside className="com__left">
+            <nav className="com-menu">
+              {MENU_ESQUERDO.map(({ key, label, Icon }) => {
+                const ativo =
+                  key === 'para-voce' ? FILTRO_PRINCIPAL.includes(filtro) && !tag : filtro === key && !tag;
+                const badge = key === 'duvida' ? lateral?.duvidasAbertas ?? 0 : 0;
+                return (
+                  <button
+                    key={key}
+                    className={`com-menu__item${ativo ? ' com-menu__item--on' : ''}`}
+                    onClick={() => selecionarFiltro(key)}
+                  >
+                    <Icon size={18} />
+                    <span>{label}</span>
+                    {badge > 0 && <span className="com-menu__badge">{badge}</span>}
+                  </button>
+                );
+              })}
+            </nav>
+
+            {lateral && lateral.topicos.length > 0 && (
+              <div className="card com-topicos">
+                <div className="com-topicos__titulo">Tópicos populares</div>
+                {lateral.topicos.map((t) => (
+                  <button key={t.tag} className="com-topicos__item" onClick={() => abrirTag(t.tag)}>
+                    <span className="com-topicos__tag">#{t.tag}</span>
+                    <span className="com-topicos__n">{formatarMilhar(t.count)}</span>
+                  </button>
+                ))}
+              </div>
+            )}
+          </aside>
+
+          <main className="com__feed">
+            <Composer
+              nome={displayName}
+              avatarUrl={user?.avatarUrl ?? null}
+              chave={user?.username ?? user?.email ?? displayName}
+              apoiador={Boolean(user?.apoiador)}
+              onPublicado={() => carregarFeed(filtro, tag)}
+            />
+
+            {tag ? (
+              <div className="com-tagbar">
+                <span>
+                  Publicações com <strong>#{tag}</strong>
+                </span>
+                <button onClick={limparTag} className="com-tagbar__x">
+                  <X size={14} /> limpar
+                </button>
+              </div>
+            ) : (
+              FILTRO_PRINCIPAL.includes(filtro) && (
+                <div className="com-tabs">
+                  {TABS.map((t) => {
+                    const ativo = filtro === t.key || (t.key === 'recentes' && filtro === 'para-voce');
+                    return (
+                      <button
+                        key={t.key}
+                        className={`com-tab${ativo ? ' com-tab--on' : ''}`}
+                        onClick={() => setFiltro(t.key)}
+                      >
+                        {t.label}
+                      </button>
+                    );
+                  })}
+                </div>
+              )
+            )}
+
+            {erro && <div className="auth__alert">{erro}</div>}
+            {carregando && posts.length === 0 && <p className="com-vazio">Carregando publicações…</p>}
+            {!carregando && postsFiltrados.length === 0 && !erro && (
+              <p className="com-vazio">
+                {busca
+                  ? 'Nada encontrado para essa busca.'
+                  : tag
+                    ? 'Ainda não há publicações com essa tag.'
+                    : filtro === 'seguindo'
+                      ? 'Você ainda não segue ninguém, ou quem você segue ainda não publicou.'
+                      : 'Ainda não há publicações por aqui. Seja o primeiro a compartilhar.'}
+              </p>
+            )}
+
+            {postsFiltrados.map((post) => (
+              <PostCard
+                key={post.id}
+                post={post}
+                destaque={post.id === postDestaque}
+                copiado={copiado === post.id}
+                onCurtir={() => toggleCurtida(post)}
+                onCompartilhar={() => compartilhar(post)}
+                onTag={abrirTag}
+                onPerfil={(u) => navigate(`/${u}`)}
+              />
+            ))}
+          </main>
+
+          <aside className="com__right">
+            <button className="com-desafio" onClick={() => navigate('/desafios')}>
+              <div className="com-desafio__eyebrow">Desafio de hoje</div>
+              <div className="com-desafio__titulo">{desafio ? desafio.title : 'Desafios diários'}</div>
+              <p className="com-desafio__desc">
+                {desafio
+                  ? `Resolva e ganhe +${desafio.xp} XP. Mantenha sua sequência viva.`
+                  : 'Resolva um desafio por dia, ganhe XP e mantenha sua sequência.'}
+              </p>
+              <span className="com-desafio__cta">
+                <Zap size={15} /> {desafio?.solved ? 'Revisar desafio' : 'Resolver agora'}
+              </span>
+            </button>
+
+            {lateral && lateral.discussoes.length > 0 && (
+              <div className="card com-side">
+                <div className="com-side__titulo">Discussões em alta</div>
+                {lateral.discussoes.map((d) => (
+                  <button key={d.id} className="com-disc" onClick={() => compartilharDiscussao(d.id, setParams)}>
+                    {d.tag && <span className="com-disc__tag">#{d.tag}</span>}
+                    <span className="com-disc__titulo">{d.titulo}</span>
+                    <span className="com-disc__n">{d.comentarios} respostas</span>
+                  </button>
+                ))}
+              </div>
+            )}
+
+            {lateral && lateral.sugestoes.length > 0 && (
+              <div className="card com-side">
+                <div className="com-side__titulo">Sugestões para seguir</div>
+                {lateral.sugestoes.map((s) => (
+                  <div key={s.username} className="com-sug">
+                    <button className="com-sug__pessoa" onClick={() => navigate(`/${s.username}`)}>
+                      <AvatarPessoa name={s.name} avatarUrl={s.avatarUrl} chave={s.username} />
+                      <span className="com-sug__info">
+                        <span className="com-sug__nome">{s.name}</span>
+                        <span className="com-sug__sub">
+                          Nível {s.level}
+                          {s.respostas > 0 ? ` · ${s.respostas} respostas` : ''}
+                        </span>
+                      </span>
+                    </button>
+                    <button
+                      className={`com-sug__btn${seguindo.has(s.username) ? ' com-sug__btn--on' : ''}`}
+                      disabled={seguindo.has(s.username)}
+                      onClick={() => seguirSugestao(s.username)}
+                    >
+                      {seguindo.has(s.username) ? 'Seguindo' : 'Seguir'}
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </aside>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function formatarMilhar(n: number): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(n >= 10000 ? 0 : 1).replace('.', ',')}k`;
+  return String(n);
+}
+
+function compartilharDiscussao(id: string, setParams: ReturnType<typeof useSearchParams>[1]) {
+  setParams({ post: id });
+  window.scrollTo({ top: 0, behavior: 'smooth' });
+}
+
+function Composer({
+  nome,
+  avatarUrl,
+  chave,
+  apoiador,
+  onPublicado,
+}: {
+  nome: string;
+  avatarUrl: string | null;
+  chave: string;
+  apoiador: boolean;
+  onPublicado: () => void;
+}) {
+  const [aberto, setAberto] = useState(false);
+  const [kind, setKind] = useState<PostKind>('post');
+  const [content, setContent] = useState('');
+  const [comCodigo, setComCodigo] = useState(false);
+  const [code, setCode] = useState('');
+  const [linguagem, setLinguagem] = useState('javascript');
+  const [tagsTexto, setTagsTexto] = useState('');
+  const [imagem, setImagem] = useState<string | null>(null);
+  const [enviando, setEnviando] = useState(false);
+  const [erro, setErro] = useState('');
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  function reset() {
+    setAberto(false);
+    setKind('post');
+    setContent('');
+    setComCodigo(false);
+    setCode('');
+    setTagsTexto('');
+    setImagem(null);
+    setErro('');
+  }
+
+  async function escolherImagem(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    e.target.value = '';
+    if (!file) return;
+    try {
+      const dataUrl = await lerArquivoComoDataUrl(file);
+      setImagem(await comprimirImagem(dataUrl));
+      setAberto(true);
+    } catch {
+      setErro('Não foi possível carregar a imagem.');
+    }
+  }
+
+  async function publicar() {
+    if (enviando) return;
+    if (!content.trim()) {
+      setErro('Escreva algo antes de publicar.');
+      return;
+    }
+    setEnviando(true);
+    setErro('');
+    try {
+      let imageUrl: string | undefined;
+      if (imagem) imageUrl = await enviarImagem(imagem);
+      const tags = tagsTexto
+        .split(/[\s,]+/)
+        .map((t) => t.replace(/^#/, '').trim().toLowerCase())
+        .filter(Boolean)
+        .slice(0, 5);
+      await publicarPost({
+        kind,
+        content: content.trim(),
+        code: comCodigo && code.trim() ? code : undefined,
+        codeLanguage: comCodigo && code.trim() ? linguagem : undefined,
+        tags,
+        imageUrl,
+      });
+      reset();
+      onPublicado();
+    } catch {
+      setErro('Não foi possível publicar. Tente novamente.');
+      setEnviando(false);
+    }
+  }
+
+  return (
+    <div className="card com-composer">
+      <div className="com-composer__topo">
+        <AvatarPessoa name={nome} avatarUrl={avatarUrl} chave={chave} />
+        {aberto ? (
+          <textarea
+            className="com-composer__area"
+            autoFocus
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            placeholder="Compartilhe uma dúvida, solução ou conquista…"
+            rows={3}
+            maxLength={2000}
+          />
+        ) : (
+          <button className="com-composer__fake" onClick={() => setAberto(true)}>
+            Compartilhe uma dúvida, solução ou conquista…
+          </button>
+        )}
+      </div>
+
+      {aberto && (
+        <>
+          <div className="com-composer__kinds">
+            {KINDS_COMPOR.map((k) => (
+              <button
+                key={k.key}
+                className={`com-kchip${kind === k.key ? ' com-kchip--on' : ''}`}
+                onClick={() => setKind(k.key)}
+              >
+                {k.label}
+              </button>
+            ))}
+          </div>
+
+          {comCodigo && (
+            <div className="com-composer__code">
+              <div className="com-composer__codehead">
+                <select value={linguagem} onChange={(e) => setLinguagem(e.target.value)}>
+                  {['javascript', 'typescript', 'python', 'java', 'c++', 'go', 'sql', 'html', 'css', 'bash'].map(
+                    (l) => (
+                      <option key={l} value={l}>
+                        {l}
+                      </option>
+                    ),
+                  )}
+                </select>
+                <button onClick={() => setComCodigo(false)} className="com-composer__coderm">
+                  <X size={13} /> remover código
+                </button>
+              </div>
+              <textarea
+                className="com-composer__codearea"
+                value={code}
+                onChange={(e) => setCode(e.target.value)}
+                placeholder="Cole seu código aqui…"
+                spellCheck={false}
+                rows={5}
+              />
+            </div>
+          )}
+
+          {imagem && (
+            <div className="com-composer__img">
+              <img src={imagem} alt="Prévia" />
+              <button onClick={() => setImagem(null)} className="com-composer__imgrm">
+                <X size={14} />
+              </button>
+            </div>
+          )}
+
+          <input
+            className="com-composer__tags"
+            value={tagsTexto}
+            onChange={(e) => setTagsTexto(e.target.value)}
+            placeholder="Tags separadas por espaço: logica while array"
+          />
+
+          {erro && <div className="com-composer__erro">{erro}</div>}
+
+          <div className="com-composer__acoes">
+            <div className="com-composer__ferramentas">
+              <button
+                className={`com-composer__ferr${comCodigo ? ' com-composer__ferr--on' : ''}`}
+                onClick={() => setComCodigo((v) => !v)}
+              >
+                <Code size={16} /> Código
+              </button>
+              {apoiador && (
+                <>
+                  <button className="com-composer__ferr" onClick={() => fileRef.current?.click()}>
+                    <Camera size={15} /> Imagem
+                  </button>
+                  <input
+                    ref={fileRef}
+                    type="file"
+                    accept="image/png,image/jpeg,image/webp"
+                    hidden
+                    onChange={escolherImagem}
+                  />
+                </>
+              )}
+            </div>
+            <div className="com-composer__enviar">
+              <button className="com-composer__cancelar" onClick={reset} disabled={enviando}>
+                Cancelar
+              </button>
+              <button
+                className="btn btn--accent com-composer__publicar"
+                onClick={publicar}
+                disabled={enviando || !content.trim()}
+              >
+                {enviando ? 'Publicando…' : 'Publicar'}
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+
+      {!aberto && (
+        <div className="com-composer__atalhos">
+          <button className="com-composer__ferr" onClick={() => { setComCodigo(true); setAberto(true); }}>
+            <Code size={16} /> Código
+          </button>
+          {apoiador && (
+            <>
+              <button className="com-composer__ferr" onClick={() => fileRef.current?.click()}>
+                <Camera size={15} /> Imagem
+              </button>
+              <input
+                ref={fileRef}
+                type="file"
+                accept="image/png,image/jpeg,image/webp"
+                hidden
+                onChange={escolherImagem}
+              />
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PostCard({
+  post,
+  destaque,
+  copiado,
+  onCurtir,
+  onCompartilhar,
+  onTag,
+  onPerfil,
+}: {
+  post: FeedPost;
+  destaque: boolean;
+  copiado: boolean;
+  onCurtir: () => void;
+  onCompartilhar: () => void;
+  onTag: (t: string) => void;
+  onPerfil: (username: string) => void;
+}) {
+  const [abertoComentarios, setAbertoComentarios] = useState(destaque);
+  const [comentarios, setComentarios] = useState<Comentario[] | null>(null);
+  const [carregandoCom, setCarregandoCom] = useState(false);
+  const [novoComentario, setNovoComentario] = useState('');
+  const [enviandoCom, setEnviandoCom] = useState(false);
+  const [totalCom, setTotalCom] = useState(post.comentarios);
+  const cardRef = useRef<HTMLElement>(null);
+
+  const meta = post.kind !== 'post' ? KIND_META[post.kind] : null;
+
+  useEffect(() => {
+    if (destaque && cardRef.current) {
+      cardRef.current.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  async function carregarComentarios() {
+    setCarregandoCom(true);
+    try {
+      const detalhe = await obterPost(post.id);
+      setComentarios(detalhe.comentariosLista);
+      setTotalCom(detalhe.comentarios);
+    } catch {
+      setComentarios([]);
+    } finally {
+      setCarregandoCom(false);
+    }
+  }
+
+  function alternarComentarios() {
+    const abrir = !abertoComentarios;
+    setAbertoComentarios(abrir);
+    if (abrir && comentarios === null) carregarComentarios();
+  }
+
+  useEffect(() => {
+    if (destaque && comentarios === null) carregarComentarios();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  async function enviarComentario() {
+    const texto = novoComentario.trim();
+    if (!texto || enviandoCom) return;
+    setEnviandoCom(true);
+    try {
+      await comentarPost(post.id, texto);
+      setNovoComentario('');
+      await carregarComentarios();
+    } catch {
+      // mantém o texto para o usuário tentar de novo
+    } finally {
+      setEnviandoCom(false);
+    }
+  }
+
+  return (
+    <article ref={cardRef} className={`com-post${destaque ? ' com-post--destaque' : ''}`}>
+      <div className="com-post__head">
+        <button className="com-post__autor" onClick={() => post.autor.username && onPerfil(post.autor.username)}>
+          <AvatarPessoa name={post.autor.name} avatarUrl={post.autor.avatarUrl} chave={post.autor.username ?? post.autor.name} />
+          <span className="com-post__ident">
+            <span className="com-post__nome">
+              {post.autor.name}
+              <span className="com-post__lv">Lv {post.autor.level}</span>
+              {post.autor.apoiador && <span className="com-post__apoiador">Apoiador</span>}
+            </span>
+            <span className="com-post__meta">
+              {post.autor.username ? `@${post.autor.username}` : 'sem @'} · {tempoRelativo(post.createdAt)}
+            </span>
+          </span>
+        </button>
+        {meta && (
+          <span className={`com-ct ${meta.cls}`}>
+            <meta.Icon size={13} /> {meta.label}
+          </span>
+        )}
+      </div>
+
+      <p className="com-post__texto">{post.content}</p>
+
+      {post.code && (
+        <pre className="com-post__code">
+          <code>{post.code}</code>
+        </pre>
+      )}
+
+      {post.imageUrl && (
+        <div className="com-post__imagem">
+          <img src={urlImagem(post.imageUrl) ?? ''} alt="Imagem da publicação" loading="lazy" />
+        </div>
+      )}
+
+      {post.tags.length > 0 && (
+        <div className="com-post__tags">
+          {post.tags.map((t) => (
+            <button key={t} className="com-hash" onClick={() => onTag(t)}>
+              #{t}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <div className="com-post__acoes">
+        <button
+          className={`com-acao${post.curtido ? ' com-acao--curtido' : ''}`}
+          onClick={onCurtir}
+        >
+          <Heart size={17} /> {post.likes}
+        </button>
+        <button className="com-acao" onClick={alternarComentarios}>
+          <ChatBubble size={17} /> {totalCom}
+        </button>
+        <button className="com-acao" onClick={onCompartilhar}>
+          <Share size={16} /> {copiado ? 'Copiado!' : 'Compartilhar'}
+        </button>
+      </div>
+
+      {abertoComentarios && (
+        <div className="com-thread">
+          <div className="com-thread__novo">
+            <textarea
+              value={novoComentario}
+              onChange={(e) => setNovoComentario(e.target.value)}
+              placeholder="Escreva um comentário…"
+              rows={2}
+              maxLength={1000}
+            />
+            <button
+              className="btn btn--accent com-thread__enviar"
+              onClick={enviarComentario}
+              disabled={enviandoCom || !novoComentario.trim()}
+            >
+              {enviandoCom ? '...' : 'Responder'}
+            </button>
+          </div>
+          {carregandoCom && <p className="com-thread__vazio">Carregando comentários…</p>}
+          {comentarios?.map((c) => (
+            <div key={c.id} className="com-coment">
+              <AvatarPessoa name={c.autor.name} avatarUrl={c.autor.avatarUrl} chave={c.autor.username ?? c.autor.name} />
+              <div className="com-coment__corpo">
+                <div className="com-coment__head">
+                  <span className="com-coment__nome">{c.autor.name}</span>
+                  <span className="com-coment__lv">Lv {c.autor.level}</span>
+                  <span className="com-coment__tempo">{tempoRelativo(c.createdAt)}</span>
+                </div>
+                <p className="com-coment__texto">{c.content}</p>
+              </div>
+            </div>
+          ))}
+          {comentarios && comentarios.length === 0 && !carregandoCom && (
+            <p className="com-thread__vazio">Ainda não há comentários. Seja o primeiro a responder.</p>
+          )}
+        </div>
+      )}
+    </article>
+  );
+}

--- a/frontend/src/pages/PerfilPublico/index.tsx
+++ b/frontend/src/pages/PerfilPublico/index.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState, type ReactNode } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { Logo } from '../../components/Logo';
+import { MobileMenu } from '../../components/MobileMenu';
+import { UserMenu } from '../../components/UserMenu';
 import { ThemeToggle } from '../../components/ThemeToggle';
 import {
   Flame,
@@ -18,7 +20,9 @@ import {
 } from '../../components/Icons';
 import { getInitials } from '../../utils/initials';
 import { urlImagem } from '../../utils/urlImagem';
+import { NAV_PRINCIPAL as NAV } from '../../data/nav';
 import { obterPerfilPublico, type PerfilPublicoData } from '../../services/perfis';
+import { estadoSeguir, seguir, deixarDeSeguir } from '../../services/comunidade';
 
 const NIVEL: Record<string, string> = {
   iniciante: 'Iniciante',
@@ -42,10 +46,12 @@ function urlSocial(valor: string, prefixo: string): string {
 
 export function PerfilPublico() {
   const { username } = useParams();
-  const { isAuthenticated } = useAuth();
+  const { user, isAuthenticated } = useAuth();
   const [perfil, setPerfil] = useState<PerfilPublicoData | null>(null);
   const [estado, setEstado] = useState<'carregando' | 'ok' | 'nao_encontrado'>('carregando');
   const [copiado, setCopiado] = useState(false);
+  const [seguindo, setSeguindo] = useState<boolean | null>(null);
+  const [salvandoSeguir, setSalvandoSeguir] = useState(false);
 
   useEffect(() => {
     if (!username) return;
@@ -57,6 +63,29 @@ export function PerfilPublico() {
       })
       .catch(() => setEstado('nao_encontrado'));
   }, [username]);
+
+  useEffect(() => {
+    setSeguindo(null);
+    if (!username || !isAuthenticated) return;
+    estadoSeguir(username)
+      .then(setSeguindo)
+      .catch(() => setSeguindo(null));
+  }, [username, isAuthenticated]);
+
+  async function alternarSeguir() {
+    if (!username || salvandoSeguir || seguindo === null) return;
+    const antes = seguindo;
+    setSeguindo(!antes);
+    setSalvandoSeguir(true);
+    try {
+      if (antes) await deixarDeSeguir(username);
+      else await seguir(username);
+    } catch {
+      setSeguindo(antes);
+    } finally {
+      setSalvandoSeguir(false);
+    }
+  }
 
   async function copiarLink() {
     try {
@@ -74,14 +103,39 @@ export function PerfilPublico() {
   return (
     <div className="home-shell">
       <div className="home">
-        <header className="topbar">
-          <Logo variant="solid" size={20} to={isAuthenticated ? '/home' : '/'} />
-          <div className="topbar__spacer" />
-          <ThemeToggle inline />
-          <Link className="btn btn--ghost" to={isAuthenticated ? '/home' : '/'}>
-            {isAuthenticated ? 'Ir para o início' : 'Entrar'}
-          </Link>
-        </header>
+        {isAuthenticated ? (
+          <header className="topbar">
+            <MobileMenu />
+            <Logo variant="solid" size={20} to="/home" />
+            <nav className="nav">
+              {NAV.map((item) => (
+                <Link key={item.to} to={item.to} className="nav__item">
+                  {item.label}
+                </Link>
+              ))}
+            </nav>
+            <div className="topbar__spacer" />
+            <div className="streak-pill">
+              <Flame size={16} /> {user?.streak ?? 0}
+            </div>
+            <ThemeToggle inline />
+            <UserMenu
+              initials={getInitials(user?.name || 'A')}
+              level={user?.level ?? 1}
+              name={user?.name ?? ''}
+              email={user?.email}
+            />
+          </header>
+        ) : (
+          <header className="topbar">
+            <Logo variant="solid" size={20} to="/" />
+            <div className="topbar__spacer" />
+            <ThemeToggle inline />
+            <Link className="btn btn--ghost" to="/">
+              Entrar
+            </Link>
+          </header>
+        )}
 
         {estado === 'carregando' && (
           <p className="track__desc" style={{ padding: '40px 26px' }}>
@@ -144,6 +198,21 @@ export function PerfilPublico() {
                   <div className="pf-id__user">@{perfil.username}</div>
                 </div>
                 <div className="pf-actions">
+                  {isAuthenticated && seguindo !== null && (
+                    <button
+                      className={`btn ${seguindo ? 'btn--ghost' : 'btn--accent'} pf-actions__btn`}
+                      onClick={alternarSeguir}
+                      disabled={salvandoSeguir}
+                    >
+                      {seguindo ? (
+                        <>
+                          <Check size={14} /> Seguindo
+                        </>
+                      ) : (
+                        'Seguir'
+                      )}
+                    </button>
+                  )}
                   <button className="btn btn--ghost pf-actions__btn" onClick={copiarLink}>
                     {copiado ? (
                       <>

--- a/frontend/src/services/comunidade.ts
+++ b/frontend/src/services/comunidade.ts
@@ -1,0 +1,112 @@
+import api from './api';
+
+export type PostKind = 'duvida' | 'solucao' | 'conquista' | 'post';
+
+export type FiltroFeed =
+  | 'para-voce'
+  | 'recentes'
+  | 'em-alta'
+  | 'sem-resposta'
+  | 'seguindo'
+  | 'duvida'
+  | 'solucao'
+  | 'conquista';
+
+export interface AutorPost {
+  name: string;
+  username: string | null;
+  avatarUrl: string | null;
+  level: number;
+  apoiador: boolean;
+}
+
+export interface FeedPost {
+  id: string;
+  kind: PostKind;
+  content: string;
+  code: string | null;
+  codeLanguage: string | null;
+  imageUrl: string | null;
+  createdAt: string;
+  tags: string[];
+  likes: number;
+  comentarios: number;
+  curtido: boolean;
+  autor: AutorPost;
+}
+
+export interface Comentario {
+  id: string;
+  content: string;
+  createdAt: string;
+  autor: Omit<AutorPost, 'apoiador'>;
+}
+
+export interface PostDetalhe extends FeedPost {
+  comentariosLista: Comentario[];
+}
+
+export interface BarraLateral {
+  topicos: { tag: string; count: number }[];
+  discussoes: { id: string; titulo: string; comentarios: number; tag: string | null }[];
+  sugestoes: { username: string; name: string; avatarUrl: string | null; level: number; respostas: number }[];
+  duvidasAbertas: number;
+}
+
+export interface NovoPost {
+  kind: PostKind;
+  content: string;
+  code?: string;
+  codeLanguage?: string;
+  tags?: string[];
+}
+
+export async function obterFeed(filtro: FiltroFeed, tag?: string | null) {
+  const { data } = await api.get<FeedPost[]>('/comunidade/feed', { params: { filtro, tag: tag || undefined } });
+  return data;
+}
+
+export async function obterLateral() {
+  const { data } = await api.get<BarraLateral>('/comunidade/lateral');
+  return data;
+}
+
+export async function publicarPost(dados: NovoPost & { imageUrl?: string }) {
+  const { data } = await api.post<{ id: string }>('/comunidade/posts', dados);
+  return data;
+}
+
+export async function enviarImagem(image: string) {
+  const { data } = await api.post<{ url: string }>('/comunidade/imagem', { image });
+  return data.url;
+}
+
+export async function obterPost(id: string) {
+  const { data } = await api.get<PostDetalhe>(`/comunidade/posts/${id}`);
+  return data;
+}
+
+export async function alternarCurtida(id: string) {
+  const { data } = await api.post<{ curtido: boolean; likes: number }>(`/comunidade/posts/${id}/curtir`);
+  return data;
+}
+
+export async function comentarPost(id: string, content: string) {
+  const { data } = await api.post<{ id: string }>(`/comunidade/posts/${id}/comentarios`, { content });
+  return data;
+}
+
+export async function estadoSeguir(username: string) {
+  const { data } = await api.get<{ seguindo: boolean }>(`/comunidade/seguir/${username}`);
+  return data.seguindo;
+}
+
+export async function seguir(username: string) {
+  const { data } = await api.post<{ seguindo: boolean }>(`/comunidade/seguir/${username}`);
+  return data;
+}
+
+export async function deixarDeSeguir(username: string) {
+  const { data } = await api.delete<{ seguindo: boolean }>(`/comunidade/seguir/${username}`);
+  return data;
+}

--- a/frontend/src/styles/comunidade.css
+++ b/frontend/src/styles/comunidade.css
@@ -1,0 +1,901 @@
+/* Comunidade — feed social em 3 colunas. Usa os tokens do tema (claro/escuro). */
+
+.com {
+  display: grid;
+  grid-template-columns: 232px 1fr 320px;
+  gap: 24px;
+  padding: 28px 40px 60px;
+  max-width: 1500px;
+  margin: 0 auto;
+  align-items: start;
+}
+
+.com__left,
+.com__right {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  position: sticky;
+  top: 22px;
+}
+.com__feed {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-width: 0;
+}
+
+/* Busca no topo: reaproveita .searchbar mas vira input real. */
+.com-search {
+  width: 260px;
+}
+.com-search input {
+  border: none;
+  background: transparent;
+  outline: none;
+  color: var(--text);
+  font-size: 13.5px;
+  width: 100%;
+}
+.com-search input::placeholder {
+  color: var(--muted);
+}
+
+/* ---------- Coluna esquerda ---------- */
+.com-menu {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-xl);
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.com-menu__item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  padding: 11px 13px;
+  border: none;
+  background: transparent;
+  border-radius: var(--r-md);
+  color: var(--muted);
+  font-size: 14.5px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 0.14s ease, color 0.14s ease;
+}
+.com-menu__item:hover {
+  background: var(--surface-2);
+  color: var(--text);
+}
+.com-menu__item--on {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+.com-menu__item span {
+  flex: 1;
+  text-align: left;
+}
+.com-menu__badge {
+  flex: none;
+  min-width: 22px;
+  height: 20px;
+  padding: 0 6px;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.com-menu__item--on .com-menu__badge {
+  background: var(--accent);
+  color: var(--on-accent);
+}
+
+.com-topicos {
+  padding: 16px 16px 10px;
+}
+.com-topicos__titulo {
+  font-size: 11.5px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 10px;
+}
+.com-topicos__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 7px 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-family: inherit;
+}
+.com-topicos__tag {
+  color: var(--accent);
+  font-weight: 600;
+  font-size: 14px;
+}
+.com-topicos__item:hover .com-topicos__tag {
+  text-decoration: underline;
+}
+.com-topicos__n {
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 500;
+}
+
+/* ---------- Avatares ---------- */
+.com-av {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.com-av--txt {
+  color: #fff;
+  font-weight: 700;
+  font-size: 15px;
+  letter-spacing: 0.02em;
+}
+
+/* ---------- Composer ---------- */
+.com-composer {
+  padding: 16px;
+}
+.com-composer__topo {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+}
+.com-composer__fake {
+  flex: 1;
+  text-align: left;
+  min-height: 44px;
+  padding: 12px 14px;
+  border-radius: var(--r-lg);
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 14.5px;
+  font-family: inherit;
+  cursor: text;
+}
+.com-composer__area {
+  flex: 1;
+  min-height: 72px;
+  padding: 11px 14px;
+  border-radius: var(--r-lg);
+  background: var(--input);
+  border: 1px solid var(--border-strong);
+  color: var(--text);
+  font-size: 14.5px;
+  font-family: inherit;
+  line-height: 1.55;
+  resize: vertical;
+  outline: none;
+}
+.com-composer__area:focus {
+  border-color: var(--accent);
+}
+
+.com-composer__kinds {
+  display: flex;
+  gap: 8px;
+  margin: 12px 0 0 54px;
+  flex-wrap: wrap;
+}
+.com-kchip {
+  padding: 5px 13px;
+  border-radius: 999px;
+  border: 1px solid var(--border-strong);
+  background: transparent;
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+}
+.com-kchip--on {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--on-accent);
+}
+
+.com-composer__code {
+  margin: 12px 0 0 54px;
+}
+.com-composer__codehead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 6px;
+}
+.com-composer__codehead select {
+  height: 32px;
+  border-radius: var(--r-sm);
+  border: 1px solid var(--border-strong);
+  background: var(--input);
+  color: var(--text);
+  font-family: inherit;
+  font-size: 13px;
+  padding: 0 8px;
+}
+.com-composer__coderm,
+.com-composer__imgrm,
+.com-tagbar__x {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  font-size: 12.5px;
+  font-family: inherit;
+  cursor: pointer;
+}
+.com-composer__coderm:hover,
+.com-tagbar__x:hover {
+  color: var(--text);
+}
+.com-composer__codearea {
+  width: 100%;
+  padding: 12px 14px;
+  border-radius: var(--r-md);
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-family: var(--font-code);
+  font-size: 13px;
+  line-height: 1.55;
+  resize: vertical;
+  outline: none;
+  tab-size: 2;
+}
+
+.com-composer__img {
+  position: relative;
+  margin: 12px 0 0 54px;
+  border-radius: var(--r-md);
+  overflow: hidden;
+  border: 1px solid var(--border);
+  max-width: 320px;
+}
+.com-composer__img img {
+  display: block;
+  width: 100%;
+}
+.com-composer__imgrm {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.55);
+  color: #fff;
+  justify-content: center;
+}
+
+.com-composer__tags {
+  margin: 12px 0 0 54px;
+  width: calc(100% - 54px);
+  height: 38px;
+  padding: 0 13px;
+  border-radius: var(--r-md);
+  background: var(--input);
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-family: inherit;
+  font-size: 13.5px;
+  outline: none;
+}
+.com-composer__tags:focus {
+  border-color: var(--accent);
+}
+.com-composer__erro {
+  margin: 10px 0 0 54px;
+  color: var(--av-red);
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.com-composer__acoes {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin: 14px 0 0 54px;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.com-composer__ferramentas,
+.com-composer__atalhos {
+  display: flex;
+  gap: 8px;
+}
+.com-composer__atalhos {
+  margin: 12px 0 0 54px;
+}
+.com-composer__ferr {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 8px 13px;
+  border-radius: var(--r-md);
+  border: 1px solid var(--border-strong);
+  background: transparent;
+  color: var(--muted);
+  font-size: 13.5px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+}
+.com-composer__ferr:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.com-composer__ferr--on {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+.com-composer__enviar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.com-composer__cancelar {
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  font-size: 13.5px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  padding: 0 8px;
+}
+.com-composer__publicar {
+  height: 40px;
+  padding: 0 20px;
+}
+.com-composer__publicar:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+/* ---------- Tabs e barra de tag ---------- */
+.com-tabs {
+  display: flex;
+  gap: 6px;
+  padding: 0 2px;
+}
+.com-tab {
+  padding: 8px 16px;
+  border-radius: var(--r-md);
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  font-size: 14px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+}
+.com-tab:hover {
+  color: var(--text);
+}
+.com-tab--on {
+  background: var(--accent);
+  color: var(--on-accent);
+}
+
+.com-tagbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-radius: var(--r-lg);
+  background: var(--accent-soft);
+  color: var(--text);
+  font-size: 14px;
+}
+.com-tagbar strong {
+  color: var(--accent);
+}
+
+.com-vazio {
+  padding: 32px 8px;
+  color: var(--muted);
+  font-size: 14.5px;
+  text-align: center;
+  line-height: 1.6;
+}
+
+/* ---------- Post ---------- */
+.com-post {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-xl);
+  padding: 18px 20px;
+}
+.com-post--destaque {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+.com-post__head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+.com-post__autor {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  border: none;
+  background: transparent;
+  padding: 0;
+  cursor: pointer;
+  font-family: inherit;
+  text-align: left;
+  min-width: 0;
+}
+.com-post__ident {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.com-post__nome {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-weight: 700;
+  font-size: 15px;
+  color: var(--text);
+  flex-wrap: wrap;
+}
+.com-post__lv {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--accent);
+  background: var(--accent-soft);
+  padding: 1px 7px;
+  border-radius: 6px;
+}
+.com-post__apoiador {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--gold);
+  background: color-mix(in srgb, var(--gold) 16%, transparent);
+  padding: 1px 7px;
+  border-radius: 6px;
+}
+.com-post__meta {
+  font-size: 13px;
+  color: var(--muted);
+}
+.com-post__autor:hover .com-post__nome {
+  text-decoration: underline;
+}
+
+.com-ct {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  flex: none;
+  padding: 4px 11px;
+  border-radius: 999px;
+  font-size: 12.5px;
+  font-weight: 700;
+}
+.ct--duvida {
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+.ct--solucao {
+  color: var(--success);
+  background: var(--success-soft);
+}
+.ct--conquista {
+  color: var(--gold);
+  background: color-mix(in srgb, var(--gold) 16%, transparent);
+}
+
+.com-post__texto {
+  margin: 14px 0 0;
+  font-size: 15px;
+  line-height: 1.62;
+  color: var(--text);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.com-post__code {
+  margin: 14px 0 0;
+  padding: 14px 16px;
+  border-radius: var(--r-md);
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  overflow-x: auto;
+}
+.com-post__code code {
+  font-family: var(--font-code);
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--text);
+  white-space: pre;
+}
+.com-post__imagem {
+  margin: 14px 0 0;
+  border-radius: var(--r-md);
+  overflow: hidden;
+  border: 1px solid var(--border);
+}
+.com-post__imagem img {
+  display: block;
+  width: 100%;
+}
+.com-post__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 14px 0 0;
+}
+.com-hash {
+  border: none;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 12.5px;
+  font-weight: 600;
+  font-family: inherit;
+  padding: 4px 10px;
+  border-radius: 7px;
+  cursor: pointer;
+}
+.com-hash:hover {
+  filter: brightness(0.97);
+  text-decoration: underline;
+}
+
+.com-post__acoes {
+  display: flex;
+  gap: 22px;
+  margin-top: 16px;
+  padding-top: 14px;
+  border-top: 1px solid var(--border);
+}
+.com-acao {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  font-size: 14px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  transition: color 0.14s ease;
+}
+.com-acao:hover {
+  color: var(--text);
+}
+.com-acao--curtido {
+  color: var(--av-red);
+}
+.com-acao--curtido:hover {
+  color: var(--av-red);
+}
+.com-acao--curtido svg {
+  fill: var(--av-red);
+}
+
+/* ---------- Thread de comentários ---------- */
+.com-thread {
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.com-thread__novo {
+  display: flex;
+  gap: 10px;
+  align-items: flex-end;
+}
+.com-thread__novo textarea {
+  flex: 1;
+  padding: 10px 12px;
+  border-radius: var(--r-md);
+  background: var(--input);
+  border: 1px solid var(--border-strong);
+  color: var(--text);
+  font-family: inherit;
+  font-size: 14px;
+  line-height: 1.5;
+  resize: vertical;
+  outline: none;
+}
+.com-thread__novo textarea:focus {
+  border-color: var(--accent);
+}
+.com-thread__enviar {
+  height: 40px;
+  padding: 0 16px;
+  flex: none;
+}
+.com-thread__enviar:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+.com-thread__vazio {
+  color: var(--muted);
+  font-size: 13.5px;
+  margin: 0;
+}
+.com-coment {
+  display: flex;
+  gap: 10px;
+}
+.com-coment .com-av {
+  width: 34px;
+  height: 34px;
+  font-size: 13px;
+}
+.com-coment__corpo {
+  flex: 1;
+  min-width: 0;
+  background: var(--surface-2);
+  border-radius: var(--r-md);
+  padding: 10px 13px;
+}
+.com-coment__head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 3px;
+}
+.com-coment__nome {
+  font-weight: 700;
+  font-size: 13.5px;
+  color: var(--text);
+}
+.com-coment__lv {
+  font-size: 10.5px;
+  font-weight: 700;
+  color: var(--accent);
+  background: var(--accent-soft);
+  padding: 1px 6px;
+  border-radius: 5px;
+}
+.com-coment__tempo {
+  font-size: 12px;
+  color: var(--muted);
+}
+.com-coment__texto {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--text);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* ---------- Coluna direita ---------- */
+.com-desafio {
+  display: block;
+  width: 100%;
+  text-align: left;
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+  border-radius: var(--r-xl);
+  padding: 20px;
+  background: linear-gradient(150deg, var(--accent), color-mix(in srgb, var(--accent) 72%, #1b2a6b));
+  color: #fff;
+  box-shadow: 0 12px 26px color-mix(in srgb, var(--accent) 30%, transparent);
+}
+.com-desafio__eyebrow {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.82;
+}
+.com-desafio__titulo {
+  margin-top: 8px;
+  font-size: 19px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  line-height: 1.25;
+}
+.com-desafio__desc {
+  margin: 8px 0 0;
+  font-size: 13.5px;
+  line-height: 1.5;
+  opacity: 0.9;
+}
+.com-desafio__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  margin-top: 16px;
+  padding: 9px 16px;
+  border-radius: var(--r-md);
+  background: #fff;
+  color: var(--accent);
+  font-size: 13.5px;
+  font-weight: 700;
+}
+
+.com-side {
+  padding: 16px 18px;
+}
+.com-side__titulo {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--text);
+  margin-bottom: 12px;
+}
+.com-disc {
+  display: block;
+  width: 100%;
+  text-align: left;
+  border: none;
+  background: transparent;
+  font-family: inherit;
+  cursor: pointer;
+  padding: 11px 0;
+  border-top: 1px solid var(--border);
+}
+.com-disc:first-of-type {
+  border-top: none;
+  padding-top: 0;
+}
+.com-disc__tag {
+  display: block;
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 600;
+  margin-bottom: 3px;
+}
+.com-disc__titulo {
+  display: block;
+  color: var(--text);
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.4;
+}
+.com-disc:hover .com-disc__titulo {
+  text-decoration: underline;
+}
+.com-disc__n {
+  display: block;
+  color: var(--muted);
+  font-size: 12.5px;
+  margin-top: 3px;
+}
+
+.com-sug {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 0;
+  border-top: 1px solid var(--border);
+}
+.com-sug:first-of-type {
+  border-top: none;
+  padding-top: 0;
+}
+.com-sug__pessoa {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 1;
+  min-width: 0;
+  border: none;
+  background: transparent;
+  padding: 0;
+  cursor: pointer;
+  font-family: inherit;
+  text-align: left;
+}
+.com-sug .com-av {
+  width: 38px;
+  height: 38px;
+  font-size: 14px;
+}
+.com-sug__info {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+.com-sug__nome {
+  font-weight: 700;
+  font-size: 14px;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.com-sug__pessoa:hover .com-sug__nome {
+  text-decoration: underline;
+}
+.com-sug__sub {
+  font-size: 12.5px;
+  color: var(--muted);
+}
+.com-sug__btn {
+  flex: none;
+  height: 34px;
+  padding: 0 15px;
+  border-radius: var(--r-md);
+  border: 1px solid var(--accent);
+  background: transparent;
+  color: var(--accent);
+  font-size: 13px;
+  font-weight: 700;
+  font-family: inherit;
+  cursor: pointer;
+}
+.com-sug__btn:hover {
+  background: var(--accent-soft);
+}
+.com-sug__btn--on {
+  border-color: var(--border-strong);
+  color: var(--muted);
+  cursor: default;
+  background: transparent;
+}
+
+/* ---------- Responsivo ---------- */
+@media (max-width: 1180px) {
+  .com {
+    grid-template-columns: 200px 1fr;
+    padding: 24px 24px 50px;
+  }
+  .com__right {
+    display: none;
+  }
+}
+@media (max-width: 820px) {
+  .com {
+    grid-template-columns: 1fr;
+  }
+  .com__left {
+    display: none;
+  }
+  .com-search {
+    display: none;
+  }
+}
+@media (max-width: 640px) {
+  .com {
+    padding: 16px 14px 40px;
+  }
+  .com-composer__kinds,
+  .com-composer__code,
+  .com-composer__img,
+  .com-composer__tags,
+  .com-composer__erro,
+  .com-composer__acoes,
+  .com-composer__atalhos {
+    margin-left: 0;
+    width: 100%;
+  }
+}

--- a/frontend/src/utils/comprimirImagem.ts
+++ b/frontend/src/utils/comprimirImagem.ts
@@ -1,0 +1,34 @@
+// Reduz uma imagem (data URL) a um JPEG com largura máxima e teto de peso,
+// baixando a qualidade em degraus até caber. Usado antes de enviar ao servidor.
+export async function comprimirImagem(dataUrl: string, maxWidth = 1200, alvoKB = 800): Promise<string> {
+  const img = await new Promise<HTMLImageElement>((resolve, reject) => {
+    const el = new Image();
+    el.onload = () => resolve(el);
+    el.onerror = () => reject(new Error('Falha ao carregar a imagem'));
+    el.src = dataUrl;
+  });
+
+  const escala = img.width > maxWidth ? maxWidth / img.width : 1;
+  const canvas = document.createElement('canvas');
+  canvas.width = Math.round(img.width * escala);
+  canvas.height = Math.round(img.height * escala);
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Canvas indisponível');
+  ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+
+  let resultado = canvas.toDataURL('image/jpeg', 0.9);
+  for (const q of [0.85, 0.8, 0.75, 0.7]) {
+    if ((resultado.length * 3) / 4 <= alvoKB * 1024) break;
+    resultado = canvas.toDataURL('image/jpeg', q);
+  }
+  return resultado;
+}
+
+export function lerArquivoComoDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result));
+    reader.onerror = () => reject(new Error('Falha ao ler o arquivo'));
+    reader.readAsDataURL(file);
+  });
+}


### PR DESCRIPTION
## O que é

Nova aba Comunidade: um feed social em três colunas onde os alunos compartilham dúvidas, soluções, conquistas e posts, seguindo o design de referência.

## Principais pontos

- Publicações dos tipos post, dúvida, solução e conquista, com bloco de código (por linguagem), imagem e tags
- Curtidas, comentários em thread e seguir/deixar de seguir usuários
- Filtros do feed: para você, seguindo, dúvidas, soluções, conquistas, em alta e sem resposta
- Coluna esquerda com tópicos populares e contagem de dúvidas em aberto
- Coluna direita com desafio do dia (dado real), discussões em alta e sugestões para seguir
- Nível do autor calculado a partir do XP real, em consultas agrupadas para não fazer uma query por autor
- Selo de apoiador no feed
- Busca no topo filtrando o feed carregado

## Apoiador

Enviar imagem na comunidade é benefício de apoiador. O botão só aparece para quem apoia, e o backend também bloqueia (upload e criação de post com imagem), então nada fura pela API.

## Perfil público

O botão de seguir foi adicionado ao perfil. Quando o visitante está logado, a página passa a usar o topbar completo do app, no lugar da barra reduzida de visitante.

## Banco

Migration 0041 cria as tabelas da comunidade (posts, tags, curtidas, comentários e follows). Nada destrutivo.

## Testes

- Testes de integração da comunidade cobrindo feed, filtros, curtir, comentar, seguir, barra lateral e o gate de apoiador
- Suíte completa passando (107 testes)

## Notas

- Há um seed de demonstração para popular o feed localmente (`backend/scripts/seed-comunidade-demo.ts`), idempotente e marcado para não rodar em produção. Em produção a comunidade começa vazia.
- No card do desafio usei o desafio real do dia com link para os desafios, em vez de um evento fictício.
