### PR TITLE
feat: legibilidade do texto com wallpaper e ajustes de conquistas

### DIFF
--- a/frontend/src/components/ConquistaToaster.tsx
+++ b/frontend/src/components/ConquistaToaster.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { obterConquistasNaoVistas, type ConquistaDesbloqueada } from '../services/trails';
 import { EVENTO_CONQUISTA } from '../utils/conquistas';
@@ -13,6 +13,7 @@ const DURACAO_MS = 6000;
 export function ConquistaToaster() {
   const { isAuthenticated } = useAuth();
   const location = useLocation();
+  const navigate = useNavigate();
   const [fila, setFila] = useState<ConquistaDesbloqueada[]>([]);
   const buscando = useRef(false);
   const timers = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
@@ -76,8 +77,11 @@ export function ConquistaToaster() {
           key={c.id}
           type="button"
           className="conq-toast"
-          onClick={() => remover(c.id)}
-          title="Dispensar"
+          onClick={() => {
+            remover(c.id);
+            navigate('/conquistas');
+          }}
+          title="Ver conquistas"
         >
           <span className="conq-toast__badge">
             <IconeConquista chave={c.icon} size={24} />

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -5853,6 +5853,41 @@ a.logo {
   background-attachment: fixed;
 }
 
+/* Com wallpaper, o texto "solto" sobre a imagem troca de cor conforme --texto-fundo,
+   calculada em JS pela luminância do wallpaper + véu + tema (accent.ts): clara sobre
+   fundo escuro, escura sobre fundo claro. Texto dentro de card não entra aqui, então
+   segue com a cor do tema. A lista cobre só o texto solto de cada página; classes
+   compartilhadas com cards (ex.: .td-h3, .track__desc) ficam de fora ou escopadas. */
+.tem-fundo .section-title,
+.tem-fundo .section-meta,
+.tem-fundo .trilhas-page__title,
+.tem-fundo .trilhas-page__sub,
+.tem-fundo .metric__value,
+.tem-fundo .metric__label,
+.tem-fundo .filters__label,
+.tem-fundo .filters__count,
+.tem-fundo .td-modules-head .td-h3,
+.tem-fundo .td-modules-meta,
+.tem-fundo .rk-title,
+.tem-fundo .rk-sub,
+.tem-fundo .sim__title,
+.tem-fundo .sim__sub,
+.tem-fundo .sim__count,
+.tem-fundo .ch-title,
+.tem-fundo .ch-sub,
+.tem-fundo .conq__title,
+.tem-fundo .conq__sub,
+.tem-fundo .conq-sec__title,
+.tem-fundo .conq-sec__hint,
+.tem-fundo .conq-legend,
+.tem-fundo .prg-head__title,
+.tem-fundo .prg-head__sub,
+.tem-fundo .com-tab,
+.tem-fundo .com-vazio,
+.tem-fundo .sim-empty {
+  color: var(--texto-fundo, inherit);
+}
+
 .apoie__cor--livre {
   display: flex;
   align-items: center;

--- a/frontend/src/styles/trilha-detalhe.css
+++ b/frontend/src/styles/trilha-detalhe.css
@@ -56,7 +56,7 @@
 .td-modules-meta { font-size: 13.5px; color: var(--muted); }
 .td-modules { display: flex; flex-direction: column; gap: 10px; }
 .td-mod { background: var(--surface); border: 1px solid var(--border); border-radius: 14px; overflow: hidden; }
-.td-mod__head { display: flex; align-items: center; gap: 12px; width: 100%; padding: 15px 18px; border: none; background: transparent; font-family: inherit; cursor: pointer; text-align: left; }
+.td-mod__head { display: flex; align-items: center; gap: 12px; width: 100%; padding: 15px 18px; border: none; background: transparent; font-family: inherit; color: var(--text); cursor: pointer; text-align: left; }
 .td-mod__head--open { background: var(--surface-2); }
 .td-mod__chev { color: var(--muted); display: flex; transform: rotate(-90deg); transition: transform .15s; }
 .td-mod__chev--open { transform: rotate(0deg); }

--- a/frontend/src/utils/accent.ts
+++ b/frontend/src/utils/accent.ts
@@ -17,13 +17,82 @@ export function accentSalvo(): string | null {
 
 const FUNDO_KEY = 'ensina:fundo';
 
+// Luminância média do wallpaper atual (0 = escuro, 1 = claro), medida ao aplicar.
+let lumWallpaper: number | null = null;
+let observadorTema: MutationObserver | null = null;
+
+// Mede a luminância média da imagem via canvas (downscale pra ser barato). Depende
+// do CORS liberado no /uploads (o backend manda os headers). Erro devolve null.
+function medirLuminancia(url: string): Promise<number | null> {
+  return new Promise((resolve) => {
+    const img = new Image();
+    img.crossOrigin = 'anonymous';
+    img.onload = () => {
+      try {
+        const canvas = document.createElement('canvas');
+        canvas.width = 24;
+        canvas.height = 24;
+        const ctx = canvas.getContext('2d');
+        if (!ctx) return resolve(null);
+        ctx.drawImage(img, 0, 0, 24, 24);
+        const { data } = ctx.getImageData(0, 0, 24, 24);
+        let soma = 0;
+        for (let i = 0; i < data.length; i += 4) {
+          soma += (0.2126 * data[i] + 0.7152 * data[i + 1] + 0.0722 * data[i + 2]) / 255;
+        }
+        resolve(soma / (data.length / 4));
+      } catch (e) {
+        console.debug('[fundo] não deu pra medir a luminância', e);
+        resolve(null);
+      }
+    };
+    img.onerror = () => resolve(null);
+    // Query própria: força uma entrada de cache com CORS, evitando reaproveitar a
+    // imagem já baixada pelo background do CSS (sem CORS), que "tainta" o canvas.
+    img.src = url + (url.includes('?') ? '&' : '?') + '_cors=1';
+  });
+}
+
+// Define a cor do texto "solto" sobre o wallpaper (--texto-fundo). Combina a
+// luminância da imagem com o véu (que mistura em direção ao --bg do tema) e o tema:
+// fundo efetivo escuro pede texto claro; fundo claro pede texto escuro.
+function recalcularContrasteFundo() {
+  const root = document.documentElement;
+  if (lumWallpaper === null) {
+    root.style.removeProperty('--texto-fundo');
+    return;
+  }
+  const veuStr = getComputedStyle(root).getPropertyValue('--fundo-veu').trim();
+  const veu = veuStr ? parseFloat(veuStr) / 100 : 0.6; // padrão do CSS
+  const lumBg = root.getAttribute('data-theme') === 'dark' ? 0.02 : 0.78; // --bg por tema
+  const efetiva = veu * lumBg + (1 - veu) * lumWallpaper;
+  root.style.setProperty('--texto-fundo', efetiva < 0.5 ? '#f4f6fb' : '#17131f');
+}
+
 // Imagem de fundo do app (benefício de apoiador). Nulo remove.
+// A classe tem-fundo liga a troca de cor do texto solto sobre o wallpaper (ver app.css).
 export function aplicarFundo(url: string | null | undefined) {
+  const root = document.documentElement;
   if (url) {
-    document.documentElement.style.setProperty('--fundo-app', `url("${url}")`);
+    root.style.setProperty('--fundo-app', `url("${url}")`);
+    root.classList.add('tem-fundo');
     localStorage.setItem(FUNDO_KEY, url);
+    // O véu mistura o wallpaper com o --bg do tema, então recalcula ao trocar de tema.
+    if (!observadorTema) {
+      observadorTema = new MutationObserver(recalcularContrasteFundo);
+      observadorTema.observe(root, { attributeFilter: ['data-theme'] });
+    }
+    medirLuminancia(url).then((l) => {
+      lumWallpaper = l;
+      recalcularContrasteFundo();
+    });
   } else {
-    document.documentElement.style.removeProperty('--fundo-app');
+    root.style.removeProperty('--fundo-app');
+    root.style.removeProperty('--texto-fundo');
+    root.classList.remove('tem-fundo');
+    lumWallpaper = null;
+    observadorTema?.disconnect();
+    observadorTema = null;
     localStorage.removeItem(FUNDO_KEY);
   }
 }
@@ -43,6 +112,7 @@ export function aplicarVeu(dim: number | null | undefined) {
     document.documentElement.style.setProperty('--fundo-veu', `${dim}%`);
     localStorage.setItem(VEU_KEY, String(dim));
   }
+  recalcularContrasteFundo();
 }
 
 export function veuSalvo(): number | null {


### PR DESCRIPTION
## O que entra

Ajustes de legibilidade e um retoque na notificação de conquista, todos surgidos ao testar as conquistas (pós #236).

### Contraste automático do texto sobre o wallpaper
O apoiador pode pôr um wallpaper e deixar o véu baixo (0% mostra a imagem crua). Nesse caso, o texto "solto" sobre a imagem (títulos, subtítulos, cabeçalhos de seção, rótulos de filtro) podia ficar ilegível, tipo texto escuro sobre wallpaper escuro no modo claro.

Agora o app mede a luminância média do wallpaper (canvas, com o CORS que o /uploads já libera), combina com o véu (que mistura em direção ao fundo do tema) e com o tema atual, e decide a cor do texto solto via `--texto-fundo`: clara sobre fundo escuro, escura sobre fundo claro. Recalcula sozinho ao mexer no véu ou trocar de tema. Sem efeito de brilho, e o texto dentro de card não é afetado (segue a cor do tema). A lista de seletores cobre o texto solto de cada aba, deixando de fora classes compartilhadas com cards.

### Título de módulo no tema escuro
Na tela de detalhe da trilha, o título do módulo saía preto sobre fundo escuro: o cabeçalho é um `button`, que não herda a cor de texto do tema. Passa a usar `var(--text)`.

### Clique na notificação de conquista
Clicar no toast de conquista agora leva para a aba de Conquistas.

## Verificação
- tsc, eslint e prettier limpos. Testado local com wallpaper escuro e véu 0: o texto solto fica branco e legível nas abas; ao subir o véu ou trocar de tema, recalcula.

## Como validar
Reload completo (o wallpaper é medido no load) com um wallpaper escuro no modo claro, e passe pelas abas.
