### PR TITLE
feat: reenviar email de verificação (+ fix do prazo do token)

### DIFF
--- a/backend/src/controllers/AuthController.ts
+++ b/backend/src/controllers/AuthController.ts
@@ -308,6 +308,32 @@ export const verifyEmail = async (req: Request, res: Response, next: NextFunctio
     }
 };
 
+export const resendVerification = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const { email } = forgotPasswordSchema.parse(req.body);
+
+        // Resposta genérica, para não revelar se o email tem conta ou já foi verificado.
+        const resposta = {
+            mensagem: "Se houver uma conta pendente de confirmação com esse email, reenviamos o link.",
+        };
+
+        const [user] = await db
+            .select({ id: users.id, email: users.email, emailVerifiedAt: users.emailVerifiedAt })
+            .from(users)
+            .where(eq(users.email, email));
+
+        // Só reenvia quando a conta existe e ainda não foi verificada.
+        if (user && !user.emailVerifiedAt) {
+            const token = await authService.gerarTokenVerificacao(user.id);
+            await emailService.enviarVerificacao(user.email, token);
+        }
+
+        res.json(resposta);
+    } catch (err) {
+        next(err);
+    }
+};
+
 export const forgotPassword = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const { email } = forgotPasswordSchema.parse(req.body);

--- a/backend/src/middlewares/rateLimit.ts
+++ b/backend/src/middlewares/rateLimit.ts
@@ -41,6 +41,12 @@ export const forgotPasswordLimiter = criarLimiter(
     "Muitos pedidos de redefinição. Tente novamente em alguns minutos.",
 );
 
+// Reenviar verificação também dispara email; mesmo teto baixo do forgot-password.
+export const resendVerificationLimiter = criarLimiter(
+    5,
+    "Muitos pedidos de verificação. Tente novamente em alguns minutos.",
+);
+
 export const resetPasswordLimiter = criarLimiter(
     20,
     "Muitas tentativas. Tente novamente em alguns minutos.",

--- a/backend/src/routes/auth.routes.ts
+++ b/backend/src/routes/auth.routes.ts
@@ -7,6 +7,7 @@ import {
     verifyEmail,
     forgotPassword,
     resetPassword,
+    resendVerification,
 } from "../controllers/AuthController.ts";
 import { iniciarOAuth, callbackOAuth } from "../controllers/OAuthController.ts";
 import {
@@ -16,6 +17,7 @@ import {
     verifyEmailLimiter,
     forgotPasswordLimiter,
     resetPasswordLimiter,
+    resendVerificationLimiter,
 } from "../middlewares/rateLimit.ts";
 import { mesmaOrigem } from "../middlewares/origem.ts";
 
@@ -28,6 +30,7 @@ router.post("/logout", mesmaOrigem, refreshLimiter, logout);
 router.post("/verify-email", verifyEmailLimiter, verifyEmail);
 router.post("/forgot-password", forgotPasswordLimiter, forgotPassword);
 router.post("/reset-password", resetPasswordLimiter, resetPassword);
+router.post("/resend-verification", resendVerificationLimiter, resendVerification);
 
 // Login social (OAuth): inicia o fluxo e trata o retorno do provedor.
 router.get("/auth/:provider", iniciarOAuth);

--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -25,7 +25,7 @@ export const authService = {
             userId,
             tokenHash: createHash("sha256").update(verificationToken).digest("hex"),
             type: "email_verification",
-            expiredAt: new Date(Date.now() + 24 * 60 * 1000),
+            expiredAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
         });
 
         return verificationToken;

--- a/frontend/src/pages/Login/index.tsx
+++ b/frontend/src/pages/Login/index.tsx
@@ -7,7 +7,8 @@ import { Logo } from '../../components/Logo';
 import { FormField } from '../../components/FormField';
 import { SocialAuth } from '../../components/auth/SocialAuth';
 import { Flame, Trophy } from '../../components/Icons';
-import { mensagemErro } from '../../utils/erro';
+import api from '../../services/api';
+import { mensagemErro, statusErro } from '../../utils/erro';
 
 // Mensagens dos erros que o callback do OAuth manda via ?erro= ao voltar pro login.
 const ERROS_OAUTH: Record<string, string> = {
@@ -28,18 +29,40 @@ export function Login() {
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const [submitting, setSubmitting] = useState(false);
+  // Login bloqueado por email não confirmado (403): oferece reenviar a verificação.
+  const [naoVerificado, setNaoVerificado] = useState(false);
+  const [reenviando, setReenviando] = useState(false);
+  const [reenvioMsg, setReenvioMsg] = useState('');
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setError('');
+    setNaoVerificado(false);
+    setReenvioMsg('');
     setSubmitting(true);
     try {
       await login(email, password);
       navigate('/home');
     } catch (e: unknown) {
       setError(mensagemErro(e, 'Erro ao fazer login. Tente novamente.'));
+      setNaoVerificado(statusErro(e) === 403);
     } finally {
       setSubmitting(false);
+    }
+  }
+
+  async function reenviarVerificacao() {
+    if (reenviando || !email) return;
+    setReenviando(true);
+    try {
+      const { data } = await api.post('/resend-verification', { email });
+      setReenvioMsg(
+        data.mensagem ?? 'Se houver uma conta pendente, reenviamos o link de confirmação.',
+      );
+    } catch {
+      setReenvioMsg('Não foi possível reenviar agora. Tente de novo em instantes.');
+    } finally {
+      setReenviando(false);
     }
   }
 
@@ -94,6 +117,20 @@ export function Login() {
       <p className="auth__subtitle">Continue de onde você parou.</p>
 
       {(error || erroOAuth) && <div className="auth__alert">{error || erroOAuth}</div>}
+
+      {naoVerificado &&
+        (reenvioMsg ? (
+          <div className="auth__alert auth__alert--ok">{reenvioMsg}</div>
+        ) : (
+          <button
+            type="button"
+            className="btn btn--ghost btn--block"
+            onClick={reenviarVerificacao}
+            disabled={reenviando}
+          >
+            {reenviando ? 'Reenviando...' : 'Reenviar email de verificação'}
+          </button>
+        ))}
 
       <form className="form" onSubmit={handleSubmit} noValidate>
         <FormField


### PR DESCRIPTION
## Contexto

Uma usuária (email @tuta.io) não recebeu o email de confirmação de conta. Diagnóstico: não é entrega nem autenticação (ela recebeu o de recuperar senha, mesmo remetente/Brevo, e o DNS SPF/DKIM/DMARC está ok) nem código (os dois emails saem do mesmo jeito). O email de verificação caiu no spam da Tutanota, que é agressiva com "confirme sua conta". E não havia como reenviar, então ela ficou travada (o login bloqueia quem não confirmou).

## O que muda

- **Reenviar verificação**: endpoint `POST /resend-verification` (resposta genérica pra não revelar se o email tem conta, só dispara se a conta existe e está pendente, com rate limit igual ao forgot-password). No login, quando dá o 403 de email não confirmado, aparece um botão "Reenviar email de verificação".
- **Fix do prazo do token**: o token de verificação expirava em 24 minutos (faltava um fator 60: `24 * 60 * 1000`). Corrigido para 24h. Link morrendo rápido demais piorava justamente os casos de email atrasado ou no spam.

## Testado no dev

- `POST /resend-verification`: 200 genérico para email inexistente; para conta não-verificada, dispara o email de verificação (confirmado no log `[EMAIL]`). Frontend no typecheck (exit 0).

## Obs

A conta da usuária (`naradt@tuta.io`) já foi marcada como verificada direto no banco de prod, então ela já entra. Este PR é pra ninguém mais ficar preso do mesmo jeito.