### PR TITLE
feat: versão mobile com navegação inferior e telas adaptadas

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -29,6 +29,7 @@ import { DesafiosAdmin } from './pages/DesafiosAdmin';
 import { ComunicadosAdmin } from './pages/ComunicadosAdmin';
 import { AssinaturasAdmin } from './pages/AssinaturasAdmin';
 import { ComunicadoPrompt } from './components/ComunicadoPrompt';
+import { BottomNav } from './components/BottomNav';
 import { DesafioEditor } from './pages/DesafiosAdmin/Editor';
 import { VerifyEmail } from './pages/VerifyEmail';
 import { RecuperarSenha } from './pages/RecuperarSenha';
@@ -339,6 +340,7 @@ function AppRoutes() {
       {/* Perfil compartilhável: /username. Fica por último; rotas fixas têm prioridade. */}
       <Route path="/:username" element={<PerfilPorUsername />} />
     </Routes>
+    {isAuthenticated && <BottomNav />}
     </>
   );
 }

--- a/frontend/src/components/BottomNav.tsx
+++ b/frontend/src/components/BottomNav.tsx
@@ -1,0 +1,48 @@
+import { Link, useLocation } from 'react-router-dom';
+import { House, BookOpen, Code, Lightbulb, User } from './Icons';
+
+const TABS = [
+  { to: '/home', label: 'Início', Icon: House },
+  { to: '/trilhas', label: 'Trilhas', Icon: BookOpen },
+  { to: '/desafios', label: 'Desafios', Icon: Code },
+  { to: '/simulados', label: 'Simulados', Icon: Lightbulb },
+  { to: '/perfil', label: 'Perfil', Icon: User },
+];
+
+// Rotas onde a barra inferior não aparece: autenticação, fluxos focados
+// (aula, editor de desafio, prova, detalhe de trilha) e o estúdio (admin).
+const OCULTAR_EXATO = new Set([
+  '/',
+  '/cadastro',
+  '/verificar-email',
+  '/recuperar-senha',
+  '/redefinir-senha',
+  '/auth/callback',
+  '/completar-perfil',
+]);
+const OCULTAR_PREFIXO = ['/estudio', '/certificados/'];
+const OCULTAR_REGEX = [/^\/trilhas\/.+/, /^\/desafios\/.+/, /^\/simulados\/.+/, /^\/roadmaps\/.+/];
+
+// Barra de navegação inferior, exibida apenas no telefone (controlado por CSS).
+export function BottomNav() {
+  const { pathname } = useLocation();
+  const oculto =
+    OCULTAR_EXATO.has(pathname) ||
+    OCULTAR_PREFIXO.some((p) => pathname.startsWith(p)) ||
+    OCULTAR_REGEX.some((r) => r.test(pathname));
+  if (oculto) return null;
+
+  return (
+    <nav className="botnav" aria-label="Navegação">
+      {TABS.map(({ to, label, Icon }) => {
+        const ativo = pathname === to || pathname.startsWith(to + '/');
+        return (
+          <Link key={to} to={to} className={`botnav__item${ativo ? ' botnav__item--on' : ''}`}>
+            <Icon size={22} />
+            <span>{label}</span>
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/frontend/src/components/Icons.tsx
+++ b/frontend/src/components/Icons.tsx
@@ -82,6 +82,33 @@ export const UserPlus = ({ size = 26 }: IconProps) => (
   </svg>
 );
 
+export const User = ({ size = 22 }: IconProps) => (
+  <svg
+    {...base(size)}
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <circle cx="12" cy="8" r="3.6" />
+    <path d="M5 20c0-3.9 3.1-6 7-6s7 2.1 7 6" />
+  </svg>
+);
+
+export const Lightbulb = ({ size = 22 }: IconProps) => (
+  <svg
+    {...base(size)}
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M9 18h6" />
+    <path d="M10 21h4" />
+    <path d="M12 3a6 6 0 0 0-4 10.5c.7.7 1 1.3 1 2.5h6c0-1.2.3-1.8 1-2.5A6 6 0 0 0 12 3z" />
+  </svg>
+);
+
 export const Plus = ({ size = 12 }: IconProps) => (
   <svg {...base(size)} stroke="currentColor" strokeWidth="3" strokeLinecap="round">
     <line x1="12" y1="6" x2="12" y2="18" />

--- a/frontend/src/components/auth/SocialAuth.tsx
+++ b/frontend/src/components/auth/SocialAuth.tsx
@@ -7,6 +7,10 @@ export function SocialAuth() {
 
   return (
     <>
+      <div className="divider">
+        <span>ou continue com</span>
+      </div>
+
       <div className="auth__social">
         <button type="button" className="btn btn--ghost" onClick={() => entrar('google')}>
           <span className="provider">G</span> Google
@@ -14,10 +18,6 @@ export function SocialAuth() {
         <button type="button" className="btn btn--ghost" onClick={() => entrar('github')}>
           <span className="provider provider--mono">&lt;&gt;</span> GitHub
         </button>
-      </div>
-
-      <div className="divider">
-        <span>ou com e-mail</span>
       </div>
     </>
   );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -6,3 +6,5 @@
 @import './styles/desafio.css';
 @import './styles/trilha-detalhe.css';
 @import './styles/comunidade.css';
+@import './styles/roadmap.css';
+@import './styles/mobile.css';

--- a/frontend/src/pages/Comunidade/index.tsx
+++ b/frontend/src/pages/Comunidade/index.tsx
@@ -19,6 +19,7 @@ import {
   ChatBubble,
   Share,
   Zap,
+  Plus,
   X,
 } from '../../components/Icons';
 import { getInitials } from '../../utils/initials';
@@ -115,6 +116,7 @@ export function Comunidade() {
   const [busca, setBusca] = useState('');
   const [copiado, setCopiado] = useState<string | null>(null);
   const [seguindo, setSeguindo] = useState<Set<string>>(new Set());
+  const [comporAberto, setComporAberto] = useState(false);
 
   const displayName = user?.name ?? '';
   const initials = getInitials(displayName || 'A');
@@ -282,13 +284,16 @@ export function Comunidade() {
           </aside>
 
           <main className="com__feed">
-            <Composer
-              nome={displayName}
-              avatarUrl={user?.avatarUrl ?? null}
-              chave={user?.username ?? user?.email ?? displayName}
-              apoiador={Boolean(user?.apoiador)}
-              onPublicado={() => carregarFeed(filtro, tag)}
-            />
+            {/* Composer inline (desktop). No telefone some e dá lugar ao "+". */}
+            <div className="com-composer-inline">
+              <Composer
+                nome={displayName}
+                avatarUrl={user?.avatarUrl ?? null}
+                chave={user?.username ?? user?.email ?? displayName}
+                apoiador={Boolean(user?.apoiador)}
+                onPublicado={() => carregarFeed(filtro, tag)}
+              />
+            </div>
 
             {tag ? (
               <div className="com-tagbar">
@@ -401,6 +406,44 @@ export function Comunidade() {
             )}
           </aside>
         </div>
+
+        {/* Botão flutuante de compor (telefone), estilo Twitter. */}
+        <button
+          className="com-fab"
+          aria-label="Nova publicação"
+          onClick={() => setComporAberto(true)}
+        >
+          <Plus size={24} />
+        </button>
+
+        {comporAberto && (
+          <div className="com-modal-scrim" onClick={() => setComporAberto(false)}>
+            <div className="com-modal" onClick={(e) => e.stopPropagation()}>
+              <div className="com-modal__head">
+                <button
+                  className="com-modal__x"
+                  aria-label="Fechar"
+                  onClick={() => setComporAberto(false)}
+                >
+                  <X size={20} />
+                </button>
+                <span className="com-modal__titulo">Nova publicação</span>
+              </div>
+              <Composer
+                nome={displayName}
+                avatarUrl={user?.avatarUrl ?? null}
+                chave={user?.username ?? user?.email ?? displayName}
+                apoiador={Boolean(user?.apoiador)}
+                iniciarAberto
+                onFechar={() => setComporAberto(false)}
+                onPublicado={() => {
+                  carregarFeed(filtro, tag);
+                  setComporAberto(false);
+                }}
+              />
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );
@@ -422,14 +465,18 @@ function Composer({
   chave,
   apoiador,
   onPublicado,
+  iniciarAberto = false,
+  onFechar,
 }: {
   nome: string;
   avatarUrl: string | null;
   chave: string;
   apoiador: boolean;
   onPublicado: () => void;
+  iniciarAberto?: boolean;
+  onFechar?: () => void;
 }) {
-  const [aberto, setAberto] = useState(false);
+  const [aberto, setAberto] = useState(iniciarAberto);
   const [kind, setKind] = useState<PostKind>('post');
   const [content, setContent] = useState('');
   const [comCodigo, setComCodigo] = useState(false);
@@ -601,7 +648,14 @@ function Composer({
               )}
             </div>
             <div className="com-composer__enviar">
-              <button className="com-composer__cancelar" onClick={reset} disabled={enviando}>
+              <button
+                className="com-composer__cancelar"
+                onClick={() => {
+                  reset();
+                  onFechar?.();
+                }}
+                disabled={enviando}
+              >
                 Cancelar
               </button>
               <button

--- a/frontend/src/pages/Login/index.tsx
+++ b/frontend/src/pages/Login/index.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { AuthShell } from '../../components/auth/AuthShell';
 import { AuthBrand } from '../../components/auth/AuthBrand';
+import { Logo } from '../../components/Logo';
 import { FormField } from '../../components/FormField';
 import { SocialAuth } from '../../components/auth/SocialAuth';
 import { Flame, Trophy } from '../../components/Icons';
@@ -86,10 +87,11 @@ export function Login() {
 
   return (
     <AuthShell brand={brand}>
+      <div className="auth__logo-m">
+        <Logo variant="solid" size={22} />
+      </div>
       <h2 className="auth__title">Bem-vindo de volta</h2>
       <p className="auth__subtitle">Continue de onde você parou.</p>
-
-      <SocialAuth />
 
       {(error || erroOAuth) && <div className="auth__alert">{error || erroOAuth}</div>}
 
@@ -121,6 +123,8 @@ export function Login() {
           {submitting ? 'Entrando...' : 'Entrar'}
         </button>
       </form>
+
+      <SocialAuth />
 
       <p className="auth__foot">
         Não tem conta?{' '}

--- a/frontend/src/pages/Register/index.tsx
+++ b/frontend/src/pages/Register/index.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import api from '../../services/api';
 import { AuthShell } from '../../components/auth/AuthShell';
 import { AuthBrand } from '../../components/auth/AuthBrand';
+import { Logo } from '../../components/Logo';
 import { FormField } from '../../components/FormField';
 import {
   birthDateDisplayToIso,
@@ -138,10 +139,11 @@ export function Register() {
 
   return (
     <AuthShell brand={brand}>
+      <div className="auth__logo-m">
+        <Logo variant="solid" size={22} />
+      </div>
       <h2 className="auth__title">Crie sua conta</h2>
       <p className="auth__subtitle">Leva menos de um minuto.</p>
-
-      <SocialAuth />
 
       {error && <div className="auth__alert">{error}</div>}
 
@@ -208,6 +210,8 @@ export function Register() {
           {submitting ? 'Criando conta...' : 'Criar conta grátis'}
         </button>
       </form>
+
+      <SocialAuth />
 
       <p className="auth__terms">
         Ao criar a conta, você concorda com os{' '}

--- a/frontend/src/pages/Roadmaps/index.tsx
+++ b/frontend/src/pages/Roadmaps/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type CSSProperties } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { Logo } from '../../components/Logo';
@@ -15,6 +15,13 @@ const NIVEL_LABEL: Record<Nivel, string> = {
   iniciante: 'Iniciante',
   intermediario: 'Intermediário',
   avancado: 'Avançado',
+};
+
+// Cada nível tem sua cor, como nas trilhas, para dar variedade aos cards.
+const LEVEL_HUE: Record<Nivel, string> = {
+  iniciante: '#2D6BF5',
+  intermediario: '#2E9E6B',
+  avancado: '#D9536B',
 };
 
 const NIVEIS: { v: string; label: string }[] = [
@@ -171,13 +178,15 @@ export function Roadmaps() {
             </p>
           )}
 
-          <div className="track-grid">
+          <div className="track-grid rm-grid">
             {filtrados.map((r) => {
               const started = r.status !== 'nao_iniciado';
+              const hue = LEVEL_HUE[r.level];
               return (
                 <div
                   key={r.id}
-                  className={`track track--clickable${r.premium ? ' track--locked' : ''}`}
+                  className={`track track--clickable roadmap-card${r.premium ? ' track--locked' : ''}`}
+                  style={{ ['--rm-hue']: hue } as CSSProperties}
                   role="button"
                   tabIndex={0}
                   onClick={() => navigate(`/roadmaps/${r.slug}`)}
@@ -186,19 +195,13 @@ export function Roadmaps() {
                   }}
                 >
                   <div className="track__head">
-                    <span
-                      className="track__icon"
-                      style={{
-                        color: 'var(--accent)',
-                        background: 'color-mix(in srgb, var(--accent) 16%, transparent)',
-                      }}
-                    >
+                    <span className="track__icon roadmap-card__icon">
                       {r.premium ? <Lock size={20} /> : glyph(r.name)}
                     </span>
                     <div className="track__meta">
                       <div className="track__name">{r.name}</div>
                       <div className="track__row">
-                        <span className="track__level" style={{ color: 'var(--accent)' }}>
+                        <span className="track__level roadmap-card__level">
                           {NIVEL_LABEL[r.level]}
                         </span>
                         <span className="track__lessons">{r.stagesTotal} estágios</span>
@@ -212,7 +215,7 @@ export function Roadmaps() {
                         className="progress__fill"
                         style={{
                           width: `${r.percent}%`,
-                          background: started ? 'var(--accent)' : 'var(--surface-2)',
+                          background: started ? hue : 'var(--surface-2)',
                         }}
                       />
                     </div>
@@ -228,8 +231,8 @@ export function Roadmaps() {
                       ))}
                     </div>
                     <span
-                      className="track__cta"
-                      style={{ color: started ? 'var(--accent)' : 'var(--text)' }}
+                      className="track__cta roadmap-card__cta"
+                      style={started ? { color: hue } : undefined}
                     >
                       {r.premium ? 'Desbloquear' : CTA[r.status]} <ChevronRight size={15} />
                     </span>

--- a/frontend/src/pages/Simulados/Prova.tsx
+++ b/frontend/src/pages/Simulados/Prova.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { ClockExam, ChevronLeft, ChevronRight, Bookmark } from '../../components/Icons';
+import { ClockExam, ChevronLeft, ChevronRight, ChevronDown, Bookmark } from '../../components/Icons';
 import { salvarResposta, enviarTentativa, type TentativaEstado } from '../../services/simulados';
+import { ConfirmModal } from './ConfirmModal';
 
 const LETRAS = ['A', 'B', 'C', 'D', 'E', 'F'];
 
@@ -22,6 +23,9 @@ export function Prova({ dados, onEnviado }: { dados: TentativaEstado; onEnviado:
   const [flags, setFlags] = useState<Set<number>>(new Set());
   const [restante, setRestante] = useState(dados.remainingSeconds);
   const [enviando, setEnviando] = useState(false);
+  // Navegador recolhido por padrão no telefone (65 células ocupam a tela toda).
+  const [navAberto, setNavAberto] = useState(false);
+  const [confirmando, setConfirmando] = useState(false);
   const enviadoRef = useRef(false);
 
   const q = questions[current];
@@ -72,13 +76,10 @@ export function Prova({ dados, onEnviado }: { dados: TentativaEstado; onEnviado:
     }
   }
 
+  const faltam = total - answeredCount;
+
   function confirmarEnvio() {
-    const faltam = total - answeredCount;
-    const msg =
-      faltam > 0
-        ? `Você deixou ${faltam} questão(ões) em branco. Enviar mesmo assim?`
-        : 'Enviar o simulado para correção?';
-    if (window.confirm(msg)) enviar();
+    setConfirmando(true);
   }
 
   // Contagem regressiva a partir do expiresAt (fonte de verdade); auto-envia ao zerar.
@@ -103,7 +104,7 @@ export function Prova({ dados, onEnviado }: { dados: TentativaEstado; onEnviado:
         <span className="exam-bar__logo">
           <ClockExam size={18} />
         </span>
-        <div>
+        <div className="exam-bar__id">
           <div className="exam-bar__title">Simulado em andamento</div>
           <div className="exam-bar__sub">{total} questões</div>
         </div>
@@ -183,35 +184,49 @@ export function Prova({ dados, onEnviado }: { dados: TentativaEstado; onEnviado:
 
         <div className="exam-side">
           <div className="card">
-            <div className="exam-nav__title">Navegador</div>
-            <div className="exam-nav__grid">
-              {questions.map((x, i) => {
-                const isCur = i === current;
-                const isAns = (respostas[x.id]?.length ?? 0) > 0;
-                const isFlag = flags.has(i);
-                let cls = 'exam-nav__cell';
-                if (isFlag) cls += ' exam-nav__cell--flag';
-                else if (isAns) cls += ' exam-nav__cell--ans';
-                if (isCur) cls += ' exam-nav__cell--cur';
-                return (
-                  <button key={x.id} className={cls} onClick={() => setCurrent(i)}>
-                    {i + 1}
-                  </button>
-                );
-              })}
-            </div>
-            <div className="exam-nav__legend">
-              <div>
-                <span className="exam-nav__dot exam-nav__dot--ans" />
-                Respondida ({answeredCount})
+            <button
+              className="exam-nav__title"
+              onClick={() => setNavAberto((v) => !v)}
+              aria-expanded={navAberto}
+            >
+              <span>Navegador</span>
+              <span className="exam-nav__resumo">
+                {answeredCount}/{total}
+              </span>
+              <span className={`exam-nav__chev${navAberto ? ' exam-nav__chev--open' : ''}`}>
+                <ChevronDown size={16} />
+              </span>
+            </button>
+            <div className={`exam-nav__body${navAberto ? ' exam-nav__body--open' : ''}`}>
+              <div className="exam-nav__grid">
+                {questions.map((x, i) => {
+                  const isCur = i === current;
+                  const isAns = (respostas[x.id]?.length ?? 0) > 0;
+                  const isFlag = flags.has(i);
+                  let cls = 'exam-nav__cell';
+                  if (isFlag) cls += ' exam-nav__cell--flag';
+                  else if (isAns) cls += ' exam-nav__cell--ans';
+                  if (isCur) cls += ' exam-nav__cell--cur';
+                  return (
+                    <button key={x.id} className={cls} onClick={() => setCurrent(i)}>
+                      {i + 1}
+                    </button>
+                  );
+                })}
               </div>
-              <div>
-                <span className="exam-nav__dot exam-nav__dot--flag" />
-                Marcada ({flags.size})
-              </div>
-              <div>
-                <span className="exam-nav__dot exam-nav__dot--none" />
-                Em branco ({total - answeredCount})
+              <div className="exam-nav__legend">
+                <div>
+                  <span className="exam-nav__dot exam-nav__dot--ans" />
+                  Respondida ({answeredCount})
+                </div>
+                <div>
+                  <span className="exam-nav__dot exam-nav__dot--flag" />
+                  Marcada ({flags.size})
+                </div>
+                <div>
+                  <span className="exam-nav__dot exam-nav__dot--none" />
+                  Em branco ({total - answeredCount})
+                </div>
               </div>
             </div>
           </div>
@@ -220,6 +235,25 @@ export function Prova({ dados, onEnviado }: { dados: TentativaEstado; onEnviado:
           </button>
         </div>
       </div>
+
+      {confirmando && (
+        <ConfirmModal
+          title="Enviar simulado?"
+          confirmLabel={enviando ? 'Enviando...' : 'Enviar para correção'}
+          loading={enviando}
+          onConfirm={enviar}
+          onCancel={() => setConfirmando(false)}
+        >
+          {faltam > 0 ? (
+            <>
+              Você deixou <b>{faltam}</b> {faltam === 1 ? 'questão' : 'questões'} em branco. Depois de
+              enviar não dá para voltar e corrigir.
+            </>
+          ) : (
+            'Respondeu todas as questões. Depois de enviar não dá para voltar e corrigir.'
+          )}
+        </ConfirmModal>
+      )}
     </>
   );
 }

--- a/frontend/src/pages/Simulados/Tentativa.tsx
+++ b/frontend/src/pages/Simulados/Tentativa.tsx
@@ -12,8 +12,12 @@ export function TentativaSimulado() {
     [attemptId],
   );
 
+  // Só a prova em andamento é fluxo focado (esconde a topbar no telefone). No
+  // resultado a topbar volta, para o aluno navegar de volta (logo, hambúrguer).
+  const emProva = Boolean(dados && !dados.submitted);
+
   return (
-    <div className="home-shell">
+    <div className={`home-shell${emProva ? ' app-mobilehdr' : ''}`}>
       <div className="home">
         <SimTopbar />
         {carregando && (

--- a/frontend/src/styles/comunidade.css
+++ b/frontend/src/styles/comunidade.css
@@ -886,7 +886,7 @@
 }
 @media (max-width: 640px) {
   .com {
-    padding: 16px 14px 40px;
+    padding: 16px 14px 0;
   }
   .com-composer__kinds,
   .com-composer__code,
@@ -897,5 +897,95 @@
   .com-composer__atalhos {
     margin-left: 0;
     width: 100%;
+  }
+}
+
+/* ==========================================================================
+   Compor no telefone: o composer inline some e dá lugar a um botão "+"
+   flutuante (estilo Twitter) que abre o composer em um modal de tela cheia.
+   ========================================================================== */
+.com-fab {
+  display: none;
+}
+.com-modal-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+}
+.com-modal {
+  width: 100%;
+  max-width: 560px;
+  max-height: calc(100% - 64px);
+  overflow-y: auto;
+  margin: 32px 12px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-xl);
+}
+.com-modal__head {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 14px;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+}
+.com-modal__x {
+  display: flex;
+  padding: 4px;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+}
+.com-modal__titulo {
+  font-size: 16px;
+  font-weight: 700;
+}
+/* O composer dentro do modal não repete a moldura de card. */
+.com-modal .com-composer {
+  border: none;
+  border-radius: 0;
+}
+
+@media (max-width: 640px) {
+  .com-composer-inline {
+    display: none;
+  }
+  .com-fab {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: fixed;
+    right: 18px;
+    bottom: calc(84px + env(safe-area-inset-bottom, 0px));
+    z-index: 55;
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    border: none;
+    background: var(--accent);
+    color: var(--on-accent);
+    box-shadow: 0 10px 26px color-mix(in srgb, var(--accent) 42%, transparent);
+    cursor: pointer;
+  }
+  /* No telefone o modal ocupa a tela inteira. */
+  .com-modal-scrim {
+    align-items: stretch;
+  }
+  .com-modal {
+    margin: 0;
+    max-width: none;
+    max-height: none;
+    min-height: 100%;
+    border: none;
+    border-radius: 0;
   }
 }

--- a/frontend/src/styles/mobile.css
+++ b/frontend/src/styles/mobile.css
@@ -1,0 +1,102 @@
+/* ==========================================================================
+   Design mobile (telefone, <= 640px). Barra de navegação inferior e layouts
+   em coluna única. Acima de 640px nada aqui se aplica: o desktop continua igual.
+   ========================================================================== */
+
+/* Barra inferior: renderizada sempre (JS), mas só visível no telefone. */
+.botnav {
+  display: none;
+}
+
+/* Logo no topo do formulário de login/cadastro: só no telefone (no desktop
+   o logo já aparece no painel de marca). */
+.auth__logo-m {
+  display: none;
+}
+
+@media (max-width: 640px) {
+  /* ----- Barra de navegação inferior ----- */
+  .botnav {
+    display: flex;
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 60;
+    justify-content: space-around;
+    align-items: stretch;
+    gap: 2px;
+    padding: 8px 6px calc(8px + env(safe-area-inset-bottom, 0px));
+    background: color-mix(in srgb, var(--surface) 92%, transparent);
+    backdrop-filter: saturate(1.2) blur(10px);
+    border-top: 1px solid var(--border);
+  }
+  .botnav__item {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 0;
+    text-decoration: none;
+    color: var(--muted);
+    font-size: 10.5px;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+  }
+  .botnav__item svg {
+    opacity: 0.85;
+  }
+  .botnav__item--on {
+    color: var(--accent);
+  }
+  .botnav__item--on svg {
+    opacity: 1;
+  }
+
+  /* A barra inferior é a navegação primária; o hambúrguer (na topbar) vira o
+     menu "mais" (Comunidade, Ranking, Roadmaps, Apoiar) e continua disponível. */
+
+  /* Fluxo focado (ex.: prova em andamento) esconde a topbar do app no telefone. */
+  .app-mobilehdr .topbar {
+    display: none;
+  }
+
+  /* Login/cadastro: o painel de marca ("Resolva um desafio todo dia") some no
+     telefone e o formulário ocupa a tela inteira, com o logo no topo. */
+  .auth__brand {
+    display: none;
+  }
+  .auth__panel {
+    padding: 40px 22px;
+  }
+  .auth__logo-m {
+    display: flex;
+    margin-bottom: 16px;
+  }
+
+  /* Reserva espaço para a barra inferior não cobrir o fim do conteúdo. */
+  .home {
+    padding-bottom: calc(72px + env(safe-area-inset-bottom, 0px));
+  }
+
+  /* ----- Início: coluna única ----- */
+  .home__body {
+    grid-template-columns: 1fr;
+    padding: 4px 16px 0;
+    gap: 20px;
+  }
+  .home__main {
+    gap: 20px;
+  }
+  .trilhas {
+    grid-template-columns: 1fr;
+  }
+  /* Desafio do dia: empilha e esconde o preview de código lateral. */
+  .challenge {
+    flex-direction: column;
+  }
+  .challenge__code {
+    display: none;
+  }
+}

--- a/frontend/src/styles/roadmap.css
+++ b/frontend/src/styles/roadmap.css
@@ -1,0 +1,54 @@
+/* Página de Roadmaps: cartões de carreira com cor por nível, uma faixa de
+   destaque no topo e um grid de cards maiores que o das trilhas. */
+
+/* Cards de largura limitada e alinhados à esquerda: some ou muitos roadmaps,
+   nunca fica um card esticado sozinho ocupando a linha inteira. */
+.rm-grid {
+  grid-template-columns: repeat(auto-fill, minmax(300px, 400px));
+  justify-content: start;
+}
+
+.roadmap-card {
+  position: relative;
+  overflow: hidden;
+  transition:
+    transform 0.16s ease,
+    box-shadow 0.16s ease,
+    border-color 0.16s ease;
+}
+.roadmap-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: var(--rm-hue, var(--accent));
+}
+.roadmap-card:hover {
+  transform: translateY(-3px);
+  border-color: color-mix(in srgb, var(--rm-hue, var(--accent)) 45%, var(--border));
+  box-shadow: 0 14px 32px color-mix(in srgb, var(--rm-hue, var(--accent)) 15%, transparent);
+}
+
+.roadmap-card__icon {
+  color: var(--rm-hue, var(--accent));
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--rm-hue, var(--accent)) 28%, transparent),
+    color-mix(in srgb, var(--rm-hue, var(--accent)) 10%, transparent)
+  );
+}
+.roadmap-card__level {
+  color: var(--rm-hue, var(--accent));
+}
+
+@media (max-width: 760px) {
+  .rm-grid {
+    grid-template-columns: 1fr;
+  }
+  .roadmap-card:hover {
+    transform: none;
+    box-shadow: none;
+  }
+}

--- a/frontend/src/styles/simulado.css
+++ b/frontend/src/styles/simulado.css
@@ -527,9 +527,31 @@
   top: 26px;
 }
 .exam-nav__title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 0;
+  margin-bottom: 14px;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font-family: inherit;
   font-size: 14px;
   font-weight: 700;
-  margin-bottom: 14px;
+  text-align: left;
+  cursor: default;
+}
+.exam-nav__title > span:first-child {
+  flex: 1;
+}
+/* Resumo e seta só no telefone (onde o navegador é recolhível). */
+.exam-nav__resumo,
+.exam-nav__chev {
+  display: none;
+}
+.exam-nav__body {
+  display: block;
 }
 .exam-nav__grid {
   display: grid;
@@ -712,6 +734,38 @@
   font-size: 11.5px;
   color: rgba(255, 255, 255, 0.82);
   margin-top: 3px;
+}
+
+/* Resultado no telefone: herói empilhado e centralizado. Sem isso o bloco de
+   texto fica espremido entre o anel e as estatísticas e quebra palavra a palavra. */
+@media (max-width: 640px) {
+  .res-hero {
+    padding: 22px 20px;
+  }
+  .res-hero__inner {
+    flex-direction: column;
+    align-items: stretch;
+    text-align: center;
+    gap: 16px;
+  }
+  .res-ring {
+    align-self: center;
+  }
+  .res-hero__meta {
+    width: 100%;
+  }
+  .res-hero__title {
+    font-size: 23px;
+    margin-top: 10px;
+  }
+  .res-stats {
+    width: 100%;
+  }
+  .res-stat {
+    flex: 1;
+    min-width: 0;
+    padding: 12px 8px;
+  }
 }
 
 .res-sec__title {
@@ -1077,6 +1131,79 @@
   }
   .exam-nav__grid {
     grid-template-columns: repeat(5, 1fr);
+  }
+}
+
+/* Exame no telefone: header compacto e rodapé sem overflow horizontal. */
+@media (max-width: 640px) {
+  .exam-bar {
+    gap: 10px;
+    padding: 10px 14px;
+  }
+  .exam-bar__id {
+    flex: 1;
+    min-width: 0;
+  }
+  .exam-bar__title {
+    font-size: 13px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .exam-bar__sub,
+  .exam-bar__prog {
+    display: none;
+  }
+  .exam-bar__timer {
+    flex: none;
+    height: 38px;
+    padding: 0 12px;
+  }
+  .exam-bar__timer span {
+    font-size: 16px;
+  }
+  .exam-bar__finish {
+    height: 38px;
+    padding: 0 14px;
+  }
+  .exam-q {
+    padding: 20px 16px;
+  }
+  .exam-q__foot {
+    gap: 10px;
+  }
+  /* O aviso "Resposta salva automaticamente" sai; Anterior e Próxima vão às pontas. */
+  .exam-q__saved {
+    display: none;
+  }
+
+  /* Navegador recolhível: 65 células não ocupam a tela toda por padrão. */
+  .exam-side {
+    position: static;
+  }
+  .exam-nav__title {
+    cursor: pointer;
+    margin-bottom: 0;
+  }
+  .exam-nav__resumo {
+    display: inline-block;
+    font-size: 12.5px;
+    font-weight: 600;
+    color: var(--muted);
+  }
+  .exam-nav__chev {
+    display: inline-flex;
+    color: var(--muted);
+    transition: transform 0.18s ease;
+  }
+  .exam-nav__chev--open {
+    transform: rotate(180deg);
+  }
+  .exam-nav__body {
+    display: none;
+    margin-top: 14px;
+  }
+  .exam-nav__body--open {
+    display: block;
   }
 }
 


### PR DESCRIPTION
## O que é

Versão mobile do app: uma barra de navegação inferior de cinco abas mais ajustes de layout tela a tela para o telefone. O desktop segue igual.

## Principais mudanças

- Barra inferior fixa (Início, Trilhas, Desafios, Simulados, Perfil), visível só no telefone e escondida nos fluxos focados (aula, editor de desafio, prova, detalhe de trilha, login e cadastro)
- Hambúrguer mantido como menu "mais" para Comunidade, Ranking, Roadmaps e Apoiar
- Comunidade: no telefone o composer inline some e um botão flutuante abre o modal de publicação
- Simulado em andamento: sem a topbar do app, header enxuto sem overflow, navegador de questões recolhível e Finalizar com modal no lugar do confirm nativo
- Resultado do simulado: herói empilhado e centralizado, com a topbar de volta para navegar
- Login e cadastro no telefone: painel de marca escondido, logo no topo e campos antes do login social
- Roadmaps: cards com cor por nível, faixa de destaque no topo e grid que se adapta a poucos ou muitos
- Conteúdo em coluna única e espaço reservado para a barra inferior não cobrir o fim da página

## Validação

Validado no viewport de telefone (430px) por inspeção do DOM e capturas: barra inferior, ausência de overflow horizontal, abertura dos modais e ordem dos elementos. O desktop não muda.

## Notas

- Mudanças só no frontend.
- A reordenação do formulário de login e cadastro (campos antes do login social) também passa a valer no desktop, que é uma ordem limpa e padrão. Dá para isolar só para o telefone se preferir.
- A barra inferior só renderiza para usuário autenticado e quando a rota não é um fluxo focado.
