### PR TITLE
feat: recuperação por WhatsApp/OTP e migração de senhas para Argon2

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,6 +11,7 @@
             "dependencies": {
                 "@types/cookie-parser": "^1.4.10",
                 "@types/cors": "^2.8.19",
+                "argon2": "^0.45.1",
                 "bcrypt": "^6.0.0",
                 "cookie-parser": "^1.4.7",
                 "cors": "^2.8.6",
@@ -50,6 +51,12 @@
             "integrity": "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==",
             "dev": true,
             "license": "Apache-2.0"
+        },
+        "node_modules/@epic-web/invariant": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+            "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+            "license": "MIT"
         },
         "node_modules/@esbuild-kit/core-utils": {
             "version": "3.3.2",
@@ -1147,6 +1154,15 @@
                 "url": "https://paulmillr.com/funding/"
             }
         },
+        "node_modules/@phc/format": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@phc/format/-/format-1.0.0.tgz",
+            "integrity": "sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/@swc/helpers": {
             "version": "0.5.23",
             "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
@@ -1660,6 +1676,22 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
+        "node_modules/argon2": {
+            "version": "0.45.1",
+            "resolved": "https://registry.npmjs.org/argon2/-/argon2-0.45.1.tgz",
+            "integrity": "sha512-skm+/WCjkGqCQxF7FG1LuZXM5yvbFjgbfiCGsud2oLgaDhh6b6dbH0b1EkghbM+xx4Bj8Ape+KKgixoIlWZicQ==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "dependencies": {
+                "@phc/format": "^1.0.0",
+                "cross-env": "^10.1.0",
+                "node-addon-api": "^8.9.0",
+                "node-gyp-build": "^4.8.4"
+            },
+            "engines": {
+                "node": ">=16.17.0"
+            }
+        },
         "node_modules/balanced-match": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -1946,11 +1978,27 @@
                 "url": "https://opencollective.com/express"
             }
         },
+        "node_modules/cross-env": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+            "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+            "license": "MIT",
+            "dependencies": {
+                "@epic-web/invariant": "^1.0.0",
+                "cross-spawn": "^7.0.6"
+            },
+            "bin": {
+                "cross-env": "dist/bin/cross-env.js",
+                "cross-env-shell": "dist/bin/cross-env-shell.js"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
             "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "path-key": "^3.1.0",
@@ -2957,7 +3005,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/js-md5": {
@@ -3225,9 +3272,9 @@
             }
         },
         "node_modules/node-addon-api": {
-            "version": "8.8.0",
-            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.8.0.tgz",
-            "integrity": "sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==",
+            "version": "8.9.0",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.0.tgz",
+            "integrity": "sha512-ekZMeaaIzSQTSpr7X2X3iJM7lTzgnx8ahAG9pJfT/7+14mlEM8ZYQ9cgCDvSSRbReFK0oHli3WrZdCiRsgAT9Q==",
             "license": "MIT",
             "engines": {
                 "node": "^18 || ^20 || >= 21"
@@ -3382,7 +3429,6 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -3821,7 +3867,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "shebang-regex": "^3.0.0"
@@ -3834,7 +3879,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -4677,7 +4721,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "isexe": "^2.0.0"

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
     "dependencies": {
         "@types/cookie-parser": "^1.4.10",
         "@types/cors": "^2.8.19",
+        "argon2": "^0.45.1",
         "bcrypt": "^6.0.0",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.6",

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -30,6 +30,11 @@ const envSchema = z.object({
         .optional()
         .transform((v) => v === "true"),
     EMAIL_FROM: z.string().default("ensina.dev <nao-responda@ensinadev.com.br>"),
+
+    // Evolution API (gateway WhatsApp). Sem URL/KEY, o envio por WhatsApp vira no-op.
+    EVOLUTION_URL: z.string().url().optional(),
+    EVOLUTION_API_KEY: z.string().optional(),
+    EVOLUTION_INSTANCE: z.string().default("ensinadev"),
     // Gateway de pagamento do apoio (AbacatePay). Sem a chave, a página existe mas não cobra.
     ABACATEPAY_API_URL: z.string().url().default("https://api.abacatepay.com/v1"),
     ABACATEPAY_API_KEY: z.string().optional(),

--- a/backend/src/controllers/AuthController.ts
+++ b/backend/src/controllers/AuthController.ts
@@ -3,8 +3,15 @@ import {
     registerSchema,
     forgotPasswordSchema,
     resetPasswordSchema,
+    forgotPasswordOtpSchema,
+    resetPasswordOtpSchema,
 } from "../schemas/auth.schema.ts";
-import bcrypt from "bcrypt";
+import {
+    hashSenha,
+    verificarSenha,
+    precisaRehash,
+    getDummyHash,
+} from "../services/password.service.ts";
 import { db } from "../../db.ts";
 import { users, tokens } from "../../schema.ts";
 import { eq, and, isNull } from "drizzle-orm";
@@ -13,8 +20,7 @@ import { env } from "../config/env.ts";
 import { authService } from "../services/auth.service.ts";
 import { createHash } from "node:crypto";
 import { emailService } from "../services/email.service.ts";
-
-const BCRYPT_COST = 10;
+import { whatsappService } from "../services/whatsapp.service.ts";
 
 // Lockout de conta: trava temporariamente após muitas senhas erradas.
 const MAX_TENTATIVAS = 5;
@@ -25,8 +31,6 @@ const JWT_SECRET = String(env.JWT_SECRET);
 if (!JWT_SECRET) {
     throw new Error("JWT_SECRET não definido");
 }
-
-const DUMMY_HASH = bcrypt.hashSync("uma_senha_qualquer_dummy", BCRYPT_COST);
 
 export const register = async (req: Request, res: Response, next: NextFunction) => {
     try {
@@ -53,7 +57,7 @@ export const register = async (req: Request, res: Response, next: NextFunction) 
         }
 
         // Criptografia da senha
-        const passwordHash = await bcrypt.hash(dados.password, BCRYPT_COST);
+        const passwordHash = await hashSenha(dados.password);
 
         // Transação atômica: Cria o usuário e gera os tokens iniciais
         const novoUsuario = await db.transaction(async (tx) => {
@@ -104,17 +108,17 @@ export const login = async (req: Request, res: Response, next: NextFunction) => 
         const encontrados = await db.select().from(users).where(eq(users.email, dados.email));
         const user = encontrados[0];
 
-        // Conta travada? Recusa antes de gastar bcrypt. Mensagem genérica (igual ao
+        // Conta travada? Recusa antes de gastar o hash. Mensagem genérica (igual ao
         // rate limit) para não distinguir "travada" de "muitas tentativas por IP".
         if (user?.lockedUntil && user.lockedUntil > new Date()) {
             return res.status(429).json({ erro: "Muitas tentativas. Tente novamente mais tarde." });
         }
 
         // Definimos qual hash será comparado. Usuário com senha usa a dele; sem usuário
-        // (ou conta só de login social, sem senha) cai no DUMMY_HASH e a comparação falha.
-        const hashParaComparar = user?.passwordHash ?? DUMMY_HASH;
+        // (ou conta só de login social, sem senha) cai num hash dummy e a comparação falha.
+        const hashParaComparar = user?.passwordHash ?? (await getDummyHash());
 
-        const senhaCorreta = await bcrypt.compare(dados.password, hashParaComparar);
+        const senhaCorreta = await verificarSenha(hashParaComparar, dados.password);
 
         if (!user || !senhaCorreta) {
             // Conta tentativas falhas só para usuário existente. Ao atingir o limite,
@@ -145,6 +149,12 @@ export const login = async (req: Request, res: Response, next: NextFunction) => 
                 .update(users)
                 .set({ failedLoginAttempts: 0, lockedUntil: null })
                 .where(eq(users.id, user.id));
+        }
+
+        // Migração transparente do hash: um bcrypt antigo vira argon2 no primeiro login.
+        if (user.passwordHash && precisaRehash(user.passwordHash)) {
+            const novoHash = await hashSenha(dados.password);
+            await db.update(users).set({ passwordHash: novoHash }).where(eq(users.id, user.id));
         }
 
         if (!user.emailVerifiedAt) {
@@ -379,12 +389,90 @@ export const resetPassword = async (req: Request, res: Response, next: NextFunct
             return res.status(400).json({ erro: "Link inválido ou expirado. Peça um novo." });
         }
 
-        const passwordHash = await bcrypt.hash(password, BCRYPT_COST);
+        const passwordHash = await hashSenha(password);
 
         await db.transaction(async (tx) => {
             // Consome o token de reset.
             await tx.update(tokens).set({ usedAt: new Date() }).where(eq(tokens.id, registro.id));
             // Troca a senha.
+            await tx.update(users).set({ passwordHash }).where(eq(users.id, registro.userId));
+            // Revoga as sessões abertas (refresh tokens) por segurança.
+            await tx
+                .update(tokens)
+                .set({ usedAt: new Date() })
+                .where(
+                    and(
+                        eq(tokens.userId, registro.userId),
+                        eq(tokens.type, "refresh"),
+                        isNull(tokens.usedAt),
+                    ),
+                );
+        });
+
+        res.json({ mensagem: "Senha redefinida com sucesso. Você já pode fazer login." });
+    } catch (err) {
+        next(err);
+    }
+};
+
+// Recuperação por código (OTP): o usuário escolhe receber por email ou WhatsApp.
+export const forgotPasswordOtp = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const { email, canal } = forgotPasswordOtpSchema.parse(req.body);
+
+        // Resposta genérica, para não revelar se o email tem conta.
+        const resposta = {
+            mensagem: "Se houver uma conta com esse email, enviamos um código para redefinir a senha.",
+        };
+
+        const [user] = await db
+            .select({ id: users.id, phone: users.phone, passwordHash: users.passwordHash })
+            .from(users)
+            .where(eq(users.email, email));
+
+        if (user && user.passwordHash) {
+            const otp = await authService.gerarOtpResetSenha(user.id);
+            // WhatsApp só se tiver telefone; senão cai no email para o código não se perder.
+            if (canal === "whatsapp" && user.phone) {
+                await whatsappService.enviarOtpReset(user.phone, otp);
+            } else {
+                await emailService.enviarOtpReset(email, otp);
+            }
+        }
+
+        res.json(resposta);
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const resetPasswordOtp = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const { email, otp, password } = resetPasswordOtpSchema.parse(req.body);
+        const generico = { erro: "Código inválido ou expirado. Peça um novo." };
+
+        const [user] = await db.select({ id: users.id }).from(users).where(eq(users.email, email));
+        if (!user) return res.status(400).json(generico);
+
+        const hashCalculado = createHash("sha256").update(`${user.id}:${otp}`).digest("hex");
+        const [registro] = await db
+            .select({
+                id: tokens.id,
+                userId: tokens.userId,
+                expiredAt: tokens.expiredAt,
+                usedAt: tokens.usedAt,
+            })
+            .from(tokens)
+            .where(and(eq(tokens.tokenHash, hashCalculado), eq(tokens.type, "password_reset_otp")));
+
+        if (!registro || registro.expiredAt < new Date() || registro.usedAt !== null) {
+            return res.status(400).json(generico);
+        }
+
+        const passwordHash = await hashSenha(password);
+
+        await db.transaction(async (tx) => {
+            await tx.update(tokens).set({ usedAt: new Date() }).where(eq(tokens.id, registro.id));
             await tx.update(users).set({ passwordHash }).where(eq(users.id, registro.userId));
             // Revoga as sessões abertas (refresh tokens) por segurança.
             await tx

--- a/backend/src/middlewares/rateLimit.ts
+++ b/backend/src/middlewares/rateLimit.ts
@@ -47,6 +47,12 @@ export const resendVerificationLimiter = criarLimiter(
     "Muitos pedidos de verificação. Tente novamente em alguns minutos.",
 );
 
+// Enviar OTP (email ou WhatsApp) também dispara mensagem; teto baixo.
+export const forgotPasswordOtpLimiter = criarLimiter(
+    5,
+    "Muitos pedidos de código. Tente novamente em alguns minutos.",
+);
+
 export const resetPasswordLimiter = criarLimiter(
     20,
     "Muitas tentativas. Tente novamente em alguns minutos.",

--- a/backend/src/routes/auth.routes.ts
+++ b/backend/src/routes/auth.routes.ts
@@ -8,6 +8,8 @@ import {
     forgotPassword,
     resetPassword,
     resendVerification,
+    forgotPasswordOtp,
+    resetPasswordOtp,
 } from "../controllers/AuthController.ts";
 import { iniciarOAuth, callbackOAuth } from "../controllers/OAuthController.ts";
 import {
@@ -18,6 +20,7 @@ import {
     forgotPasswordLimiter,
     resetPasswordLimiter,
     resendVerificationLimiter,
+    forgotPasswordOtpLimiter,
 } from "../middlewares/rateLimit.ts";
 import { mesmaOrigem } from "../middlewares/origem.ts";
 
@@ -30,6 +33,8 @@ router.post("/logout", mesmaOrigem, refreshLimiter, logout);
 router.post("/verify-email", verifyEmailLimiter, verifyEmail);
 router.post("/forgot-password", forgotPasswordLimiter, forgotPassword);
 router.post("/reset-password", resetPasswordLimiter, resetPassword);
+router.post("/forgot-password-otp", forgotPasswordOtpLimiter, forgotPasswordOtp);
+router.post("/reset-password-otp", resetPasswordLimiter, resetPasswordOtp);
 router.post("/resend-verification", resendVerificationLimiter, resendVerification);
 
 // Login social (OAuth): inicia o fluxo e trata o retorno do provedor.

--- a/backend/src/schemas/auth.schema.ts
+++ b/backend/src/schemas/auth.schema.ts
@@ -22,7 +22,12 @@ export const registerSchema = z.object({
     password: senhaForte,
     birthDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Data deve ser AAAA-MM-DD"),
     gender: z.string().max(50),
-    phone: z.string().trim().max(20, "Telefone muito longo"),
+    phone: z
+        .string()
+        .trim()
+        .min(1, "Informe o telefone")
+        .max(20, "Telefone muito longo")
+        .refine((s) => s.replace(/\D/g, "").length >= 10, "Telefone inválido"),
 });
 
 export const forgotPasswordSchema = z.object({
@@ -31,6 +36,17 @@ export const forgotPasswordSchema = z.object({
 
 export const resetPasswordSchema = z.object({
     token: z.string().min(1, "Token é obrigatório.").max(512),
+    password: senhaForte,
+});
+
+export const forgotPasswordOtpSchema = z.object({
+    email: z.email("Email inválido"),
+    canal: z.enum(["email", "whatsapp"]),
+});
+
+export const resetPasswordOtpSchema = z.object({
+    email: z.email("Email inválido"),
+    otp: z.string().trim().regex(/^\d{6}$/, "O código deve ter 6 dígitos"),
     password: senhaForte,
 });
 

--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -1,8 +1,9 @@
-import { createHash, randomBytes } from "node:crypto";
+import { createHash, randomBytes, randomInt } from "node:crypto";
 import { db } from "../../db.ts";
 import { env } from "../config/env.ts";
 import jwt from "jsonwebtoken";
 import { tokens } from "../../schema.ts";
+import { and, eq } from "drizzle-orm";
 
 export const authService = {
     async gerarEGravarTokens(userId: string, tx: Pick<typeof db, "insert"> = db) {
@@ -41,5 +42,21 @@ export const authService = {
         });
 
         return resetToken;
+    },
+    // OTP de 6 dígitos para redefinir a senha por WhatsApp. Guarda só o hash
+    // (com o userId no meio, para não colidir entre usuários com o mesmo código)
+    // e mantém um único OTP ativo por usuário.
+    async gerarOtpResetSenha(userId: string) {
+        const otp = String(randomInt(100000, 1000000));
+        await db
+            .delete(tokens)
+            .where(and(eq(tokens.userId, userId), eq(tokens.type, "password_reset_otp")));
+        await db.insert(tokens).values({
+            userId,
+            tokenHash: createHash("sha256").update(`${userId}:${otp}`).digest("hex"),
+            type: "password_reset_otp",
+            expiredAt: new Date(Date.now() + 10 * 60 * 1000),
+        });
+        return otp;
     },
 };

--- a/backend/src/services/email.service.ts
+++ b/backend/src/services/email.service.ts
@@ -69,4 +69,14 @@ export const emailService = {
         const text = `Redefina sua senha no ensina.dev (o link vale por 1 hora):\n${link}\n\nSe você não pediu isso, ignore este email.`;
         await enviar({ to: email, subject: "Redefinir sua senha · ensina.dev", html, text });
     },
+    async enviarOtpReset(email: string, otp: string) {
+        const html = layout(
+            "Seu código para redefinir a senha",
+            `<p style="font-size:15px;line-height:1.6;color:#555">Use o código abaixo para redefinir sua senha. Ele vale por 10 minutos.</p>
+  <div style="font-size:30px;font-weight:700;letter-spacing:6px;color:#2d6bf5;margin:18px 0">${otp}</div>
+  <p style="font-size:13px;color:#888;margin-top:24px">Se você não pediu isso, ignore este email: sua senha continua a mesma.</p>`,
+        );
+        const text = `Seu código para redefinir a senha no ensina.dev é ${otp}. Ele vale por 10 minutos.\n\nSe você não pediu isso, ignore este email.`;
+        await enviar({ to: email, subject: "Seu código de redefinição · ensina.dev", html, text });
+    },
 };

--- a/backend/src/services/password.service.ts
+++ b/backend/src/services/password.service.ts
@@ -1,0 +1,40 @@
+import argon2 from "argon2";
+import bcrypt from "bcrypt";
+
+// Argon2id é o algoritmo recomendado (OWASP) para hash de senha. Hashes antigos em
+// bcrypt continuam sendo verificados e são migrados para argon2 no login (rehash
+// transparente), então ninguém precisa redefinir a senha por causa da troca.
+const OPCOES = { type: argon2.argon2id };
+
+export async function hashSenha(senha: string): Promise<string> {
+    return argon2.hash(senha, OPCOES);
+}
+
+export async function verificarSenha(hash: string, senha: string): Promise<boolean> {
+    try {
+        if (hash.startsWith("$argon2")) return await argon2.verify(hash, senha);
+        if (hash.startsWith("$2")) return await bcrypt.compare(senha, hash); // bcrypt legado
+        return false;
+    } catch {
+        return false;
+    }
+}
+
+// Precisa reescrever o hash? bcrypt antigo (ou formato desconhecido), ou os
+// parâmetros do argon2 mudaram desde que ele foi gerado.
+export function precisaRehash(hash: string): boolean {
+    if (!hash.startsWith("$argon2")) return true;
+    try {
+        return argon2.needsRehash(hash, OPCOES);
+    } catch {
+        return true;
+    }
+}
+
+// Hash "dummy" para o login gastar um tempo parecido quando o usuário não existe
+// (mitiga enumeração por timing). Calculado uma vez, sob demanda.
+let dummy: Promise<string> | null = null;
+export function getDummyHash(): Promise<string> {
+    if (!dummy) dummy = hashSenha("uma_senha_qualquer_dummy_para_timing");
+    return dummy;
+}

--- a/backend/src/services/password.service.ts
+++ b/backend/src/services/password.service.ts
@@ -1,13 +1,12 @@
 import argon2 from "argon2";
 import bcrypt from "bcrypt";
 
-// Argon2id é o algoritmo recomendado (OWASP) para hash de senha. Hashes antigos em
-// bcrypt continuam sendo verificados e são migrados para argon2 no login (rehash
-// transparente), então ninguém precisa redefinir a senha por causa da troca.
-const OPCOES = { type: argon2.argon2id };
-
+// Argon2id é o algoritmo recomendado (OWASP) para hash de senha, e é o default do
+// node-argon2 (com custo de memória/tempo já fortes). Hashes antigos em bcrypt
+// continuam sendo verificados e migram para argon2 no login (rehash transparente),
+// então ninguém precisa redefinir a senha por causa da troca.
 export async function hashSenha(senha: string): Promise<string> {
-    return argon2.hash(senha, OPCOES);
+    return argon2.hash(senha);
 }
 
 export async function verificarSenha(hash: string, senha: string): Promise<boolean> {
@@ -25,7 +24,7 @@ export async function verificarSenha(hash: string, senha: string): Promise<boole
 export function precisaRehash(hash: string): boolean {
     if (!hash.startsWith("$argon2")) return true;
     try {
-        return argon2.needsRehash(hash, OPCOES);
+        return argon2.needsRehash(hash);
     } catch {
         return true;
     }

--- a/backend/src/services/whatsapp.service.ts
+++ b/backend/src/services/whatsapp.service.ts
@@ -1,0 +1,55 @@
+import { env } from "../config/env.ts";
+
+// Envia mensagens via Evolution API (gateway WhatsApp/Baileys) hospedado na VPS.
+// Sem EVOLUTION_URL/EVOLUTION_API_KEY (ex.: dev), o envio vira no-op logado, igual
+// ao email quando o SMTP não está configurado.
+const configurado = !!(env.EVOLUTION_URL && env.EVOLUTION_API_KEY);
+
+// Normaliza para o formato do WhatsApp (só dígitos, com DDI). Aceita telefone
+// brasileiro sem DDI (10-11 dígitos) e prefixa 55; se já vier com DDI, mantém.
+function normalizarNumero(telefone: string): string | null {
+    const digitos = telefone.replace(/\D/g, "");
+    if (digitos.length < 10) return null;
+    if (digitos.startsWith("55")) return digitos;
+    if (digitos.length === 10 || digitos.length === 11) return "55" + digitos;
+    return digitos;
+}
+
+// Uma falha é logada, não propagada: a recuperação não deve quebrar porque o
+// WhatsApp não saiu (o email continua como canal padrão).
+async function enviarTexto(telefone: string, texto: string) {
+    const numero = normalizarNumero(telefone);
+    if (!numero) {
+        console.warn(`[WHATSAPP] telefone inválido, envio ignorado: ${telefone}`);
+        return;
+    }
+    if (!configurado) {
+        console.log(`[WHATSAPP] (Evolution não configurado) para=${numero}\n${texto}`);
+        return;
+    }
+    try {
+        const resp = await fetch(
+            `${env.EVOLUTION_URL}/message/sendText/${env.EVOLUTION_INSTANCE}`,
+            {
+                method: "POST",
+                headers: { "Content-Type": "application/json", apikey: env.EVOLUTION_API_KEY! },
+                body: JSON.stringify({ number: numero, text: texto }),
+            },
+        );
+        if (!resp.ok) {
+            const corpo = await resp.text().catch(() => "");
+            console.error(`Falha ao enviar WhatsApp para ${numero}: HTTP ${resp.status} ${corpo}`);
+        }
+    } catch (e) {
+        console.error(`Falha ao enviar WhatsApp para ${numero}:`, e);
+    }
+}
+
+export const whatsappService = {
+    async enviarOtpReset(telefone: string, otp: string) {
+        const texto =
+            `ensina.dev\n\nSeu código para redefinir a senha é *${otp}*.\n` +
+            `Ele vale por 10 minutos. Se você não pediu, ignore esta mensagem.`;
+        await enviarTexto(telefone, texto);
+    },
+};

--- a/frontend/src/components/ProfileCompletionFields.tsx
+++ b/frontend/src/components/ProfileCompletionFields.tsx
@@ -72,6 +72,8 @@ export function validateProfileCompletionFields(
   }
   if (!values.phone.trim()) {
     errors.phone = 'Informe seu telefone';
+  } else if (values.phone.replace(/\D/g, '').length < 10) {
+    errors.phone = 'Telefone inválido';
   }
   return errors;
 }

--- a/frontend/src/pages/RecuperarSenha/index.tsx
+++ b/frontend/src/pages/RecuperarSenha/index.tsx
@@ -16,32 +16,50 @@ const brand = (
         <span className="auth__headline-main">Recupere seu acesso</span>
       </h1>
       <p className="auth__lede">
-        Informe seu email e enviamos um link para você criar uma nova senha em segundos.
+        Enviamos um código de 6 dígitos por email ou WhatsApp para você criar uma nova senha em
+        segundos.
       </p>
     </div>
   </AuthBrand>
 );
 
-export function RecuperarSenha() {
-  const [email, setEmail] = useState('');
-  const [submitting, setSubmitting] = useState(false);
-  const [enviado, setEnviado] = useState(false);
-  const [mensagem, setMensagem] = useState('');
-  const [error, setError] = useState('');
+type Canal = 'email' | 'whatsapp';
 
-  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+export function RecuperarSenha() {
+  const [etapa, setEtapa] = useState<'pedir' | 'codigo' | 'ok'>('pedir');
+  const [email, setEmail] = useState('');
+  const [canal, setCanal] = useState<Canal | null>(null);
+  const [otp, setOtp] = useState('');
+  const [password, setPassword] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+  const [mensagem, setMensagem] = useState('');
+
+  async function pedirCodigo(c: Canal) {
+    if (submitting || !email) return;
+    setError('');
+    setCanal(c);
+    setSubmitting(true);
+    try {
+      await api.post('/forgot-password-otp', { email, canal: c });
+      setEtapa('codigo');
+    } catch (e: unknown) {
+      setError(mensagemErro(e, 'Não foi possível enviar o código. Tente novamente.'));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function redefinir(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setError('');
     setSubmitting(true);
     try {
-      const { data } = await api.post('/forgot-password', { email });
-      setMensagem(
-        data.mensagem ??
-          'Se houver uma conta com esse email, enviamos um link para redefinir a senha.',
-      );
-      setEnviado(true);
+      const { data } = await api.post('/reset-password-otp', { email, otp, password });
+      setMensagem(data.mensagem ?? 'Senha redefinida com sucesso. Você já pode fazer login.');
+      setEtapa('ok');
     } catch (e: unknown) {
-      setError(mensagemErro(e, 'Não foi possível enviar o link. Tente novamente.'));
+      setError(mensagemErro(e, 'Não foi possível redefinir a senha. Confira o código e a senha.'));
     } finally {
       setSubmitting(false);
     }
@@ -50,9 +68,8 @@ export function RecuperarSenha() {
   return (
     <AuthShell brand={brand}>
       <h2 className="auth__title">Esqueceu a senha?</h2>
-      <p className="auth__subtitle">Enviamos um link de redefinição para o seu email.</p>
 
-      {enviado ? (
+      {etapa === 'ok' ? (
         <>
           <div className="auth__alert auth__alert--ok">{mensagem}</div>
           <p className="auth__foot">
@@ -61,10 +78,11 @@ export function RecuperarSenha() {
             </Link>
           </p>
         </>
-      ) : (
+      ) : etapa === 'pedir' ? (
         <>
+          <p className="auth__subtitle">Como você quer receber o código de 6 dígitos?</p>
           {error && <div className="auth__alert">{error}</div>}
-          <form className="form" onSubmit={handleSubmit} noValidate>
+          <div className="form">
             <FormField
               label="E-mail"
               type="email"
@@ -74,15 +92,72 @@ export function RecuperarSenha() {
               onChange={(e) => setEmail(e.target.value)}
               required
             />
-            <button className="btn btn--accent btn--block" type="submit" disabled={submitting}>
-              {submitting ? 'Enviando...' : 'Enviar link'}
+            <button
+              className="btn btn--accent btn--block"
+              type="button"
+              disabled={submitting || !email}
+              onClick={() => pedirCodigo('whatsapp')}
+            >
+              {submitting && canal === 'whatsapp' ? 'Enviando...' : 'Receber no WhatsApp'}
             </button>
-          </form>
+            <button
+              className="btn btn--ghost btn--block"
+              type="button"
+              disabled={submitting || !email}
+              onClick={() => pedirCodigo('email')}
+            >
+              {submitting && canal === 'email' ? 'Enviando...' : 'Receber por email'}
+            </button>
+          </div>
           <p className="auth__foot">
             Lembrou a senha?{' '}
             <Link className="link" to="/">
               Voltar ao login
             </Link>
+          </p>
+        </>
+      ) : (
+        <>
+          <p className="auth__subtitle">
+            Digite o código que enviamos {canal === 'whatsapp' ? 'no WhatsApp' : 'por email'} e a
+            nova senha.
+          </p>
+          {error && <div className="auth__alert">{error}</div>}
+          <form className="form" onSubmit={redefinir} noValidate>
+            <FormField
+              label="Código (6 dígitos)"
+              type="text"
+              autoComplete="one-time-code"
+              placeholder="000000"
+              value={otp}
+              onChange={(e) => setOtp(e.target.value.replace(/\D/g, '').slice(0, 6))}
+              required
+            />
+            <FormField
+              label="Nova senha"
+              type="password"
+              autoComplete="new-password"
+              placeholder="••••••••••"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
+            <button className="btn btn--accent btn--block" type="submit" disabled={submitting}>
+              {submitting ? 'Redefinindo...' : 'Redefinir senha'}
+            </button>
+          </form>
+          <p className="auth__foot">
+            <button
+              type="button"
+              className="link link--btn"
+              onClick={() => {
+                setEtapa('pedir');
+                setOtp('');
+                setError('');
+              }}
+            >
+              Não recebeu? Escolher outro canal
+            </button>
           </p>
         </>
       )}


### PR DESCRIPTION
Dois ganhos de segurança/recuperação, testados no dev pela UI e por API.

## Recuperação de senha por código (OTP), email ou WhatsApp

- Na tela "Esqueceu a senha", o usuário digita o email e escolhe **receber o código no WhatsApp ou por email**. Os dois mandam um OTP de 6 dígitos; depois ele digita o código + a nova senha.
- **Telefone obrigatório** no cadastro (o front já exigia; alinhei o schema do backend e a validação de dígitos), pra o WhatsApp ter pra onde mandar.
- WhatsApp sai pela **Evolution API** que subi na VPS (stack isolado, só interno, sem salvar histórico). Se não tiver telefone, cai no email.
- Backend: `POST /forgot-password-otp` e `POST /reset-password-otp` com rate limit; OTP guardado só como `sha256(userId:otp)`, validade 10 min, um ativo por usuário; reset revoga as sessões abertas. Sem migração (usa a tabela `tokens`).

## Migração de bcrypt para Argon2id

- Novo `password.service.ts`: hash em **Argon2id** (recomendado pela OWASP), verificação que aceita argon2 (novo) e bcrypt (legado) pelo prefixo, e `needsRehash`.
- **Rehash transparente no login**: senha correta com hash bcrypt antigo é reescrita em argon2 na hora, sem forçar ninguém a redefinir. Register e reset já geram argon2.

## Testes no dev

- OTP por email pela UI ponta a ponta: enviar → código → redefinir → banco confirma bcrypt... (agora argon2) e token consumido. WhatsApp: roteou pro envio com o telefone normalizado. Telefone vazio no register → 400.
- Argon2: register gera `$argon2id`; usuário legado `$2b$` faz login (200) e o hash migra pra `$argon2id`; senha errada → 401. Front no typecheck.

## Pra ir pra prod (deploy)

Sem migração de banco. Só adicionar ao `.env.prod` do backend, na VPS: `EVOLUTION_URL=http://evolution_api:8080`, `EVOLUTION_API_KEY=<chave do .env do Evolution>`, `EVOLUTION_INSTANCE=ensinadev`. Faço isso no deploy.