### PR TITLE
feat: mais questões nos simulados para variar as tentativas

### DIFF
--- a/backend/scripts/seed-ai-900.ts
+++ b/backend/scripts/seed-ai-900.ts
@@ -1453,6 +1453,216 @@ const QUESTOES: Questao[] = [
             ["Desativar toda a moderação para acelerar as respostas", false],
         ],
     },
+    // ===== Questões adicionais (banco ampliado para variar as tentativas) =====
+    {
+        statement: "Uma equipe quer que seu assistente de IA sempre responda em tom formal, assuma o papel de um especialista em jardinagem e recuse assuntos fora desse tema. Onde essa orientação de comportamento e escopo costuma ser definida?",
+        explanation: "A mensagem de sistema (system message) estabelece papel, tom e limites do assistente no início da interação, orientando como ele deve se comportar.",
+        topic: "IA generativa",
+        options: [
+            ["Em uma lista de exemplos de perguntas e respostas anexada ao final de cada solicitação para ilustrar o formato desejado da saída.", false],
+            ["No conjunto de dados de treinamento original usado para criar o modelo base.", false],
+            ["Na mensagem de sistema, que define papel, tom e limites do assistente antes da conversa.", true],
+            ["No número máximo de tokens configurado para a resposta.", false],
+        ],
+    },
+    {
+        statement: "Uma empresa jurídica quer adaptar um modelo de linguagem base para usar o vocabulário e o estilo dos seus próprios pareceres, fornecendo muitos exemplos rotulados de perguntas e respostas do domínio. Qual técnica atende a esse objetivo?",
+        explanation: "O ajuste fino (fine-tuning) reaproveita um modelo base e o treina com exemplos próprios rotulados, especializando-o no vocabulário e no estilo de um domínio.",
+        topic: "IA generativa",
+        options: [
+            ["Ajuste fino (fine-tuning), que treina o modelo com exemplos próprios para especializá-lo.", true],
+            ["Aumentar o valor da temperatura nas chamadas para que o modelo produza respostas mais criativas e variadas a cada solicitação.", false],
+            ["Reduzir o número de tokens de entrada para diminuir o custo das chamadas.", false],
+            ["Converter os documentos em embeddings apenas para exibi-los ao usuário.", false],
+        ],
+    },
+    {
+        statement: "Ao chamar um modelo do Azure OpenAI Service, uma desenvolvedora quer que as respostas fiquem mais previsíveis e repetíveis, reduzindo a aleatoriedade. Qual parâmetro ela deve diminuir?",
+        explanation: "A temperatura ajusta a aleatoriedade da geração: valores mais baixos deixam as respostas mais determinísticas e repetíveis, enquanto valores altos as tornam mais variadas.",
+        topic: "IA generativa",
+        options: [
+            ["O número de tokens cobrados por cada requisição enviada.", false],
+            ["A quantidade de exemplos incluídos na mensagem de sistema para demonstrar o formato de saída esperado pelo usuário final.", false],
+            ["A versão da API utilizada na integração com o serviço.", false],
+            ["A temperatura, que controla o grau de aleatoriedade das respostas geradas.", true],
+        ],
+    },
+    {
+        statement: "Um aplicativo precisa enviar, na mesma solicitação, uma foto de um prato de comida junto com a pergunta 'quais ingredientes você identifica?' e receber uma resposta em texto. Que tipo de modelo generativo suporta esse cenário?",
+        explanation: "Modelos multimodais aceitam mais de um tipo de entrada, como imagem e texto ao mesmo tempo, e conseguem gerar uma resposta textual analisando ambos.",
+        topic: "IA generativa",
+        options: [
+            ["Um modelo exclusivamente de conversão de fala em texto, que transcreve áudio falado em diferentes idiomas para documentos escritos.", false],
+            ["Um modelo multimodal, capaz de receber imagem e texto como entrada e gerar texto.", true],
+            ["Um modelo de regressão que prevê um único valor numérico contínuo.", false],
+            ["Um modelo que só aceita texto como entrada e recusa qualquer imagem.", false],
+        ],
+    },
+    {
+        statement: "Uma operadora de telefonia já possui um documento de perguntas frequentes e quer disponibilizar um bot que responda os clientes com base nesse material, sem programar cada resposta. Qual recurso do Azure AI Language atende melhor?",
+        explanation: "O recurso Question Answering do Azure AI Language monta uma base de conhecimento a partir de pares de pergunta e resposta, ideal para bots baseados em FAQs.",
+        topic: "Processamento de linguagem natural",
+        options: [
+            ["Análise de sentimento, que classifica cada mensagem recebida como positiva, negativa ou neutra e atribui uma pontuação de confiança.", false],
+            ["Detecção de idioma, que identifica em qual língua cada mensagem foi escrita.", false],
+            ["Extração de frases-chave, que lista os principais termos de um texto.", false],
+            ["Question Answering, que cria uma base de conhecimento a partir de perguntas e respostas existentes.", true],
+        ],
+    },
+    {
+        statement: "Um aplicativo de viagens quer converter nomes de ruas escritos em japonês para o alfabeto latino, preservando a pronúncia, sem mudar o idioma do conteúdo. Qual recurso do Azure AI Translator faz isso?",
+        explanation: "A transliteração converte o texto de um sistema de escrita para outro, por exemplo de caracteres japoneses para o alfabeto latino, mantendo a pronúncia, sem traduzir o significado.",
+        topic: "Processamento de linguagem natural",
+        options: [
+            ["A síntese de fala, que transforma o texto escrito em áudio falado com uma voz natural em diversos idiomas disponíveis.", false],
+            ["A tradução, que reescreve o conteúdo original em outro idioma.", false],
+            ["A transliteração, que converte o texto de um sistema de escrita para outro.", true],
+            ["A detecção de idioma, que apenas informa qual é a língua do texto.", false],
+        ],
+    },
+    {
+        statement: "Uma marca quer que seu assistente por voz fale com um timbre exclusivo e reconhecível, diferente das vozes prontas oferecidas pelo serviço. Qual recurso do Azure AI Speech permite criar essa voz personalizada?",
+        explanation: "O Custom Neural Voice permite treinar uma voz sintética exclusiva a partir de amostras, indo além das vozes neurais prontas usadas na síntese de fala.",
+        topic: "Processamento de linguagem natural",
+        options: [
+            ["A voz neural personalizada (Custom Neural Voice), que gera uma voz sintética sob medida.", true],
+            ["O reconhecimento de fala, que transcreve o áudio falado pelos usuários em texto para posterior análise e armazenamento.", false],
+            ["A tradução de fala, que converte o áudio de um idioma para outro.", false],
+            ["A detecção de idioma, que identifica a língua de um texto escrito.", false],
+        ],
+    },
+    {
+        statement: "Uma transportadora monta uma tabela para prever o tempo de entrega de cada pedido. As colunas distância, peso do pacote e nível de trânsito servem como entrada, e o tempo de entrega é o valor a prever. Como são chamadas as colunas de entrada?",
+        explanation: "As colunas de entrada usadas para prever o alvo são as características (features); o valor a prever, neste caso o tempo de entrega, é o rótulo (label).",
+        topic: "Machine learning",
+        options: [
+            ["Rótulos (labels), que representam o valor conhecido que o modelo deve aprender a prever durante o treinamento supervisionado.", false],
+            ["Características (features), as variáveis de entrada usadas para prever o alvo.", true],
+            ["Hiperparâmetros, que configuram o processo de treinamento do modelo.", false],
+            ["Previsões, que são os resultados devolvidos pelo modelo já treinado.", false],
+        ],
+    },
+    {
+        statement: "Depois de treinar e implantar um modelo, uma equipe passa a enviar novos dados para ele e receber previsões em produção. Como se chama essa fase de uso do modelo já pronto?",
+        explanation: "A inferência (inferencing) é a fase em que o modelo já treinado e implantado recebe novos dados e devolve previsões, diferente do treinamento, quando ele ainda está aprendendo.",
+        topic: "Machine learning",
+        options: [
+            ["Treinamento, a fase em que o algoritmo ajusta seus parâmetros repetidamente a partir de um conjunto de dados rotulado até aprender o padrão.", false],
+            ["Rotulagem, o processo de atribuir rótulos aos dados brutos.", false],
+            ["Validação, a etapa que mede o desempenho antes da implantação.", false],
+            ["Inferência (inferencing), quando o modelo treinado gera previsões para novos dados.", true],
+        ],
+    },
+    {
+        statement: "Uma distribuidora de energia quer estimar a demanda de eletricidade para cada um dos próximos sete dias, usando anos de histórico de consumo ordenado no tempo. No Azure Machine Learning, qual tipo de tarefa de Automated ML se aplica?",
+        explanation: "A previsão de séries temporais (forecasting) usa dados históricos ordenados no tempo para projetar valores futuros, sendo um dos tipos de tarefa do Automated ML, ao lado de classificação e regressão.",
+        topic: "Machine learning",
+        options: [
+            ["Clustering, que agrupa registros semelhantes sem rótulos conhecidos, separando os dados em conjuntos com características parecidas.", false],
+            ["Classificação, que atribui cada registro a uma categoria discreta.", false],
+            ["Previsão de séries temporais (forecasting), que projeta valores futuros a partir do histórico.", true],
+            ["Detecção de objetos, que localiza itens dentro de imagens.", false],
+        ],
+    },
+    {
+        statement: "Uma agência de publicidade quer identificar automaticamente quando logotipos de marcas conhecidas aparecem nas fotos que os usuários publicam nas redes sociais. Qual recurso do Azure AI Vision atende diretamente a isso?",
+        explanation: "A detecção de marcas do Azure AI Vision reconhece logotipos de empresas conhecidas dentro das imagens, útil para monitorar aparições de marca.",
+        topic: "Visão computacional",
+        options: [
+            ["A detecção de marcas, que reconhece logotipos de empresas conhecidas nas imagens.", true],
+            ["O reconhecimento óptico de caracteres (OCR), que localiza e extrai texto impresso ou manuscrito presente em imagens e documentos digitalizados.", false],
+            ["A segmentação semântica, que classifica cada pixel da imagem em uma categoria.", false],
+            ["A síntese de imagens, que cria figuras inéditas a partir de descrições.", false],
+        ],
+    },
+    {
+        statement: "Uma plataforma de classificados quer sinalizar automaticamente fotos enviadas por usuários que contenham conteúdo adulto, sugestivo ou violento antes de publicá-las. Qual capacidade do Azure AI Vision ajuda nessa triagem?",
+        explanation: "O Azure AI Vision pode sinalizar imagens com conteúdo adulto, sugestivo (racy) ou violento (gory), apoiando fluxos de moderação antes da publicação.",
+        topic: "Visão computacional",
+        options: [
+            ["A leitura de texto (Read), que extrai palavras e linhas de texto impresso e manuscrito de imagens para transformá-las em conteúdo pesquisável.", false],
+            ["A verificação facial, que confirma se dois rostos pertencem à mesma pessoa.", false],
+            ["A geração de legendas, que descreve a cena da imagem em uma frase.", false],
+            ["A detecção de conteúdo adulto, sugestivo e violento nas imagens.", true],
+        ],
+    },
+    {
+        statement: "Um portal de notícias exibe listas de artigos com miniaturas pequenas e quer que o recorte automático mantenha o assunto principal da foto sempre visível e centralizado. Qual recurso do Azure AI Vision faz esse recorte inteligente?",
+        explanation: "O recurso de miniaturas (smart crop) do Azure AI Vision gera recortes que mantêm a região de interesse da imagem em foco, útil para thumbnails.",
+        topic: "Visão computacional",
+        options: [
+            ["A detecção de objetos, que localiza vários itens em uma imagem e desenha uma caixa delimitadora ao redor de cada um deles com seu rótulo.", false],
+            ["A geração de miniaturas com recorte inteligente, que preserva a região de interesse.", true],
+            ["A detecção de idioma, que identifica a língua de um texto.", false],
+            ["A análise de sentimento, que avalia a emoção expressa em um texto.", false],
+        ],
+    },
+    {
+        statement: "Uma rede de hotéis fotografa o documento de identidade de cada hóspede no check-in e quer extrair automaticamente nome, número do documento e data de validade em campos estruturados, e não apenas o texto solto. Qual carga de trabalho de IA se aplica?",
+        explanation: "A inteligência de documentos identifica e extrai pares de campo e valor estruturados de formulários e documentos, indo além do OCR, que apenas devolve o texto bruto.",
+        topic: "Cargas de trabalho de IA",
+        options: [
+            ["Mineração de conhecimento, que indexa grandes volumes de conteúdo variado para permitir buscas e descoberta de informações relacionadas entre si.", false],
+            ["IA generativa, que cria textos e imagens originais a partir de instruções.", false],
+            ["Inteligência de documentos (Document Intelligence), que extrai campos estruturados de documentos.", true],
+            ["Detecção de objetos, que localiza itens físicos dentro de uma cena.", false],
+        ],
+    },
+    {
+        statement: "Uma emissora acumulou décadas de documentos, imagens e transcrições e quer que os funcionários pesquisem em todo esse acervo e descubram conexões e informações relevantes espalhadas pelos arquivos. Qual carga de trabalho descreve melhor essa solução?",
+        explanation: "A mineração de conhecimento (knowledge mining) indexa grandes volumes de conteúdo heterogêneo para permitir buscas e revelar informações e relações antes ocultas nos arquivos.",
+        topic: "Cargas de trabalho de IA",
+        options: [
+            ["Mineração de conhecimento, que torna grandes acervos pesquisáveis e extrai informações.", true],
+            ["Inteligência de documentos, voltada a extrair campos e valores específicos e estruturados de formulários padronizados, como faturas, recibos e contratos.", false],
+            ["Visão computacional, focada em interpretar o conteúdo visual de imagens.", false],
+            ["Reconhecimento de fala, que converte áudio falado em texto escrito.", false],
+        ],
+    },
+    {
+        statement: "Um laboratório quer prever, a partir de valores numéricos de exames de sangue organizados em tabela, se um tumor é benigno ou maligno. Não há imagens envolvidas, apenas dados tabulares rotulados. Qual carga de trabalho de IA melhor descreve o problema?",
+        explanation: "Prever uma categoria (benigno ou maligno) a partir de dados tabulares rotulados é uma tarefa de classificação em aprendizado de máquina; como não há imagens, não se trata de visão computacional.",
+        topic: "Cargas de trabalho de IA",
+        options: [
+            ["Aprendizado de máquina, que prevê uma categoria a partir de dados tabulares rotulados.", true],
+            ["Visão computacional, que interpreta o conteúdo de imagens e vídeos, como identificar tumores diretamente em exames de imagem e radiografias.", false],
+            ["Processamento de linguagem natural, que interpreta e gera texto em linguagem humana.", false],
+            ["IA generativa, que produz conteúdo original como texto e imagens.", false],
+        ],
+    },
+    {
+        statement: "Uma empresa de dispositivos de casa inteligente coleta áudio e vídeo dos usuários e precisa garantir que esses dados sejam criptografados, protegidos contra acesso não autorizado e que o usuário controle seu uso. Qual princípio de IA responsável está em foco?",
+        explanation: "O princípio de privacidade e segurança trata de proteger os dados das pessoas, com criptografia, controle de acesso e respeito ao consentimento, diferente de confiabilidade e segurança, que trata da operação segura e consistente do sistema.",
+        topic: "IA responsável",
+        options: [
+            ["Inclusão, que garante que a solução atenda pessoas de diferentes capacidades.", false],
+            ["Confiabilidade e segurança, que exige que o sistema opere de forma consistente e segura mesmo diante de condições inesperadas, com testes rigorosos.", false],
+            ["Privacidade e segurança, que protege os dados das pessoas contra uso indevido.", true],
+            ["Transparência, que torna claro como o sistema funciona e suas limitações.", false],
+        ],
+    },
+    {
+        statement: "Ao projetar um assistente virtual, uma equipe quer garantir que o produto beneficie e alcance pessoas de diferentes capacidades físicas, idiomas e origens culturais, sem deixar nenhum grupo de fora. Qual princípio de IA responsável orienta essa preocupação?",
+        explanation: "A inclusão busca que a IA capacite e envolva pessoas de todas as capacidades e origens; a imparcialidade, por outro lado, foca em tratar grupos semelhantes de forma equitativa, sem viés.",
+        topic: "IA responsável",
+        options: [
+            ["Inclusão, que busca capacitar e envolver pessoas de todas as capacidades e origens.", true],
+            ["Imparcialidade, que exige que o sistema trate de forma equitativa pessoas em situações semelhantes, sem favorecer ou prejudicar grupos por vieses nos dados.", false],
+            ["Responsabilidade, que define quem responde pelos resultados do sistema.", false],
+            ["Confiabilidade e segurança, que garante operação segura e consistente.", false],
+        ],
+    },
+    {
+        statement: "Um banco define que pessoas específicas respondem pelas decisões do seu modelo de crédito, mantém registros para auditoria e assegura que o sistema cumpra as leis e normas do setor. Qual princípio de IA responsável está sendo aplicado?",
+        explanation: "O princípio da responsabilidade (accountability) determina que pessoas e organizações respondam pelo funcionamento dos sistemas de IA, incluindo governança, auditoria e conformidade legal.",
+        topic: "IA responsável",
+        options: [
+            ["Transparência, pela qual os usuários são informados de que interagem com uma IA e recebem explicações sobre como ela funciona e quais são as suas limitações.", false],
+            ["Inclusão, que garante que o sistema atenda pessoas de diferentes perfis.", false],
+            ["Privacidade e segurança, que protege os dados pessoais dos clientes.", false],
+            ["Responsabilidade (accountability), pela qual pessoas respondem pelo sistema e sua conformidade.", true],
+        ],
+    },
 ];
 
 async function seed() {
@@ -1486,13 +1696,23 @@ async function seed() {
         .select({ n: count() })
         .from(simuladoQuestions)
         .where(eq(simuladoQuestions.simuladoId, simulado.id));
-    if (Number(n) > 0) {
+    const jaExistem = new Set(
+        (
+            await db
+                .select({ statement: simuladoQuestions.statement })
+                .from(simuladoQuestions)
+                .where(eq(simuladoQuestions.simuladoId, simulado.id))
+        ).map((r) => r.statement),
+    );
+    const inseridas = QUESTOES.filter((q) => !jaExistem.has(q.statement)).length;
+    if (inseridas === 0) {
         console.log(`Simulado já tem ${n} questões, nada a fazer.`);
         return;
     }
 
     for (let i = 0; i < QUESTOES.length; i++) {
         const q = QUESTOES[i];
+        if (jaExistem.has(q.statement)) continue;
         const [questao] = await db
             .insert(simuladoQuestions)
             .values({
@@ -1511,7 +1731,7 @@ async function seed() {
             })),
         );
     }
-    console.log(`Seed concluído: ${QUESTOES.length} questões inseridas.`);
+    console.log(`Seed: ${inseridas} questões novas inseridas (${QUESTOES.length} no banco).`);
 }
 
 seed()

--- a/backend/scripts/seed-ai-901.ts
+++ b/backend/scripts/seed-ai-901.ts
@@ -2407,7 +2407,239 @@ const QUESTOES: Questao[] = [
                 false
             ]
         ]
-    }
+    },
+    // ===== Questões adicionais (banco ampliado para variar as tentativas) =====
+    {
+        statement: "Uma equipe cria um assistente de reservas que precisa entender frases como 'quero uma mesa para quatro na sexta' e transformá-las em uma ação, identificando a data e o número de pessoas. Qual capacidade de linguagem faz esse reconhecimento de intenção e de entidades?",
+        explanation: "O Conversational Language Understanding interpreta enunciados, classifica a intenção e extrai entidades como data e quantidade. Detecção de idioma, TTS e OCR resolvem outros problemas.",
+        topic: "Texto, fala, visão e extração no Foundry",
+        options: [
+            ["O reconhecimento de intenções e entidades, oferecido pelo Conversational Language Understanding", true],
+            ["A detecção de idioma, que apenas identifica em que língua a frase foi escrita", false],
+            ["O text to speech, que converte em áudio falado a frase que o usuário digitou", false],
+            ["O OCR, que lê o texto impresso apenas quando a frase chega ao sistema como uma imagem digitalizada", false],
+        ],
+    },
+    {
+        statement: "Uma empresa já tem um manual e uma lista de perguntas frequentes em texto e quer um bot que responda às dúvidas dos clientes com base nesse conteúdo, sem treinar um modelo generativo do zero. Qual recurso do Azure AI Language se encaixa?",
+        explanation: "A resposta a perguntas personalizada (custom question answering) transforma FAQs e documentos em uma base de conhecimento consultável. Os outros recursos tratam de sentimento, termos-chave e tradução.",
+        topic: "Texto, fala, visão e extração no Foundry",
+        options: [
+            ["A análise de sentimento, que examina cada mensagem recebida e a classifica como positiva, negativa ou neutra para priorização", false],
+            ["A extração de frases-chave, que apenas lista os termos mais relevantes de cada pergunta", false],
+            ["A resposta a perguntas personalizada, que cria uma base de conhecimento a partir das FAQs e retorna a melhor resposta", true],
+            ["A tradução de texto, que converte as perguntas para outro idioma", false],
+        ],
+    },
+    {
+        statement: "Um sistema de controle de acesso precisa localizar e contar rostos em fotos da portaria e, por privacidade, borrar cada rosto encontrado antes de arquivar a imagem. Qual capacidade de visão computacional atende a esse requisito?",
+        explanation: "A detecção de rostos do Azure AI Vision encontra e delimita as faces presentes na imagem, permitindo contar e ocultar cada uma. Geração de imagem, frases-chave e fala tratam de outras tarefas.",
+        topic: "Texto, fala, visão e extração no Foundry",
+        options: [
+            ["A geração de imagem, que cria rostos sintéticos a partir de uma descrição em texto", false],
+            ["A extração de frases-chave, que resume em palavras os termos centrais de um texto", false],
+            ["O reconhecimento de fala, que transcreve em texto o áudio que seria captado pelos microfones das câmeras da portaria", false],
+            ["A detecção de rostos, que localiza as faces na imagem e retorna a posição de cada uma", true],
+        ],
+    },
+    {
+        statement: "Uma equipe transcreve reuniões e, além do texto, precisa saber quem falou cada trecho, separando e rotulando os diferentes participantes ao longo da gravação. Qual recurso do Azure AI Speech resolve isso?",
+        explanation: "A diarização identifica e rotula os diferentes locutores, indicando quem falou cada parte da transcrição. Síntese, tradução de fala e detecção de idioma cobrem outras necessidades.",
+        topic: "Texto, fala, visão e extração no Foundry",
+        options: [
+            ["A síntese de fala, que gera uma voz natural para ler a ata da reunião em voz alta", false],
+            ["A separação de locutores (diarização), que atribui cada trecho transcrito ao participante que o falou", true],
+            ["A tradução de fala, que converte o áudio falado da reunião para outro idioma quase em tempo real durante a chamada", false],
+            ["A detecção de idioma, que identifica em qual língua cada participante está falando na sala", false],
+        ],
+    },
+    {
+        statement: "Uma seguradora recebe todo mês o mesmo formulário próprio de sinistro, com um layout que os modelos prontos não reconhecem bem, e quer treinar um extrator usando alguns exemplos rotulados desse formulário. Qual abordagem do Document Intelligence é indicada?",
+        explanation: "Quando os modelos prontos não cobrem um layout específico, o Document Intelligence permite treinar um modelo personalizado com poucos exemplos rotulados. Os demais recursos não extraem campos de formulários próprios.",
+        topic: "Texto, fala, visão e extração no Foundry",
+        options: [
+            ["Usar o modelo pronto de fatura, que já vem preparado para notas fiscais e recibos comerciais", false],
+            ["Aplicar a detecção de idioma para descobrir em que língua o formulário foi preenchido", false],
+            ["Treinar um modelo personalizado do Document Intelligence com exemplos rotulados do próprio formulário", true],
+            ["Enviar o formulário para a síntese de fala, que lê em voz alta cada um dos campos preenchidos pelo segurado no documento", false],
+        ],
+    },
+    {
+        statement: "Um cartório digitaliza fichas antigas que misturam texto datilografado e anotações feitas à mão e precisa converter tudo em texto editável. Qual capacidade de visão computacional lê tanto o texto impresso quanto o manuscrito nessas imagens?",
+        explanation: "O OCR (recurso Read do Azure AI Vision) reconhece texto impresso e manuscrito em imagens e documentos digitalizados, gerando texto editável. Sentimento, geração de imagem e tradução resolvem outros problemas.",
+        topic: "Texto, fala, visão e extração no Foundry",
+        options: [
+            ["A análise de sentimento, que avalia se o conteúdo das fichas é positivo ou negativo", false],
+            ["A geração de imagem, que produz novas fichas ilustradas a partir de uma descrição textual", false],
+            ["A tradução de texto, que converte para outro idioma o conteúdo textual que já estava presente nas fichas escaneadas", false],
+            ["O reconhecimento óptico de caracteres (OCR), que extrai texto impresso e manuscrito das imagens", true],
+        ],
+    },
+    {
+        statement: "Um banco quer que seu assistente generativo responda perguntas de clientes usando os documentos internos de políticas, em vez de depender só do conhecimento geral do modelo. Qual abordagem no Foundry atende a isso?",
+        explanation: "O RAG (geração aumentada por recuperação) busca trechos relevantes dos seus documentos em um índice e os fornece ao modelo, que responde com base neles. Ajustar temperature, max_tokens ou a voz não traz o conteúdo interno.",
+        topic: "IA generativa e agentes no Foundry",
+        options: [
+            ["Aumentar a temperature do modelo para que ele invente respostas mais variadas sobre as políticas", false],
+            ["Usar RAG, conectando o modelo a um índice com os documentos internos para fundamentar as respostas", true],
+            ["Reduzir o max_tokens para que as respostas do assistente fiquem sempre bem curtas", false],
+            ["Trocar a voz de saída no text to speech para que o assistente soe mais natural ao ler as políticas", false],
+        ],
+    },
+    {
+        statement: "Depois de fundamentar (grounding) o modelo com trechos recuperados dos documentos da empresa, a equipe observa menos respostas inventadas. Qual afirmação explica melhor por que o grounding ajuda?",
+        explanation: "Fundamentar o modelo com dados recuperados confiáveis faz a resposta se apoiar em fatos concretos, reduzindo alucinações. O grounding não altera limite de tokens, tamanho do modelo nem a mensagem de sistema.",
+        topic: "IA generativa e agentes no Foundry",
+        options: [
+            ["Ao receber trechos reais e relevantes com a pergunta, o modelo se baseia neles e tende a alucinar menos", true],
+            ["O grounding aumenta o limite de tokens da resposta, permitindo ao modelo escrever textos consideravelmente mais longos que o normal", false],
+            ["O grounding substitui o modelo por um de menor tamanho, o que reduz o custo por token processado", false],
+            ["O grounding desativa a mensagem de sistema, deixando o modelo responder sem instrução prévia", false],
+        ],
+    },
+    {
+        statement: "Uma equipe quer montar visualmente um fluxo que encadeia a busca de dados, a montagem do prompt e a chamada ao modelo, e ainda avaliar a qualidade das respostas antes de publicar. Qual recurso do Foundry é indicado?",
+        explanation: "O prompt flow permite construir, testar e avaliar fluxos que encadeiam recuperação de dados, prompts e chamadas ao modelo antes de implantar. TTS, detecção de idioma e OCR não orquestram esse fluxo.",
+        topic: "IA generativa e agentes no Foundry",
+        options: [
+            ["O text to speech, que transforma cada resposta gerada em áudio com uma voz natural para ser ouvida pelo usuário", false],
+            ["A detecção de idioma, que descobre em que língua a pergunta do usuário foi escrita", false],
+            ["O prompt flow, que orquestra as etapas do fluxo generativo e permite avaliá-lo antes da implantação", true],
+            ["O OCR, que extrai o texto presente em imagens e documentos digitalizados enviados ao fluxo", false],
+        ],
+    },
+    {
+        statement: "Ao criar um agente no Azure AI Agent Service, a equipe quer que ele consulte um conjunto de arquivos internos para responder com base neles, além de seguir as instruções de comportamento. O que precisa ser adicionado ao agente?",
+        explanation: "Agentes ganham acesso a dados e ações por meio de ferramentas; uma ferramenta de busca em arquivos deixa o agente recuperar conteúdo interno para fundamentar respostas. Temperature, voz e threads extras não cumprem esse papel.",
+        topic: "IA generativa e agentes no Foundry",
+        options: [
+            ["Um valor de temperature igual a zero, o que por si só faz o agente ler os arquivos internos", false],
+            ["Uma voz de text to speech, para que o agente leia os arquivos internos em áudio ao usuário", false],
+            ["Um segundo thread de conversa, criado a cada nova mensagem do usuário, para que o agente acesse os arquivos automaticamente", false],
+            ["Uma ferramenta de conhecimento, como busca em arquivos, para o agente recuperar e citar o conteúdo interno", true],
+        ],
+    },
+    {
+        statement: "Uma empresa precisa que o modelo adote de forma consistente um estilo de redação muito específico e um formato fixo de saída, e tem milhares de exemplos rotulados desse padrão. Qual abordagem de personalização ajusta o próprio modelo a partir desses exemplos?",
+        explanation: "O ajuste fino re-treina o modelo com exemplos rotulados, fazendo-o incorporar um estilo e formato específicos de forma consistente. Geração de imagem, detecção de idioma e reconhecimento de fala não personalizam o texto gerado.",
+        topic: "IA generativa e agentes no Foundry",
+        options: [
+            ["O ajuste fino (fine-tuning), que treina o modelo com os exemplos rotulados para incorporar o padrão desejado", true],
+            ["A geração de imagem, que cria ilustrações originais e inéditas a partir das descrições textuais enviadas pela equipe da empresa", false],
+            ["A detecção de idioma, que identifica em que língua cada exemplo rotulado foi escrito", false],
+            ["O reconhecimento de fala, que transcreve em texto os áudios gravados pela equipe de redação", false],
+        ],
+    },
+    {
+        statement: "Sem treinar nada, um desenvolvedor quer orientar o formato da resposta incluindo no próprio prompt dois ou três exemplos de pergunta e resposta antes da pergunta real. Como se chama essa técnica?",
+        explanation: "No few-shot, exemplos são incluídos no próprio prompt para mostrar ao modelo o padrão esperado, sem re-treinar nada. Ajuste fino, implantação e Content Safety são conceitos diferentes.",
+        topic: "IA generativa e agentes no Foundry",
+        options: [
+            ["Ajuste fino, que re-treina os pesos do modelo usando um grande conjunto de dados rotulados", false],
+            ["Fornecer exemplos no prompt (few-shot), guiando o modelo pelo padrão dos exemplos incluídos", true],
+            ["Implantação (deployment), que disponibiliza o modelo escolhido em um endpoint para ser chamado", false],
+            ["Content Safety, que analisa o prompt em busca de conteúdo nocivo antes de enviá-lo ao modelo", false],
+        ],
+    },
+    {
+        statement: "Uma rede social precisa analisar automaticamente textos e imagens enviados pelos usuários para detectar conteúdo de ódio, violência, sexual ou de automutilação e bloqueá-lo. Qual serviço do Azure é voltado a isso?",
+        explanation: "O Azure AI Content Safety identifica e classifica conteúdo nocivo (ódio, violência, sexual e automutilação) em texto e imagens, com níveis de severidade. Speech, Document Intelligence e detecção de idioma têm outras finalidades.",
+        topic: "IA responsável e modelos",
+        options: [
+            ["O Azure AI Speech, que converte em texto o áudio das publicações enviadas pelos usuários da rede", false],
+            ["O Document Intelligence, que extrai campos estruturados como fornecedor, data e valor total de documentos e formulários digitalizados", false],
+            ["O Azure AI Content Safety, que detecta conteúdo nocivo em texto e imagem por categoria e severidade", true],
+            ["A detecção de idioma, que apenas informa em que língua cada publicação foi escrita pelo usuário", false],
+        ],
+    },
+    {
+        statement: "Ao implantar um modelo generativo no Foundry, a equipe percebe que já existe, por padrão, um sistema que examina os prompts e as respostas e pode bloquear conteúdo nocivo por categoria e nível de severidade. Como se chama esse mecanismo?",
+        explanation: "Cada implantação no Foundry aplica filtros de conteúdo que analisam entradas e saídas e bloqueiam conteúdo nocivo conforme a severidade. Temperature, prompt flow e tokenizador não fazem essa moderação.",
+        topic: "IA responsável e modelos",
+        options: [
+            ["O parâmetro temperature, que controla o quanto as respostas do modelo ficam aleatórias, variadas e criativas a cada chamada", false],
+            ["O prompt flow, que encadeia visualmente as etapas de recuperação, prompt e chamada ao modelo", false],
+            ["O tokenizador, que quebra o texto de entrada em unidades menores antes de o modelo processá-lo", false],
+            ["Os filtros de conteúdo do deployment, que avaliam prompts e respostas e bloqueiam conteúdo nocivo pela severidade", true],
+        ],
+    },
+    {
+        statement: "Antes de colocar um assistente em produção, a equipe quer medir de forma sistemática se as respostas do modelo são fundamentadas nos dados fornecidos, relevantes e coerentes, comparando configurações. Que atividade do Foundry apoia essa decisão?",
+        explanation: "A avaliação de modelos no Foundry aplica métricas como fundamentação, relevância, coerência e fluência para comparar e validar respostas antes da produção. Síntese de fala, detecção de idioma e temperature não avaliam qualidade.",
+        topic: "IA responsável e modelos",
+        options: [
+            ["A síntese de fala, que lê as respostas do assistente em voz alta, com entonação natural, para toda a equipe ouvir", false],
+            ["A avaliação de modelos, que mede as respostas por métricas como fundamentação, relevância e coerência", true],
+            ["A detecção de idioma, que informa em que língua cada resposta do assistente foi redigida", false],
+            ["O aumento da temperature, que aleatoriza as respostas para que fiquem sempre diferentes entre si", false],
+        ],
+    },
+    {
+        statement: "Uma equipe navega pelo catálogo de modelos do Foundry para escolher um modelo generativo. Qual conjunto de critérios é mais adequado para orientar essa escolha?",
+        explanation: "A escolha de um modelo deve considerar a tarefa e a modalidade, os benchmarks de desempenho, o custo e o tamanho de contexto necessários. Critérios como cor do ícone ou ordem na lista são irrelevantes.",
+        topic: "IA responsável e modelos",
+        options: [
+            ["O tipo de tarefa, a modalidade suportada, os benchmarks de desempenho, o custo e o tamanho do contexto", true],
+            ["A cor do ícone do modelo no catálogo e a ordem alfabética em que ele aparece na lista de resultados", false],
+            ["Apenas o nome do fornecedor, escolhendo sempre o primeiro modelo que aparecer logo na página inicial do catálogo de modelos", false],
+            ["Somente a data de publicação, adotando invariavelmente o modelo mais recente sem avaliar mais nada", false],
+        ],
+    },
+    {
+        statement: "A Microsoft organiza sua abordagem de IA responsável em torno de um conjunto de princípios. Qual das opções a seguir NÃO é um desses princípios?",
+        explanation: "Os princípios de IA responsável da Microsoft incluem imparcialidade, confiabilidade e segurança, privacidade e segurança, inclusão, transparência e responsabilização. Priorizar o lucro acima de tudo não é um deles.",
+        topic: "IA responsável e modelos",
+        options: [
+            ["Tratar as pessoas de forma justa, sem discriminar grupos por características como gênero ou etnia", false],
+            ["Priorizar o lucro acima de tudo", true],
+            ["Operar de maneira confiável e segura, inclusive diante de situações inesperadas", false],
+            ["Proteger a privacidade e a segurança dos dados usados pelo sistema de IA", false],
+        ],
+    },
+    {
+        statement: "Uma rede de lojas quer prever, em reais, o faturamento do próximo mês de cada filial a partir de dados históricos de vendas. Que tipo de tarefa de machine learning corresponde a prever um valor numérico contínuo?",
+        explanation: "A regressão prevê um valor numérico contínuo, como faturamento ou temperatura, a partir de variáveis de entrada. Classificação atribui categorias, e os demais tratam de imagem e fala.",
+        topic: "Cargas e capacidades de IA",
+        options: [
+            ["Classificação, que atribui a cada exemplo um rótulo entre categorias previamente definidas", false],
+            ["Geração de imagem, que cria figuras originais a partir de uma descrição escrita em texto", false],
+            ["Regressão, que estima um valor numérico contínuo a partir dos dados de entrada", true],
+            ["Reconhecimento de fala, que transcreve em texto o áudio das ligações de vendas das filiais", false],
+        ],
+    },
+    {
+        statement: "Uma equipe de marketing tem uma base de clientes sem rótulos e quer descobrir automaticamente grupos de perfis parecidos, sem definir as categorias de antemão. Que tipo de tarefa de machine learning faz esse agrupamento?",
+        explanation: "O agrupamento (clustering) é uma tarefa não supervisionada que forma grupos de itens semelhantes sem rótulos predefinidos. Regressão, TTS e OCR resolvem outros tipos de problema.",
+        topic: "Cargas e capacidades de IA",
+        options: [
+            ["Agrupamento (clustering), que reúne exemplos semelhantes sem depender de rótulos definidos antes", true],
+            ["Regressão, que prevê um valor numérico contínuo a partir das variáveis de entrada disponíveis", false],
+            ["Text to speech, que converte em áudio falado o texto dos perfis cadastrados dos clientes", false],
+            ["OCR, que lê o texto impresso presente em imagens e documentos digitalizados enviados pela equipe", false],
+        ],
+    },
+    {
+        statement: "Um sistema financeiro monitora transações em tempo real e precisa apontar automaticamente as que fogem muito do padrão normal, para sinalizar possível fraude. Que tipo de capacidade de IA se aplica a identificar esses pontos fora do padrão?",
+        explanation: "A detecção de anomalias identifica pontos que destoam do comportamento normal dos dados, útil para fraude e falhas. Geração de texto, síntese de fala e tradução têm outros objetivos.",
+        topic: "Cargas e capacidades de IA",
+        options: [
+            ["A geração de texto, que redige descrições originais para cada transação processada pelo sistema", false],
+            ["A síntese de fala, que anuncia em voz alta o valor de cada transação aprovada pelo sistema", false],
+            ["A tradução automática, que converte a descrição de cada transação para o idioma do analista responsável", false],
+            ["A detecção de anomalias, que sinaliza registros que se desviam de forma incomum do padrão esperado", true],
+        ],
+    },
+    {
+        statement: "Uma empresa tem milhões de documentos, e-mails e PDFs dispersos e quer torná-los pesquisáveis, extraindo e indexando informações para que as pessoas encontrem respostas rapidamente. Que tipo de carga de IA descreve isso?",
+        explanation: "A mineração de conhecimento (knowledge mining) extrai, enriquece e indexa informações de grandes volumes de conteúdo, tornando-o pesquisável. Geração de imagem, reconhecimento e síntese de fala não cumprem esse papel.",
+        topic: "Cargas e capacidades de IA",
+        options: [
+            ["Mineração de conhecimento, que enriquece e indexa grandes volumes de conteúdo para torná-lo pesquisável", true],
+            ["Geração de imagem, que produz ilustrações originais a partir de descrições escritas pelos usuários", false],
+            ["Reconhecimento de fala, que transcreve em texto o áudio de reuniões e de ligações telefônicas gravadas pela empresa", false],
+            ["Síntese de fala, que lê em voz alta, com voz natural, o conteúdo dos documentos armazenados", false],
+        ],
+    },
 ];
 
 async function seed() {
@@ -2440,13 +2672,23 @@ async function seed() {
         .select({ n: count() })
         .from(simuladoQuestions)
         .where(eq(simuladoQuestions.simuladoId, simulado.id));
-    if (Number(n) > 0) {
+    const jaExistem = new Set(
+        (
+            await db
+                .select({ statement: simuladoQuestions.statement })
+                .from(simuladoQuestions)
+                .where(eq(simuladoQuestions.simuladoId, simulado.id))
+        ).map((r) => r.statement),
+    );
+    const inseridas = QUESTOES.filter((q) => !jaExistem.has(q.statement)).length;
+    if (inseridas === 0) {
         console.log("Simulado já tem " + n + " questões, nada a fazer.");
         return;
     }
 
     for (let i = 0; i < QUESTOES.length; i++) {
         const q = QUESTOES[i];
+        if (jaExistem.has(q.statement)) continue;
         const [questao] = await db
             .insert(simuladoQuestions)
             .values({
@@ -2465,7 +2707,7 @@ async function seed() {
             })),
         );
     }
-    console.log("Seed concluído: " + QUESTOES.length + " questões inseridas.");
+    console.log("Seed: " + inseridas + " questões novas inseridas (" + QUESTOES.length + " no banco).");
 }
 
 seed()

--- a/backend/scripts/seed-aif-c01.ts
+++ b/backend/scripts/seed-aif-c01.ts
@@ -911,6 +911,1107 @@ const QUESTOES: Questao[] = [
             ["Substitui a criptografia dos dados em repouso e em trânsito", false],
         ],
     },
+    // ===== Questões adicionais (banco ampliado para variar as tentativas) =====
+    {
+        statement: "Um time de logística quer que um sistema aprenda sozinho a melhor sequência de movimentos de um robô em um armazém, recebendo recompensa quando entrega rápido e penalidade quando colide com uma prateleira. Que tipo de aprendizado de máquina descreve melhor essa abordagem?",
+        explanation: "O aprendizado por reforço é aquele em que um agente aprende por tentativa e erro, guiado por recompensas e penalidades, exatamente como o robô do cenário. O supervisionado depende de exemplos já rotulados com a resposta certa, o não supervisionado busca padrões sem rótulos e o semissupervisionado mistura poucos dados rotulados com muitos não rotulados.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Aprendizado supervisionado, treinando o modelo com um grande conjunto de exemplos previamente rotulados com a ação correta", false],
+            ["Aprendizado não supervisionado", false],
+            ["Aprendizado por reforço", true],
+            ["Aprendizado semissupervisionado", false],
+        ],
+    },
+    {
+        statement: "Em uma apresentação técnica, alguém pergunta o que caracteriza o aprendizado profundo (deep learning) dentro do campo de machine learning. Qual resposta está correta?",
+        explanation: "Deep learning é um subcampo do ML baseado em redes neurais com muitas camadas, capazes de aprender representações complexas dos dados. Não é sinônimo de IA, que é um conceito muito mais amplo, nem se define pelo hardware usado ou por uma etapa de limpeza de dados.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["É um sinônimo de inteligência artificial, abrangendo qualquer sistema que tente imitar o raciocínio e o comportamento humano", false],
+            ["O uso de redes neurais com várias camadas para aprender padrões complexos a partir dos dados", true],
+            ["Qualquer modelo de ML executado em hardware com GPUs de alto desempenho", false],
+            ["A etapa de limpeza profunda dos dados antes do treino do modelo", false],
+        ],
+    },
+    {
+        statement: "Uma central de atendimento recebe milhares de e-mails por dia e quer que um modelo direcione cada mensagem automaticamente para um entre quatro departamentos (financeiro, técnico, vendas e outros). Que tipo de tarefa de ML é essa?",
+        explanation: "Direcionar cada e-mail para uma entre categorias predefinidas (os departamentos) é classificação. Regressão prevê valores numéricos contínuos, clustering agrupa sem categorias definidas e a redução de dimensionalidade apenas comprime as variáveis, sem rotular as mensagens.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Regressão, já que a saída desejada seria um número contínuo", false],
+            ["Clustering, agrupando os e-mails por similaridade sem categorias predefinidas", false],
+            ["Redução de dimensionalidade dos textos recebidos", false],
+            ["Classificação em categorias predefinidas", true],
+        ],
+    },
+    {
+        statement: "Qual é a diferença fundamental entre um problema de regressão e um de classificação no aprendizado supervisionado?",
+        explanation: "Na regressão a saída é um número contínuo; na classificação, uma categoria discreta. Ambas usam dados rotulados no aprendizado supervisionado, funcionam com diferentes tipos de dados e são usadas tanto no treino quanto na inferência, o que elimina as demais opções.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["A regressão prevê um valor numérico contínuo, enquanto a classificação atribui uma categoria discreta", true],
+            ["A regressão usa dados rotulados e a classificação sempre usa dados sem rótulo algum", false],
+            ["A regressão só aceita dados estruturados em tabelas, ao passo que a classificação só serve para imagens e vídeos", false],
+            ["A regressão ocorre apenas no treino e a classificação apenas na inferência em produção", false],
+        ],
+    },
+    {
+        statement: "Um modelo apresenta desempenho ruim tanto nos dados de treino quanto nos de teste, indicando que é simples demais para capturar os padrões presentes nos dados. Como esse problema é chamado?",
+        explanation: "Desempenho ruim tanto no treino quanto no teste indica underfitting: o modelo é simples demais para os padrões dos dados. Overfitting seria bom no treino e ruim em dados novos, enquanto vazamento de dados e desbalanceamento de classes descrevem outros problemas.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Overfitting, quando o modelo decora os dados de treino e vai mal em dados novos", false],
+            ["Vazamento de dados entre os conjuntos de treino e teste", false],
+            ["Underfitting (subajuste)", true],
+            ["Desbalanceamento entre as classes do problema", false],
+        ],
+    },
+    {
+        statement: "Uma equipe percebeu que seu modelo está com overfitting, indo muito bem no treino e mal em dados novos. Qual medida ajuda a REDUZIR o overfitting?",
+        explanation: "Mais dados de treino e regularização reduzem o overfitting ao limitar a memorização dos exemplos. Treinar por mais épocas, aumentar a complexidade do modelo ou descartar os dados de validação tendem a agravar o overfitting, não a resolvê-lo.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Aumentar o volume e a diversidade dos dados de treino e aplicar regularização", true],
+            ["Continuar o treino por muito mais épocas para reduzir ainda mais o erro nos dados de treino", false],
+            ["Acrescentar mais parâmetros e camadas para deixar o modelo mais complexo", false],
+            ["Descartar o conjunto de validação e usar todos os registros no treino", false],
+        ],
+    },
+    {
+        statement: "No equilíbrio entre viés (bias) e variância (variance) de um modelo, o que costuma acontecer quando o modelo é complexo demais para o problema?",
+        explanation: "Modelos complexos demais costumam ter alta variância e tendem ao overfitting; modelos simples demais têm alto viés e underfitting. Viés e variância não caem juntos a zero, e um modelo treinado não passa a prever de forma totalmente aleatória.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Alto viés (bias), levando o modelo ao underfitting", false],
+            ["Alta variância, levando o modelo ao overfitting", true],
+            ["Tanto o viés quanto a variância desaparecem por completo", false],
+            ["O modelo deixa de considerar as features e passa a prever de forma aleatória", false],
+        ],
+    },
+    {
+        statement: "No treino de um modelo supervisionado para prever inadimplência, informações como renda, idade e histórico de pagamento do cliente são usadas como entradas do modelo. Como esses atributos de entrada são chamados?",
+        explanation: "Os atributos de entrada usados pelo modelo (renda, idade, histórico) são as features. Rótulos são a resposta que o modelo deve prever, hiperparâmetros configuram o algoritmo e épocas contam as passagens completas pelos dados de treino.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Rótulos (labels), que representam a resposta que o modelo deve prever", false],
+            ["Hiperparâmetros de configuração do algoritmo de treino", false],
+            ["Épocas, o número de passagens completas do algoritmo pelos dados de treino", false],
+            ["Features, os atributos de entrada usados pelo modelo", true],
+        ],
+    },
+    {
+        statement: "Ao dividir os dados em treino, validação e teste, para que serve especificamente o conjunto de validação?",
+        explanation: "O conjunto de validação serve para ajustar hiperparâmetros e comparar versões do modelo durante o desenvolvimento. O treino ajusta os pesos, o teste fornece a estimativa final e imparcial reservada para o fim do projeto, e nenhum deles guarda dados descartados por qualidade.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Ajustar hiperparâmetros e comparar versões do modelo durante o desenvolvimento", true],
+            ["Treinar e ajustar os pesos internos finais do modelo", false],
+            ["Servir como estimativa final e imparcial do desempenho, reservada para o fim do projeto", false],
+            ["Guardar os registros descartados por problemas de qualidade", false],
+        ],
+    },
+    {
+        statement: "Um filtro de spam corporativo está enviando muitos e-mails legítimos para a lixeira (falsos positivos), o que irrita os usuários. Para reduzir esse tipo específico de erro, qual métrica a equipe deve priorizar melhorar?",
+        explanation: "Falsos positivos, ou seja, e-mails legítimos marcados como spam, atacam a precisão, então melhorar a precisão reduz esse erro. Recall foca nos falsos negativos, MAE é métrica de regressão e o tempo de inferência não mede acerto de classificação.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Recall (sensibilidade) do classificador", false],
+            ["MAE, o erro absoluto médio das previsões", false],
+            ["Precisão (precision)", true],
+            ["O tempo médio de inferência para processar cada mensagem recebida", false],
+        ],
+    },
+    {
+        statement: "Uma equipe quer uma única métrica que equilibre precisão e recall ao avaliar um classificador com classes bastante desbalanceadas. Qual métrica atende a esse objetivo?",
+        explanation: "O F1-score é a média harmônica entre precisão e recall, útil justamente quando há desbalanceamento entre as classes. A acurácia pode enganar nesses casos, e RMSE e R2 são métricas de regressão, não de classificação.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Acurácia, a proporção total de acertos do modelo", false],
+            ["F1-score", true],
+            ["RMSE, a raiz do erro quadrático médio", false],
+            ["Coeficiente de determinação (R2) das previsões do modelo", false],
+        ],
+    },
+    {
+        statement: "Ao avaliar um classificador, uma tabela mostra as contagens de verdadeiros positivos, falsos positivos, verdadeiros negativos e falsos negativos. Que ferramenta de avaliação é essa?",
+        explanation: "A tabela que cruza verdadeiros e falsos positivos e negativos é a matriz de confusão. A curva ROC relaciona taxas em vários limiares, enquanto o histograma de resíduos e a matriz de correlação entre features servem a outros propósitos.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Curva ROC do classificador", false],
+            ["Histograma dos resíduos das previsões", false],
+            ["Matriz de correlação entre as variáveis de entrada", false],
+            ["Matriz de confusão", true],
+        ],
+    },
+    {
+        statement: "Um cientista de dados avalia um classificador binário observando a curva que relaciona a taxa de verdadeiros positivos e a de falsos positivos em diferentes limiares. Um valor de AUC próximo de 1 indica o quê?",
+        explanation: "Uma AUC próxima de 1 indica que o modelo separa bem as classes; próxima de 0,5 equivaleria a um palpite aleatório. A curva ROC por si só não confirma overfitting nem desbalanceamento do conjunto de dados.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Que o modelo tem boa capacidade de distinguir as classes", true],
+            ["Que o modelo certamente está sofrendo de overfitting", false],
+            ["Que o desempenho é pior do que o de um simples palpite aleatório", false],
+            ["Que o conjunto de dados de treino está fortemente desbalanceado", false],
+        ],
+    },
+    {
+        statement: "Um modelo que detecta uma doença rara, presente em apenas 1% dos casos, alcançou 99% de acurácia simplesmente prevendo 'saudável' para todo mundo. Por que a acurácia é uma métrica enganosa nesse cenário?",
+        explanation: "Com uma classe presente em apenas 1% dos casos, prever sempre 'saudável' gera 99% de acurácia sem detectar nenhum doente, ou seja, a métrica mascara o mau desempenho na classe rara. Acurácia se aplica a classificação, 99% não é ruim por si só e ela não mede latência.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Porque a acurácia só se aplica a problemas de regressão contínua, nunca a classificação", false],
+            ["Porque um valor de 99% é sempre sinal de erro de medição no experimento", false],
+            ["Porque, com classes muito desbalanceadas, ela esconde o mau desempenho na classe rara", true],
+            ["Porque a acurácia mede a latência de resposta do modelo, e não a qualidade das previsões geradas", false],
+        ],
+    },
+    {
+        statement: "Para avaliar um modelo de regressão que prevê a demanda diária de um produto em unidades, quais métricas são apropriadas?",
+        explanation: "MAE e RMSE medem a diferença entre os valores previstos e os reais, adequadas a regressão. Precisão, recall, matriz de confusão, F1 e AUC/ROC são métricas de classificação, inapropriadas para avaliar a previsão de uma quantidade numérica.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Precisão e recall", false],
+            ["MAE e RMSE", true],
+            ["Matriz de confusão e F1-score", false],
+            ["Área sob a curva ROC (AUC), típica de classificadores binários", false],
+        ],
+    },
+    {
+        statement: "Uma empresa armazena dados de vendas em tabelas com colunas bem definidas (data, produto, valor) e também guarda vídeos e áudios das gravações de atendimento. Como classificar esses dois tipos de dados, respectivamente?",
+        explanation: "Tabelas com colunas bem definidas são dados estruturados; vídeos e áudios são dados não estruturados. As demais opções invertem os conceitos ou classificam ambos os tipos de forma incorreta.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Não estruturados e estruturados, respectivamente", false],
+            ["Os dois tipos são considerados estruturados", false],
+            ["Os dois são semiestruturados, por pertencerem à mesma base corporativa", false],
+            ["Estruturados e não estruturados, respectivamente", true],
+        ],
+    },
+    {
+        statement: "No ciclo de vida de um projeto de machine learning, qual sequência representa melhor a ordem geral das principais etapas?",
+        explanation: "O fluxo geral vai de coletar e preparar os dados a treinar, avaliar, implantar e monitorar o modelo. As outras sequências colocam etapas fora de ordem, como implantar ou avaliar antes mesmo de ter os dados coletados e o modelo treinado.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Coletar e preparar os dados, treinar, avaliar, implantar e monitorar", true],
+            ["Implantar o modelo em produção, depois treiná-lo, em seguida coletar os dados e por último avaliar os resultados", false],
+            ["Treinar primeiro, coletar os dados depois, monitorar e só então avaliar o desempenho", false],
+            ["Avaliar, implantar, coletar os dados e por fim treinar o modelo do zero", false],
+        ],
+    },
+    {
+        statement: "Uma equipe quer começar rapidamente a partir de modelos pré-treinados e soluções prontas dentro do Amazon SageMaker, com a possibilidade de ajustá-los às suas necessidades. Qual recurso atende a isso?",
+        explanation: "O SageMaker JumpStart oferece modelos pré-treinados e soluções prontas para acelerar o início de um projeto e permitir ajustes. O Canvas é voltado a modelos no-code, o Macie protege dados sensíveis e o Ground Truth cuida da rotulagem de dados.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Amazon SageMaker Canvas, para criar modelos em interface no-code", false],
+            ["Amazon Macie, para descoberta de dados sensíveis", false],
+            ["Amazon SageMaker JumpStart", true],
+            ["Amazon SageMaker Ground Truth, para rotulagem de dados de treino", false],
+        ],
+    },
+    {
+        statement: "O que caracteriza uma abordagem de AutoML (aprendizado de máquina automatizado)?",
+        explanation: "AutoML automatiza etapas como a seleção do algoritmo, o ajuste de hiperparâmetros e a escolha de features. Ele não dispensa a necessidade de dados, não garante ausência de viés ou erros nem elimina a etapa de treino do modelo.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["Eliminar por completo a necessidade de dados históricos para treinar o modelo", false],
+            ["Automatizar a escolha do algoritmo, o ajuste de hiperparâmetros e a seleção de features", true],
+            ["Assegurar que o modelo resultante jamais apresentará viés ou erros de previsão", false],
+            ["Permitir que o modelo faça inferência em produção sem exigir nenhuma etapa de treino ou preparação anterior", false],
+        ],
+    },
+    {
+        statement: "Durante a fase de treino de um modelo de machine learning supervisionado, o que essencialmente acontece?",
+        explanation: "No treino, o algoritmo ajusta seus parâmetros internos a partir dos exemplos para reduzir o erro das previsões. Guardar dados apenas para consulta, gerar previsões em produção (que é a inferência) e rotular manualmente as saídas descrevem outras coisas.",
+        topic: "Fundamentos de IA e ML",
+        options: [
+            ["O modelo apenas guarda os dados brutos para depois consultá-los um a um quando for necessário", false],
+            ["O modelo gera as previsões finais sobre os dados novos que chegam em produção", false],
+            ["Os usuários finais rotulam manualmente cada previsão à medida que ela é gerada", false],
+            ["O algoritmo ajusta seus parâmetros internos com base nos exemplos para reduzir o erro", true],
+        ],
+    },
+    {
+        statement: "A arquitetura transformer, base da maioria dos LLMs modernos, pondera a importância de diferentes partes da sequência de entrada ao processar cada token. Como esse mecanismo é conhecido?",
+        explanation: "O diferencial do transformer é o mecanismo de atenção, que pondera a relevância de cada token em relação aos demais. Convolução e pooling são típicos de redes convolucionais, e a recorrência caracteriza as RNNs anteriores ao transformer.",
+        topic: "IA generativa",
+        options: [
+            ["Convolução, que desliza filtros sobre a entrada para extrair características locais como em imagens", false],
+            ["Recorrência, que processa a sequência token a token mantendo um estado oculto repassado adiante", false],
+            ["Mecanismo de atenção (attention)", true],
+            ["Agrupamento (pooling), que reduz a dimensionalidade combinando valores vizinhos em um resumo", false],
+        ],
+    },
+    {
+        statement: "Qual afirmação distingue corretamente um modelo generativo de um modelo discriminativo?",
+        explanation: "Modelos generativos aprendem a distribuição dos dados para criar novos exemplos, enquanto os discriminativos aprendem fronteiras para classificar. A distinção não depende do tipo de dado nem exclusivamente do uso de rótulos.",
+        topic: "IA generativa",
+        options: [
+            ["O generativo cria novos conteúdos, e o discriminativo separa classes de dados existentes", true],
+            ["O generativo só funciona com imagens, enquanto o discriminativo trabalha exclusivamente com texto e dados tabulares", false],
+            ["Ambos apenas classificam dados, diferindo somente na quantidade de camadas da rede neural que utilizam", false],
+            ["O generativo exige dados rotulados manualmente, ao passo que o discriminativo aprende sempre sem qualquer rótulo", false],
+        ],
+    },
+    {
+        statement: "Uma empresa quer um foundation model capaz de receber uma imagem junto com uma pergunta em texto e responder sobre o conteúdo da imagem. Que característica do modelo é essencial para isso?",
+        explanation: "Modelos multimodais aceitam mais de um tipo de entrada, como texto e imagem, sendo necessários para interpretar uma imagem junto de uma pergunta. RLHF melhora o alinhamento e a difusão gera imagens, mas nenhum dos dois dá essa capacidade.",
+        topic: "IA generativa",
+        options: [
+            ["Ser treinado com aprendizado por reforço a partir de feedback humano para alinhar as respostas ao usuário", false],
+            ["Ter uma janela de contexto pequena para reduzir o custo de cada chamada de inferência ao modelo", false],
+            ["Usar exclusivamente modelos de difusão, a única categoria capaz de interpretar imagens de entrada", false],
+            ["Ser multimodal, processando mais de um tipo de entrada como texto e imagem", true],
+        ],
+    },
+    {
+        statement: "No Amazon Bedrock, o que é a família de modelos Amazon Titan?",
+        explanation: "O Amazon Titan é a família de foundation models desenvolvida pela AWS, disponível no Bedrock para geração de texto, embeddings e imagens. Não são instâncias de GPU, ferramenta de rotulagem nem serviço exclusivo de terceiros.",
+        topic: "IA generativa",
+        options: [
+            ["Um conjunto de instâncias de GPU otimizadas que o cliente aluga para treinar seus próprios modelos do zero", false],
+            ["Foundation models criados pela própria AWS, oferecidos para tarefas como geração de texto e de embeddings", true],
+            ["Uma ferramenta de rotulagem de dados que prepara datasets antes do treinamento supervisionado de modelos", false],
+            ["Um serviço separado do Bedrock que hospeda apenas modelos de imagem de provedores terceiros", false],
+        ],
+    },
+    {
+        statement: "Uma equipe de desenvolvimento quer um assistente de IA integrado ao ambiente de codificação que sugira trechos de código, explique funções e ajude a depurar. Qual serviço da AWS é o mais indicado?",
+        explanation: "O Amazon Q Developer é o assistente de IA generativa voltado a desenvolvedores, com sugestão e explicação de código e apoio à depuração. Q Business foca em dados corporativos, Comprehend em NLP e Polly em síntese de voz.",
+        topic: "IA generativa",
+        options: [
+            ["Amazon Q Developer", true],
+            ["Amazon Q Business, voltado a responder perguntas sobre documentos e dados corporativos internos", false],
+            ["Amazon Comprehend, que extrai entidades e sentimentos de textos em linguagem natural", false],
+            ["Amazon Polly, que converte texto em fala com vozes naturais em vários idiomas", false],
+        ],
+    },
+    {
+        statement: "Uma pessoa iniciante quer experimentar e prototipar aplicativos de IA generativa em um ambiente pronto, sem escrever código nem provisionar infraestrutura. O que é o PartyRock, da AWS, nesse contexto?",
+        explanation: "O PartyRock é um playground do Amazon Bedrock para construir e explorar apps de IA generativa sem código. Não é banco vetorial, serviço de treino distribuído nem ferramenta de linha de comando para deploy.",
+        topic: "IA generativa",
+        options: [
+            ["Um banco de dados vetorial totalmente gerenciado usado para armazenar embeddings em aplicações de busca semântica de larga escala", false],
+            ["Um serviço de treinamento distribuído que particiona grandes modelos entre várias GPUs automaticamente", false],
+            ["Um playground no Amazon Bedrock para criar e experimentar apps de IA generativa sem código", true],
+            ["Uma ferramenta de linha de comando para implantar modelos treinados em endpoints do SageMaker", false],
+        ],
+    },
+    {
+        statement: "Uma cientista de dados quer acessar foundation models e soluções pré-construídas dentro do Amazon SageMaker para implantar e ajustar modelos rapidamente. Qual recurso oferece esse catálogo?",
+        explanation: "O SageMaker JumpStart oferece um hub de foundation models e soluções pré-construídas para acelerar o deploy e o ajuste. Ground Truth faz rotulagem, Feature Store gerencia atributos e Clarify trata viés e explicabilidade.",
+        topic: "IA generativa",
+        options: [
+            ["SageMaker Ground Truth, que gerencia fluxos de rotulagem de dados feita por revisores humanos ou de forma automatizada", false],
+            ["SageMaker Feature Store, que armazena e serve atributos de ML de forma centralizada", false],
+            ["SageMaker Clarify, que analisa viés e explica as previsões dos modelos", false],
+            ["SageMaker JumpStart", true],
+        ],
+    },
+    {
+        statement: "Um desenvolvedor envia exatamente o mesmo prompt a um LLM duas vezes e recebe respostas com redações diferentes. Como se explica esse comportamento?",
+        explanation: "LLMs costumam amostrar o próximo token de forma probabilística, então a mesma entrada pode gerar respostas diferentes (não-determinismo). Não é erro nem estouro de contexto, e reduzir a temperatura torna a saída mais estável.",
+        topic: "IA generativa",
+        options: [
+            ["O modelo travou e retornou um erro interno, pois o mesmo prompt deveria gerar sempre a resposta idêntica palavra por palavra", false],
+            ["LLMs geralmente têm saída não-determinística, com amostragem probabilística que pode variar entre chamadas", true],
+            ["A janela de contexto foi excedida, o que obriga o modelo a inventar tokens aleatórios no lugar da resposta correta", false],
+            ["Os embeddings do prompt mudam a cada requisição porque são recalculados com valores aleatórios diferentes", false],
+        ],
+    },
+    {
+        statement: "Ao ajustar os parâmetros de inferência de um LLM, o que o parâmetro top-p (nucleus sampling) controla?",
+        explanation: "O top-p limita a amostragem ao menor conjunto de tokens cuja soma de probabilidades alcança p, controlando a diversidade. Limitar o tamanho é papel do máximo de tokens, exemplos no prompt são few-shot e as camadas são fixas na arquitetura.",
+        topic: "IA generativa",
+        options: [
+            ["Restringe a escolha do próximo token ao menor conjunto cuja probabilidade acumulada atinge o valor p", true],
+            ["Define o número máximo de tokens que a resposta pode conter antes de o modelo ser interrompido automaticamente", false],
+            ["Determina quantos exemplos devem ser incluídos no prompt para orientar o formato da resposta desejada", false],
+            ["Fixa a quantidade de camadas de atenção que o modelo ativa durante o processamento de cada requisição", false],
+        ],
+    },
+    {
+        statement: "Qual é o efeito de reduzir o parâmetro top-k na geração de texto de um LLM?",
+        explanation: "Reduzir o top-k deixa menos candidatos a próximo token, tornando a saída mais focada e previsível. Isso não altera a janela de contexto, não libera todos os tokens nem afeta o treinamento.",
+        topic: "IA generativa",
+        options: [
+            ["O modelo passa a aceitar prompts mais longos, aumentando proporcionalmente o tamanho da janela de contexto disponível", false],
+            ["O modelo aumenta a criatividade ao sortear livremente entre todos os tokens do vocabulário sem qualquer corte", false],
+            ["O modelo reduz o tempo de treinamento necessário para aprender novos idiomas a partir de dados adicionais", false],
+            ["O modelo considera menos candidatos a próximo token, tornando a saída mais restrita e previsível", true],
+        ],
+    },
+    {
+        statement: "Uma equipe compara dois foundation models para um chatbot: um modelo grande e um modelo menor. Que tradeoff geral costuma valer nessa escolha?",
+        explanation: "Modelos maiores costumam ser mais capazes, mas custam mais e respondem com mais latência; menores são mais baratos e rápidos, com possível perda de qualidade. As demais opções invertem ou negam esse tradeoff.",
+        topic: "IA generativa",
+        options: [
+            ["O modelo menor sempre entrega respostas de qualidade superior porque foi treinado com muito mais dados e parâmetros", false],
+            ["O modelo maior tende a ser mais capaz, porém com maior custo e latência por requisição", true],
+            ["Ambos têm exatamente o mesmo custo e a mesma latência, já que rodam na mesma infraestrutura gerenciada", false],
+            ["O modelo maior reduz a latência porque precisa de menos cálculos para gerar cada token da resposta", false],
+        ],
+    },
+    {
+        statement: "Em qual cenário a IA generativa é MENOS apropriada, sendo o ML tradicional a melhor escolha?",
+        explanation: "Prever um valor numérico a partir de dados históricos é regressão, bem resolvida por ML tradicional. Redigir e-mails, gerar imagens e resumir textos são casos típicos de IA generativa.",
+        topic: "IA generativa",
+        options: [
+            ["Redigir automaticamente rascunhos de e-mails de marketing personalizados a partir de instruções em texto livre", false],
+            ["Gerar variações de imagens de produtos para campanhas a partir de descrições textuais fornecidas", false],
+            ["Prever numericamente a demanda de estoque do próximo mês a partir de dados históricos de vendas", true],
+            ["Resumir longos relatórios em poucos parágrafos preservando os pontos principais para os executivos", false],
+        ],
+    },
+    {
+        statement: "Antes de um LLM processar um texto, ele passa pela tokenização. O que ocorre nessa etapa?",
+        explanation: "A tokenização quebra o texto em tokens (palavras ou subpalavras) mapeados para IDs numéricos que o modelo processa. Não há tradução obrigatória, criptografia nem busca por respostas prontas.",
+        topic: "IA generativa",
+        options: [
+            ["O texto é dividido em unidades menores (tokens) que o modelo converte em números", true],
+            ["O texto é traduzido automaticamente para o inglês, único idioma que os grandes modelos conseguem processar internamente", false],
+            ["O texto é comprimido em um arquivo binário criptografado para trafegar com segurança até o servidor de inferência", false],
+            ["O texto é comparado com um banco de dados de respostas prontas para localizar a saída mais parecida", false],
+        ],
+    },
+    {
+        statement: "No Amazon Bedrock, o modo de precificação sob demanda (on-demand) para foundation models cobra com base em quê?",
+        explanation: "No modo sob demanda paga-se pelo uso, tipicamente por tokens de entrada e de saída, sem compromisso de longo prazo. Não é taxa fixa ilimitada, não exige provisionar GPUs nem cobra por usuário cadastrado.",
+        topic: "IA generativa",
+        options: [
+            ["Em uma taxa mensal fixa que dá direito a chamadas ilimitadas a qualquer modelo disponível no serviço", false],
+            ["No número de servidores de GPU que o cliente precisa provisionar e manter ligados o tempo todo", false],
+            ["Na quantidade de usuários cadastrados na conta, independentemente de quantas requisições cada um faz", false],
+            ["No volume processado, como a quantidade de tokens de entrada e de saída", true],
+        ],
+    },
+    {
+        statement: "Um desenvolvedor descreve em linguagem natural a função que precisa e recebe do assistente uma implementação em Python pronta para revisar. Que capacidade de IA generativa está sendo usada?",
+        explanation: "Transformar uma descrição em linguagem natural em código pronto é um caso clássico de geração de código. As demais opções descrevem classificação, detecção de anomalias e OCR.",
+        topic: "IA generativa",
+        options: [
+            ["Classificação de sentimentos do texto para medir a satisfação do desenvolvedor com a linguagem escolhida", false],
+            ["Geração de código a partir de linguagem natural", true],
+            ["Detecção de anomalias em métricas de infraestrutura para prever falhas antes que elas aconteçam", false],
+            ["Reconhecimento óptico de caracteres para extrair texto de imagens de documentos escaneados", false],
+        ],
+    },
+    {
+        statement: "Um departamento jurídico recebe contratos de dezenas de páginas e quer versões curtas com os pontos principais para leitura rápida. Qual capacidade de IA generativa atende diretamente a essa necessidade?",
+        explanation: "Reduzir documentos longos a resumos com os pontos-chave é sumarização, um uso central da IA generativa. Tradução, síntese de voz e criptografia resolvem outras necessidades.",
+        topic: "IA generativa",
+        options: [
+            ["Tradução simultânea dos contratos para diversos idiomas estrangeiros exigidos por filiais no exterior", false],
+            ["Conversão dos contratos em áudio narrado para que a equipe possa ouvir durante os deslocamentos", false],
+            ["Sumarização de textos longos", true],
+            ["Criptografia do conteúdo dos contratos para impedir acesso não autorizado aos dados sensíveis", false],
+        ],
+    },
+    {
+        statement: "Uma empresa quer um chatbot de atendimento que entenda perguntas escritas de forma livre pelos clientes e responda em linguagem natural. Por que um LLM é adequado nesse caso?",
+        explanation: "LLMs entendem e produzem linguagem natural, sustentando diálogos com respostas contextualizadas, ideais para chatbots. Eles não garantem correção total, não conhecem dados internos sem integração nem se limitam a roteiros fixos.",
+        topic: "IA generativa",
+        options: [
+            ["Ele interpreta e gera linguagem natural, mantendo diálogo com respostas contextualizadas", true],
+            ["Ele garante respostas sempre 100% corretas e verificadas, eliminando por completo qualquer supervisão humana", false],
+            ["Ele dispensa qualquer conexão com dados ou sistemas da empresa, pois já sabe de fábrica todas as políticas internas", false],
+            ["Ele funciona apenas com perguntas de múltipla escolha previamente cadastradas em um roteiro fixo", false],
+        ],
+    },
+    {
+        statement: "Como, em linhas gerais, os modelos de difusão geram uma imagem?",
+        explanation: "Modelos de difusão partem de ruído e o removem gradualmente, condicionados pelo prompt, até formar uma imagem nova. Não colam trechos de fotos, não buscam uma imagem pronta nem mapeiam palavras diretamente para pixels.",
+        topic: "IA generativa",
+        options: [
+            ["Recortam e colam pedaços de fotos reais de um banco de imagens até montar a composição final solicitada", false],
+            ["Selecionam a imagem mais parecida já armazenada e apenas ajustam o brilho e o contraste conforme o pedido", false],
+            ["Traduzem cada palavra do prompt em um pixel fixo segundo uma tabela pré-definida de cores", false],
+            ["Partem de ruído aleatório e o refinam passo a passo até formar a imagem", true],
+        ],
+    },
+    {
+        statement: "Em uma busca semântica, dois textos com significados parecidos tendem a ter embeddings que se comportam como?",
+        explanation: "Embeddings mapeiam textos para vetores em que a proximidade indica semelhança de significado, base da busca semântica. Eles não exigem palavras idênticas, não são aleatórios nem imagens.",
+        topic: "IA generativa",
+        options: [
+            ["Sequências de caracteres idênticas, já que textos parecidos precisam usar exatamente as mesmas palavras", false],
+            ["Vetores próximos no espaço, refletindo a semelhança de significado", true],
+            ["Valores numéricos totalmente aleatórios, sem qualquer relação com o conteúdo original dos textos", false],
+            ["Arquivos de imagem que representam visualmente cada frase para comparação pixel a pixel", false],
+        ],
+    },
+    {
+        statement: "Uma aplicação envia um documento muito extenso a um LLM e parte do conteúdo parece ser ignorada. Qual limite do modelo provavelmente foi atingido?",
+        explanation: "A janela de contexto define o total de tokens que o modelo considera de uma vez; conteúdo que a excede é ignorado ou truncado. Temperatura, embeddings e número de parâmetros não causam esse corte.",
+        topic: "IA generativa",
+        options: [
+            ["A temperatura, parâmetro que ao chegar ao máximo faz o modelo descartar o início do texto enviado", false],
+            ["O número de embeddings gratuitos, que se esgota e passa a truncar automaticamente qualquer entrada adicional", false],
+            ["A quantidade de parâmetros do modelo, que diminui conforme mais texto é enviado em uma única chamada", false],
+            ["A janela de contexto, que limita quantos tokens o modelo processa de uma vez", true],
+        ],
+    },
+    {
+        statement: "Qual afirmação descreve corretamente a relação entre foundation models e LLMs?",
+        explanation: "LLMs são foundation models focados em texto, mas há também FMs de imagem, áudio e multimodais, então nem todo FM é um LLM. As demais alternativas confundem ou invertem essa relação.",
+        topic: "IA generativa",
+        options: [
+            ["LLMs são foundation models especializados em linguagem, e nem todo foundation model é um LLM", true],
+            ["São termos idênticos e intercambiáveis, pois todo foundation model processa exclusivamente texto em linguagem natural", false],
+            ["Foundation models são um subtipo de LLM voltado apenas para a geração de imagens a partir de descrições", false],
+            ["Não há relação entre eles, pois LLMs não são treinados com grandes volumes de dados", false],
+        ],
+    },
+    {
+        statement: "Uma equipe precisa gerar embeddings de texto na AWS para uma busca semântica e prefere um modelo da própria Amazon no Bedrock. Qual opção atende?",
+        explanation: "O Amazon Titan Embeddings é o modelo da AWS no Bedrock para gerar embeddings de texto usados em busca semântica. Lex cria chatbots, Textract extrai dados de documentos e Rekognition analisa imagens.",
+        topic: "IA generativa",
+        options: [
+            ["Amazon Lex, serviço para construir interfaces de conversação e chatbots com reconhecimento de intenções e slots", false],
+            ["Amazon Textract, que extrai texto, formulários e tabelas de documentos digitalizados", false],
+            ["Amazon Titan Embeddings", true],
+            ["Amazon Rekognition, que analisa imagens e vídeos para identificar objetos e rostos", false],
+        ],
+    },
+    {
+        statement: "Os parâmetros de inferência de um LLM, como temperature, top-p e top-k, servem principalmente para?",
+        explanation: "Os parâmetros de inferência ajustam como o modelo amostra os tokens, controlando aleatoriedade e diversidade sem alterar seus pesos. Eles não retreinam o modelo, não definem fontes externas nem escolhem provedor.",
+        topic: "IA generativa",
+        options: [
+            ["Retreinar os pesos internos do modelo a cada requisição para que ele aprenda com o novo prompt recebido", false],
+            ["Influenciar a aleatoriedade e a diversidade do texto gerado na resposta", true],
+            ["Definir quais fontes de dados externas o modelo deve consultar obrigatoriamente antes de responder", false],
+            ["Selecionar automaticamente o provedor de nuvem mais barato para hospedar o modelo em cada chamada", false],
+        ],
+    },
+    {
+        statement: "Uma aplicação de atendimento em tempo real precisa de respostas com baixa latência. Qual abordagem ajuda a reduzir o tempo de resposta percebido pelo usuário?",
+        explanation: "Modelos menores respondem mais rápido e o streaming mostra os tokens à medida que saem, reduzindo a latência percebida. Modelos maiores e respostas longas aumentam a latência, e a temperatura não afeta a velocidade.",
+        topic: "IA generativa",
+        options: [
+            ["Escolher sempre o maior modelo disponível e pedir a maior quantidade possível de tokens em cada resposta", false],
+            ["Aumentar a temperatura ao máximo para que o modelo produza cada token com mais rapidez e menos cálculo", false],
+            ["Enviar todo o histórico da conversa repetido várias vezes no prompt para garantir contexto suficiente", false],
+            ["Usar um modelo menor e transmitir a resposta em streaming conforme os tokens são gerados", true],
+        ],
+    },
+    {
+        statement: "Antes de indexar documentos longos em uma base de conhecimento para RAG, uma equipe divide cada documento em trechos menores. Por que essa etapa de 'chunking' costuma ser feita?",
+        explanation: "Dividir em trechos permite gerar um embedding por trecho e recuperar apenas os pedaços mais relevantes, que cabem na janela de contexto do modelo.",
+        topic: "RAG e customização",
+        options: [
+            ["Para que cada trecho vire um embedding e a busca retorne apenas as partes relevantes ao contexto do modelo", true],
+            ["Para converter automaticamente todos os documentos em um único vetor de alta dimensão que representa a base inteira e dispensa a busca por similaridade", false],
+            ["Para criptografar o conteúdo dos documentos antes de enviá-los ao foundation model durante a geração da resposta", false],
+            ["Para treinar novamente o foundation model com os documentos, ajustando seus pesos a cada novo arquivo adicionado", false],
+        ],
+    },
+    {
+        statement: "Uma empresa jurídica quer que um foundation model conheça melhor a terminologia e o estilo de textos da sua área, usando um grande volume de documentos internos sem rótulos. Qual abordagem de customização se encaixa nesse objetivo?",
+        explanation: "O pré-treino continuado usa um corpus grande e sem rótulos para adaptar o modelo ao vocabulário e ao estilo de um domínio, diferente do fine-tuning, que usa exemplos rotulados.",
+        topic: "RAG e customização",
+        options: [
+            ["Retrieval-augmented generation, que injeta trechos recuperados no prompt sem alterar o modelo", false],
+            ["Continued pre-training (pré-treino continuado), que adapta o modelo a um domínio usando um corpus amplo e não rotulado", true],
+            ["Prompt engineering com exemplos few-shot cuidadosamente selecionados e um prompt de sistema detalhado que descreve todas as regras do domínio jurídico", false],
+            ["Guardrails configurados para bloquear qualquer termo que não pertença ao vocabulário jurídico da empresa", false],
+        ],
+    },
+    {
+        statement: "Um banco quer que seu assistente responda sempre no mesmo tom de marca e em um formato fixo de resposta, comportamento que prompts e RAG não vêm mantendo de forma consistente. Qual abordagem tende a resolver melhor?",
+        explanation: "Quando o objetivo é internalizar um tom e um formato de saída consistentes, o fine-tuning com exemplos rotulados costuma superar RAG e ajustes de prompt.",
+        topic: "RAG e customização",
+        options: [
+            ["Aumentar a temperatura para o modelo variar mais o estilo das respostas", false],
+            ["Adicionar mais documentos à base de conhecimento de RAG, já que recuperar mais trechos faz o modelo aprender o tom de marca ao longo do tempo", false],
+            ["Reduzir a janela de contexto para forçar respostas mais curtas e padronizadas em qualquer situação", false],
+            ["Fazer fine-tuning do modelo com exemplos rotulados no tom e no formato desejados", true],
+        ],
+    },
+    {
+        statement: "Ao configurar uma Amazon Bedrock Knowledge Base, a equipe precisa escolher onde armazenar os vetores gerados a partir dos documentos. Qual opção lista serviços que podem servir como banco vetorial nesse cenário?",
+        explanation: "Bases de conhecimento do Bedrock podem usar bancos vetoriais como o OpenSearch Serverless e o Aurora PostgreSQL com a extensão pgvector para armazenar e buscar embeddings.",
+        topic: "RAG e customização",
+        options: [
+            ["Amazon Polly e Amazon Transcribe", false],
+            ["Amazon CloudFront e Amazon Route 53", false],
+            ["Amazon OpenSearch Serverless e Aurora PostgreSQL com pgvector", true],
+            ["Amazon QuickSight conectado a um data warehouse Redshift, que indexa os vetores automaticamente para busca por similaridade", false],
+        ],
+    },
+    {
+        statement: "Uma equipe vai fazer fine-tuning de um foundation model no Amazon Bedrock para uma tarefa específica. Como os dados de treino normalmente precisam ser preparados?",
+        explanation: "O fine-tuning supervisionado usa exemplos rotulados com a entrada e a saída esperada, normalmente em arquivos no Amazon S3.",
+        topic: "RAG e customização",
+        options: [
+            ["Como exemplos rotulados de entrada e saída desejada, em arquivos armazenados no Amazon S3", true],
+            ["Como uma coleção de imagens sem rótulos que o serviço converte sozinho em pares de pergunta e resposta durante o treinamento", false],
+            ["Como consultas SQL que extraem os dados diretamente de um banco relacional em tempo de inferência", false],
+            ["Como embeddings pré-calculados que substituem a necessidade de qualquer exemplo de treino", false],
+        ],
+    },
+    {
+        statement: "Antes de investir em RAG ou fine-tuning, uma equipe quer testar a abordagem de menor custo e esforço para melhorar as respostas de um foundation model. Por onde começar?",
+        explanation: "Prompt engineering é a abordagem mais barata e rápida de experimentar, pois não exige treino nem infraestrutura extra antes de partir para RAG ou fine-tuning.",
+        topic: "RAG e customização",
+        options: [
+            ["Por continued pre-training com todo o histórico de documentos da empresa, pois isso garante o melhor resultado logo na primeira tentativa", false],
+            ["Por treinar um modelo próprio do zero para a tarefa", false],
+            ["Por prompt engineering, ajustando as instruções e os exemplos no prompt", true],
+            ["Por provisionar um cluster de GPUs dedicado antes de qualquer teste", false],
+        ],
+    },
+    {
+        statement: "Em uma solução de RAG, qual é o papel do modelo de embeddings?",
+        explanation: "O modelo de embeddings transforma textos em vetores que representam o significado; o mesmo modelo embute documentos e consultas para a busca por similaridade.",
+        topic: "RAG e customização",
+        options: [
+            ["Gerar a resposta final em linguagem natural a partir dos trechos recuperados", false],
+            ["Converter textos em vetores numéricos que capturam o significado, para permitir a busca por similaridade", true],
+            ["Armazenar permanentemente os documentos originais e controlar as permissões de acesso de cada usuário à base", false],
+            ["Traduzir os documentos para o idioma do usuário antes de exibir a resposta", false],
+        ],
+    },
+    {
+        statement: "Quando um usuário faz uma pergunta a um sistema de RAG, o que acontece na etapa de recuperação (retrieval)?",
+        explanation: "Na recuperação, a pergunta é convertida em embedding e o sistema retorna os trechos mais próximos por similaridade, usados depois para compor a resposta.",
+        topic: "RAG e customização",
+        options: [
+            ["O foundation model tem seus pesos reajustados com base na pergunta do usuário", false],
+            ["Todos os documentos da base são enviados por completo dentro do prompt para que o modelo leia tudo antes de responder", false],
+            ["A pergunta é encaminhada para um humano que seleciona manualmente os documentos relevantes", false],
+            ["A pergunta vira um vetor e o sistema busca os trechos mais similares na base vetorial", true],
+        ],
+    },
+    {
+        statement: "Ao comparar abordagens de customização, qual afirmação está correta sobre os pesos do modelo?",
+        explanation: "Fine-tuning e pré-treino continuado modificam os pesos do modelo; RAG e prompt engineering influenciam a resposta sem retreinar o modelo.",
+        topic: "RAG e customização",
+        options: [
+            ["RAG e prompt engineering reajustam os pesos do modelo a cada consulta", false],
+            ["Continued pre-training não altera os pesos e apenas adiciona documentos a uma base vetorial consultada em tempo de execução", false],
+            ["Fine-tuning e continued pre-training alteram os pesos; RAG e prompt engineering não", true],
+            ["Foundation models são imutáveis, portanto nenhuma dessas abordagens muda seu comportamento", false],
+        ],
+    },
+    {
+        statement: "Depois de fazer fine-tuning de um modelo para uma tarefa recorrente, qual benefício a equipe pode esperar em relação ao uso de prompts longos com muitos exemplos?",
+        explanation: "Com o comportamento internalizado pelo fine-tuning, dá para usar prompts mais curtos e menos exemplos, o que pode reduzir custo e latência.",
+        topic: "RAG e customização",
+        options: [
+            ["O modelo passa a atualizar sozinho seu conhecimento sobre fatos novos do mundo sem qualquer necessidade de retreinar ou de recuperar dados externos", false],
+            ["O comportamento desejado fica embutido no modelo, reduzindo a necessidade de muitos exemplos no prompt", true],
+            ["A janela de contexto do modelo passa a ser ilimitada", false],
+            ["O modelo deixa de cobrar por tokens de entrada e de saída", false],
+        ],
+    },
+    {
+        statement: "Uma equipe sem experiência em construir pipelines de dados quer implementar RAG. Que trabalho o Amazon Bedrock Knowledge Bases automatiza para ela?",
+        explanation: "A base de conhecimento gerencia a ingestão: faz o chunking, gera os embeddings e grava os vetores no banco vetorial, sem a equipe construir esse pipeline.",
+        topic: "RAG e customização",
+        options: [
+            ["A criação de exemplos rotulados e o treino supervisionado de um modelo customizado", false],
+            ["A definição das políticas de IAM, o provisionamento da VPC e a configuração de todo o monitoramento de custos da conta AWS", false],
+            ["A escrita manual dos prompts de sistema e a curadoria humana de cada resposta gerada", false],
+            ["A divisão dos documentos em trechos, a geração dos embeddings e o armazenamento no banco vetorial", true],
+        ],
+    },
+    {
+        statement: "Em uma arquitetura de RAG, o que fica armazenado no banco de dados vetorial após a ingestão dos documentos?",
+        explanation: "O banco vetorial guarda os embeddings dos trechos junto a metadados que referenciam o texto original, o que permite recuperar a fonte e citar a resposta.",
+        topic: "RAG e customização",
+        options: [
+            ["Os embeddings dos trechos, com metadados que apontam para o texto de origem", true],
+            ["Os pesos ajustados do foundation model após o treinamento", false],
+            ["Uma cópia integral do modelo de linguagem, incluindo o vocabulário de tokens e os parâmetros de inferência padrão de cada consulta", false],
+            ["Apenas as perguntas históricas dos usuários, usadas para reordenar respostas futuras", false],
+        ],
+    },
+    {
+        statement: "Um desenvolvedor inclui no prompt exatamente um exemplo de pergunta com a resposta desejada antes de apresentar a tarefa real ao modelo. Como essa técnica é chamada?",
+        explanation: "Fornecer um único exemplo no prompt caracteriza o one-shot; nenhum exemplo seria zero-shot e vários exemplos, few-shot.",
+        topic: "Prompt engineering",
+        options: [
+            ["Zero-shot prompting", false],
+            ["One-shot prompting", true],
+            ["Chain-of-thought prompting, em que o modelo detalha cada passo do raciocínio antes de concluir a resposta final", false],
+            ["Continued pre-training", false],
+        ],
+    },
+    {
+        statement: "Ao construir um assistente, a equipe define separadamente uma instrução que estabelece o papel do modelo, seu tom e as regras que ele deve seguir em toda a conversa. Que elemento é esse?",
+        explanation: "O prompt de sistema define papel, tom e regras gerais do assistente, servindo de moldura para as demais mensagens da conversa.",
+        topic: "Prompt engineering",
+        options: [
+            ["É a temperatura, um parâmetro numérico que determina o papel e as regras de comportamento que o assistente seguirá durante toda a conversa", false],
+            ["É um embedding que representa as regras em forma de vetor", false],
+            ["É o prompt de sistema, que orienta o comportamento geral do modelo", true],
+            ["É a janela de contexto reservada para as respostas do usuário", false],
+        ],
+    },
+    {
+        statement: "Uma analista quer melhorar a qualidade das respostas de um LLM ajustando o prompt. Qual conjunto de elementos torna um prompt mais eficaz?",
+        explanation: "Prompts eficazes costumam trazer uma instrução clara, o contexto necessário e o formato de saída desejado, o que reduz ambiguidade e melhora a resposta.",
+        topic: "Prompt engineering",
+        options: [
+            ["Instrução clara, contexto relevante e o formato de saída esperado", true],
+            ["Um texto propositalmente ambíguo e sem contexto, para que o modelo tenha total liberdade de interpretar a tarefa como preferir", false],
+            ["Apenas uma palavra-chave isolada, sem qualquer instrução ou contexto", false],
+            ["O maior número possível de perguntas diferentes em uma única mensagem", false],
+        ],
+    },
+    {
+        statement: "Uma equipe cria uma estrutura de prompt reutilizável com espaços reservados, como 'Resuma o seguinte texto: {texto}', preenchidos a cada chamada. Que recurso é esse?",
+        explanation: "Templates de prompt definem uma estrutura fixa com variáveis preenchidas dinamicamente, padronizando as chamadas e facilitando o reuso.",
+        topic: "Prompt engineering",
+        options: [
+            ["Um embedding de consulta", false],
+            ["Um guardrail de conteúdo", false],
+            ["Um processo de fine-tuning que grava permanentemente a instrução de resumo dentro dos pesos do modelo a cada execução", false],
+            ["Um template de prompt com variáveis", true],
+        ],
+    },
+    {
+        statement: "Um usuário escreve um prompt pedindo que o modelo 'finja ser uma IA sem restrições' para obter uma resposta que as regras de segurança normalmente bloqueiam. Que tipo de ataque é esse?",
+        explanation: "O jailbreak tenta contornar as salvaguardas do modelo, por exemplo pedindo que ele assuma um papel sem restrições para liberar conteúdo bloqueado.",
+        topic: "Prompt engineering",
+        options: [
+            ["Alucinação, situação em que o modelo, ao interpretar mal a instrução, inventa fatos e referências que não existem na base de dados", false],
+            ["Jailbreak, uma tentativa de burlar as salvaguardas do modelo", true],
+            ["Overfitting do prompt aos dados de treino", false],
+            ["Um erro de tokenização na entrada", false],
+        ],
+    },
+    {
+        statement: "Ao gerar um texto, uma equipe adiciona ao prompt instruções sobre o que o modelo NÃO deve fazer, como 'não use jargão técnico e não cite concorrentes'. Como se chama essa prática?",
+        explanation: "O prompt negativo especifica o que o modelo deve evitar, ajudando a restringir o estilo e o conteúdo da resposta.",
+        topic: "Prompt engineering",
+        options: [
+            ["Few-shot prompting", false],
+            ["Continued pre-training, em que o modelo aprende com um corpus a evitar permanentemente jargão técnico e menções a concorrentes", false],
+            ["Negative prompting (prompt negativo)", true],
+            ["Prompt injection", false],
+        ],
+    },
+    {
+        statement: "Um aplicativo insere o texto enviado pelo usuário dentro de um prompt maior. A equipe teme que alguém escreva instruções para o modelo ignorar as regras do sistema. Qual medida ajuda a mitigar esse risco?",
+        explanation: "Mitigar prompt injection envolve validar e isolar a entrada do usuário, aplicar guardrails e não misturar dados do usuário com as instruções de sistema.",
+        topic: "Prompt engineering",
+        options: [
+            ["Aumentar a temperatura e o limite de tokens de saída, para que o modelo tenha liberdade de responder qualquer instrução que o usuário venha a inserir no texto", false],
+            ["Publicar o prompt de sistema completo na interface para o usuário conferir", false],
+            ["Desativar qualquer registro de log das chamadas ao modelo", false],
+            ["Validar a entrada e usar guardrails, separando as instruções do sistema do conteúdo do usuário", true],
+        ],
+    },
+    {
+        statement: "Um modelo retorna respostas em formatos variados quando recebe apenas a instrução da tarefa. A equipe então acrescenta ao prompt dois ou três exemplos com o formato exato desejado. Por que isso ajuda?",
+        explanation: "Poucos exemplos no prompt (few-shot) orientam o modelo a reproduzir o formato desejado em tempo de inferência, sem necessidade de retreino.",
+        topic: "Prompt engineering",
+        options: [
+            ["Os exemplos guiam o modelo a seguir o padrão de saída, sem precisar treinar o modelo", true],
+            ["Os exemplos reajustam os pesos do modelo permanentemente durante a inferência", false],
+            ["Os exemplos aumentam a janela de contexto do modelo, o que por si só garante que qualquer formato de resposta seja sempre respeitado", false],
+            ["Os exemplos substituem a necessidade de um banco vetorial em soluções de RAG", false],
+        ],
+    },
+    {
+        statement: "Uma empresa quer um assistente que receba fotos de produtos e gere descrições em texto a partir das imagens. Que critério deve guiar a escolha do foundation model?",
+        explanation: "A tarefa exige interpretar imagens, então o modelo precisa ser multimodal; janela de contexto e preço não substituem o suporte a essa modalidade.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["Escolher o modelo com a maior janela de contexto disponível, pois isso é o que determina a capacidade de interpretar imagens enviadas pelo usuário", false],
+            ["Escolher qualquer modelo de texto, já que todos aceitam imagens como entrada", false],
+            ["Escolher um modelo multimodal, capaz de receber imagens como entrada", true],
+            ["Escolher o modelo mais barato por token, independentemente das modalidades que ele suporta", false],
+        ],
+    },
+    {
+        statement: "Uma equipe precisa classificar milhões de mensagens curtas por sentimento com baixo custo e, separadamente, redigir relatórios complexos que exigem raciocínio elaborado. Que estratégia de escolha de modelo faz sentido?",
+        explanation: "Casar a capacidade do modelo com a complexidade da tarefa equilibra custo e qualidade: modelos menores atendem tarefas simples de alto volume e modelos maiores, tarefas que exigem mais raciocínio.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["Usar o maior modelo disponível para as duas tarefas, sem considerar custo", false],
+            ["Usar um modelo menor e barato na classificação e um modelo maior no relatório", true],
+            ["Usar o mesmo modelo minúsculo para tudo, pois o tamanho do modelo não influencia a qualidade em tarefas de raciocínio mais elaborado", false],
+            ["Escolher o modelo apenas pela popularidade, ignorando a complexidade de cada tarefa", false],
+        ],
+    },
+    {
+        statement: "Uma equipe quer avaliar se as respostas de um assistente soam úteis, educadas e alinhadas ao tom da marca, aspectos difíceis de medir por métricas numéricas. Que método de avaliação é mais adequado?",
+        explanation: "Aspectos subjetivos como utilidade e tom são melhor avaliados por julgamento humano, já que métricas automáticas nem sempre capturam essas qualidades.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["Medir exclusivamente a latência e o número de tokens por resposta, pois esses valores refletem diretamente o quão educada e útil a resposta é", false],
+            ["Contar quantas vezes cada palavra aparece no conjunto de treino", false],
+            ["Verificar o tamanho do arquivo do modelo em disco", false],
+            ["Avaliação humana, com pessoas julgando a qualidade das respostas", true],
+        ],
+    },
+    {
+        statement: "Para avaliar automaticamente a qualidade de resumos gerados por um modelo, comparando-os a resumos de referência, qual tipo de recurso é apropriado?",
+        explanation: "Métricas automáticas como ROUGE comparam a saída gerada com textos de referência e são comuns para avaliar resumos e outras tarefas de geração de texto.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["Uma métrica automática como ROUGE, que compara a saída com textos de referência", true],
+            ["Uma pesquisa de satisfação enviada aos usuários finais semanas depois, cujo resultado serve como métrica automática objetiva de qualidade do resumo", false],
+            ["O parâmetro de temperatura usado durante a geração dos resumos", false],
+            ["O número de documentos presentes no banco vetorial", false],
+        ],
+    },
+    {
+        statement: "Ao desenhar uma solução de RAG de ponta a ponta, qual sequência representa corretamente o fluxo em tempo de consulta?",
+        explanation: "No RAG, a pergunta é transformada em embedding, os trechos mais relevantes são recuperados e enviados ao modelo, que gera a resposta fundamentada neles.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["Converter a pergunta em embedding, recuperar trechos relevantes e enviá-los ao modelo para gerar a resposta", true],
+            ["Fazer fine-tuning do modelo com a pergunta, publicar um novo endpoint e só então permitir que o usuário receba qualquer resposta do sistema", false],
+            ["Gerar a resposta primeiro e depois procurar documentos que a confirmem no banco vetorial", false],
+            ["Enviar a base inteira de documentos ao modelo a cada pergunta, sem nenhuma etapa de busca", false],
+        ],
+    },
+    {
+        statement: "Um assistente de suporte deve dar respostas factuais e consistentes, evitando variações a cada nova execução da mesma pergunta. Que ajuste de parâmetro de inferência favorece esse comportamento?",
+        explanation: "Temperaturas baixas reduzem a aleatoriedade e tornam as respostas mais determinísticas e consistentes, o que é desejável em suporte factual.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["Aumentar bastante a temperatura e o top_p, pois valores altos tornam as respostas mais previsíveis e idênticas entre execuções repetidas", false],
+            ["Reduzir o limite de tokens de saída até que a resposta caiba em uma única palavra", false],
+            ["Desligar o modelo de embeddings usado na etapa de recuperação", false],
+            ["Usar uma temperatura baixa, para respostas mais determinísticas", true],
+        ],
+    },
+    {
+        statement: "Ao configurar um Agent for Amazon Bedrock para automatizar um processo, como a equipe define quais ações o agente pode executar, por exemplo chamar uma função que registra um pedido?",
+        explanation: "Nos Agents for Amazon Bedrock, os action groups conectam o agente a funções (por exemplo, via Lambda), definindo as ações que ele pode executar.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["Aumentando a temperatura do modelo até que ele descubra sozinho quais APIs chamar", false],
+            ["Definindo action groups que associam o agente a funções, tipicamente via AWS Lambda", true],
+            ["Adicionando os documentos das APIs a um banco vetorial, o que faz o agente executar automaticamente qualquer função encontrada durante a busca", false],
+            ["Escrevendo um prompt negativo que lista tudo o que o agente não deve fazer", false],
+        ],
+    },
+    {
+        statement: "Em que situação um agente (Agents for Amazon Bedrock) é mais adequado do que uma solução de RAG simples que apenas responde perguntas?",
+        explanation: "Agentes se justificam quando a solução precisa agir e orquestrar várias etapas, como chamar APIs e sistemas; para apenas responder com base em documentos, o RAG basta.",
+        topic: "Aplicações de foundation models",
+        options: [
+            ["Quando o objetivo é apenas resumir um único documento curto que já cabe inteiro na janela de contexto do modelo, sem chamar nenhum sistema externo", false],
+            ["Quando não há necessidade de chamar nenhuma API nem realizar ações", false],
+            ["Quando a tarefa exige executar ações e coordenar várias etapas, não só recuperar informação", true],
+            ["Quando se deseja apenas converter documentos em embeddings para busca", false],
+        ],
+    },
+    {
+        statement: "Uma empresa implanta um assistente de IA e exige um mecanismo para pausar, ajustar ou substituir o comportamento do sistema caso ele passe a agir de forma indesejada em produção. Essa capacidade corresponde a qual dimensão da IA responsável?",
+        explanation: "Controlabilidade é a dimensão que trata da capacidade de supervisionar, guiar e intervir no comportamento de um sistema de IA, incluindo pausar ou ajustar sua operação.",
+        topic: "IA responsável",
+        options: [
+            ["Explicabilidade, pois descreve em detalhes como o modelo processou as variáveis de entrada e chegou a cada previsão individual", false],
+            ["Controlabilidade, a capacidade de monitorar e orientar o comportamento do sistema de IA", true],
+            ["Veracidade, que garante que as respostas geradas sejam sempre factualmente corretas", false],
+            ["Sustentabilidade, relacionada a reduzir o consumo de energia da infraestrutura de treino", false],
+        ],
+    },
+    {
+        statement: "Ao lançar um chatbot de atendimento, a equipe jurídica recomenda deixar claro ao usuário que ele conversa com um assistente de IA e informar suas limitações. Qual dimensão da IA responsável essa recomendação reforça?",
+        explanation: "Transparência significa comunicar de forma clara quando a IA está sendo usada, além de suas capacidades e limitações, para que as pessoas saibam que interagem com um sistema automatizado.",
+        topic: "IA responsável",
+        options: [
+            ["Robustez, que mede se o modelo mantém desempenho estável diante de entradas ruidosas ou inesperadas", false],
+            ["Justiça (fairness), que busca evitar tratamento desigual entre diferentes grupos de pessoas", false],
+            ["Privacidade, que trata da proteção de dados pessoais usados pelo sistema", false],
+            ["Transparência, que envolve comunicar de forma aberta como e quando a IA é usada", true],
+        ],
+    },
+    {
+        statement: "Um banco usa um modelo para recomendar aprovação de crédito e precisa mostrar, para cada decisão, quais variáveis mais pesaram no resultado. Qual recurso ajuda a produzir essa atribuição de importância por previsão?",
+        explanation: "O SageMaker Clarify fornece explicações de atributos baseadas em valores SHAP, indicando quanto cada variável contribuiu para uma previsão, o que apoia a explicabilidade.",
+        topic: "IA responsável",
+        options: [
+            ["Amazon SageMaker Clarify, que calcula a contribuição de cada atributo para as previsões do modelo", true],
+            ["Amazon SageMaker Model Monitor, voltado a detectar desvio de dados no ambiente de produção ao longo do tempo", false],
+            ["Amazon Macie, que descobre e classifica dados sensíveis armazenados em buckets do Amazon S3", false],
+            ["AWS CloudTrail, que registra as chamadas de API feitas na conta para fins de auditoria", false],
+        ],
+    },
+    {
+        statement: "Após avaliar um modelo de triagem de currículos, uma equipe percebe que a taxa de aprovação é muito menor para candidatas mulheres do que para homens com qualificações equivalentes. O que essa diferença indica?",
+        explanation: "Resultados sistematicamente desiguais entre grupos comparáveis caracterizam um problema de justiça (fairness), uma dimensão central da IA responsável.",
+        topic: "IA responsável",
+        options: [
+            ["Indica desvio de conceito (concept drift) e deve ser corrigido apenas com mais poder de computação no treino", false],
+            ["Indica um problema de justiça (fairness), pois o modelo produz resultados sistematicamente desiguais entre grupos", true],
+            ["Indica falta de explicabilidade, um problema que se resolve somente publicando o código-fonte completo do modelo para todos os usuários finais", false],
+            ["Indica sobreajuste (overfitting), situação em que o modelo memoriza os dados de treino e falha em dados novos", false],
+        ],
+    },
+    {
+        statement: "Uma seguradora quer que seu assistente generativo no Amazon Bedrock remova automaticamente números de documentos e outros dados pessoais que apareçam nas respostas ao usuário. Qual recurso atende a essa necessidade?",
+        explanation: "Os Guardrails do Amazon Bedrock incluem filtros de informações sensíveis capazes de detectar e mascarar ou bloquear dados pessoais (PII) em prompts e respostas.",
+        topic: "IA responsável",
+        options: [
+            ["Ativar os filtros de informações sensíveis do Amazon Bedrock Guardrails para detectar e mascarar dados pessoais", true],
+            ["Aumentar o valor do parâmetro de temperatura nas chamadas ao modelo para reduzir a repetição de dados sensíveis", false],
+            ["Trocar o foundation model por um modelo de embeddings especializado em busca vetorial de documentos internos", false],
+            ["Habilitar o AWS CloudTrail para registrar todas as chamadas de API feitas na conta e assim, por si só, impedir o vazamento de dados pessoais nas respostas", false],
+        ],
+    },
+    {
+        statement: "Durante os testes, um modelo de visão computacional funciona bem com fotos limpas, mas erra muito quando as imagens têm ruído, baixa iluminação ou pequenas distorções. Qual dimensão da IA responsável está em falha?",
+        explanation: "Robustez é a dimensão que descreve a capacidade de um sistema manter desempenho confiável mesmo diante de entradas ruidosas, adversas ou fora do padrão de treino.",
+        topic: "IA responsável",
+        options: [
+            ["Justiça (fairness), que se concentra em evitar disparidades de tratamento entre diferentes grupos de usuários", false],
+            ["Sustentabilidade, que busca reduzir o consumo de recursos computacionais e o impacto ambiental do modelo", false],
+            ["Robustez, a capacidade de manter desempenho confiável diante de entradas imperfeitas ou inesperadas", true],
+            ["Transparência, que trata de comunicar de forma clara quando e como a IA é utilizada", false],
+        ],
+    },
+    {
+        statement: "Antes de liberar um modelo de linguagem para clientes, uma equipe quer medir com que frequência ele gera respostas ofensivas ou tóxicas. Qual abordagem é a mais adequada?",
+        explanation: "Medir a frequência de saídas tóxicas exige avaliar as respostas do modelo com testes e métricas de toxicidade, prática apoiada por ferramentas de avaliação de modelos antes do lançamento.",
+        topic: "IA responsável",
+        options: [
+            ["Confiar que modelos de fundação recentes nunca produzem conteúdo tóxico e liberar o modelo diretamente para produção", false],
+            ["Reduzir o número máximo de tokens das respostas para que o modelo tenha menos espaço para gerar qualquer conteúdo ofensivo", false],
+            ["Treinar o modelo do zero com uma quantidade muito maior de dados para eliminar por completo a possibilidade de toxicidade", false],
+            ["Executar uma avaliação automatizada de toxicidade nas saídas do modelo usando conjuntos de teste e métricas apropriadas", true],
+        ],
+    },
+    {
+        statement: "Uma organização quer reduzir o custo ambiental de suas cargas de IA sem abandonar os projetos. Qual prática está alinhada à sustentabilidade como dimensão da IA responsável?",
+        explanation: "Dimensionar corretamente os modelos e otimizar a inferência reduz o uso de computação e energia, contribuindo para a sustentabilidade e para um menor custo ambiental.",
+        topic: "IA responsável",
+        options: [
+            ["Escolher sempre o maior modelo disponível, independentemente da tarefa, para garantir a melhor qualidade em qualquer caso", false],
+            ["Manter todos os endpoints de inferência ativos permanentemente, mesmo sem tráfego, para evitar qualquer atraso de resposta", false],
+            ["Selecionar modelos do tamanho adequado e otimizar a inferência para consumir menos recursos computacionais e energia", true],
+            ["Duplicar os ambientes de treino em várias regiões ao mesmo tempo para acelerar cada experimento de ajuste de hiperparâmetros", false],
+        ],
+    },
+    {
+        statement: "Ao preparar dados para treinar um modelo de saúde, uma equipe decide coletar apenas os campos estritamente necessários e anonimizar identificadores dos pacientes. Que princípio de IA responsável essa decisão apoia?",
+        explanation: "Coletar o mínimo de dados necessários e anonimizar identificadores reduz a exposição de informações pessoais, apoiando a dimensão de privacidade e segurança.",
+        topic: "IA responsável",
+        options: [
+            ["Justiça, garantindo que todos os grupos demográficos estejam igualmente representados nas previsões do modelo final", false],
+            ["Privacidade e segurança, minimizando a exposição de dados pessoais durante o ciclo de vida do modelo", true],
+            ["Controlabilidade, permitindo pausar ou ajustar o comportamento do modelo sempre que ele agir de forma inesperada", false],
+            ["Explicabilidade, permitindo descrever em detalhe quais atributos influenciaram cada previsão individual gerada", false],
+        ],
+    },
+    {
+        statement: "Um sistema de reconhecimento de voz funciona bem para alguns sotaques, mas falha para falantes de regiões sub-representadas nos dados de treino. Qual medida está mais alinhada à inclusão na IA responsável?",
+        explanation: "Inclusão exige que os dados representem de forma diversa os grupos atendidos, para que o sistema funcione bem também para populações antes sub-representadas.",
+        topic: "IA responsável",
+        options: [
+            ["Restringir o serviço apenas aos grupos de usuários para os quais o modelo já apresenta bom desempenho atualmente", false],
+            ["Aumentar o parâmetro de temperatura durante a inferência para que o modelo produza transcrições mais variadas", false],
+            ["Reduzir o tamanho do conjunto de dados de treino para acelerar os ciclos de experimentação e reduzir os custos", false],
+            ["Ampliar o conjunto de treino para representar de forma diversa os diferentes grupos e sotaques de usuários", true],
+        ],
+    },
+    {
+        statement: "Uma empresa processa documentos com um modelo, mas quer que os casos em que o modelo tem baixa confiança sejam revisados por uma pessoa antes da decisão final. Qual serviço facilita esse fluxo de revisão humana?",
+        explanation: "O Amazon A2I (Augmented AI) permite encaminhar previsões, por exemplo as de baixa confiança, para revisão humana antes da decisão final, implementando human-in-the-loop.",
+        topic: "IA responsável",
+        options: [
+            ["Amazon Augmented AI (A2I), que integra revisão humana às previsões de modelos de machine learning", true],
+            ["Amazon SageMaker Model Monitor, que acompanha a qualidade das previsões e detecta desvios ao longo do tempo", false],
+            ["AWS Artifact, que fornece sob demanda relatórios de conformidade e certificações de segurança da AWS", false],
+            ["Amazon Macie, que identifica e classifica automaticamente dados sensíveis armazenados no Amazon S3", false],
+        ],
+    },
+    {
+        statement: "Uma equipe precisa de um modelo cujas decisões possam ser entendidas diretamente pela sua própria estrutura, sem depender de ferramentas externas de explicação. Qual opção descreve um modelo intrinsecamente interpretável?",
+        explanation: "Modelos como árvores de decisão simples e regressões lineares são intrinsecamente interpretáveis, pois sua estrutura revela como as entradas levam à saída, sem métodos de explicação posteriores.",
+        topic: "IA responsável",
+        options: [
+            ["Uma rede neural profunda com muitas camadas ocultas, tratada como caixa-preta e explicada só depois com métodos auxiliares", false],
+            ["Uma árvore de decisão simples, cujas regras de decisão podem ser lidas e compreendidas diretamente", true],
+            ["Um grande modelo de linguagem generativo com bilhões de parâmetros ajustados sobre enormes volumes de texto da internet", false],
+            ["Um conjunto (ensemble) de centenas de modelos combinados, cuja lógica final é difícil de acompanhar manualmente", false],
+        ],
+    },
+    {
+        statement: "Em uma solução de RAG no Amazon Bedrock, a equipe quer bloquear respostas que não estejam apoiadas nos documentos recuperados, reduzindo alucinações. Qual recurso ajuda a impor essa checagem?",
+        explanation: "A verificação de embasamento contextual dos Guardrails do Bedrock avalia se a resposta está fundamentada na fonte fornecida, ajudando a bloquear conteúdo não sustentado e a reduzir alucinações.",
+        topic: "IA responsável",
+        options: [
+            ["A configuração de uma chave gerenciada pelo cliente no AWS KMS para criptografar os documentos de origem em repouso", false],
+            ["A criação de um endpoint de interface com AWS PrivateLink para manter o tráfego dentro da rede privada da AWS", false],
+            ["A verificação de embasamento contextual (contextual grounding) do Amazon Bedrock Guardrails", true],
+            ["O aumento do limite de tokens de saída para permitir que o modelo detalhe melhor a origem de cada afirmação gerada", false],
+        ],
+    },
+    {
+        statement: "O SageMaker Clarify revelou que um modelo de concessão de crédito favorece um grupo específico por causa de desequilíbrios no conjunto de treino. Qual é uma ação de mitigação apropriada?",
+        explanation: "Quando o viés vem de desequilíbrios nos dados, uma mitigação apropriada é rebalancear ou aumentar o conjunto de treino e reavaliar as métricas de viés, em vez de ignorar o achado.",
+        topic: "IA responsável",
+        options: [
+            ["Remover completamente o relatório de viés para que a auditoria não registre o problema encontrado no modelo", false],
+            ["Colocar o modelo em produção sem alterações, já que a acurácia geral média ficou dentro da meta definida pela equipe", false],
+            ["Aumentar o número máximo de tokens das respostas do modelo para que ele justifique melhor cada decisão de crédito", false],
+            ["Rebalancear ou aumentar os dados de treino para representar melhor os grupos e reavaliar o viés depois", true],
+        ],
+    },
+    {
+        statement: "Uma empresa quer garantir que apenas a equipe de dados possa invocar os modelos do Amazon Bedrock e que os demais times não tenham esse acesso. Qual é a forma recomendada de aplicar esse controle?",
+        explanation: "O AWS IAM permite definir políticas que concedem a invocação de modelos apenas aos perfis autorizados, aplicando controle de acesso a serviços de IA com privilégio mínimo.",
+        topic: "Segurança e governança",
+        options: [
+            ["Criar políticas do AWS IAM que concedam as permissões de invocação apenas aos perfis autorizados", true],
+            ["Compartilhar uma única chave de acesso raiz da conta com todos os times para simplificar o uso dos modelos", false],
+            ["Publicar o endpoint do modelo na internet e confiar em um segredo em texto no código dos aplicativos internos", false],
+            ["Desativar o registro de chamadas de API para que ninguém consiga descobrir quais equipes usam quais modelos", false],
+        ],
+    },
+    {
+        statement: "Uma empresa precisa garantir que os dados de treino no Amazon S3 e os artefatos de modelo fiquem criptografados em repouso, com controle sobre as chaves. Qual serviço atende a esse requisito?",
+        explanation: "O AWS KMS gerencia as chaves de criptografia usadas para proteger dados em repouso, como os conjuntos de treino no S3 e os artefatos de modelo.",
+        topic: "Segurança e governança",
+        options: [
+            ["Amazon CloudWatch, para coletar métricas operacionais e disparar alarmes sobre o uso dos recursos de treino", false],
+            ["AWS Artifact, para baixar relatórios de conformidade e certificações de segurança dos data centers da AWS", false],
+            ["AWS Key Management Service (KMS), para criptografar os dados e artefatos em repouso e gerenciar as chaves", true],
+            ["Amazon Augmented AI, para incluir uma etapa de revisão humana nas previsões geradas pelos modelos já treinados", false],
+        ],
+    },
+    {
+        statement: "Ao enviar dados de um aplicativo para um endpoint de inferência, a equipe de segurança exige proteção contra interceptação durante o trânsito na rede. Qual medida atende a esse objetivo?",
+        explanation: "A criptografia em trânsito com TLS (HTTPS) protege os dados enquanto trafegam pela rede entre o cliente e o endpoint, evitando interceptação.",
+        topic: "Segurança e governança",
+        options: [
+            ["Armazenar os dados de entrada em um bucket público para que o endpoint consiga lê-los sem autenticação adicional", false],
+            ["Usar conexões criptografadas com TLS (HTTPS) para proteger os dados em trânsito entre o aplicativo e o endpoint", true],
+            ["Registrar o conteúdo completo de cada requisição em texto simples em logs compartilhados para facilitar a depuração", false],
+            ["Aumentar o número de instâncias do endpoint para que o tráfego seja distribuído e fique mais difícil de interceptar", false],
+        ],
+    },
+    {
+        statement: "Uma instituição financeira treina modelos com dados sigilosos e precisa que os jobs do SageMaker não tenham acesso à internet pública, acessando o Amazon S3 por rotas privadas. Qual abordagem atende a esse requisito?",
+        explanation: "Executar o SageMaker dentro de uma VPC com isolamento de rede e acessar o S3 por endpoints de VPC mantém o tráfego fora da internet pública, adequado a dados sensíveis.",
+        topic: "Segurança e governança",
+        options: [
+            ["Publicar os dados de treino em um repositório público para que qualquer serviço da conta possa baixá-los rapidamente", false],
+            ["Conceder a todos os usuários da conta permissão de administrador para que possam configurar a rede quando precisarem", false],
+            ["Desabilitar a criptografia dos volumes de treino para reduzir a latência de leitura durante o processamento dos dados", false],
+            ["Executar os jobs em uma VPC com isolamento de rede e acesso ao S3 por endpoint de VPC, sem gateway de internet", true],
+        ],
+    },
+    {
+        statement: "Uma empresa deve manter os dados de clientes armazenados e processados dentro do país por exigência regulatória. No contexto dos serviços de IA da AWS, qual decisão apoia esse requisito de residência de dados?",
+        explanation: "A residência de dados é atendida escolhendo a região da AWS no local exigido, já que os dados de um serviço em geral permanecem na região selecionada pelo cliente.",
+        topic: "Segurança e governança",
+        options: [
+            ["Confiar que a AWS move automaticamente os dados para a região mais barata disponível em cada momento do dia", false],
+            ["Distribuir cópias dos dados por todas as regiões globais para aumentar a disponibilidade e o desempenho de leitura", false],
+            ["Selecionar uma região da AWS localizada no país exigido para armazenar e processar os dados", true],
+            ["Ignorar a escolha de região, pois serviços gerenciados de IA replicam os dados livremente entre continentes por padrão", false],
+        ],
+    },
+    {
+        statement: "Uma equipe de governança precisa saber exatamente qual versão do conjunto de dados gerou cada modelo implantado, para reproduzir resultados e responder a auditorias. Qual recurso apoia esse rastreamento?",
+        explanation: "O rastreamento de linhagem (ML Lineage Tracking) do SageMaker registra as relações entre dados, código e versões de modelo, apoiando reprodutibilidade e auditoria.",
+        topic: "Segurança e governança",
+        options: [
+            ["O Amazon Bedrock Guardrails, que aplica filtros de conteúdo e bloqueia temas indesejados nas respostas do modelo", false],
+            ["O rastreamento de linhagem do SageMaker, que registra a relação entre dados, código e versões de modelo", true],
+            ["O aumento do parâmetro de temperatura, que torna as previsões mais variadas e portanto mais fáceis de reproduzir", false],
+            ["O Amazon Macie, que descobre e classifica dados sensíveis, mas não relaciona conjuntos de dados a modelos treinados", false],
+        ],
+    },
+    {
+        statement: "Meses após implantar um modelo, uma equipe percebe queda de desempenho porque a distribuição dos dados de entrada mudou em relação ao treino. Qual recurso ajuda a detectar automaticamente esse desvio (drift)?",
+        explanation: "O SageMaker Model Monitor compara continuamente os dados e as previsões em produção com uma linha de base e emite alertas quando detecta desvio, indicando necessidade de retreino.",
+        topic: "Segurança e governança",
+        options: [
+            ["AWS CloudTrail, que registra chamadas de API na conta, mas não avalia a distribuição estatística dos dados de entrada", false],
+            ["AWS KMS, que gerencia chaves de criptografia, mas não acompanha mudanças na qualidade das previsões do modelo", false],
+            ["AWS PrivateLink, que mantém o tráfego na rede privada, mas não mede o desempenho preditivo do modelo em produção", false],
+            ["Amazon SageMaker Model Monitor, que compara os dados de produção com uma linha de base e alerta sobre desvios", true],
+        ],
+    },
+    {
+        statement: "Uma empresa usa um serviço gerenciado de IA da AWS. Segundo o modelo de responsabilidade compartilhada, qual tarefa é responsabilidade do cliente, e não da AWS?",
+        explanation: "No modelo de responsabilidade compartilhada, a AWS cuida da segurança da nuvem (a infraestrutura física), enquanto o cliente é responsável pela segurança na nuvem, como IAM e a classificação e proteção dos seus dados.",
+        topic: "Segurança e governança",
+        options: [
+            ["Manter a segurança física e a manutenção do hardware nos data centers onde o serviço é executado", false],
+            ["Aplicar patches no sistema operacional e no hardware subjacente que hospeda o serviço gerenciado de IA", false],
+            ["Configurar as permissões de IAM e classificar os dados que serão enviados ao serviço", true],
+            ["Garantir a disponibilidade global da infraestrutura de rede que interliga as regiões e zonas de disponibilidade", false],
+        ],
+    },
+    {
+        statement: "Uma empresa quer personalizar (fine-tuning) um foundation model no Amazon Bedrock com dados proprietários, mas teme que esses dados melhorem o modelo base de terceiros. O que é correto sobre esse cenário?",
+        explanation: "No Bedrock, os dados usados para personalização e o modelo customizado resultante ficam privados na conta do cliente e não são usados para treinar os modelos base.",
+        topic: "Segurança e governança",
+        options: [
+            ["Os dados enviados para o ajuste passam a ser incorporados ao modelo base e ficam disponíveis para outros clientes da AWS", false],
+            ["Os dados de personalização e o modelo ajustado permanecem privados na conta e não são usados para treinar o modelo base", true],
+            ["É obrigatório publicar o modelo ajustado em um repositório público para que a AWS valide a qualidade do resultado obtido", false],
+            ["O ajuste só é permitido se a empresa autorizar o provedor do modelo a reutilizar os dados em treinos futuros do modelo base", false],
+        ],
+    },
+    {
+        statement: "A liderança quer acompanhar e receber alertas sobre os gastos com inferência de IA generativa por equipe e por projeto. Qual combinação de recursos atende melhor a essa necessidade?",
+        explanation: "O AWS Budgets define limites e alertas de gasto, o Cost Explorer analisa os custos e as tags de alocação de custos permitem separar os valores por equipe e projeto.",
+        topic: "Segurança e governança",
+        options: [
+            ["Apenas o AWS CloudTrail, que registra chamadas de API, mas não consolida nem projeta os valores gastos por equipe", false],
+            ["Apenas o Amazon Macie, cuja função é descobrir dados sensíveis e não tem relação com o acompanhamento de custos", false],
+            ["Apenas os Guardrails do Bedrock, que filtram conteúdo das respostas, mas não fornecem relatórios financeiros de uso", false],
+            ["AWS Budgets e o Cost Explorer com tags de alocação de custos para monitorar e alertar sobre os gastos", true],
+        ],
+    },
+    {
+        statement: "Depois de publicar um endpoint de inferência, a equipe de operações quer acompanhar quase em tempo real o número de invocações, a latência e a taxa de erros, com alarmes automáticos. Qual serviço é o mais indicado?",
+        explanation: "O Amazon CloudWatch coleta métricas operacionais como invocações, latência e erros de um endpoint e permite configurar alarmes automáticos sobre esses indicadores.",
+        topic: "Segurança e governança",
+        options: [
+            ["AWS Artifact, que disponibiliza relatórios de conformidade e certificações, mas não coleta métricas de operação em tempo real", false],
+            ["AWS KMS, que gerencia chaves de criptografia dos dados, mas não acompanha latência nem taxa de erros do endpoint", false],
+            ["Amazon CloudWatch, que coleta métricas operacionais do endpoint e dispara alarmes com base em limites definidos", true],
+            ["Amazon A2I, que adiciona revisão humana às previsões, mas não monitora indicadores operacionais da infraestrutura", false],
+        ],
+    },
+    {
+        statement: "Um job de treinamento do SageMaker precisa ler dados de um bucket do Amazon S3. Qual é a prática recomendada para conceder esse acesso com segurança?",
+        explanation: "Atribuir uma função (execution role) do IAM ao job concede credenciais temporárias com permissões mínimas, evitando o uso de chaves permanentes embutidas no código.",
+        topic: "Segurança e governança",
+        options: [
+            ["Incorporar uma chave de acesso permanente do usuário raiz diretamente no script de treinamento do modelo", false],
+            ["Atribuir ao job uma função (role) do IAM com permissões restritas, usando credenciais temporárias", true],
+            ["Tornar o bucket do S3 público para leitura, evitando a necessidade de configurar qualquer permissão de acesso", false],
+            ["Compartilhar a mesma senha de console entre todos os cientistas de dados que executam jobs de treinamento na conta", false],
+        ],
+    },
+    {
+        statement: "Uma organização quer garantir que somente modelos revisados e aprovados cheguem à produção, mantendo um histórico de versões e status de aprovação. Qual recurso apoia essa governança?",
+        explanation: "O SageMaker Model Registry versiona os modelos e registra o status de aprovação, permitindo que apenas versões aprovadas sejam implantadas em produção.",
+        topic: "Segurança e governança",
+        options: [
+            ["O aumento do parâmetro de temperatura na inferência, que introduz variação e assim sinaliza modelos aprovados", false],
+            ["O AWS PrivateLink, que mantém o tráfego na rede privada, mas não controla quais versões de modelo vão a produção", false],
+            ["O Amazon Macie, que classifica dados sensíveis em buckets, mas não gerencia aprovação de versões de modelos de ML", false],
+            ["O SageMaker Model Registry, que versiona modelos e controla o status de aprovação antes da implantação", true],
+        ],
+    },
+    {
+        statement: "Uma empresa monta uma base de conhecimento para RAG no Amazon Bedrock com documentos internos confidenciais. Qual conjunto de medidas protege melhor esses dados?",
+        explanation: "Proteger os dados de uma base de conhecimento envolve criptografar as fontes e o armazenamento vetorial com o AWS KMS e limitar o acesso por políticas do IAM, combinando criptografia e controle de acesso.",
+        topic: "Segurança e governança",
+        options: [
+            ["Criptografar os dados de origem e o armazenamento vetorial com o AWS KMS e restringir o acesso por políticas do IAM", true],
+            ["Deixar o armazenamento vetorial sem criptografia para acelerar as buscas e liberar leitura pública dos documentos internos", false],
+            ["Confiar apenas na obscuridade do endpoint, sem aplicar criptografia nem políticas de acesso aos documentos confidenciais", false],
+            ["Enviar os documentos por e-mail para todos os funcionários, de modo que qualquer pessoa possa validar a qualidade das buscas", false],
+        ],
+    },
 ];
 
 async function seed() {
@@ -943,12 +2044,22 @@ async function seed() {
         .select({ n: count() })
         .from(simuladoQuestions)
         .where(eq(simuladoQuestions.simuladoId, simulado.id));
-    if (Number(n) > 0) {
+    const jaExistem = new Set(
+        (
+            await db
+                .select({ statement: simuladoQuestions.statement })
+                .from(simuladoQuestions)
+                .where(eq(simuladoQuestions.simuladoId, simulado.id))
+        ).map((r) => r.statement),
+    );
+    const inseridas = QUESTOES.filter((q) => !jaExistem.has(q.statement)).length;
+    if (inseridas === 0) {
         console.log(`Simulado já tem ${n} questões, nada a fazer.`);
         return;
     }
 
     for (const q of QUESTOES) {
+        if (jaExistem.has(q.statement)) continue;
         const [questao] = await db
             .insert(simuladoQuestions)
             .values({
@@ -967,7 +2078,7 @@ async function seed() {
             })),
         );
     }
-    console.log(`Seed concluído: ${QUESTOES.length} questões inseridas.`);
+    console.log(`Seed: ${inseridas} questões novas inseridas (${QUESTOES.length} no banco).`);
 }
 
 seed()

--- a/backend/scripts/seed-databricks-de-associate.ts
+++ b/backend/scripts/seed-databricks-de-associate.ts
@@ -1195,6 +1195,282 @@ const QUESTOES: Questao[] = [
             ["SELECT regiao, mes, SUM(valor) OVER (PARTITION BY regiao ORDER BY mes) AS receita, pedido_id AS pedidos FROM silver", false],
         ],
     },
+    // ===== Questões adicionais (banco ampliado para variar as tentativas) =====
+    {
+        statement: "Uma engenheira quer entender como uma tabela Delta garante atomicidade quando dois jobs gravam quase ao mesmo tempo. Onde o Delta Lake registra cada operacao de escrita para oferecer transacoes ACID e time travel?",
+        explanation: "O log de transacoes (_delta_log) guarda commits JSON ordenados e checkpoints Parquet periodicos; e isso que da ACID, isolamento de snapshot e time travel, sem depender de bloqueio externo.",
+        topic: "Delta Lake - transaction log",
+        options: [
+            ["Todo o estado da tabela fica apenas no metastore do Hive, que controla os bloqueios de concorrencia entre os jobs que gravam.", false],
+            ["Dentro do rodape de cada arquivo Parquet de dados, que guarda a lista completa das versoes anteriores da tabela.", false],
+            ["Em um servico externo de bloqueio distribuido que precisa ser provisionado a parte para coordenar as gravacoes concorrentes.", false],
+            ["Em arquivos de commit JSON ordenados dentro da pasta _delta_log, que descrevem cada transacao da tabela.", true],
+        ],
+    },
+    {
+        statement: "Uma equipe tem um diretorio grande de arquivos Parquet ja particionados no object storage e quer passar a usar recursos do Delta Lake sem reescrever todos os dados. Qual abordagem atende a esse objetivo?",
+        explanation: "CONVERT TO DELTA cria o _delta_log a partir dos arquivos Parquet existentes, tornando o diretorio uma tabela Delta sem reescrever os dados.",
+        topic: "Delta Lake - CONVERT TO DELTA",
+        options: [
+            ["Rodar CONVERT TO DELTA sobre o diretorio Parquet, gerando o log de transacoes sem reescrever os arquivos de dados.", true],
+            ["Executar OPTIMIZE no diretorio Parquet, que reorganiza os arquivos e automaticamente os promove para o formato Delta.", false],
+            ["Ler todos os Parquet em um DataFrame e regravar em outro caminho com format('delta'), duplicando os dados no armazenamento.", false],
+            ["Criar uma tabela externa apontando para o Parquet, pois o Unity Catalog trata qualquer tabela externa como Delta por padrao.", false],
+        ],
+    },
+    {
+        statement: "Antes de um teste de carga arriscado, um engenheiro quer uma copia totalmente independente da tabela vendas_gold, para validar sem afetar a tabela original nem depender dos arquivos dela. Qual comando cria essa copia?",
+        explanation: "O DEEP CLONE copia os arquivos de dados e os metadados, resultando em uma tabela independente; o SHALLOW CLONE so copia metadados e continua apontando para os arquivos da origem.",
+        topic: "Delta Lake - DEEP CLONE",
+        options: [
+            ["CREATE TABLE ... SHALLOW CLONE, que copia apenas os metadados e continua referenciando os arquivos de dados da tabela de origem.", false],
+            ["CREATE TABLE ... AS SELECT, que gera uma view materializada sincronizada automaticamente com qualquer mudanca feita na origem.", false],
+            ["CREATE TABLE ... DEEP CLONE, que copia dados e metadados para uma tabela independente da origem.", true],
+            ["CREATE TABLE ... LIKE, que so replica o schema e as propriedades, sem copiar nenhum dado nem o historico da tabela de origem.", false],
+        ],
+    },
+    {
+        statement: "Um append em uma tabela Delta falha porque o DataFrame de origem passou a ter uma coluna nova que nao existe na tabela. A equipe quer que essa coluna seja adicionada automaticamente na gravacao. O que explica o erro e resolve o caso?",
+        explanation: "O schema enforcement bloqueia gravacoes com schema divergente por padrao; habilitar mergeSchema (ou o autoMerge) permite evoluir o schema adicionando a nova coluna no append.",
+        topic: "Delta Lake - schema enforcement e mergeSchema",
+        options: [
+            ["O Delta nunca aceita novas colunas; e preciso recriar a tabela do zero com CREATE OR REPLACE a cada mudanca de schema da origem.", false],
+            ["Por schema enforcement, o Delta rejeita schemas divergentes; usar a opcao mergeSchema como true no append adiciona a coluna.", true],
+            ["O erro vem do particionamento; basta reparticionar o DataFrame pela nova coluna para que a gravacao passe a aceita-la.", false],
+            ["O append no formato Delta ignora colunas extras silenciosamente, entao o erro so pode ter sido causado por um tipo de dado incompativel.", false],
+        ],
+    },
+    {
+        statement: "A camada gold precisa consumir, de forma incremental, apenas as linhas que foram inseridas, atualizadas ou removidas em uma tabela silver Delta, sabendo o tipo de cada mudanca. Qual recurso entrega isso?",
+        explanation: "O Change Data Feed registra as mudancas em nivel de linha com o tipo (_change_type: insert, update_preimage/postimage, delete); e habilitado por propriedade de tabela e lido com a opcao readChangeFeed ou table_changes().",
+        topic: "Delta Lake - Change Data Feed",
+        options: [
+            ["O time travel com VERSION AS OF, que retorna o conteudo completo de uma versao anterior, mas nao marca o tipo de cada mudanca linha a linha.", false],
+            ["O comando DESCRIBE HISTORY, que lista as operacoes feitas na tabela, mas nao devolve as linhas de dados que mudaram.", false],
+            ["O Change Data Feed, habilitado por delta.enableChangeDataFeed, lido com readChangeFeed e a coluna _change_type.", true],
+            ["O comando OPTIMIZE com ZORDER, que agrupa fisicamente as linhas alteradas para acelerar a leitura das mudancas recentes.", false],
+        ],
+    },
+    {
+        statement: "Um engenheiro quer criar a tabela clientes_ativos ja populada com o resultado de uma consulta que filtra clientes por status, sem declarar manualmente cada coluna e tipo. Qual comando faz isso?",
+        explanation: "O CTAS (CREATE TABLE AS SELECT) cria a tabela inferindo o schema a partir do SELECT e ja a popula com o resultado, sem precisar declarar colunas manualmente.",
+        topic: "Spark SQL - CREATE TABLE AS SELECT",
+        options: [
+            ["CREATE TABLE clientes_ativos AS SELECT ..., que deriva o schema do resultado da consulta e grava as linhas.", true],
+            ["CREATE TABLE clientes_ativos (col1 ..., col2 ...) e depois um COPY INTO separado para carregar as linhas vindas da consulta.", false],
+            ["CREATE OR REPLACE TEMP VIEW clientes_ativos AS SELECT ..., que persiste os dados fisicamente como uma nova tabela gerenciada.", false],
+            ["INSERT INTO clientes_ativos SELECT ..., que cria a tabela automaticamente caso ela ainda nao exista no schema atual da sessao.", false],
+        ],
+    },
+    {
+        statement: "Em um cluster compartilhado, uma view temporaria criada em um notebook precisa ser consultada por outro notebook anexado ao mesmo cluster. Qual objeto permite esse compartilhamento entre sessoes?",
+        explanation: "A global temp view fica no schema global_temp e e visivel por outras sessoes do mesmo cluster/aplicacao; a temp view comum e restrita a sessao que a criou.",
+        topic: "Spark SQL - TEMP VIEW x GLOBAL TEMP VIEW",
+        options: [
+            ["Uma TEMP VIEW comum, que fica disponivel para qualquer notebook enquanto o cluster estiver ligado, independentemente da sessao.", false],
+            ["Uma view criada com CREATE VIEW, que existe apenas na sessao que a definiu e e descartada ao desanexar o notebook do cluster.", false],
+            ["Um DataFrame em cache com persist(), que replica automaticamente a definicao da consulta para todas as sessoes conectadas ao cluster.", false],
+            ["Uma GLOBAL TEMP VIEW, acessivel por outras sessoes do mesmo cluster pelo schema global_temp.", true],
+        ],
+    },
+    {
+        statement: "Uma coluna payload de uma tabela bronze guarda uma string JSON como texto, e a equipe precisa extrair o campo cliente.id de dentro dela usando Spark SQL. Qual abordagem e adequada?",
+        explanation: "Quando o JSON esta guardado como string, a sintaxe de dois pontos (payload:cliente.id) extrai os campos; o ponto so funciona depois de converter em struct, por exemplo com from_json.",
+        topic: "Spark SQL - dados JSON aninhados",
+        options: [
+            ["Usar EXPLODE(payload), que transforma automaticamente cada chave do JSON em uma nova linha com o seu respectivo valor.", false],
+            ["Aplicar CAST(payload AS STRUCT) direto, pois o Spark converte qualquer string em struct sem precisar informar o schema dos campos.", false],
+            ["Navegar com a sintaxe de dois pontos, como payload:cliente.id, que le campos de um JSON armazenado como string.", true],
+            ["Referenciar payload.cliente.id com ponto, que e a forma de acessar chaves de uma string JSON ainda nao convertida em struct.", false],
+        ],
+    },
+    {
+        statement: "Uma tabela tem uma coluna itens do tipo array, com varios produtos por pedido, e o time precisa de uma linha por produto para conseguir agregar as vendas item a item. Qual funcao resolve isso?",
+        explanation: "explode() cria uma linha por elemento do array (ou par chave-valor de um map), permitindo agregar item a item.",
+        topic: "Spark SQL - explode",
+        options: [
+            ["explode(itens), que gera uma linha para cada elemento do array em uma nova coluna.", true],
+            ["collect_list(itens), que junta os elementos de varias linhas em um unico array consolidado por pedido.", false],
+            ["array_contains(itens, valor), que verifica a presenca de um elemento e retorna um booleano por linha do pedido.", false],
+            ["size(itens), que devolve a quantidade de elementos do array, mas mantem tudo em uma unica linha por pedido.", false],
+        ],
+    },
+    {
+        statement: "Um job PySpark ficou lento depois que a equipe passou a limpar textos com uma UDF em Python. Um revisor sugere trocar a UDF por funcoes nativas do Spark sempre que possivel. Qual e a justificativa correta?",
+        explanation: "As funcoes nativas sao compreendidas e otimizadas pelo Catalyst e nao pagam o custo de serializacao entre a JVM e o Python que uma UDF impoe, por isso costumam ser mais rapidas.",
+        topic: "PySpark - UDF x funcoes nativas",
+        options: [
+            ["UDFs em Python nao conseguem acessar colunas do DataFrame, entao qualquer transformacao de texto obriga a coletar os dados no driver antes.", false],
+            ["Funcoes nativas rodam somente no driver, o que evita a rede e por isso sempre superam qualquer UDF distribuida pelos executores.", false],
+            ["Funcoes nativas sao otimizadas pelo Catalyst e evitam a serializacao extra que uma UDF Python impoe.", true],
+            ["UDFs em Python desabilitam completamente o particionamento do DataFrame, forcando todo o processamento a rodar em uma unica particao.", false],
+        ],
+    },
+    {
+        statement: "Um DataFrame precisa substituir completamente o conteudo atual da tabela destino a cada execucao do job, apagando as linhas antigas. Qual modo de escrita do DataFrameWriter deve ser usado?",
+        explanation: "O mode('overwrite') substitui o conteudo da tabela pelo do DataFrame; append acrescenta, ignore nao faz nada se ja houver dados e errorIfExists (padrao) falha se a tabela ja existir.",
+        topic: "PySpark - save modes",
+        options: [
+            ["mode('append'), que acrescenta as novas linhas as existentes e, por ser o padrao, dispensa qualquer configuracao adicional no writer.", false],
+            ["mode('ignore'), que sobrescreve os dados apenas quando o schema do DataFrame difere do schema atual da tabela de destino.", false],
+            ["mode('errorIfExists'), que atualiza somente as linhas que ja existem e insere as demais, funcionando como um upsert automatico.", false],
+            ["mode('overwrite'), que substitui os dados existentes na tabela pelo conteudo do DataFrame.", true],
+        ],
+    },
+    {
+        statement: "Depois de transformar dados com a API de DataFrame, uma engenheira quer consultar o resultado usando comandos SQL (spark.sql) no mesmo notebook, sem gravar nada em disco. O que ela deve fazer?",
+        explanation: "createOrReplaceTempView registra o DataFrame como uma view temporaria de sessao, permitindo consulta-lo com spark.sql sem persistir dados.",
+        topic: "PySpark - createOrReplaceTempView",
+        options: [
+            ["Salvar o DataFrame como tabela gerenciada com saveAsTable e remove-la ao final, ja que SQL so enxerga objetos persistidos no metastore.", false],
+            ["Registrar o DataFrame com createOrReplaceTempView e entao consulta-lo por nome via spark.sql.", true],
+            ["Converter o DataFrame para Pandas com toPandas e executar as consultas SQL diretamente sobre o objeto Pandas resultante da conversao.", false],
+            ["Exportar o DataFrame para um arquivo temporario Parquet e recarrega-lo com spark.read antes de executar qualquer consulta em SQL.", false],
+        ],
+    },
+    {
+        statement: "Ao final de um pipeline, um DataFrame com 200 particoes precisa ser reduzido para poucos arquivos de saida, evitando ao maximo o custo de embaralhar os dados pela rede. Qual operacao e a mais indicada?",
+        explanation: "coalesce reduz particoes sem shuffle completo; repartition faz shuffle completo (e pode aumentar ou reduzir), sendo mais custoso quando o objetivo e so diminuir a quantidade de arquivos.",
+        topic: "PySpark - repartition x coalesce",
+        options: [
+            ["repartition(4), que reduz o numero de particoes sem nunca provocar shuffle, por sempre apenas mesclar as particoes vizinhas.", false],
+            ["coalesce(4), que diminui o numero de particoes evitando um shuffle completo.", true],
+            ["repartition('coluna'), que garante o menor numero possivel de arquivos ao reparticionar pelos valores distintos da coluna escolhida.", false],
+            ["cache() seguido de count(), que consolida as particoes em memoria e grava tudo em um unico arquivo na acao seguinte do pipeline.", false],
+        ],
+    },
+    {
+        statement: "Ao ler um CSV com spark.read, uma equipe percebe que as colunas vieram nomeadas como _c0, _c1 e todas como string, apesar de o arquivo ter cabecalho e valores numericos. Quais opcoes corrigem isso?",
+        explanation: "header=true usa a primeira linha como nome das colunas e inferSchema=true faz o Spark deduzir os tipos (com uma passada extra pelos dados); sem elas, as colunas viram _c0, _c1 e ficam como string.",
+        topic: "PySpark - leitura de CSV",
+        options: [
+            ["Usar as opcoes mode como PERMISSIVE e badRecordsPath, que interpretam o cabecalho e ajustam os tipos numericos das colunas.", false],
+            ["Aplicar a opcao multiLine como true, que faz o leitor reconhecer a primeira linha como cabecalho e inferir os tipos automaticamente.", false],
+            ["Trocar o format para 'text' e depois dividir as colunas na mao, pois o leitor de CSV nao suporta cabecalho nem tipos numericos.", false],
+            ["Definir as opcoes header como true e inferSchema como true na leitura do CSV.", true],
+        ],
+    },
+    {
+        statement: "Uma consulta de Structured Streaming faz uma agregacao de contagem por categoria e precisa manter o resultado completo atualizado a cada micro-lote no destino. Qual output mode atende a esse caso?",
+        explanation: "O modo complete reescreve todo o resultado a cada micro-lote, adequado para agregacoes; append serve para linhas novas que nao mudam e update grava apenas as linhas alteradas. Nao existe output mode overwrite em streaming.",
+        topic: "Structured Streaming - output modes",
+        options: [
+            ["O modo append, que e o padrao e reescreve todas as linhas do resultado agregado a cada gatilho de processamento do stream.", false],
+            ["O modo complete, que reescreve todo o resultado da agregacao a cada micro-lote.", true],
+            ["O modo update com trigger('once'), unica forma de manter agregacoes sem exigir a definicao de uma coluna de watermark no stream.", false],
+            ["O modo overwrite, que trunca a tabela de destino e regrava o resultado inteiro da agregacao em cada execucao do stream.", false],
+        ],
+    },
+    {
+        statement: "Uma equipe quer que um pipeline declarativo do Lakeflow processe os dados que ja chegaram e depois desligue a computacao, para reduzir custo, em vez de manter os clusters ligados o tempo todo. Qual modo de execucao escolher?",
+        explanation: "No modo triggered o pipeline processa os dados disponiveis e desliga a computacao, sendo mais economico; o modo continuous mantem tudo rodando para baixa latencia.",
+        topic: "Lakeflow Declarative Pipelines - triggered x continuous",
+        options: [
+            ["O modo continuous, pois ele processa o lote disponivel e encerra os recursos ate a proxima janela agendada pela equipe.", false],
+            ["O modo development, que alem de reduzir a latencia mantem o cluster sempre ativo para reprocessar os dados a cada alteracao de codigo.", false],
+            ["O modo continuous com trigger AvailableNow, combinacao que garante o desligamento automatico dos clusters apos cada atualizacao do pipeline.", false],
+            ["O modo triggered, que processa os dados disponiveis e entao encerra a computacao do pipeline.", true],
+        ],
+    },
+    {
+        statement: "Depois de corrigir uma regra de transformacao, uma engenheira precisa reprocessar todos os dados historicos de uma tabela do pipeline, e nao apenas os registros novos. Qual acao faz isso?",
+        explanation: "O full refresh limpa e recalcula as tabelas a partir da origem, aplicando as novas regras a todo o historico; a atualizacao normal so processa dados novos de forma incremental.",
+        topic: "Lakeflow Declarative Pipelines - full refresh",
+        options: [
+            ["Executar uma atualizacao com full refresh, que limpa as tabelas e as recalcula a partir da origem.", true],
+            ["Executar uma atualizacao normal, que ao detectar a mudanca de codigo ja reprocessa todo o historico das tabelas afetadas automaticamente.", false],
+            ["Rodar OPTIMIZE nas tabelas do pipeline, o que reescreve os arquivos aplicando as novas regras de transformacao a todo o historico.", false],
+            ["Alterar o pipeline para o modo continuous, que refaz o calculo de todas as tabelas desde a origem a cada micro-lote processado.", false],
+        ],
+    },
+    {
+        statement: "Em um pipeline declarativo do Lakeflow com uma tabela bronze, uma silver que le da bronze e uma gold que le da silver, a equipe quer saber como definir a ordem de execucao entre essas tabelas. O que e correto?",
+        explanation: "O Lakeflow Declarative Pipelines resolve o DAG automaticamente a partir das referencias entre os datasets, executando bronze, silver e gold na ordem correta sem configuracao manual de dependencias.",
+        topic: "Declarative Pipelines - dependencias entre datasets",
+        options: [
+            ["E preciso numerar cada dataset e informar essa ordem em uma configuracao a parte, senao o pipeline executa as tabelas em ordem aleatoria.", false],
+            ["A ordem precisa ser controlada por um Lakeflow Job externo, com uma task separada e dependencias explicitas para cada uma das tres tabelas.", false],
+            ["O pipeline monta o grafo de dependencias automaticamente a partir das referencias entre os datasets.", true],
+            ["Cada tabela deve ficar em um pipeline separado e encadeada por gatilhos de Table update, ja que um pipeline so executa um dataset por vez.", false],
+        ],
+    },
+    {
+        statement: "Uma organizacao com varios workspaces na mesma regiao quer um conteiner de metadados no topo do Unity Catalog, sob o qual ficam os catalogos, schemas e tabelas. Que componente e esse e como costuma ser provisionado?",
+        explanation: "O metastore e o conteiner de mais alto nivel do Unity Catalog (normalmente um por regiao) e e atribuido aos workspaces daquela regiao pelo admin da conta; abaixo dele vem catalogos, schemas e tabelas.",
+        topic: "Unity Catalog - metastore",
+        options: [
+            ["O catalogo, que e o objeto de nivel mais alto do Unity Catalog e existe obrigatoriamente um por workspace, criado pelo admin do workspace.", false],
+            ["O metastore, conteiner de topo do Unity Catalog, em geral um por regiao e associado aos workspaces daquela regiao.", true],
+            ["O schema, conteiner de topo que agrupa os catalogos e e criado automaticamente junto com o primeiro workspace da conta na regiao.", false],
+            ["O external location, objeto de nivel mais alto que reune os catalogos e as credenciais de acesso ao armazenamento em nuvem da conta.", false],
+        ],
+    },
+    {
+        statement: "Para governar o acesso a uma pasta especifica de object storage onde ficam tabelas externas, um admin precisa combinar a autenticacao na nuvem com o caminho de armazenamento dentro do Unity Catalog. Quais objetos ele usa?",
+        explanation: "A storage credential encapsula a autenticacao na nuvem (por exemplo uma role IAM) e a external location combina essa credencial com um caminho de armazenamento, permitindo ao Unity Catalog governar o acesso aquele local.",
+        topic: "Unity Catalog - external location",
+        options: [
+            ["Uma storage credential para a autenticacao na nuvem e uma external location que associa essa credencial a um caminho.", true],
+            ["Apenas um volume gerenciado, que ja embute as credenciais de nuvem e o caminho, dispensando qualquer objeto adicional de autenticacao.", false],
+            ["Somente uma service principal com permissao de leitura no bucket, pois o Unity Catalog acessa qualquer caminho de nuvem direto por ela.", false],
+            ["Um catalogo externo apontando para o bucket, que gera de forma transparente as credenciais e o mapeamento de caminho necessarios ao acesso.", false],
+        ],
+    },
+    {
+        statement: "Uma equipe precisa governar, dentro do Unity Catalog, o acesso a arquivos nao tabulares, como PDFs e imagens, organizados por catalogo e schema. Qual objeto atende a isso e qual a diferenca entre os dois tipos?",
+        explanation: "Volumes governam dados nao tabulares (arquivos) dentro do namespace do Unity Catalog; o volume gerenciado usa armazenamento gerido pelo proprio Unity Catalog e o volume externo aponta para um caminho de uma external location.",
+        topic: "Unity Catalog - volumes (managed x external)",
+        options: [
+            ["Uma tabela externa, pois volumes servem apenas para dados tabulares e nao conseguem enderecar arquivos binarios como PDFs, imagens ou documentos.", false],
+            ["Uma storage credential por arquivo, criada individualmente para cada PDF ou imagem que a equipe precisar disponibilizar aos usuarios.", false],
+            ["Um schema do tipo binario, que e um conteiner especial de arquivos nao tabulares provisionado a parte dos schemas comuns de tabelas.", false],
+            ["Um volume: o gerenciado usa armazenamento do Unity Catalog e o externo referencia um caminho de external location.", true],
+        ],
+    },
+    {
+        statement: "A area de FinOps quer analisar, com consultas SQL, o consumo de computacao e os eventos de auditoria de acesso de toda a conta Databricks, usando dados ja disponibilizados pela plataforma. Onde esses dados ficam?",
+        explanation: "As system tables, no catalogo system, expoem dados operacionais da conta como faturamento (system.billing.usage) e auditoria (system.access.audit), prontos para analise em SQL.",
+        topic: "Unity Catalog - system tables",
+        options: [
+            ["No event log de cada pipeline declarativo, que centraliza o consumo de todos os workspaces e os registros de auditoria de acesso da conta.", false],
+            ["Nas system tables (catalogo system), como system.billing.usage e system.access.audit, consultaveis por SQL.", true],
+            ["No INFORMATION_SCHEMA de cada catalogo, que alem dos metadados de objetos guarda o historico de faturamento e de acessos da conta inteira.", false],
+            ["Nos logs do driver de cada cluster, que precisam ser exportados e unificados na mao para reconstruir o consumo e a auditoria da conta.", false],
+        ],
+    },
+    {
+        statement: "Uma tabela foi criada por uma engenheira que saiu da equipe, e agora ninguem consegue conceder novos privilegios nem alterar o objeto. Qual conceito do Unity Catalog explica isso e como resolver?",
+        explanation: "No Unity Catalog o owner de um securavel pode conceder privilegios e executar operacoes como ALTER e DROP; por isso recomenda-se atribuir a ownership a um grupo, e a correcao aqui e transferir a propriedade para um grupo ativo.",
+        topic: "Unity Catalog - owner (ownership)",
+        options: [
+            ["Cada securavel tem um owner, que pode gerenciar privilegios e alterar o objeto; a solucao e transferir a ownership para um grupo ativo.", true],
+            ["O problema e a heranca de privilegios do catalogo, que precisa ser recriada do zero sempre que o usuario criador de uma tabela deixa a conta.", false],
+            ["Toda tabela pertence automaticamente ao metastore admin, entao basta pedir a ele um GRANT de SELECT para que qualquer um volte a administrar.", false],
+            ["Sem o usuario criador, a tabela fica permanentemente bloqueada e a unica saida e recria-la com CREATE OR REPLACE a partir de um backup dos dados.", false],
+        ],
+    },
+    {
+        statement: "A mesma logica de um notebook precisa rodar para regioes diferentes, recebendo o nome da regiao como parametro na hora em que um Lakeflow Job o executa, sem editar o codigo. Qual recurso permite isso?",
+        explanation: "Os widgets (dbutils.widgets) criam parametros de entrada do notebook, que podem ser preenchidos por um Lakeflow Job na execucao, permitindo reaproveitar o mesmo codigo com valores diferentes.",
+        topic: "dbutils.widgets",
+        options: [
+            ["O comando %run, que importa outro notebook e por isso injeta nele os valores de parametros definidos no job que disparou a execucao.", false],
+            ["A funcao spark.conf.get sobre uma chave fixa, unica forma de um notebook receber valores externos passados por um job agendado.", false],
+            ["O dbutils.secrets.get, que recupera valores de parametros gerais do job a partir de um escopo de segredos configurado para o workspace.", false],
+            ["Os widgets (dbutils.widgets), que criam parametros lidos no notebook e podem receber valores do job.", true],
+        ],
+    },
+    {
+        statement: "Um time de BI reclama que os paineis do Databricks SQL demoram para responder apos periodos ociosos, por causa do tempo de inicializacao da computacao. Qual tipo de SQL warehouse minimiza esse tempo de partida?",
+        explanation: "O SQL warehouse serverless usa computacao gerenciada pela Databricks e inicia quase instantaneamente, reduzindo a latencia apos periodos ociosos; classic e pro tem partida mais lenta.",
+        topic: "Databricks SQL - SQL Warehouse",
+        options: [
+            ["O SQL warehouse classic, que por rodar no plano de computacao do cliente inicia praticamente na hora e e o mais rapido para sair da ociosidade.", false],
+            ["Um cluster all-purpose anexado ao painel, que mantem a computacao sempre quente e por isso elimina qualquer tempo de inicializacao das consultas.", false],
+            ["O SQL warehouse serverless, que inicia quase instantaneamente por usar computacao gerenciada pela Databricks.", true],
+            ["O SQL warehouse pro com autoscaling no minimo em zero, configuracao que desliga a computacao sem impor tempo de partida nas proximas consultas.", false],
+        ],
+    },
 ];
 
 async function seed() {
@@ -1226,10 +1502,23 @@ async function seed() {
         .select({ n: count() })
         .from(simuladoQuestions)
         .where(eq(simuladoQuestions.simuladoId, simulado.id));
-    if (Number(n) > 0) { console.log(`Simulado ja tem ${n} questoes, nada a fazer.`); return; }
+    const jaExistem = new Set(
+        (
+            await db
+                .select({ statement: simuladoQuestions.statement })
+                .from(simuladoQuestions)
+                .where(eq(simuladoQuestions.simuladoId, simulado.id))
+        ).map((r) => r.statement),
+    );
+    const inseridas = QUESTOES.filter((q) => !jaExistem.has(q.statement)).length;
+    if (inseridas === 0) {
+        console.log(`Simulado ja tem ${n} questoes, nada a fazer.`);
+        return;
+    }
 
     for (let i = 0; i < QUESTOES.length; i++) {
         const q = QUESTOES[i];
+        if (jaExistem.has(q.statement)) continue;
         const [questao] = await db
             .insert(simuladoQuestions)
             .values({ simuladoId: simulado.id, statement: q.statement, explanation: q.explanation, topic: q.topic })
@@ -1238,7 +1527,7 @@ async function seed() {
             q.options.map(([text, isCorrect], idx) => ({ questionId: questao.id, text, isCorrect, position: idx + 1 })),
         );
     }
-    console.log(`Seed concluido: ${QUESTOES.length} questoes inseridas.`);
+    console.log(`Seed: ${inseridas} questoes novas inseridas (${QUESTOES.length} no banco).`);
 }
 
 seed().then(() => process.exit(0)).catch((e) => { console.error("Falha no seed:", e); process.exit(1); });

--- a/backend/scripts/seed-databricks-de-professional.ts
+++ b/backend/scripts/seed-databricks-de-professional.ts
@@ -1195,6 +1195,667 @@ const QUESTOES: Questao[] = [
             ["Favorecer um esquema estrela, com dimensões mais desnormalizadas, reduzindo o número de joins exigidos pelas consultas de BI frente a um esquema normalizado.", true],
         ],
     },
+    // ===== Questões adicionais (banco ampliado para variar as tentativas) =====
+    {
+        statement: "Uma equipe processa arquivos que chegam ao longo do dia em um volume e quer, em um job agendado de hora em hora, consumir tudo o que estiver disponível e então encerrar o stream, respeitando o limite de maxFilesPerTrigger para não sobrecarregar o cluster. Qual trigger atende esse requisito?",
+        explanation: "Trigger.AvailableNow processa todo o backlog em vários micro-lotes respeitando os limites de vazão e depois para, sendo o sucessor recomendado do Trigger.Once para cargas agendadas.",
+        topic: "Structured Streaming - trigger AvailableNow",
+        options: [
+            ["Trigger.ProcessingTime de 1 hora, que dispara um micro-lote a cada hora mas mantém a consulta rodando indefinidamente sem encerrar.", false],
+            ["Trigger contínuo (continuous), que oferece baixa latência de ponta a ponta e é a forma recomendada de processar lotes agendados que precisam parar ao fim.", false],
+            ["Trigger.AvailableNow, que consome todos os dados disponíveis em vários micro-lotes respeitando limites como maxFilesPerTrigger e encerra a consulta sozinho ao terminar.", true],
+            ["Trigger.Once, que lê tudo o que estiver disponível em um único micro-lote, ignorando limites de vazão como maxFilesPerTrigger, o que pode sobrecarregar o cluster e estourar a memória quando há muitos arquivos acumulados de uma vez.", false],
+        ],
+    },
+    {
+        statement: "Uma consulta de streaming com agregação por chave roda há meses gravando em um checkpoint. A equipe quer alterar as colunas de agrupamento da agregação e reiniciar a consulta reaproveitando o mesmo diretório de checkpoint. O que é correto esperar?",
+        explanation: "Alterar o tipo ou as chaves de uma operação stateful é incompatível com o estado já persistido; nesses casos usa-se um novo checkpoint, ciente de que o estado anterior é perdido.",
+        topic: "Structured Streaming - checkpoint e mudança de query",
+        options: [
+            ["Mudar o tipo ou as chaves de uma operação com estado é incompatível com o estado já gravado no checkpoint; é preciso um novo diretório de checkpoint, reprocessando conforme a fonte permitir.", true],
+            ["O checkpoint guarda apenas offsets de origem, então qualquer alteração na consulta é aplicada sem problemas ao reiniciar.", false],
+            ["Basta incrementar manualmente o número de versão do checkpoint para que o novo formato de estado seja aceito.", false],
+            ["Ao reiniciar, o Spark converte automaticamente o estado antigo para o novo formato de agrupamento, remapeando as chaves de agregação sem qualquer intervenção e sem precisar reprocessar dados da fonte.", false],
+        ],
+    },
+    {
+        statement: "Uma agregação de streaming por janela de tempo grava no modo complete. Depois de dias rodando, o uso de memória do estado cresce sem parar, mesmo com um watermark definido na consulta. Qual explicação está correta?",
+        explanation: "O modo complete exige manter o estado de todas as janelas para reescrever o resultado completo a cada gatilho, de forma que a limpeza de estado por watermark só ocorre nos modos append e update.",
+        topic: "Structured Streaming - output mode complete",
+        options: [
+            ["O modo complete só funciona em conjunto com watermark e expira as janelas antigas automaticamente, então o crescimento indica um watermark mal configurado.", false],
+            ["Complete e append consomem estado da mesma forma; a única diferença entre eles é o formato aceito pelo sink de saída.", false],
+            ["No modo complete o Spark grava apenas as janelas alteradas no último micro-lote e usa o watermark para expirar o estado, sendo por isso a opção mais econômica em memória para agregações de longa duração e alta cardinalidade.", false],
+            ["No modo complete a tabela de resultado inteira é reescrita a cada micro-lote e o estado de todas as janelas é mantido, então o watermark não descarta estado antigo e ele cresce indefinidamente.", true],
+        ],
+    },
+    {
+        statement: "Uma consulta faz um left outer join entre a stream de impressões e a stream de cliques. A equipe percebe que as impressões sem clique correspondente nunca aparecem no resultado com o lado direito em NULL. Qual é a causa e a correção?",
+        explanation: "Outer joins stream-stream exigem watermark nos dois lados e uma restrição temporal no join, pois o engine só emite a linha com NULL quando tem certeza de que nenhuma correspondência ainda pode chegar.",
+        topic: "Structured Streaming - stream-stream outer join",
+        options: [
+            ["Joins outer entre duas streams não são suportados no Structured Streaming; é preciso materializar uma das streams como tabela e fazer um join estático.", false],
+            ["Em joins outer entre streams, as linhas sem correspondência só saem com NULL quando o watermark e a condição temporal garantem que nenhum match futuro é possível; sem isso o resultado nunca é finalizado.", true],
+            ["Basta trocar o output mode para complete para que as linhas sem correspondência sejam emitidas imediatamente pelo join.", false],
+            ["O join outer emite cada linha sem correspondência assim que ela chega, já preenchendo o outro lado com NULL, e depois corrige o resultado automaticamente caso um match apareça em micro-lotes seguintes, reescrevendo a saída anterior.", false],
+        ],
+    },
+    {
+        statement: "Uma consulta une eventos de duas streams com watermarks de atraso bem diferentes. A equipe nota que o estado só expira no ritmo da stream mais lenta e quer acelerar a limpeza. O que explica o comportamento padrão e o efeito de mudar a política?",
+        explanation: "A propriedade spark.sql.streaming.multipleWatermarkPolicy é min por padrão; mudar para max acelera a expiração do estado, ao custo de tratar como atrasados eventos ainda válidos pela stream mais lenta.",
+        topic: "Structured Streaming - watermark com múltiplas streams",
+        options: [
+            ["Por padrão o Spark adota o menor dos watermarks como watermark global, o mais conservador; definir a política como max acelera a expiração de estado, mas pode descartar como atrasados dados ainda válidos da stream mais lenta.", true],
+            ["Com múltiplas streams o Spark sempre usa o maior watermark e não há configuração que altere esse comportamento.", false],
+            ["Cada stream mantém um watermark totalmente independente e eles nunca são combinados em um valor global para a consulta.", false],
+            ["O Spark calcula a média aritmética dos watermarks de todas as streams envolvidas e aplica esse valor como limite global, equilibrando de forma automática a retenção de estado e a tolerância a dados atrasados de cada uma delas.", false],
+        ],
+    },
+    {
+        statement: "Um job de streaming com estado por chave e milhões de chaves distintas sofre pausas longas de coleta de lixo e estouros de memória nos executores, pois o estado padrão fica no heap da JVM. Qual mudança ataca a causa?",
+        explanation: "O provedor RocksDB armazena o estado nativamente fora do heap e em disco local, sendo a recomendação para consultas stateful com estado grande, onde o provedor padrão baseado no heap causa pressão de GC.",
+        topic: "Structured Streaming - state store RocksDB",
+        options: [
+            ["Aumentar o número de partições de shuffle, já que o estado é recalculado do zero a cada micro-lote e o problema é apenas de paralelismo.", false],
+            ["Trocar o output mode para complete, o que move todo o estado para o driver e alivia a memória dos executores.", false],
+            ["Configurar o provedor de estado RocksDB, que mantém o estado fora do heap da JVM e em disco local, reduzindo a pressão de memória e as pausas de GC em consultas com estado muito grande.", true],
+            ["Desabilitar o diretório de checkpoint, fazendo o estado ser mantido apenas em memória volátil e liberado ao fim de cada micro-lote, o que evita o crescimento acumulado que causa os estouros de memória nos executores.", false],
+        ],
+    },
+    {
+        statement: "Uma equipe precisa implementar uma lógica de sessão customizada que as janelas nativas não expressam: manter estado por usuário, atualizá-lo a cada evento e emitir a sessão quando não houver atividade por um intervalo. Qual abordagem é a adequada?",
+        explanation: "flatMapGroupsWithState é a API de processamento com estado arbitrário: expõe o GroupState por chave e suporta timeouts de tempo de evento ou processamento, ideal para sessionização customizada.",
+        topic: "Streaming - estado arbitrário (flatMapGroupsWithState)",
+        options: [
+            ["Usar dropDuplicatesWithinWatermark, que já implementa sessões customizadas por chave com controle de expiração.", false],
+            ["Usar flatMapGroupsWithState, que dá controle explícito do estado por chave via GroupState e permite emitir resultados e expirar sessões por timeout.", true],
+            ["Usar uma window() com slide adequado, que cobre qualquer lógica de sessão sem precisar de estado customizado.", false],
+            ["Usar foreachBatch e, dentro de cada micro-lote, consultar a tabela de destino para reconstruir manualmente o estado de sessão de cada usuário a partir de todo o histórico já gravado, decidindo a cada lote quais sessões encerrar.", false],
+        ],
+    },
+    {
+        statement: "Dentro de um foreachBatch, o DataFrame do micro-lote é gravado em duas saídas: uma tabela Delta e um tópico Kafka. A equipe observa que a fonte é lida duas vezes por micro-lote e o custo dobrou. Qual é a boa prática?",
+        explanation: "Cada ação de escrita dispara a reavaliação do DataFrame do micro-lote; persistir o DataFrame antes das múltiplas gravações e liberá-lo depois evita reler a fonte a cada saída.",
+        topic: "foreachBatch - reuso do DataFrame",
+        options: [
+            ["Nada precisa ser feito: o Spark materializa o DataFrame do micro-lote uma única vez e reaproveita o resultado para todas as escritas dentro do foreachBatch.", false],
+            ["Trocar foreachBatch por foreach, que envia cada linha individualmente e por isso elimina qualquer recomputação do DataFrame.", false],
+            ["Criar uma consulta de streaming separada para cada saída, ambas lendo da mesma fonte com um checkpoint compartilhado, o que garante que os dados sejam lidos uma só vez e distribuídos entre as duas escritas sem duplicação de custo.", false],
+            ["Chamar persist no DataFrame do micro-lote antes das duas escritas e unpersist ao final, pois cada ação de escrita, sem isso, recomputa o DataFrame e relê a fonte.", true],
+        ],
+    },
+    {
+        statement: "Um foreachBatch faz apenas append em uma tabela Delta. Após uma falha, o mesmo micro-lote pode ser reprocessado e reanexado, gerando linhas duplicadas. Qual é a forma mais direta, usando recursos nativos do Delta, de tornar esse append idempotente?",
+        explanation: "As opções txnAppId e txnVersion habilitam as escritas idempotentes nativas do Delta: uma transação com o mesmo par de identificadores é reconhecida e ignorada, evitando duplicatas em reprocessamentos.",
+        topic: "foreachBatch - escritas idempotentes",
+        options: [
+            ["Passar as opções txnAppId e txnVersion (com o batchId) na escrita Delta, para que a transação seja reconhecida e ignorada caso o mesmo micro-lote seja reprocessado após a falha.", true],
+            ["Usar apenas mode append, pois o Delta detecta e descarta linhas duplicadas automaticamente a cada escrita.", false],
+            ["Habilitar o Change Data Feed na tabela de destino, o que faz o Delta descartar micro-lotes repetidos na ingestão.", false],
+            ["Manter uma tabela de controle com o último batchId processado e, no início de cada micro-lote, lê-la e compará-la para abortar a escrita quando o identificador já constar como concluído, recriando essa verificação manualmente a cada execução.", false],
+        ],
+    },
+    {
+        statement: "Uma streaming table bronze usa Auto Loader com o modo de evolução de schema padrão (addNewColumns). Um novo campo passa a aparecer nos arquivos de entrada. Qual é o comportamento esperado?",
+        explanation: "No modo addNewColumns o stream para ao encontrar colunas novas, atualiza o local de schema e as incorpora no próximo início; nenhum dado é perdido, mas o job precisa reiniciar sozinho.",
+        topic: "Auto Loader - schema evolution (addNewColumns)",
+        options: [
+            ["A nova coluna é adicionada em tempo real, sem interromper o stream, e nenhum reinício da consulta é necessário.", false],
+            ["A nova coluna é silenciosamente ignorada e seus valores descartados até que o schema seja alterado manualmente pela equipe.", false],
+            ["O stream falha ao detectar a nova coluna, registra o schema atualizado e, ao ser reiniciado, passa a incluí-la; por isso o job deve estar configurado para reiniciar automaticamente.", true],
+            ["O stream é encerrado em definitivo e marca como corrompidos todos os arquivos que contêm a nova coluna, exigindo que a equipe apague o diretório de schema e reprocesse a ingestão desde o início para conseguir recuperá-los.", false],
+        ],
+    },
+    {
+        statement: "O Auto Loader infere como string uma coluna que deveria ser decimal e um campo que deveria ser timestamp, mas a equipe quer manter a inferência automática para todas as demais colunas. Qual é a solução recomendada?",
+        explanation: "cloudFiles.schemaHints permite sobrescrever o tipo de colunas específicas mantendo a inferência para as demais, sem precisar fixar o schema inteiro manualmente.",
+        topic: "Auto Loader - schemaHints",
+        options: [
+            ["Desligar a inferência com cloudFiles.inferColumnTypes igual a false, o que já converte cada coluna para o tipo adequado de forma automática.", false],
+            ["Definir cloudFiles.schemaHints apenas para as colunas específicas, informando os tipos corretos e deixando o Auto Loader inferir o restante do schema normalmente.", true],
+            ["Usar a coluna _rescued_data, que reescreve no schema da tabela os tipos que foram inferidos de forma incorreta.", false],
+            ["Recriar a streaming table a cada mudança com um schema totalmente fixo definido à mão, já que o Auto Loader não permite corrigir o tipo de colunas individuais sem abrir mão da inferência de todas as outras colunas do arquivo.", false],
+        ],
+    },
+    {
+        statement: "Um Auto Loader roda em modo file notification. A equipe sabe que, raramente, notificações de eventos da nuvem podem se perder, deixando alguns arquivos sem serem processados. Como garantir que esses arquivos eventualmente sejam ingeridos?",
+        explanation: "cloudFiles.backfillInterval agenda uma reconciliação por listagem de diretório assíncrona sobre a ingestão por notificação, garantindo o processamento eventual de arquivos cujas notificações foram perdidas.",
+        topic: "Auto Loader - backfillInterval",
+        options: [
+            ["Configurar cloudFiles.backfillInterval para que o Auto Loader faça, periodicamente, uma listagem de diretório assíncrona e capture arquivos cujas notificações eventualmente tenham se perdido.", true],
+            ["Aumentar maxFilesPerTrigger, o que faz o serviço de nuvem reenviar as notificações que haviam se perdido.", false],
+            ["Alternar de tempos em tempos para Trigger.Once, que força a releitura de todos os arquivos já notificados anteriormente.", false],
+            ["Desabilitar o file notification e voltar em definitivo ao directory listing, pois essa é a única forma de assegurar que nenhum arquivo se perca, ainda que ao custo de listar todo o diretório de forma síncrona em cada micro-lote.", false],
+        ],
+    },
+    {
+        statement: "Uma ingestão bronze lê de um bucket que acumulou milhões de arquivos, e a latência da listagem de diretório cresce a cada micro-lote. A equipe avalia migrar para o modo file notification. Qual afirmação é correta?",
+        explanation: "O modo file notification evita listar o diretório completo, escalando para volumes altos de arquivos, e o Auto Loader pode provisionar automaticamente a fila e a inscrição de eventos quando recebe as permissões de nuvem necessárias.",
+        topic: "Auto Loader - file notification x directory listing",
+        options: [
+            ["O file notification é sempre preferível, inclusive em diretórios pequenos, por ter menor custo fixo e nenhuma dependência de permissões extras na nuvem.", false],
+            ["Os modos directory listing e file notification não podem ser trocados sem recriar o checkpoint e reprocessar toda a ingestão desde o início.", false],
+            ["O file notification exige que a equipe crie e mantenha manualmente a fila de mensagens e as regras de evento em cada conta de armazenamento, pois o Auto Loader apenas consome a fila e nunca provisiona esses recursos por conta própria em nenhuma nuvem.", false],
+            ["O file notification escala melhor em diretórios com muitos arquivos por não listar o diretório inteiro; com as permissões adequadas, o Auto Loader cria automaticamente a fila e a assinatura de eventos.", true],
+        ],
+    },
+    {
+        statement: "Uma dimensão silver precisa refletir apenas o estado mais recente de cada cliente, sem manter histórico, e é alimentada por eventos de mudança que às vezes chegam fora de ordem. Como modelar isso com AUTO CDC?",
+        explanation: "No SCD Type 1 o AUTO CDC sobrescreve o registro, mantendo apenas o estado atual; a cláusula SEQUENCE BY continua sendo usada para ordenar os eventos e descartar os que chegam fora de ordem.",
+        topic: "AUTO CDC - SCD Type 1",
+        options: [
+            ["Usar SCD Type 1, que preserva todas as versões históricas de cada chave, apenas sem colunas de vigência explícitas.", false],
+            ["Usar AUTO CDC com STORED AS SCD TYPE 1 e SEQUENCE BY: mantém só a versão mais recente de cada chave, sobrescrevendo a anterior, e usa a coluna de sequência para ignorar eventos que chegam atrasados.", true],
+            ["Usar SCD Type 1 sem SEQUENCE BY, pois esse tipo não aceita coluna de sequência e por isso o último evento a chegar sempre vence.", false],
+            ["Usar SCD Type 1, que cria uma nova linha a cada alteração e marca a anterior com uma data de fim de vigência, permitindo consultar tanto o valor atual quanto o histórico completo de todas as mudanças de cada registro ao longo do tempo.", false],
+        ],
+    },
+    {
+        statement: "Uma dimensão de clientes é mantida como SCD Type 2 por AUTO CDC. Uma coluna de ultimo_acesso muda a todo instante e está gerando uma nova versão histórica do registro a cada evento, inflando a tabela. Como evitar isso?",
+        explanation: "A cláusula TRACK HISTORY ON (com EXCEPT para excluir colunas) define quais colunas disparam uma nova versão no SCD Type 2, evitando históricos gerados por campos que mudam com muita frequência.",
+        topic: "AUTO CDC - TRACK HISTORY",
+        options: [
+            ["Não há como evitar: em SCD Type 2 qualquer alteração em qualquer coluna sempre cria uma nova linha histórica do registro.", false],
+            ["Basta remover a coluna volátil do SEQUENCE BY para que ela deixe de disparar novas versões da dimensão.", false],
+            ["Usar TRACK HISTORY ON com uma lista EXCEPT para as colunas voláteis, de modo que apenas mudanças nas colunas rastreadas gerem uma nova versão SCD Type 2.", true],
+            ["Criar um job separado que, periodicamente, varre a dimensão e mescla versões consecutivas cujas únicas diferenças estejam nas colunas voláteis, colapsando manualmente o histórico redundante que é gerado a cada alteração desses campos.", false],
+        ],
+    },
+    {
+        statement: "Um engenheiro mantém uma streaming table alimentada por AUTO CDC INTO e quer, em paralelo, aplicar alguns MERGE manuais nessa mesma tabela a partir de outro job. Qual afirmação está correta?",
+        explanation: "O alvo do AUTO CDC é totalmente gerenciado pelo pipeline, que cuida da ordenação via SEQUENCE BY e da deduplicação; escritas externas nessa tabela entram em conflito com esse controle.",
+        topic: "AUTO CDC - alvo gerenciado",
+        options: [
+            ["A streaming table alvo do AUTO CDC é gerenciada inteiramente pelo pipeline; não se deve aplicar MERGE ou outras escritas externas nela, pois o AUTO CDC controla a ordenação e a aplicação das mudanças.", true],
+            ["É possível combinar livremente AUTO CDC e comandos MERGE manuais na mesma tabela, desde que sejam executados em horários diferentes.", false],
+            ["O AUTO CDC exige que a fonte já esteja deduplicada e ordenada, pois ele próprio não trata eventos repetidos nem que chegam fora de ordem.", false],
+            ["O alvo do AUTO CDC pode ser lido e escrito por qualquer outro job do workspace, e o pipeline apenas acrescenta as novas mudanças sem assumir o controle da ordenação, que passa a ser responsabilidade da aplicação que produz os eventos de origem.", false],
+        ],
+    },
+    {
+        statement: "Uma equipe teme habilitar o Change Data Feed em uma tabela bronze que só recebe appends, achando que isso dobraria o armazenamento ao duplicar cada linha inserida. O que de fato acontece?",
+        explanation: "Para inserções puras o CDF deriva as mudanças dos próprios arquivos de dados, sem custo extra; apenas operações que alteram linhas existentes (update, delete, merge) gravam arquivos dedicados em _change_data.",
+        topic: "Change Data Feed - custo de armazenamento",
+        options: [
+            ["O CDF sempre duplica cada linha escrita em uma pasta _change_data, dobrando o armazenamento independentemente do tipo de operação realizada.", false],
+            ["O CDF registra apenas as inserções; updates e deletes precisam ser capturados por um mecanismo separado configurado à parte.", false],
+            ["O CDF materializa uma cópia completa da tabela a cada versão do log de transações, de forma que o custo de armazenamento cresce proporcionalmente ao número total de commits, mesmo quando todas as operações são apenas inserções de novas linhas.", false],
+            ["Em operações que só inserem linhas, o CDF não grava arquivos de mudança separados e lê as alterações direto dos próprios arquivos de dados; apenas updates, deletes e merges geram arquivos em _change_data.", true],
+        ],
+    },
+    {
+        statement: "Um job em lote lê o Change Data Feed de uma tabela Delta com a função table_changes, pedindo um intervalo de versões. Qual afirmação descreve corretamente o resultado?",
+        explanation: "table_changes expõe os quatro valores de _change_type (insert, update_preimage, update_postimage, delete) junto de _commit_version e _commit_timestamp, e lança erro ao abranger versões anteriores à ativação do CDF.",
+        topic: "Change Data Feed - leitura com table_changes",
+        options: [
+            ["A função retorna apenas a versão mais recente de cada linha alterada, sem distinguir a imagem anterior da posterior em uma atualização.", false],
+            ["A função retorna as linhas com _change_type entre insert, update_preimage, update_postimage e delete, e falha se o intervalo pedido incluir versões anteriores à habilitação do CDF.", true],
+            ["O _change_type traz somente os valores insert e delete, e um update aparece como um delete seguido de um insert com o mesmo _commit_version.", false],
+            ["A função reconstrói o histórico completo mesmo para versões anteriores à habilitação do CDF, inferindo as mudanças a partir das versões antigas do log do Delta e preenchendo retroativamente a imagem anterior e a posterior de cada linha alterada.", false],
+        ],
+    },
+    {
+        statement: "Em um pipeline declarativo, a equipe quer que uma constraint crítica interrompa a atualização imediatamente ao encontrar qualquer linha inválida, e precisa entender como isso difere do comportamento padrão de uma expectation. Qual afirmação está correta?",
+        explanation: "O padrão de uma expectation sem ON VIOLATION é registrar a violação e manter a linha; DROP ROW descarta a linha e FAIL UPDATE falha a atualização, parando o pipeline.",
+        topic: "Expectations - ON VIOLATION",
+        options: [
+            ["O comportamento padrão de uma expectation é descartar a linha inválida, enquanto FAIL UPDATE apenas registra a violação nas métricas e segue processando.", false],
+            ["FAIL UPDATE descarta as linhas inválidas e continua o processamento, enquanto o comportamento padrão é interromper todo o pipeline.", false],
+            ["Com ON VIOLATION FAIL UPDATE a atualização falha e o pipeline para ao encontrar uma linha inválida; sem cláusula ON VIOLATION o padrão é apenas registrar a violação nas métricas e manter a linha.", true],
+            ["Sem cláusula ON VIOLATION a linha inválida é enviada automaticamente para uma tabela de quarentena separada, e FAIL UPDATE faz o mesmo, mas dispara também um alerta por e-mail enquanto mantém o pipeline rodando normalmente.", false],
+        ],
+    },
+    {
+        statement: "Em um pipeline declarativo em SQL, uma streaming table de destino precisa ler outra tabela do mesmo pipeline processando somente os registros novos acrescentados desde a última execução. Como referenciar a tabela de origem?",
+        explanation: "A palavra-chave STREAM (por exemplo STREAM(live.tabela)) faz o pipeline ler a origem como fonte de streaming, processando de forma incremental apenas os novos dados; sem ela a leitura é um snapshot completo.",
+        topic: "Declarative Pipelines - leitura incremental STREAM",
+        options: [
+            ["Referenciar a origem com STREAM, por exemplo FROM STREAM(live.upstream), o que faz a leitura ser incremental, processando apenas os novos registros acrescentados desde o último micro-lote.", true],
+            ["Qualquer SELECT dentro de um pipeline já é incremental por padrão; a função STREAM só muda o nome exibido no grafo do pipeline.", false],
+            ["Usar STREAM força a releitura completa da tabela de origem a cada execução, sendo indicado para agregações que precisam de todo o histórico.", false],
+            ["Para ler de forma incremental é obrigatório exportar antes a tabela de origem para um tópico Kafka e consumir de lá, pois uma streaming table de um pipeline não pode servir de fonte de streaming direta para outra tabela do mesmo pipeline.", false],
+        ],
+    },
+    {
+        statement: "Uma tabela Delta muito ativa acumulou milhares de commits no diretorio _delta_log. Uma engenheira nota que abrir a tabela para leitura continua rapido e quer entender como o Delta reconstroi o estado atual sem reler todos os arquivos JSON de commit. Qual explicacao esta correta?",
+        explanation: "A cada certo numero de commits (10 por padrao) o Delta grava um checkpoint em Parquet com o estado consolidado; o leitor usa _last_checkpoint para achar o mais recente e so aplica os commits JSON seguintes.",
+        topic: "Delta Lake - Transaction Log",
+        options: [
+            ["Cada leitura reprocessa integralmente todos os arquivos JSON de commit desde a versao 0 para montar a lista de arquivos ativos, e a rapidez vem apenas do cache de disco do cluster.", false],
+            ["O Delta mantem a lista de arquivos ativos somente na memoria do driver que criou a tabela, e novos clusters precisam recalcular tudo a partir do primeiro commit.", false],
+            ["Periodicamente o Delta grava um checkpoint em Parquet que consolida o estado, e o leitor parte do ultimo checkpoint aplicando so os commits JSON posteriores.", true],
+            ["O arquivo _last_checkpoint guarda a lista completa e final de arquivos de dados da tabela, dispensando por completo a leitura dos commits JSON e dos checkpoints Parquet.", false],
+        ],
+    },
+    {
+        statement: "Dois jobs independentes gravam ao mesmo tempo na mesma tabela Delta nao particionada. Um deles falha com ConcurrentAppendException ao tentar commitar. A equipe quer entender a causa e como reduzir esses conflitos. Qual afirmacao esta correta?",
+        explanation: "O Delta faz controle de concorrencia otimista: cada transacao le um snapshot e valida os arquivos no commit; operacoes que tocam os mesmos arquivos conflitam, e isolar por particoes disjuntas evita a sobreposicao.",
+        topic: "Delta Lake - Controle de Concorrencia",
+        options: [
+            ["O Delta usa controle de concorrencia otimista e valida no commit; escritas que tocam arquivos sobrepostos conflitam, e restringir cada job a particoes disjuntas reduz o problema.", true],
+            ["O Delta nao suporta escritas concorrentes de forma alguma, entao a unica solucao e serializar os jobs com um agendador externo que garanta execucao de um por vez, esperando cada commit finalizar antes de iniciar o proximo job.", false],
+            ["O conflito ocorre porque o Delta usa bloqueio pessimista e o segundo job esperou alem do timeout de lock configurado no metastore do workspace.", false],
+            ["Basta habilitar deletion vectors para que ambas as escritas sejam aplicadas sem qualquer validacao de conflito no momento do commit da transacao.", false],
+        ],
+    },
+    {
+        statement: "Um pipeline de Structured Streaming grava continuamente em uma tabela Delta e gera muitos arquivos pequenos. A equipe nao quer manter um job separado agendado so para rodar OPTIMIZE. Qual abordagem resolve o problema de forma automatica dentro das proprias escritas?",
+        explanation: "optimizeWrite reorganiza os dados antes de gravar para produzir arquivos maiores, e autoCompact dispara uma compactacao de arquivos pequenos ao final da escrita, evitando um OPTIMIZE manual agendado.",
+        topic: "Auto Compaction",
+        options: [
+            ["Habilitar deletion vectors na tabela, que passam a mesclar fisicamente os arquivos pequenos a cada micro-batch sem necessidade de qualquer reescrita posterior.", false],
+            ["Aumentar spark.sql.shuffle.partitions para um valor bem alto, forcando o stream a produzir menos arquivos por micro-batch em cada gravacao feita na tabela.", false],
+            ["Reduzir a frequencia do trigger para Trigger.Once em producao, o que consolida automaticamente os arquivos ja existentes na tabela a cada nova execucao do stream.", false],
+            ["Ativar as propriedades delta.autoOptimize.optimizeWrite e autoCompact, que reorganizam a escrita e compactam pequenos arquivos automaticamente.", true],
+        ],
+    },
+    {
+        statement: "Uma tabela Delta de 80 GB foi particionada por uma coluna cliente_id de altissima cardinalidade. As consultas ficaram lentas e o diretorio tem milhoes de subpastas com arquivos minusculos. Qual e o diagnostico e a melhor correcao?",
+        explanation: "Particionar por coluna de alta cardinalidade gera muitas particoes minusculas e degrada a performance; tabelas desse porte se beneficiam de Liquid Clustering (ou Z-order) em vez de particionamento fisico.",
+        topic: "Particionamento",
+        options: [
+            ["O problema e falta de estatisticas; basta rodar ANALYZE TABLE para que o particionamento por cliente_id passe a acelerar as consultas filtradas por qualquer coluna.", false],
+            ["Houve over-partitioning por coluna de alta cardinalidade; o ideal e remover esse particionamento e usar Liquid Clustering ou Z-order pelas colunas mais filtradas.", true],
+            ["O particionamento esta correto e o problema e o Photon desabilitado; ativar Photon reorganiza fisicamente as particoes pequenas e elimina os arquivos minusculos gerados.", false],
+            ["Como a tabela e pequena demais para ter particoes, a solucao recomendada e aumentar ainda mais a granularidade, particionando tambem por uma segunda coluna de data para equilibrar os arquivos.", false],
+        ],
+    },
+    {
+        statement: "Uma tabela usa OPTIMIZE ZORDER BY (regiao, produto) semanalmente, mas cada execucao reescreve muitos arquivos e fica cara conforme a tabela cresce. A equipe avalia migrar para Liquid Clustering. Qual e a principal vantagem do Liquid Clustering nesse caso?",
+        explanation: "Diferente do Z-order, que reordena com reescritas custosas, o Liquid Clustering clusteriza de forma incremental e adaptativa e permite mudar as chaves de clustering sem reescrever os dados ja existentes.",
+        topic: "Liquid Clustering x Z-order",
+        options: [
+            ["O Liquid Clustering dispensa qualquer execucao de OPTIMIZE, pois reordena todos os dados historicos automaticamente a cada leitura da tabela feita pelos usuarios de BI.", false],
+            ["O Z-order e o Liquid Clustering podem ser combinados na mesma tabela, somando os dois esquemas de organizacao para maximizar o data skipping em qualquer coluna filtrada.", false],
+            ["O Liquid Clustering agrupa os dados de forma incremental, sem reescrever tudo, e permite alterar as chaves de clustering sem reprocessar a tabela inteira.", true],
+            ["O Liquid Clustering elimina a necessidade de coletar estatisticas de min/max por arquivo, passando a fazer file pruning por hashing deterministico das chaves de clustering.", false],
+        ],
+    },
+    {
+        statement: "Para economizar armazenamento, um engenheiro quer rodar VACUUM com retencao de apenas 1 hora em uma tabela Delta usada por varias consultas longas e por time travel. Qual afirmacao descreve corretamente o risco?",
+        explanation: "O VACUUM remove arquivos de dados nao referenciados mais antigos que a retencao; o padrao de 7 dias protege leituras longas e time travel, e baixa-lo exige desligar retentionDurationCheck, arriscando corromper consultas concorrentes.",
+        topic: "VACUUM e Retencao",
+        options: [
+            ["Reduzir a retencao abaixo do padrao de 7 dias exige desabilitar uma trava de seguranca e pode remover arquivos ainda usados por leituras concorrentes e por time travel.", true],
+            ["Nao ha risco algum, pois o VACUUM so apaga arquivos de log de transacao antigos e nunca toca nos arquivos de dados Parquet referenciados pela tabela.", false],
+            ["O VACUUM com 1 hora e seguro porque o Delta mantem automaticamente uma copia oculta de todos os arquivos removidos por pelo menos 30 dias para permitir restauracao.", false],
+            ["O unico efeito colateral e que o proximo OPTIMIZE precisara recompactar a tabela do zero, sem qualquer impacto sobre as consultas em andamento ou sobre o time travel disponivel.", false],
+        ],
+    },
+    {
+        statement: "Uma tabela Delta tem estatisticas de min/max coletadas normalmente, mas consultas filtrando por uma coluna id_transacao ainda leem quase todos os arquivos. Os dados foram inseridos em ordem aleatoria por id_transacao. Qual e a causa mais provavel?",
+        explanation: "O file pruning depende de os arquivos terem intervalos min/max estreitos; sem clustering ou ordenacao por id_transacao cada arquivo abrange quase todo o dominio e o skipping perde eficacia. Z-order ou Liquid Clustering resolveriam.",
+        topic: "Data Skipping e File Pruning",
+        options: [
+            ["As estatisticas de min/max nao sao usadas para file pruning em Delta; o skipping depende exclusivamente de um indice bloom criado manualmente sobre a coluna filtrada.", false],
+            ["O data skipping so funciona sobre colunas de particao, entao nenhuma coluna comum como id_transacao pode ser usada para pular arquivos durante a leitura da tabela.", false],
+            ["O problema e o numero de colunas indexadas; basta aumentar dataSkippingNumIndexedCols para centenas e o pruning por id_transacao passa a ocorrer mesmo sem reordenar os dados.", false],
+            ["Como os dados nao estao co-localizados por id_transacao, o intervalo min/max de cada arquivo cobre quase todo o dominio, e quase nada e pulado.", true],
+        ],
+    },
+    {
+        statement: "Um job com bug sobrescreveu dados corretos em uma tabela Delta ha duas versoes. A equipe quer reverter a tabela ao estado anterior ao erro de forma rastreavel, sem restaurar backups externos. Qual abordagem e a adequada?",
+        explanation: "O log de transacoes do Delta mantem versoes anteriores dentro da retencao, permitindo consultar com VERSION AS OF e reverter com RESTORE TABLE, sem depender de Change Data Feed nem de backups externos.",
+        topic: "Time Travel",
+        options: [
+            ["Nao e possivel reverter uma sobrescrita em Delta; a unica saida e recriar a tabela a partir das fontes originais e reprocessar todo o historico manualmente.", false],
+            ["Usar time travel para inspecionar a versao anterior e entao RESTORE TABLE ... TO VERSION AS OF para retornar a tabela aquele estado.", true],
+            ["Executar VACUUM com retencao zero para forcar o Delta a descartar a versao com bug e promover automaticamente a versao imediatamente anterior como atual.", false],
+            ["Reverter so e viavel se o Change Data Feed estiver habilitado, pois sem ele o Delta nao mantem as versoes anteriores necessarias para consultar o historico da tabela.", false],
+        ],
+    },
+    {
+        statement: "Um MERGE INTO diario atualiza uma tabela fato Delta particionada por data_evento, mas esta lento: o plano mostra varredura da tabela inteira. A condicao ON usa apenas chave_natural. Qual mudanca melhora mais a performance?",
+        explanation: "Incluir na condicao ON um filtro pela coluna de particao (data_evento) deixa o Delta podar arquivos e limitar a varredura do alvo as particoes relevantes, acelerando o merge.",
+        topic: "MERGE INTO - Performance",
+        options: [
+            ["Trocar o MERGE por um DELETE seguido de INSERT em duas transacoes separadas, o que evita a varredura da tabela alvo porque cada comando toca menos arquivos por vez.", false],
+            ["Aumentar spark.sql.autoBroadcastJoinThreshold para que a tabela fato inteira seja transmitida por broadcast aos executores durante a fase de casamento do merge.", false],
+            ["Adicionar a condicao ON um predicado sobre data_evento, permitindo ao Delta podar particoes e evitar varrer a tabela alvo inteira.", true],
+            ["Desabilitar o Adaptive Query Execution para o comando, forcando um numero fixo de particoes de shuffle e reduzindo o custo de reorganizacao durante o merge.", false],
+        ],
+    },
+    {
+        statement: "Uma equipe quer clusterizar uma tabela Delta por dia sem manter manualmente uma coluna de data derivada de um timestamp de evento, e quer que consultas que filtram pelo timestamp aproveitem a poda de arquivos. Qual recurso atende a isso?",
+        explanation: "Generated columns sao calculadas e mantidas pelo proprio Delta; quando derivam de outra coluna, o otimizador gera filtros de particao automaticamente para consultas que filtram a coluna de origem.",
+        topic: "Generated Columns",
+        options: [
+            ["Uma generated column como dia GENERATED ALWAYS AS (CAST(ts AS DATE)), que o Delta preenche sozinho e usa para derivar filtros a partir de ts.", true],
+            ["Uma view SQL que calcula a coluna de data em tempo de consulta, o que garante a poda de arquivos porque a expressao e reavaliada em cada leitura sobre a tabela base.", false],
+            ["Uma UDF Python registrada que converte o timestamp em data e e chamada em cada INSERT, mantendo a coluna sincronizada e habilitando o data skipping por intervalo.", false],
+            ["Uma coluna comum preenchida por um trigger de banco de dados no momento da escrita, ja que o Delta nao oferece nenhum mecanismo nativo para colunas derivadas automaticamente.", false],
+        ],
+    },
+    {
+        statement: "Um engenheiro forca um broadcast join com o hint BROADCAST sobre a tabela do lado maior de um join, achando que sempre acelera. O job passa a falhar com erros de memoria no driver e nos executores. Qual afirmacao esta correta?",
+        explanation: "O broadcast join replica o lado pequeno para todos os executores evitando shuffle; forcar o broadcast de uma tabela grande materializa dados demais em memoria e causa OOM. O padrao so transmite tabelas abaixo de autoBroadcastJoinThreshold.",
+        topic: "Broadcast Join",
+        options: [
+            ["O hint BROADCAST nunca causa problemas de memoria, pois o Spark envia a tabela em pedacos sob demanda e nunca a materializa inteira em um unico no do cluster.", false],
+            ["Broadcast join so e possivel quando ambas as tabelas cabem juntas no limite spark.sql.autoBroadcastJoinThreshold, senao o hint e silenciosamente convertido em sort-merge join.", false],
+            ["O erro ocorre porque o hint desabilita o AQE; reabilitar o Adaptive Query Execution faria o broadcast da tabela grande caber automaticamente na memoria disponivel dos executores.", false],
+            ["Broadcast so compensa quando um lado e pequeno, pois ele e coletado no driver e replicado aos executores; transmitir uma tabela grande estoura a memoria.", true],
+        ],
+    },
+    {
+        statement: "Um job processa volumes de dados muito variaveis. Com spark.sql.shuffle.partitions fixo em 200, as vezes ha spill em disco (particoes grandes demais) e as vezes ha overhead de tarefas minusculas. Qual abordagem e a mais recomendada hoje no Databricks?",
+        explanation: "O Adaptive Query Execution coalesce as particoes de shuffle em tempo de execucao com base no tamanho real dos dados, evitando ajustar manualmente um valor fixo que raramente serve para todos os volumes.",
+        topic: "spark.sql.shuffle.partitions",
+        options: [
+            ["Fixar shuffle.partitions em 2000 permanentemente, pois um numero alto sempre elimina spill e o custo de agendar muitas tarefas pequenas e desprezivel em qualquer volume de dados.", false],
+            ["Manter o AQE habilitado, que coalesce dinamicamente as particoes de shuffle conforme o volume real de cada estagio em tempo de execucao.", true],
+            ["Definir shuffle.partitions igual ao numero de cores do cluster e desabilitar o AQE, garantindo exatamente uma tarefa de shuffle por nucleo em todos os estagios do job.", false],
+            ["Reduzir shuffle.partitions para 1, deixando todo o processamento em uma unica particao, o que remove o shuffle e resolve tanto o spill quanto o overhead de tarefas.", false],
+        ],
+    },
+    {
+        statement: "Um sort-merge join sofre com uma chave muito frequente: uma tarefa demora muito mais que as demais por uma particao de shuffle enorme. A equipe pergunta o que o Adaptive Query Execution pode fazer automaticamente nesse caso. Qual afirmacao esta correta?",
+        explanation: "Entre suas otimizacoes, o AQE detecta particoes de shuffle assimetricas e as quebra em pedacos menores (skew join optimization), distribuindo melhor a carga entre as tarefas.",
+        topic: "Adaptive Query Execution",
+        options: [
+            ["O AQE elimina o skew reparticionando toda a tabela por hash antes do join, garantindo particoes exatamente do mesmo tamanho independentemente da distribuicao das chaves.", false],
+            ["O AQE nao atua sobre skew; ele apenas escolhe a ordem das colunas no ORDER BY final e nao interfere na forma como as particoes de shuffle do join sao formadas.", false],
+            ["O AQE detecta particoes assimetricas em tempo de execucao e as divide em subparticoes menores, equilibrando o trabalho do join.", true],
+            ["O AQE resolve o skew convertendo o sort-merge join em broadcast join, transmitindo o lado maior aos executores mesmo quando ele excede em muito o limite de broadcast configurado.", false],
+        ],
+    },
+    {
+        statement: "Mesmo com AQE, um join continua desbalanceado porque poucas chaves concentram a grande maioria das linhas em uma tabela enorme. A equipe quer uma tecnica manual para distribuir melhor essas chaves quentes. Qual abordagem e apropriada?",
+        explanation: "O salting adiciona um sufixo aleatorio a chave concentrada para dividi-la em varias particoes, replicando as linhas correspondentes do lado menor; assim o trabalho da chave quente se espalha entre tarefas.",
+        topic: "Data Skew e Salting",
+        options: [
+            ["Aplicar salting: adicionar um componente aleatorio a chave quente para espalha-la por varias particoes e replicar as linhas correspondentes do lado menor.", true],
+            ["Aumentar o numero de executores do cluster, pois adicionar mais nos redistribui automaticamente as chaves quentes e desfaz qualquer concentracao de linhas em uma so particao.", false],
+            ["Ordenar globalmente a tabela maior pela chave de join antes do shuffle, o que agrupa as chaves quentes e naturalmente equilibra o tamanho de todas as particoes resultantes.", false],
+            ["Converter a coluna da chave para string e aplicar uma funcao de hash criptografico, ja que hashes distribuem uniformemente qualquer valor e removem completamente o skew do join.", false],
+        ],
+    },
+    {
+        statement: "Um job critico e dominado por uma UDF Python que faz calculos linha a linha, com pouco tempo em scans e agregacoes SQL. A equipe habilita Photon esperando grande ganho, mas quase nao ve diferenca. Qual e a explicacao correta?",
+        explanation: "O motor Photon acelera scans, joins, agregacoes e escritas vetorizadas, mas UDFs Python rodam fora dele; um job dominado por UDF Python ve pouco ganho porque o gargalo nao passa pelo Photon.",
+        topic: "Photon",
+        options: [
+            ["Photon exige que o cluster use apenas SQL warehouses serverless; em clusters classicos ele fica inativo e por isso a UDF Python nao recebeu nenhuma aceleracao.", false],
+            ["Photon foi aplicado normalmente a UDF, mas o ganho foi anulado porque UDFs Python ja rodam em codigo nativo compilado, sem espaco para otimizacao vetorizada adicional.", false],
+            ["O problema e a versao do runtime; Photon acelera UDFs Python apenas quando a tabela de origem esta em Delta com deletion vectors e Liquid Clustering habilitados.", false],
+            ["Photon acelera operacoes SQL e DataFrame vetorizadas, mas nao executa UDFs Python; a parte dominante do job recai fora do motor Photon.", true],
+        ],
+    },
+    {
+        statement: "A partir de uma tabela de leituras de sensor (sensor_id, ts, valor), a equipe precisa, para cada linha, trazer o valor da leitura imediatamente anterior do mesmo sensor, para calcular a variacao. Qual abordagem SQL e a adequada?",
+        explanation: "LAG devolve o valor de uma linha anterior dentro da particao ordenada, ideal para comparar cada leitura com a imediatamente anterior do mesmo sensor sem self join.",
+        topic: "Funcoes de Janela",
+        options: [
+            ["Um self join da tabela com ela mesma por sensor_id e uma subconsulta correlacionada que busca o MAX(ts) menor que o ts corrente, calculando a diferenca entre os dois valores encontrados.", false],
+            ["LAG(valor) OVER (PARTITION BY sensor_id ORDER BY ts) para acessar o valor da linha anterior de cada sensor.", true],
+            ["ROW_NUMBER() OVER (PARTITION BY sensor_id ORDER BY ts) e filtrar pela numeracao, pois a numeracao sequencial ja devolve o valor anterior na mesma linha automaticamente.", false],
+            ["Uma agregacao GROUP BY sensor_id com SUM(valor), ja que funcoes de janela nao conseguem acessar valores de outras linhas dentro da mesma particao ordenada.", false],
+        ],
+    },
+    {
+        statement: "Em uma arquitetura Medallion, uma equipe discute o que colocar na camada Silver e o que colocar na Gold. Qual divisao de responsabilidades esta correta?",
+        explanation: "Bronze retem o dado bruto; Silver entrega dados limpos, conformados e deduplicados numa visao corporativa; Gold expoe agregacoes e modelos dimensionais orientados a casos de negocio.",
+        topic: "Arquitetura Medallion",
+        options: [
+            ["Silver guarda os dados exatamente como chegam da origem, sem limpeza, e Gold apenas replica o Silver adicionando uma coluna de data de carga para fins de auditoria e reprocessamento.", false],
+            ["Silver contem agregacoes de negocio prontas para dashboards, e Gold mantem os dados brutos imutaveis servindo como fonte de reprocessamento para toda a plataforma de dados.", false],
+            ["Silver traz dados limpos, conformados e deduplicados numa visao integrada, e Gold entrega agregacoes e modelos dimensionais prontos para consumo de negocio.", true],
+            ["Silver e Gold sao intercambiaveis e diferem apenas no nome do schema; a escolha entre uma e outra depende so de qual time e dono da tabela dentro do catalogo do workspace.", false],
+        ],
+    },
+    {
+        statement: "Ao projetar uma tabela fato de vendas na camada Gold, um time debate por onde comecar o design. Qual principio de modelagem dimensional deve guiar a decisao?",
+        explanation: "Em modelagem dimensional, define-se primeiro o grao da fato (o que cada linha representa); as medidas devem ser aditivas e coerentes com esse grao, evitando misturar niveis de detalhe na mesma tabela.",
+        topic: "Modelagem Dimensional",
+        options: [
+            ["Declarar primeiro a granularidade (o que uma linha representa) e garantir que as medidas sejam consistentes e aditivas nesse nivel de detalhe.", true],
+            ["Comecar pela escolha das chaves naturais de cada dimensao e so depois decidir a granularidade, ja que a granularidade da fato e sempre inferida automaticamente pelas chaves.", false],
+            ["Definir primeiro os indices e as particoes fisicas da tabela fato, porque a granularidade dos fatos e uma consequencia direta do particionamento escolhido no armazenamento.", false],
+            ["Misturar diferentes granularidades na mesma fato para reduzir o numero de tabelas, deixando as medidas em niveis distintos de detalhe e somando tudo nas consultas de BI depois.", false],
+        ],
+    },
+    {
+        statement: "Uma tabela dimensao Gold usa uma coluna sk GENERATED ALWAYS AS IDENTITY como chave substituta. Um analista assume que os valores serao consecutivos, sem lacunas, e quer usa-los para contar linhas. Qual afirmacao esta correta?",
+        explanation: "Colunas identity produzem valores unicos e monotonicamente crescentes, porem nao necessariamente contiguos (lacunas surgem de paralelismo e transacoes abortadas), entao nao servem para contar linhas nem para cravar ordem de insercao.",
+        topic: "Surrogate Keys",
+        options: [
+            ["Os valores de uma identity column sao sempre consecutivos e sem lacunas, entao usa-los para contar linhas ou inferir a ordem de insercao e seguro em qualquer situacao de carga.", false],
+            ["Com GENERATED ALWAYS AS IDENTITY e possivel inserir manualmente valores na coluna sk, o que permite controlar exatamente a sequencia e evitar quaisquer lacunas na numeracao.", false],
+            ["Identity columns nao servem como chave substituta porque repetem valores entre execucoes paralelas; o correto e usar a chave natural da origem como chave primaria da dimensao.", false],
+            ["Identity columns geram valores unicos e crescentes, mas nao garantem sequencia contigua; podem existir lacunas, e nao devem ser usadas para contagem.", true],
+        ],
+    },
+    {
+        statement: "Numa dimensao de clientes, o negocio precisa analisar vendas passadas segundo o endereco que o cliente tinha na data de cada compra, preservando o historico completo de mudancas de endereco. Qual estrategia de SCD atende ao requisito?",
+        explanation: "Analisar fatos segundo o valor vigente na data exige historico completo por versao, o que caracteriza SCD Tipo 2 (nova linha por mudanca com datas de vigencia e flag de atual); Tipo 1 e Tipo 3 nao preservam todo o historico.",
+        topic: "Slowly Changing Dimensions",
+        options: [
+            ["SCD Tipo 1, sobrescrevendo o endereco antigo pelo novo, pois manter apenas o valor mais recente e suficiente para reconstruir o endereco vigente em qualquer data passada.", false],
+            ["SCD Tipo 2, criando uma nova versao da linha a cada mudanca com vigencia e indicador de registro atual, preservando o historico.", true],
+            ["SCD Tipo 0, mantendo o endereco fixo do primeiro cadastro, ja que atributos de dimensao nunca devem mudar depois da carga inicial do cliente na tabela.", false],
+            ["SCD Tipo 3, guardando apenas o endereco anterior e o atual em duas colunas, o que cobre qualquer necessidade de historico independentemente de quantas vezes o endereco mudar ao longo do tempo.", false],
+        ],
+    },
+    {
+        statement: "Um analista recebeu o privilegio SELECT diretamente na tabela vendas.comercial.pedidos, mas ao executar SELECT * FROM vendas.comercial.pedidos recebe erro de permissao. Nenhum outro privilegio foi concedido a ele. O que falta para a consulta funcionar?",
+        explanation: "No Unity Catalog o acesso a um objeto exige privilegios de travessia em cada nivel pai: USE CATALOG no catalogo e USE SCHEMA no schema, alem do SELECT na tabela. Sem os privilegios de uso, o SELECT concedido na tabela nao basta.",
+        topic: "Unity Catalog - hierarquia de nomes",
+        options: [
+            ["Conceder USE CATALOG em vendas e USE SCHEMA em vendas.comercial, pois o acesso a uma tabela exige percorrer a hierarquia de tres niveis", true],
+            ["Conceder o privilegio MODIFY na tabela, pois SELECT sozinho so habilita leitura de metadados e nao das linhas", false],
+            ["Recriar a tabela como managed e mover o storage para o metastore raiz, ja que tabelas external nao aceitam SELECT concedido a usuarios individuais sem ownership explicito no schema", false],
+            ["Tornar o analista owner do schema vendas.comercial, unica forma de habilitar leitura em tabelas herdadas", false],
+        ],
+    },
+    {
+        statement: "Duas tabelas guardam os mesmos dados: bronze.eventos_m e managed e bronze.eventos_e e external, apontando para um caminho em um external location. Um engenheiro executa DROP TABLE nas duas. O que acontece com os arquivos de dados subjacentes?",
+        explanation: "Ao dropar uma managed table, o Unity Catalog remove tambem os dados (elegiveis para exclusao fisica), pois controla o storage dela. Ao dropar uma external table, apenas os metadados saem do metastore e os arquivos permanecem no storage.",
+        topic: "Unity Catalog - managed x external",
+        options: [
+            ["Ambos os conjuntos de arquivos sao removidos imediatamente, pois DROP TABLE sempre apaga os dados no Unity Catalog", false],
+            ["Os arquivos da managed sao removidos (elegiveis para exclusao fisica), enquanto os da external permanecem no storage, pois o UC so gerencia os metadados dela", true],
+            ["Os arquivos da external sao removidos e os da managed permanecem, ja que o UC controla o ciclo de vida do storage externo", false],
+            ["Ambos os conjuntos de arquivos sao preservados no storage por padrao, e so sao apagados apos o VACUUM subsequente rodar sobre o external location, respeitando o periodo de retencao configurado no metastore", false],
+        ],
+    },
+    {
+        statement: "Um administrador executa GRANT SELECT ON SCHEMA vendas.comercial TO grupo_analistas. Uma semana depois, um pipeline cria a nova tabela vendas.comercial.devolucoes. Sobre o acesso do grupo a essa tabela recem-criada, o que e correto?",
+        explanation: "Privilegios no Unity Catalog sao herdados de cima para baixo: um SELECT concedido no schema vale para todas as tabelas atuais e futuras dele, sem necessidade de novo grant a cada objeto criado.",
+        topic: "Unity Catalog - heranca de privilegios",
+        options: [
+            ["O grupo precisa do privilegio USE SCHEMA renovado a cada nova tabela para que a heranca do SELECT volte a valer", false],
+            ["O grupo so podera ler apos um novo GRANT SELECT ser executado especificamente na tabela devolucoes, pois a heranca vale apenas para as tabelas que existiam no momento do grant", false],
+            ["O grupo ja pode ler a nova tabela, pois o SELECT concedido no schema e herdado por todas as tabelas atuais e futuras dele", true],
+            ["O grupo nunca podera ler tabelas criadas por um pipeline, pois o SELECT herdado nao se aplica a objetos cujo owner difere de quem concedeu o privilegio", false],
+        ],
+    },
+    {
+        statement: "Uma tabela tem como owner o grupo eng_dados. Um membro desse grupo, que nao e administrador do metastore nem do catalogo, precisa aplicar um row filter na tabela e conceder SELECT a outro time. Ele consegue?",
+        explanation: "O owner de um objeto no Unity Catalog (usuario ou grupo) pode administra-lo por completo: alterar, conceder e revogar privilegios e aplicar funcoes de row filter e column mask, sem precisar ser administrador do metastore.",
+        topic: "Unity Catalog - poderes do owner",
+        options: [
+            ["Nao, aplicar row filter e conceder privilegios sao acoes reservadas exclusivamente ao administrador do metastore, e o owner de uma tabela so pode ler, gravar e alterar o schema dela, mas nunca delegar acesso a terceiros", false],
+            ["Ele consegue conceder SELECT, mas nao aplicar o row filter, pois filtros de linha so podem ser definidos por quem tem o privilegio MANAGE no catalogo inteiro", false],
+            ["Ele consegue aplicar o row filter, mas nao conceder SELECT, pois a concessao de privilegios exige ownership individual, nao de grupo", false],
+            ["Sim, como membro do grupo owner ele pode aplicar o row filter e conceder SELECT, pois o owner administra a tabela e seus privilegios", true],
+        ],
+    },
+    {
+        statement: "Uma equipe espera ver, no grafo de linhagem do Unity Catalog, o fluxo de uma tabela gold gerada por um job. O job rodou uma unica vez, ha treze meses, em um cluster sem Unity Catalog, e nunca mais executou. A linhagem nao aparece. Qual a explicacao mais provavel?",
+        explanation: "A captura de linhagem no Unity Catalog depende de a operacao ser executada em compute compativel com UC e e retida por uma janela limitada (cerca de um ano). Uma execucao unica e antiga em cluster sem UC nao gera linhagem visivel.",
+        topic: "Unity Catalog - linhagem",
+        options: [
+            ["A linhagem so e capturada quando a operacao roda em compute habilitado para Unity Catalog, e alem disso os dados de linhagem tem janela de retencao limitada", true],
+            ["A linhagem nunca e capturada para tabelas na camada gold, apenas para bronze e silver, por decisao de arquitetura do Unity Catalog", false],
+            ["A linhagem precisa ser habilitada manualmente por tabela com ALTER TABLE SET LINEAGE ON antes de qualquer execucao do job", false],
+            ["A linhagem exige que a tabela gold seja recriada como materialized view, pois apenas objetos gerenciados por Lakeflow Declarative Pipelines tem o grafo de dependencias registrado nas system tables de linhagem", false],
+        ],
+    },
+    {
+        statement: "Um engenheiro vai proteger a tabela financeiro.transacoes com um row filter que so exibe linhas cuja coluna unidade coincide com a unidade do usuario. O que caracteriza corretamente a implementacao de um row filter no Unity Catalog?",
+        explanation: "Um row filter e uma funcao SQL com retorno BOOLEAN, ligada a tabela via ALTER TABLE ... SET ROW FILTER e recebendo colunas como argumentos; cada tabela aceita apenas um row filter ativo. Linhas para as quais a funcao retorna falso ficam ocultas.",
+        topic: "Row filter - fundamentos",
+        options: [
+            ["Concede-se o privilegio ROW FILTER ao usuario e o Unity Catalog infere as linhas visiveis a partir do grupo dele, sem necessidade de funcao", false],
+            ["Cria-se uma funcao SQL que retorna BOOLEAN e associa-se a tabela com ALTER TABLE ... SET ROW FILTER, passando a coluna como argumento; a tabela aceita um filtro por vez", true],
+            ["Define-se uma coluna gerada do tipo BOOLEAN na propria tabela e marca-se com a propriedade delta.rowFilter, aplicada automaticamente a cada leitura", false],
+            ["Cria-se uma view materializada que reescreve fisicamente a tabela filtrando as linhas por usuario, e agenda-se um job de refresh para que cada usuario enxergue apenas a sua particao, substituindo o acesso direto a tabela base", false],
+        ],
+    },
+    {
+        statement: "Uma organizacao precisa mascarar automaticamente qualquer coluna que contenha CPF em centenas de tabelas, sem editar tabela por tabela. Usando o modelo ABAC (attribute-based access control) do Unity Catalog, qual abordagem atende melhor?",
+        explanation: "O ABAC do Unity Catalog permite criar policies de mascaramento ligadas a governed tags: ao marcar as colunas com a tag, a mascara passa a ser aplicada automaticamente em escala, sem alterar cada tabela individualmente.",
+        topic: "ABAC - mascara por governed tag",
+        options: [
+            ["Aplicar um unico row filter no catalogo raiz, que o Unity Catalog propaga como mascara para todas as colunas marcadas como sensiveis nos schemas filhos", false],
+            ["Escrever um job que percorre o information_schema, identifica colunas com nome parecido com cpf e executa dinamicamente um ALTER TABLE ... SET MASK em cada uma, reexecutando sempre que novas tabelas surgirem para manter a cobertura", false],
+            ["Definir uma policy de column mask associada a uma governed tag e marcar as colunas sensiveis com essa tag, de modo que a mascara passe a valer em escala", true],
+            ["Habilitar a redacao automatica de segredos, que substitui por [REDACTED] qualquer valor de coluna que se pareca com um CPF em tempo de consulta", false],
+        ],
+    },
+    {
+        statement: "Em um secret scope Databricks-backed, um lider tecnico criou os segredos e quer que um grupo de engenheiros possa le-los e usa-los em jobs, mas sem poder adicionar, remover segredos nem alterar as permissoes do scope. Qual permissao concede a eles?",
+        explanation: "As ACLs de secret scope tem tres niveis: READ (ler valores e listar chaves), WRITE (inclui criar e excluir segredos) e MANAGE (inclui alterar as ACLs). READ e suficiente para que jobs resolvam os segredos sem poder modifica-los.",
+        topic: "Secret scopes - ACLs e permissoes",
+        options: [
+            ["MANAGE na ACL do scope, pois e a permissao intermediaria que libera o uso dos segredos sem permitir criar ou excluir chaves", false],
+            ["Nenhuma permissao especifica, pois em scopes Databricks-backed qualquer usuario do workspace le os segredos por padrao", false],
+            ["WRITE na ACL do scope, unico nivel que permite resolver dbutils.secrets.get em jobs; READ isoladamente cobre apenas a listagem dos nomes das chaves e nunca a leitura dos valores em tempo de execucao", false],
+            ["READ na ACL do scope, que permite ler os valores dos segredos e listar os nomes, sem autorizar gravacao nem gestao de permissoes", true],
+        ],
+    },
+    {
+        statement: "Uma empresa quer usar suas proprias chaves (customer-managed keys) tanto para criptografar notebooks, resultados de consulta e segredos armazenados no control plane quanto os dados no storage do workspace. Como isso e configurado?",
+        explanation: "A Databricks separa customer-managed keys em duas categorias: managed services (criptografa notebooks, resultados de consulta e segredos no control plane) e workspace storage (dados no seu bucket). Sao configuraveis de forma independente, com chaves iguais ou diferentes.",
+        topic: "Customer-managed keys - managed services x storage",
+        options: [
+            ["Sao duas configuracoes de chave distintas: uma para managed services (control plane) e outra para o workspace storage, que podem usar chaves diferentes", true],
+            ["Apenas o workspace storage aceita customer-managed keys; notebooks e segredos no control plane usam obrigatoriamente a chave gerenciada pela Databricks, sem alternativa", false],
+            ["A criptografia com chave propria e definida por tabela, via propriedade delta.encryptionKey, e nao existe no nivel de workspace", false],
+            ["Uma unica customer-managed key cobre simultaneamente o control plane e o storage, e precisa ser rotacionada manualmente a cada consulta para que os resultados intermediarios permanecam criptografados de ponta a ponta", false],
+        ],
+    },
+    {
+        statement: "Um provedor compartilha uma tabela Delta via Delta Sharing D2D. O recipiente quer consumir a tabela como fonte de Structured Streaming e usar time travel. Ao criar o share, o que o provedor precisa garantir?",
+        explanation: "Para o recipiente ler a tabela em streaming, via CDF ou com time travel, o provedor deve compartilha-la com o historico (WITH HISTORY) ao adiciona-la ao share. Sem o historico, so e possivel ler o snapshot atual em lote.",
+        topic: "Delta Sharing - compartilhar historico",
+        options: [
+            ["Conceder ao recipiente o privilegio MODIFY na tabela de origem, unico que libera leitura incremental via streaming do outro lado", false],
+            ["Adicionar a tabela ao share com o historico habilitado (WITH HISTORY), pois leituras em streaming, CDF e time travel no lado do recipiente dependem do historico compartilhado", true],
+            ["Habilitar deletion vectors na tabela, requisito tecnico para que o recipiente consiga fazer time travel atraves de um share", false],
+            ["Converter a tabela em materialized view antes de adiciona-la ao share, ja que o Delta Sharing so transmite snapshots estaticos e o recipiente reconstroi o historico localmente ao configurar um checkpoint apontando para o share", false],
+        ],
+    },
+    {
+        statement: "Uma equipe de FinOps ja consulta system.billing.usage e ve a quantidade de DBUs por job, mas o gestor pediu o custo estimado em dolares, nao apenas em DBUs. Como obter o valor monetario?",
+        explanation: "system.billing.list_prices traz o preco por SKU ao longo do tempo; ao fazer join com system.billing.usage pelo SKU e pela janela de vigencia do preco, multiplica-se os DBUs consumidos pelo preco unitario para estimar o custo em dolares.",
+        topic: "System Tables - custo em dinheiro (list_prices)",
+        options: [
+            ["Basta ativar a coluna oculta usd_cost em system.billing.usage com um ALTER, que passa a preencher o custo em dolares retroativamente", false],
+            ["O valor em dolares so esta disponivel na conta de cobranca do provedor de nuvem, pois as system tables registram exclusivamente unidades de consumo e nunca expoem qualquer informacao de preco, mesmo aproximada, dentro do Databricks", false],
+            ["Fazer join de system.billing.usage com system.billing.list_prices pelo SKU e periodo de vigencia do preco, multiplicando os DBUs pelo preco unitario", true],
+            ["Consultar system.access.audit, que registra o custo monetario de cada operacao faturavel junto ao evento de auditoria correspondente", false],
+        ],
+    },
+    {
+        statement: "Um administrador abre o catalogo system e percebe que o schema access (auditoria) aparece, mas sem dados, enquanto billing ja traz registros. Ele tambem tenta, sem sucesso, inserir uma linha em uma system table para corrigir um valor. O que explica esse comportamento?",
+        explanation: "Varios schemas do catalogo system (como access) exigem habilitacao explicita por um administrador antes de passarem a registrar dados, e todas as system tables sao somente leitura, o que impede insercoes ou correcoes manuais.",
+        topic: "System Tables - habilitacao de schemas",
+        options: [
+            ["O schema access esta corrompido e precisa ser recriado com CREATE SCHEMA system.access, o que tambem reabilita a escrita nas tabelas", false],
+            ["A ausencia de dados indica que o workspace nao tem Unity Catalog, e a insercao falhou por falta do privilegio USE CATALOG em system", false],
+            ["O schema access so recebe dados em workspaces com Delta Sharing ativo, e a insercao falhou porque exige que o administrador assuma o ownership do catalogo system e o marque como gravavel por meio de um GRANT MODIFY sobre todo o metastore", false],
+            ["Alguns schemas do catalogo system precisam ser habilitados explicitamente por um administrador antes de comecar a coletar dados, e as system tables sao somente leitura", true],
+        ],
+    },
+    {
+        statement: "Em uma pipeline Lakeflow Spark Declarative Pipelines, uma equipe quer acompanhar ao longo do tempo quantos registros violaram as expectations de cada tabela, consultando o event log com SQL. Onde estao essas metricas?",
+        explanation: "No event log, os eventos flow_progress carregam no campo details (JSON) as metricas de qualidade de dados, incluindo quantos registros passaram e falharam em cada expectation, permitindo acompanhar a evolucao por consulta SQL.",
+        topic: "Event log - metricas de qualidade (expectations)",
+        options: [
+            ["Nos eventos do tipo flow_progress, cujo campo details traz, em JSON, as metricas de data quality com contagens de registros que passaram e falharam por expectation", true],
+            ["Nos eventos do tipo user_action, que registram cada linha descartada individualmente junto com o usuario que disparou a atualizacao da pipeline", false],
+            ["Em uma coluna expectations_failed adicionada automaticamente a cada tabela da pipeline, consultavel com um SELECT direto na tabela de destino", false],
+            ["As metricas de expectations nao ficam no event log; e preciso habilitar uma system table especifica de data quality e cruza-la com a linhagem de colunas para reconstruir, por inferencia, quantos registros teriam violado cada constraint em cada execucao", false],
+        ],
+    },
+    {
+        statement: "Um estagio de agregacao esta lento. Na Spark UI, o engenheiro nota, nas metricas do estagio, valores altos de Spill (Memory) e Spill (Disk) em varias tarefas, embora nao haja falha. O que isso indica e qual a mitigacao mais direta?",
+        explanation: "Spill (Memory) e Spill (Disk) na Spark UI indicam que os dados nao couberam na memoria de execucao e foram derramados para disco, sinal de pressao de memoria no shuffle. Aumentar a memoria por tarefa ou aumentar o paralelismo (mais particoes) costuma reduzir o spill.",
+        topic: "Spark UI - spill de memoria",
+        options: [
+            ["O spill e sempre benefico e sinaliza uso eficiente do disk cache; nenhuma acao e necessaria, pois nao houve falha de tarefa", false],
+            ["Ha pressao de memoria durante o shuffle, forcando gravacao em disco; aumentar a memoria por tarefa ou reduzir o volume por particao (mais particoes) tende a reduzir o spill", true],
+            ["O spill ocorre porque o Photon esta desabilitado; basta ativar o Photon para que o shuffle passe a rodar inteiramente em memoria, sem qualquer escrita em disco", false],
+            ["O spill indica que os arquivos de origem estao corrompidos e sendo relidos do disco repetidamente; a correcao e rodar OPTIMIZE com ZORDER na tabela de entrada para que o Spark deixe de materializar particoes intermediarias em disco durante a agregacao", false],
+        ],
+    },
+    {
+        statement: "No Query Profiler, uma consulta que filtra por WHERE data = '2026-07-01' em uma tabela particionada por data esta lenta. O no de scan mostra 'files pruned: 0' e 'files read' igual ao total de arquivos da tabela. O que isso revela?",
+        explanation: "files pruned igual a zero com leitura de todos os arquivos indica ausencia de partition pruning: a consulta varre a tabela inteira. Isso costuma acontecer quando o predicado nao bate diretamente com a coluna de particao, por diferenca de tipo ou por aplicar uma funcao sobre ela.",
+        topic: "Query Profiler - partition pruning",
+        options: [
+            ["O valor 'files pruned: 0' e apenas informativo e nao afeta o desempenho, pois o disk cache ja servia todos os arquivos a partir da memoria local", false],
+            ["A tabela perdeu suas estatisticas e precisa de um ANALYZE TABLE COMPUTE STATISTICS antes de qualquer filtro funcionar; enquanto isso nao for feito, o Delta ignora todos os predicados de particao e sempre reporta zero arquivos podados", false],
+            ["O pruning de particao nao ocorreu e a consulta esta lendo a tabela inteira; provavelmente o predicado nao casa com a coluna de particionamento (tipo divergente ou funcao aplicada sobre a coluna)", true],
+            ["O scan esta correto e o gargalo esta no shuffle seguinte; o numero de arquivos lidos nunca reflete o pruning de particao no Query Profiler", false],
+        ],
+    },
+    {
+        statement: "Uma equipe promove um Automation Bundle para o target prod. A politica interna exige que os jobs em producao nao rodem sob a identidade pessoal de quem faz o deploy, e sim sob uma conta de servico. Como o bundle atende a isso?",
+        explanation: "Em Automation Bundles, o campo run_as define a identidade de execucao dos recursos; aponta-lo para um service principal no target prod garante que os jobs rodem sob a conta de servico, e nao sob o usuario que executou o deploy.",
+        topic: "Automation Bundles - run_as em producao",
+        options: [
+            ["Definindo mode: development no target prod, que automaticamente troca o executor para o service principal padrao do workspace", false],
+            ["Marcando cada job com a tag production, o que faz o Databricks substituir o executor pela conta de servico da conta de faturamento", false],
+            ["Isso nao e configuravel no bundle: o job sempre roda sob a identidade de quem executou databricks bundle deploy, entao a equipe precisa compartilhar as credenciais de um usuario tecnico e usa-las manualmente a cada promocao para producao", false],
+            ["Configurando run_as com um service principal no target prod, para que os recursos implantados executem sob essa identidade em vez da do usuario que fez o deploy", true],
+        ],
+    },
+    {
+        statement: "Uma engenheira precisa alternar, na mesma maquina, entre um workspace de desenvolvimento e um de producao ao usar a Databricks CLI. Qual e a forma idiomatica de gerenciar essas duas conexoes?",
+        explanation: "A Databricks CLI guarda multiplos perfis nomeados no arquivo .databrickscfg, cada um com seu host e credenciais; a flag --profile (ou o perfil DEFAULT) seleciona qual conexao usar, permitindo alternar entre dev e prod na mesma maquina.",
+        topic: "Databricks CLI - perfis de autenticacao",
+        options: [
+            ["Configurar perfis nomeados no arquivo .databrickscfg (cada um com host e credenciais) e escolher com a flag --profile em cada comando", true],
+            ["Passar host e token como argumentos posicionais em todo comando, ja que a CLI nao persiste configuracoes de autenticacao entre execucoes", false],
+            ["Usar databricks bundle validate para trocar de workspace, pois a CLI deriva o host automaticamente do target do bundle e ignora qualquer perfil", false],
+            ["Manter dois clones separados do repositorio, um por workspace, e editar as variaveis de ambiente do sistema antes de cada comando para reapontar o host, pois a CLI so reconhece uma configuracao global por vez e nao suporta multiplas conexoes", false],
+        ],
+    },
+    {
+        statement: "Uma funcao aplica regras de negocio complexas, mas hoje ela le a tabela bronze com spark.read.table, transforma e grava a silver com saveAsTable, tudo junto. A equipe quer cobri-la com testes unitarios rapidos e deterministicos. Qual refatoracao melhor viabiliza isso?",
+        explanation: "Separar a transformacao (funcao pura DataFrame para DataFrame) da leitura e escrita torna a logica testavel com pequenos DataFrames criados na memoria, sem depender de tabelas reais, resultando em testes unitarios rapidos e deterministicos.",
+        topic: "Teste unitario - funcao pura de transformacao",
+        options: [
+            ["Substituir o teste unitario por uma expectation da pipeline, pois regras de negocio so podem ser validadas com dados reais em producao", false],
+            ["Isolar a logica em uma funcao pura que recebe um DataFrame e devolve outro, deixando leitura e escrita fora dela, para testar a transformacao com DataFrames montados na memoria", true],
+            ["Envolver a funcao em um job agendado que roda a cada commit e falha se a contagem de linhas da silver mudar em relacao a execucao anterior", false],
+            ["Manter a leitura e a escrita dentro da funcao e, no teste, apontar spark.read.table para a tabela de producao em horario de baixo movimento, comparando o resultado gravado com uma copia de referencia gerada pelo pipeline oficial do dia anterior", false],
+        ],
+    },
+    {
+        statement: "Uma tabela e compartilhada por Delta Sharing aberto (open sharing) com um parceiro externo, que acessa via token do recipiente. A seguranca pede que o acesso expire periodicamente e possa ser cortado imediatamente se o token vazar. O que e correto sobre o token de recipiente no open sharing?",
+        explanation: "No open sharing, o token do recipiente tem tempo de expiracao configuravel e pode ser rotacionado a qualquer momento; a rotacao invalida o token antigo, permitindo cortar o acesso caso ele vaze, sem afetar outros recipientes.",
+        topic: "Delta Sharing D2O - rotacao de token do recipiente",
+        options: [
+            ["A seguranca do open sharing depende exclusivamente de allowlist de IP; o token e permanente e serve apenas para identificar o recipiente nos logs", false],
+            ["O token de recipiente do open sharing nunca expira por design e nao pode ser revogado individualmente; para cortar o acesso e necessario excluir o share inteiro, o que tambem derruba todos os demais recipientes ligados a ele", false],
+            ["O token tem expiracao configuravel e pode ser rotacionado; rotaciona-lo invalida o token anterior, cortando o acesso de quem o possuia", true],
+            ["Rotacionar o token exige recriar a tabela de origem, pois o token e derivado do identificador fisico dos arquivos Delta compartilhados", false],
+        ],
+    },
+    {
+        statement: "Uma equipe precisa governar arquivos nao tabulares (PDFs, imagens de modelo, arquivos de configuracao) no Unity Catalog, com controle de acesso, e conceder a um grupo apenas leitura desses arquivos. O que e adequado?",
+        explanation: "Volumes do Unity Catalog governam dados nao tabulares (arquivos e diretorios) dentro de um schema, com os privilegios READ VOLUME e WRITE VOLUME; conceder READ VOLUME ao grupo da acesso somente de leitura aos arquivos.",
+        topic: "Unity Catalog - volumes",
+        options: [
+            ["Guardar os arquivos no DBFS root e controlar o acesso por ACL de secret scope, unico mecanismo de permissao para conteudo binario", false],
+            ["Conceder MODIFY no schema inteiro ao grupo, pois nao existe privilegio especifico de leitura para arquivos, apenas para tabelas", false],
+            ["Usar um volume (managed ou external) dentro de um schema e conceder READ VOLUME ao grupo, pois volumes governam dados nao tabulares com privilegios proprios", true],
+            ["Registrar cada arquivo como uma external table apontando para o caminho do objeto no storage e conceder SELECT, ja que o Unity Catalog so aplica controle de acesso sobre objetos tabulares e trata qualquer arquivo como uma tabela de uma coluna", false],
+        ],
+    },
 ];
 
 async function seed() {
@@ -1226,10 +1887,23 @@ async function seed() {
         .select({ n: count() })
         .from(simuladoQuestions)
         .where(eq(simuladoQuestions.simuladoId, simulado.id));
-    if (Number(n) > 0) { console.log(`Simulado ja tem ${n} questoes, nada a fazer.`); return; }
+    const jaExistem = new Set(
+        (
+            await db
+                .select({ statement: simuladoQuestions.statement })
+                .from(simuladoQuestions)
+                .where(eq(simuladoQuestions.simuladoId, simulado.id))
+        ).map((r) => r.statement),
+    );
+    const inseridas = QUESTOES.filter((q) => !jaExistem.has(q.statement)).length;
+    if (inseridas === 0) {
+        console.log(`Simulado ja tem ${n} questoes, nada a fazer.`);
+        return;
+    }
 
     for (let i = 0; i < QUESTOES.length; i++) {
         const q = QUESTOES[i];
+        if (jaExistem.has(q.statement)) continue;
         const [questao] = await db
             .insert(simuladoQuestions)
             .values({ simuladoId: simulado.id, statement: q.statement, explanation: q.explanation, topic: q.topic })
@@ -1238,7 +1912,7 @@ async function seed() {
             q.options.map(([text, isCorrect], idx) => ({ questionId: questao.id, text, isCorrect, position: idx + 1 })),
         );
     }
-    console.log(`Seed concluido: ${QUESTOES.length} questoes inseridas.`);
+    console.log(`Seed: ${inseridas} questoes novas inseridas (${QUESTOES.length} no banco).`);
 }
 
 seed().then(() => process.exit(0)).catch((e) => { console.error("Falha no seed:", e); process.exit(1); });

--- a/backend/scripts/seed-dp-900.ts
+++ b/backend/scripts/seed-dp-900.ts
@@ -1408,6 +1408,216 @@ const QUESTOES: Questao[] = [
             ["O Power BI Desktop só funciona na nuvem e não pode ser instalado localmente", false],
         ],
     },
+    // ===== Questões adicionais (banco ampliado para variar as tentativas) =====
+    {
+        statement: "Uma empresa armazena mensagens de e-mail em que cada uma tem campos padronizados de cabeçalho, como remetente, data e assunto, além de um corpo de texto livre e anexos variados. Como esses dados são melhor classificados?",
+        explanation: "E-mails são um exemplo clássico de dados semiestruturados: os cabeçalhos seguem uma estrutura previsível, enquanto o corpo e os anexos são de formato livre. Eles não se encaixam em linhas e colunas rígidas nem são totalmente sem estrutura.",
+        topic: "Conceitos de dados",
+        options: [
+            ["Dados estruturados, pois possuem cabeçalhos padronizados", false],
+            ["Dados não estruturados, pois contêm anexos de formato livre", false],
+            ["Dados semiestruturados, pois combinam campos organizados com conteúdo de formato livre", true],
+            ["Dados relacionais, pois podem ser organizados em tabelas com linhas e colunas e consultados diretamente com SQL", false],
+        ],
+    },
+    {
+        statement: "Uma equipe classifica o banco de dados que atende ao sistema de pedidos de uma loja virtual como uma carga OLTP. Qual característica é típica desse tipo de carga de trabalho?",
+        explanation: "Sistemas OLTP lidam com muitas transações curtas e frequentes sobre dados operacionais atuais, priorizando escrita e leitura rápidas. Consultas analíticas complexas sobre grandes volumes históricos são características de cargas OLAP.",
+        topic: "Conceitos de dados",
+        options: [
+            ["Executa muitas transações curtas de inserção, atualização e leitura sobre dados atuais", true],
+            ["Armazena dados históricos organizados em um esquema estrela para relatórios", false],
+            ["É otimizado para poucas consultas complexas que agregam grandes volumes de dados históricos e alimentam relatórios gerenciais", false],
+            ["Prioriza a leitura de grandes lotes de dados em vez de escritas frequentes", false],
+        ],
+    },
+    {
+        statement: "Uma equipe de dados compara os formatos CSV e Parquet para armazenar tabelas em um data lake analítico. Qual afirmação sobre o Parquet está correta?",
+        explanation: "O Parquet é um formato binário colunar: por armazenar os valores agrupados por coluna, comprime melhor e permite que consultas leiam apenas as colunas necessárias. O CSV, em contraste, é um formato de texto orientado a linhas.",
+        topic: "Conceitos de dados",
+        options: [
+            ["É um formato de texto legível por humanos, ideal para abrir, editar e inspecionar manualmente em qualquer editor de texto simples", false],
+            ["Guarda uma linha por registro com campos separados por vírgula", false],
+            ["Não aplica nenhuma compressão para manter a máxima simplicidade de leitura", false],
+            ["Armazena os dados organizados por coluna, o que melhora a compressão e permite ler apenas as colunas necessárias", true],
+        ],
+    },
+    {
+        statement: "Uma administradora quer disponibilizar aos analistas uma consulta sobre a tabela de funcionários que exiba apenas nome e cargo, ocultando o salário, sem duplicar fisicamente os dados. Qual objeto relacional oferece essa representação virtual e restrita?",
+        explanation: "Uma exibição (view) é uma consulta salva que se comporta como uma tabela virtual, podendo expor apenas um subconjunto de colunas sem armazenar os dados novamente. É útil para simplificar consultas e restringir o acesso a colunas sensíveis.",
+        topic: "Dados relacionais",
+        options: [
+            ["Uma exibição (view)", true],
+            ["Um índice", false],
+            ["Uma chave estrangeira", false],
+            ["Uma stored procedure que copia os dados filtrados para uma nova tabela a cada consulta", false],
+        ],
+    },
+    {
+        statement: "Em um banco com altíssimo volume de inserções e atualizações, um desenvolvedor propõe criar índices em quase todas as colunas para acelerar qualquer consulta. Qual é a principal desvantagem dessa abordagem?",
+        explanation: "Índices aceleram leituras, mas cada índice consome armazenamento e precisa ser atualizado sempre que os dados mudam. Em cargas com muitas escritas, um excesso de índices pode degradar o desempenho de inserções e atualizações.",
+        topic: "Dados relacionais",
+        options: [
+            ["Índices só podem ser criados em colunas do tipo numérico", false],
+            ["Cada índice ocupa espaço e precisa ser mantido a cada escrita, o que pode tornar inserções e atualizações mais lentas", true],
+            ["Índices impedem que a tabela utilize chaves estrangeiras para garantir a integridade referencial entre as tabelas relacionadas do modelo de dados", false],
+            ["Índices removem automaticamente as linhas duplicadas da tabela", false],
+        ],
+    },
+    {
+        statement: "Uma empresa quer que os dados armazenados no Azure Blob Storage sejam copiados automaticamente para uma segunda região geográfica, protegendo-os contra a indisponibilidade de uma região inteira do Azure. Qual opção de redundância atende a esse requisito?",
+        explanation: "A redundância geográfica (GRS) replica os dados para uma região secundária distante, oferecendo proteção contra falhas em nível regional. A redundância local (LRS) mantém as cópias apenas dentro de um único datacenter.",
+        topic: "Armazenamento não relacional",
+        options: [
+            ["Armazenamento com redundância local (LRS)", false],
+            ["Camada de acesso Cool", false],
+            ["Armazenamento com redundância geográfica (GRS)", true],
+            ["Uma conta de armazenamento com desempenho Premium e replicação apenas dentro do mesmo datacenter", false],
+        ],
+    },
+    {
+        statement: "Uma aplicação parceira externa precisa de acesso temporário e limitado a um único contêiner do Blob Storage, e a equipe não quer compartilhar a chave da conta de armazenamento. Qual recurso concede esse acesso delegado, com escopo e prazo definidos?",
+        explanation: "Uma assinatura de acesso compartilhado (SAS) concede acesso delegado, limitado por escopo, permissões e validade, sem expor a chave da conta. Compartilhar a chave da conta daria acesso total e irrestrito a todo o armazenamento.",
+        topic: "Armazenamento não relacional",
+        options: [
+            ["A chave de acesso da conta de armazenamento", false],
+            ["A camada de acesso Hot", false],
+            ["Uma regra de redundância que replica o contêiner para outra região a fim de liberar o acesso externo", false],
+            ["Uma assinatura de acesso compartilhado (SAS)", true],
+        ],
+    },
+    {
+        statement: "Usando o Azure Synapse Analytics, uma equipe quer consultar arquivos que já estão em um data lake sob demanda, pagando apenas pelos dados processados em cada consulta, sem precisar provisionar e manter um cluster dedicado. Qual recurso do Synapse atende a isso?",
+        explanation: "O pool de SQL sem servidor do Synapse permite consultar dados diretamente no data lake sob demanda, cobrando pelo volume processado, sem infraestrutura provisionada. O pool dedicado, por outro lado, reserva recursos de computação de forma contínua.",
+        topic: "Análise e data warehouse",
+        options: [
+            ["Pool de SQL dedicado", false],
+            ["Pool de SQL sem servidor (serverless)", true],
+            ["Pool do Apache Spark", false],
+            ["Um pipeline de integração que copia previamente todos os arquivos para um banco relacional antes da consulta", false],
+        ],
+    },
+    {
+        statement: "Ao projetar um data warehouse com esquema estrela para uma rede varejista, um analista precisa decidir o conteúdo das tabelas de dimensão. O que uma tabela de dimensão normalmente armazena?",
+        explanation: "As tabelas de dimensão guardam atributos descritivos (como produto, cliente, tempo e local) que dão contexto para filtrar e agrupar. As medidas numéricas do negócio ficam na tabela de fatos central.",
+        topic: "Análise e data warehouse",
+        options: [
+            ["As medidas numéricas e os valores agregados das transações do negócio", false],
+            ["Apenas os índices e as estatísticas de desempenho usados pela tabela de fatos central", false],
+            ["Atributos descritivos usados para filtrar e agrupar, como produto, cliente, tempo e local", true],
+            ["As chaves estrangeiras e os totais consolidados de cada transação processada ao longo do período", false],
+        ],
+    },
+    {
+        statement: "Em uma arquitetura de lakehouse, os dados costumam ser organizados em camadas sucessivas: brutos na primeira, limpos e enriquecidos na intermediária e agregados e prontos para consumo na final. Como essa organização em camadas é comumente chamada?",
+        explanation: "A arquitetura medalhão organiza o lakehouse em camadas bronze (dados brutos), prata (limpos e integrados) e ouro (agregados para consumo). Cada camada refina progressivamente os dados para análise.",
+        topic: "Análise e data warehouse",
+        options: [
+            ["Esquema estrela", false],
+            ["Terceira forma normal", false],
+            ["Modelo entidade-relacionamento aplicado sobre os arquivos brutos do data lake para reforçar a normalização", false],
+            ["Arquitetura medalhão, com camadas bronze, prata e ouro", true],
+        ],
+    },
+    {
+        statement: "Uma empresa mantém uma aplicação web em PHP que usa um banco de dados MySQL e quer movê-la para um serviço totalmente gerenciado no Azure, sem administrar servidores nem o sistema operacional. Qual serviço deve escolher?",
+        explanation: "O Azure Database for MySQL é o serviço PaaS totalmente gerenciado para bancos MySQL, ideal para migrar aplicações que já usam esse mecanismo. O Azure SQL Database é baseado no mecanismo do SQL Server, não no MySQL.",
+        topic: "Serviços relacionais no Azure",
+        options: [
+            ["Azure Database for MySQL", true],
+            ["Azure SQL Database", false],
+            ["Azure Database for PostgreSQL", false],
+            ["SQL Server instalado e configurado manualmente em uma máquina virtual do Azure", false],
+        ],
+    },
+    {
+        statement: "Para garantir continuidade de negócios, uma empresa quer manter uma cópia legível do seu Azure SQL Database em outra região do Azure, pronta para assumir a operação caso a região principal fique indisponível. Qual recurso atende a esse objetivo?",
+        explanation: "A replicação geográfica cria réplicas legíveis do banco em outra região, permitindo failover em caso de indisponibilidade regional. O pool elástico serve para compartilhar recursos entre vários bancos, não para recuperação de desastres.",
+        topic: "Serviços relacionais no Azure",
+        options: [
+            ["Pool elástico", false],
+            ["Replicação geográfica (geo-replicação)", true],
+            ["Camada de computação sem servidor", false],
+            ["Uma tarefa agendada que exporta o banco para um arquivo e o copia manualmente para outra região toda noite", false],
+        ],
+    },
+    {
+        statement: "Uma equipe de arquitetura compara as opções de banco relacional no Azure segundo o nível de controle e de responsabilidade administrativa que cada uma exige. Qual sequência as ordena corretamente, do MAIOR controle para o MENOR?",
+        explanation: "Rodar SQL Server em uma VM (IaaS) dá o maior controle, mas exige gerenciar o sistema operacional e o mecanismo. O SQL Managed Instance fica no meio-termo, e o Azure SQL Database (PaaS) oferece o menor esforço administrativo.",
+        topic: "Serviços relacionais no Azure",
+        options: [
+            ["Azure SQL Database, depois SQL Managed Instance, depois SQL Server em uma máquina virtual", false],
+            ["SQL Managed Instance, depois Azure SQL Database, depois SQL Server em uma máquina virtual", false],
+            ["SQL Server em uma máquina virtual, depois SQL Managed Instance, depois Azure SQL Database", true],
+            ["Azure SQL Database, depois SQL Server em uma máquina virtual, depois SQL Managed Instance", false],
+        ],
+    },
+    {
+        statement: "Uma solução industrial precisa de comunicação bidirecional com milhões de dispositivos IoT: além de receber a telemetria enviada por eles, precisa enviar comandos e atualizações de configuração de volta a cada dispositivo. Qual serviço do Azure é o mais adequado?",
+        explanation: "O Azure IoT Hub oferece comunicação bidirecional segura com dispositivos, incluindo o envio de comandos e configurações de volta a eles. O Event Hubs é voltado à ingestão de eventos em alta escala, mas não à comunicação de volta com cada dispositivo.",
+        topic: "Tempo real e streaming",
+        options: [
+            ["Azure Event Hubs", false],
+            ["Azure Stream Analytics", false],
+            ["Azure Blob Storage configurado com gatilhos para responder a cada dispositivo individualmente", false],
+            ["Azure IoT Hub", true],
+        ],
+    },
+    {
+        statement: "Um trabalho do Azure Stream Analytics calcula métricas continuamente a partir de um fluxo de eventos e precisa exibir esses resultados em um painel que se atualiza em tempo quase real. Qual serviço é comumente configurado como saída para essa visualização?",
+        explanation: "O Power BI pode ser definido como saída de um trabalho do Stream Analytics, recebendo os resultados processados para alimentar painéis em tempo quase real. Event Hubs e IoT Hub costumam atuar como entradas de streaming, não como destino de visualização.",
+        topic: "Tempo real e streaming",
+        options: [
+            ["Power BI", true],
+            ["Azure Event Hubs", false],
+            ["Azure IoT Hub", false],
+            ["Azure Data Factory executando um pipeline de cópia agendado para atualizar os dados periodicamente", false],
+        ],
+    },
+    {
+        statement: "Ao revisar comandos SQL, uma DBA quer agrupar os que consultam e alteram os dados armazenados na categoria DML. Qual conjunto pertence à Linguagem de Manipulação de Dados (DML)?",
+        explanation: "A DML reúne os comandos que consultam e modificam dados: SELECT, INSERT, UPDATE e DELETE. CREATE, ALTER e DROP são DDL (estrutura) e GRANT e REVOKE são DCL (permissões).",
+        topic: "SQL e objetos de banco",
+        options: [
+            ["CREATE, ALTER e DROP", false],
+            ["SELECT, INSERT, UPDATE e DELETE", true],
+            ["GRANT, REVOKE e DENY", false],
+            ["COMMIT, ROLLBACK e SAVEPOINT usados para controlar transações", false],
+        ],
+    },
+    {
+        statement: "Um administrador precisa remover completamente uma tabela do banco de dados, eliminando tanto os dados quanto a própria estrutura e definição do objeto. Qual comando SQL ele deve usar?",
+        explanation: "O comando DROP TABLE remove a tabela por inteiro, incluindo estrutura e dados. DELETE e TRUNCATE apagam apenas as linhas, mas mantêm a definição da tabela.",
+        topic: "SQL e objetos de banco",
+        options: [
+            ["DELETE", false],
+            ["TRUNCATE TABLE", false],
+            ["DROP TABLE", true],
+            ["ALTER TABLE, ajustando a definição de cada coluna até esvaziar completamente o objeto", false],
+        ],
+    },
+    {
+        statement: "Um gerente quer visualizar qual é a participação percentual de cada categoria de produto no faturamento total, mostrando como cada parte contribui para um todo. Qual visualização do Power BI é a mais indicada?",
+        explanation: "Gráficos de pizza ou de rosca mostram a proporção de cada parte em relação ao todo, sendo adequados para participações percentuais entre poucas categorias. Gráficos de linhas são melhores para tendências ao longo do tempo.",
+        topic: "Power BI e visualização",
+        options: [
+            ["Gráfico de linhas", false],
+            ["Gráfico de dispersão", false],
+            ["Um mapa coroplético que colore cada região conforme o valor total de vendas registrado", false],
+            ["Gráfico de pizza (ou de rosca)", true],
+        ],
+    },
+    {
+        statement: "No fluxo de trabalho do Power BI Desktop, um analista precisa se conectar às fontes e limpar os dados antes de modelá-los, por exemplo removendo colunas, corrigindo tipos e filtrando linhas inválidas. Qual ferramenta é usada para essa preparação dos dados?",
+        explanation: "O Power Query é a ferramenta de conexão, limpeza e transformação de dados do Power BI, usada antes da modelagem. O DAX, por sua vez, serve para criar cálculos e medidas sobre o modelo já carregado.",
+        topic: "Power BI e visualização",
+        options: [
+            ["Power Query", true],
+            ["DAX", false],
+            ["O Power BI Service", false],
+            ["Um gráfico de dispersão configurado para destacar e descartar visualmente os valores inconsistentes", false],
+        ],
+    },
 ];
 
 async function seed() {
@@ -1441,13 +1651,23 @@ async function seed() {
         .select({ n: count() })
         .from(simuladoQuestions)
         .where(eq(simuladoQuestions.simuladoId, simulado.id));
-    if (Number(n) > 0) {
+    const jaExistem = new Set(
+        (
+            await db
+                .select({ statement: simuladoQuestions.statement })
+                .from(simuladoQuestions)
+                .where(eq(simuladoQuestions.simuladoId, simulado.id))
+        ).map((r) => r.statement),
+    );
+    const inseridas = QUESTOES.filter((q) => !jaExistem.has(q.statement)).length;
+    if (inseridas === 0) {
         console.log(`Simulado já tem ${n} questões, nada a fazer.`);
         return;
     }
 
     for (let i = 0; i < QUESTOES.length; i++) {
         const q = QUESTOES[i];
+        if (jaExistem.has(q.statement)) continue;
         const [questao] = await db
             .insert(simuladoQuestions)
             .values({
@@ -1466,7 +1686,7 @@ async function seed() {
             })),
         );
     }
-    console.log(`Seed concluído: ${QUESTOES.length} questões inseridas.`);
+    console.log(`Seed: ${inseridas} questões novas inseridas (${QUESTOES.length} no banco).`);
 }
 
 seed()

--- a/backend/scripts/seed-dva-c02.ts
+++ b/backend/scripts/seed-dva-c02.ts
@@ -1647,6 +1647,678 @@ const QUESTOES: Questao[] = [
             ["O CloudFront so serve conteudo estatico e nunca conteudo dinamico", false],
         ],
     },
+    // ===== Questões adicionais (banco ampliado para variar as tentativas) =====
+    {
+        statement: "Uma funcao Lambda guarda uma chave de API de terceiros em uma variavel de ambiente. A equipe de seguranca exige que o valor fique cifrado em repouso e que apenas a funcao consiga decifra-lo em tempo de execucao. Qual abordagem atende a esse requisito?",
+        explanation: "As variaveis de ambiente ja ficam cifradas em repouso, mas para segredos usa-se uma CMK do KMS com os encryption helpers, que decifram o valor no codigo em tempo de execucao. Base64 nao e criptografia e enviar a chave em todo payload aumenta a exposicao.",
+        topic: "Lambda",
+        options: [
+            ["Habilitar a criptografia com uma chave do KMS gerenciada pelo cliente e usar os helpers de criptografia para decifrar o valor no codigo durante a inicializacao.", true],
+            ["Confiar apenas na criptografia padrao em repouso, que ja usa uma chave gerenciada pela AWS, pois isso impede que qualquer pessoa com acesso ao console leia o valor em texto claro.", false],
+            ["Ofuscar o valor em Base64 antes de salva-lo na variavel de ambiente, ja que o Lambda decodifica automaticamente as variaveis marcadas como sensiveis na inicializacao.", false],
+            ["Passar a chave de API no payload de cada invocacao, evitando armazena-la na configuracao da funcao e eliminando a necessidade de criptografia.", false],
+        ],
+    },
+    {
+        statement: "Uma funcao Lambda e invocada de forma assincrona pelo S3. A equipe quer que, quando o processamento falhar apos todas as retentativas, o evento seja enviado com o contexto do erro para uma fila SQS de analise. Qual recurso e o mais indicado?",
+        explanation: "Os Lambda destinations para invocacao assincrona enviam ao destino on-failure o evento junto com o contexto da resposta, incluindo detalhes do erro, mais informacao do que a DLQ, que so entrega o payload. Event source mapping nao se aplica a invocacao assincrona pelo S3.",
+        topic: "Lambda",
+        options: [
+            ["Configurar uma dead-letter queue (DLQ) na funcao, que encaminha o evento para o SQS, mas entrega apenas o payload original sem os detalhes da resposta nem o contexto da execucao que falhou.", false],
+            ["Aumentar o numero de retentativas assincronas para o maximo e ativar o X-Ray, de modo que o evento com erro fique registrado no trace e possa ser reprocessado manualmente a partir dele.", false],
+            ["Usar um event source mapping entre a funcao e a fila SQS, garantindo que qualquer invocacao com falha seja reenviada automaticamente para a mesma fila.", false],
+            ["Configurar um destino de invocacao para o caso de falha (on failure) apontando para a fila SQS, capturando o evento junto com o contexto da resposta.", true],
+        ],
+    },
+    {
+        statement: "Uma funcao Lambda baixa arquivos temporarios grandes durante o processamento e precisa de espaco em disco local. O que e correto sobre o armazenamento efemero disponivel para a funcao?",
+        explanation: "O Lambda oferece o diretorio /tmp como armazenamento efemero, com tamanho configuravel, reaproveitado enquanto o mesmo ambiente de execucao quente atende novas invocacoes. Para dados persistentes e compartilhados usa-se EFS ou S3.",
+        topic: "Lambda",
+        options: [
+            ["A funcao dispoe do diretorio /tmp, configuravel e reaproveitado enquanto o ambiente de execucao permanecer quente entre invocacoes.", true],
+            ["O unico armazenamento gravavel e a memoria RAM alocada a funcao, portanto arquivos temporarios precisam ser mantidos inteiramente em variaveis na memoria durante a execucao.", false],
+            ["A funcao deve montar um sistema de arquivos externo obrigatoriamente, pois o ambiente de execucao do Lambda e totalmente somente leitura e nao oferece nenhum diretorio gravavel.", false],
+            ["O diretorio /tmp existe, porem e apagado e recriado a cada invocacao, mesmo quando o mesmo ambiente de execucao e reutilizado para requisicoes seguintes.", false],
+        ],
+    },
+    {
+        statement: "Uma tabela DynamoDB guarda sessoes de usuario que devem ser removidas automaticamente algum tempo apos expirarem, sem custo extra de escrita e sem que a aplicacao precise varrer e apagar itens. Qual recurso resolve isso?",
+        explanation: "O TTL do DynamoDB remove itens automaticamente apos o timestamp definido em um atributo, sem consumir capacidade de escrita. Varrer a tabela com Lambda gera custo e o modo on-demand nao apaga itens por conta propria.",
+        topic: "DynamoDB",
+        options: [
+            ["Criar uma regra do EventBridge que, a cada minuto, dispara uma funcao Lambda para escanear a tabela e executar DeleteItem em cada sessao cujo timestamp de expiracao ja tenha passado.", false],
+            ["Habilitar o DynamoDB Streams e processar cada item com uma Lambda que verifica a data de expiracao e remove os itens vencidos assim que eles sao gravados na tabela.", false],
+            ["Habilitar o TTL na tabela, indicando o atributo que contem o timestamp de expiracao para que o servico apague os itens vencidos automaticamente.", true],
+            ["Definir a capacidade da tabela como on-demand, pois nesse modo o DynamoDB descarta itens antigos sozinho quando o armazenamento cresce alem do previsto.", false],
+        ],
+    },
+    {
+        statement: "Dois processos podem atualizar o mesmo item de estoque ao mesmo tempo, e a equipe quer evitar que uma escrita sobrescreva a outra sem perceber (lost update). Qual tecnica do DynamoDB previne isso?",
+        explanation: "O bloqueio otimista usa um atributo de versao com uma condition expression: a escrita so ocorre se a versao nao mudou, caso contrario falha com erro condicional. Leitura consistente e GSI nao previnem lost updates.",
+        topic: "DynamoDB",
+        options: [
+            ["Ativar leituras fortemente consistentes em todas as operacoes, o que faz o DynamoDB serializar as escritas concorrentes e impede automaticamente que uma sobrescreva a outra.", false],
+            ["Configurar um GSI sobre o atributo de versao, pois assim o DynamoDB rejeita qualquer PutItem cujo numero de versao seja menor do que o ja indexado no indice secundario.", false],
+            ["Aumentar o visibility timeout no DynamoDB Streams para que a segunda escrita aguarde a primeira ser propagada antes de ser aplicada sobre o mesmo item.", false],
+            ["Manter um atributo de versao no item e usar uma condition expression que so aplica a escrita se a versao atual for a esperada.", true],
+        ],
+    },
+    {
+        statement: "Uma nova aplicacao tera trafego imprevisivel, com picos subitos e periodos de quase nenhuma atividade, e a equipe nao quer gerenciar capacidade nem arriscar throttling durante os picos. Qual modo de capacidade do DynamoDB e o mais adequado?",
+        explanation: "O modo on-demand escala instantaneamente com o trafego e cobra por requisicao, ideal para cargas imprevisiveis sem planejamento de capacidade. Auto scaling provisionado reage mais devagar e capacidade fixa ou reservada desperdica recurso nos periodos de baixa.",
+        topic: "DynamoDB",
+        options: [
+            ["Provisionado com auto scaling configurado com um alvo de utilizacao baixo e limites maximos altos, para que a tabela reaja aos picos ajustando as RCUs e WCUs conforme a demanda aumenta.", false],
+            ["On-demand, que escala automaticamente conforme o trafego e cobra por requisicao, sem exigir estimativa previa de capacidade.", true],
+            ["Provisionado com capacidade fixa dimensionada para o maior pico ja observado, garantindo margem de sobra e evitando qualquer throttling mesmo nos momentos de baixa atividade.", false],
+            ["Provisionado com capacidade reservada comprada por um ano, aproveitando o desconto e cobrindo os picos com a capacidade de burst acumulada nos periodos ociosos.", false],
+        ],
+    },
+    {
+        statement: "Um desenvolvedor executa uma operacao Query com uma FilterExpression e se surpreende porque o consumo de capacidade de leitura e alto mesmo retornando poucos itens. Qual explicacao esta correta?",
+        explanation: "A FilterExpression e aplicada depois que o DynamoDB le os itens que casam com a KeyConditionExpression, entao a capacidade e cobrada sobre os itens avaliados, nao sobre os poucos retornados. Reduzir o custo exige melhor modelagem de chaves ou um indice.",
+        topic: "DynamoDB",
+        options: [
+            ["A FilterExpression foi aplicada sobre a partition key, e filtrar pela partition key forca um Scan completo da tabela antes de qualquer filtragem dos resultados.", false],
+            ["O consumo e alto porque a FilterExpression exige leituras fortemente consistentes obrigatoriamente, o que dobra as RCUs de toda a operacao de Query.", false],
+            ["O filtro e aplicado depois que os itens sao lidos, entao a capacidade e consumida com base nos itens avaliados, nao nos itens retornados.", true],
+            ["So e possivel filtrar itens no DynamoDB usando um Scan, que percorre a tabela inteira, e por isso qualquer filtragem sempre custa a leitura de todos os itens existentes.", false],
+        ],
+    },
+    {
+        statement: "Uma tabela DynamoDB precisa disparar uma Lambda a cada alteracao, e a funcao precisa comparar o estado anterior e o novo do item para auditar o que mudou. Como configurar o DynamoDB Streams?",
+        explanation: "O StreamViewType NEW_AND_OLD_IMAGES coloca no registro do stream a imagem do item antes e depois da alteracao, ideal para auditar diferencas. KEYS_ONLY e NEW_IMAGE nao trazem o estado anterior completo.",
+        topic: "DynamoDB Streams",
+        options: [
+            ["Habilitar o stream com a visao KEYS_ONLY e, dentro da Lambda, fazer um GetItem para buscar o estado anterior do item antes de ele ter sido alterado na tabela.", false],
+            ["Habilitar o stream com a visao NEW_AND_OLD_IMAGES, que entrega tanto o item antes quanto depois da alteracao em cada registro.", true],
+            ["Habilitar o stream com a visao NEW_IMAGE e reconstruir o estado anterior a partir dos registros passados mantidos no stream por ate 24 horas de retencao.", false],
+            ["Nao e possivel obter o estado anterior pelo stream, entao a auditoria precisa ser feita ativando o TTL e lendo os itens expirados que o DynamoDB arquiva automaticamente.", false],
+        ],
+    },
+    {
+        statement: "Uma equipe vai expor uma API simples de proxy para funcoes Lambda e quer o menor custo e a menor latencia, abrindo mao de recursos como cache integrado, validacao de request e API keys com usage plans. Qual tipo de API do API Gateway escolher?",
+        explanation: "As HTTP APIs foram feitas para casos simples de proxy, com menor custo e latencia, abrindo mao de recursos das REST APIs, como cache e usage plans. WebSocket serve para comunicacao bidirecional, nao para request/response de baixa latencia.",
+        topic: "API Gateway",
+        options: [
+            ["REST API, porque e a unica que suporta integracao de proxy com Lambda e oferece a menor latencia entre todos os tipos disponiveis no API Gateway.", false],
+            ["WebSocket API, indicada para qualquer integracao com Lambda de baixo custo, mantendo uma conexao persistente que reduz a latencia de cada chamada individual.", false],
+            ["REST API com cache habilitado no stage, o que reduz o custo por chamada ao evitar que a maioria das requisicoes chegue de fato ate a funcao Lambda de backend.", false],
+            ["HTTP API, que tem custo menor e menor latencia, com um conjunto de recursos mais enxuto.", true],
+        ],
+    },
+    {
+        statement: "Um endpoint GET do API Gateway serve dados que mudam pouco e recebe muitas requisicoes repetidas, sobrecarregando o backend. A equipe quer reduzir as chamadas ao backend sem alterar o codigo. O que fazer?",
+        explanation: "O cache de stage do API Gateway guarda as respostas por um TTL configuravel e serve as requisicoes repetidas sem acionar o backend. Throttling apenas limita a taxa e usage plans com API keys controlam acesso, nao fazem cache.",
+        topic: "API Gateway",
+        options: [
+            ["Ativar o throttling no stage com um limite baixo de requisicoes por segundo, o que faz o API Gateway devolver respostas ja processadas anteriormente enquanto o limite nao e excedido.", false],
+            ["Configurar um usage plan com API keys para cada cliente, distribuindo as requisicoes entre varias chaves e assim diminuindo a quantidade total de chamadas que alcancam o backend.", false],
+            ["Habilitar o cache no stage e definir um TTL, para que respostas repetidas sejam servidas pelo cache sem chegar ao backend.", true],
+            ["Trocar a integracao para WebSocket, mantendo uma conexao aberta por cliente para que respostas anteriores sejam reaproveitadas sem novas chamadas ao backend.", false],
+        ],
+    },
+    {
+        statement: "Uma API publica e consumida por varios parceiros e a equipe precisa limitar quantas requisicoes cada parceiro pode fazer por mes e a que taxa, cobrando de forma diferente por nivel de servico. Qual recurso do API Gateway atende a isso?",
+        explanation: "Usage plans associados a API keys definem quota, por exemplo mensal, e throttling por cliente, ideais para diferentes niveis de parceiros. O throttling de conta e global e stage variables nao impoem limites de uso.",
+        topic: "API Gateway",
+        options: [
+            ["Associar API keys a usage plans, que definem quota e limites de throttling por cliente.", true],
+            ["Configurar o throttling no nivel da conta e da regiao, que ja aplica limites separados para cada API key emitida e permite cobrar por faixa de consumo.", false],
+            ["Criar um Lambda authorizer que conta as requisicoes de cada parceiro em uma tabela e rejeita as chamadas quando o parceiro ultrapassa a cota mensal contratada.", false],
+            ["Usar stage variables para armazenar o limite de cada parceiro e deixar o API Gateway bloquear automaticamente as chamadas que excederem o valor configurado na variavel.", false],
+        ],
+    },
+    {
+        statement: "Um app de chat precisa que o servidor envie mensagens aos clientes conectados no momento em que elas chegam, sem que o cliente fique fazendo polling. Qual tipo de API do API Gateway suporta esse padrao bidirecional?",
+        explanation: "A WebSocket API mantem uma conexao persistente e roteia mensagens por rotas como $connect, $disconnect e customizadas, permitindo ao servidor enviar dados ao cliente a qualquer momento. REST e HTTP APIs seguem o modelo request/response.",
+        topic: "API Gateway",
+        options: [
+            ["REST API com long polling habilitado no stage, mantendo cada requisicao do cliente aberta ate o servidor ter uma nova mensagem para responder e entao fecha-la.", false],
+            ["HTTP API com CORS configurado, que permite ao backend abrir conexoes de saida para o navegador do cliente e empurrar mensagens assim que elas ficam disponiveis.", false],
+            ["WebSocket API, que mantem uma conexao persistente e usa rotas como $connect, $disconnect e rotas customizadas para troca bidirecional.", true],
+            ["REST API integrada ao SNS, publicando cada mensagem em um topico ao qual os navegadores dos clientes se inscrevem diretamente para recebe-las em tempo real.", false],
+        ],
+    },
+    {
+        statement: "Uma equipe vai orquestrar um fluxo de curtissima duracao invocado dezenas de milhares de vezes por segundo, priorizando alto volume e menor custo por execucao, e nao precisa do historico visual de cada execucao guardado por muito tempo. Qual tipo de workflow do Step Functions escolher?",
+        explanation: "Os workflows Express sao feitos para alto volume e curta duracao, com cobranca por quantidade e tempo de execucao, ao custo de menos historico. O modo Standard privilegia durabilidade e historico longo, com semantica exactly-once.",
+        topic: "Step Functions",
+        options: [
+            ["Standard, porque e o unico que garante a execucao exatamente uma vez e mantem o custo baixo mesmo em cenarios de altissimo volume de invocacoes por segundo.", false],
+            ["Express, otimizado para alto volume e curta duracao, com cobranca por numero e duracao das execucoes.", true],
+            ["Standard, pois workflows Express nao conseguem invocar funcoes Lambda nem integrar com outros servicos da AWS dentro dos estados do fluxo.", false],
+            ["Express com o historico completo de execucao habilitado no console, que retem cada transicao de estado por ate um ano para auditoria detalhada, como no modo Standard.", false],
+        ],
+    },
+    {
+        statement: "Em uma maquina de estados do Step Functions, um estado Task que chama uma Lambda as vezes falha por erros transitorios. A equipe quer repetir automaticamente algumas vezes com backoff e, se ainda assim falhar, desviar para um estado de tratamento. Como configurar isso?",
+        explanation: "Estados como Task suportam os campos Retry, com intervalo, backoff e numero maximo de tentativas, e Catch, que desvia para outro estado quando o erro persiste. Parallel e DLQ nao sao o mecanismo de tratamento de erro entre estados.",
+        topic: "Step Functions",
+        options: [
+            ["Envolver a chamada em um estado Parallel com dois ramos identicos, de modo que, se um ramo falhar, o outro assuma o resultado e a maquina de estados continue normalmente.", false],
+            ["Configurar uma DLQ diretamente no estado Task, para onde o Step Functions envia a execucao apos esgotar as tentativas, permitindo reprocessa-la a partir da fila mais tarde.", false],
+            ["Tratar todos os erros dentro do codigo da Lambda com try/catch e retornar sempre sucesso, ja que o Step Functions nao oferece mecanismo proprio de retentativa entre estados.", false],
+            ["Adicionar campos Retry, com backoff, e Catch no estado Task para repetir e depois desviar para um estado de tratamento de erro.", true],
+        ],
+    },
+    {
+        statement: "Um consumidor faz ReceiveMessage em uma fila SQS em loop e a equipe percebe muitas respostas vazias, elevando o custo de requisicoes quando a fila esta quase sempre sem mensagens. Qual ajuste reduz as respostas vazias?",
+        explanation: "O long polling, com WaitTimeSeconds maior que zero, faz o ReceiveMessage esperar por mensagens antes de retornar, reduzindo respostas vazias e o custo de requisicoes. Visibility timeout, FIFO e maxReceiveCount nao tem esse efeito.",
+        topic: "SQS",
+        options: [
+            ["Diminuir o visibility timeout da fila para zero, de modo que as mensagens fiquem imediatamente disponiveis e o consumidor nunca receba uma resposta vazia em suas chamadas.", false],
+            ["Habilitar o long polling definindo WaitTimeSeconds maior que zero, para a chamada aguardar mensagens chegarem antes de retornar.", true],
+            ["Trocar a fila Standard por uma fila FIFO, pois o modo FIFO agrupa as mensagens e responde somente quando ha um lote completo pronto para entrega ao consumidor.", false],
+            ["Aumentar o maxReceiveCount na redrive policy, o que mantem a chamada de recebimento aberta por mais tempo aguardando novas mensagens antes de considera-la vazia.", false],
+        ],
+    },
+    {
+        statement: "Uma equipe precisa executar uma funcao Lambda todos os dias as 2h da manha para gerar um relatorio, sem manter servidores ligados nem codigo de agendamento proprio. Qual recurso e o mais indicado?",
+        explanation: "Uma regra agendada do EventBridge, com cron ou rate, dispara alvos como uma Lambda em horarios definidos, sem infraestrutura de agendamento propria. Padroes de evento reagem a eventos, e SQS ou TTL nao sao agendadores confiaveis.",
+        topic: "EventBridge",
+        options: [
+            ["Uma regra do EventBridge baseada em padrao de evento que casa com um evento de relogio publicado pela AWS no barramento padrao a cada hora cheia do dia.", false],
+            ["Um DynamoDB Streams com TTL configurado para expirar um item exatamente as 2h, acionando a Lambda associada ao stream no momento em que o item e removido da tabela.", false],
+            ["Uma fila SQS com delay de 24 horas por mensagem, garantindo que cada nova mensagem enfileirada invoque a Lambda pontualmente no mesmo horario do dia seguinte.", false],
+            ["Uma regra agendada do EventBridge com expressao cron, que dispara a Lambda no horario definido.", true],
+        ],
+    },
+    {
+        statement: "Varios servicos se inscrevem em um unico topico SNS, mas cada assinante so quer receber um subconjunto das mensagens conforme atributos como tipo de pedido, evitando processar o que nao lhe interessa. Como fazer isso sem criar um topico por assinante?",
+        explanation: "A filter policy definida na assinatura faz o SNS avaliar os atributos da mensagem e entregar apenas as que casam, sem logica extra nem um topico por assinante. Descartar no codigo ou usar um roteador intermediario desperdica processamento.",
+        topic: "SNS",
+        options: [
+            ["Publicar cada mensagem para todos os assinantes e deixar cada um descartar no proprio codigo as mensagens cujos atributos nao correspondem ao que ele deveria processar.", false],
+            ["Definir uma filter policy em cada assinatura, para o SNS entregar apenas as mensagens cujos atributos casam com o filtro.", true],
+            ["Criar um assinante intermediario do tipo Lambda que le todas as mensagens do topico e as reencaminha para o assinante certo conforme o valor dos atributos de cada mensagem.", false],
+            ["Usar um topico SNS FIFO com message group ID por tipo de pedido, pois cada assinante recebe automaticamente somente o grupo de mensagens correspondente ao seu identificador.", false],
+        ],
+    },
+    {
+        statement: "Uma aplicacao envia arquivos de varios gigabytes ao S3 em redes instaveis e a equipe quer paralelizar o envio e reenviar apenas a parte que falhar, sem recomecar o upload inteiro. Qual recurso do S3 atende a isso?",
+        explanation: "O multipart upload divide o objeto em partes que podem ser enviadas em paralelo e reenviadas individualmente quando falham, ideal para arquivos grandes em redes instaveis. Presigned URL, versionamento e Transfer Acceleration nao reenviam por parte.",
+        topic: "S3",
+        options: [
+            ["O upload com presigned URL unica, que divide o arquivo internamente e reenvia sozinho apenas os trechos corrompidos assim que detecta uma falha de rede durante a transferencia.", false],
+            ["O versionamento do bucket, que mantem cada tentativa de envio como uma versao e recompoe o objeto final juntando as partes bem-sucedidas de todas as versoes gravadas.", false],
+            ["O multipart upload, que divide o objeto em partes enviadas em paralelo e permite reenviar apenas as que falharem.", true],
+            ["A S3 Transfer Acceleration, que roteia o trafego por edge locations e, por isso, reinicia automaticamente do zero qualquer upload interrompido usando o caminho mais rapido.", false],
+        ],
+    },
+    {
+        statement: "Uma equipe precisa de um cache que tambem ofereca replicas para leitura, persistencia opcional e estruturas de dados como sorted sets para montar um placar de lideres. Qual motor do ElastiCache atende a esses requisitos?",
+        explanation: "O Redis oferece replicas, persistencia e estruturas como sorted sets, uteis para placares, recursos que o Memcached, focado em cache simples e multithread, nao possui. Os dois motores nao sao equivalentes em recursos.",
+        topic: "ElastiCache",
+        options: [
+            ["Redis, que suporta replicas, persistencia e estruturas de dados avancadas como sorted sets.", true],
+            ["Memcached, que oferece replicas de leitura, snapshots de persistencia e sorted sets nativos, alem de escalar horizontalmente adicionando nos ao cluster de forma simples.", false],
+            ["Memcached, porque e o unico motor do ElastiCache com suporte a estruturas de dados ricas e replicacao, enquanto o Redis se limita a pares chave-valor simples em memoria.", false],
+            ["Qualquer um dos dois, ja que Redis e Memcached expoem exatamente o mesmo conjunto de recursos no ElastiCache e diferem apenas no protocolo de rede usado pelos clientes.", false],
+        ],
+    },
+    {
+        statement: "Um app mobile precisa buscar, em uma unica requisicao, dados que vem de uma tabela DynamoDB e de uma funcao Lambda, deixando o cliente escolher exatamente quais campos quer, alem de receber atualizacoes em tempo real. Qual servico atende melhor a esse caso?",
+        explanation: "O AWS AppSync e um servico gerenciado de GraphQL que resolve multiplos data sources, como DynamoDB e Lambda, em uma requisicao, deixa o cliente escolher os campos e oferece subscriptions em tempo real. API Gateway e SNS nao fornecem GraphQL nativo.",
+        topic: "AppSync",
+        options: [
+            ["API Gateway com REST API, expondo um endpoint por recurso e deixando o app fazer varias chamadas e juntar no cliente os campos vindos do DynamoDB e da Lambda.", false],
+            ["Amazon SNS com fanout, entregando ao app as atualizacoes em tempo real e agregando na propria mensagem os campos do DynamoDB e o resultado da Lambda a cada evento.", false],
+            ["API Gateway com WebSocket API, que ja implementa o padrao GraphQL nativamente e permite ao cliente selecionar os campos desejados diretamente na string de conexao.", false],
+            ["AWS AppSync, um servico de GraphQL gerenciado que resolve varios data sources em uma requisicao e suporta subscriptions em tempo real.", true],
+        ],
+    },
+    {
+        statement: "Uma equipe quer que a permissao para excluir objetos de um bucket S3 so seja concedida quando o usuario tiver se autenticado com MFA na sessao atual. Como expressar isso em uma policy do IAM?",
+        explanation: "A chave de condicao aws:MultiFactorAuthPresent avalia se a sessao foi autenticada com MFA; combinada com Effect Allow, ela so libera a acao quando o valor e true. MFA Delete do S3 e um recurso a parte, ligado ao versionamento, e nao substitui essa condicao na policy do IAM.",
+        topic: "IAM",
+        options: [
+            ["Anexar uma permissions boundary que remova a acao s3:DeleteObject de todos os usuarios que nao pertencem ao grupo de administradores da conta.", false],
+            ["Definir a exclusao em uma policy separada e habilitar o versionamento do bucket, pois o MFA Delete passa a valer para qualquer chamada de API feita pela aplicacao.", false],
+            ["Incluir um bloco Condition com a chave aws:MultiFactorAuthPresent igual a true na declaracao que permite s3:DeleteObject.", true],
+            ["Usar o elemento Principal apontando para o ARN do usuario e ativar a federacao, garantindo que so sessoes temporarias do STS consigam apagar objetos.", false],
+        ],
+    },
+    {
+        statement: "Uma empresa deixa que os desenvolvedores criem IAM roles para suas aplicacoes, mas quer garantir que nenhuma role criada por eles ultrapasse um conjunto maximo de permissoes, mesmo que a policy anexada conceda mais. Qual recurso atende a isso?",
+        explanation: "A permissions boundary e uma policy gerenciada que define o maximo de permissoes de uma identidade; as permissoes efetivas sao a intersecao entre a boundary e a policy de permissoes. SCPs atuam no nivel de contas de uma organizacao, nao em uma role individual.",
+        topic: "IAM",
+        options: [
+            ["Uma Service Control Policy (SCP) aplicada diretamente a role, que passa a limitar as permissoes efetivas daquela role especifica dentro da conta.", false],
+            ["Uma permissions boundary anexada as roles, que define o teto de permissoes efetivas independentemente do que a policy de permissoes conceda.", true],
+            ["Uma policy inline com muitas declaracoes Deny cobrindo cada servico que os desenvolvedores nao devem acessar em nenhuma hipotese.", false],
+            ["Uma role de sessao do STS com DurationSeconds reduzido, forcando a renovacao frequente das credenciais temporarias das aplicacoes.", false],
+        ],
+    },
+    {
+        statement: "Uma politica de conformidade exige que todo upload para um bucket S3 seja recusado caso o objeto nao venha com criptografia server-side. Como configurar isso no proprio bucket?",
+        explanation: "Uma bucket policy e uma policy baseada em recurso; com Effect Deny e uma Condition sobre o header de criptografia, ela recusa qualquer PutObject sem criptografia. A criptografia padrao apenas aplica a cifra automaticamente e nao bloqueia uploads.",
+        topic: "S3",
+        options: [
+            ["Habilitar a criptografia padrao do bucket, o que faz o S3 devolver um erro 403 Access Denied toda vez que um PutObject chegar sem o header de criptografia informado pelo cliente na requisicao.", false],
+            ["Anexar uma policy de identidade a cada usuario com um Deny para s3:PutObject, listando manualmente todas as contas que enviam arquivos ao bucket.", false],
+            ["Criar uma regra de ciclo de vida que criptografa os objetos ja existentes e move para outra classe os que estiverem sem criptografia apos 30 dias.", false],
+            ["Adicionar uma bucket policy que nega s3:PutObject com uma Condition quando o header s3:x-amz-server-side-encryption esta ausente.", true],
+        ],
+    },
+    {
+        statement: "Ao revisar os tipos de policy do IAM, uma desenvolvedora quer usar policies mantidas e atualizadas pela propria AWS conforme novos recursos surgem, sem ter que edita-las. Qual caracteristica descreve essas policies?",
+        explanation: "AWS managed policies sao criadas e administradas pela AWS, que cuida das atualizacoes quando novos servicos ou acoes surgem; voce as anexa mas nao altera seu conteudo. Customer managed e inline policies sao de sua responsabilidade editar.",
+        topic: "IAM",
+        options: [
+            ["Sao AWS managed policies, criadas e mantidas pela AWS, que voce anexa a varias identidades mas nao pode editar.", true],
+            ["Sao customer managed policies, que voce escreve e versiona, e que a AWS atualiza automaticamente sempre que um servico novo e lancado na regiao.", false],
+            ["Sao inline policies, embutidas diretamente em um unico usuario, grupo ou role, com relacao de um-para-um e replicacao automatica entre contas.", false],
+            ["Sao permissions boundaries, que a AWS aplica por padrao a toda identidade nova para garantir que ninguem exceda o conjunto de permissoes recomendado.", false],
+        ],
+    },
+    {
+        statement: "Em um Cognito User Pool, uma equipe quer que o app faca login sem enviar a senha do usuario pela rede, provando o conhecimento da senha por um desafio criptografico. Qual fluxo de autenticacao usar?",
+        explanation: "O fluxo USER_SRP_AUTH usa o protocolo Secure Remote Password para autenticar sem enviar a senha pela rede. Fluxos como ADMIN_USER_PASSWORD_AUTH transmitem a senha e exigem protecao adicional do canal.",
+        topic: "Cognito",
+        options: [
+            ["O fluxo ADMIN_USER_PASSWORD_AUTH, em que o backend envia usuario e senha para a API admin e o User Pool valida as credenciais diretamente.", false],
+            ["O fluxo de client credentials do OAuth, proprio para comunicacao maquina a maquina, que dispensa usuario e senha e emite apenas um access token.", false],
+            ["O fluxo SRP (Secure Remote Password), em que o cliente prova conhecer a senha sem transmiti-la.", true],
+            ["O fluxo de refresh token, em que o app troca o refresh token guardado por novos tokens de ID e de acesso quando os atuais expiram.", false],
+        ],
+    },
+    {
+        statement: "Um app protege uma API com Cognito e precisa decidir qual token o cliente deve enviar para autorizar o acesso a endpoints associados a escopos OAuth, e nao para identificar quem e o usuario. Qual token cumpre esse papel?",
+        explanation: "O access token do Cognito carrega os escopos OAuth 2.0 e serve para autorizar o acesso a recursos protegidos. O ID token traz claims de identidade e nao e o token indicado para decisoes de autorizacao por escopo.",
+        topic: "Cognito",
+        options: [
+            ["O ID token, que carrega as claims de identidade do usuario e e o indicado para autorizar chamadas com base nos escopos configurados no resource server.", false],
+            ["O access token, que carrega os escopos OAuth 2.0 e e usado para autorizar o acesso aos recursos protegidos.", true],
+            ["O refresh token, que e enviado a cada requisicao para que a API valide os escopos e, quando necessario, emita um novo par de tokens.", false],
+            ["A chave de API do usuario, gerada pelo User Pool no cadastro e apresentada no header Authorization em vez dos tokens JWT emitidos no login.", false],
+        ],
+    },
+    {
+        statement: "Um app de noticias quer que visitantes nao logados tambem obtenham credenciais AWS temporarias e limitadas para ler um bucket S3 de manchetes, antes mesmo de qualquer login. Qual recurso do Cognito permite isso?",
+        explanation: "O Identity Pool pode conceder acesso nao autenticado (guest), entregando credenciais temporarias associadas a uma unauthenticated role com permissoes restritas. User Pools autenticam usuarios e emitem tokens, mas nao fornecem credenciais AWS por si sos.",
+        topic: "Cognito",
+        options: [
+            ["Um Cognito User Pool com auto-registro habilitado, que cria um usuario anonimo temporario e emite um ID token de convidado a cada visita.", false],
+            ["Um grupo de convidados dentro do User Pool, mapeado para uma IAM role de leitura, cujos tokens sao trocados diretamente nas APIs da AWS.", false],
+            ["Um fluxo de federacao SAML que autentica o visitante em um provedor externo e devolve credenciais de curta duracao com escopo restrito ao bucket.", false],
+            ["Um Cognito Identity Pool com acesso nao autenticado (guest) habilitado, que entrega credenciais temporarias vinculadas a uma role de convidado.", true],
+        ],
+    },
+    {
+        statement: "Um administrador com a policy AdministratorAccess no IAM tenta usar uma CMK simetrica para criptografar dados e recebe AccessDenied, mesmo tendo permissoes amplas na conta. Qual e a causa mais provavel?",
+        explanation: "No KMS, a key policy e o controle de acesso primario de cada CMK; sem uma concessao nela (ou sem delegar ao IAM), nem um administrador consegue usar a chave. Permissoes amplas no IAM nao bastam se a key policy nao as reconhecer.",
+        topic: "KMS",
+        options: [
+            ["A key policy da CMK nao concede acesso a esse administrador, e toda CMK depende da sua key policy para autorizar o uso.", true],
+            ["A CMK esta com a rotacao automatica de material criptografico desabilitada, o que bloqueia as operacoes de Encrypt ate que a proxima rotacao anual seja concluida.", false],
+            ["A policy AdministratorAccess nao inclui a acao kms:Encrypt por padrao, sendo necessario anexar a policy gerenciada especifica de KMS ao usuario administrador.", false],
+            ["O administrador precisa primeiro exportar a chave simetrica em texto claro do KMS para a aplicacao e assinar a requisicao de Encrypt com esse material.", false],
+        ],
+    },
+    {
+        statement: "Uma equipe de seguranca precisa definir a propria key policy, controlar o agendamento da rotacao e conceder grants sobre a chave usada para criptografar dados de um servico. Que tipo de chave do KMS atende a esses requisitos?",
+        explanation: "A customer managed key e criada e administrada por voce, permitindo definir a key policy, criar grants e controlar a rotacao. AWS managed e AWS owned keys sao administradas pela AWS, sem esse nivel de controle.",
+        topic: "KMS",
+        options: [
+            ["Uma AWS managed key (aws/servico), pois ela permite editar a key policy e ajustar o intervalo de rotacao conforme a necessidade de cada aplicacao.", false],
+            ["Uma AWS owned key, compartilhada entre contas pela AWS, que a equipe administra pelo console definindo grants e politicas proprias de acesso.", false],
+            ["Uma customer managed key, que permite definir a key policy, criar grants e controlar a rotacao.", true],
+            ["Uma data key gerada por GenerateDataKey, armazenada no KMS com uma key policy dedicada que a equipe usa para controlar o acesso e a rotacao da chave.", false],
+        ],
+    },
+    {
+        statement: "Um sistema guarda dados criptografados por uma CMK antiga e precisa passar a protege-los com uma nova CMK, sem que o texto puro apareca na aplicacao durante a troca. Qual operacao do KMS faz isso?",
+        explanation: "A operacao ReEncrypt descriptografa o dado com a chave de origem e o recriptografa com a chave de destino inteiramente dentro do KMS, sem expor o texto puro. A rotacao automatica nao recriptografa dados ja existentes; ela so passa a usar o novo material em novas operacoes.",
+        topic: "KMS",
+        options: [
+            ["Chamar Decrypt com a chave antiga na aplicacao e, em seguida, Encrypt com a nova chave, mantendo o texto puro em memoria apenas pelo tempo minimo da troca.", false],
+            ["Chamar ReEncrypt, que descriptografa e recriptografa o dado inteiramente dentro do KMS, sem expor o texto puro.", true],
+            ["Habilitar a rotacao automatica da CMK antiga, que recriptografa em segundo plano todos os dados existentes com o novo material criptografico da chave.", false],
+            ["Criar um grant da chave nova para a chave antiga, o que autoriza o KMS a migrar automaticamente os dados de uma CMK para a outra sem intervencao.", false],
+        ],
+    },
+    {
+        statement: "Durante a rotacao automatica de um segredo no Secrets Manager, a funcao de rotacao cria o novo valor e precisa marca-lo antes de promove-lo, para que as aplicacoes continuem lendo o valor atual ate a troca ser concluida. Qual staging label identifica a versao em vigor?",
+        explanation: "O staging label AWSCURRENT aponta para a versao atual, que o GetSecretValue devolve quando nenhum VersionStage e informado. Durante a rotacao, o novo valor recebe AWSPENDING e so vira AWSCURRENT no passo final.",
+        topic: "Secrets Manager",
+        options: [
+            ["O label AWSPENDING marca a versao que as aplicacoes leem por padrao quando chamam GetSecretValue sem informar um VersionStage especifico.", false],
+            ["O label AWSPREVIOUS e aplicado a nova versao durante os passos createSecret e setSecret, sendo promovido a atual so no passo finishSecret.", false],
+            ["A rotacao nao usa labels; ela sobrescreve o valor no lugar e mantem apenas um historico numerico de versoes acessivel por VersionId.", false],
+            ["O label AWSCURRENT identifica a versao atual do segredo, retornada por padrao pelo GetSecretValue.", true],
+        ],
+    },
+    {
+        statement: "Uma aplicacao precisa guardar uma chave de API de terceiro de forma criptografada, sem necessidade de rotacao automatica, e o time quer a opcao de menor custo. Qual servico atende melhor?",
+        explanation: "O Parameter Store oferece o tipo SecureString, cifrado por KMS, sem cobranca por parametro no standard tier, sendo a opcao de menor custo quando a rotacao automatica nao e necessaria. O Secrets Manager cobra por segredo e se justifica quando a rotacao gerenciada e desejada.",
+        topic: "Parameter Store",
+        options: [
+            ["O SSM Parameter Store, com um parametro SecureString cifrado por KMS, que armazena o valor sem custo por segredo.", true],
+            ["O Secrets Manager, que tambem criptografa com KMS e e a escolha de menor custo por oferecer rotacao automatica nativa mesmo quando ela nao e usada.", false],
+            ["Uma variavel de ambiente criptografada da funcao Lambda, protegida por uma CMK, que dispensa qualquer chamada de API para recuperar o valor em runtime.", false],
+            ["O Parameter Store no advanced tier, necessario porque o standard tier nao oferece o tipo SecureString nem integracao com o KMS para criptografia.", false],
+        ],
+    },
+    {
+        statement: "Uma empresa contrata um SaaS de terceiros que assume uma role na conta dela para coletar metricas. Para evitar o problema do confused deputy, que mecanismo deve ser exigido na hora do AssumeRole?",
+        explanation: "O ExternalId e um valor combinado entre voce e o terceiro e verificado por uma Condition (sts:ExternalId) na trust policy, mitigando o confused deputy. Ele garante que o SaaS so assuma a role em nome do cliente correto.",
+        topic: "STS",
+        options: [
+            ["Reduzir o DurationSeconds da sessao ao minimo, de modo que as credenciais temporarias do terceiro expirem antes que possam ser reutilizadas por outro cliente.", false],
+            ["Exigir MFA do terceiro em cada AssumeRole, adicionando a condicao aws:MultiFactorAuthPresent na trust policy da role assumida pelo SaaS.", false],
+            ["Exigir um ExternalId acordado entre as partes, validado por uma Condition na trust policy da role.", true],
+            ["Trocar a role por um IAM user dedicado ao terceiro, com chaves de acesso de longa duracao rotacionadas periodicamente e escopo restrito as metricas.", false],
+        ],
+    },
+    {
+        statement: "Uma aplicacao assume uma role e recebe credenciais temporarias do STS. O que a equipe precisa considerar sobre a validade dessas credenciais?",
+        explanation: "As credenciais temporarias do STS tem duracao definida (DurationSeconds, dentro do maximo da role) e param de funcionar ao expirar; a aplicacao deve chamar AssumeRole de novo para renova-las. O STS nao faz a renovacao automaticamente.",
+        topic: "STS",
+        options: [
+            ["As credenciais temporarias valem indefinidamente enquanto a role existir, e so deixam de funcionar se a trust policy for removida ou a role for excluida.", false],
+            ["As credenciais expiram ao fim da duracao da sessao e, depois disso, a aplicacao precisa assumir a role de novo para obter credenciais validas.", true],
+            ["O STS renova as credenciais automaticamente em segundo plano antes de expirarem, sem que a aplicacao precise chamar AssumeRole novamente em nenhum momento.", false],
+            ["As credenciais so expiram quando a chave de acesso de longa duracao do IAM user que originou a chamada de AssumeRole for rotacionada manualmente pelo time.", false],
+        ],
+    },
+    {
+        statement: "Ao enviar uma requisicao para uma API da AWS, o SDK anexa uma assinatura calculada com as credenciais do chamador. Qual e o proposito dessa assinatura SigV4?",
+        explanation: "O SigV4 usa as credenciais para autenticar quem faz a chamada e garante a integridade da requisicao, detectando qualquer alteracao em transito. A assinatura nao substitui o TLS nem expoe a chave secreta na requisicao.",
+        topic: "SigV4",
+        options: [
+            ["Criptografar o corpo da requisicao de ponta a ponta, de modo que nem o servico da AWS consiga ler o conteudo sem a chave privada do chamador.", false],
+            ["Comprimir e assinar o payload para reduzir a latencia, substituindo o TLS no transporte entre o SDK e o endpoint regional do servico.", false],
+            ["Anexar as credenciais de longa duracao em texto claro no header Authorization, para que o servico as valide contra o banco de identidades do IAM.", false],
+            ["Autenticar o chamador e proteger a integridade da requisicao contra alteracoes em transito.", true],
+        ],
+    },
+    {
+        statement: "Um servico precisa chamar um dominio do Amazon OpenSearch protegido por IAM usando um cliente HTTP proprio, sem SDK da AWS. O que a aplicacao tem que fazer para as chamadas serem aceitas?",
+        explanation: "Sem o SDK, que assina automaticamente, a aplicacao precisa calcular e anexar a assinatura SigV4 em cada requisicao usando suas credenciais. Endpoints protegidos por IAM, como o OpenSearch, recusam chamadas sem assinatura valida.",
+        topic: "SigV4",
+        options: [
+            ["Assinar manualmente cada requisicao com SigV4, usando as credenciais da aplicacao.", true],
+            ["Enviar as chaves de acesso e a chave secreta em headers customizados, deixando que o dominio do OpenSearch as valide diretamente contra o IAM da conta.", false],
+            ["Anexar um API key gerado no console do OpenSearch ao header Authorization, dispensando qualquer assinatura porque o controle de acesso passa a ser por chave.", false],
+            ["Abrir o acesso ao dominio por uma policy baseada em IP e chamar por HTTP simples, ja que a assinatura so e exigida quando se usa o SDK oficial da AWS.", false],
+        ],
+    },
+    {
+        statement: "Uma aplicacao gera uma presigned URL para que um cliente baixe um objeto privado do S3 por tempo limitado. O que determina as permissoes e a validade dessa URL?",
+        explanation: "A presigned URL carrega a assinatura das credenciais de quem a criou, entao herda as permissoes desse principal, e vale ate o tempo de expiracao definido na geracao. Enquanto valida, qualquer um que tenha a URL consegue acessar o objeto, sem precisar de credenciais proprias.",
+        topic: "S3",
+        options: [
+            ["A URL usa sempre as permissoes da role de execucao do S3 e vale por 7 dias fixos, independentemente de quem a gerou ou das credenciais utilizadas.", false],
+            ["Qualquer pessoa que receba a URL precisa autenticar-se no S3 com as proprias credenciais IAM, que sao checadas contra a bucket policy no momento do download.", false],
+            ["A URL herda as permissoes de quem a gerou e expira no prazo definido na criacao, funcionando ate la para quem a tiver.", true],
+            ["A URL so funciona se o objeto tiver ACL public-read, porque o S3 exige acesso publico para servir downloads sem passar pelas credenciais do gerador.", false],
+        ],
+    },
+    {
+        statement: "Uma empresa quer uma trava que impeca buckets de ficarem publicos por engano, mesmo que alguem aplique uma ACL ou uma bucket policy que conceda acesso publico. Qual recurso oferece essa protecao?",
+        explanation: "O S3 Block Public Access atua como uma trava que se sobrepoe a ACLs e bucket policies, bloqueando o acesso publico mesmo que essas configuracoes o concedam. E aplicavel no nivel da conta ou de cada bucket.",
+        topic: "S3",
+        options: [
+            ["O IAM Access Analyzer, que reverte automaticamente qualquer bucket policy que conceda acesso publico assim que detecta a alteracao na conta.", false],
+            ["O S3 Block Public Access, que sobrepoe ACLs e bucket policies e bloqueia o acesso publico mesmo quando elas o concedem.", true],
+            ["A criptografia padrao do bucket, que ao ser habilitada passa a exigir credenciais assinadas em toda requisicao e assim elimina qualquer forma de acesso anonimo.", false],
+            ["Uma SCP na organizacao que remove a acao s3:PutBucketPolicy de todas as contas, impedindo que qualquer policy publica chegue a ser aplicada a um bucket.", false],
+        ],
+    },
+    {
+        statement: "Um requisito de seguranca determina que objetos de um bucket S3 so podem ser acessados por conexoes criptografadas (HTTPS), recusando qualquer chamada por HTTP. Como impor isso no bucket?",
+        explanation: "Uma bucket policy com Effect Deny condicionado a aws:SecureTransport igual a false recusa qualquer requisicao que nao use HTTPS. A criptografia padrao protege os dados em repouso e nao controla o protocolo de transporte.",
+        topic: "S3",
+        options: [
+            ["Habilitar a criptografia server-side padrao do bucket, que passa a rejeitar automaticamente toda requisicao que nao chegue por uma conexao TLS.", false],
+            ["Configurar um endpoint de acesso somente-HTTPS no CloudFront e apontar o bucket como origem, o que faz o S3 recusar o trafego HTTP direto na origem.", false],
+            ["Ativar o S3 Block Public Access, que alem de bloquear acesso publico forca todas as requisicoes restantes a usarem o protocolo HTTPS por padrao.", false],
+            ["Adicionar uma bucket policy com Deny quando a condicao aws:SecureTransport for false.", true],
+        ],
+    },
+    {
+        statement: "Uma funcao Lambda so precisa ler itens de uma tabela DynamoDB especifica e gravar seus logs. Seguindo o menor privilegio, como deve ser a execution role?",
+        explanation: "O menor privilegio concede so as acoes necessarias (leitura na tabela especifica e escrita de logs), reduzindo o impacto de credenciais comprometidas. Policies amplas como AmazonDynamoDBFullAccess ou dynamodb:* violam esse principio.",
+        topic: "Lambda",
+        options: [
+            ["Conceder apenas dynamodb:GetItem e dynamodb:Query na tabela especifica, alem das permissoes de escrita em logs do CloudWatch.", true],
+            ["Anexar a policy gerenciada AmazonDynamoDBFullAccess, que ja cobre a leitura necessaria e evita ajustes de permissao caso a funcao passe a escrever na tabela depois.", false],
+            ["Reaproveitar uma role administrativa existente, pois a funcao roda em ambiente isolado e as permissoes amplas nao representam risco dentro da propria conta.", false],
+            ["Conceder dynamodb:* na conta inteira e a policy AWSLambdaBasicExecutionRole, garantindo acesso a qualquer tabela que a funcao venha a usar no futuro.", false],
+        ],
+    },
+    {
+        statement: "Um template do CloudFormation precisa selecionar o ID da AMI correto conforme a regiao onde a stack e criada, ja que cada regiao tem um ID de AMI diferente. A equipe quer resolver isso dentro do proprio template, sem passar o ID como parametro. Qual recurso do template atende a essa necessidade?",
+        explanation: "A secao Mappings guarda pares chave-valor fixos, como regiao para ID de AMI, e Fn::FindInMap resolve o valor certo em tempo de criacao usando a pseudo-variavel AWS::Region.",
+        topic: "CloudFormation",
+        options: [
+            ["Uma secao Mappings com os IDs por regiao, consultada em runtime por Fn::FindInMap usando AWS::Region como chave.", true],
+            ["Uma secao Parameters do tipo AWS::EC2::Image::Id que obriga quem cria a stack a digitar manualmente o ID da AMI de cada regiao antes de cada deploy.", false],
+            ["Uma secao Outputs que exporta o ID da AMI para que outras stacks importem o valor correto por Fn::ImportValue.", false],
+            ["Uma Condition que compara a regiao atual e, para cada uma, cria um recurso EC2 separado com o ID de AMI fixo embutido.", false],
+        ],
+    },
+    {
+        statement: "Uma stack de rede cria uma VPC e exporta o ID de uma subnet. Uma segunda stack, gerenciada por outra equipe e implantada separadamente, precisa criar instancias nessa subnet referenciando o valor da primeira stack. As stacks nao tem relacao de aninhamento. Como a segunda stack obtem o ID da subnet?",
+        explanation: "Referencias entre stacks independentes usam Output com Export na stack de origem e Fn::ImportValue na stack consumidora; o aninhamento seria uma abordagem diferente, com stacks pai e filhas.",
+        topic: "CloudFormation",
+        options: [
+            ["Declarando a primeira stack como um recurso AWS::CloudFormation::Stack aninhado dentro da segunda e lendo a saida pela referencia ao recurso aninhado.", false],
+            ["Usando Fn::GetAtt diretamente sobre o nome logico do recurso de subnet, ja que o CloudFormation resolve referencias entre quaisquer stacks da conta automaticamente.", false],
+            ["Declarando um Output com Export na primeira stack e consumindo esse nome exportado com Fn::ImportValue na segunda.", true],
+            ["Copiando o ID da subnet para um parametro da segunda stack a cada deploy, pois o CloudFormation nao oferece mecanismo nativo para compartilhar valores entre stacks independentes.", false],
+        ],
+    },
+    {
+        statement: "Um template recebe a senha de um banco de dados como parametro. O time de seguranca exige que esse valor nao apareca em texto claro no console, nos eventos nem na descricao da stack. Qual configuracao do parametro atende a esse requisito?",
+        explanation: "NoEcho true faz o CloudFormation mascarar o valor do parametro como asteriscos no console, nos eventos e nas respostas de API. AllowedPattern e Metadata nao ocultam valores, e SecureString e um tipo do Parameter Store.",
+        topic: "CloudFormation",
+        options: [
+            ["Definir o parametro com AllowedPattern e MinLength, o que impede o CloudFormation de exibir o valor apos a validacao.", false],
+            ["Definir a propriedade NoEcho como true no parametro, mascarando o valor exibido como asteriscos.", true],
+            ["Colocar o parametro na secao Metadata, que o CloudFormation trata como conteudo interno e nunca exibe.", false],
+            ["Marcar o parametro com o tipo SecureString, fazendo o CloudFormation cifrar e ocultar o valor automaticamente com uma chave do KMS gerenciada pela stack.", false],
+        ],
+    },
+    {
+        statement: "Uma instancia EC2 criada por uma stack roda um script de bootstrap demorado que instala e configura a aplicacao. A equipe quer que o CloudFormation so considere o recurso como criado com sucesso depois que o script confirmar que a aplicacao esta pronta, evitando que a stack conclua antes da hora. Qual abordagem atende a isso?",
+        explanation: "Um CreationPolicy faz o CloudFormation aguardar um numero de sinais de sucesso enviados por cfn-signal antes de marcar o recurso como CREATE_COMPLETE, garantindo que a aplicacao esteja realmente pronta.",
+        topic: "CloudFormation",
+        options: [
+            ["Adicionar um DependsOn na instancia apontando para ela mesma, forcando o CloudFormation a esperar o termino do bootstrap.", false],
+            ["Aumentar o timeout global da stack nas configuracoes do console, o que faz o CloudFormation reavaliar o estado da aplicacao periodicamente.", false],
+            ["Definir uma DeletionPolicy de Retain na instancia para que, em caso de falha do bootstrap, o CloudFormation preserve o recurso e continue tentando executar o script ate obter sucesso.", false],
+            ["Adicionar um CreationPolicy a instancia e chamar cfn-signal ao final do script, sinalizando sucesso; o recurso so fica CREATE_COMPLETE apos o sinal.", true],
+        ],
+    },
+    {
+        statement: "Em um template do AWS SAM, a equipe quer que cada atualizacao de uma funcao Lambda desloque o trafego gradualmente, enviando 10% para a nova versao por 5 minutos e revertendo automaticamente se um alarme do CloudWatch disparar. Que combinacao de propriedades no AWS::Serverless::Function habilita isso?",
+        explanation: "No SAM, AutoPublishAlias cria e aponta um alias para cada nova versao, e DeploymentPreference define a estrategia de shift (Canary/Linear), integrando com CodeDeploy e alarmes para rollback automatico.",
+        topic: "SAM",
+        options: [
+            ["AutoPublishAlias para publicar versoes e um DeploymentPreference com Type Canary10Percent5Minutes e Alarms.", true],
+            ["Uma propriedade ProvisionedConcurrencyConfig combinada com um bloco RollbackConfiguration que monitora alarmes e desfaz a publicacao da versao se as metricas de erro ultrapassarem o limite definido.", false],
+            ["Um evento do tipo Schedule que reavalia as metricas a cada 5 minutos e ajusta os pesos do alias manualmente conforme o resultado.", false],
+            ["Definir VersionDescription e uma AutoPublishCodeSha256, deixando o proprio SAM escolher a estrategia canary padrao sem configuracao adicional.", false],
+        ],
+    },
+    {
+        statement: "Um template do SAM declara varias funcoes Lambda que compartilham o mesmo Runtime, Timeout e um conjunto de variaveis de ambiente. Para nao repetir essas configuracoes em cada funcao, onde a equipe pode declara-las uma unica vez e deixa-las valerem para todas as funcoes?",
+        explanation: "A secao Globals do SAM define propriedades padrao herdadas por todos os recursos de um tipo suportado (Function, Api, HttpApi, SimpleTable), evitando repeticao; cada recurso ainda pode sobrescrever um valor.",
+        topic: "SAM",
+        options: [
+            ["Na secao Mappings, criando uma chave por funcao e aplicando os valores com Fn::FindInMap em cada recurso.", false],
+            ["Na secao Outputs, exportando os valores para que cada AWS::Serverless::Function os importe automaticamente durante o build.", false],
+            ["Na secao Globals, que aplica propriedades padrao a todos os recursos de um tipo suportado, como funcoes.", true],
+            ["Em um arquivo samconfig.toml separado, que o SAM CLI le durante o sam deploy e injeta as mesmas propriedades em cada funcao antes de gerar o template do CloudFormation equivalente.", false],
+        ],
+    },
+    {
+        statement: "Uma aplicacao em conteiner roda em um servico do Amazon ECS e a equipe faz deploy blue/green pelo CodeDeploy. Ela quer subir a nova versao da task em paralelo, valida-la por um listener de teste e so entao direcionar o trafego de producao. Como o CodeDeploy conduz esse deploy no ECS?",
+        explanation: "No blue/green do CodeDeploy com ECS, um novo conjunto de tasks sobe em um segundo target group; o trafego de producao e deslocado no listener do balanceador do target group original para o novo, permitindo validacao via listener de teste e rollback rapido.",
+        topic: "CodeDeploy",
+        options: [
+            ["Ele atualiza a task definition no mesmo target group e reinicia as tasks uma a uma, mantendo um unico listener durante toda a troca.", false],
+            ["Ele provisiona um novo replacement set de tasks em um segundo target group e desloca o trafego do listener de producao do target group antigo para o novo.", true],
+            ["Ele cria um cluster ECS totalmente separado com a nova versao, aguarda a drenagem completa das conexoes do cluster antigo e depois atualiza o registro DNS no Route 53 para apontar os usuarios ao novo cluster.", false],
+            ["Ele publica a nova task como uma revisao e usa pesos de roteamento no proprio servico ECS, sem envolver listeners nem target groups do balanceador.", false],
+        ],
+    },
+    {
+        statement: "Um CodePipeline implanta automaticamente em homologacao, mas a equipe exige que uma pessoa autorize explicitamente a promocao para producao antes que o estagio de deploy em prod execute. Como adicionar essa pausa para autorizacao humana no pipeline?",
+        explanation: "Uma acao de aprovacao manual (Manual approval) pausa o pipeline e aguarda um usuario com permissao aprovar ou rejeitar, opcionalmente notificando via SNS; so apos a aprovacao o pipeline avanca.",
+        topic: "CodePipeline",
+        options: [
+            ["Configurar um webhook no estagio de producao que bloqueia a transicao ate receber uma chamada externa de aprovacao de um sistema de terceiros.", false],
+            ["Habilitar o modo de execucao SUPERSEDED no pipeline, que retem cada execucao ate um administrador confirmar pelo console.", false],
+            ["Inserir um estagio de build adicional que roda testes de aceitacao e, se todos passarem, marca o artefato como aprovado e libera automaticamente o estagio seguinte sem intervencao de ninguem.", false],
+            ["Adicionar uma acao do tipo Manual approval antes do estagio de producao; o pipeline pausa ate alguem aprovar ou rejeitar.", true],
+        ],
+    },
+    {
+        statement: "Uma task do ECS no Fargate falha ao iniciar porque nao consegue baixar a imagem do Amazon ECR nem ler um segredo do Secrets Manager referenciado na task definition. Ja o codigo da aplicacao, quando roda, precisa gravar objetos em um bucket S3. Como distribuir corretamente essas permissoes?",
+        explanation: "O task execution role e usado pelo agente do ECS para puxar a imagem do ECR, buscar segredos e enviar logs; o task role concede permissoes ao codigo da aplicacao em runtime, como gravar no S3. No Fargate nao ha instance role do host.",
+        topic: "ECS",
+        options: [
+            ["Dar ao task execution role o acesso ao ECR e ao Secrets Manager, e ao task role a permissao de escrita no S3.", true],
+            ["Dar ao task role o acesso ao ECR e ao Secrets Manager, e ao task execution role a permissao de escrita no S3.", false],
+            ["Colocar todas as permissoes (ECR, Secrets Manager e S3) na instance role da EC2 do cluster, ja que no Fargate as tasks herdam as permissoes do host onde sao agendadas.", false],
+            ["Anexar ECR e Secrets Manager ao execution role e tambem mover a escrita no S3 para ele, deixando o task role sem nenhuma permissao.", false],
+        ],
+    },
+    {
+        statement: "Um repositorio do Amazon ECR acumula muitas imagens antigas e sem tag a cada build, e o custo de armazenamento cresce. A equipe quer remover automaticamente as imagens obsoletas segundo regras de idade ou quantidade, sem rodar scripts manuais. Qual recurso do ECR faz isso?",
+        explanation: "A lifecycle policy do ECR remove imagens automaticamente conforme regras baseadas em idade ou em contagem (e em tag ou sem tag), reduzindo o armazenamento sem automacao externa. Image scanning e imutabilidade de tags servem a outros propositos.",
+        topic: "ECR",
+        options: [
+            ["Habilitar image scanning on push, que identifica imagens vulneraveis e as expira do repositorio apos o relatorio de findings.", false],
+            ["Ativar a imutabilidade de tags no repositorio, o que impede novas imagens e libera espaco ao rejeitar pushes duplicados.", false],
+            ["Configurar uma lifecycle policy no repositorio com regras que expiram imagens por idade ou por contagem.", true],
+            ["Criar uma regra no EventBridge que dispara diariamente uma funcao Lambda encarregada de listar todas as imagens do repositorio, ordena-las e chamar a API de exclusao para as que excederem o limite definido.", false],
+        ],
+    },
+    {
+        statement: "Uma equipe roda a aplicacao no Elastic Beanstalk e quer fazer blue/green: subir a nova versao em um ambiente separado, testa-la com sua propria URL e, quando aprovada, direcionar o trafego de producao para ela quase sem downtime, podendo reverter rapido. Qual recurso do Beanstalk faz essa troca?",
+        explanation: "O Swap Environment URLs troca os CNAMEs de dois ambientes do Beanstalk, movendo o trafego de producao para o ambiente novo quase sem downtime e permitindo reverter ao trocar de novo. As politicas Immutable e Rolling atuam dentro de um unico ambiente.",
+        topic: "Elastic Beanstalk",
+        options: [
+            ["A politica de deploy Immutable, que substitui as instancias do ambiente de producao por novas ja com a versao nova validada.", false],
+            ["O Swap Environment URLs, que troca os CNAMEs dos dois ambientes, redirecionando o trafego para o novo.", true],
+            ["A politica de deploy Rolling with additional batch, que adiciona um lote extra de instancias com a nova versao antes de remover as antigas.", false],
+            ["O recurso de Saved Configurations, que guarda as definicoes do ambiente antigo e as reaplica sobre o ambiente novo caso seja necessario reverter o trafego para a versao anterior.", false],
+        ],
+    },
+    {
+        statement: "Ao instrumentar uma aplicacao com o X-Ray, um desenvolvedor adiciona o customerId em cada segmento e depois quer filtrar e agrupar traces por esse valor diretamente na console do X-Ray. Como ele deve registrar o customerId para conseguir filtrar por ele?",
+        explanation: "Annotations sao pares chave-valor indexados pelo X-Ray e podem ser usados em filter expressions para buscar e agrupar traces; metadata guarda dados nao indexados, apenas para contexto adicional, sem suporte a filtro.",
+        topic: "X-Ray",
+        options: [
+            ["Como metadata, pois campos de metadata sao indexados pelo X-Ray e ficam disponiveis para filtro por expressao de busca.", false],
+            ["Como um subsegmento nomeado com o valor do customerId, ja que o X-Ray cria automaticamente um indice a partir dos nomes de subsegmentos para permitir consultas por qualquer um deles no service map.", false],
+            ["Em qualquer um dos dois, annotation ou metadata, porque o X-Ray indexa ambos e a diferenca e apenas o tamanho maximo permitido para o valor.", false],
+            ["Como annotation, pois annotations sao indexadas e podem ser usadas em filter expressions.", true],
+        ],
+    },
+    {
+        statement: "Uma equipe quer ver traces de uma funcao Lambda no X-Ray, incluindo o tempo gasto nas chamadas que ela faz ao DynamoDB. O que e necessario para que a funcao apareca no service map e as chamadas downstream sejam detalhadas?",
+        explanation: "Ativar o Active tracing na configuracao da funcao faz o Lambda emitir segmentos e gerenciar o daemon do X-Ray; instrumentar o SDK adiciona subsegmentos para chamadas downstream como o DynamoDB. Memoria e sampling isoladamente nao habilitam o tracing.",
+        topic: "X-Ray",
+        options: [
+            ["Habilitar o Active tracing na funcao e instrumentar o cliente AWS com o X-Ray SDK para gerar os subsegmentos downstream.", true],
+            ["Apenas aumentar a memoria da funcao, pois o X-Ray so captura traces de funcoes acima de um limite minimo de memoria alocada.", false],
+            ["Instalar e rodar o daemon do X-Ray como um processo dentro do pacote de implantacao da funcao, ja que no Lambda e responsabilidade do desenvolvedor manter o daemon ativo para receber e encaminhar os segmentos.", false],
+            ["Configurar uma sampling rule com taxa de 100% no console do X-Ray, o que por si so ativa a coleta de traces em todas as funcoes da conta.", false],
+        ],
+    },
+    {
+        statement: "Depois de um incidente, a equipe precisa vasculhar interativamente os logs de um grupo do CloudWatch Logs para contar quantas requisicoes tiveram latencia acima de 1 segundo e agrupa-las por endpoint, sem exportar os dados para outro servico. Qual recurso faz essa analise ad hoc sobre os logs?",
+        explanation: "O CloudWatch Logs Insights consulta interativamente grupos de logs com uma linguagem propria (filter, stats, sort), ideal para agregacoes ad hoc como contar e agrupar por campo. Metric filters geram metricas continuas, nao consultas exploratorias.",
+        topic: "CloudWatch Logs",
+        options: [
+            ["Um metric filter aplicado ao grupo de logs, que retorna a lista de eventos correspondentes ja agrupados por endpoint em uma tabela interativa.", false],
+            ["Uma subscription filter que envia continuamente os eventos para uma funcao Lambda, onde a equipe escreve o codigo de agregacao por endpoint e devolve o resultado consolidado para uma nova consulta no console.", false],
+            ["O CloudWatch Logs Insights, com uma query que filtra por latencia e usa stats count por endpoint.", true],
+            ["O Log group export para o S3, seguido de uma consulta com o Amazon Athena sobre os arquivos exportados.", false],
+        ],
+    },
+    {
+        statement: "Uma aplicacao ja grava linhas contendo a palavra ERROR no CloudWatch Logs quando algo falha. A equipe quer disparar um alarme quando o numero dessas linhas ultrapassar um limite em 5 minutos, sem alterar o codigo da aplicacao para publicar metricas. Como transformar essas ocorrencias de log em algo alarmavel?",
+        explanation: "Um metric filter varre os eventos do grupo de logs, conta os que casam com o padrao (ERROR) e publica o resultado como uma metrica do CloudWatch, sobre a qual se cria o alarme, tudo sem tocar no codigo. O EMF exigiria instrumentar a aplicacao.",
+        topic: "CloudWatch",
+        options: [
+            ["Ativar o Contributor Insights no grupo de logs para que ele gere automaticamente uma metrica de contagem de erros e vincule um alarme a essa metrica assim que o padrao ERROR for detectado pela primeira vez.", false],
+            ["Criar um metric filter no grupo de logs que conta as linhas com ERROR e publica uma metrica, e entao criar um alarme sobre ela.", true],
+            ["Instrumentar a aplicacao com o Embedded Metric Format para emitir a contagem de erros como metrica estruturada a cada linha de log.", false],
+            ["Habilitar a alta resolucao no grupo de logs, o que faz o CloudWatch converter cada padrao de texto recorrente em uma metrica de um segundo.", false],
+        ],
+    },
+    {
+        statement: "Uma funcao Lambda que faz processamento intensivo de CPU esta lenta e a equipe cogita reduzir custo, mas as execucoes demoram muito. Sabe-se que a funcao esta limitada por CPU, nao por I/O. Qual ajuste tende a reduzir a duracao e pode ate diminuir o custo total?",
+        explanation: "No Lambda, a CPU (e a rede) e alocada proporcionalmente a memoria configurada; para cargas limitadas por CPU, aumentar a memoria reduz a duracao e, como a cobranca e por GB-segundo, uma execucao bem mais rapida pode sair mais barata. Provisioned concurrency reduz cold start, nao a duracao do processamento.",
+        topic: "Lambda - otimizacao",
+        options: [
+            ["Reduzir a memoria alocada ao minimo, ja que menos memoria libera mais ciclos de CPU para o processamento na Lambda.", false],
+            ["Manter a memoria baixa e habilitar concorrencia provisionada, pois o pre-aquecimento dos ambientes de execucao acelera cada invocacao ao dedicar mais nucleos de CPU exclusivamente as funcoes ja inicializadas.", false],
+            ["Aumentar a memoria alocada, porque a Lambda escala a CPU proporcionalmente a memoria, reduzindo a duracao.", true],
+            ["Dividir a funcao em duas e encadea-las de forma assincrona, o que soma a capacidade de CPU das duas alocacoes durante o processamento.", false],
+        ],
+    },
+    {
+        statement: "Uma funcao Lambda abre uma nova conexao com o banco de dados no inicio do handler a cada invocacao, e o tempo de execucao aumenta sob carga. A equipe quer aproveitar a reutilizacao do ambiente de execucao para reduzir esse custo por invocacao. Qual mudanca no codigo consegue isso?",
+        explanation: "Codigo no escopo de inicializacao (fora do handler) roda uma vez por ambiente de execucao e e reaproveitado enquanto o ambiente permanece quente; declarar a conexao ali evita recria-la a cada invocacao. Variaveis de ambiente guardam strings, nao conexoes abertas.",
+        topic: "Lambda - otimizacao",
+        options: [
+            ["Mover a abertura da conexao para dentro de um bloco try no final do handler, garantindo que ela seja recriada e fechada a cada chamada.", false],
+            ["Aumentar o timeout da funcao e envolver a criacao da conexao em um laco de retry, de modo que cada invocacao tente reaproveitar a conexao da invocacao anterior consultando uma variavel salva no servico de configuracao.", false],
+            ["Configurar a conexao como uma variavel de ambiente da funcao, pois variaveis de ambiente persistem entre invocacoes e mantem o socket aberto.", false],
+            ["Criar a conexao fora do handler, no escopo de inicializacao, para reaproveita-la enquanto o ambiente de execucao estiver quente.", true],
+        ],
+    },
+    {
+        statement: "Uma tabela DynamoDB sofre throttling concentrado em poucas particoes, enquanto a capacidade total provisionada parece suficiente. A investigacao mostra que a partition key e um campo de baixa cardinalidade, com poucos valores muito acessados. Qual mudanca de modelagem melhor distribui a carga?",
+        explanation: "O throttling por hot partition vem de uma partition key com poucos valores muito acessados; escolher uma chave de alta cardinalidade (ou adicionar sufixo com write sharding) distribui as requisicoes por mais particoes. Aumentar a capacidade total nao resolve a concentracao em uma particao.",
+        topic: "DynamoDB - performance",
+        options: [
+            ["Escolher uma partition key de alta cardinalidade, que espalhe as requisicoes por muitas particoes.", true],
+            ["Manter a mesma partition key, mas aumentar bastante a capacidade provisionada de leitura e escrita da tabela inteira, ja que o throttling desaparece quando a soma das RCUs e WCUs supera o pico agregado de todas as particoes juntas.", false],
+            ["Trocar a partition key pela sort key atual e promover o campo de baixa cardinalidade a sort key, invertendo os papeis das duas chaves.", false],
+            ["Adicionar um Local Secondary Index sobre o campo de baixa cardinalidade, o que replica os itens e divide automaticamente o acesso entre a tabela e o indice.", false],
+        ],
+    },
+    {
+        statement: "Sob picos de trafego, uma aplicacao recebe ocasionalmente ProvisionedThroughputExceededException do DynamoDB. A equipe quer tratar esses picos transitorios sem sobrecarregar ainda mais a tabela com novas tentativas. Qual e a abordagem recomendada?",
+        explanation: "Requisicoes limitadas (throttled) devem ser reenviadas com exponential backoff e jitter para espacar as tentativas; os SDKs da AWS ja fazem retries automaticos com backoff. Reenviar em laco apertado piora a sobrecarga.",
+        topic: "DynamoDB - performance",
+        options: [
+            ["Repetir a operacao imediatamente em um laco apertado ate obter sucesso, pois quanto antes a requisicao for reenviada, menor a chance de novo throttling.", false],
+            ["Capturar a excecao e ignora-la silenciosamente, seguindo o fluxo como se a operacao tivesse tido sucesso, ja que o DynamoDB persiste a escrita internamente e apenas atrasa a confirmacao para o cliente sob carga.", false],
+            ["Reexecutar com exponential backoff e jitter; o SDK ja aplica retries automaticos assim por padrao.", true],
+            ["Trocar todas as leituras para fortemente consistentes, o que faz o DynamoDB priorizar essas requisicoes e deixar de recusa-las por throttling.", false],
+        ],
+    },
+    {
+        statement: "Uma equipe usa o ElastiCache na frente de um banco e quer que o cache seja populado somente quando um dado e solicitado e nao esta presente, buscando no banco e gravando no cache nesse momento. Que estrategia descreve esse comportamento, e qual e sua principal desvantagem?",
+        explanation: "No lazy loading (cache-aside), o cache so e preenchido quando ocorre um miss, carregando o dado do banco naquele momento; a desvantagem e que dados alterados no banco podem ficar defasados no cache ate expirarem. O write-through atualiza o cache a cada escrita.",
+        topic: "Estrategias de cache",
+        options: [
+            ["Write-through: o cache e atualizado a cada escrita no banco, o que garante dados sempre frescos, mas tem como desvantagem manter no cache muitos itens que talvez nunca sejam lidos, desperdicando memoria com dados frios.", false],
+            ["Lazy loading: o cache e preenchido no cache miss; a desvantagem e servir dado potencialmente desatualizado ate expirar.", true],
+            ["Write-behind: as escritas vao primeiro ao cache e sao persistidas no banco depois; a desvantagem e a perda de dados se o no do cache falhar antes da gravacao.", false],
+            ["TTL absoluto: cada item nasce com um tempo de vida fixo; a desvantagem e que itens muito acessados sao descartados no vencimento mesmo ainda sendo uteis.", false],
+        ],
+    },
+    {
+        statement: "Um servico que a aplicacao chama retorna, de forma intermitente, respostas HTTP 500 e 503, e em outras ocasioes um 400 consistente para a mesma requisicao malformada. Como a aplicacao deve tratar cada classe de resposta?",
+        explanation: "Respostas 5xx apontam problemas no servidor, normalmente transitorios, e sao candidatas a retry com exponential backoff; ja um 4xx como 400 indica erro do cliente (requisicao malformada) que se repetira igual ate a requisicao ser corrigida.",
+        topic: "Erros 4xx vs 5xx",
+        options: [
+            ["Os 5xx indicam falha do lado do servidor, em geral transitoria, e devem ser repetidos com exponential backoff; o 400 e erro do cliente e nao deve ser repetido sem corrigir a requisicao.", true],
+            ["Tanto os 5xx quanto o 400 devem ser repetidos imediatamente o mesmo numero de vezes, pois qualquer erro HTTP tende a se resolver sozinho em uma nova tentativa.", false],
+            ["Os 5xx sao erros do cliente e nao devem ser repetidos, enquanto o 400 vem do servidor e deve ser reenviado varias vezes com backoff crescente ate que a infraestrutura do servico se recupere e passe a aceitar a requisicao.", false],
+            ["Nenhuma das duas classes deve ser repetida pela aplicacao; convem apenas registrar o erro e devolver a falha ao usuario, deixando o balanceador de carga refazer a chamada.", false],
+        ],
+    },
 ];
 
 async function seed() {
@@ -1680,13 +2352,23 @@ async function seed() {
         .select({ n: count() })
         .from(simuladoQuestions)
         .where(eq(simuladoQuestions.simuladoId, simulado.id));
-    if (Number(n) > 0) {
+    const jaExistem = new Set(
+        (
+            await db
+                .select({ statement: simuladoQuestions.statement })
+                .from(simuladoQuestions)
+                .where(eq(simuladoQuestions.simuladoId, simulado.id))
+        ).map((r) => r.statement),
+    );
+    const inseridas = QUESTOES.filter((q) => !jaExistem.has(q.statement)).length;
+    if (inseridas === 0) {
         console.log(`Simulado já tem ${n} questões, nada a fazer.`);
         return;
     }
 
     for (let i = 0; i < QUESTOES.length; i++) {
         const q = QUESTOES[i];
+        if (jaExistem.has(q.statement)) continue;
         const [questao] = await db
             .insert(simuladoQuestions)
             .values({
@@ -1705,7 +2387,7 @@ async function seed() {
             })),
         );
     }
-    console.log(`Seed concluído: ${QUESTOES.length} questões inseridas.`);
+    console.log(`Seed: ${inseridas} questões novas inseridas (${QUESTOES.length} no banco).`);
 }
 
 seed()

--- a/backend/scripts/seed-isc2-cc.ts
+++ b/backend/scripts/seed-isc2-cc.ts
@@ -2108,7 +2108,822 @@ const QUESTOES: Questao[] = [
                 false
             ]
         ]
-    }
+    },
+    // ===== Questões adicionais (banco ampliado para variar as tentativas) =====
+    {
+        statement: "Ao receber um e-mail supostamente enviado pelo diretor financeiro, o sistema verifica a assinatura digital anexada e confirma que a mensagem realmente partiu dele, e não de um impostor. Qual propriedade de segurança está sendo garantida nesse momento?",
+        explanation: "A autenticidade garante que a origem alegada de uma comunicação é genuína, o que a verificação da assinatura comprova. Confidencialidade trata do sigilo do conteúdo, disponibilidade do acesso e redundância de cópias, sem confirmar quem enviou a mensagem.",
+        topic: "Princípios de Segurança",
+        options: [
+            ["A disponibilidade, que assegura que os sistemas de e-mail permaneçam acessíveis sempre que os usuários precisarem enviar mensagens.", false],
+            ["A confidencialidade, que impede que pessoas não autorizadas leiam o conteúdo da mensagem transmitida.", false],
+            ["A autenticidade, que confirma que a origem alegada da comunicação é genuína.", true],
+            ["A redundância, que mantém cópias adicionais da mensagem em servidores distintos para evitar perda de dados.", false],
+        ],
+    },
+    {
+        statement: "Ao acessar um sistema, João primeiro informa seu nome de usuário, depois digita a senha e, por fim, o sistema verifica que ele pode abrir apenas os relatórios do setor de vendas. Esses três momentos correspondem, respectivamente, a:",
+        explanation: "Informar o usuário é identificação, comprovar a identidade com a senha é autenticação e definir o que ele pode acessar é autorização. As demais opções trocam a ordem das etapas ou incluem auditoria, que é o registro posterior das ações.",
+        topic: "Princípios de Segurança",
+        options: [
+            ["Identificação, autenticação e autorização.", true],
+            ["Autenticação, identificação e auditoria.", false],
+            ["Autorização, autenticação e identificação.", false],
+            ["Identificação, autorização e responsabilização (accountability).", false],
+        ],
+    },
+    {
+        statement: "Um banco afirma ter implantado autenticação multifator ao exigir, no login, uma senha e também um PIN numérico memorizado pelo cliente. Um auditor aponta que isso não caracteriza MFA verdadeira. Qual é a justificativa correta?",
+        explanation: "MFA exige combinar fatores de categorias distintas (algo que se sabe, se tem ou se é); senha e PIN são ambos algo que o usuário sabe, então contam como um único fator. Não são necessários quatro fatores, nem a fraqueza relativa ou o meio de digitação é o motivo.",
+        topic: "Princípios de Segurança",
+        options: [
+            ["MFA exige no mínimo quatro fatores diferentes combinados entre si.", false],
+            ["O PIN é considerado um fator mais fraco e por isso é desconsiderado na contagem.", false],
+            ["Como ambos são digitados pelo teclado, o sistema os trata como um único dado de entrada combinado.", false],
+            ["Senha e PIN pertencem ao mesmo fator, algo que o usuário sabe.", true],
+        ],
+    },
+    {
+        statement: "Durante a análise de risco de um data center, a equipe lista enchentes, um funcionário mal-intencionado e falhas de energia como possíveis causas de dano aos ativos. Como esses itens são classificados na gestão de risco?",
+        explanation: "Ameaça é qualquer evento ou agente com potencial de causar dano a um ativo. Vulnerabilidade é a fraqueza que a ameaça explora, risco residual é o que permanece após os controles e salvaguardas são os próprios controles de proteção.",
+        topic: "Princípios de Segurança",
+        options: [
+            ["Vulnerabilidades, pois representam fraquezas internas dos sistemas.", false],
+            ["Ameaças, pois são eventos ou agentes com potencial de causar dano.", true],
+            ["Riscos residuais que permanecem após a aplicação dos controles.", false],
+            ["Salvaguardas, pois indicam onde controles de proteção precisarão futuramente ser implementados.", false],
+        ],
+    },
+    {
+        statement: "Uma equipe precisa priorizar dois riscos: um com alta probabilidade de ocorrer, mas impacto financeiro pequeno, e outro com baixa probabilidade, porém impacto potencialmente catastrófico. Qual é a forma mais adequada de comparar a severidade dos dois?",
+        explanation: "A severidade de um risco resulta da combinação entre probabilidade e impacto, não de apenas um dos fatores isoladamente. Olhar só a probabilidade ou só o impacto distorce a priorização, e adiar a análise até a concretização anula o propósito da gestão de risco.",
+        topic: "Princípios de Segurança",
+        options: [
+            ["Considerar apenas a probabilidade, tratando primeiro o que tem mais chance de ocorrer.", false],
+            ["Considerar apenas o impacto, tratando primeiro o de maior perda potencial.", false],
+            ["Avaliar cada risco combinando sua probabilidade com o impacto esperado.", true],
+            ["Ignorar ambos até que um deles efetivamente se concretize e gere prejuízo mensurável à operação.", false],
+        ],
+    },
+    {
+        statement: "Uma empresa avalia lançar um aplicativo que coletaria dados de saúde dos usuários, mas conclui que os riscos regulatórios e de vazamento superam qualquer benefício e decide cancelar o projeto por completo. Que tratamento de risco foi adotado?",
+        explanation: "Cancelar por completo a atividade que gera o risco caracteriza evitar o risco. Mitigar seria reduzir o risco com controles, transferir seria repassá-lo a terceiros e aceitar seria conviver com ele mantendo o projeto.",
+        topic: "Princípios de Segurança",
+        options: [
+            ["Evitar o risco.", true],
+            ["Mitigar o risco.", false],
+            ["Transferir o risco.", false],
+            ["Aceitar o risco como parte do custo de inovação da organização.", false],
+        ],
+    },
+    {
+        statement: "Preocupada com invasões, uma empresa mantém no ar o serviço online que precisa oferecer, mas instala firewall, sistema de detecção de intrusão e aplica atualizações de segurança para reduzir a chance de comprometimento. Esse tratamento de risco é chamado de:",
+        explanation: "Aplicar controles para reduzir a probabilidade ou o impacto, mantendo a atividade, é mitigar o risco. A empresa não deixou de oferecer o serviço (não evitou), não o repassou a terceiros (não transferiu) e não escolheu apenas conviver com ele (não aceitou).",
+        topic: "Princípios de Segurança",
+        options: [
+            ["Aceitação do risco.", false],
+            ["Transferência do risco.", false],
+            ["Evitação do risco, já que a empresa deixa de expor o serviço à internet.", false],
+            ["Mitigação do risco.", true],
+        ],
+    },
+    {
+        statement: "Após avaliar o risco de um servidor interno de testes ficar indisponível por algumas horas, a direção conclui que o impacto é mínimo e que qualquer proteção adicional não se justifica, optando por não tomar nenhuma ação além de documentar a decisão. Esse tratamento é:",
+        explanation: "Reconhecer o risco, julgá-lo tolerável e conviver com ele de forma consciente e documentada é aceitar o risco. Não houve controle adicional (mitigar), repasse a terceiros (transferir) nem eliminação da atividade (evitar).",
+        topic: "Princípios de Segurança",
+        options: [
+            ["Transferência do risco.", false],
+            ["Aceitação do risco.", true],
+            ["Mitigação do risco.", false],
+            ["Evitação do risco, com a desativação definitiva do servidor de testes envolvido.", false],
+        ],
+    },
+    {
+        statement: "Depois de implantar criptografia, controle de acesso e backups para proteger um banco de dados, a equipe reconhece que ainda permanece uma pequena chance de comprometimento. Como se chama o risco que permanece após a aplicação dos controles?",
+        explanation: "Risco residual é o que sobra após a aplicação dos controles. Risco inerente é o existente antes de qualquer controle e apetite de risco é quanto risco a organização se dispõe a assumir, nenhum deles correspondendo ao que remanesce.",
+        topic: "Princípios de Segurança",
+        options: [
+            ["Risco inerente.", false],
+            ["Apetite de risco.", false],
+            ["Risco residual.", true],
+            ["Risco total, que corresponde à soma de todas as ameaças mapeadas no ambiente.", false],
+        ],
+    },
+    {
+        statement: "Ao classificar seus controles de segurança, uma empresa precisa enquadrar a política de mesa limpa, o treinamento de conscientização e a verificação de antecedentes de candidatos. A que categoria de controle esses três exemplos pertencem?",
+        explanation: "Políticas, treinamentos e verificações de RH são controles administrativos, baseados em regras e processos definidos por pessoas. Controles físicos protegem o ambiente, técnicos atuam por meio de tecnologia e corretivo se refere à função, não à natureza do controle.",
+        topic: "Princípios de Segurança",
+        options: [
+            ["Controles administrativos.", true],
+            ["Controles físicos.", false],
+            ["Controles técnicos, também chamados de lógicos.", false],
+            ["Controles corretivos, aplicados somente após a ocorrência de um incidente de segurança.", false],
+        ],
+    },
+    {
+        statement: "Após um ataque de ransomware criptografar arquivos, a equipe restaura os dados a partir dos backups e reconstrói os servidores afetados para retornar à operação normal. Quanto à função, esse tipo de controle é classificado como:",
+        explanation: "Controles corretivos atuam após o incidente para restaurar a operação, como a restauração de backups. Preventivos buscam impedir o incidente, detectivos identificam sua ocorrência e dissuasórios desencorajam o atacante antes da ação.",
+        topic: "Princípios de Segurança",
+        options: [
+            ["Preventivo.", false],
+            ["Detectivo.", false],
+            ["Dissuasório, cujo objetivo é desencorajar o atacante antes de qualquer tentativa.", false],
+            ["Corretivo.", true],
+        ],
+    },
+    {
+        statement: "Uma empresa instala placas visíveis avisando que o local é monitorado e mantém um carro de segurança estacionado à vista na entrada, com o objetivo principal de desencorajar invasores antes que tentem qualquer ação. Quanto à função, esses controles são classificados como:",
+        explanation: "Controles dissuasórios buscam desencorajar a ação antes que ela ocorra, como avisos e presença ostensiva de segurança. Detectivos identificam eventos, corretivos restauram após o fato e compensatórios substituem outro controle que não pôde ser implementado.",
+        topic: "Princípios de Segurança",
+        options: [
+            ["Corretivos.", false],
+            ["Dissuasórios.", true],
+            ["Detectivos.", false],
+            ["Compensatórios, adotados como alternativa quando o controle principal não pode ser implementado.", false],
+        ],
+    },
+    {
+        statement: "No conjunto de documentos de governança de uma empresa, um deles reúne recomendações e boas práticas sugeridas, que as equipes podem seguir com flexibilidade e sem caráter obrigatório. Esse tipo de documento é conhecido como:",
+        explanation: "Diretrizes são recomendações e boas práticas de caráter opcional. Políticas definem intenções de alto nível, normas estabelecem requisitos obrigatórios específicos e procedimentos detalham passos obrigatórios de execução.",
+        topic: "Princípios de Segurança",
+        options: [
+            ["Política (policy).", false],
+            ["Norma ou padrão (standard).", false],
+            ["Diretriz (guideline).", true],
+            ["Procedimento (procedure), que descreve o passo a passo obrigatório a ser executado.", false],
+        ],
+    },
+    {
+        statement: "A diretoria de uma empresa publica uma declaração de alto nível afirmando que todo dado de cliente deve ser protegido. Em seguida, a área técnica precisa criar um documento obrigatório determinando que todos os discos sejam criptografados com AES de 256 bits. Esse documento técnico e obrigatório é:",
+        explanation: "Normas (standards) estabelecem requisitos obrigatórios e específicos, como o algoritmo de criptografia a ser usado, dando concretude à política. Diretrizes são recomendações opcionais, a política é a declaração de alto nível e leis vêm de autoridades externas.",
+        topic: "Princípios de Segurança",
+        options: [
+            ["Uma norma (standard).", true],
+            ["Uma diretriz (guideline).", false],
+            ["Uma política (policy).", false],
+            ["Uma lei, imposta por um órgão externo de regulação do setor de tecnologia.", false],
+        ],
+    },
+    {
+        statement: "Um analista precisa distinguir duas proteções: cifrar um banco de dados para que apenas pessoas autorizadas leiam seu conteúdo e calcular um valor de hash para perceber se os registros foram alterados sem autorização. Essas duas medidas protegem, respectivamente:",
+        explanation: "Cifrar para impedir a leitura não autorizada protege a confidencialidade; verificar alterações por hash protege a integridade. Disponibilidade trata do acesso quando necessário e autenticidade da origem, que não são o foco dessas duas medidas.",
+        topic: "Princípios de Segurança",
+        options: [
+            ["A integridade e a disponibilidade.", false],
+            ["A disponibilidade e a autenticidade.", false],
+            ["A confidencialidade e a disponibilidade, garantindo sigilo e acesso contínuo aos registros armazenados.", false],
+            ["A confidencialidade e a integridade.", true],
+        ],
+    },
+    {
+        statement: "Uma empresa mantém constantemente uma equipe pesquisando novas ameaças, revisando fornecedores e verificando se seus controles continuam adequados ao longo do tempo. Essa conduta contínua de investigar e acompanhar para tomar decisões informadas é melhor descrita como:",
+        explanation: "Due diligence é o esforço contínuo de investigar, monitorar e reunir informações para agir de forma responsável. Due care é a aplicação prática das medidas de proteção no dia a dia; os demais termos tratam de acesso e de risco.",
+        topic: "Princípios de Segurança",
+        options: [
+            ["Due care (devido cuidado).", false],
+            ["Due diligence (devida diligência).", true],
+            ["Separação de funções.", false],
+            ["Aceitação de risco formalizada por meio de um termo assinado pela alta direção.", false],
+        ],
+    },
+    {
+        statement: "Em vez de confiar apenas na senha de login, a empresa protege um sistema crítico combinando senha, autenticação em duas etapas, criptografia dos dados, segmentação de rede e monitoramento de acessos, de modo que a falha de uma camada não comprometa todo o conjunto. Que princípio orienta essa abordagem?",
+        explanation: "Defesa em profundidade empilha múltiplas camadas de controle para que a falha de uma não exponha todo o sistema. Privilégio mínimo limita permissões, não repúdio impede negar autoria e segurança por obscuridade aposta em esconder detalhes, o que não é o caso.",
+        topic: "Princípios de Segurança",
+        options: [
+            ["Privilégio mínimo.", false],
+            ["Não repúdio.", false],
+            ["Defesa em profundidade.", true],
+            ["Segurança por obscuridade, que se baseia em manter secretos os detalhes de funcionamento do sistema.", false],
+        ],
+    },
+    {
+        statement: "Ao revisar quais dados exigem proteção reforçada de privacidade, uma equipe analisa uma lista de campos. Qual dos itens a seguir é uma informação pessoal identificável (PII) que merece esse tratamento?",
+        explanation: "O CPF identifica uma pessoa específica, sendo uma informação pessoal identificável (PII). Cotação do dólar, horário de funcionamento e versão de sistema operacional não identificam indivíduos e não são dados pessoais.",
+        topic: "Princípios de Segurança",
+        options: [
+            ["O número de CPF de um cliente.", true],
+            ["A cotação atual do dólar comercial.", false],
+            ["O horário de funcionamento da loja divulgado ao público.", false],
+            ["A versão do sistema operacional instalada em um servidor de uso interno da empresa.", false],
+        ],
+    },
+    {
+        statement: "O Código de Ética da ISC2 organiza a conduta dos profissionais em quatro cânones ordenados por prioridade. Qual preocupação o primeiro cânone coloca acima das demais?",
+        explanation: "O primeiro cânone determina proteger a sociedade, o bem comum e a confiança pública, tendo precedência sobre os demais. Agir com honra, servir bem os contratantes e zelar pela profissão são os cânones seguintes, subordinados a esse.",
+        topic: "Princípios de Segurança",
+        options: [
+            ["Agir de forma honrada, honesta e legal com cada cliente.", false],
+            ["Prestar serviço diligente e competente aos contratantes.", false],
+            ["Promover e proteger a reputação e o avanço contínuo da própria profissão de segurança.", false],
+            ["Proteger a sociedade, o bem comum e a confiança pública.", true],
+        ],
+    },
+    {
+        statement: "A diretoria pergunta qual é a diferença essencial entre o plano de continuidade de negócios (BCP) e o plano de recuperação de desastres (DRP) da empresa. Qual resposta descreve corretamente essa distinção?",
+        explanation: "O BCP tem escopo amplo e visa manter o negócio funcionando durante a crise; o DRP é o componente técnico voltado a restaurar sistemas e TI após o desastre. Eles não são o mesmo documento nem se limitam a backups, RH ou comunicação.",
+        topic: "Continuidade, DR e Resposta a Incidentes",
+        options: [
+            ["O BCP trata apenas de backups de dados, ao passo que o DRP cuida da comunicação com a imprensa e com os clientes durante a crise.", false],
+            ["O BCP mantém as funções essenciais do negócio operando durante a interrupção; o DRP foca em restaurar a TI depois do desastre.", true],
+            ["O DRP é mais amplo e engloba o BCP, que cuidaria somente da folha de pagamento e dos recursos humanos da organização afetada.", false],
+            ["Ambos são o mesmo documento, apenas com nomes diferentes conforme o setor.", false],
+        ],
+    },
+    {
+        statement: "O time de segurança nota atividades incomuns em um servidor, examina os logs para confirmar se realmente houve comprometimento, determina o escopo e classifica a gravidade da ocorrência. Nenhum sistema foi isolado ainda. A que fase da resposta a incidentes essa atuação corresponde?",
+        explanation: "Identificar sinais, examinar logs e classificar a gravidade da ocorrência é a fase de detecção e análise. A preparação ocorre antes do incidente, a contenção só começa depois (e nada foi isolado ainda) e o pós-incidente vem ao final.",
+        topic: "Continuidade, DR e Resposta a Incidentes",
+        options: [
+            ["Preparação.", false],
+            ["Contenção, erradicação e recuperação.", false],
+            ["Atividade pós-incidente, quando são documentadas as lições aprendidas com o caso.", false],
+            ["Detecção e análise.", true],
+        ],
+    },
+    {
+        statement: "Encerrado um incidente e restabelecida a operação normal, a equipe se reúne para revisar o que funcionou, o que falhou e como atualizar os procedimentos para reduzir a chance de recorrência. Essa reunião faz parte de qual fase?",
+        explanation: "Revisar o incidente já encerrado para extrair lições e melhorar os processos é a atividade pós-incidente. Detecção, contenção e erradicação acontecem durante o tratamento, e a preparação antecede qualquer incidente.",
+        topic: "Continuidade, DR e Resposta a Incidentes",
+        options: [
+            ["Atividade pós-incidente (lições aprendidas).", true],
+            ["Detecção e análise.", false],
+            ["Contenção e erradicação.", false],
+            ["Preparação, etapa em que a organização ainda está montando sua capacidade inicial de resposta.", false],
+        ],
+    },
+    {
+        statement: "Um analista precisa usar a terminologia correta para três casos: um login de rotina bem-sucedido; um acesso não autorizado que efetivamente expôs dados de clientes; e uma tentativa suspeita que infringiu a política de segurança. Como esses casos são melhor classificados, respectivamente?",
+        explanation: "Um login de rotina é apenas um evento (ocorrência observável); o acesso que expôs dados de clientes é uma violação (breach); a tentativa que infringiu a política é um incidente. Nem toda ocorrência é incidente, e nem todo incidente resulta em breach.",
+        topic: "Continuidade, DR e Resposta a Incidentes",
+        options: [
+            ["Incidente, evento e violação de dados.", false],
+            ["Violação de dados, incidente e evento.", false],
+            ["Evento, violação de dados (breach) e incidente.", true],
+            ["Todos são incidentes, diferenciados apenas pela gravidade e pelo momento em que são detectados pela equipe.", false],
+        ],
+    },
+    {
+        statement: "Atacantes começam a explorar uma falha em um software para a qual o fabricante ainda não disponibilizou correção, pois desconhecia o problema. O código ou técnica usado para tirar proveito dessa falha também tem um nome específico. Como se chamam, respectivamente, a falha e a técnica de exploração?",
+        explanation: "Uma falha ainda desconhecida do fornecedor e sem correção é uma vulnerabilidade de dia zero (zero-day); o código ou técnica que a explora é o exploit. As demais opções invertem os termos ou citam conceitos não relacionados à pergunta.",
+        topic: "Continuidade, DR e Resposta a Incidentes",
+        options: [
+            ["Exploit e vulnerabilidade de dia zero.", false],
+            ["Vulnerabilidade de dia zero (zero-day) e exploit.", true],
+            ["Incidente e violação de dados (breach).", false],
+            ["Ameaça persistente avançada e engenharia social aplicada em larga escala contra os usuários.", false],
+        ],
+    },
+    {
+        statement: "Um administrador quer uma estratégia de backup em que cada rotina diária copie somente os arquivos alterados desde o último backup completo, acumulando as mudanças até o próximo backup completo. Que tipo de backup atende a essa descrição?",
+        explanation: "O backup diferencial copia tudo o que mudou desde o último backup completo, acumulando as alterações. O incremental copia apenas o que mudou desde o último backup de qualquer tipo, e o completo copia todos os dados a cada execução.",
+        topic: "Continuidade, DR e Resposta a Incidentes",
+        options: [
+            ["Backup incremental.", false],
+            ["Backup completo (full) diário.", false],
+            ["Backup incremental combinado com espelhamento contínuo dos dados em tempo real.", false],
+            ["Backup diferencial.", true],
+        ],
+    },
+    {
+        statement: "Uma empresa quer um local alternativo capaz de assumir a operação quase imediatamente após um desastre, com hardware, software e dados já replicados e prontos para uso. Que tipo de site de recuperação atende a essa necessidade?",
+        explanation: "O hot site já possui hardware, software e dados replicados, permitindo retomar a operação quase imediatamente. O warm site tem infraestrutura parcial e exige configuração, o cold site oferece só o espaço básico, e backup offline demanda restauração demorada.",
+        topic: "Continuidade, DR e Resposta a Incidentes",
+        options: [
+            ["Site quente (hot site).", true],
+            ["Site morno (warm site).", false],
+            ["Site frio (cold site).", false],
+            ["Backup em nuvem armazenado offline, restaurado manualmente somente após a reconstrução completa do ambiente.", false],
+        ],
+    },
+    {
+        statement: "Uma analista percebe que os funcionarios conseguem acessar sites digitando nomes como intranet.empresa.com, mas o servico responsavel por traduzir esses nomes em enderecos IP parou de responder e ninguem mais consegue navegar por nome. Qual servico apresentou falha?",
+        explanation: "O DNS (Domain Name System), que opera tipicamente na porta 53, traduz nomes como intranet.empresa.com nos enderecos IP correspondentes; sem ele, a navegacao por nome falha.",
+        topic: "Segurança de Redes",
+        options: [
+            ["DHCP, que distribui automaticamente enderecos IP e outras configuracoes de rede para os dispositivos que se conectam ao segmento", false],
+            ["DNS, que resolve nomes de dominio para os enderecos IP correspondentes", true],
+            ["SMTP, responsavel pelo envio de mensagens de e-mail entre servidores", false],
+            ["ARP, que associa enderecos IP a enderecos fisicos MAC dentro da rede local", false],
+        ],
+    },
+    {
+        statement: "Ao conectar um notebook novo a rede cabeada do escritorio, ele recebe automaticamente um endereco IP, a mascara de sub-rede e o gateway padrao, sem que o usuario configure nada manualmente. Qual protocolo fornece essas informacoes de forma automatica?",
+        explanation: "O DHCP (Dynamic Host Configuration Protocol) atribui dinamicamente endereco IP, mascara, gateway e servidores DNS aos dispositivos, dispensando a configuracao manual.",
+        topic: "Segurança de Redes",
+        options: [
+            ["DNS, responsavel por converter nomes de dominio em enderecos IP na internet e tambem dentro da rede interna da empresa", false],
+            ["NAT, que traduz enderecos privados em publicos na saida para a internet", false],
+            ["DHCP, que atribui enderecos IP e parametros de rede automaticamente aos dispositivos", true],
+            ["SNMP, usado para monitorar e gerenciar equipamentos de rede remotamente", false],
+        ],
+    },
+    {
+        statement: "Uma empresa transfere diariamente arquivos com dados de clientes para um parceiro. A equipe de seguranca descobre que o protocolo em uso envia login, senha e conteudo em texto claro pela rede. Qual alternativa mantem a transferencia de arquivos, porem de forma cifrada?",
+        explanation: "O SFTP realiza a transferencia de arquivos sobre um canal criptografado (SSH), protegendo credenciais e conteudo; o FTP tradicional trafega tudo em texto claro, e restringir IP nao protege o dado em transito.",
+        topic: "Segurança de Redes",
+        options: [
+            ["Continuar com FTP, mas restringindo o acesso apenas a determinados enderecos IP por meio de regras configuradas no firewall de borda", false],
+            ["Adotar HTTP para publicar os arquivos em um servidor web interno da empresa", false],
+            ["Usar Telnet para acessar o servidor remoto e copiar os arquivos manualmente", false],
+            ["Substituir por SFTP, que transfere os arquivos sobre um canal criptografado", true],
+        ],
+    },
+    {
+        statement: "Uma empresa vai implantar videoconferencia e chamadas de voz em tempo real. Os engenheiros preferem um protocolo de transporte que priorize velocidade e baixa latencia, tolerando a perda ocasional de alguns pacotes em vez de retransmiti-los. Qual protocolo atende melhor a esse requisito?",
+        explanation: "O UDP e sem conexao e nao retransmite pacotes perdidos, o que reduz a latencia e o torna adequado a voz e video em tempo real; o TCP prioriza a confiabilidade em detrimento da velocidade.",
+        topic: "Segurança de Redes",
+        options: [
+            ["TCP, porque estabelece conexao com handshake de tres vias e retransmite qualquer pacote perdido para garantir a entrega ordenada", false],
+            ["ICMP, porque e usado para diagnostico e mensagens de controle entre dispositivos de rede", false],
+            ["UDP, porque e sem conexao e prioriza a rapidez em vez de garantir a entrega", true],
+            ["HTTP, porque e o protocolo padrao para o trafego de aplicacoes web modernas", false],
+        ],
+    },
+    {
+        statement: "O administrador de e-mail investiga por que as mensagens enviadas pelos funcionarios nao estao saindo para destinatarios externos, embora o recebimento funcione. Ele suspeita de bloqueio no protocolo usado para enviar mensagens entre servidores de correio. Qual protocolo e responsavel por esse envio?",
+        explanation: "O SMTP (Simple Mail Transfer Protocol), tipicamente nas portas 25 ou 587, realiza o envio de mensagens entre servidores; IMAP e POP3 tratam do recebimento e da leitura.",
+        topic: "Segurança de Redes",
+        options: [
+            ["IMAP, que permite ao cliente ler e organizar as mensagens mantidas no servidor a partir de varios dispositivos diferentes", false],
+            ["POP3, que baixa as mensagens do servidor para o dispositivo local do usuario", false],
+            ["SNMP, usado para o gerenciamento e a coleta de metricas de equipamentos de rede", false],
+            ["SMTP, responsavel pelo envio de e-mails entre servidores de correio", true],
+        ],
+    },
+    {
+        statement: "Um analista revisa o modelo OSI e precisa identificar em qual camada operam o enderecamento logico IP e o roteamento de pacotes entre redes diferentes. Qual camada desempenha essa funcao?",
+        explanation: "A camada de rede (camada 3 do OSI) cuida do enderecamento logico IP e do roteamento de pacotes entre redes distintas; os roteadores operam nessa camada.",
+        topic: "Segurança de Redes",
+        options: [
+            ["A camada de rede (camada 3), responsavel pelo enderecamento IP e pelo roteamento entre redes", true],
+            ["A camada de enlace (camada 2), que organiza os bits em quadros e usa enderecos MAC dentro do mesmo segmento local", false],
+            ["A camada de transporte (camada 4), que segmenta os dados e controla a entrega fim a fim", false],
+            ["A camada fisica (camada 1), que trata da transmissao eletrica dos bits pelo meio", false],
+        ],
+    },
+    {
+        statement: "Em uma rede local, um dispositivo recebe quadros e os encaminha apenas para a porta onde esta conectado o destinatario, com base em uma tabela de enderecos fisicos que ele aprende. Que dispositivo desempenha esse papel dentro do segmento local?",
+        explanation: "O switch opera na camada de enlace e usa a tabela de enderecos MAC para encaminhar quadros somente a porta do destinatario, ao contrario do hub, que replica para todas as portas.",
+        topic: "Segurança de Redes",
+        options: [
+            ["Um roteador, que interliga redes diferentes e decide o caminho dos pacotes com base no endereco IP de destino", false],
+            ["Um switch, que encaminha quadros na rede local com base em enderecos MAC", true],
+            ["Um repetidor, que apenas amplifica o sinal para estender o alcance fisico", false],
+            ["Um modem, que converte sinais entre a rede local e a operadora", false],
+        ],
+    },
+    {
+        statement: "Uma empresa quer que todo o acesso dos funcionarios a sites externos passe por um unico ponto capaz de aplicar filtros de conteudo, registrar os acessos e ocultar os enderecos internos das estacoes. Qual solucao atende diretamente a esse objetivo?",
+        explanation: "Um proxy de saida (forward proxy) intermedeia as requisicoes dos usuarios a internet, permitindo filtragem de conteudo, registro de acessos e ocultacao dos IPs internos.",
+        topic: "Segurança de Redes",
+        options: [
+            ["Um servidor proxy de saida, que intermedeia as requisicoes web dos usuarios para a internet", true],
+            ["Um switch gerenciavel, que segmenta a rede em VLANs e separa os dominios de broadcast entre os diferentes setores", false],
+            ["Um servidor DHCP, que centraliza a distribuicao de enderecos IP para os dispositivos", false],
+            ["Um ponto de acesso sem fio, que conecta os dispositivos moveis a rede cabeada", false],
+        ],
+    },
+    {
+        statement: "Uma empresa tem escritorios em tres cidades diferentes e precisa interliga-los para que funcionem como uma unica rede corporativa, trocando dados por longas distancias. Que tipo de rede descreve essa interligacao entre sites geograficamente distantes?",
+        explanation: "Uma WAN (Wide Area Network) interliga redes em locais geograficamente distantes, como escritorios em cidades diferentes; a LAN se limita a uma area local.",
+        topic: "Segurança de Redes",
+        options: [
+            ["LAN, uma rede local que conecta dispositivos dentro de um mesmo predio ou area restrita usando cabeamento proprio", false],
+            ["VLAN, um agrupamento logico que separa o trafego de grupos de dispositivos em um mesmo switch", false],
+            ["PAN, uma rede pessoal de curtissimo alcance entre dispositivos de um unico usuario", false],
+            ["WAN, uma rede que interliga sites em areas geograficamente distantes", true],
+        ],
+    },
+    {
+        statement: "Duas filiais de uma empresa, em cidades diferentes, precisam trocar trafego interno como se estivessem na mesma rede, usando a internet publica, mas sem expor os dados. A equipe quer um tunel cifrado permanente entre os dois roteadores das filiais. Qual solucao atende?",
+        explanation: "Uma VPN site a site cria um tunel criptografado permanente entre os gateways das duas redes, permitindo que as filiais troquem trafego interno com seguranca pela internet publica.",
+        topic: "Segurança de Redes",
+        options: [
+            ["Publicar os servicos internos de cada filial em uma DMZ acessivel pela internet, protegida por um firewall dedicado em cada ponta", false],
+            ["Uma conta de proxy reverso hospedada na nuvem para encaminhar as requisicoes entre as filiais", false],
+            ["Uma VPN site a site, que estabelece um tunel criptografado permanente entre as redes das filiais", true],
+            ["Um servidor FTP central para que cada filial deposite e retire os arquivos que precisa trocar", false],
+        ],
+    },
+    {
+        statement: "Durante a analise de um ataque, a equipe descobre que os pacotes maliciosos traziam um endereco IP de origem falsificado, fazendo-os parecer vindos de um servidor confiavel da propria rede. Que tecnica o atacante utilizou?",
+        explanation: "No spoofing, o atacante falsifica o endereco de origem (por exemplo, IP ou MAC) para se passar por uma entidade confiavel e enganar controles baseados na identidade de rede.",
+        topic: "Segurança de Redes",
+        options: [
+            ["Sniffing, capturando passivamente o trafego que circula pela rede para extrair dados sensiveis que trafegam em texto claro", false],
+            ["Spoofing, forjando o endereco de origem para se passar por uma fonte confiavel", true],
+            ["Forca bruta, testando sistematicamente combinacoes de credenciais ate acertar", false],
+            ["Phishing, enviando mensagens fraudulentas para induzir a vitima a revelar informacoes", false],
+        ],
+    },
+    {
+        statement: "Em uma rede onde varios servicos ainda usam protocolos sem criptografia, um atacante com acesso ao segmento consegue capturar e ler senhas e mensagens que trafegam entre os dispositivos, sem alterar o trafego. Qual medida elimina de forma mais direta a exposicao desse conteudo?",
+        explanation: "O sniffing e a captura passiva de trafego; cifrar as comunicacoes com HTTPS, SSH ou TLS torna o conteudo interceptado ilegivel, neutralizando a leitura de senhas e mensagens.",
+        topic: "Segurança de Redes",
+        options: [
+            ["Aumentar a frequencia de troca de senhas dos usuarios e exigir senhas mais longas em toda a organizacao", false],
+            ["Instalar um antivirus atualizado em cada estacao de trabalho da rede", false],
+            ["Cifrar as comunicacoes com protocolos como HTTPS e SSH", true],
+            ["Ativar um servidor DHCP redundante para evitar conflitos de endereco IP", false],
+        ],
+    },
+    {
+        statement: "Uma organizacao abandona a ideia de que tudo dentro do perimetro da rede e confiavel. Agora, cada tentativa de acesso a um recurso, mesmo partindo de dentro, precisa ser autenticada e autorizada de forma explicita. Que abordagem a empresa adotou?",
+        explanation: "O modelo zero trust ('nunca confie, sempre verifique') nao concede confianca implicita com base na localizacao na rede e exige autenticacao e autorizacao a cada acesso.",
+        topic: "Segurança de Redes",
+        options: [
+            ["Defesa em profundidade, empilhando varias camadas independentes de controle para que a falha de uma seja compensada pelas demais", false],
+            ["Seguranca por obscuridade, baseando a protecao em manter os detalhes do sistema em segredo", false],
+            ["Rede plana, na qual todos os dispositivos compartilham o mesmo segmento sem divisoes", false],
+            ["Zero trust, que nao confia implicitamente em nenhuma origem e verifica cada acesso", true],
+        ],
+    },
+    {
+        statement: "Um data center virtualizado quer impedir que, se uma carga de trabalho for comprometida, o atacante consiga se mover lateralmente para as demais. A equipe decide aplicar politicas de isolamento no nivel de cada maquina virtual individual, e nao apenas por sub-rede. Que tecnica descreve essa abordagem?",
+        explanation: "A micro-segmentacao define politicas de isolamento granulares no nivel de cada carga de trabalho ou maquina virtual, limitando o movimento lateral mesmo dentro do mesmo segmento.",
+        topic: "Segurança de Redes",
+        options: [
+            ["Micro-segmentacao, que aplica politicas de isolamento no nivel de cada carga de trabalho", true],
+            ["Balanceamento de carga, que distribui as requisicoes entre varios servidores para melhorar o desempenho e a disponibilidade do servico", false],
+            ["Traducao de enderecos NAT, que mapeia os enderecos internos para um endereco publico na saida", false],
+            ["Tunelamento VPN, que cifra o trafego entre um cliente remoto e a rede corporativa", false],
+        ],
+    },
+    {
+        statement: "Ao configurar a rede sem fio de um novo escritorio, a equipe quer o padrao de seguranca mais recente para redes Wi-Fi, com protecao mais forte contra ataques de adivinhacao de senha em comparacao as geracoes anteriores. Qual opcao escolher?",
+        explanation: "O WPA3 e a geracao mais atual de seguranca Wi-Fi e oferece protecao mais robusta contra ataques de dicionario e adivinhacao de senha do que o WPA2 e, principalmente, do que o obsoleto WEP.",
+        topic: "Segurança de Redes",
+        options: [
+            ["WEP, um dos primeiros esquemas de protecao sem fio, ainda encontrado em equipamentos legados de redes domesticas e corporativas", false],
+            ["WPA3, a geracao mais recente de seguranca para redes Wi-Fi", true],
+            ["Rede aberta com um portal de autenticacao exibido no navegador do usuario", false],
+            ["Ocultar o SSID para que a rede nao apareca na lista de redes disponiveis", false],
+        ],
+    },
+    {
+        statement: "Uma equipe de desenvolvimento quer publicar suas aplicacoes sem se preocupar em instalar e manter sistema operacional, servidores de aplicacao ou runtime, apenas enviando o codigo para um ambiente pronto e gerenciado pelo provedor. Que modelo de nuvem atende a essa necessidade?",
+        explanation: "No modelo PaaS (Platform as a Service), o provedor gerencia a infraestrutura, o sistema operacional e o runtime, enquanto o cliente foca apenas em desenvolver e implantar suas aplicacoes.",
+        topic: "Segurança de Redes",
+        options: [
+            ["IaaS, no qual o provedor entrega maquinas virtuais e o cliente instala e mantem o sistema operacional e todo o software acima dele", false],
+            ["SaaS, no qual o cliente apenas consome um software pronto pela internet", false],
+            ["PaaS, que oferece uma plataforma pronta para desenvolver e executar aplicacoes", true],
+            ["Colocation, em que a empresa aloja seus proprios servidores fisicos em um data center de terceiros", false],
+        ],
+    },
+    {
+        statement: "Uma pequena empresa nao tem equipe propria de TI e contrata um terceiro para operar, monitorar e manter remotamente sua infraestrutura de rede e servidores, por meio de um contrato de servico continuo. Como se chama esse tipo de fornecedor?",
+        explanation: "Um MSP (Managed Service Provider) assume a gestao e a operacao continua da infraestrutura de TI do cliente, opcao util para organizacoes sem equipe interna dedicada.",
+        topic: "Segurança de Redes",
+        options: [
+            ["ISP, provedor que fornece apenas a conectividade de acesso a internet para a empresa", false],
+            ["MSP, provedor que gerencia e opera a infraestrutura de TI do cliente de forma continua", true],
+            ["CDN, rede de distribuicao que entrega conteudo web a partir de servidores geograficamente proximos do usuario final", false],
+            ["CASB, ferramenta que fica entre o usuario e os servicos de nuvem para aplicar politicas de seguranca e visibilidade", false],
+        ],
+    },
+    {
+        statement: "Uma fabrica instalou dezenas de sensores e cameras inteligentes conectados a rede. A equipe de seguranca se preocupa porque muitos vem com senhas padrao de fabrica e raramente recebem atualizacao. Qual conjunto de medidas reduz melhor esse risco?",
+        explanation: "Dispositivos IoT costumam ter credenciais padrao fracas e pouca atualizacao; trocar as senhas de fabrica e segmenta-los em uma rede isolada limita o impacto de um eventual comprometimento.",
+        topic: "Segurança de Redes",
+        options: [
+            ["Trocar as credenciais padrao e isolar os dispositivos em um segmento de rede separado", true],
+            ["Confiar na protecao do firewall de borda, ja que ele inspeciona todo o trafego que entra e sai da rede corporativa pela internet", false],
+            ["Conectar os dispositivos a mesma rede dos servidores para facilitar o gerenciamento centralizado", false],
+            ["Manter as senhas de fabrica, porem desativar os logs dos dispositivos para economizar armazenamento", false],
+        ],
+    },
+    {
+        statement: "Uma aplicacao web coleta dados de cartao de credito dos clientes. A equipe quer garantir que essas informacoes nao possam ser lidas por quem interceptar a comunicacao entre o navegador do cliente e o servidor. Qual medida protege os dados enquanto eles trafegam pela rede?",
+        explanation: "A criptografia em transito, tipicamente via TLS (HTTPS), protege os dados enquanto eles se movem pela rede; cifrar o banco protege os dados em repouso, mas nao durante a transmissao.",
+        topic: "Operações de Segurança",
+        options: [
+            ["Cifrar o banco de dados em repouso no servidor, de modo que os arquivos em disco fiquem ilegiveis para quem obtiver acesso fisico ao armazenamento", false],
+            ["Aplicar hash com sal em todas as senhas dos usuarios armazenadas no cadastro", false],
+            ["Fazer backups periodicos e criptografados dos dados em uma localidade remota", false],
+            ["Criptografar a comunicacao com TLS, usando HTTPS entre o navegador e o servidor", true],
+        ],
+    },
+    {
+        statement: "Um funcionario tem o notebook corporativo furtado. A empresa quer garantir que, mesmo removendo o disco e conectando-o a outra maquina, o ladrao nao consiga ler os arquivos armazenados. Qual controle atende diretamente a esse objetivo?",
+        explanation: "A criptografia de disco completo protege os dados em repouso: sem a chave, o conteudo permanece ilegivel mesmo que o disco seja removido e lido em outro equipamento. Uma senha de login sozinha nao protege o disco retirado.",
+        topic: "Operações de Segurança",
+        options: [
+            ["Exigir que o usuario use uma VPN com tunel criptografado sempre que acessar os sistemas internos pela internet a partir de redes externas", false],
+            ["Criptografia de disco completo no notebook, deixando os dados em repouso ilegiveis sem a chave", true],
+            ["Uma senha forte de login no sistema operacional, trocada periodicamente conforme a politica", false],
+            ["Um antivirus atualizado com verificacao automatica de todos os arquivos abertos", false],
+        ],
+    },
+    {
+        statement: "Depois de baixar um instalador do site de um fornecedor, um administrador quer confirmar que o arquivo nao foi corrompido nem adulterado durante o download. O fornecedor publica um valor de referencia ao lado do link. Que tecnica permite essa verificacao?",
+        explanation: "Uma funcao de hash gera um valor unico para o conteudo do arquivo; se o hash calculado localmente coincide com o publicado pelo fornecedor, o arquivo esta integro e nao foi alterado.",
+        topic: "Operações de Segurança",
+        options: [
+            ["Cifrar o arquivo com uma chave simetrica compartilhada previamente com o fornecedor antes de executa-lo na maquina de destino", false],
+            ["Verificar se o arquivo foi transferido por uma conexao HTTPS valida com o site", false],
+            ["Comparar o hash calculado do arquivo baixado com o valor publicado pelo fornecedor", true],
+            ["Executar o instalador em uma conta de usuario sem privilegios administrativos", false],
+        ],
+    },
+    {
+        statement: "Ao projetar um sistema que precisa cifrar grandes volumes de dados com bom desempenho, mas tambem resolver o problema de distribuir a chave com seguranca entre partes que nunca se comunicaram, um arquiteto combina os dois tipos de criptografia. Como essa combinacao costuma funcionar?",
+        explanation: "Sistemas hibridos usam a criptografia assimetrica (mais lenta) apenas para trocar com seguranca uma chave simetrica, e depois a simetrica (mais rapida) para cifrar o grande volume de dados.",
+        topic: "Operações de Segurança",
+        options: [
+            ["Usa criptografia assimetrica para proteger a troca da chave e simetrica para cifrar os dados em massa", true],
+            ["Usa exclusivamente criptografia assimetrica para tudo, por ser mais rapida do que a simetrica ao processar grandes quantidades de dados de forma continua", false],
+            ["Usa apenas funcoes de hash, que permitiriam recuperar o conteudo original a partir do resumo gerado", false],
+            ["Usa a mesma chave publica para cifrar e decifrar, compartilhando-a abertamente com todos", false],
+        ],
+    },
+    {
+        statement: "Apos uma alteracao nao documentada em um servidor de producao derrubar um sistema critico, a diretoria determina que toda mudanca passe por solicitacao formal, avaliacao de impacto, aprovacao e plano de reversao antes de ser aplicada. Que processo esta sendo implantado?",
+        explanation: "A gestao de mudanca (change management) exige que as alteracoes passem por solicitacao formal, avaliacao de impacto, aprovacao e plano de reversao, reduzindo interrupcoes causadas por mudancas descontroladas.",
+        topic: "Operações de Segurança",
+        options: [
+            ["Gestao de incidentes, focada em detectar, responder e restaurar os servicos o mais rapido possivel apos uma interrupcao ja ocorrida", false],
+            ["Gestao de patches, restrita a aplicacao de correcoes de seguranca liberadas pelos fornecedores", false],
+            ["Analise de risco, que identifica e prioriza as ameacas aos ativos da organizacao", false],
+            ["Gestao de mudanca, que formaliza solicitacao, avaliacao, aprovacao e reversao das alteracoes", true],
+        ],
+    },
+    {
+        statement: "Uma equipe define uma configuracao segura padrao para todos os servidores e passa a comparar periodicamente cada maquina com esse padrao, para detectar desvios nao autorizados. Que pratica descreve o estabelecimento e a manutencao dessa referencia?",
+        explanation: "A gestao de configuracao estabelece uma baseline segura de referencia e monitora os sistemas em busca de desvios (drift), garantindo que permanecam em um estado conhecido e aprovado.",
+        topic: "Operações de Segurança",
+        options: [
+            ["Gestao de configuracao, com uma baseline segura usada para detectar desvios", true],
+            ["Recuperacao de desastres, que planeja como restaurar as operacoes em um local alternativo depois de um evento que destrua o ambiente principal", false],
+            ["Teste de penetracao, em que especialistas simulam ataques para encontrar vulnerabilidades exploraveis", false],
+            ["Classificacao de dados, que rotula as informacoes conforme o seu grau de sensibilidade", false],
+        ],
+    },
+    {
+        statement: "Apos um incidente, os investigadores tiveram dificuldade porque cada servidor guardava seus registros apenas localmente e muitos ja haviam sido sobrescritos. A equipe quer garantir que os logs sejam reunidos em um repositorio central e preservados por um periodo definido. Que medida atende a esse objetivo?",
+        explanation: "Centralizar os logs em um repositorio dedicado, com politica de retencao definida, evita a perda por sobrescrita local e facilita a correlacao e a investigacao apos incidentes.",
+        topic: "Operações de Segurança",
+        options: [
+            ["Aumentar o nivel de detalhe dos registros em cada servidor, mantendo-os apenas no disco local de cada maquina, para nao sobrecarregar a rede", false],
+            ["Encaminhar os logs para um servidor central e aplicar uma politica de retencao", true],
+            ["Desativar os registros dos sistemas menos criticos para liberar espaco em disco", false],
+            ["Permitir que cada administrador defina livremente quando apagar os proprios logs", false],
+        ],
+    },
+    {
+        statement: "Em um sistema de controle de acesso, uma analista de RH acessa um arquivo com a folha de pagamento armazenado em um servidor. Nessa interação, como são classificados a analista e o arquivo, respectivamente?",
+        explanation: "O sujeito e a entidade ativa que solicita acesso (a analista), e o objeto e o recurso passivo acessado (o arquivo). Processos e servidores tambem podem atuar como sujeitos, mas aqui quem inicia o acesso e a pessoa.",
+        topic: "Controle de Acesso",
+        options: [
+            ["A analista e o sujeito e o arquivo e o objeto.", true],
+            ["A analista e o objeto e o arquivo e o sujeito, pois o dado tem prioridade.", false],
+            ["Ambos sao objetos, ja que o servidor e o unico sujeito da operacao.", false],
+            ["A analista e o objeto porque e ela quem sofre a acao de autenticacao, enquanto o servidor que hospeda o arquivo assume o papel de sujeito ativo da transacao.", false],
+        ],
+    },
+    {
+        statement: "Uma empresa quer que o acesso a cada documento seja decidido dinamicamente combinando varios atributos ao mesmo tempo: o departamento do usuario, a localizacao de onde ele se conecta, o horario e o tipo de dispositivo. Qual modelo de controle de acesso atende melhor a essa necessidade?",
+        explanation: "O ABAC (Attribute-Based Access Control) decide o acesso avaliando atributos do sujeito, do objeto e do ambiente, sendo ideal quando as regras dependem de multiplos fatores contextuais. O RBAC associa permissoes apenas a papeis fixos.",
+        topic: "Controle de Acesso",
+        options: [
+            ["RBAC, pois basta criar um papel para cada departamento.", false],
+            ["ABAC, que avalia atributos do usuario, do recurso e do contexto.", true],
+            ["MAC, ja que o sistema operacional impoe rotulos fixos aos arquivos.", false],
+            ["DAC, porque o proprietario de cada documento pode ajustar manualmente as permissoes conforme o departamento, o horario e o dispositivo de cada colega.", false],
+        ],
+    },
+    {
+        statement: "Uma analista possui liberacao de seguranca no nivel 'confidencial', o mesmo nivel de um relatorio de um projeto interno. Ainda assim, o sistema nega seu acesso porque ela nao faz parte da equipe daquele projeto. Qual principio justifica essa negacao?",
+        explanation: "O need-to-know (necessidade de conhecer) restringe o acesso apenas a quem precisa da informacao para executar suas tarefas, mesmo que a pessoa tenha o nivel de classificacao adequado. Ter a liberacao correta e necessario, mas nao suficiente.",
+        topic: "Controle de Acesso",
+        options: [
+            ["Separacao de funcoes, que impede que uma unica pessoa concentre etapas conflitantes de um mesmo processo critico de negocio.", false],
+            ["Menor privilegio apenas, ja que o nivel de liberacao dela e suficiente.", false],
+            ["Need-to-know, pois ter o nivel de liberacao nao basta sem necessidade de conhecer.", true],
+            ["Nao repudio, que garante a autoria das acoes realizadas no sistema.", false],
+        ],
+    },
+    {
+        statement: "A porta de uma sala de servidores usa um leitor de iris para liberar a entrada. A equipe de seguranca esta preocupada com a taxa de falsa aceitacao (FAR) desse leitor. O que uma FAR alta significa na pratica?",
+        explanation: "A taxa de falsa aceitacao (FAR) mede com que frequencia o sistema biometrico aceita por engano uma pessoa nao autorizada, o que representa uma falha de seguranca. Ja a falsa rejeicao (FRR) recusa pessoas legitimas.",
+        topic: "Controle de Acesso",
+        options: [
+            ["Pessoas nao autorizadas podem ser aceitas indevidamente pelo leitor.", true],
+            ["Pessoas autorizadas sao rejeitadas com frequencia ao tentar entrar.", false],
+            ["O leitor demora muito para cadastrar novos usuarios no sistema.", false],
+            ["O leitor passa a exigir um segundo fator de autenticacao sempre que a iluminacao do ambiente muda, tornando a entrada mais lenta para todos.", false],
+        ],
+    },
+    {
+        statement: "Um funcionario com acesso a varios sistemas criticos e desligado da empresa. Do ponto de vista de controle de acesso, qual e a acao mais importante a ser tomada imediatamente?",
+        explanation: "No desprovisionamento (offboarding), as contas de quem sai devem ser desativadas imediatamente para evitar acessos indevidos por parte de ex-funcionarios. Contas orfas ou ativas apos o desligamento sao um risco comum.",
+        topic: "Controle de Acesso",
+        options: [
+            ["Trocar a senha do Wi-Fi corporativo para todos os funcionarios.", false],
+            ["Manter as contas ativas por 90 dias para o caso de o funcionario ser recontratado e precisar retomar suas atividades sem retrabalho.", false],
+            ["Desabilitar ou revogar todas as contas de acesso dele sem demora.", true],
+            ["Registrar o desligamento no sistema de RH e aguardar a revisao trimestral.", false],
+        ],
+    },
+    {
+        statement: "Para agilizar a criacao de contas de novos funcionarios, um administrador costuma copiar todas as permissoes de um colega antigo da mesma area. Qual e o principal risco dessa pratica de provisionamento?",
+        explanation: "Copiar (clonar) o perfil de outro usuario costuma conceder acessos alem do necessario, violando o menor privilegio e favorecendo o acumulo de permissoes (privilege creep). O provisionamento deve se basear no cargo e em aprovacao formal.",
+        topic: "Controle de Acesso",
+        options: [
+            ["A senha do colega antigo e revelada durante a copia das permissoes.", false],
+            ["O sistema de RH deixa de registrar a data de admissao do novo funcionario, o que impede o calculo correto do tempo de casa e dos beneficios.", false],
+            ["O colega antigo perde suas proprias permissoes ao servir de modelo.", false],
+            ["O novo usuario acumula permissoes desnecessarias ao seu cargo.", true],
+        ],
+    },
+    {
+        statement: "Um administrador de sistemas usa a mesma conta com privilegios de administrador para tarefas do dia a dia, como ler e-mails e navegar na internet. Qual recomendacao de seguranca para contas privilegiadas ele esta deixando de seguir?",
+        explanation: "Contas privilegiadas devem ser separadas das contas de uso cotidiano e utilizadas apenas para tarefas administrativas especificas, reduzindo a exposicao em caso de comprometimento. Navegar e ler e-mails com uma conta de administrador amplia o impacto de um ataque.",
+        topic: "Controle de Acesso",
+        options: [
+            ["Compartilhar a conta de administrador com toda a equipe de TI para que qualquer um possa resolver incidentes fora do horario comercial sem depender de uma so pessoa.", false],
+            ["Usar uma conta comum no dia a dia e a privilegiada so quando necessario.", true],
+            ["Desabilitar completamente a conta de administrador e nunca mais utiliza-la.", false],
+            ["Compartilhar a senha privilegiada com o gestor para fins de auditoria.", false],
+        ],
+    },
+    {
+        statement: "Uma auditoria descobriu que varios funcionarios que mudaram de area ao longo dos anos ainda mantem acessos de suas funcoes anteriores. Qual pratica de controle de acesso teria evitado esse acumulo?",
+        explanation: "A revisao periodica de acessos (recertificacao) verifica se cada usuario ainda precisa das permissoes que possui, corrigindo o acumulo causado por transferencias (privilege creep). MFA e senhas fortes nao resolvem permissoes excessivas.",
+        topic: "Controle de Acesso",
+        options: [
+            ["Exigir autenticacao multifator no login de todos os sistemas.", false],
+            ["Aumentar a complexidade exigida das senhas e reduzir o prazo de expiracao para que os usuarios troquem suas credenciais com mais frequencia.", false],
+            ["Revisar periodicamente os acessos de cada usuario e remover os indevidos.", true],
+            ["Criptografar os discos das estacoes de trabalho de todos os funcionarios.", false],
+        ],
+    },
+    {
+        statement: "Uma empresa possui os seguintes controles: uma politica de uso aceitavel assinada pelos funcionarios, uma catraca na entrada do predio e uma regra de firewall que bloqueia portas. Como esses tres controles sao classificados, na ordem?",
+        explanation: "Politicas e procedimentos sao controles administrativos, barreiras como catracas e portas sao controles fisicos, e mecanismos como firewalls e senhas sao controles tecnicos (logicos). A mesma protecao pode combinar os tres tipos.",
+        topic: "Controle de Acesso",
+        options: [
+            ["Administrativo, fisico e tecnico (logico).", true],
+            ["Fisico, administrativo e tecnico (logico).", false],
+            ["Tecnico (logico), fisico e administrativo.", false],
+            ["Todos sao considerados controles tecnicos, pois envolvem tecnologia e documentos que precisam ser gerenciados por sistemas informatizados da empresa.", false],
+        ],
+    },
+    {
+        statement: "Para liberar uma transferencia bancaria acima de um valor alto, um banco exige que dois funcionarios diferentes aprovem a operacao, cada um com sua propria credencial. Que mecanismo de controle de acesso esta sendo aplicado?",
+        explanation: "O controle dual (dual control ou regra das duas pessoas) exige que dois individuos autorizados atuem em conjunto para executar uma operacao sensivel, reduzindo fraude e erro. E uma forma de reforcar a segregacao de funcoes.",
+        topic: "Controle de Acesso",
+        options: [
+            ["Menor privilegio, pois cada funcionario recebe apenas as permissoes estritamente necessarias para desempenhar as tarefas especificas do seu cargo no banco.", false],
+            ["Controle dual, que exige duas pessoas para concluir uma acao critica.", true],
+            ["Autenticacao multifator, que combina senha e token no login.", false],
+            ["Federacao de identidades entre diferentes sistemas do banco.", false],
+        ],
+    },
+    {
+        statement: "As portas eletronicas de uma empresa sao configuradas para destrancar automaticamente em caso de falta de energia, priorizando a saida rapida das pessoas em uma emergencia. Como esse comportamento de fechadura e chamado?",
+        explanation: "Uma fechadura fail-safe destranca na falta de energia para priorizar a vida (life safety), enquanto uma fail-secure permanece trancada para priorizar a protecao do ativo. A escolha depende do que se quer proteger em cada porta.",
+        topic: "Controle de Acesso",
+        options: [
+            ["Fail-secure, pois a prioridade absoluta e impedir qualquer entrada nao autorizada mesmo durante uma emergencia com risco a vida das pessoas no predio.", false],
+            ["Fail-closed, garantindo que as portas permanecam trancadas.", false],
+            ["Fail-safe, que prioriza a seguranca das pessoas destrancando as portas.", true],
+            ["Tolerancia a falhas, que mantem o sistema de crachas sempre online.", false],
+        ],
+    },
+    {
+        statement: "Uma empresa implementa uma solucao em que o funcionario se autentica uma unica vez pela manha e, a partir dai, acessa o e-mail, o ERP e a intranet sem digitar a senha novamente. Como se chama esse recurso?",
+        explanation: "O Single Sign-On (SSO) permite que o usuario se autentique uma vez e acesse varios sistemas sem novo login, melhorando a experiencia e a gestao de credenciais. Em contrapartida, exige protecao reforcada dessa credencial unica.",
+        topic: "Controle de Acesso",
+        options: [
+            ["Autenticacao multifator (MFA).", false],
+            ["Logon unico (Single Sign-On, SSO).", true],
+            ["Federacao obrigatoria de crachas fisicos, que sincroniza a entrada no predio com o desbloqueio automatico de todos os aplicativos corporativos.", false],
+            ["Menor privilegio aplicado as credenciais.", false],
+        ],
+    },
+    {
+        statement: "Em um setor, varios operadores utilizam uma mesma conta generica chamada 'operador01' para acessar o sistema. Do ponto de vista de controle de acesso, qual e o maior problema dessa configuracao?",
+        explanation: "Contas compartilhadas eliminam a responsabilizacao individual (accountability), pois as acoes nao podem ser atribuidas a uma pessoa especifica, prejudicando auditoria e nao repudio. Cada usuario deve ter sua propria conta.",
+        topic: "Controle de Acesso",
+        options: [
+            ["As senhas compartilhadas expiram mais rapido do que as individuais, obrigando toda a equipe a redefinir a credencial simultaneamente varias vezes por mes.", false],
+            ["Contas genericas nao conseguem receber permissoes de leitura em arquivos.", false],
+            ["Nao e possivel saber qual pessoa realizou cada acao na conta.", true],
+            ["O sistema passa a exigir autenticacao multifator para todos os setores.", false],
+        ],
+    },
+    {
+        statement: "Para dificultar ataques de tentativa e erro de senha, um sistema e configurado para bloquear a conta apos cinco tentativas de login malsucedidas seguidas. Que tipo de controle de acesso e ameaca essa medida combate?",
+        explanation: "O bloqueio de conta apos varias tentativas e um controle tecnico (logico) que dificulta ataques de forca bruta, nos quais o atacante testa muitas senhas em sequencia. Ele previne o acesso, nao apenas o registra.",
+        topic: "Controle de Acesso",
+        options: [
+            ["Um controle fisico contra o acesso de visitantes ao predio.", false],
+            ["Um controle administrativo que substitui a necessidade de qualquer politica de senha escrita, pois o proprio sistema passa a definir sozinho as regras de complexidade.", false],
+            ["Um controle de deteccao que apenas registra as tentativas sem impedi-las.", false],
+            ["Um controle logico contra ataques de forca bruta de senha.", true],
+        ],
+    },
+    {
+        statement: "Depois que um usuario comprova sua identidade com senha e token, o sistema verifica se ele tem permissao para excluir um registro especifico do banco de dados. Essa verificacao de permissao corresponde a qual etapa?",
+        explanation: "A autorizacao ocorre apos a autenticacao e determina quais recursos e acoes o usuario ja identificado tem permissao de acessar. Autenticacao prova quem e o usuario; autorizacao define o que ele pode fazer.",
+        topic: "Controle de Acesso",
+        options: [
+            ["Autenticacao, que confirma a identidade declarada pelo usuario.", false],
+            ["Identificacao, o momento inicial em que o usuario apenas declara quem e ao digitar o nome de usuario, antes de qualquer comprovacao de identidade.", false],
+            ["Autorizacao, que define o que o usuario pode fazer no sistema.", true],
+            ["Auditoria, que registra as acoes executadas para analise posterior.", false],
+        ],
+    },
+    {
+        statement: "Uma aplicacao web precisa apenas ler registros de uma tabela de produtos, mas seu desenvolvedor configurou a conta de servico do banco de dados com permissoes de administrador. Qual principio foi violado e qual seria a correcao?",
+        explanation: "O menor privilegio tambem se aplica a contas de servico e de aplicacao, que devem ter apenas as permissoes estritamente necessarias para sua funcao. Uma conta de servico com direitos de administrador amplia muito o impacto de uma invasao.",
+        topic: "Controle de Acesso",
+        options: [
+            ["A segregacao de funcoes foi violada; a correcao e dividir a aplicacao em dois modulos operados por equipes diferentes para que ninguem controle todo o fluxo.", false],
+            ["O menor privilegio foi violado; conceda a conta apenas permissao de leitura.", true],
+            ["O nao repudio foi violado; a correcao e assinar digitalmente cada consulta.", false],
+            ["A defesa em profundidade foi violada; a correcao e adicionar um segundo firewall.", false],
+        ],
+    },
+    {
+        statement: "Depois de classificar suas informacoes em niveis como 'publico' e 'confidencial', uma empresa carimba cada documento e adiciona metadados indicando o nivel a que ele pertence. Qual e o principal objetivo dessa rotulagem?",
+        explanation: "A rotulagem (labeling) torna visivel a classificacao da informacao para que pessoas e sistemas apliquem as regras de manuseio, armazenamento e descarte adequadas. O rotulo orienta o tratamento, mas nao substitui os controles de acesso.",
+        topic: "Operações de Segurança",
+        options: [
+            ["Sinalizar como cada informacao deve ser tratada e protegida.", true],
+            ["Criptografar automaticamente o conteudo de todos os documentos.", false],
+            ["Substituir a necessidade de controles de acesso, ja que o rotulo por si so impede tecnicamente que pessoas nao autorizadas abram o arquivo.", false],
+            ["Reduzir o tamanho dos arquivos armazenados no servidor da empresa.", false],
+        ],
+    },
+    {
+        statement: "O setor juridico informa que certos contratos precisam ser guardados por cinco anos por exigencia legal, e depois disso nao ha motivo para mante-los. Qual politica orienta por quanto tempo os dados devem ser conservados antes do descarte?",
+        explanation: "A politica de retencao de dados define por quanto tempo cada tipo de informacao deve ser mantida para atender a requisitos legais e de negocio, e quando deve ser descartada com seguranca. Guardar dados alem do necessario aumenta risco e custo.",
+        topic: "Operações de Segurança",
+        options: [
+            ["A politica de uso aceitavel, que descreve as formas permitidas e proibidas de utilizar os recursos e sistemas de informacao disponibilizados pela empresa.", false],
+            ["A politica de retencao de dados.", true],
+            ["A politica de senhas.", false],
+            ["A politica de mesa limpa.", false],
+        ],
+    },
+    {
+        statement: "Uma empresa vai se desfazer de varios SSDs (unidades de estado solido) que armazenaram dados sensiveis. A equipe lembra que a desmagnetizacao (degaussing) funciona em HDs magneticos, mas nao em SSDs. Qual e a abordagem adequada para sanitizar esses SSDs?",
+        explanation: "SSDs nao sao afetados por desmagnetizacao e distribuem os dados internamente, entao a sanitizacao confiavel usa apagamento criptografico (crypto-erase) ou destruicao fisica. Apagar arquivos ou formatar rapidamente nao remove os dados de fato.",
+        topic: "Operações de Segurança",
+        options: [
+            ["Desmagnetizar cada SSD com um degausser potente antes do descarte.", false],
+            ["Usar apagamento criptografico ou destruicao fisica da unidade.", true],
+            ["Apagar os arquivos e esvaziar a lixeira do sistema operacional.", false],
+            ["Formatar rapidamente a unidade varias vezes seguidas, o que sobrescreve todos os blocos de memoria flash de forma garantida por causa do gerenciamento interno do SSD.", false],
+        ],
+    },
+    {
+        statement: "Uma empresa passa a exigir que os funcionarios guardem documentos em papel em gavetas trancadas e bloqueiem a tela ao se ausentar da mesa. Que politica de seguranca esta sendo implementada?",
+        explanation: "A politica de mesa limpa (clean desk) e tela bloqueada reduz o risco de pessoas nao autorizadas verem ou levarem informacoes sensiveis deixadas a vista. E especialmente util contra curiosos e visitantes no ambiente de trabalho.",
+        topic: "Operações de Segurança",
+        options: [
+            ["Politica BYOD, que estabelece as condicoes sob as quais dispositivos pessoais dos funcionarios podem se conectar aos sistemas e a rede corporativa da empresa.", false],
+            ["Politica de retencao de dados.", false],
+            ["Politica de mesa limpa e tela bloqueada.", true],
+            ["Politica de classificacao de dados.", false],
+        ],
+    },
+    {
+        statement: "Uma empresa envia lembretes rapidos, cartazes e e-mails para manter a seguranca na mente dos funcionarios no dia a dia, sem ensinar nenhuma habilidade tecnica especifica. Como se classifica melhor esse tipo de iniciativa?",
+        explanation: "A conscientizacao (awareness) usa lembretes e mensagens para reforcar comportamentos seguros, sem ensinar habilidades tecnicas. O treinamento desenvolve competencias praticas, e a educacao aprofunda o entendimento teorico.",
+        topic: "Operações de Segurança",
+        options: [
+            ["Treinamento, que ensina habilidades praticas e especificas para que o funcionario saiba executar uma tarefa tecnica de seguranca, como configurar corretamente uma ferramenta.", false],
+            ["Educacao, que aprofunda conceitos teoricos em nivel avancado.", false],
+            ["Auditoria, que avalia a conformidade com as politicas internas.", false],
+            ["Conscientizacao (awareness), que mantem a seguranca presente no cotidiano.", true],
+        ],
+    },
+    {
+        statement: "Ao projetar a sala de servidores de uma nova instalacao, a equipe se preocupa em controlar temperatura e umidade e em instalar um sistema de supressao de incendio adequado a equipamentos eletronicos. Que categoria de controle de seguranca fisica ela esta tratando?",
+        explanation: "Temperatura, umidade, supressao de incendio e energia fazem parte dos controles ambientais da seguranca fisica, que protegem os equipamentos e a disponibilidade. Agua comum, por exemplo, nao e adequada para incendios em equipamentos eletricos.",
+        topic: "Operações de Segurança",
+        options: [
+            ["Controle de acesso logico dos usuarios aos servidores.", false],
+            ["Controles ambientais da instalacao.", true],
+            ["Controles de segregacao de funcoes entre os administradores, garantindo que nenhum deles consiga concluir sozinho uma alteracao critica na configuracao dos servidores.", false],
+            ["Controles criptograficos dos dados em repouso nos discos.", false],
+        ],
+    },
+    {
+        statement: "Em uma empresa, surge a duvida sobre quem deve definir o nivel de classificacao de um conjunto de dados. Segundo as boas praticas de seguranca da informacao, essa responsabilidade e principalmente de quem?",
+        explanation: "A classificacao e responsabilidade do proprietario (data owner) da informacao, que conhece seu valor e sensibilidade para o negocio. O custodiante apenas protege os dados conforme a classificacao definida pelo proprietario.",
+        topic: "Operações de Segurança",
+        options: [
+            ["Do usuario final que consome os dados no dia a dia, pois e ele quem melhor conhece a rotina operacional e decide o nivel conforme a conveniencia de cada tarefa.", false],
+            ["Do administrador de rede que configura os firewalls da empresa.", false],
+            ["Do proprietario (owner) dos dados, responsavel por defini-los e classifica-los.", true],
+            ["Da equipe de limpeza que tem acesso fisico as instalacoes.", false],
+        ],
+    },
 ];
 
 async function seed() {
@@ -2140,13 +2955,23 @@ async function seed() {
         .select({ n: count() })
         .from(simuladoQuestions)
         .where(eq(simuladoQuestions.simuladoId, simulado.id));
-    if (Number(n) > 0) {
+    const jaExistem = new Set(
+        (
+            await db
+                .select({ statement: simuladoQuestions.statement })
+                .from(simuladoQuestions)
+                .where(eq(simuladoQuestions.simuladoId, simulado.id))
+        ).map((r) => r.statement),
+    );
+    const inseridas = QUESTOES.filter((q) => !jaExistem.has(q.statement)).length;
+    if (inseridas === 0) {
         console.log("Simulado ja tem " + n + " questoes, nada a fazer.");
         return;
     }
 
     for (let i = 0; i < QUESTOES.length; i++) {
         const q = QUESTOES[i];
+        if (jaExistem.has(q.statement)) continue;
         const [questao] = await db
             .insert(simuladoQuestions)
             .values({
@@ -2165,7 +2990,7 @@ async function seed() {
             })),
         );
     }
-    console.log("Seed concluido: " + QUESTOES.length + " questoes inseridas.");
+    console.log("Seed: " + inseridas + " questoes novas inseridas (" + QUESTOES.length + " no banco).");
 }
 
 seed()

--- a/backend/scripts/seed-saa-c03.ts
+++ b/backend/scripts/seed-saa-c03.ts
@@ -1441,6 +1441,634 @@ const QUESTOES: Questao[] = [
             ["Contratar um Savings Plan para o novo uso redimensionado", true],
         ],
     },
+    // ===== Questões adicionais (banco ampliado para variar as tentativas) =====
+    {
+        statement: "Uma empresa replica objetos de um bucket do Amazon S3 em us-east-1 para um bucket em eu-west-1 usando replicacao entre regioes, e todos os objetos usam SSE-KMS. A equipe quer que a aplicacao de cada regiao descriptografe os objetos localmente com a mesma identidade criptografica de chave, sem chamadas KMS entre regioes. Qual abordagem atende a esse requisito?",
+        explanation: "Chaves multi-regiao do KMS tem uma primaria e replicas que compartilham o mesmo ID e material criptografico, permitindo descriptografar em qualquer regiao sem chamadas entre regioes. Chaves KMS regionais comuns sao isoladas por regiao.",
+        topic: "AWS KMS - multi-region keys",
+        options: [
+            ["Criar uma chave KMS independente e sem relacao em cada regiao e configurar a regra de replicacao do S3 para descriptografar cada objeto na origem e recriptografa-lo com a chave de destino durante a transferencia.", false],
+            ["Habilitar a rotacao automatica anual da chave de us-east-1 para que o material criptografico seja copiado para uma chave equivalente em eu-west-1.", false],
+            ["Criar uma chave KMS multi-regiao primaria em us-east-1 e replica-la para eu-west-1, mantendo o mesmo ID e material de chave nas duas regioes.", true],
+            ["Manter uma unica chave em us-east-1 e permitir que a aplicacao de eu-west-1 chame a API Decrypt no endpoint regional de us-east-1.", false],
+        ],
+    },
+    {
+        statement: "Uma funcao AWS Lambda precisa de permissao temporaria para usar uma chave KMS gerenciada pelo cliente apenas durante uma janela de processamento em lote. A equipe de seguranca quer conceder esse acesso de forma granular e revogavel, sem editar a politica da chave a cada execucao. Qual mecanismo do KMS e mais adequado?",
+        explanation: "Grants do KMS concedem permissoes temporarias e granulares a um principal para usar uma chave e podem ser revogados sem alterar a politica da chave. Isso e ideal para acessos programaticos e de curta duracao.",
+        topic: "AWS KMS - grants",
+        options: [
+            ["Criar um grant do KMS para a role da funcao, autorizando as operacoes necessarias e permitindo revogar o acesso quando o lote terminar.", true],
+            ["Adicionar a role da funcao como principal em uma nova declaracao da politica da chave a cada execucao e remove-la ao final.", false],
+            ["Compartilhar a chave por meio de uma politica de bucket do S3 que referencia a role da funcao durante a janela de execucao.", false],
+            ["Habilitar a rotacao automatica de chave e criar um alias exclusivo apontando para a chave, concedendo a role da funcao acesso ao alias somente durante o periodo em que o processamento em lote esta previsto para rodar.", false],
+        ],
+    },
+    {
+        statement: "A conta A possui uma chave KMS gerenciada pelo cliente usada para criptografar objetos em um bucket do S3. A conta B precisa descriptografar esses objetos a partir de uma aplicacao em EC2. Como conceder a conta B o uso da chave seguindo as praticas recomendadas?",
+        explanation: "O acesso entre contas a uma chave KMS exige que a politica da chave na conta proprietaria permita a outra conta e que a conta destino delegue a permissao a role apropriada. Ambas as camadas sao necessarias.",
+        topic: "AWS KMS - politica de chave cross-account",
+        options: [
+            ["Exportar o material da chave da conta A e importa-lo em uma nova chave KMS criada na conta B, para que a aplicacao descriptografe os objetos localmente sem depender da conta A.", false],
+            ["Tornar a chave KMS publica para que qualquer principal autenticado da conta B possa chamar Decrypt sem configuracao adicional.", false],
+            ["Adicionar apenas uma politica de identidade na conta B permitindo kms:Decrypt, o que e suficiente para acesso entre contas.", false],
+            ["Na politica da chave na conta A, permitir o acesso ao principal da conta B e conceder kms:Decrypt a role da aplicacao na conta B.", true],
+        ],
+    },
+    {
+        statement: "Uma aplicacao web precisa permitir que usuarios autenticados facam download de arquivos privados no S3 por um curto periodo, sem tornar o bucket publico e sem distribuir credenciais da AWS aos clientes. Qual solucao atende a esse requisito?",
+        explanation: "URLs pre-assinadas concedem acesso temporario a objetos especificos usando as credenciais de quem as gera, sem expor o bucket publicamente nem compartilhar credenciais permanentes com os usuarios.",
+        topic: "Amazon S3 - Pre-signed URLs",
+        options: [
+            ["Anexar uma bucket policy que concede s3:GetObject a qualquer principal e usar uma condicao de intervalo de horarios para limitar o acesso apenas ao periodo em que os usuarios costumam baixar os arquivos.", false],
+            ["Gerar URLs pre-assinadas no backend com validade curta, usando as credenciais da aplicacao, e entrega-las aos usuarios para o download.", true],
+            ["Desabilitar o Block Public Access e conceder acesso de leitura anonimo somente aos objetos que precisam ser baixados.", false],
+            ["Distribuir aos clientes as chaves de acesso de um usuario do IAM com permissao de leitura restrita ao bucket.", false],
+        ],
+    },
+    {
+        statement: "Um unico bucket do S3 armazena dados compartilhados por dezenas de aplicacoes e equipes, cada uma exigindo permissoes de acesso diferentes. A bucket policy unica cresceu demais e ficou dificil de manter. Qual recurso simplifica a gestao desses acessos distintos?",
+        explanation: "S3 Access Points fornecem endpoints nomeados com politicas de acesso proprias sobre um bucket compartilhado, permitindo escalar e isolar permissoes por aplicacao sem inflar uma unica bucket policy.",
+        topic: "Amazon S3 - Access Points",
+        options: [
+            ["Dividir o bucket em dezenas de buckets menores, um por aplicacao, cada um com sua propria bucket policy.", false],
+            ["Criar uma role do IAM por aplicacao e consolidar todas as permissoes de acesso em uma politica gerenciada compartilhada anexada a um unico grupo do IAM que contem todas as equipes.", false],
+            ["Criar S3 Access Points, cada um com sua propria politica e nome de host dedicado, para atender aos diferentes padroes de acesso ao mesmo bucket.", true],
+            ["Habilitar o versionamento do bucket e usar prefixos de objeto distintos para separar o acesso de cada equipe.", false],
+        ],
+    },
+    {
+        statement: "Uma auditoria de seguranca exige que todo acesso a um bucket do S3 ocorra somente por conexoes criptografadas, bloqueando qualquer requisicao feita por HTTP simples. Qual medida atende a esse requisito?",
+        explanation: "Uma bucket policy com Deny condicionado a aws:SecureTransport igual a false bloqueia qualquer requisicao nao-HTTPS. Criptografia em repouso e Block Public Access nao controlam o protocolo de transporte.",
+        topic: "Amazon S3 - criptografia em transito (aws:SecureTransport)",
+        options: [
+            ["Adicionar uma bucket policy que negue as acoes quando a condicao aws:SecureTransport for falsa.", true],
+            ["Habilitar SSE-KMS no bucket, o que passa a rejeitar automaticamente requisicoes feitas por HTTP.", false],
+            ["Ativar o Block Public Access, que forca todas as conexoes ao bucket a usarem TLS.", false],
+            ["Configurar uma regra de ciclo de vida que remova objetos enviados por conexoes nao criptografadas e habilitar o versionamento para reter as versoes enviadas corretamente por HTTPS.", false],
+        ],
+    },
+    {
+        statement: "Uma empresa precisa garantir que nenhum objeto seja gravado em um bucket do S3 sem criptografia do lado do servidor com SSE-KMS, rejeitando uploads que nao especifiquem esse tipo de criptografia. Qual abordagem atende ao requisito?",
+        explanation: "Uma bucket policy com Deny condicionado a ausencia do cabecalho de criptografia SSE-KMS rejeita uploads nao criptografados. A criptografia padrao apenas aplica a criptografia, mas nao rejeita a requisicao.",
+        topic: "Amazon S3 - politica de bucket para SSE obrigatorio",
+        options: [
+            ["Criar uma funcao do AWS Lambda acionada por eventos do S3 que verifica cada objeto recem-criado e, se ele nao estiver criptografado com SSE-KMS, exclui o objeto e notifica a equipe de seguranca por e-mail.", false],
+            ["Habilitar a criptografia padrao do bucket, o que faz o S3 recusar qualquer requisicao PUT sem cabecalho de criptografia.", false],
+            ["Ativar o Object Lock em modo compliance para impedir o upload de objetos nao criptografados.", false],
+            ["Aplicar uma bucket policy que negue s3:PutObject quando o cabecalho de criptografia SSE-KMS nao estiver presente na requisicao.", true],
+        ],
+    },
+    {
+        statement: "Um provedor de SaaS hospeda uma aplicacao atras de um Network Load Balancer em sua propria VPC e quer disponibiliza-la a VPCs de clientes de forma privada, sem expor a aplicacao a internet e sem peering de VPC nem sobreposicao de faixas de IP. Qual solucao atende a esse cenario?",
+        explanation: "O AWS PrivateLink permite publicar um servico via endpoint service sobre um NLB, e os consumidores acessam por interface endpoints privados, sem peering, sem exposicao a internet e sem conflito de faixas de IP.",
+        topic: "AWS PrivateLink",
+        options: [
+            ["Criar uma conexao de VPC peering entre a VPC do provedor e cada VPC de cliente e ajustar as tabelas de rotas e faixas de IP de todas as partes para evitar sobreposicao de enderecos.", false],
+            ["Publicar um VPC endpoint service (AWS PrivateLink) sobre o Network Load Balancer e permitir que os clientes criem interface endpoints para consumi-lo.", true],
+            ["Expor a aplicacao por um Application Load Balancer publico e restringir o acesso por security groups que referenciam os IPs dos clientes.", false],
+            ["Configurar um Transit Gateway compartilhado que conecta a VPC do provedor a todas as VPCs de clientes em uma malha unica.", false],
+        ],
+    },
+    {
+        statement: "Uma organizacao com varias contas AWS quer uma visao central e padronizada das descobertas do GuardDuty, do Inspector e do Macie, alem de verificar automaticamente a conformidade com padroes como o CIS AWS Foundations Benchmark. Qual servico atende a essa necessidade?",
+        explanation: "O AWS Security Hub consolida descobertas de GuardDuty, Inspector, Macie e outros servicos num formato padronizado e executa verificacoes contra frameworks como o CIS Benchmark. O Config avalia configuracao de recursos, mas nao agrega descobertas de ameacas.",
+        topic: "AWS Security Hub",
+        options: [
+            ["Amazon Detective, que agrega e prioriza as descobertas de todas as contas em um unico painel de conformidade.", false],
+            ["Amazon CloudWatch, criando um dashboard consolidado que coleta metricas e eventos de cada servico de seguranca em todas as contas e avalia continuamente os controles do CIS Benchmark.", false],
+            ["AWS Security Hub, que agrega descobertas de varios servicos de seguranca e executa verificacoes de conformidade automatizadas.", true],
+            ["AWS Config, que centraliza as descobertas dos servicos de seguranca e gera um score de conformidade unificado.", false],
+        ],
+    },
+    {
+        statement: "Uma equipe de conformidade precisa detectar continuamente recursos que violam regras internas, como volumes do EBS nao criptografados ou security groups com a porta 22 aberta para a internet, e registrar o historico de mudancas de configuracao de cada recurso. Qual servico atende a esse objetivo?",
+        explanation: "O AWS Config avalia continuamente a configuracao dos recursos contra regras gerenciadas ou personalizadas e registra o historico de mudancas. CloudTrail registra chamadas de API e GuardDuty detecta ameacas, nao conformidade de configuracao.",
+        topic: "AWS Config",
+        options: [
+            ["AWS Config, com regras gerenciadas que avaliam a conformidade dos recursos e mantem o historico de configuracoes.", true],
+            ["Amazon Inspector, que faz varredura continua de configuracoes de recursos e mantem uma linha do tempo de alteracoes.", false],
+            ["AWS CloudTrail, que avalia regras de conformidade sobre o estado atual de cada recurso da conta.", false],
+            ["Amazon GuardDuty, que analisa continuamente as configuracoes dos recursos, sinaliza os que estao fora de conformidade com as regras definidas e registra cada alteracao de configuracao ao longo do tempo.", false],
+        ],
+    },
+    {
+        statement: "Uma empresa contrata um fornecedor SaaS de terceiros que precisa assumir uma role do IAM na conta da empresa para monitorar recursos. A equipe de seguranca quer proteger essa relacao de confianca contra o problema do confused deputy, garantindo que apenas o fornecedor correto assuma a role. Qual medida atende a esse requisito?",
+        explanation: "O External ID e o mecanismo recomendado para acesso entre contas com terceiros: a trust policy exige um sts:ExternalId combinado, evitando o problema do confused deputy sem depender de credenciais de longa duracao.",
+        topic: "IAM Roles - Cross-Account External ID",
+        options: [
+            ["Restringir a trust policy da role ao intervalo de enderecos IP publicos usados pelo fornecedor por meio da condicao aws:SourceIp.", false],
+            ["Criar um usuario do IAM dedicado ao fornecedor, gerar chaves de acesso de longa duracao, envia-las ao fornecedor por um canal seguro e rotaciona-las manualmente a cada noventa dias.", false],
+            ["Habilitar a autenticacao multifator na conta do fornecedor e exigir MFA na trust policy da role.", false],
+            ["Exigir um External ID acordado com o fornecedor na condicao sts:ExternalId da trust policy da role.", true],
+        ],
+    },
+    {
+        statement: "Uma equipe de seguranca quer identificar automaticamente quais buckets do S3, roles do IAM, filas do SQS e chaves do KMS estao acessiveis por entidades externas a organizacao, para revisar e reduzir acessos nao intencionais. Qual servico fornece essa analise?",
+        explanation: "O IAM Access Analyzer usa raciocinio automatizado sobre politicas para identificar recursos compartilhados com principais externos a zona de confianca da conta ou da organizacao. Macie classifica dados e Trusted Advisor nao faz essa analise de politicas.",
+        topic: "IAM Access Analyzer",
+        options: [
+            ["AWS Trusted Advisor, que analisa as politicas baseadas em recurso e alerta sobre qualquer acesso concedido a entidades externas.", false],
+            ["IAM Access Analyzer, que examina politicas baseadas em recurso e identifica acessos concedidos a principais fora da zona de confianca.", true],
+            ["Amazon Macie, que inspeciona as politicas dos recursos em busca de concessoes de acesso externo.", false],
+            ["AWS Config, que mantem regras avaliando cada recurso e gera descobertas sempre que uma politica concede acesso a uma conta que nao pertence a organizacao definida como zona de confianca.", false],
+        ],
+    },
+    {
+        statement: "Um pipeline de CI/CD executado em um provedor externo precisa implantar recursos na AWS. A equipe quer eliminar as chaves de acesso de longa duracao hoje armazenadas no sistema de CI e obter credenciais temporarias por meio de tokens OIDC emitidos pelo provedor. Qual abordagem atende a esse requisito?",
+        explanation: "Registrando o provedor OIDC como IAM identity provider, o pipeline troca seu token por credenciais temporarias com AssumeRoleWithWebIdentity, eliminando chaves de longa duracao. Instance profiles so se aplicam a recursos EC2 na AWS.",
+        topic: "IAM - Federacao OIDC (Web Identity)",
+        options: [
+            ["Armazenar as chaves de acesso no AWS Secrets Manager e fazer o pipeline recupera-las a cada execucao em vez de mante-las no sistema de CI.", false],
+            ["Criar um usuario do IAM exclusivo para o pipeline, anexar as politicas necessarias e configurar a rotacao automatica das suas chaves de acesso para reduzir o risco de exposicao das credenciais de longa duracao.", false],
+            ["Configurar o provedor OIDC como identity provider no IAM e permitir que o pipeline assuma uma role via AssumeRoleWithWebIdentity.", true],
+            ["Compartilhar as credenciais de uma role de EC2 exportando-as do instance profile para o pipeline externo.", false],
+        ],
+    },
+    {
+        statement: "Uma empresa usa o AWS Organizations e quer impedir que administradores de qualquer conta membro desativem o AWS CloudTrail, o Amazon GuardDuty ou o AWS Config, mesmo que tenham permissoes de administrador nessas contas. Qual abordagem atende a esse objetivo?",
+        explanation: "Uma SCP funciona como teto de permissoes e nega as acoes de desativacao dos servicos de seguranca em todas as contas afetadas, sobrepondo-se ate a permissoes de administrador locais. Politicas de identidade por conta nao garantem esse controle de forma centralizada.",
+        topic: "AWS Organizations SCP - protecao de servicos de seguranca",
+        options: [
+            ["Aplicar uma SCP as unidades organizacionais que negue acoes como cloudtrail:StopLogging, guardduty:DeleteDetector e config:DeleteConfigurationRecorder.", true],
+            ["Editar a politica de identidade de cada administrador em todas as contas membro para remover as permissoes de desativar esses servicos e revisar periodicamente essas politicas para garantir que nenhuma nova permissao seja adicionada.", false],
+            ["Habilitar o Block Public Access na organizacao para impedir alteracoes nos servicos de seguranca pelas contas membro.", false],
+            ["Mover todas as contas para uma unica unidade organizacional e ativar a protecao contra exclusao no console do Organizations.", false],
+        ],
+    },
+    {
+        statement: "Uma aplicacao web atras de um Application Load Balancer sofre tentativas de injecao de SQL e ataques que exploram vulnerabilidades comuns do OWASP Top 10. A equipe quer bloquear essas requisicoes maliciosas na camada de aplicacao com o minimo de esforco de manutencao. Qual solucao e a mais adequada?",
+        explanation: "Os grupos de regras gerenciadas da AWS para o WAF cobrem SQL injection e vulnerabilidades comuns do OWASP e sao mantidos pela AWS, exigindo pouco esforco. Shield Advanced foca em DDoS e security groups nao inspecionam conteudo HTTP.",
+        topic: "AWS WAF - regras gerenciadas",
+        options: [
+            ["Habilitar o AWS Shield Advanced no ALB para inspecionar o conteudo das requisicoes HTTP e bloquear payloads de injecao de SQL.", false],
+            ["Configurar security groups no ALB que bloqueiem requisicoes contendo padroes de injecao de SQL na camada de rede.", false],
+            ["Escrever e manter manualmente um conjunto de regras personalizadas do WAF que descrevam cada assinatura conhecida de injecao de SQL e de exploracao do OWASP, atualizando-as sempre que surgir uma nova tecnica de ataque.", false],
+            ["Associar ao ALB uma web ACL do AWS WAF com os grupos de regras gerenciadas para SQL injection e OWASP.", true],
+        ],
+    },
+    {
+        statement: "Durante um incidente, a equipe identifica um unico endereco IP publico de origem realizando atividade maliciosa contra instancias em uma subnet. Ela precisa bloquear explicitamente todo o trafego desse IP no nivel da subnet, algo que os security groups nao conseguem fazer. Qual recurso deve ser usado?",
+        explanation: "Security groups so permitem regras de allow e nao tem deny, entao bloquear um IP especifico exige uma regra Deny em uma Network ACL, que e stateless e avaliada no nivel da subnet. Tabelas de rotas nao filtram por origem.",
+        topic: "VPC - Network ACL",
+        options: [
+            ["Adicionar uma regra de saida no security group das instancias negando o trafego destinado ao IP malicioso.", false],
+            ["Adicionar uma regra de negacao (Deny) para o IP de origem em uma Network ACL associada a subnet.", true],
+            ["Criar uma regra de entrada no security group que negue explicitamente o trafego vindo do IP malicioso.", false],
+            ["Configurar uma rota na tabela de rotas da subnet apontando o IP de origem malicioso para uma interface de rede descartada, de modo que o trafego desse endereco nunca alcance as instancias.", false],
+        ],
+    },
+    {
+        statement: "Instancias EC2 em uma subnet privada acessam o S3 por um gateway endpoint. A equipe de seguranca quer garantir que, por esse endpoint, as instancias so consigam acessar um conjunto especifico de buckets corporativos, bloqueando qualquer outro bucket do S3. Qual medida atende a esse requisito?",
+        explanation: "A endpoint policy do gateway endpoint controla quais recursos do S3 podem ser acessados atraves dele, permitindo restringir a ARNs de buckets especificos. Security groups nao se aplicam a gateway endpoints e faixas de IP nao distinguem buckets.",
+        topic: "VPC Endpoints - endpoint policy",
+        options: [
+            ["Anexar uma bucket policy a cada bucket corporativo, o que impede o acesso a qualquer outro bucket a partir do gateway endpoint.", false],
+            ["Configurar security groups no endpoint restringindo o acesso apenas aos buckets corporativos permitidos.", false],
+            ["Definir uma endpoint policy no gateway endpoint que permita acesso somente aos ARNs dos buckets corporativos.", true],
+            ["Criar uma Network ACL na subnet privada com regras que permitam trafego apenas para as faixas de enderecos IP publicadas do servico S3 correspondentes aos buckets corporativos autorizados.", false],
+        ],
+    },
+    {
+        statement: "Uma empresa quer permitir que qualquer conta dentro da sua AWS Organizations acesse um topico do Amazon SNS compartilhado, mas bloquear o acesso de qualquer conta externa. A empresa adiciona novas contas com frequencia e nao quer atualizar a politica a cada nova conta. Qual abordagem atende a esse requisito?",
+        explanation: "A chave de condicao global aws:PrincipalOrgID permite conceder acesso a todos os principais da organizacao em uma politica baseada em recurso, sem listar contas individualmente nem atualizar a politica quando novas contas entram. SCPs restringem permissoes, nao as concedem.",
+        topic: "AWS Organizations - aws:PrincipalOrgID",
+        options: [
+            ["Usar uma politica baseada em recurso no topico com a condicao aws:PrincipalOrgID igual ao ID da organizacao.", true],
+            ["Listar explicitamente o ID de cada conta membro na politica do topico e atualiza-la sempre que uma conta for adicionada.", false],
+            ["Aplicar uma SCP na organizacao concedendo a todas as contas membro permissao de publicar no topico SNS compartilhado.", false],
+            ["Criar uma role do IAM em cada conta membro com permissao de acesso ao topico e configurar uma automacao que, a cada nova conta criada, provisione essa role e atualize as relacoes de confianca correspondentes.", false],
+        ],
+    },
+    {
+        statement: "Uma empresa precisa descobrir e classificar automaticamente dados sensiveis, como CPFs e numeros de cartao de credito, espalhados por centenas de buckets do S3, para atender a uma auditoria de privacidade. A solucao deve usar aprendizado de maquina e nao exigir a construcao de scanners proprios. Qual servico atende a esse objetivo?",
+        explanation: "O Amazon Macie usa aprendizado de maquina e correspondencia de padroes para descobrir e classificar dados sensiveis como PII em buckets do S3. Inspector foca em vulnerabilidades e GuardDuty em ameacas, nao em classificacao de dados.",
+        topic: "Amazon Macie",
+        options: [
+            ["Amazon Inspector, que varre os objetos dos buckets do S3 e classifica os dados sensiveis por tipo.", false],
+            ["AWS Glue com um crawler configurado para percorrer todos os buckets, inferir o esquema dos arquivos e marcar as colunas que aparentam conter dados pessoais para posterior revisao manual.", false],
+            ["Amazon GuardDuty, que analisa o conteudo dos objetos do S3 e identifica informacoes pessoais identificaveis.", false],
+            ["Amazon Macie, que usa aprendizado de maquina para descobrir e classificar dados sensiveis armazenados no S3.", true],
+        ],
+    },
+    {
+        statement: "Uma aplicacao de mensagens instantaneas atende usuarios na America do Norte e na Europa e usa o Amazon DynamoDB. A empresa precisa de leituras e gravacoes com baixa latencia nas duas regioes e que a aplicacao continue funcionando mesmo se uma regiao inteira ficar indisponivel. Qual solucao atende a esses requisitos?",
+        explanation: "O DynamoDB Global Tables mantem replicas multirregiao ativo-ativo com replicacao gerenciada, oferecendo leitura e escrita locais de baixa latencia e resiliencia a falha de regiao. O DAX apenas acelera leituras em uma regiao e nao replica dados entre regioes.",
+        topic: "DynamoDB Global Tables",
+        options: [
+            ["Criar uma tabela do DynamoDB em uma unica regiao e distribuir o conteudo globalmente com o Amazon CloudFront na frente da aplicacao.", false],
+            ["Habilitar o DynamoDB Accelerator (DAX) na regiao primaria para reduzir a latencia de leitura dos usuarios das duas regioes.", false],
+            ["Configurar o DynamoDB Global Tables com replicas nas regioes da America do Norte e da Europa para replicacao ativo-ativo.", true],
+            ["Criar uma tabela em cada regiao e escrever um processo proprio com o DynamoDB Streams e o AWS Lambda para copiar todas as alteracoes entre elas continuamente.", false],
+        ],
+    },
+    {
+        statement: "Um desenvolvedor executou por engano um script que corrompeu milhares de itens de uma tabela do Amazon DynamoDB em producao que tem o point-in-time recovery (PITR) habilitado. A equipe percebeu o problema poucas horas depois e quer voltar a tabela ao estado imediatamente anterior ao script, com o menor esforco operacional. O que deve ser feito?",
+        explanation: "O PITR mantem backups continuos e permite restaurar a tabela para qualquer segundo dos ultimos 35 dias, desde que ja estivesse habilitado antes do incidente. Ativa-lo apos a corrupcao nao recupera o estado anterior.",
+        topic: "DynamoDB Point-in-Time Recovery",
+        options: [
+            ["Usar o point-in-time recovery para restaurar a tabela a um instante imediatamente anterior a execucao do script.", true],
+            ["Reprocessar as gravacoes do script em ordem inversa a partir do DynamoDB Streams para desfazer cada alteracao item a item.", false],
+            ["Recriar a tabela a partir do ultimo snapshot manual e reaplicar apenas as gravacoes legitimas identificadas no AWS CloudTrail.", false],
+            ["Ativar agora o point-in-time recovery e usa-lo para reverter as alteracoes que o script ja fez nas ultimas horas.", false],
+        ],
+    },
+    {
+        statement: "Uma plataforma de negociacao financeira precisa distribuir milhoes de requisicoes por segundo com latencia ultrabaixa sobre TCP. Ela tambem exige um endereco IP estatico por zona de disponibilidade para constar na lista de permissoes (allowlist) dos parceiros e precisa preservar o IP de origem dos clientes. Qual balanceador atende a esses requisitos?",
+        explanation: "O Network Load Balancer atua na camada 4, escala para milhoes de requisicoes por segundo com latencia muito baixa e oferece um IP estatico por AZ, alem de preservar o IP de origem. O Application Load Balancer opera na camada 7 e nao fornece IP estatico.",
+        topic: "Network Load Balancer",
+        options: [
+            ["Application Load Balancer, pois opera na camada 7 e oferece o melhor desempenho para trafego TCP de altissimo volume com IP fixo.", false],
+            ["Network Load Balancer, que opera na camada 4, sustenta altissimo volume com baixa latencia e fornece IP estatico por zona.", true],
+            ["Gateway Load Balancer, que distribui trafego TCP em escala e expoe um IP estatico para os parceiros incluirem em allowlist.", false],
+            ["Classic Load Balancer, que suporta TCP e HTTP e permite associar um Elastic IP fixo a cada no para atender a exigencia dos parceiros.", false],
+        ],
+    },
+    {
+        statement: "Uma empresa quer inserir appliances virtuais de firewall de um fornecedor terceiro no caminho do trafego de rede da sua VPC, para inspecionar todos os pacotes. Ela precisa distribuir o trafego entre uma frota desses appliances e escala-los de forma transparente, sem alterar as rotas dos aplicativos a cada mudanca. Qual servico e o mais indicado?",
+        explanation: "O Gateway Load Balancer foi feito para implantar, escalar e gerenciar appliances virtuais de terceiros como firewalls e IDS/IPS de forma transparente, encaminhando o trafego com o protocolo GENEVE. Os demais balanceadores nao inserem appliances de inspecao no caminho do trafego.",
+        topic: "Gateway Load Balancer",
+        options: [
+            ["Application Load Balancer com regras baseadas em host e caminho para encaminhar o trafego as instancias de firewall conforme a URL da requisicao.", false],
+            ["Network Load Balancer com verificacoes de integridade para enviar as conexoes TCP dos clientes diretamente a frota de appliances de firewall.", false],
+            ["Amazon Route 53 com roteamento ponderado para dividir o trafego de inspecao igualmente entre os varios appliances virtuais de firewall.", false],
+            ["Gateway Load Balancer, que implanta e escala appliances virtuais de terceiros de forma transparente usando o protocolo GENEVE.", true],
+        ],
+    },
+    {
+        statement: "Uma aplicacao de e-commerce foi dividida em microsservicos. As requisicoes para /api/pagamentos devem ir para um conjunto de instancias e as requisicoes para /api/catalogo para outro, tudo sob um unico nome de dominio HTTPS. A equipe tambem quer que instancias com falha sejam retiradas de rotacao automaticamente. Qual solucao atende a isso?",
+        explanation: "O Application Load Balancer roteia na camada 7 com regras baseadas em caminho e host e executa verificacoes de integridade por grupo de destino, retirando instancias nao saudaveis de rotacao. O NLB opera na camada 4 e nao enxerga o caminho da URL.",
+        topic: "Application Load Balancer",
+        options: [
+            ["Usar um Network Load Balancer com um listener TCP e grupos de destino distintos por microsservico, roteando pelo conteudo da URL de cada requisicao.", false],
+            ["Usar o Amazon Route 53 com roteamento baseado em latencia para direcionar cada caminho de URL ao grupo de instancias correspondente.", false],
+            ["Usar um Application Load Balancer com regras de roteamento baseadas em caminho e verificacoes de integridade por grupo de destino.", true],
+            ["Usar o Amazon CloudFront com multiplos comportamentos de cache por caminho apontando para instancias EC2 registradas manualmente como origens.", false],
+        ],
+    },
+    {
+        statement: "Uma empresa implantou copias identicas da sua aplicacao web em regioes nos Estados Unidos, na Irlanda e em Singapura. Ela quer que cada usuario seja direcionado automaticamente para a regiao que oferecer o menor tempo de resposta de rede. Qual politica de roteamento do Amazon Route 53 atende a esse objetivo?",
+        explanation: "O roteamento baseado em latencia resolve o DNS para a regiao que oferece a menor latencia de rede para o usuario, ideal quando ha copias da aplicacao em varias regioes. A geolocalizacao escolhe pela localizacao geografica, que nem sempre corresponde a menor latencia.",
+        topic: "Route 53 - Latency-Based Routing",
+        options: [
+            ["Roteamento baseado em latencia, que envia o usuario para a regiao com a menor latencia de rede medida.", true],
+            ["Roteamento por geolocalizacao, que direciona o usuario para a regiao com base no continente ou pais de origem da consulta DNS.", false],
+            ["Roteamento ponderado, que distribui as requisicoes entre as regioes segundo pesos que a equipe define manualmente para cada endpoint.", false],
+            ["Roteamento de failover, que mantem todo o trafego na regiao primaria e so usa as demais quando a verificacao de integridade falha.", false],
+        ],
+    },
+    {
+        statement: "Uma equipe quer lancar uma nova versao da aplicacao de forma gradual. No inicio, apenas 5% do trafego de producao deve ir para o novo conjunto de servidores e 95% deve continuar na versao atual, aumentando a proporcao aos poucos conforme a confianca na nova versao cresce. Qual politica de roteamento do Amazon Route 53 e a mais adequada?",
+        explanation: "O roteamento ponderado distribui o trafego entre endpoints conforme pesos definidos, permitindo liberar uma fracao controlada para a nova versao e aumenta-la aos poucos, o que suporta implantacoes canario. As demais politicas nao dividem o trafego por proporcao configuravel.",
+        topic: "Route 53 - Weighted Routing",
+        options: [
+            ["Roteamento baseado em latencia, associando o novo ambiente a regiao de menor latencia para receber uma fracao inicial pequena do trafego.", false],
+            ["Roteamento por geolocalizacao, liberando a nova versao primeiro para um pais especifico antes de expandir para os demais gradualmente.", false],
+            ["Roteamento de failover, mantendo a nova versao como destino secundario que so recebe trafego quando a versao atual apresenta falhas.", false],
+            ["Roteamento ponderado, atribuindo peso 5 ao novo ambiente e peso 95 ao atual e aumentando os pesos gradualmente.", true],
+        ],
+    },
+    {
+        statement: "Uma empresa de streaming precisa, por questoes de licenciamento de conteudo, servir usuarios da Alemanha a partir de endpoints especificos e redirecionar o acesso de outros paises conforme os direitos de exibicao. As decisoes devem se basear no pais de origem do usuario. Qual politica de roteamento do Amazon Route 53 atende a esse requisito?",
+        explanation: "O roteamento por geolocalizacao escolhe o endpoint com base na localizacao geografica (pais ou continente) da consulta DNS, adequado para restricoes de licenciamento e conformidade regional. Latencia e pesos nao consideram o pais de origem.",
+        topic: "Route 53 - Geolocation Routing",
+        options: [
+            ["Roteamento baseado em latencia, que encaminha cada usuario ao endpoint de menor tempo de resposta e assim respeita as fronteiras de licenciamento.", false],
+            ["Roteamento por geolocalizacao, que direciona as respostas DNS conforme o pais ou continente de origem da consulta.", true],
+            ["Roteamento ponderado, que separa o trafego por pais ao atribuir pesos diferentes a cada endpoint regional de conteudo.", false],
+            ["Roteamento de multiplos valores, que devolve varios endpoints saudaveis e deixa o cliente escolher o mais proximo do seu pais.", false],
+        ],
+    },
+    {
+        statement: "Uma aplicacao usa varios servidores web com IPs publicos distintos. A equipe quer que o Amazon Route 53 retorne multiplos enderecos saudaveis nas consultas DNS, associando verificacoes de integridade a cada registro, para obter uma distribuicao simples de carga com melhoria de disponibilidade, sem provisionar um balanceador de carga. Qual recurso atende a isso?",
+        explanation: "O roteamento de multiplos valores devolve ate oito registros saudaveis por consulta e verifica a integridade de cada um, oferecendo uma distribuicao simples e mais resiliente sem um balanceador de carga. O roteamento simples nao faz verificacao de integridade dos valores retornados.",
+        topic: "Route 53 - Multivalue Answer Routing",
+        options: [
+            ["Roteamento de failover com um registro primario e um secundario, retornando o secundario apenas quando o primario fica nao saudavel.", false],
+            ["Roteamento simples com varios enderecos IP em um unico registro, sem qualquer verificacao de integridade associada aos valores retornados.", false],
+            ["Roteamento de multiplos valores (multivalue answer) com verificacoes de integridade associadas a cada registro.", true],
+            ["Roteamento ponderado com pesos iguais em todos os registros e verificacoes de integridade para retirar endpoints nao saudaveis das respostas.", false],
+        ],
+    },
+    {
+        statement: "Um sistema bancario processa transacoes que precisam ser tratadas exatamente na ordem em que foram enviadas por cada cliente, e nenhuma mensagem pode ser processada em duplicidade. A equipe quer desacoplar o produtor do consumidor com uma fila gerenciada. Qual solucao atende a esses requisitos?",
+        explanation: "A fila SQS FIFO garante a ordem de entrega dentro de cada grupo de mensagens e o processamento exatamente uma vez, atendendo a requisitos de ordenacao estrita e ausencia de duplicatas. A fila padrao oferece apenas ordenacao de melhor esforco e entrega pelo menos uma vez.",
+        topic: "SQS FIFO",
+        options: [
+            ["Usar uma fila SQS FIFO, que preserva a ordem das mensagens e garante processamento exatamente uma vez.", true],
+            ["Usar uma fila SQS padrao e confiar na entrega ordenada de melhor esforco, adicionando um numero de sequencia em cada mensagem para o consumidor reordenar.", false],
+            ["Usar um topico do Amazon SNS padrao com uma assinatura de fila, aproveitando a ordenacao total garantida pela entrega fan-out do SNS.", false],
+            ["Usar uma fila SQS padrao com deduplicacao ativada e o atributo de grupo de mensagens para manter a ordem por cliente durante o consumo.", false],
+        ],
+    },
+    {
+        statement: "Uma empresa quer construir uma arquitetura orientada a eventos em que mudancas de estado de varios servicos da AWS e eventos de aplicativos SaaS de parceiros sejam roteados para diferentes destinos, como funcoes Lambda, filas e Step Functions, com base em regras de correspondencia de conteudo. Qual servico e o mais adequado?",
+        explanation: "O Amazon EventBridge e um barramento de eventos serverless que recebe eventos de servicos da AWS, aplicativos proprios e parceiros SaaS e os roteia para varios destinos por meio de regras baseadas em conteudo. Ele elimina a necessidade de os produtores conhecerem os consumidores.",
+        topic: "Amazon EventBridge",
+        options: [
+            ["Amazon SQS, criando uma fila para cada destino e fazendo os produtores decidirem em qual fila publicar conforme o tipo de cada evento.", false],
+            ["Amazon Kinesis Data Streams, com consumidores que leem todos os eventos do stream e filtram no codigo apenas os que interessam a cada destino.", false],
+            ["AWS Step Functions, definindo uma maquina de estado central que recebe todos os eventos e ramifica o fluxo para cada destino conforme o conteudo.", false],
+            ["Amazon EventBridge, usando um barramento de eventos com regras que filtram por conteudo e roteiam para multiplos destinos.", true],
+        ],
+    },
+    {
+        statement: "Uma empresa precisa de uma estrategia de disaster recovery para uma aplicacao critica com RTO de poucos minutos. A restricao e o custo: manter uma copia identica em escala total em outra regiao o tempo todo e caro demais. A empresa aceita manter uma versao reduzida, porem totalmente funcional, sempre em execucao na regiao secundaria, pronta para escalar. Qual estrategia descreve essa abordagem?",
+        explanation: "No warm standby, uma copia funcional em escala reduzida da aplicacao fica sempre em execucao na regiao secundaria e e ampliada durante o failover, equilibrando custo e RTO baixo. No pilot light, os servidores de aplicacao nao ficam ativos ate o desastre.",
+        topic: "Disaster Recovery - Warm Standby",
+        options: [
+            ["Backup e restauracao (backup and restore), em que os dados sao copiados para a outra regiao e toda a infraestrutura e provisionada somente durante o desastre.", false],
+            ["Warm standby, com uma versao reduzida e funcional da aplicacao sempre ativa na regiao secundaria, escalada no failover.", true],
+            ["Pilot light, em que apenas o banco de dados fica replicado e ativo e nenhum servidor de aplicacao permanece em execucao ate o failover ocorrer.", false],
+            ["Multi-site ativo-ativo, com a infraestrutura completa processando trafego de producao nas duas regioes simultaneamente o tempo todo.", false],
+        ],
+    },
+    {
+        statement: "Uma aplicacao interna de baixa criticidade pode tolerar varias horas de indisponibilidade e a perda de algumas horas de dados em caso de desastre regional. A empresa quer a estrategia de disaster recovery de menor custo possivel. Qual abordagem atende a esse objetivo?",
+        explanation: "A estrategia de backup e restauracao tem o menor custo porque nenhuma infraestrutura de recuperacao fica em execucao ate o desastre, ao preco de um RTO e um RPO mais altos, aceitaveis para cargas de baixa criticidade. As demais mantem recursos ativos e custam mais.",
+        topic: "Disaster Recovery - Backup and Restore",
+        options: [
+            ["Warm standby, mantendo uma versao reduzida da aplicacao sempre em execucao na regiao secundaria para reduzir o tempo de recuperacao.", false],
+            ["Pilot light, deixando o banco de dados continuamente replicado e ativo na regiao secundaria, com os servidores desligados ate o failover.", false],
+            ["Backup e restauracao, copiando dados e imagens para outra regiao e provisionando a infraestrutura apenas durante o desastre.", true],
+            ["Multi-site ativo-ativo, distribuindo o trafego de producao entre duas regioes o tempo todo para eliminar qualquer tempo de recuperacao.", false],
+        ],
+    },
+    {
+        statement: "Uma empresa esta migrando aplicacoes Windows legadas para a AWS. Essas aplicacoes precisam de um sistema de arquivos compartilhado que use o protocolo SMB, ofereca compatibilidade com NTFS e se integre ao Active Directory existente para controle de permissoes. Qual servico atende a esses requisitos?",
+        explanation: "O Amazon FSx for Windows File Server oferece compartilhamentos de arquivos SMB totalmente gerenciados, com compatibilidade NTFS e integracao nativa ao Active Directory, ideal para aplicacoes Windows. O EFS usa NFS e o FSx for Lustre e voltado a HPC.",
+        topic: "FSx for Windows File Server",
+        options: [
+            ["Amazon FSx for Windows File Server, que fornece compartilhamentos SMB totalmente gerenciados com integracao ao Active Directory.", true],
+            ["Amazon EFS, que oferece um sistema de arquivos elastico compartilhado por NFS e se integra ao Active Directory para permissoes NTFS.", false],
+            ["Amazon FSx for Lustre, que entrega um sistema de arquivos de alto desempenho via SMB otimizado para cargas de trabalho Windows corporativas.", false],
+            ["Amazon S3 montado como unidade de rede nas instancias Windows, usando SMB e as permissoes de grupos e usuarios do Active Directory.", false],
+        ],
+    },
+    {
+        statement: "Uma equipe precisa de um sistema de arquivos NFS compartilhado por instancias EC2 distribuidas em tres zonas de disponibilidade. O requisito principal e que os dados permanecam acessiveis mesmo que uma zona de disponibilidade inteira fique indisponivel. Qual configuracao do Amazon EFS atende a isso?",
+        explanation: "A classe de armazenamento EFS Standard e regional e armazena os dados de forma redundante em varias zonas de disponibilidade, mantendo o acesso mesmo com a falha de uma zona inteira. A classe One Zone guarda os dados em uma unica zona e nao sobrevive a perda dela.",
+        topic: "Amazon EFS - Storage Classes",
+        options: [
+            ["Uma classe de armazenamento EFS One Zone, que replica os dados dentro de uma unica zona e alcanca o menor custo mantendo alta disponibilidade regional.", false],
+            ["Um volume Amazon EBS Multi-Attach compartilhado simultaneamente pelas instancias EC2 das tres zonas de disponibilidade por meio do protocolo NFS.", false],
+            ["Varios sistemas EFS One Zone, um por zona, sincronizados entre si com uma tarefa do AWS DataSync executada a cada poucos minutos.", false],
+            ["Um sistema de arquivos EFS com classe de armazenamento Standard (regional), que armazena os dados de forma redundante em varias zonas.", true],
+        ],
+    },
+    {
+        statement: "Uma empresa roda o Amazon RDS for PostgreSQL na regiao us-east-1. Ela quer melhorar a resiliencia a uma falha regional e, ao mesmo tempo, oferecer leituras de baixa latencia a usuarios na Europa. A solucao deve permitir a promocao do recurso na segunda regiao para banco principal em caso de desastre. O que a equipe deve implementar?",
+        explanation: "Uma replica de leitura entre regioes replica os dados de forma assincrona para a Europa, atende leituras locais com baixa latencia e pode ser promovida a banco principal em um desastre regional. O RDS Multi-AZ mantem o standby na mesma regiao, nao em outra.",
+        topic: "RDS Cross-Region Read Replica",
+        options: [
+            ["Uma instancia RDS Multi-AZ, que mantem um standby sincrono em outra regiao e o promove automaticamente durante uma falha regional.", false],
+            ["Snapshots automaticos copiados para a regiao europeia a cada 24 horas, restaurados como um novo banco de dados sempre que a regiao primaria falhar.", false],
+            ["Uma replica de leitura entre regioes (cross-region read replica) na Europa, que serve leituras locais e pode ser promovida a principal.", true],
+            ["O Amazon RDS Proxy configurado na regiao europeia para rotear as leituras dos usuarios locais diretamente ao banco de dados primario em us-east-1.", false],
+        ],
+    },
+    {
+        statement: "Uma aplicacao usa um cluster Amazon Aurora e enfrenta picos imprevisiveis de trafego de leitura que as vezes sobrecarregam as replicas existentes, degradando o desempenho das consultas. A equipe quer que a capacidade de leitura acompanhe a demanda automaticamente, sem intervencao manual. O que deve ser configurado?",
+        explanation: "O Aurora Replica Auto Scaling adiciona ou remove replicas de leitura automaticamente com base em uma metrica de destino, como CPU ou numero de conexoes, acompanhando picos imprevisiveis de leitura. O Global Database serve disaster recovery entre regioes, nao escalonamento automatico local.",
+        topic: "Aurora Replica Auto Scaling",
+        options: [
+            ["Habilitar o Aurora Global Database para adicionar replicas de leitura em outra regiao sempre que o uso de CPU das replicas locais aumentar.", false],
+            ["Configurar o Aurora Replica Auto Scaling para adicionar e remover replicas conforme uma metrica de destino, como a utilizacao de CPU.", true],
+            ["Aumentar manualmente a classe de instancia do escritor do Aurora para uma maior, de modo que ele tambem absorva o trafego de leitura nos picos.", false],
+            ["Ativar o Amazon RDS Multi-AZ no cluster para que a instancia standby passe a atender parte das consultas de leitura durante os periodos de pico.", false],
+        ],
+    },
+    {
+        statement: "Um grupo do Amazon EC2 Auto Scaling esta atras de um Application Load Balancer. Algumas instancias continuam em execucao, e por isso passam na verificacao de status do EC2, mas o processo da aplicacao travou e elas nao respondem mais as requisicoes. A equipe quer que o Auto Scaling substitua automaticamente essas instancias. O que deve ser feito?",
+        explanation: "Ao ativar o tipo de verificacao de integridade do ELB, o Auto Scaling passa a considerar nao saudaveis as instancias reprovadas na verificacao do balanceador e as substitui, mesmo que a verificacao de status do EC2 esteja passando. A verificacao do EC2 sozinha nao detecta falhas no nivel da aplicacao.",
+        topic: "EC2 Auto Scaling - Health Checks",
+        options: [
+            ["Ativar as verificacoes de integridade do Elastic Load Balancing no grupo de Auto Scaling para que instancias reprovadas sejam substituidas.", true],
+            ["Reduzir o periodo de carencia (health check grace period) do grupo para zero, forcando o Auto Scaling a reavaliar e reiniciar as instancias com mais frequencia.", false],
+            ["Depender apenas das verificacoes de status do EC2, que ja detectam falhas do sistema operacional e do processo da aplicacao em cada instancia.", false],
+            ["Criar um alarme do Amazon CloudWatch de CPU alta e associa-lo a uma politica de scaling para trocar as instancias que nao respondem as requisicoes.", false],
+        ],
+    },
+    {
+        statement: "Uma plataforma publica todos os eventos de pedidos em um unico topico do Amazon SNS com varias assinaturas. Cada consumidor, porem, so deve receber um subconjunto dos eventos: um processa apenas pedidos acima de determinado valor e outro apenas pedidos de certas regioes. A equipe quer evitar que cada consumidor receba tudo e descarte o que nao interessa. Qual recurso resolve isso?",
+        explanation: "As politicas de filtro do Amazon SNS avaliam os atributos de cada mensagem por assinatura, entregando a cada consumidor apenas os eventos relevantes sem codigo adicional. Criar um topico por tipo aumenta o acoplamento e a complexidade no produtor.",
+        topic: "SNS Message Filtering",
+        options: [
+            ["Publicar os eventos em uma fila SQS FIFO com grupos de mensagens distintos e deixar cada consumidor ler somente o seu grupo de mensagens.", false],
+            ["Criar um topico do SNS separado para cada tipo de evento e fazer o produtor decidir em qual topico publicar conforme os atributos de cada pedido.", false],
+            ["Aplicar politicas de filtro (filter policies) nas assinaturas do SNS, baseadas nos atributos de mensagem de cada evento.", true],
+            ["Encaminhar todos os eventos para uma funcao AWS Lambda que inspeciona cada mensagem e a redireciona ao consumidor certo conforme o conteudo.", false],
+        ],
+    },
+    {
+        statement: "Uma equipe armazena logs de clickstream comprimidos em um bucket do Amazon S3 e precisa executar consultas SQL ad hoc esporádicas sobre esses dados, sem provisionar nem gerenciar servidores e pagando apenas pelo que consultar. Qual solução atende melhor a esse requisito?",
+        explanation: "O Amazon Athena é serverless e consulta dados diretamente no S3 com SQL padrão, cobrando pelos dados lidos em cada consulta, ideal para análises ad hoc esporádicas sem infraestrutura para gerenciar.",
+        topic: "Amazon Athena",
+        options: [
+            ["Provisionar um cluster Amazon Redshift, carregar os logs com COPY a partir do S3 e manter o cluster ligado para atender às consultas ocasionais.", false],
+            ["Usar o Amazon Athena para consultar os arquivos diretamente no Amazon S3 com SQL, pagando apenas pelos dados lidos em cada consulta.", true],
+            ["Criar um cluster Amazon EMR com Hive e mantê-lo sempre em execução para responder às consultas quando surgirem.", false],
+            ["Importar os arquivos para um banco Amazon RDS for MySQL em uma instância grande e consultar por SQL.", false],
+        ],
+    },
+    {
+        statement: "Uma equipe de operações quer centralizar logs de aplicações e servidores para fazer busca por texto completo, montar painéis e investigar incidentes com análise quase em tempo real. Qual solução atende melhor a essa necessidade?",
+        explanation: "O Amazon OpenSearch Service indexa logs para busca de texto completo e análise operacional quase em tempo real, com o OpenSearch Dashboards integrado, algo que datastores relacionais ou consultas ad hoc no S3 não entregam com a mesma latência interativa.",
+        topic: "Amazon OpenSearch Service",
+        options: [
+            ["Carregar continuamente os logs em um cluster Amazon Redshift dedicado e criar consultas SQL agendadas com visualizações no Amazon QuickSight para investigar cada incidente.", false],
+            ["Guardar os logs no Amazon S3 e usar o Amazon Athena para buscas por texto sempre que houver um incidente.", false],
+            ["Enviar os logs para um banco Amazon RDS e criar índices de texto para permitir a busca das equipes de operação.", false],
+            ["Ingerir os logs no Amazon OpenSearch Service e usar o OpenSearch Dashboards para busca de texto completo e análise quase em tempo real.", true],
+        ],
+    },
+    {
+        statement: "Uma aplicação tem uma carga de banco de dados relacional com demanda imprevisível e que varia bruscamente ao longo do dia. A equipe quer que a capacidade escale automaticamente e pagar pelo que for consumido, sem ficar redimensionando instâncias. O que recomendar?",
+        explanation: "O Aurora Serverless v2 ajusta a capacidade de forma fina e automática (em ACUs) acompanhando cargas imprevisíveis e variáveis, evitando pagar por uma instância dimensionada para o pico o tempo todo.",
+        topic: "Amazon Aurora Serverless v2",
+        options: [
+            ["Usar o Amazon Aurora Serverless v2, que ajusta a capacidade automaticamente conforme a carga e cobra pelo que é consumido.", true],
+            ["Provisionar uma instância Amazon Aurora dimensionada para o pico previsto e mantê-la ligada o tempo todo para suportar todas as variações de demanda.", false],
+            ["Usar o Amazon RDS for MySQL e alterar manualmente a classe da instância sempre que a demanda mudar ao longo do dia.", false],
+            ["Migrar a aplicação para o Amazon DynamoDB no modo sob demanda para acompanhar a variação de tráfego automaticamente.", false],
+        ],
+    },
+    {
+        statement: "Uma aplicação de processamento precisa de uma camada de armazenamento local com a menor latência e o maior número de IOPS possível para dados temporários que podem ser recriados e não precisam sobreviver à parada da instância. Qual opção oferece o melhor desempenho para esse caso?",
+        explanation: "O instance store oferece armazenamento NVMe local com a menor latência e o maior IOPS, sem custo adicional de armazenamento, e é ideal para dados temporários que podem ser recriados, já que não persiste quando a instância para ou é encerrada.",
+        topic: "Amazon EC2 Instance Store",
+        options: [
+            ["Anexar um volume Amazon EBS io2 Block Express e habilitar o Multi-Attach para obter a menor latência possível para os dados temporários entre as instâncias.", false],
+            ["Usar o Amazon EFS montado nas instâncias para armazenar os dados temporários com alto desempenho compartilhado.", false],
+            ["Usar o armazenamento de instância (instance store) NVMe local das instâncias EC2 para os dados temporários que podem ser recriados.", true],
+            ["Anexar volumes Amazon EBS gp3 e aumentar os IOPS e o throughput provisionados para atender à necessidade de baixa latência.", false],
+        ],
+    },
+    {
+        statement: "Uma aplicação envia objetos de vários gigabytes para o Amazon S3 por uma rede instável, e as transferências às vezes falham perto do fim e recomeçam do zero. A equipe quer uploads mais rápidos e resilientes desses arquivos grandes. Qual abordagem resolve isso?",
+        explanation: "O multipart upload divide o objeto em partes enviadas em paralelo e permite reenviar somente as partes que falharam, aumentando a velocidade e a resiliência dos uploads de arquivos grandes.",
+        topic: "Amazon S3 (multipart upload)",
+        options: [
+            ["Aumentar o tempo limite do cliente e reenviar o objeto inteiro em uma única operação PUT toda vez que a transferência for interrompida perto do fim.", false],
+            ["Usar o multipart upload do Amazon S3 para enviar o objeto em partes paralelas, reenviando apenas as partes que falharem.", true],
+            ["Habilitar o S3 Transfer Acceleration para que o objeto seja enviado por uma única conexão otimizada de longa distância.", false],
+            ["Solicitar um dispositivo AWS Snowball e transferir os arquivos grandes fisicamente para contornar as falhas de rede.", false],
+        ],
+    },
+    {
+        statement: "Uma empresa está migrando aplicações Windows que dependem de um compartilhamento de arquivos SMB integrado ao Active Directory, com permissões NTFS. Ela quer um armazenamento de arquivos totalmente gerenciado e de alto desempenho. Qual serviço atende melhor?",
+        explanation: "O Amazon FSx for Windows File Server entrega compartilhamento de arquivos SMB totalmente gerenciado, com integração ao Active Directory e ACLs do Windows, ideal para aplicações Windows, enquanto o EFS atende cargas Linux via NFS.",
+        topic: "Amazon FSx for Windows File Server",
+        options: [
+            ["Provisionar um Amazon EFS e montá-lo nas instâncias Windows para fornecer o compartilhamento de arquivos via NFS.", false],
+            ["Armazenar os arquivos no Amazon S3 e acessá-los como um compartilhamento de rede a partir das aplicações Windows.", false],
+            ["Configurar um servidor de arquivos Windows autogerenciado em instâncias EC2, com replicação entre zonas e uma rotina de backups própria.", false],
+            ["Usar o Amazon FSx for Windows File Server, que oferece armazenamento SMB gerenciado integrado ao Active Directory.", true],
+        ],
+    },
+    {
+        statement: "Uma aplicação ingere um fluxo de eventos em alto volume que precisa ser consumido simultaneamente por várias aplicações independentes, com possibilidade de reprocessar os dados dentro de um período de retenção e realizar processamento personalizado em tempo real. Qual serviço atende melhor?",
+        explanation: "O Kinesis Data Streams mantém os registros por um período de retenção e permite que vários consumidores independentes leiam e reprocessem os mesmos dados com processamento personalizado, enquanto o Firehose apenas entrega os dados a destinos, sem releitura por múltiplos consumidores.",
+        topic: "Amazon Kinesis (Data Streams x Firehose)",
+        options: [
+            ["Usar o Amazon Kinesis Data Firehose para entregar os eventos automaticamente a um bucket do Amazon S3 e reprocessá-los de lá quando for necessário.", false],
+            ["Usar uma fila do Amazon SQS para distribuir os eventos, permitindo que várias aplicações os consumam e reprocessem quando quiserem.", false],
+            ["Usar o Amazon Kinesis Data Streams, que permite múltiplos consumidores independentes e a releitura dos dados dentro do período de retenção.", true],
+            ["Usar o Amazon Kinesis Data Firehose com transformação por Lambda para que cada aplicação leia o stream de forma independente e em tempo real.", false],
+        ],
+    },
+    {
+        statement: "Uma aplicação usa um cache em memória para dados de sessão e exige alta disponibilidade, com replicação e failover automático entre zonas para que a falha de um nó não descarte todos os dados em cache. Qual opção atende a esses requisitos?",
+        explanation: "Para alta disponibilidade com replicação e failover automático entre zonas, o ElastiCache for Redis é a escolha; o Memcached não oferece replicação nem failover nativos e perde os dados quando um nó falha.",
+        topic: "Amazon ElastiCache (Redis x Memcached)",
+        options: [
+            ["Usar o Amazon ElastiCache for Redis, que oferece réplicas de leitura, failover automático entre zonas e alta disponibilidade dos dados em cache.", true],
+            ["Usar o Amazon ElastiCache for Memcached, que fornece replicação entre nós, failover automático e alta disponibilidade nativa para os dados em cache.", false],
+            ["Usar o Amazon ElastiCache for Memcached e distribuir os dados por vários nós, aceitando a perda das sessões quando um nó falhar.", false],
+            ["Instalar o Memcached em instâncias EC2 em zonas diferentes e implementar a replicação e o failover manualmente na aplicação.", false],
+        ],
+    },
+    {
+        statement: "Um sistema de arquivos Amazon EFS atende uma carga analítica crescente com muitos clientes EC2 em paralelo e sofre limitação de throughput nos picos, porque esgota os créditos do modo Bursting. A equipe quer throughput alto e consistente que acompanhe a demanda sem gerenciar capacidade. O que fazer?",
+        explanation: "O modo Elastic Throughput do Amazon EFS escala a taxa de transferência automaticamente para atender a picos imprevisíveis e cobra pelo uso, resolvendo o esgotamento de créditos do modo Bursting; o modo de desempenho Max I/O trata de IOPS e latência, não do limite de throughput.",
+        topic: "Amazon EFS (modos de throughput)",
+        options: [
+            ["Aumentar a quantidade de dados armazenados no sistema de arquivos para acumular mais créditos de burst e sustentar os picos de throughput ao longo do dia.", false],
+            ["Alterar o sistema de arquivos para o modo de throughput Elástico (Elastic Throughput), que escala automaticamente conforme a demanda.", true],
+            ["Mudar o modo de desempenho do sistema de arquivos para Max I/O a fim de remover o limite de throughput durante os picos.", false],
+            ["Migrar os dados para volumes Amazon EBS gp3 anexados a cada instância para eliminar o compartilhamento do sistema de arquivos.", false],
+        ],
+    },
+    {
+        statement: "Uma equipe executa o treinamento de modelos de deep learning, fortemente dependente de cálculos matriciais paralelos, e quer reduzir o tempo de treinamento. Qual tipo de instância EC2 é o mais adequado?",
+        explanation: "O treinamento de deep learning depende de processamento paralelo massivo, no qual as GPUs das instâncias de computação acelerada (por exemplo, a família P) superam de longe as famílias baseadas apenas em CPU.",
+        topic: "Amazon EC2 (computação acelerada com GPU)",
+        options: [
+            ["Usar instâncias da família otimizada para computação (família C), que oferecem a maior proporção de vCPU por memória para acelerar o treinamento em paralelo.", false],
+            ["Usar instâncias da família otimizada para memória (família R) para manter todo o conjunto de dados em memória durante o treinamento.", false],
+            ["Usar instâncias de propósito geral (família M) e aumentar o número de instâncias no cluster para paralelizar o treinamento.", false],
+            ["Usar instâncias com GPU da família de computação acelerada (como a família P) para o treinamento de deep learning.", true],
+        ],
+    },
+    {
+        statement: "Uma empresa vai assumir um compromisso de 3 anos com Savings Plans, mas planeja modernizar os workloads: migrar parte para o AWS Fargate e o AWS Lambda e trocar as famílias de instâncias EC2 ao longo do tempo. Ela quer que o desconto continue se aplicando automaticamente conforme o uso muda. Qual opção escolher?",
+        explanation: "O Compute Savings Plans oferece a maior flexibilidade: o desconto acompanha mudanças de família, tamanho, região, sistema operacional e locação de EC2 e ainda cobre o AWS Fargate e o AWS Lambda, ideal para quem vai modernizar os workloads.",
+        topic: "AWS Savings Plans",
+        options: [
+            ["Comprar EC2 Instance Savings Plans para a família de instâncias atual, aproveitando o maior desconto possível mesmo com as futuras mudanças de família e a adoção do Fargate.", false],
+            ["Comprar Standard Reserved Instances para as instâncias atuais e revendê-las no marketplace quando os workloads migrarem para contêineres e funções.", false],
+            ["Comprar Compute Savings Plans, cujo desconto se aplica automaticamente a EC2 de qualquer família e região e também ao Fargate e ao Lambda.", true],
+            ["Continuar em On-Demand até concluir toda a modernização e só então avaliar algum compromisso de longo prazo.", false],
+        ],
+    },
+    {
+        statement: "O time financeiro quer ser avisado automaticamente quando houver um aumento incomum e inesperado no gasto da AWS, por exemplo por uma configuração equivocada que dispare custos, usando detecção baseada em aprendizado de máquina em vez de acompanhar painéis manualmente. Qual serviço atende melhor?",
+        explanation: "O AWS Cost Anomaly Detection aplica aprendizado de máquina para identificar aumentos incomuns de gasto e alertar automaticamente, diferentemente do AWS Budgets, que dispara apenas quando um limite previamente definido é ultrapassado.",
+        topic: "AWS Cost Anomaly Detection",
+        options: [
+            ["Ativar o AWS Cost Anomaly Detection, que usa aprendizado de máquina para detectar gastos anômalos e enviar alertas automaticamente.", true],
+            ["Configurar o AWS Cost Explorer para revisar manualmente os relatórios de gasto todos os dias e identificar variações fora do padrão.", false],
+            ["Criar um AWS Budget com um limite fixo de gasto mensal e receber um alerta somente quando esse valor for ultrapassado.", false],
+            ["Consultar o AWS Trusted Advisor periodicamente em busca de recomendações de redução de custo nos recursos ociosos.", false],
+        ],
+    },
+    {
+        statement: "Uma empresa com centenas de buckets do Amazon S3 distribuídos em várias contas de uma organização quer visibilidade do uso e das tendências de armazenamento em toda a organização, além de recomendações acionáveis para otimizar custos. Qual recurso atende melhor?",
+        explanation: "O S3 Storage Lens oferece um painel com métricas de uso e atividade e recomendações acionáveis de otimização de custo em todas as contas e buckets da organização, algo que o S3 Inventory ou métricas isoladas por bucket não entregam.",
+        topic: "Amazon S3 Storage Lens",
+        options: [
+            ["Habilitar o Amazon S3 Inventory em cada bucket para gerar listas de objetos e analisar manualmente onde é possível economizar.", false],
+            ["Usar o AWS Cost Explorer filtrando por Amazon S3 para ver o gasto total do serviço mês a mês em toda a organização.", false],
+            ["Ativar o Amazon S3 Storage Lens para obter visibilidade e recomendações de otimização do armazenamento em toda a organização.", true],
+            ["Criar métricas do Amazon CloudWatch por bucket e montar painéis individuais para acompanhar o uso de cada um separadamente.", false],
+        ],
+    },
+    {
+        statement: "Em uma conta de desenvolvimento, uma empresa quer não apenas ser alertada, mas executar automaticamente uma ação, como aplicar uma policy restritiva ou parar instâncias EC2, quando o gasto ultrapassar um limite definido, evitando estouros de custo. O que usar?",
+        explanation: "As ações do AWS Budgets (budget actions) executam automaticamente respostas como aplicar uma policy restritiva do IAM ou parar instâncias EC2 quando o gasto atinge o limite definido, evitando estouros sem intervenção manual.",
+        topic: "AWS Budgets",
+        options: [
+            ["Configurar o AWS Cost Anomaly Detection para detectar o excesso de gasto e depender da equipe para desligar os recursos manualmente depois do alerta.", false],
+            ["Usar o AWS Cost Explorer para acompanhar o gasto do ambiente de desenvolvimento e revisar os recursos ao final de cada mês.", false],
+            ["Habilitar o AWS Trusted Advisor para receber recomendações sobre instâncias ociosas na conta de desenvolvimento.", false],
+            ["Criar um AWS Budget com ações que apliquem automaticamente uma policy restritiva ou parem instâncias ao atingir o limite.", true],
+        ],
+    },
+    {
+        statement: "Uma empresa arquiva imagens médicas acessadas muito raramente, talvez uma ou duas vezes por ano, mas que, quando solicitadas, precisam ser recuperadas em milissegundos. Ela quer o menor custo de armazenamento possível mantendo o acesso instantâneo. Qual classe do Amazon S3 usar?",
+        explanation: "O S3 Glacier Instant Retrieval tem custo de armazenamento bem menor que o Standard-IA para dados acessados apenas uma ou duas vezes ao ano, mantendo recuperação em milissegundos, enquanto o Deep Archive economizaria mais, mas leva horas para recuperar.",
+        topic: "Amazon S3 Glacier Instant Retrieval",
+        options: [
+            ["Usar a classe S3 Glacier Instant Retrieval, que tem custo de armazenamento baixo e ainda permite acesso em milissegundos.", true],
+            ["Usar a classe S3 Glacier Deep Archive, que oferece o menor custo de armazenamento, aceitando a recuperação em várias horas quando os dados forem necessários.", false],
+            ["Usar a classe S3 Standard-IA, que mantém o acesso imediato, ainda que o custo de armazenamento seja mais alto do que o necessário para dados tão raramente acessados.", false],
+            ["Usar a classe S3 Standard e criar uma regra de lifecycle para excluir os arquivos após um ano sem acesso.", false],
+        ],
+    },
+    {
+        statement: "Uma frota de volumes Amazon EBS gp2 entrega desempenho adequado, mas o time financeiro quer reduzir o custo de EBS sem perder desempenho. Qual é a forma mais direta de conseguir isso?",
+        explanation: "O gp3 custa cerca de 20% menos por GB que o gp2 e permite configurar IOPS e throughput de forma independente do tamanho, sendo a maneira direta de reduzir o custo de EBS sem perder desempenho.",
+        topic: "Amazon EBS gp3 (otimização de custo)",
+        options: [
+            ["Migrar os volumes para o tipo io2, pois os volumes SSD com IOPS provisionados são mais baratos que os de uso geral quando o objetivo é reduzir custos.", false],
+            ["Migrar os volumes gp2 para gp3, que custa cerca de 20% menos por GB e mantém o desempenho necessário.", true],
+            ["Migrar os volumes para o tipo st1 (HDD otimizado para throughput) para reduzir o custo por GB armazenado.", false],
+            ["Reduzir o tamanho de cada volume gp2 pela metade para diminuir o custo, ainda que isso limite a capacidade disponível.", false],
+        ],
+    },
+    {
+        statement: "Uma empresa executa uma grande frota de instâncias EC2 x86 para um workload cujos runtimes são compatíveis com ARM, como Java, Go e contêineres, e quer melhor relação preço-desempenho, reduzindo custos sem um grande redesenho. O que recomendar?",
+        explanation: "As instâncias baseadas em AWS Graviton (ARM) entregam melhor relação preço-desempenho que as equivalentes x86 para cargas compatíveis, reduzindo o custo sem sacrificar desempenho, muitas vezes com pouca ou nenhuma alteração na aplicação.",
+        topic: "AWS Graviton",
+        options: [
+            ["Migrar para instâncias x86 de última geração e maiores para melhorar o desempenho, ainda que o custo por hora aumente proporcionalmente à capacidade.", false],
+            ["Mover toda a frota para instâncias Spot x86 para reduzir o custo, aceitando que qualquer instância possa ser interrompida a qualquer momento.", false],
+            ["Migrar a frota para instâncias baseadas em AWS Graviton (ARM), que oferecem melhor relação preço-desempenho para cargas compatíveis.", true],
+            ["Adquirir Dedicated Hosts para a frota atual a fim de obter previsibilidade de custo por servidor físico dedicado.", false],
+        ],
+    },
+    {
+        statement: "Uma camada de processamento web sem estado e tolerante a falhas roda atrás de um grupo de Auto Scaling. A empresa quer reduzir bastante o custo mantendo uma base de capacidade confiável, mesmo que ocorram interrupções de capacidade. Qual abordagem é a mais adequada?",
+        explanation: "A política de instâncias mistas do EC2 Auto Scaling combina uma base garantida em On-Demand com instâncias Spot para a expansão, reduzindo o custo de forma expressiva sem arriscar toda a capacidade em uma interrupção de Spot.",
+        topic: "Amazon EC2 Auto Scaling (instâncias mistas com Spot)",
+        options: [
+            ["Executar todo o grupo com instâncias On-Demand para garantir capacidade e comprar Reserved Instances para cobrir a frota inteira durante todo o período.", false],
+            ["Executar todo o grupo exclusivamente com instâncias Spot para obter o menor custo, aceitando o risco de perder toda a capacidade em uma interrupção.", false],
+            ["Migrar a camada para Dedicated Hosts para reduzir o custo por meio do isolamento físico do hardware.", false],
+            ["Usar um grupo de Auto Scaling com política de instâncias mistas, combinando uma base On-Demand com Spot para a expansão.", true],
+        ],
+    },
+    {
+        statement: "Uma empresa serve downloads estáticos grandes, como instaladores e mídia, diretamente do Amazon S3 para um público global, e a conta mensal de transferência de dados de saída está alta. O time financeiro quer reduzir esse custo. Qual solução recomendar?",
+        explanation: "O Amazon CloudFront reduz o custo de transferência ao servir conteúdo em cache a partir das bordas, diminuindo as buscas na origem, e por ter preços de saída para a internet menores que os do S3; a transferência da origem AWS para o CloudFront não é cobrada.",
+        topic: "Amazon CloudFront (otimização de custo de transferência)",
+        options: [
+            ["Ativar o S3 Transfer Acceleration no bucket de origem para que os downloads dos usuários fiquem mais baratos e mais rápidos.", false],
+            ["Distribuir o conteúdo por meio do Amazon CloudFront, cujo cache nas bordas e preços de transferência reduzem o custo de saída de dados.", true],
+            ["Contratar o AWS Direct Connect para reduzir o custo de transferência dos downloads entregues aos usuários pela internet.", false],
+            ["Aumentar o tamanho das instâncias EC2 que servem os downloads e adicionar mais réplicas em outras zonas de disponibilidade para melhorar a entrega e diminuir o custo por download entregue aos usuários.", false],
+        ],
+    },
 ];
 
 async function seed() {
@@ -1473,13 +2101,23 @@ async function seed() {
         .select({ n: count() })
         .from(simuladoQuestions)
         .where(eq(simuladoQuestions.simuladoId, simulado.id));
-    if (Number(n) > 0) {
+    const jaExistem = new Set(
+        (
+            await db
+                .select({ statement: simuladoQuestions.statement })
+                .from(simuladoQuestions)
+                .where(eq(simuladoQuestions.simuladoId, simulado.id))
+        ).map((r) => r.statement),
+    );
+    const inseridas = QUESTOES.filter((q) => !jaExistem.has(q.statement)).length;
+    if (inseridas === 0) {
         console.log(`Simulado ja tem ${n} questoes, nada a fazer.`);
         return;
     }
 
     for (let i = 0; i < QUESTOES.length; i++) {
         const q = QUESTOES[i];
+        if (jaExistem.has(q.statement)) continue;
         const [questao] = await db
             .insert(simuladoQuestions)
             .values({
@@ -1498,7 +2136,7 @@ async function seed() {
             })),
         );
     }
-    console.log(`Seed concluido: ${QUESTOES.length} questoes inseridas.`);
+    console.log(`Seed: ${inseridas} questoes novas inseridas (${QUESTOES.length} no banco).`);
 }
 
 seed()

--- a/backend/scripts/seed-sc-900.ts
+++ b/backend/scripts/seed-sc-900.ts
@@ -2223,7 +2223,327 @@ const QUESTOES: Questao[] = [
                 false
             ]
         ]
-    }
+    },
+    // ===== Questões adicionais (banco ampliado para variar as tentativas) =====
+    {
+        statement: "Um time de segurança organiza seus controles em torno de três objetivos fundamentais da segurança da informação, conhecidos como tríade CIA. Quais são esses três pilares?",
+        explanation: "A tríade CIA reúne confidencialidade (evitar acesso não autorizado), integridade (evitar alterações indevidas) e disponibilidade (garantir o acesso quando necessário).",
+        topic: "Conceitos de SCI e Microsoft Entra",
+        options: [
+            ["Confidencialidade, integridade e disponibilidade", true],
+            ["Confidencialidade, identidade e autorização", false],
+            ["Criptografia, integridade e autenticação", false],
+            ["Confidencialidade, disponibilidade e o não repúdio garantido por assinaturas digitais e trilhas de auditoria", false],
+        ],
+    },
+    {
+        statement: "Uma empresa quer proteger tanto os dados gravados nos discos dos servidores quanto os dados que trafegam entre o navegador do cliente e a aplicação. Como se classificam essas duas formas de proteção por criptografia?",
+        explanation: "Criptografia em repouso protege dados gravados em disco ou banco de dados; criptografia em trânsito protege os dados enquanto trafegam pela rede, por exemplo via TLS.",
+        topic: "Conceitos de SCI e Microsoft Entra",
+        options: [
+            ["Criptografia simétrica para os discos e criptografia assimétrica para a rede", false],
+            ["Criptografia em repouso para o que está armazenado e criptografia em trânsito para o que trafega", true],
+            ["Hashing para os discos e criptografia em trânsito para a rede", false],
+            ["Criptografia em trânsito para os dados gravados nos discos e criptografia em repouso para os dados que circulam pela rede entre cliente e servidor", false],
+        ],
+    },
+    {
+        statement: "Uma varejista está lançando um aplicativo público de compras e quer que os clientes finais se cadastrem e façam login com contas próprias, como e-mail ou provedores sociais, sem se tornarem usuários internos do diretório corporativo. Qual recurso do Microsoft Entra atende a esse cenário?",
+        explanation: "O Azure AD B2C, parte do Microsoft Entra External ID, oferece cadastro e login para clientes finais com e-mail, contas locais ou provedores sociais, separado do diretório de funcionários.",
+        topic: "Conceitos de SCI e Microsoft Entra",
+        options: [
+            ["Microsoft Entra B2B, para colaboração com parceiros de negócio externos", false],
+            ["Identidade híbrida, sincronizando as contas dos clientes a partir do Active Directory local para o Microsoft Entra ID", false],
+            ["Microsoft Entra External ID para consumidores (Azure AD B2C)", true],
+            ["Privileged Identity Management (PIM)", false],
+        ],
+    },
+    {
+        statement: "Ao planejar a autenticação multifator, um analista precisa combinar fatores de categorias diferentes para aumentar a segurança. Quais são as três categorias de fatores de autenticação?",
+        explanation: "Os fatores se dividem em algo que você sabe (senha ou PIN), algo que você tem (telefone ou token) e algo que você é (biometria); a MFA combina categorias diferentes.",
+        topic: "Conceitos de SCI e Microsoft Entra",
+        options: [
+            ["Algo que você sabe, algo que você vê e algo que você assina", false],
+            ["Usuário, senha e código de verificação", false],
+            ["Uma senha memorizada, um token físico registrado previamente e uma pergunta de segurança respondida no primeiro acesso", false],
+            ["Algo que você sabe, algo que você tem e algo que você é", true],
+        ],
+    },
+    {
+        statement: "Ao assinar o Microsoft 365, uma organização recebe uma instância dedicada e isolada do Microsoft Entra ID, onde ficam seus usuários, grupos e aplicativos. Como se chama essa instância?",
+        explanation: "Cada organização possui seu próprio locatário (tenant) do Microsoft Entra ID, uma instância dedicada e isolada que hospeda suas identidades e o acesso aos recursos.",
+        topic: "Conceitos de SCI e Microsoft Entra",
+        options: [
+            ["Assinatura (subscription)", false],
+            ["Locatário (tenant)", true],
+            ["Unidade organizacional (OU)", false],
+            ["Floresta do Active Directory Domain Services sincronizada com a nuvem pelo Microsoft Entra Connect", false],
+        ],
+    },
+    {
+        statement: "Uma pequena empresa sem licenças avançadas quer ativar rapidamente proteções básicas de identidade, como exigir MFA de todos os usuários e bloquear a autenticação legada, sem criar políticas individuais. Qual recurso do Microsoft Entra oferece esse conjunto pré-configurado?",
+        explanation: "Os padrões de segurança aplicam um conjunto básico e gratuito de proteções, como exigir MFA de todos e bloquear a autenticação legada, sem precisar criar políticas individuais.",
+        topic: "Conceitos de SCI e Microsoft Entra",
+        options: [
+            ["Políticas de Acesso Condicional personalizadas, criadas uma a uma para cada grupo de usuários e aplicativo da organização", false],
+            ["Privileged Identity Management (PIM)", false],
+            ["Redefinição de senha self-service (SSPR)", false],
+            ["Padrões de segurança (security defaults)", true],
+        ],
+    },
+    {
+        statement: "Uma empresa quer que parceiros externos solicitem, por autoatendimento, um pacote de acessos (grupos, aplicativos e sites) com aprovação e prazo de expiração automáticos. Qual recurso do Microsoft Entra ID Governance atende a isso?",
+        explanation: "O gerenciamento de direitos usa pacotes de acesso para agrupar recursos e concedê-los com solicitação, aprovação e expiração automáticas, inclusive para usuários externos.",
+        topic: "Conceitos de SCI e Microsoft Entra",
+        options: [
+            ["Gerenciamento de direitos (entitlement management), com pacotes de acesso", true],
+            ["Acesso Condicional", false],
+            ["Redefinição de senha self-service, com registro dos métodos de autenticação e notificação aos administradores a cada uso", false],
+            ["Proteção de senha (password protection)", false],
+        ],
+    },
+    {
+        statement: "Seguindo o privilégio mínimo, uma organização quer restringir ao menor número possível de pessoas a função que concede controle total sobre todos os recursos do Microsoft Entra ID e do Microsoft 365. Qual função é essa?",
+        explanation: "O Administrador global tem controle total sobre o locatário e deve ser dado a pouquíssimas pessoas; para o dia a dia, a recomendação é usar funções mais específicas.",
+        topic: "Conceitos de SCI e Microsoft Entra",
+        options: [
+            ["Leitor global (Global Reader)", false],
+            ["Administrador de suporte técnico (Helpdesk Administrator)", false],
+            ["Administrador global (Global Administrator)", true],
+            ["Administrador de autenticação, que redefine métodos de autenticação e senhas apenas de usuários sem privilégios administrativos", false],
+        ],
+    },
+    {
+        statement: "Uma organização com Active Directory local quer sincronizar contas e hashes de senha para o Microsoft Entra ID, permitindo login com as mesmas credenciais nos serviços de nuvem. Qual componente realiza essa sincronização?",
+        explanation: "O Microsoft Entra Connect sincroniza as identidades do Active Directory local com o Microsoft Entra ID, viabilizando a identidade híbrida e o uso das mesmas credenciais na nuvem.",
+        topic: "Conceitos de SCI e Microsoft Entra",
+        options: [
+            ["O Microsoft Defender for Identity, instalado nos controladores de domínio para monitorar e replicar as contas para a nuvem", false],
+            ["O Microsoft Entra Connect", true],
+            ["O Privileged Identity Management (PIM)", false],
+            ["O Acesso Condicional", false],
+        ],
+    },
+    {
+        statement: "Uma analista de SOC quer, de forma proativa, pesquisar sinais de ataque escrevendo consultas personalizadas sobre até 30 dias de dados brutos de e-mails, dispositivos e identidades no portal do Defender. Qual recurso ela deve usar?",
+        explanation: "A caça avançada permite consultar proativamente grandes volumes de dados brutos com a linguagem KQL, enquanto a análise de ameaças traz relatórios curados sobre campanhas conhecidas.",
+        topic: "Defender XDR e proteção contra ameaças",
+        options: [
+            ["Caça avançada (advanced hunting), com consultas na linguagem KQL", true],
+            ["Análise de ameaças (threat analytics), com relatórios prontos sobre campanhas conhecidas", false],
+            ["Secure score do ambiente", false],
+            ["A fila de incidentes, que apenas lista os alertas já correlacionados automaticamente pelo Defender para a triagem manual", false],
+        ],
+    },
+    {
+        statement: "Para reduzir a carga do time de segurança, uma empresa quer que o Defender XDR investigue automaticamente certos alertas, determine se há ameaça real e execute correções, como remover arquivos maliciosos, sem intervenção manual. Qual capacidade oferece isso?",
+        explanation: "A investigação e resposta automatizadas (AIR) examinam alertas sozinhas, decidem se há ameaça real e aplicam correções, reduzindo o trabalho manual do SOC.",
+        topic: "Defender XDR e proteção contra ameaças",
+        options: [
+            ["A caça avançada, em que analistas escrevem manualmente consultas KQL para localizar e depois remediar cada ameaça encontrada", false],
+            ["A análise de ameaças (threat analytics)", false],
+            ["A investigação e resposta automatizadas (AIR)", true],
+            ["O gerenciamento de vulnerabilidades", false],
+        ],
+    },
+    {
+        statement: "Uma empresa quer bloquear preventivamente comportamentos de risco nos dispositivos, como documentos do Office que iniciam processos filhos ou execução de conteúdo vindo de e-mail. Qual capacidade do Microsoft Defender for Endpoint atende a isso?",
+        explanation: "As regras de redução da superfície de ataque (ASR) do Defender for Endpoint bloqueiam preventivamente comportamentos explorados por malware, como o Office iniciando processos filhos.",
+        topic: "Defender XDR e proteção contra ameaças",
+        options: [
+            ["Isolamento do dispositivo da rede", false],
+            ["O Defender for Cloud Apps, que atua como CASB para descobrir e controlar o uso de aplicativos SaaS não aprovados pela empresa", false],
+            ["Análise de ameaças (threat analytics)", false],
+            ["Regras de redução da superfície de ataque (ASR)", true],
+        ],
+    },
+    {
+        statement: "No Microsoft Defender for Office 365, um administrador quer entender a diferença entre os recursos Anexos Seguros (Safe Attachments) e Links Seguros (Safe Links). Qual afirmação os distingue corretamente?",
+        explanation: "Anexos Seguros abre anexos em uma sandbox antes da entrega; Links Seguros reescreve e verifica as URLs no momento do clique para proteger contra links maliciosos.",
+        topic: "Defender XDR e proteção contra ameaças",
+        options: [
+            ["Ambos apenas colocam em quarentena qualquer e-mail vindo de remetentes externos à organização", false],
+            ["Anexos Seguros abre os anexos em uma sandbox para detonar ameaças; Links Seguros verifica as URLs no momento do clique", true],
+            ["Anexos Seguros verifica URLs no clique; Links Seguros procura contas comprometidas no Active Directory local", false],
+            ["Anexos Seguros e Links Seguros bloqueiam a movimentação lateral entre controladores de domínio usando técnicas como pass-the-hash e pass-the-ticket no ambiente local", false],
+        ],
+    },
+    {
+        statement: "Dois produtos têm nomes parecidos e são confundidos: um é um CASB que dá visibilidade e controle sobre aplicativos SaaS; o outro protege a postura e as cargas de trabalho em nuvem no Azure, AWS e Google Cloud. Qual associação está correta?",
+        explanation: "O Defender for Cloud Apps é o CASB que dá visibilidade e controle sobre apps SaaS; o Defender for Cloud avalia a postura e protege cargas de trabalho em Azure, AWS e GCP.",
+        topic: "Defender XDR e proteção contra ameaças",
+        options: [
+            ["Defender for Cloud Apps é o CASB; Defender for Cloud cuida da postura e das cargas de trabalho em nuvem", true],
+            ["Defender for Cloud é o CASB para aplicativos SaaS, e Defender for Cloud Apps protege as máquinas virtuais e os bancos de dados hospedados em Azure, AWS e Google Cloud", false],
+            ["Os dois são o mesmo produto, apenas com nomes diferentes conforme o portal usado", false],
+            ["Defender for Cloud Apps protege caixas de e-mail contra phishing; Defender for Cloud verifica anexos maliciosos", false],
+        ],
+    },
+    {
+        statement: "Para reduzir o sucesso de ataques de phishing, uma empresa quer enviar aos próprios funcionários e-mails simulados de phishing e, com base em quem cair, direcioná-los a treinamentos. Qual recurso do Microsoft Defender for Office 365 oferece isso?",
+        explanation: "O treinamento de simulação de ataque executa campanhas de phishing simuladas para medir a vulnerabilidade dos usuários e direcionar treinamentos a quem precisa.",
+        topic: "Defender XDR e proteção contra ameaças",
+        options: [
+            ["Anexos Seguros (Safe Attachments)", false],
+            ["A investigação e resposta automatizadas, que isolam o dispositivo do funcionário assim que ele clica em um link de phishing real", false],
+            ["O gerenciamento de vulnerabilidades e configurações", false],
+            ["O treinamento de simulação de ataque (attack simulation training)", true],
+        ],
+    },
+    {
+        statement: "Uma instituição financeira precisa demonstrar aderência a padrões como PCI DSS e ISO 27001 e visualizar, para os recursos no Azure, quais controles já estão atendidos e quais ainda exigem ação. Qual recurso atende a essa necessidade?",
+        explanation: "O painel de conformidade regulatória do Defender for Cloud mapeia a configuração dos recursos para padrões como PCI DSS e ISO 27001, mostrando os controles atendidos e as ações pendentes. O Secure Score mede a postura geral, não a aderência a uma norma específica.",
+        topic: "Segurança de infraestrutura, Defender for Cloud e Sentinel",
+        options: [
+            ["O Microsoft Sentinel, coletando e correlacionando logs de segurança de toda a organização para investigação de incidentes.", false],
+            ["O painel de conformidade regulatória do Microsoft Defender for Cloud.", true],
+            ["O Secure Score do Defender for Cloud, que resume a postura geral em uma única pontuação percentual.", false],
+            ["O Compliance Manager do Microsoft Purview, restrito a serviços do Microsoft 365 e sem visibilidade sobre os recursos do Azure.", false],
+        ],
+    },
+    {
+        statement: "Uma equipe acabou de habilitar o Microsoft Sentinel e precisa começar a ingerir sinais de fontes como Microsoft Entra ID, Office 365, Azure Activity e firewalls de terceiros. Qual componente do Sentinel é usado para trazer esses dados para análise?",
+        explanation: "Os conectores de dados integram o Sentinel a fontes internas e externas, ingerindo logs e eventos para análise. Playbooks respondem a incidentes, workbooks visualizam dados e regras de análise geram alertas.",
+        topic: "Segurança de infraestrutura, Defender for Cloud e Sentinel",
+        options: [
+            ["Os conectores de dados (data connectors).", true],
+            ["Os playbooks, que executam ações automatizadas de resposta usando o Azure Logic Apps quando um incidente é disparado.", false],
+            ["As pastas de trabalho (workbooks), que criam painéis visuais e relatórios interativos sobre os dados já ingeridos.", false],
+            ["As regras de análise, que correlacionam eventos para gerar alertas e incidentes de segurança.", false],
+        ],
+    },
+    {
+        statement: "Ao apresentar o Microsoft Sentinel, um arquiteto quer diferenciar suas capacidades de SIEM e de SOAR. Qual afirmação faz essa distinção corretamente?",
+        explanation: "O SIEM (Security Information and Event Management) reúne e correlaciona sinais para detectar ameaças; o SOAR (Security Orchestration, Automation and Response) automatiza a resposta. O Sentinel combina as duas capacidades.",
+        topic: "Segurança de infraestrutura, Defender for Cloud e Sentinel",
+        options: [
+            ["O SIEM automatiza e orquestra as ações de resposta com playbooks, enquanto o SOAR apenas armazena logs para consulta futura.", false],
+            ["SIEM e SOAR são termos equivalentes; ambos se referem exclusivamente à coleta de logs de máquinas virtuais no Azure.", false],
+            ["O SIEM coleta e correlaciona dados para detectar ameaças, e o SOAR automatiza e orquestra a resposta a incidentes.", true],
+            ["O SIEM protege apenas cargas de trabalho locais, ao passo que o SOAR se limita a recursos hospedados exclusivamente na nuvem pública.", false],
+        ],
+    },
+    {
+        statement: "Depois de conectar suas fontes de dados ao Microsoft Sentinel, uma equipe de SOC quer que o sistema correlacione automaticamente os eventos ingeridos e gere incidentes sempre que identificar padrões que indiquem uma ameaça. O que a equipe deve configurar?",
+        explanation: "As regras de análise avaliam e correlacionam os dados ingeridos e geram alertas e incidentes quando detectam atividades suspeitas. Conectores apenas coletam dados e workbooks apenas os visualizam.",
+        topic: "Segurança de infraestrutura, Defender for Cloud e Sentinel",
+        options: [
+            ["Conectores de dados adicionais, que apenas trazem mais logs para o workspace, sem avaliar ou correlacionar o conteúdo.", false],
+            ["Pastas de trabalho (workbooks), voltadas à visualização e à criação de painéis, sem capacidade de disparar incidentes.", false],
+            ["Grupos de segurança de rede (NSG), que filtram o tráfego de entrada e saída no nível da sub-rede.", false],
+            ["Regras de análise (analytics rules).", true],
+        ],
+    },
+    {
+        statement: "Uma empresa quer centralizar suas chaves de criptografia e certificados em um serviço gerenciado do Azure que permita proteger chaves por hardware (HSM), controlar o acesso por meio do Microsoft Entra ID e registrar cada operação para auditoria. Qual serviço atende a esses requisitos?",
+        explanation: "O Azure Key Vault armazena e gerencia de forma centralizada segredos, chaves e certificados, com suporte a proteção por HSM, controle de acesso via Entra ID e registro de operações para auditoria.",
+        topic: "Segurança de infraestrutura, Defender for Cloud e Sentinel",
+        options: [
+            ["O Azure Bastion, que fornece conectividade RDP e SSH às máquinas virtuais pelo portal, sem expor portas à internet.", false],
+            ["O Azure Key Vault.", true],
+            ["Um grupo de segurança de rede (NSG), aplicado à sub-rede para permitir ou negar o tráfego que chega aos recursos.", false],
+            ["O Microsoft Defender for Cloud, que avalia a postura de segurança e emite recomendações para reduzir configurações incorretas.", false],
+        ],
+    },
+    {
+        statement: "Uma arquiteta precisa explicar a diferença entre o Web Application Firewall (WAF) e o Azure Firewall. Qual afirmação descreve corretamente essa diferença?",
+        explanation: "O WAF (em Application Gateway ou Front Door) atua na camada de aplicação, protegendo aplicações web contra explorações como SQL injection e XSS. O Azure Firewall é um firewall de rede gerenciado que controla o tráfego das redes virtuais.",
+        topic: "Segurança de infraestrutura, Defender for Cloud e Sentinel",
+        options: [
+            ["Ambos operam apenas na camada de rede (camadas 3 e 4) e são intercambiáveis para qualquer cenário de filtragem.", false],
+            ["O WAF filtra o tráfego geral de entrada e saída entre redes virtuais usando apenas regras de porta e protocolo, enquanto o Azure Firewall se dedica a inspecionar requisições HTTP em busca de injeção de SQL e scripts maliciosos.", false],
+            ["O WAF protege aplicações web contra ataques da camada de aplicação, como SQL injection e XSS; o Azure Firewall filtra o tráfego de rede das redes virtuais.", true],
+            ["O Azure Firewall é um recurso gratuito associado a interfaces de rede, ao passo que o WAF é um appliance físico instalado no datacenter do cliente.", false],
+        ],
+    },
+    {
+        statement: "Uma organização quer controlar, de forma centralizada, para quais nomes de domínio (FQDN) as máquinas virtuais de suas redes virtuais podem abrir conexões de saída, permitindo apenas destinos aprovados. Qual serviço permite criar essas regras de aplicação?",
+        explanation: "O Azure Firewall permite regras de aplicação que liberam ou bloqueiam o tráfego de saída com base em FQDNs, controlando de forma centralizada os destinos permitidos. O DDoS Protection e o Bastion tratam de outros problemas.",
+        topic: "Segurança de infraestrutura, Defender for Cloud e Sentinel",
+        options: [
+            ["O Azure Firewall, por meio de regras de aplicação baseadas em FQDN.", true],
+            ["O Azure DDoS Protection, que monitora o tráfego para mitigar ataques volumétricos de negação de serviço contra os recursos publicados.", false],
+            ["O Azure Key Vault, que armazena de forma segura as credenciais usadas pelas máquinas virtuais para autenticar nesses domínios.", false],
+            ["O Azure Bastion, que intermedia o acesso administrativo às máquinas virtuais sem a necessidade de IP público.", false],
+        ],
+    },
+    {
+        statement: "Uma empresa quer identificar automaticamente documentos por categoria de conteúdo, como contratos, currículos e código-fonte, mesmo quando não há um padrão fixo como número de cartão ou CPF. Que recurso do Microsoft Purview reconhece esse tipo de conteúdo com base em aprendizado de máquina?",
+        explanation: "Os classificadores treináveis usam aprendizado de máquina para reconhecer categorias de conteúdo por exemplos, e não por padrões fixos. Tipos de informação sensível, ao contrário, detectam dados com formato conhecido, como números de cartão.",
+        topic: "Conformidade com o Microsoft Purview",
+        options: [
+            ["Os tipos de informação sensível, que localizam dados por padrões predefinidos, como expressões regulares e somas de verificação.", false],
+            ["Os rótulos de retenção, que definem por quanto tempo o conteúdo é mantido antes de ser excluído automaticamente.", false],
+            ["A prevenção contra perda de dados (DLP), que bloqueia o compartilhamento externo de informações sensíveis por e-mail e outros canais.", false],
+            ["Os classificadores treináveis (trainable classifiers).", true],
+        ],
+    },
+    {
+        statement: "Além de bloquear e-mails com dados sensíveis, uma empresa quer impedir que usuários copiem arquivos confidenciais para pen drives USB ou os enviem a aplicativos de nuvem não aprovados diretamente nos computadores corporativos. Qual capacidade do Microsoft Purview atende a isso?",
+        explanation: "A DLP de ponto de extremidade estende as políticas de prevenção contra perda de dados aos dispositivos, controlando ações como cópia para USB, impressão e upload para serviços não aprovados.",
+        topic: "Conformidade com o Microsoft Purview",
+        options: [
+            ["O gerenciamento de risco interno, que gera alertas sobre comportamentos potencialmente arriscados de usuários, mas não impõe controles de bloqueio nos dispositivos.", false],
+            ["A prevenção contra perda de dados de ponto de extremidade (Endpoint DLP).", true],
+            ["Os rótulos de confidencialidade, que aplicam criptografia e marca d'água a documentos e e-mails individuais conforme a classificação.", false],
+            ["O eDiscovery, usado para localizar e preservar conteúdo relevante a investigações e processos judiciais.", false],
+        ],
+    },
+    {
+        statement: "Uma empresa quer detectar mensagens internas inadequadas, como assédio, linguagem ofensiva ou compartilhamento de informações confidenciais, trocadas por e-mail e no Microsoft Teams, para que as áreas de RH e conformidade possam revisá-las. Qual solução do Microsoft Purview é indicada?",
+        explanation: "A conformidade de comunicações analisa mensagens em canais como e-mail e Teams para identificar violações de políticas, como assédio ou vazamento de dados, encaminhando-as para revisão. A DLP foca em impedir a saída de dados sensíveis.",
+        topic: "Conformidade com o Microsoft Purview",
+        options: [
+            ["A conformidade de comunicações (Communication Compliance).", true],
+            ["A prevenção contra perda de dados (DLP), voltada a impedir o vazamento de dados sensíveis por canais como e-mail, e não a avaliar o teor das conversas.", false],
+            ["O gerenciamento do ciclo de vida de dados, que define políticas de retenção e exclusão de conteúdo ao longo do tempo.", false],
+            ["As barreiras de informação, que impedem a comunicação entre determinados grupos de usuários.", false],
+        ],
+    },
+    {
+        statement: "Ao planejar a retenção no Microsoft Purview, uma equipe precisa entender a diferença entre uma política de retenção e um rótulo de retenção. Qual afirmação está correta?",
+        explanation: "Políticas de retenção atuam sobre locais inteiros, como Exchange, SharePoint e Teams; rótulos de retenção são atribuídos a itens individuais e podem ser aplicados manual ou automaticamente. Ambos podem reter e depois excluir o conteúdo.",
+        topic: "Conformidade com o Microsoft Purview",
+        options: [
+            ["Rótulos de retenção criptografam o conteúdo, enquanto políticas de retenção aplicam marca d'água aos documentos afetados.", false],
+            ["Ambos só podem ser aplicados manualmente pelo usuário final e nunca de forma automática por regras da organização.", false],
+            ["A política de retenção é aplicada de forma ampla a locais, como caixas de correio e sites; o rótulo de retenção é aplicado a itens específicos, como um documento ou e-mail.", true],
+            ["A política de retenção serve apenas para excluir conteúdo imediatamente, ao passo que o rótulo de retenção serve unicamente para reter, jamais permitindo exclusão automática ao fim do período.", false],
+        ],
+    },
+    {
+        statement: "Uma corretora precisa impedir que os funcionários da mesa de operações troquem mensagens no Teams com os analistas de pesquisa, evitando conflitos de interesse exigidos pela regulação. Qual solução do Microsoft Purview permite restringir essa comunicação entre grupos?",
+        explanation: "As barreiras de informação restringem ou bloqueiam a comunicação e a colaboração entre grupos específicos de usuários, ajudando a evitar conflitos de interesse. A DLP foca no vazamento de dados, não na separação entre grupos internos.",
+        topic: "Conformidade com o Microsoft Purview",
+        options: [
+            ["A prevenção contra perda de dados (DLP), que inspeciona o conteúdo das mensagens para impedir o vazamento de dados sensíveis para fora da organização.", false],
+            ["As barreiras de informação (information barriers).", true],
+            ["Os rótulos de confidencialidade, que classificam e protegem documentos e e-mails de acordo com o nível de sensibilidade do conteúdo.", false],
+            ["A auditoria, que registra as atividades dos usuários para investigação posterior, sem bloquear a comunicação em tempo real.", false],
+        ],
+    },
+    {
+        statement: "Para que uma política de DLP reconheça que um documento contém, por exemplo, um número de cartão de crédito válido, o Microsoft Purview precisa de um componente que detecte esse dado por padrões como formato, palavras-chave próximas e soma de verificação. Que componente é esse?",
+        explanation: "Os tipos de informação sensível identificam dados com formato reconhecível, como cartões de crédito, CPF ou passaportes, usando padrões, palavras-chave e somas de verificação, e servem de base para DLP e rotulagem automática. Classificadores treináveis, por outro lado, reconhecem categorias por aprendizado de máquina.",
+        topic: "Conformidade com o Microsoft Purview",
+        options: [
+            ["Um rótulo de confidencialidade, que aplica criptografia e restrições de acesso ao documento depois que ele é classificado pelo usuário ou automaticamente.", false],
+            ["Um classificador treinável, que aprende a reconhecer categorias de conteúdo a partir de exemplos, e não a partir de um formato conhecido.", false],
+            ["Um rótulo de retenção, que determina o tempo de guarda do documento antes da exclusão.", false],
+            ["Um tipo de informação sensível (sensitive information type).", true],
+        ],
+    },
+    {
+        statement: "Uma organização quer agrupar, em uma única solução do Microsoft Purview, as políticas e os rótulos que controlam por quanto tempo o conteúdo é mantido e quando ele deve ser excluído automaticamente. Qual solução cumpre esse papel?",
+        explanation: "O gerenciamento do ciclo de vida de dados reúne as políticas e os rótulos de retenção que definem por quanto tempo manter o conteúdo e quando excluí-lo. eDiscovery e DLP resolvem problemas distintos.",
+        topic: "Conformidade com o Microsoft Purview",
+        options: [
+            ["O gerenciamento do ciclo de vida de dados (Data Lifecycle Management).", true],
+            ["O eDiscovery, que identifica, preserva e coleta conteúdo relevante para investigações internas e processos judiciais em andamento.", false],
+            ["A prevenção contra perda de dados (DLP), que detecta e impede o compartilhamento indevido de informações sensíveis.", false],
+            ["O gerenciamento de risco interno, que analisa sinais de atividade para identificar comportamentos potencialmente arriscados de usuários.", false],
+        ],
+    },
 ];
 
 async function seed() {
@@ -2256,13 +2576,23 @@ async function seed() {
         .select({ n: count() })
         .from(simuladoQuestions)
         .where(eq(simuladoQuestions.simuladoId, simulado.id));
-    if (Number(n) > 0) {
+    const jaExistem = new Set(
+        (
+            await db
+                .select({ statement: simuladoQuestions.statement })
+                .from(simuladoQuestions)
+                .where(eq(simuladoQuestions.simuladoId, simulado.id))
+        ).map((r) => r.statement),
+    );
+    const inseridas = QUESTOES.filter((q) => !jaExistem.has(q.statement)).length;
+    if (inseridas === 0) {
         console.log("Simulado já tem " + n + " questões, nada a fazer.");
         return;
     }
 
     for (let i = 0; i < QUESTOES.length; i++) {
         const q = QUESTOES[i];
+        if (jaExistem.has(q.statement)) continue;
         const [questao] = await db
             .insert(simuladoQuestions)
             .values({
@@ -2281,7 +2611,7 @@ async function seed() {
             })),
         );
     }
-    console.log("Seed concluído: " + QUESTOES.length + " questões inseridas.");
+    console.log("Seed: " + inseridas + " questões novas inseridas (" + QUESTOES.length + " no banco).");
 }
 
 seed()


### PR DESCRIPTION
## O que muda

Cada simulado sorteia um subconjunto aleatório do banco por tentativa. Quando o banco é pequeno (fator banco dividido pelo sorteio perto de 1), refazer a prova cai quase nas mesmas questões. Dez dos doze simulados estavam abaixo de 2,5x.

Ampliei os bancos com questões autorais novas até cerca de 2,5x o sorteio:

| simulado | sorteia | banco antes | banco depois |
|---|---|---|---|
| aws-ai-practitioner (AIF-C01) | 65 | 65 | 165 |
| isc2-cc | 65 | 91 | 165 |
| dva-c02 | 65 | 104 | 165 |
| saa-c03 | 65 | 108 | 165 |
| databricks-de-professional | 59 | 90 | 150 |
| sc-900 | 50 | 96 | 125 |
| ai-901 | 50 | 104 | 125 |
| ai-900 | 50 | 106 | 125 |
| dp-900 | 50 | 106 | 125 |
| databricks-de-associate | 45 | 90 | 115 |

São 465 questões novas. O az-900 (4,10x) e o aws-cloud-practitioner (3,25x) já variavam bem e ficaram como estavam. O pior caso era o AIF-C01, que sorteava as 65 de um banco de 65: a mesma prova toda vez.

## Qualidade

- Cada questão tem 4 alternativas, uma correta, distribuídas pelos domínios oficiais de cada exame.
- Verificação cega: revisores independentes responderam sem ver o gabarito e 465 de 465 bateram com a resposta esperada.
- Alternativas equilibradas (a correta nunca é a mais longa) e sem repetir o que o banco já tinha.

## Seeds

Os seeds passaram a ser aditivos por enunciado: inserem só o que ainda não existe no banco. Dá pra rodar de novo em produção que só entram as questões novas, sem duplicar. Continuam sendo rodados manualmente depois do deploy.

## Antes de mergear

Vale rodar um dos simulados ampliados no ambiente e refazer, pra ver a variação nas questões sorteadas.