### PR TITLE
chore: remove buscas quebradas da topbar e oculta o botão de apoiar

### DIFF
--- a/frontend/src/components/UserMenu.tsx
+++ b/frontend/src/components/UserMenu.tsx
@@ -94,14 +94,17 @@ export function UserMenu({ initials, level, name, email }: UserMenuProps) {
           >
             Conquistas
           </button>
-          <button
-            type="button"
-            role="menuitem"
-            className="user-menu__item"
-            onClick={() => go('/apoie')}
-          >
-            {user?.apoiador ? 'Minha assinatura' : 'Apoiar o projeto'}
-          </button>
+          {/* 'Apoiar o projeto' oculto temporariamente; quem já é apoiador ainda acessa a assinatura. */}
+          {user?.apoiador && (
+            <button
+              type="button"
+              role="menuitem"
+              className="user-menu__item"
+              onClick={() => go('/apoie')}
+            >
+              Minha assinatura
+            </button>
+          )}
           {user?.role === 'admin' && (
             <button
               type="button"

--- a/frontend/src/data/nav.ts
+++ b/frontend/src/data/nav.ts
@@ -7,7 +7,7 @@ export const NAV_PRINCIPAL = [
   { label: 'Desafios', to: '/desafios' },
   { label: 'Ranking', to: '/ranking' },
   { label: 'Comunidade', to: '/comunidade' },
-  { label: 'Apoiar', to: '/apoie' },
+  // 'Apoiar' oculto temporariamente; readicionar: { label: 'Apoiar', to: '/apoie' }
 ];
 
 export const NAV_ESTUDIO = [

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -6,7 +6,7 @@ import { MobileMenu } from '../../components/MobileMenu';
 import { UserMenu } from '../../components/UserMenu';
 import { ThemeToggle } from '../../components/ThemeToggle';
 import { Avatar } from '../../components/Avatar';
-import { Flame, Search, Play } from '../../components/Icons';
+import { Flame, Play } from '../../components/Icons';
 import { getInitials } from '../../utils/initials';
 import { tempoRelativo } from '../../utils/tempo';
 import { user, MEDALS } from '../../data/home';
@@ -153,10 +153,6 @@ export function Home() {
             ))}
           </nav>
           <div className="topbar__spacer" />
-          <div className="searchbar">
-            <Search size={16} />
-            <span>Buscar exercício…</span>
-          </div>
           <div className="streak-pill">
             <Flame size={16} /> {authUser?.streak ?? 0}
           </div>

--- a/frontend/src/pages/Ranking/index.tsx
+++ b/frontend/src/pages/Ranking/index.tsx
@@ -7,7 +7,7 @@ import { MobileMenu } from '../../components/MobileMenu';
 import { UserMenu } from '../../components/UserMenu';
 import { ThemeToggle } from '../../components/ThemeToggle';
 import { Avatar } from '../../components/Avatar';
-import { Flame, Search, Trophy, Check, Lock, ChevronUp, ChevronDown , Heart } from '../../components/Icons';
+import { Flame, Trophy, Check, Lock, ChevronUp, ChevronDown , Heart } from '../../components/Icons';
 import { getInitials } from '../../utils/initials';
 import { user as homeUser } from '../../data/home';
 import { obterRanking, type RankingResposta, type RankingPeriodo } from '../../services/trails';
@@ -90,10 +90,6 @@ export function Ranking() {
             ))}
           </nav>
           <div className="topbar__spacer" />
-          <div className="searchbar">
-            <Search size={16} />
-            <span>Buscar exercício…</span>
-          </div>
           <div className="streak-pill">
             <Flame size={16} /> {authUser?.streak ?? 0}
           </div>

--- a/frontend/src/pages/Roadmaps/index.tsx
+++ b/frontend/src/pages/Roadmaps/index.tsx
@@ -5,7 +5,7 @@ import { Logo } from '../../components/Logo';
 import { MobileMenu } from '../../components/MobileMenu';
 import { UserMenu } from '../../components/UserMenu';
 import { ThemeToggle } from '../../components/ThemeToggle';
-import { Flame, Search, ChevronRight, Lock, Play } from '../../components/Icons';
+import { Flame, ChevronRight, Lock, Play } from '../../components/Icons';
 import { getInitials } from '../../utils/initials';
 import { user } from '../../data/home';
 import { NAV_PRINCIPAL as NAV } from '../../data/nav';
@@ -90,10 +90,6 @@ export function Roadmaps() {
             ))}
           </nav>
           <div className="topbar__spacer" />
-          <div className="searchbar">
-            <Search size={16} />
-            <span>Buscar roadmap…</span>
-          </div>
           <div className="streak-pill">
             <Flame size={16} /> {authUser?.streak ?? 0}
           </div>

--- a/frontend/src/pages/Trilhas/index.tsx
+++ b/frontend/src/pages/Trilhas/index.tsx
@@ -6,7 +6,7 @@ import { Logo } from '../../components/Logo';
 import { MobileMenu } from '../../components/MobileMenu';
 import { UserMenu } from '../../components/UserMenu';
 import { ThemeToggle } from '../../components/ThemeToggle';
-import { Flame, Search, Play, ChevronRight } from '../../components/Icons';
+import { Flame, Play, ChevronRight } from '../../components/Icons';
 import { getInitials } from '../../utils/initials';
 import { user } from '../../data/home';
 import { type Trail, type TrailLevel } from '../../data/trails';
@@ -153,10 +153,6 @@ export function Trilhas() {
             ))}
           </nav>
           <div className="topbar__spacer" />
-          <div className="searchbar">
-            <Search size={16} />
-            <span>Buscar trilha…</span>
-          </div>
           <div className="streak-pill">
             <Flame size={16} /> {authUser?.streak ?? 0}
           </div>


### PR DESCRIPTION
## O que muda

- **Buscas da topbar**: remove os campos "Buscar trilha/roadmap/exercício" de Início, Trilhas, Roadmaps e Ranking. Eram divs estáticos, sem funcionalidade. A busca real dos filtros da página de Trilhas ("Nome da trilha") continua.
- **Botão de apoiar** (temporário): sai o "Apoiar" da navegação principal e o "Apoiar o projeto" do menu do usuário. Quem já é apoiador mantém o atalho "Minha assinatura". A página /apoie continua existindo (só os botões saíram). O nav tem um comentário com a linha exata para readicionar quando for divulgar.

## Conferir antes de mergear

Dar uma olhada na topbar (sem a caixa de busca) e no menu do usuário. Frontend passou no typecheck.