### PR TITLE
feat: 5 questões por aula (Java, C++, Go) e indentação do código no quiz

### DIFF
--- a/backend/scripts/cercar-codigo-questoes.ts
+++ b/backend/scripts/cercar-codigo-questoes.ts
@@ -1,0 +1,43 @@
+// Cerca em ``` o código dos enunciados de quiz que perderam a indentação. O código já
+// está no banco com as quebras e os espaços certos, mas sem cerca de código o markdown
+// inline (TextoMath) colapsa os espaços, quebrando a indentação (crítico em Python).
+// Idempotente (pula quem já tem ```) e conservador (só mexe em enunciado com linha
+// indentada). Casa a linguagem da aula na cerca.
+//
+// Rodar:      docker compose exec -T backend node scripts/cercar-codigo-questoes.ts [--dry]
+// Em prod:    docker compose -f docker-compose.prod.yml exec -T backend node scripts/cercar-codigo-questoes.ts [--dry]
+import { db } from "../db.ts";
+import { questions, lessons } from "../schema.ts";
+import { eq } from "drizzle-orm";
+import { cercarCodigo } from "./cercar-codigo.lib.ts";
+
+async function main() {
+    const dry = process.argv.includes("--dry");
+    const rows = await db
+        .select({ id: questions.id, statement: questions.statement, lang: lessons.language })
+        .from(questions)
+        .innerJoin(lessons, eq(questions.lessonId, lessons.id));
+
+    let alterados = 0;
+    let amostras = 0;
+    for (const r of rows) {
+        const novo = cercarCodigo(r.statement, r.lang);
+        if (novo === r.statement) continue;
+        alterados++;
+        if (dry) {
+            if (amostras < 4) {
+                amostras++;
+                console.log("\n----- ANTES -----\n" + r.statement + "\n----- DEPOIS -----\n" + novo);
+            }
+            continue;
+        }
+        await db.update(questions).set({ statement: novo }).where(eq(questions.id, r.id));
+    }
+    console.log(`\n${dry ? "[DRY] " : ""}Enunciados cercados: ${alterados}`);
+    process.exit(0);
+}
+
+main().catch((e) => {
+    console.error("Falha ao cercar código:", e);
+    process.exit(1);
+});

--- a/backend/scripts/cercar-codigo-seeds.ts
+++ b/backend/scripts/cercar-codigo-seeds.ts
@@ -1,0 +1,40 @@
+// Codemod: cerca o código nos enunciados dos seeds (a fonte), para instalações limpas já
+// nascerem com a indentação preservada. Espelha o backfill do banco (mesma lib) e é
+// idempotente. Usa cerca simples (```), que renderiza igual à cerca com linguagem.
+//
+// Rodar: docker compose exec -T backend node scripts/cercar-codigo-seeds.ts [--dry] <arquivo...>
+import { readFileSync, writeFileSync } from "node:fs";
+import { cercarCodigo } from "./cercar-codigo.lib.ts";
+
+const args = process.argv.slice(2);
+const dry = args.includes("--dry");
+const arquivos = args.filter((a) => !a.startsWith("--"));
+
+// Casa `"statement": "..."` (chave com aspas) e `statement: "..."` (sem aspas): string de
+// aspas duplas em uma linha só (os seeds usam \n escapado, não quebra de linha literal).
+const RE = /((?:"statement"|statement)\s*:\s*)"((?:\\.|[^"\\])*)"/g;
+
+let totalArquivos = 0;
+let totalCercados = 0;
+for (const arq of arquivos) {
+    const orig = readFileSync(arq, "utf8");
+    let n = 0;
+    const novo = orig.replace(RE, (m, prefixo, corpo) => {
+        let texto: string;
+        try {
+            texto = JSON.parse('"' + corpo + '"');
+        } catch {
+            console.warn("Enunciado ignorado (não decodou):", arq);
+            return m;
+        }
+        const cercado = cercarCodigo(texto);
+        if (cercado === texto) return m;
+        n++;
+        return prefixo + JSON.stringify(cercado);
+    });
+    totalCercados += n;
+    if (n > 0) totalArquivos++;
+    console.log(`${arq}: ${n} enunciado(s) cercado(s)`);
+    if (!dry && n > 0) writeFileSync(arq, novo);
+}
+console.log(`\n${dry ? "[DRY] " : ""}Total: ${totalCercados} enunciado(s) em ${totalArquivos} arquivo(s).`);

--- a/backend/scripts/cercar-codigo.lib.ts
+++ b/backend/scripts/cercar-codigo.lib.ts
@@ -1,0 +1,51 @@
+// Detecção e cerca de blocos de código em enunciados de quiz. Sem cerca de código, o
+// markdown inline (TextoMath) colapsa os espaços e quebra a indentação, o que é crítico
+// em Python. Usado pelo backfill do banco (cercar-codigo-questoes.ts) e pelo codemod dos
+// seeds (cercar-codigo-seeds.ts), para manter banco e fonte consistentes.
+
+// Uma linha é "código" se está indentada, começa com uma construção de código, ou tem
+// pontuação/atribuição de código. Pergunta (termina em ?) é sempre prosa.
+export const KW =
+    /^(def\b|class\b|function\b|func\b|let\b|const\b|var\b|return\b|import\b|from\b|for\b|while\b|if\b|elif\b|else\b|switch\b|match\b|case\b|with\b|try\b|except\b|finally\b|raise\b|throw\b|catch\b|lambda\b|yield\b|global\b|nonlocal\b|assert\b|print\(|println\b|printf\b|console\.|System\.|public\b|private\b|protected\b|static\b|void\b|SELECT\b|INSERT\b|UPDATE\b|DELETE\b|CREATE\b|ALTER\b|DROP\b|FROM\b|WHERE\b|JOIN\b|VALUES\b|GROUP\b|ORDER\b)/i;
+
+export function isCode(line: string): boolean {
+    if (/^\s+\S/.test(line)) return true; // indentada = código
+    const t = line.trim();
+    if (t === "") return false;
+    if (/[?]$/.test(t)) return false; // pergunta = prosa
+    if (KW.test(t)) return true; // começa com construção de código
+    if (/[;{}]/.test(t)) return true; // pontuação de bloco
+    if (/\w+\s*\([^)]*\)/.test(t)) return true; // chamada foo(...) (mesmo terminando em :)
+    if (/^[\w.[\]"'()]+\s*[-+*/%]?=[^=]/.test(t)) return true; // atribuição no início da linha
+    return false;
+}
+
+// Envolve o bloco de código (da primeira à última linha de código) numa cerca, mantendo a
+// intro antes e a pergunta depois. Retorna o enunciado inalterado se já houver cerca ou se
+// não houver bloco de código indentado de fato (conservador e idempotente).
+export function cercarCodigo(statement: string, lang?: string | null): string {
+    if (!statement || statement.includes("```")) return statement;
+    if (!/\n[ \t]+\S/.test(statement)) return statement; // sem linha indentada: não mexe
+    const lines = statement.replace(/\r\n/g, "\n").split("\n");
+    let first = -1;
+    let last = -1;
+    for (let i = 0; i < lines.length; i++) {
+        if (isCode(lines[i])) {
+            if (first === -1) first = i;
+            last = i;
+        }
+    }
+    if (first === -1) return statement;
+    const intro = lines.slice(0, first).join("\n").replace(/\s+$/, "");
+    const code = lines.slice(first, last + 1).join("\n");
+    const outro = lines
+        .slice(last + 1)
+        .join("\n")
+        .replace(/^\s+/, "");
+    const fence = lang ? "```" + lang : "```";
+    const partes: string[] = [];
+    if (intro.trim()) partes.push(intro);
+    partes.push(fence + "\n" + code + "\n```");
+    if (outro.trim()) partes.push(outro);
+    return partes.join("\n\n");
+}

--- a/backend/scripts/seed-trilha-banco-de-dados.ts
+++ b/backend/scripts/seed-trilha-banco-de-dados.ts
@@ -3932,7 +3932,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Uma rota está assim:\n\napp.get('/tarefas', (req, res) => {\n  const resultado = client.query('SELECT * FROM tarefas');\n  res.json(resultado.rows);\n});\n\nAo testar, a rota devolve um objeto de Promise pendente em vez da lista de tarefas. Qual é o problema?",
+                        "statement": "Uma rota está assim:\n\n```\napp.get('/tarefas', (req, res) => {\n  const resultado = client.query('SELECT * FROM tarefas');\n  res.json(resultado.rows);\n});\n```\n\nAo testar, a rota devolve um objeto de Promise pendente em vez da lista de tarefas. Qual é o problema?",
                         "difficulty": "dificil",
                         "options": [
                             {
@@ -4367,7 +4367,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Uma rota de atualizar tarefa está assim:\n\napp.put('/tarefas/:id', async (req, res) => {\n  const { id } = req.params;\n  const { titulo, concluida } = req.body;\n  const resultado = await pool.query(\n    'UPDATE tarefas SET titulo = $1, concluida = $2 WHERE id = $3 RETURNING *',\n    [titulo, concluida, id]\n  );\n  if (resultado.rows.length === 0) {\n    return res.status(404).json({ mensagem: 'Tarefa não encontrada' });\n  }\n  res.json(resultado.rows[0]);\n});\n\nPor que essa rota é considerada segura contra SQL injection e correta para um CRUD persistente?",
+                        "statement": "Uma rota de atualizar tarefa está assim:\n\n```\napp.put('/tarefas/:id', async (req, res) => {\n  const { id } = req.params;\n  const { titulo, concluida } = req.body;\n  const resultado = await pool.query(\n    'UPDATE tarefas SET titulo = $1, concluida = $2 WHERE id = $3 RETURNING *',\n    [titulo, concluida, id]\n  );\n  if (resultado.rows.length === 0) {\n    return res.status(404).json({ mensagem: 'Tarefa não encontrada' });\n  }\n  res.json(resultado.rows[0]);\n});\n```\n\nPor que essa rota é considerada segura contra SQL injection e correta para um CRUD persistente?",
                         "difficulty": "dificil",
                         "options": [
                             {

--- a/backend/scripts/seed-trilha-cpp.ts
+++ b/backend/scripts/seed-trilha-cpp.ts
@@ -5,8 +5,9 @@
 import { db } from "../db.ts";
 import { trails, modules, lessons, questions, questionOptions } from "../schema.ts";
 import { eq } from "drizzle-orm";
+import { pathToFileURL } from "node:url";
 
-const NOME = "C++";
+export const NOME = "C++";
 const LEVEL: "iniciante" | "intermediario" | "avancado" = "iniciante";
 const DESCRICAO =
     "A linguagem C++ do zero ao avançado: sintaxe e tipos, controle de fluxo, funções e passagem por referência, ponteiros e gerenciamento de memória, classes e RAII, herança e funções virtuais, a STL com containers e templates, e o C++ moderno com smart pointers e lambdas. A linguagem de jogos, sistemas de alto desempenho e software de baixo nível.";
@@ -70,6 +71,26 @@ const MODULO_1: Modulo = {
                         { text: "Exclusivamente pequenos scripts de automação rápidos", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "Historicamente, como o C++ surgiu?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Como uma extensão da linguagem C com orientação a objetos", isCorrect: true },
+                        { text: "Como uma linguagem totalmente nova, sem nenhuma relação com o C", isCorrect: false },
+                        { text: "Como uma versão interpretada da linguagem Java", isCorrect: false },
+                        { text: "Como um dialeto do Python voltado a jogos", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "No build de um programa C++, o que o linker faz depois da compilação?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Traduz o código-fonte em código de máquina", isCorrect: false },
+                        { text: "Une o código já compilado às bibliotecas e forma o executável", isCorrect: true },
+                        { text: "Roda o executável e mostra a saída na tela", isCorrect: false },
+                        { text: "Confere os tipos de todas as variáveis do programa antes da compilação", isCorrect: false },
+                    ],
+                },
             ],
         },
         {
@@ -123,6 +144,26 @@ const MODULO_1: Modulo = {
                         { text: "Encerrar o programa ao final da execução", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "No programa, o que a linha `return 0;` dentro do main indica?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Que o programa deve reiniciar do início", isCorrect: false },
+                        { text: "Que ocorreu um erro durante a execução", isCorrect: false },
+                        { text: "Que a saída ainda será impressa na tela", isCorrect: false },
+                        { text: "Que o programa terminou com sucesso", isCorrect: true },
+                    ],
+                },
+                {
+                    statement: "Para ler um valor digitado pelo usuário, o que se usa?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "std::cin com o operador >>", isCorrect: true },
+                        { text: "std::cout com o operador <<", isCorrect: false },
+                        { text: "std::endl com o operador <<", isCorrect: false },
+                        { text: "std::read com o operador >>", isCorrect: false },
+                    ],
+                },
             ],
         },
         {
@@ -170,6 +211,26 @@ const MODULO_1: Modulo = {
                         { text: "Impede o uso de qualquer nome da biblioteca padrão", isCorrect: false },
                         { text: "Cria um novo namespace chamado std", isCorrect: false },
                         { text: "Compila o programa em modo otimizado", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que muita gente evita `using namespace std;` em projetos grandes?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Porque isso impede o uso do std::cout no código", isCorrect: false },
+                        { text: "Porque trazer todo o namespace pode causar colisões de nomes", isCorrect: true },
+                        { text: "Porque deixa a compilação do programa muito mais lenta e pesada", isCorrect: false },
+                        { text: "Porque apaga os nomes da biblioteca padrão", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como dois trechos de código podem ter, cada um, uma função `imprimir` sem conflito?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Se cada uma ficar em um namespace diferente", isCorrect: true },
+                        { text: "Se as duas forem marcadas como const", isCorrect: false },
+                        { text: "Se ambas estiverem escritas dentro da função main principal", isCorrect: false },
+                        { text: "Se nenhuma delas usar a biblioteca std", isCorrect: false },
                     ],
                 },
             ],
@@ -235,6 +296,26 @@ const MODULO_2: Modulo = {
                         { text: "bool", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "Qual tipo é apropriado para guardar um único caractere, como a letra 'Z'?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "char", isCorrect: true },
+                        { text: "int", isCorrect: false },
+                        { text: "double", isCorrect: false },
+                        { text: "bool", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que o C++ moderno prefere `std::string` aos arrays de caracteres herdados da linguagem C?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Porque ocupa sempre menos memória que eles", isCorrect: false },
+                        { text: "Porque dispensa incluir qualquer biblioteca", isCorrect: false },
+                        { text: "Porque é mais seguro e prático de usar", isCorrect: true },
+                        { text: "Porque guarda números além de texto", isCorrect: false },
+                    ],
+                },
             ],
         },
         {
@@ -288,6 +369,26 @@ const MODULO_2: Modulo = {
                         { text: "convert(valor, int)", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "Qual é o resultado de `static_cast<int>(19.99)`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "20, pois o valor é arredondado para cima", isCorrect: false },
+                        { text: "19.99, pois o valor não muda em nada", isCorrect: false },
+                        { text: "19, pois a parte decimal é descartada", isCorrect: true },
+                        { text: "Um erro, pois um double não vira int", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que acontece se você tentar alterar uma variável declarada com `const`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A alteração é feita normalmente", isCorrect: false },
+                        { text: "Ocorre um erro de compilação", isCorrect: true },
+                        { text: "O valor volta a zero automaticamente", isCorrect: false },
+                        { text: "O programa trava apenas ao ser executado", isCorrect: false },
+                    ],
+                },
             ],
         },
         {
@@ -339,6 +440,26 @@ const MODULO_2: Modulo = {
                         { text: "Como a palavra true por extenso", isCorrect: false },
                         { text: "Como um espaço em branco", isCorrect: false },
                         { text: "Como a letra T", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Para que `7 / 2` resulte em `3.5` em vez de `3`, o que é necessário?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Que os dois operandos sejam do tipo inteiro (int)", isCorrect: false },
+                        { text: "Que se use o operador % no lugar da /", isCorrect: false },
+                        { text: "Que o resultado seja guardado em um bool", isCorrect: false },
+                        { text: "Que ao menos um dos operandos seja double", isCorrect: true },
+                    ],
+                },
+                {
+                    statement: "Depois de `int total = 10; total += 5; total++;`, quanto vale total?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "15", isCorrect: false },
+                        { text: "16", isCorrect: true },
+                        { text: "11", isCorrect: false },
+                        { text: "17", isCorrect: false },
                     ],
                 },
             ],
@@ -396,6 +517,26 @@ const MODULO_3: Modulo = {
                         { text: "A e B, pois os dois blocos executam", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "Que tipo de valor um `switch` compara com seus casos?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Apenas valores do tipo double", isCorrect: false },
+                        { text: "Qualquer texto do tipo std::string", isCorrect: false },
+                        { text: "Um valor inteiro ou um caractere", isCorrect: true },
+                        { text: "Somente valores do tipo bool", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "No `switch`, para que serve o caso `default`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Repetir o primeiro case do switch", isCorrect: false },
+                        { text: "Tratar os valores que não caíram em nenhum case", isCorrect: true },
+                        { text: "Encerrar o programa imediatamente", isCorrect: false },
+                        { text: "Obrigar todos os case a terem um break ao final", isCorrect: false },
+                    ],
+                },
             ],
         },
         {
@@ -449,6 +590,26 @@ const MODULO_3: Modulo = {
                         { text: "Repete a volta atual mais uma vez", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "Quantas vezes o trecho a seguir imprime algo?\n```cpp\nint n = 10;\ndo {\n    std::cout << n;\n    n++;\n} while (n <= 3);\n```",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Nenhuma, pois 10 não é menor ou igual a 3", isCorrect: false },
+                        { text: "Uma vez, pois o do-while roda antes de testar", isCorrect: true },
+                        { text: "Três vezes, para n valendo 1, 2 e 3", isCorrect: false },
+                        { text: "Para sempre, pois n apenas aumenta a cada volta", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Em um laço `while`, quando a condição é testada?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Depois de executar o bloco interno, a cada repetição feita", isCorrect: false },
+                        { text: "Apenas na última volta do laço", isCorrect: false },
+                        { text: "Somente quando o laço usa um break", isCorrect: false },
+                        { text: "Antes de cada repetição, e o bloco pode nem rodar", isCorrect: true },
+                    ],
+                },
             ],
         },
         {
@@ -496,6 +657,26 @@ const MODULO_3: Modulo = {
                         { text: "Para copiar cada elemento e ganhar desempenho", isCorrect: false },
                         { text: "Porque auto não funciona em um range-based for", isCorrect: false },
                         { text: "Para converter cada elemento em uma string", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quais são as três partes que um `for` clássico reúne no cabeçalho?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Nome, tipo e valor da variável", isCorrect: false },
+                        { text: "Início, meio e fim do bloco", isCorrect: false },
+                        { text: "Entrada, processamento e saída de dados", isCorrect: false },
+                        { text: "Inicialização, condição e passo", isCorrect: true },
+                    ],
+                },
+                {
+                    statement: "Quando o `for` clássico costuma ser a melhor escolha?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Quando você sabe quantas vezes repetir ou precisa do índice", isCorrect: true },
+                        { text: "Quando quer apenas percorrer todos os elementos", isCorrect: false },
+                        { text: "Quando o container não tem tamanho definido", isCorrect: false },
+                        { text: "Quando você quer percorrer todos os elementos de uma vez só", isCorrect: false },
                     ],
                 },
             ],
@@ -553,6 +734,26 @@ const MODULO_4: Modulo = {
                         { text: "Porque toda função precisa estar no arquivo main", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "Qual tipo de retorno se usa em uma função que não devolve nenhum valor?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "int", isCorrect: false },
+                        { text: "null", isCorrect: false },
+                        { text: "void", isCorrect: true },
+                        { text: "empty", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que é um protótipo de função em C++?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Uma versão da função que roda logo antes de todas as outras no início", isCorrect: false },
+                        { text: "A assinatura da função, sem o corpo, declarada antes do uso", isCorrect: true },
+                        { text: "Uma função que chama a si mesma repetidamente", isCorrect: false },
+                        { text: "Uma função sem nenhum tipo de retorno", isCorrect: false },
+                    ],
+                },
             ],
         },
         {
@@ -606,6 +807,26 @@ const MODULO_4: Modulo = {
                         { text: "Impedir que a função leia o objeto", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "Após `int n = 5; dobrar(n);`, onde `dobrar(int& x)` faz `x = x * 2`, quanto vale n?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "5, pois a função recebe apenas uma cópia", isCorrect: false },
+                        { text: "Indefinido, pois n perde o valor logo após a chamada", isCorrect: false },
+                        { text: "10, pois a referência altera a própria variável", isCorrect: true },
+                        { text: "0, pois n é apagado após a chamada", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Segundo a tabela da aula, o que a passagem por valor (`int x`) faz?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Não copia, mas altera o original", isCorrect: false },
+                        { text: "Não copia e não altera o original", isCorrect: false },
+                        { text: "Copia o argumento e ainda altera o original de quem chamou", isCorrect: false },
+                        { text: "Copia o argumento, mas não altera o original", isCorrect: true },
+                    ],
+                },
             ],
         },
         {
@@ -653,6 +874,26 @@ const MODULO_4: Modulo = {
                         { text: "Sempre no início, antes de todos os demais", isCorrect: false },
                         { text: "No meio, entre os parâmetros obrigatórios", isCorrect: false },
                         { text: "Em qualquer posição, sem nenhuma restrição", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Em uma função sobrecarregada, como o compilador escolhe qual versão usar?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Pela ordem em que as versões foram escritas", isCorrect: false },
+                        { text: "Pelos argumentos passados na chamada", isCorrect: true },
+                        { text: "Pelo tipo de retorno de cada versão", isCorrect: false },
+                        { text: "Sempre pela primeira versão declarada", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Com `void cumprimentar(std::string nome, std::string saudacao = \"Olá\")`, o que `cumprimentar(\"Ana\")` imprime?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Olá, Ana", isCorrect: true },
+                        { text: "Ana, Olá", isCorrect: false },
+                        { text: "Oi, Ana", isCorrect: false },
+                        { text: "Apenas Ana, sem nenhuma saudação", isCorrect: false },
                     ],
                 },
             ],
@@ -714,6 +955,26 @@ const MODULO_5: Modulo = {
                         { text: "O valor undefined", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "O que o operador `&`, como em `&x`, devolve?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O valor guardado dentro de x", isCorrect: false },
+                        { text: "Uma cópia da variável x", isCorrect: false },
+                        { text: "O endereço da variável x", isCorrect: true },
+                        { text: "O tipo declarado da variável x", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que acontece ao desreferenciar (`*p`) um ponteiro nulo ou não inicializado?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O ponteiro passa a apontar para o valor zero", isCorrect: false },
+                        { text: "É um erro grave que costuma travar o programa", isCorrect: true },
+                        { text: "O valor apontado vira nullptr de forma automática", isCorrect: false },
+                        { text: "Nada, o C++ simplesmente ignora a operação", isCorrect: false },
+                    ],
+                },
             ],
         },
         {
@@ -761,6 +1022,26 @@ const MODULO_5: Modulo = {
                         { text: "Nada, pois a heap se limpa sozinha", isCorrect: false },
                         { text: "Chamar new novamente para fechar", isCorrect: false },
                         { text: "Converter o ponteiro em int", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o `new` devolve ao alocar memória na heap?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Uma cópia do valor recém-alocado", isCorrect: false },
+                        { text: "O tamanho exato da memória em bytes", isCorrect: false },
+                        { text: "O endereço do topo da stack naquele momento", isCorrect: false },
+                        { text: "Um ponteiro para a memória reservada", isCorrect: true },
+                    ],
+                },
+                {
+                    statement: "Qual regra vale para memória alocada na heap com `new`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O new já libera sozinho ao fim da função", isCorrect: false },
+                        { text: "A heap se limpa sozinha entre as chamadas", isCorrect: false },
+                        { text: "Para cada new deve haver um delete", isCorrect: true },
+                        { text: "Um único delete libera todos os new de uma vez", isCorrect: false },
                     ],
                 },
             ],
@@ -814,6 +1095,26 @@ const MODULO_5: Modulo = {
                         { text: "Nunca alocar memória em nenhum programa", isCorrect: false },
                         { text: "Alocar tudo com new e nunca liberar", isCorrect: false },
                         { text: "Evitar completamente o uso de ponteiros", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que ocorre ao desreferenciar um ponteiro pendente, após o `delete`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O ponteiro volta a apontar para nullptr de forma automática", isCorrect: false },
+                        { text: "Comportamento indefinido, um dos bugs mais traiçoeiros", isCorrect: true },
+                        { text: "A memória é realocada na mesma hora", isCorrect: false },
+                        { text: "O valor antigo é sempre recuperado intacto", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual é o efeito de vazamentos de memória em um programa que roda por muito tempo?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Vão consumindo a memória até causar problemas", isCorrect: true },
+                        { text: "Deixam o programa mais rápido com o tempo", isCorrect: false },
+                        { text: "Liberam a memória usada por todos os outros programas", isCorrect: false },
+                        { text: "Não têm efeito algum sobre a execução", isCorrect: false },
                     ],
                 },
             ],
@@ -871,6 +1172,26 @@ const MODULO_6: Modulo = {
                         { text: "struct não pode ter métodos, só class", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "O que caracteriza um membro `protected` em uma classe?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "É acessível de qualquer parte do código do programa", isCorrect: false },
+                        { text: "Só pode ser lido, mas nunca alterado", isCorrect: false },
+                        { text: "É como private, mas também visível às subclasses", isCorrect: true },
+                        { text: "É retirado da classe no momento de compilar", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Em uma classe, os dados que ela guarda e o comportamento que ela executa se chamam, respectivamente:",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Métodos e atributos", isCorrect: false },
+                        { text: "Objetos e instâncias", isCorrect: false },
+                        { text: "Chaves e valores", isCorrect: false },
+                        { text: "Atributos e métodos", isCorrect: true },
+                    ],
+                },
             ],
         },
         {
@@ -920,6 +1241,26 @@ const MODULO_6: Modulo = {
                         { text: "Impedir o acesso aos membros privados", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "O que caracteriza a assinatura de um construtor?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Tem o nome da classe com um til (~) escrito na frente", isCorrect: false },
+                        { text: "Tem o mesmo nome da classe e nenhum tipo de retorno", isCorrect: true },
+                        { text: "Tem um nome qualquer e retorna void", isCorrect: false },
+                        { text: "Tem um nome livre e retorna um int", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como se escreve o nome do destrutor de uma classe chamada `Cachorro`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "~Cachorro", isCorrect: true },
+                        { text: "Cachorro", isCorrect: false },
+                        { text: "!Cachorro", isCorrect: false },
+                        { text: "delete Cachorro", isCorrect: false },
+                    ],
+                },
             ],
         },
         {
@@ -967,6 +1308,26 @@ const MODULO_6: Modulo = {
                         { text: "O programador precisa liberar tudo manualmente", isCorrect: false },
                         { text: "Os recursos nunca são liberados durante a execução", isCorrect: false },
                         { text: "A liberação só ocorre quando o programa inteiro termina", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Em `double getSaldo() const`, o que o `const` após o nome do método promete?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Que o método é sempre privado à classe", isCorrect: false },
+                        { text: "Que o valor retornado nunca muda", isCorrect: false },
+                        { text: "Que o método não recebe parâmetros", isCorrect: false },
+                        { text: "Que o método não altera o objeto", isCorrect: true },
+                    ],
+                },
+                {
+                    statement: "No padrão RAII, qual é o papel do construtor e do destrutor?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O construtor adquire o recurso e o destrutor o libera", isCorrect: true },
+                        { text: "O construtor libera o recurso e o destrutor volta a adquiri-lo", isCorrect: false },
+                        { text: "Os dois adquirem o recurso ao mesmo tempo", isCorrect: false },
+                        { text: "Nenhum dos dois lida com o recurso adquirido", isCorrect: false },
                     ],
                 },
             ],
@@ -1024,6 +1385,26 @@ const MODULO_7: Modulo = {
                         { text: "Herança apenas entre classes de mesmo nome", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "Que relação a herança entre `Gato` e `Animal` modela?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um animal é um tipo de gato", isCorrect: false },
+                        { text: "Um gato é um tipo de animal", isCorrect: true },
+                        { text: "Um gato tem um animal dentro de si", isCorrect: false },
+                        { text: "Um gato usa um animal por fora", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que a herança múltipla do C++ exige cuidado?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Porque pode gerar ambiguidades entre as bases", isCorrect: true },
+                        { text: "Porque impede a classe de ter métodos próprios", isCorrect: false },
+                        { text: "Porque proíbe o uso de public na herança", isCorrect: false },
+                        { text: "Porque apaga os membros herdados da base", isCorrect: false },
+                    ],
+                },
             ],
         },
         {
@@ -1073,6 +1454,26 @@ const MODULO_7: Modulo = {
                         { text: "Tornar o método privado na classe derivada", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "Sem `virtual`, qual versão do método um ponteiro da base chama?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "A do objeto real, decidida em tempo de execução", isCorrect: false },
+                        { text: "As duas versões, uma após a outra", isCorrect: false },
+                        { text: "A da base, decidida em tempo de compilação", isCorrect: true },
+                        { text: "Nenhuma, pois isso vira erro de compilação", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o polimorfismo permite, na prática?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Ter dois ou mais métodos de mesmo nome na mesma classe", isCorrect: false },
+                        { text: "Tratar objetos de tipos diferentes por uma base comum", isCorrect: true },
+                        { text: "Herdar de várias classes base ao mesmo tempo", isCorrect: false },
+                        { text: "Impedir que a classe base seja instanciada", isCorrect: false },
+                    ],
+                },
             ],
         },
         {
@@ -1120,6 +1521,26 @@ const MODULO_7: Modulo = {
                         { text: "Para acelerar bastante a destruição do objeto", isCorrect: false },
                         { text: "Para impedir a criação de classes derivadas", isCorrect: false },
                         { text: "Porque destrutores nunca podem ser chamados", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como se declara um método virtual puro em C++?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Escrevendo a palavra `pure` antes do método", isCorrect: false },
+                        { text: "Marcando o método como `const`", isCorrect: false },
+                        { text: "Removendo a palavra `virtual` dele", isCorrect: false },
+                        { text: "Atribuindo `= 0` e sem dar corpo ao método", isCorrect: true },
+                    ],
+                },
+                {
+                    statement: "Qual é o papel de uma classe abstrata em relação às suas derivadas?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Implementar no lugar delas todos os métodos virtuais puros existentes", isCorrect: false },
+                        { text: "Servir de contrato, obrigando-as a implementar o método puro", isCorrect: true },
+                        { text: "Impedir que elas tenham métodos próprios", isCorrect: false },
+                        { text: "Copiar os atributos delas ao ser criada", isCorrect: false },
                     ],
                 },
             ],
@@ -1177,6 +1598,26 @@ const MODULO_8: Modulo = {
                         { text: "Ele só funciona com valores do tipo string", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "O que é a STL (Standard Template Library) do C++?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A biblioteca padrão com estruturas de dados e algoritmos", isCorrect: true },
+                        { text: "Um compilador próprio que traduz o código-fonte da linguagem", isCorrect: false },
+                        { text: "Um tipo de ponteiro que gerencia a memória sozinho", isCorrect: false },
+                        { text: "Uma ferramenta que executa o programa já compilado", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o método `size()` de um `std::vector` retorna?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O elemento que está guardado na primeira posição", isCorrect: false },
+                        { text: "A quantidade de elementos que ele guarda", isCorrect: true },
+                        { text: "A capacidade máxima e fixa do vetor", isCorrect: false },
+                        { text: "O tipo dos elementos guardados nele", isCorrect: false },
+                    ],
+                },
             ],
         },
         {
@@ -1226,6 +1667,26 @@ const MODULO_8: Modulo = {
                         { text: "O tipo dos elementos que o container guarda", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "No uso de iteradores, o que `begin()` e `end()` indicam?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "begin() aponta o primeiro elemento e end() marca o fim", isCorrect: true },
+                        { text: "begin() conta todos os elementos e end() apaga cada um deles", isCorrect: false },
+                        { text: "Os dois apontam sempre para o mesmo elemento", isCorrect: false },
+                        { text: "begin() abre e end() fecha um arquivo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "No tipo `std::map<std::string, int>`, o que são a `std::string` e o `int`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O tipo do valor e o tipo da chave, nessa ordem", isCorrect: false },
+                        { text: "Dois valores diferentes guardados juntos", isCorrect: false },
+                        { text: "O nome e o tamanho do map", isCorrect: false },
+                        { text: "O tipo da chave e o tipo do valor", isCorrect: true },
+                    ],
+                },
             ],
         },
         {
@@ -1273,6 +1734,26 @@ const MODULO_8: Modulo = {
                         { text: "Os ponteiros", isCorrect: false },
                         { text: "Os destrutores", isCorrect: false },
                         { text: "As referências const", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Na função `template <typename T> T maximo(T a, T b)`, o que o `T` representa?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um valor inteiro fixo que é sempre passado como argumento à função", isCorrect: false },
+                        { text: "Um tipo qualquer, definido por quem chama a função", isCorrect: true },
+                        { text: "O nome da função que será gerada depois", isCorrect: false },
+                        { text: "Uma variável global do programa inteiro", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Além do desempenho, o que os templates preservam por serem resolvidos na compilação?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "A capacidade de misturar vários tipos juntos", isCorrect: false },
+                        { text: "A liberação automática de toda a memória que foi usada", isCorrect: false },
+                        { text: "A execução do código mesmo sem compilar antes", isCorrect: false },
+                        { text: "A segurança de tipos, verificada antes de rodar", isCorrect: true },
                     ],
                 },
             ],
@@ -1330,6 +1811,26 @@ const MODULO_9: Modulo = {
                         { text: "Nunca, pois shared_ptr não libera memória", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "Como se cria um `std::unique_ptr` no C++ moderno?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Com `new` seguido de `delete`", isCorrect: false },
+                        { text: "Com `std::make_unique`", isCorrect: true },
+                        { text: "Com `std::make_shared`", isCorrect: false },
+                        { text: "Com `malloc` da linguagem C", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como o `std::shared_ptr` sabe a hora de liberar o recurso?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Por contagem de referências, quando a última some", isCorrect: true },
+                        { text: "Ao terminar a primeira função que o utiliza no código", isCorrect: false },
+                        { text: "Assim que qualquer cópia dele é criada em memória", isCorrect: false },
+                        { text: "Somente ao encerrar todo o programa", isCorrect: false },
+                    ],
+                },
             ],
         },
         {
@@ -1377,6 +1878,26 @@ const MODULO_9: Modulo = {
                         { text: "Mover um arquivo de uma pasta para outra no disco", isCorrect: false },
                         { text: "Reposicionar elementos na tela do programa", isCorrect: false },
                         { text: "Alterar o endereço físico de uma variável", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Nas listas de captura de uma lambda, qual é a diferença entre `[x]` e `[&x]`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "`[x]` captura por referência e `[&x]` captura por cópia", isCorrect: false },
+                        { text: "`[x]` captura por cópia e `[&x]`, por referência", isCorrect: true },
+                        { text: "As duas capturam sempre por cópia", isCorrect: false },
+                        { text: "Nenhuma das duas captura variáveis", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Dada `auto dobro = [](int x) { return x * 2; };`, quanto vale `dobro(5)`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "5", isCorrect: false },
+                        { text: "25", isCorrect: false },
+                        { text: "10", isCorrect: true },
+                        { text: "7", isCorrect: false },
                     ],
                 },
             ],
@@ -1428,12 +1949,32 @@ const MODULO_9: Modulo = {
                         { text: "Eles substituem a necessidade de escrever classes", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "Segundo a revisão, qual padrão é descrito como o que define o C++?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A sobrecarga de funções", isCorrect: false },
+                        { text: "A passagem de argumentos por valor", isCorrect: false },
+                        { text: "O RAII", isCorrect: true },
+                        { text: "O range-based for dos laços", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Entre os caminhos sugeridos para continuar depois dos fundamentos, está:",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Dominar a semântica de movimento e as referências rvalue", isCorrect: true },
+                        { text: "Abandonar de vez qualquer uso de ponteiros", isCorrect: false },
+                        { text: "Passar a programar apenas sobre máquinas virtuais dedicadas", isCorrect: false },
+                        { text: "Trocar o C++ por uma linguagem interpretada", isCorrect: false },
+                    ],
+                },
             ],
         },
     ],
 };
 
-const MODULOS: Modulo[] = [
+export const MODULOS: Modulo[] = [
     MODULO_1,
     MODULO_2,
     MODULO_3,
@@ -1512,9 +2053,13 @@ async function seed() {
     );
 }
 
-seed()
-    .then(() => process.exit(0))
-    .catch((e) => {
-        console.error("Falha no seed:", e);
-        process.exit(1);
-    });
+// Só semeia quando executado direto. Se for importado (ex.: sincronizar-questoes-trilha),
+// expõe MODULOS/NOME sem rodar o seed nem chamar process.exit.
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+    seed()
+        .then(() => process.exit(0))
+        .catch((e) => {
+            console.error("Falha no seed:", e);
+            process.exit(1);
+        });
+}

--- a/backend/scripts/seed-trilha-go.ts
+++ b/backend/scripts/seed-trilha-go.ts
@@ -5,8 +5,9 @@
 import { db } from "../db.ts";
 import { trails, modules, lessons, questions, questionOptions } from "../schema.ts";
 import { eq } from "drizzle-orm";
+import { pathToFileURL } from "node:url";
 
-const NOME = "Go";
+export const NOME = "Go";
 const LEVEL: "iniciante" | "intermediario" | "avancado" = "iniciante";
 const DESCRICAO =
     "A linguagem Go (Golang) do zero ao avançado: sintaxe e tipos, controle de fluxo, funções com múltiplos retornos, slices e maps, structs e métodos, interfaces implícitas, tratamento de erros e ponteiros, e a concorrência com goroutines e channels. A linguagem por trás de Docker, Kubernetes e serviços de nuvem de grande escala.";
@@ -70,6 +71,26 @@ const MODULO_1: Modulo = {
                         { text: "Exclusivamente editores de imagem", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "Por quem e em que ano a linguagem Go foi criada?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "No Google, lançada em 2009", isCorrect: true },
+                        { text: "Na Microsoft, lançada em 2001", isCorrect: false },
+                        { text: "Na Sun Microsystems, nos anos 90", isCorrect: false },
+                        { text: "Na Apple, lançada em 2014", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual é o papel da ferramenta gofmt no dia a dia?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Traduzir o código Go para a linguagem C", isCorrect: false },
+                        { text: "Detectar todos os bugs lógicos do programa", isCorrect: false },
+                        { text: "Padronizar a formatação do código automaticamente", isCorrect: true },
+                        { text: "Gerenciar as versões das bibliotecas externas do projeto", isCorrect: false },
+                    ],
+                },
             ],
         },
         {
@@ -123,6 +144,26 @@ const MODULO_1: Modulo = {
                         { text: "Compilar o programa em um executável", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "O que o comando 'go build ola.go' faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Gera o executável, que você roda depois", isCorrect: true },
+                        { text: "Compila e já executa o programa na hora", isCorrect: false },
+                        { text: "Formata o arquivo de código automaticamente", isCorrect: false },
+                        { text: "Apaga o executável criado anteriormente", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Sobre o ponto e vírgula ao fim das linhas em Go, o que é correto?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "É obrigatório ao fim de toda e qualquer instrução", isCorrect: false },
+                        { text: "Não é necessário; a ferramenta cuida disso", isCorrect: true },
+                        { text: "Só é exigido dentro da função main", isCorrect: false },
+                        { text: "Serve para separar os imports entre si", isCorrect: false },
+                    ],
+                },
             ],
         },
         {
@@ -174,6 +215,26 @@ const MODULO_1: Modulo = {
                         { text: "Porque toda função em Go começa com maiúscula", isCorrect: false },
                         { text: "Porque a maiúscula acelera a execução da função", isCorrect: false },
                         { text: "Porque Println é uma palavra reservada da linguagem", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Um pacote com nome diferente de main produz o quê?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Uma biblioteca, feita para ser importada", isCorrect: true },
+                        { text: "Um executável pronto para rodar sozinho no sistema", isCorrect: false },
+                        { text: "Um erro, pois todo pacote deve ser main", isCorrect: false },
+                        { text: "Um arquivo de configuração do projeto", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "A função validar do exemplo, com inicial minúscula, pode ser usada onde?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Por qualquer pacote que a importe", isCorrect: false },
+                        { text: "Apenas pelo pacote main do programa", isCorrect: false },
+                        { text: "Só dentro do próprio pacote onde vive", isCorrect: true },
+                        { text: "De qualquer lugar, como toda função em Go", isCorrect: false },
                     ],
                 },
             ],
@@ -235,6 +296,26 @@ const MODULO_2: Modulo = {
                         { text: "O compilador troca a variável por outra automaticamente", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "Qual é o zero value de um slice, um map ou um ponteiro declarados sem valor?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "nil", isCorrect: true },
+                        { text: "0", isCorrect: false },
+                        { text: "Uma string vazia", isCorrect: false },
+                        { text: "false", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Além de variáveis não usadas, o que mais causa erro de compilação em Go?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Usar a forma := dentro de uma função", isCorrect: false },
+                        { text: "Declarar uma variável usando var", isCorrect: false },
+                        { text: "Um import declarado e não utilizado", isCorrect: true },
+                        { text: "Deixar uma variável receber o zero value", isCorrect: false },
+                    ],
+                },
             ],
         },
         {
@@ -292,6 +373,26 @@ const MODULO_2: Modulo = {
                         { text: "int e float64 são exatamente o mesmo tipo em Go", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "O que o tipo rune representa em Go?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um caractere Unicode, apelido de int32", isCorrect: true },
+                        { text: "Um número decimal de altíssima precisão", isCorrect: false },
+                        { text: "Uma cadeia de vários caracteres de texto", isCorrect: false },
+                        { text: "Um valor booleano guardado em um só bit", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual é o resultado de int(3.9) em Go?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "4, pois arredonda para cima sempre", isCorrect: false },
+                        { text: "3, pois trunca a parte decimal", isCorrect: true },
+                        { text: "3.9, mantendo o valor original", isCorrect: false },
+                        { text: "Um erro de conversão inválida", isCorrect: false },
+                    ],
+                },
             ],
         },
         {
@@ -343,6 +444,26 @@ const MODULO_2: Modulo = {
                         { text: "Println não existe no pacote fmt do Go", isCorrect: false },
                         { text: "Printf só imprime números, nunca textos", isCorrect: false },
                         { text: "Println exige uma string de formato obrigatória", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o operador % faz em Go, como em 'a % b'?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Devolve o resto da divisão", isCorrect: true },
+                        { text: "Calcula a porcentagem de a", isCorrect: false },
+                        { text: "Eleva a à potência de b", isCorrect: false },
+                        { text: "Divide a por b como decimal", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que a expressão 'x := i++' é inválida em Go?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Porque o Go não tem operador de incremento", isCorrect: false },
+                        { text: "Porque só se pode incrementar dentro de um for", isCorrect: false },
+                        { text: "Porque i++ só funciona com números decimais", isCorrect: false },
+                        { text: "Porque i++ é uma instrução, não uma expressão", isCorrect: true },
                     ],
                 },
             ],
@@ -404,6 +525,26 @@ const MODULO_3: Modulo = {
                         { text: "Em nenhum lugar, pois a sintaxe é inválida", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "No switch do Go, o que a palavra fallthrough faz?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Encerra o switch naquele ponto de imediato", isCorrect: false },
+                        { text: "Faz a execução cair para o próximo case", isCorrect: true },
+                        { text: "Repete o case atual mais uma vez", isCorrect: false },
+                        { text: "Pula direto para o bloco default", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "No switch, quando o bloco default é executado?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Sempre, antes de qualquer outro case", isCorrect: false },
+                        { text: "Sempre, logo depois do primeiro case", isCorrect: false },
+                        { text: "Nunca, pois é apenas decorativo", isCorrect: false },
+                        { text: "Quando nenhum outro caso combina", isCorrect: true },
+                    ],
+                },
             ],
         },
         {
@@ -453,6 +594,26 @@ const MODULO_3: Modulo = {
                         { text: "Um laço que executa exatamente uma vez", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "Na forma clássica 'for i := 0; i < 5; i++', quais são as três partes?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Início, meio e fim do laço", isCorrect: false },
+                        { text: "Inicialização, condição e passo", isCorrect: true },
+                        { text: "Tipo, nome e valor da variável", isCorrect: false },
+                        { text: "Condição, corpo e retorno do laço", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que interrompe um laço 'for { ... }' infinito?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A instrução while", isCorrect: false },
+                        { text: "A palavra loop", isCorrect: false },
+                        { text: "A instrução break", isCorrect: true },
+                        { text: "A instrução stop", isCorrect: false },
+                    ],
+                },
             ],
         },
         {
@@ -500,6 +661,26 @@ const MODULO_3: Modulo = {
                         { text: "Porque o range não funciona sem o identificador _", isCorrect: false },
                         { text: "Porque o _ acelera a execução do laço", isCorrect: false },
                         { text: "Porque sem o _ o valor viria sempre vazio", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Sobre quais tipos o for...range pode iterar, segundo a aula?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Apenas slices de inteiros", isCorrect: false },
+                        { text: "Somente maps com chave string", isCorrect: false },
+                        { text: "Apenas strings e nada além", isCorrect: false },
+                        { text: "Slice, array, string e map", isCorrect: true },
+                    ],
+                },
+                {
+                    statement: "Para pegar só o valor de cada elemento com range, como se escreve?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "for v := range slice", isCorrect: false },
+                        { text: "for _, v := range slice", isCorrect: true },
+                        { text: "for v, _ := range slice", isCorrect: false },
+                        { text: "for range slice", isCorrect: false },
                     ],
                 },
             ],
@@ -557,6 +738,26 @@ const MODULO_4: Modulo = {
                         { text: "Do fall-through automático do switch", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "Como escrever, de forma abreviada, dois parâmetros int seguidos?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "func somar(int a, int b)", isCorrect: false },
+                        { text: "func somar(a: int, b: int)", isCorrect: false },
+                        { text: "func somar(a, b int)", isCorrect: true },
+                        { text: "func somar(a int, b)", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "No exemplo, o que a função 'dividir(a, b int) (int, int)' devolve?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Apenas o quociente da divisão inteira", isCorrect: false },
+                        { text: "O quociente e o resto da divisão", isCorrect: true },
+                        { text: "Apenas o resto da divisão inteira", isCorrect: false },
+                        { text: "A soma e o produto entre a e b", isCorrect: false },
+                    ],
+                },
             ],
         },
         {
@@ -606,6 +807,26 @@ const MODULO_4: Modulo = {
                         { text: "Encerra o programa inteiro imediatamente", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "Por que o fmt.Println aceita quantos argumentos você quiser?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Porque converte tudo em uma só string antes", isCorrect: false },
+                        { text: "Porque só aceita um argumento por vez", isCorrect: false },
+                        { text: "Porque ignora todos os argumentos extras", isCorrect: false },
+                        { text: "Porque é uma função variádica", isCorrect: true },
+                    ],
+                },
+                {
+                    statement: "Com retornos nomeados, o que os nomes na assinatura se tornam dentro da função?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Constantes que não podem mudar de valor", isCorrect: false },
+                        { text: "Variáveis já prontas para uso", isCorrect: true },
+                        { text: "Novos parâmetros de entrada da função", isCorrect: false },
+                        { text: "Apenas rótulos sem efeito no código", isCorrect: false },
+                    ],
+                },
             ],
         },
         {
@@ -653,6 +874,26 @@ const MODULO_4: Modulo = {
                         { text: "Só podem ser declaradas dentro do pacote main", isCorrect: false },
                         { text: "Precisam sempre devolver vários valores de uma vez", isCorrect: false },
                         { text: "Não podem ter nenhum parâmetro de entrada", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Com vários defer em uma função, em que ordem eles são executados?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Na mesma ordem em que foram escritos", isCorrect: false },
+                        { text: "Na ordem inversa, o último primeiro", isCorrect: true },
+                        { text: "Todos de uma vez, ao mesmo tempo", isCorrect: false },
+                        { text: "Em ordem aleatória a cada execução", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que é uma função anônima em Go?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Uma função sem nenhum parâmetro", isCorrect: false },
+                        { text: "Uma função que não devolve valor algum", isCorrect: false },
+                        { text: "Uma função privada de um pacote", isCorrect: false },
+                        { text: "Uma função criada na hora, sem nome", isCorrect: true },
                     ],
                 },
             ],
@@ -714,6 +955,26 @@ const MODULO_5: Modulo = {
                         { text: "[30 40], pois conta a partir do fim", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "O que a função len faz com um slice?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Acrescenta um elemento a ele", isCorrect: false },
+                        { text: "Remove o último elemento dele", isCorrect: false },
+                        { text: "Devolve o seu tamanho", isCorrect: true },
+                        { text: "Ordena os elementos dele", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que escrevemos 'numeros = append(numeros, 40)', reatribuindo a numeros?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Porque sem a reatribuição o código não compilaria", isCorrect: false },
+                        { text: "Porque append devolve um novo slice pronto", isCorrect: true },
+                        { text: "Porque append apaga o slice antigo da memória", isCorrect: false },
+                        { text: "Porque append só funciona dentro de um for", isCorrect: false },
+                    ],
+                },
             ],
         },
         {
@@ -763,6 +1024,26 @@ const MODULO_5: Modulo = {
                         { text: "Nada, pois toda atribuição já copia tudo", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "O que você informa ao criar um slice com make?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Apenas o nome da variável", isCorrect: false },
+                        { text: "O tipo e o tamanho inicial", isCorrect: true },
+                        { text: "Somente os valores já prontos", isCorrect: false },
+                        { text: "A ordem de classificação dos dados", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "No exemplo, após 'fatia := original[:2]' e 'fatia[0] = 99', o que ocorre com original?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Ele continua totalmente inalterado", isCorrect: false },
+                        { text: "Ele é apagado da memória por completo", isCorrect: false },
+                        { text: "Ele passa a ser uma cópia isolada", isCorrect: false },
+                        { text: "Seu primeiro elemento também vira 99", isCorrect: true },
+                    ],
+                },
             ],
         },
         {
@@ -810,6 +1091,26 @@ const MODULO_5: Modulo = {
                         { text: "Comparar o valor com null diretamente", isCorrect: false },
                         { text: "Usar a função len sobre a chave", isCorrect: false },
                         { text: "Percorrer o map inteiro com um for a cada acesso", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual função remove uma chave de um map em Go?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "remove", isCorrect: false },
+                        { text: "pop", isCorrect: false },
+                        { text: "delete", isCorrect: true },
+                        { text: "clear", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "No idioma comma-ok 'valor, existe := m[chave]', o que é 'existe'?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O total de chaves guardadas no map", isCorrect: false },
+                        { text: "Um bool que diz se a chave existia", isCorrect: true },
+                        { text: "A posição da chave dentro do map", isCorrect: false },
+                        { text: "Uma cópia do valor da chave anterior", isCorrect: false },
                     ],
                 },
             ],
@@ -867,6 +1168,26 @@ const MODULO_6: Modulo = {
                         { text: "É removido da struct automaticamente", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "O que o Go NÃO possui, o que leva ao uso de structs?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Funções com vários parâmetros de entrada", isCorrect: false },
+                        { text: "Classes e herança tradicionais", isCorrect: true },
+                        { text: "Tipos numéricos como o int", isCorrect: false },
+                        { text: "Laços de repetição como o for", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Em uma struct, um campo cujo nome começa com letra minúscula é:",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Exportado e visível de qualquer pacote", isCorrect: false },
+                        { text: "Sempre ignorado quando se cria a struct", isCorrect: false },
+                        { text: "Convertido automaticamente em um método", isCorrect: false },
+                        { text: "Privado ao pacote onde a struct vive", isCorrect: true },
+                    ],
+                },
             ],
         },
         {
@@ -920,6 +1241,26 @@ const MODULO_6: Modulo = {
                         { text: "Converte x para o tipo ponteiro texto", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "O que o operador * faz em '*p', quando p é um ponteiro?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Cria um novo ponteiro para p", isCorrect: false },
+                        { text: "Acessa o valor apontado por p", isCorrect: true },
+                        { text: "Devolve o endereço de memória de p", isCorrect: false },
+                        { text: "Multiplica p por ele mesmo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Com um receiver de valor, como '(p Pessoa)', o que ocorre ao alterar um campo no método?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O original é alterado junto com a cópia recebida", isCorrect: false },
+                        { text: "Ocorre um erro de compilação na hora", isCorrect: false },
+                        { text: "A mudança fica só na cópia local", isCorrect: true },
+                        { text: "O método passa a devolver um ponteiro", isCorrect: false },
+                    ],
+                },
             ],
         },
         {
@@ -967,6 +1308,26 @@ const MODULO_6: Modulo = {
                         { text: "Herança profunda de muitas classes", isCorrect: false },
                         { text: "Ausência total de reúso de código", isCorrect: false },
                         { text: "Cópia manual de comportamento entre tipos", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que caracteriza o embedding em uma struct Go?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Copiar todos os campos de outra struct manualmente", isCorrect: false },
+                        { text: "Declarar um tipo dentro de outro sem nomeá-lo", isCorrect: true },
+                        { text: "Herdar de uma classe base com a palavra extends", isCorrect: false },
+                        { text: "Guardar várias structs dentro de um único slice", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que 'rex.Comer()' funciona, mesmo Comer sendo método de Animal?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Porque o embedding faz o método subir", isCorrect: true },
+                        { text: "Porque Comer foi reescrito dentro do Cachorro", isCorrect: false },
+                        { text: "Porque todo método em Go é global ao programa", isCorrect: false },
+                        { text: "Porque Cachorro herda de Animal usando extends", isCorrect: false },
                     ],
                 },
             ],
@@ -1024,6 +1385,26 @@ const MODULO_7: Modulo = {
                         { text: "Eliminam a necessidade de escrever métodos", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "Qual palavra-chave o Go usa para declarar que um tipo implementa uma interface?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A palavra-chave implements, antes do tipo", isCorrect: false },
+                        { text: "A palavra-chave extends, como em Java", isCorrect: false },
+                        { text: "Nenhuma; a satisfação é implícita", isCorrect: true },
+                        { text: "A palavra-chave interface no tipo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O acoplamento fraco das interfaces do Go permite que:",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Dois tipos jamais compartilhem um mesmo método", isCorrect: false },
+                        { text: "Um pacote use tipos de outro que a satisfaçam", isCorrect: true },
+                        { text: "Interfaces guardem campos de dados também", isCorrect: false },
+                        { text: "Um tipo troque de interface ao ser executado", isCorrect: false },
+                    ],
+                },
             ],
         },
         {
@@ -1073,6 +1454,26 @@ const MODULO_7: Modulo = {
                         { text: "Interfaces que só contêm campos de dados", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "O que um tipo controla ao implementar a interface Stringer, com String() string?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "A ordem dos seus campos na memória", isCorrect: false },
+                        { text: "Como ele é impresso pelo pacote fmt", isCorrect: true },
+                        { text: "A velocidade de compilação do programa", isCorrect: false },
+                        { text: "Quais pacotes conseguem importá-lo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Ao receber uma interface, a função chama o método:",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Apenas se souber o tipo concreto exato", isCorrect: false },
+                        { text: "Somente para valores do tipo string informado", isCorrect: false },
+                        { text: "Sem saber o tipo concreto por trás", isCorrect: true },
+                        { text: "Depois de converter tudo em um map", isCorrect: false },
+                    ],
+                },
             ],
         },
         {
@@ -1120,6 +1521,26 @@ const MODULO_7: Modulo = {
                         { text: "Para acelerar a conversão entre os tipos", isCorrect: false },
                         { text: "Porque a asserção não funciona sem duas variáveis", isCorrect: false },
                         { text: "Para transformar o valor em uma interface vazia", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "No Go moderno, qual palavra é sinônimo de interface{}?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "object", isCorrect: false },
+                        { text: "any", isCorrect: true },
+                        { text: "void", isCorrect: false },
+                        { text: "var", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Para tratar vários tipos possíveis de um valor em interface, o Go oferece:",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Um laço for sobre todos os tipos possíveis", isCorrect: false },
+                        { text: "A conversão automática entre os tipos", isCorrect: false },
+                        { text: "Um bloco try seguido de um catch", isCorrect: false },
+                        { text: "O type switch, que age pelo tipo dinâmico", isCorrect: true },
                     ],
                 },
             ],
@@ -1181,6 +1602,26 @@ const MODULO_8: Modulo = {
                         { text: "O Go não permite devolver um error", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "O tipo error em Go é, na verdade:",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Uma struct com vários campos de texto", isCorrect: false },
+                        { text: "Uma interface com o método Error() string", isCorrect: true },
+                        { text: "Um tipo numérico que guarda um código", isCorrect: false },
+                        { text: "Uma palavra-chave reservada da linguagem Go", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Um valor de error diferente de nil indica que:",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A operação foi um sucesso total", isCorrect: false },
+                        { text: "O programa ainda está compilando", isCorrect: false },
+                        { text: "Houve uma falha na operação", isCorrect: true },
+                        { text: "O resultado deve ser ignorado sempre", isCorrect: false },
+                    ],
+                },
             ],
         },
         {
@@ -1230,6 +1671,26 @@ const MODULO_8: Modulo = {
                         { text: "Converter o erro em uma string sem tipo definido", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "Quando usar fmt.Errorf em vez de errors.New?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Quando o erro não tiver texto nenhum", isCorrect: false },
+                        { text: "Quando quiser montar a mensagem com valores", isCorrect: true },
+                        { text: "Quando quiser encerrar o programa na mesma hora", isCorrect: false },
+                        { text: "Quando não existir erro algum de fato", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que significa 'propagar' um erro em Go?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Apagá-lo em silêncio e seguir em frente normalmente", isCorrect: false },
+                        { text: "Transformá-lo em um panic imediato", isCorrect: false },
+                        { text: "Guardá-lo em uma variável global", isCorrect: false },
+                        { text: "Devolvê-lo para cima, a quem chamou", isCorrect: true },
+                    ],
+                },
             ],
         },
         {
@@ -1277,6 +1738,26 @@ const MODULO_8: Modulo = {
                         { text: "Panic para tudo, evitando retornar erros", isCorrect: false },
                         { text: "Erros e panic são intercambiáveis, tanto faz", isCorrect: false },
                         { text: "Nunca tratar erros, deixando o programa cair", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que um panic faz ao fluxo do programa?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Continua o fluxo como se nada tivesse ocorrido", isCorrect: false },
+                        { text: "Interrompe o fluxo normal e desmonta a pilha", isCorrect: true },
+                        { text: "Reinicia o programa a partir do main", isCorrect: false },
+                        { text: "Ignora a linha atual e segue adiante", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual é o efeito do recover ao capturar um panic?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Faz o panic acontecer mais uma vez", isCorrect: false },
+                        { text: "Converte o panic em um erro ainda pior", isCorrect: false },
+                        { text: "Impede que o panic derrube o programa", isCorrect: true },
+                        { text: "Encerra o programa de forma imediata", isCorrect: false },
                     ],
                 },
             ],
@@ -1338,6 +1819,26 @@ const MODULO_9: Modulo = {
                         { text: "O main nunca termina enquanto houver goroutines", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "Qual é a distinção que o Go faz entre concorrência e paralelismo?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Paralelismo é sempre mais lento do que a concorrência em Go", isCorrect: false },
+                        { text: "Concorrência estrutura tarefas; paralelismo as executa", isCorrect: true },
+                        { text: "As duas palavras significam exatamente a mesma coisa", isCorrect: false },
+                        { text: "Concorrência exige vários núcleos de processador", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quem gerencia as goroutines em execução?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O sistema operacional sozinho", isCorrect: false },
+                        { text: "O programador, manualmente, linha a linha", isCorrect: false },
+                        { text: "O runtime do próprio Go", isCorrect: true },
+                        { text: "O compilador, antes de o programa rodar", isCorrect: false },
+                    ],
+                },
             ],
         },
         {
@@ -1385,6 +1886,26 @@ const MODULO_9: Modulo = {
                         { text: "Criar um novo channel com um buffer bem maior", isCorrect: false },
                         { text: "Fechar todos os channels do programa de uma vez só", isCorrect: false },
                         { text: "Converter um channel em um slice de valores", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual operador envia e recebe valores em um channel?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O sinal de igual =", isCorrect: false },
+                        { text: "A seta <-", isCorrect: true },
+                        { text: "Os dois pontos e igual :=", isCorrect: false },
+                        { text: "O operador de soma +", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Em um channel sem buffer, o que acontece com quem tenta receber antes de haver envio?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Recebe o zero value do tipo naquele instante", isCorrect: false },
+                        { text: "Recebe um erro, e o programa para", isCorrect: false },
+                        { text: "Segue adiante sem receber nada", isCorrect: false },
+                        { text: "Fica bloqueado até que alguém envie", isCorrect: true },
                     ],
                 },
             ],
@@ -1436,12 +1957,32 @@ const MODULO_9: Modulo = {
                         { text: "Erros não têm relação com o fluxo do programa", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "Qual pacote padrão a aula sugere para escrever testes em Go?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "assert", isCorrect: false },
+                        { text: "junit", isCorrect: false },
+                        { text: "testing", isCorrect: true },
+                        { text: "quicktest", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Segundo a aula, qual pacote padrão serve para construir uma API HTTP simples?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "web/server", isCorrect: false },
+                        { text: "net/http", isCorrect: true },
+                        { text: "http/router", isCorrect: false },
+                        { text: "fmt/web", isCorrect: false },
+                    ],
+                },
             ],
         },
     ],
 };
 
-const MODULOS: Modulo[] = [
+export const MODULOS: Modulo[] = [
     MODULO_1,
     MODULO_2,
     MODULO_3,
@@ -1520,9 +2061,13 @@ async function seed() {
     );
 }
 
-seed()
-    .then(() => process.exit(0))
-    .catch((e) => {
-        console.error("Falha no seed:", e);
-        process.exit(1);
-    });
+// Só semeia quando executado direto. Se for importado (ex.: sincronizar-questoes-trilha),
+// expõe MODULOS/NOME sem rodar o seed nem chamar process.exit.
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+    seed()
+        .then(() => process.exit(0))
+        .catch((e) => {
+            console.error("Falha no seed:", e);
+            process.exit(1);
+        });
+}

--- a/backend/scripts/seed-trilha-java.ts
+++ b/backend/scripts/seed-trilha-java.ts
@@ -5,8 +5,9 @@
 import { db } from "../db.ts";
 import { trails, modules, lessons, questions, questionOptions } from "../schema.ts";
 import { eq } from "drizzle-orm";
+import { pathToFileURL } from "node:url";
 
-const NOME = "Java";
+export const NOME = "Java";
 const LEVEL: "iniciante" | "intermediario" | "avancado" = "iniciante";
 const DESCRICAO =
     "A linguagem Java do zero ao avançado: sintaxe e tipos, controle de fluxo, arrays e strings, métodos, orientação a objetos (classes, herança, polimorfismo e interfaces), coleções e generics, tratamento de exceções e o Java moderno com lambdas e streams. A base para back-end, Android e sistemas de grande escala.";
@@ -74,6 +75,26 @@ const MODULO_1: Modulo = {
                         { text: "Nenhum componente, pois o Java já vem em todo processador", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "O que significa dizer que Java é uma linguagem fortemente tipada?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Que os tipos das variáveis mudam sozinhos durante a execução", isCorrect: false },
+                        { text: "Que cada variável tem um tipo declarado e conferido pelo compilador", isCorrect: true },
+                        { text: "Que não é preciso declarar o tipo de nenhuma variável", isCorrect: false },
+                        { text: "Que uma variável pode guardar qualquer tipo de valor a qualquer hora", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual é a relação entre JDK, JRE e JVM?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O JDK inclui o JRE, que por sua vez inclui a JVM", isCorrect: true },
+                        { text: "A JVM inclui o JDK, que por sua vez inclui o JRE", isCorrect: false },
+                        { text: "Os três são nomes diferentes para a mesma coisa", isCorrect: false },
+                        { text: "Cada um é instalado de forma totalmente separada", isCorrect: false },
+                    ],
+                },
             ],
         },
         {
@@ -131,6 +152,26 @@ const MODULO_1: Modulo = {
                         { text: "Declara uma variável chamada Oi no programa", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "Uma classe pública chamada Ola deve ser salva em um arquivo com qual nome?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "ola.class", isCorrect: false },
+                        { text: "main.java", isCorrect: false },
+                        { text: "Ola.txt", isCorrect: false },
+                        { text: "Ola.java", isCorrect: true },
+                    ],
+                },
+                {
+                    statement: "Qual é a diferença entre System.out.print e System.out.println?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O println imprime sem pular a linha, e o print pula", isCorrect: false },
+                        { text: "O print não pula a linha ao final, e o println pula", isCorrect: true },
+                        { text: "Os dois são idênticos e nunca pulam a linha", isCorrect: false },
+                        { text: "O print não existe em Java, só o println funciona", isCorrect: false },
+                    ],
+                },
             ],
         },
         {
@@ -178,6 +219,26 @@ const MODULO_1: Modulo = {
                         { text: "Que o método devolve sempre um número inteiro", isCorrect: false },
                         { text: "Que o método é privado e invisível de fora", isCorrect: false },
                         { text: "Que o método não pode conter instruções dentro", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "No método main, para que serve o parâmetro String[] args?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Definir o nome da classe do programa", isCorrect: false },
+                        { text: "Guardar o valor de retorno do método", isCorrect: false },
+                        { text: "Receber argumentos passados pela linha de comando", isCorrect: true },
+                        { text: "Informar qual versão do Java está sendo usada agora", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "No cabeçalho do main, o que o modificador public indica?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Que o método pertence à classe, e não a um objeto", isCorrect: false },
+                        { text: "Que o método não devolve nenhum valor", isCorrect: false },
+                        { text: "Que o método só roda uma única vez no programa", isCorrect: false },
+                        { text: "Que o método pode ser chamado de fora da classe", isCorrect: true },
                     ],
                 },
             ],
@@ -243,6 +304,26 @@ const MODULO_2: Modulo = {
                         { text: "char", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "O tipo char guarda o quê, e com qual delimitador?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um único caractere, entre aspas simples", isCorrect: true },
+                        { text: "Um texto qualquer, entre aspas duplas", isCorrect: false },
+                        { text: "Um número inteiro, sem nenhuma aspa", isCorrect: false },
+                        { text: "Vários caracteres seguidos, entre aspas simples", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Entre int, double, boolean e String, qual não é um tipo primitivo?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "int", isCorrect: false },
+                        { text: "String", isCorrect: true },
+                        { text: "boolean", isCorrect: false },
+                        { text: "double", isCorrect: false },
+                    ],
+                },
             ],
         },
         {
@@ -300,6 +381,26 @@ const MODULO_2: Modulo = {
                         { text: "10, pois += não altera a variável original", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "Como obter 3.5 ao dividir 7 por 2 em Java?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Usar ao menos um double, como em 7.0 / 2", isCorrect: true },
+                        { text: "Usar dois int, pois o Java arredonda sozinho", isCorrect: false },
+                        { text: "Trocar a divisão pelo operador de módulo %", isCorrect: false },
+                        { text: "Não é possível obter casas decimais em Java", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Depois de 'int n = 16; n++;', qual é o valor de n?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "15, pois o ++ subtrai 1 da variável", isCorrect: false },
+                        { text: "16, pois o ++ não altera o valor", isCorrect: false },
+                        { text: "17, pois o ++ soma 1 à variável", isCorrect: true },
+                        { text: "32, pois o ++ dobra o valor", isCorrect: false },
+                    ],
+                },
             ],
         },
         {
@@ -353,6 +454,26 @@ const MODULO_2: Modulo = {
                         { text: "Um erro, pois != não existe em Java", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "O operador || (OU) resulta em true quando:",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Ao menos um dos lados é verdadeiro", isCorrect: true },
+                        { text: "Os dois lados são verdadeiros ao mesmo tempo", isCorrect: false },
+                        { text: "Os dois lados são falsos ao mesmo tempo", isCorrect: false },
+                        { text: "Os dois lados têm o mesmo valor booleano", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual é a diferença entre = e == em Java?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Os dois comparam a igualdade entre dois valores dados", isCorrect: false },
+                        { text: "Os dois atribuem um valor a uma variável", isCorrect: false },
+                        { text: "O = compara valores, e o == atribui um valor", isCorrect: false },
+                        { text: "O = atribui um valor, e o == compara igualdade", isCorrect: true },
+                    ],
+                },
             ],
         },
         {
@@ -404,6 +525,26 @@ const MODULO_2: Modulo = {
                         { text: "É proibido em Java, e gera sempre um erro de compilação", isCorrect: false },
                         { text: "Exige sempre um cast explícito escrito entre parênteses", isCorrect: false },
                         { text: "O int e o double são exatamente o mesmo tipo em Java", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que acontece ao tentar reatribuir uma variável declarada com final?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Ocorre um erro de compilação", isCorrect: true },
+                        { text: "O valor muda normalmente, sem aviso", isCorrect: false },
+                        { text: "O programa só falha ao ser executado", isCorrect: false },
+                        { text: "A variável volta ao seu valor inicial", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que o Java exige um cast explícito ao converter de double para int?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Porque int e double são o mesmo tipo por dentro", isCorrect: false },
+                        { text: "Porque a conversão nunca perde nenhuma informação relevante", isCorrect: false },
+                        { text: "Porque o double ocupa menos espaço que o int", isCorrect: false },
+                        { text: "Porque pode haver perda de informação na conversão", isCorrect: true },
                     ],
                 },
             ],
@@ -465,6 +606,26 @@ const MODULO_3: Modulo = {
                         { text: "A e B, pois os dois blocos são executados", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "Em qual ordem o Java avalia as condições de um if / else if / else?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "De cima para baixo, parando na primeira verdadeira", isCorrect: true },
+                        { text: "De baixo para cima, parando sempre na primeira condição falsa", isCorrect: false },
+                        { text: "Em ordem aleatória, sem seguir a escrita", isCorrect: false },
+                        { text: "Todas ao mesmo tempo, escolhendo a maior", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Um if isolado, sem else, cuja condição é falsa faz o quê?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Executa o bloco mesmo assim, uma única vez", isCorrect: false },
+                        { text: "Não executa o seu bloco e segue adiante", isCorrect: true },
+                        { text: "Provoca um erro de compilação no programa", isCorrect: false },
+                        { text: "Repete o teste até a condição ficar verdadeira", isCorrect: false },
+                    ],
+                },
             ],
         },
         {
@@ -516,6 +677,26 @@ const MODULO_3: Modulo = {
                         { text: "Ao testar faixas de valores com maior e menor", isCorrect: false },
                         { text: "Ao combinar muitas condições com && e ||", isCorrect: false },
                         { text: "Ao repetir um bloco de código muitas vezes", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Para que serve o break ao final de um case no switch clássico?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Encerrar o case e sair do switch", isCorrect: true },
+                        { text: "Iniciar o próximo case da lista", isCorrect: false },
+                        { text: "Repetir o switch desde o começo", isCorrect: false },
+                        { text: "Pular direto para o bloco default", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que a sintaxe moderna de switch com seta (->) traz de vantagem?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Permite comparar faixas de valores com > e <", isCorrect: false },
+                        { text: "Faz todos os cases rodarem em sequência", isCorrect: false },
+                        { text: "Substitui o switch por um laço de repetição", isCorrect: false },
+                        { text: "Evita o fall-through sem precisar de break", isCorrect: true },
                     ],
                 },
             ],
@@ -575,6 +756,26 @@ const MODULO_3: Modulo = {
                         { text: "Infinitas vezes, pois o laço nunca termina", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "Em que situação o bloco de um while não executa nenhuma vez?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Quando a condição já é falsa na primeira checagem", isCorrect: true },
+                        { text: "Quando a condição já é verdadeira no início", isCorrect: false },
+                        { text: "Quando o laço contém um contador interno", isCorrect: false },
+                        { text: "Nunca, pois o while sempre roda ao menos uma única vez", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Em 'int n = 10; do { imprime n; n++; } while (n <= 3);', quantas vezes n é impresso?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Nenhuma vez, pois 10 não é menor ou igual a 3", isCorrect: false },
+                        { text: "Uma vez, pois o do-while roda antes de testar", isCorrect: true },
+                        { text: "Três vezes, para os valores 10, 11 e 12", isCorrect: false },
+                        { text: "Infinitas vezes, pois n apenas aumenta", isCorrect: false },
+                    ],
+                },
             ],
         },
         {
@@ -626,6 +827,26 @@ const MODULO_3: Modulo = {
                         { text: "Encerra o laço por completo de imediato", isCorrect: false },
                         { text: "Reinicia o laço desde a primeira repetição", isCorrect: false },
                         { text: "Repete a mesma repetição atual mais uma vez", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quais são as três partes escritas entre os parênteses de um for?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Inicialização, condição e passo", isCorrect: true },
+                        { text: "Início, meio e fim do laço", isCorrect: false },
+                        { text: "Nome, tipo e valor inicial da variável", isCorrect: false },
+                        { text: "Condição, corpo e retorno", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o comando break faz dentro de um laço?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Pula para a próxima repetição do laço", isCorrect: false },
+                        { text: "Reinicia o laço desde a sua primeira volta", isCorrect: false },
+                        { text: "Encerra o laço por completo de imediato", isCorrect: true },
+                        { text: "Repete a volta atual mais uma vez", isCorrect: false },
                     ],
                 },
             ],
@@ -687,6 +908,26 @@ const MODULO_4: Modulo = {
                         { text: "Aumenta o array automaticamente para caber", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "O que caracteriza o tamanho de um array em Java?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "É fixo: definido na criação e não muda depois", isCorrect: true },
+                        { text: "Cresce sozinho conforme você adiciona novos itens", isCorrect: false },
+                        { text: "Muda toda vez que um elemento é lido", isCorrect: false },
+                        { text: "É sempre igual a dez posições por padrão", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Em um array de 5 posições, qual índice tem o último elemento?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "5, pois o array tem 5 posições", isCorrect: false },
+                        { text: "4, pois o último índice é length - 1", isCorrect: true },
+                        { text: "0, pois a contagem sempre começa do zero", isCorrect: false },
+                        { text: "6, pois soma-se 1 ao tamanho", isCorrect: false },
+                    ],
+                },
             ],
         },
         {
@@ -744,6 +985,26 @@ const MODULO_4: Modulo = {
                         { text: "J, o primeiro caractere da string", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "O que 'nome.charAt(0)' retorna para a string \"Java\"?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "J, o caractere na posição 0", isCorrect: true },
+                        { text: "a, o segundo caractere da string", isCorrect: false },
+                        { text: "Java, a string inteira", isCorrect: false },
+                        { text: "4, o número de caracteres", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Ao comparar duas strings, o que o operador == verifica?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Se as duas têm exatamente o mesmo conteúdo", isCorrect: false },
+                        { text: "Se as duas têm o mesmo número de letras", isCorrect: false },
+                        { text: "Se as duas são o mesmo objeto na memória", isCorrect: true },
+                        { text: "Se a primeira vem antes da outra na ordem", isCorrect: false },
+                    ],
+                },
             ],
         },
         {
@@ -795,6 +1056,26 @@ const MODULO_4: Modulo = {
                         { text: "length", isCorrect: false },
                         { text: "equals", isCorrect: false },
                         { text: "charAt", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual método do StringBuilder devolve a String final já pronta?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "toString", isCorrect: true },
+                        { text: "append", isCorrect: false },
+                        { text: "getString", isCorrect: false },
+                        { text: "concat", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual é a diferença central entre String e StringBuilder?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "String é mutável, e StringBuilder é imutável", isCorrect: false },
+                        { text: "String é imutável, e StringBuilder é mutável", isCorrect: true },
+                        { text: "Os dois são imutáveis e idênticos no uso", isCorrect: false },
+                        { text: "O StringBuilder não guarda texto, só números", isCorrect: false },
                     ],
                 },
             ],
@@ -852,6 +1133,26 @@ const MODULO_5: Modulo = {
                         { text: "Uma classe especial que não tem corpo próprio", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "Por que um bom nome de método, como calcularMedia, ajuda quem lê o código?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Explica a intenção sem precisar ler o corpo", isCorrect: true },
+                        { text: "Faz o método rodar bem mais rápido dentro da JVM", isCorrect: false },
+                        { text: "Elimina a necessidade de parâmetros", isCorrect: false },
+                        { text: "Garante que o método não tenha erros", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Idealmente, um bom método deve:",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Concentrar todas as tarefas do programa", isCorrect: false },
+                        { text: "Ter sempre o nome main, como padrão", isCorrect: false },
+                        { text: "Fazer uma coisa bem feita, com nome claro", isCorrect: true },
+                        { text: "Evitar qualquer nome que descreva a tarefa", isCorrect: false },
+                    ],
+                },
             ],
         },
         {
@@ -901,6 +1202,26 @@ const MODULO_5: Modulo = {
                         { text: "Gera um erro de compilação obrigatório", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "Na chamada 'saudar(\"Ana\")', o que é o valor \"Ana\"?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O argumento passado ao parâmetro do método", isCorrect: true },
+                        { text: "O tipo de retorno do método saudar", isCorrect: false },
+                        { text: "O nome do próprio método chamado", isCorrect: false },
+                        { text: "Uma variável local declarada dentro do método", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que 'int total = somar(3, 4);' guarda em total, se somar devolve a + b?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "34, os dois números escritos lado a lado", isCorrect: false },
+                        { text: "12, o produto dos dois argumentos", isCorrect: false },
+                        { text: "0, pois o retorno é sempre ignorado", isCorrect: false },
+                        { text: "7, o resultado da soma dos argumentos", isCorrect: true },
+                    ],
+                },
             ],
         },
         {
@@ -948,6 +1269,26 @@ const MODULO_5: Modulo = {
                         { text: "Compilam normalmente como uma sobrecarga válida", isCorrect: false },
                         { text: "Fazem o método rodar duas vezes a cada chamada", isCorrect: false },
                         { text: "Transformam o método em um construtor da classe", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Com somar(int, int) e somar(double, double), como o compilador escolhe qual versão usar?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Pelos tipos dos argumentos passados na chamada", isCorrect: true },
+                        { text: "Pela ordem em que as duas foram declaradas no código", isCorrect: false },
+                        { text: "Pelo tipo de retorno de cada versão", isCorrect: false },
+                        { text: "Sempre pela versão com menos parâmetros", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Duas variáveis locais com o mesmo nome, cada uma em um método diferente:",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Compartilham sempre exatamente o mesmo valor", isCorrect: false },
+                        { text: "São independentes entre si, sem conflito", isCorrect: true },
+                        { text: "Provocam um erro de nome duplicado na classe", isCorrect: false },
+                        { text: "Passam a existir no programa inteiro", isCorrect: false },
                     ],
                 },
             ],
@@ -1009,6 +1350,26 @@ const MODULO_6: Modulo = {
                         { text: "Os dados existem só na classe, não nos objetos", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "Para que serve o ponto (.) em 'rex.latir()'?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Acessar um método ou dado do objeto rex", isCorrect: true },
+                        { text: "Criar um novo objeto chamado rex", isCorrect: false },
+                        { text: "Declarar a classe do objeto rex", isCorrect: false },
+                        { text: "Encerrar a instrução atual no lugar do ponto e vírgula", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que uma classe descreve sobre os objetos que ela modela?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Apenas a quantidade de objetos que existirão", isCorrect: false },
+                        { text: "Quais dados eles têm e o que sabem fazer", isCorrect: true },
+                        { text: "Somente o endereço deles na memória", isCorrect: false },
+                        { text: "Só o nome do arquivo onde ficam salvos", isCorrect: false },
+                    ],
+                },
             ],
         },
         {
@@ -1062,6 +1423,26 @@ const MODULO_6: Modulo = {
                         { text: "Nunca pode receber nenhum parâmetro de entrada", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "Em uma classe, qual é o papel dos atributos?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Guardar o estado, os dados do objeto", isCorrect: true },
+                        { text: "Definir as ações que o objeto executa", isCorrect: false },
+                        { text: "Criar novos objetos a partir da classe", isCorrect: false },
+                        { text: "Inicializar o objeto ao ser criado", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que acontece com o construtor padrão sem argumentos quando você declara o seu próprio?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Ele continua disponível junto do seu", isCorrect: false },
+                        { text: "Ele passa a exigir dois argumentos", isCorrect: false },
+                        { text: "Ele vira um método comum da classe", isCorrect: false },
+                        { text: "Ele deixa de existir automaticamente", isCorrect: true },
+                    ],
+                },
             ],
         },
         {
@@ -1113,6 +1494,26 @@ const MODULO_6: Modulo = {
                         { text: "Copiar um objeto inteiro para criar outro igual", isCorrect: false },
                         { text: "Fazer uma classe herdar dados de outra classe", isCorrect: false },
                         { text: "Ter vários métodos com o mesmo nome na classe", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual é a diferença entre um getter e um setter?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O getter lê o atributo, e o setter o altera", isCorrect: true },
+                        { text: "O getter altera o atributo, e o setter o lê", isCorrect: false },
+                        { text: "Os dois apenas leem o valor do atributo", isCorrect: false },
+                        { text: "Os dois criam um novo objeto da classe", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Além de impor regras, encapsular bem permite que a classe:",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Rode sem precisar de um construtor", isCorrect: false },
+                        { text: "Dispense a declaração de seus atributos", isCorrect: false },
+                        { text: "Mude por dentro sem quebrar quem a usa", isCorrect: true },
+                        { text: "Seja usada sem criar objetos com new", isCorrect: false },
                     ],
                 },
             ],
@@ -1174,6 +1575,26 @@ const MODULO_7: Modulo = {
                         { text: "A subclasse deve ter o mesmo nome da superclasse", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "Para que serve super(...) no construtor de uma subclasse?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Chamar o construtor da superclasse", isCorrect: true },
+                        { text: "Criar um objeto da própria subclasse", isCorrect: false },
+                        { text: "Apagar os atributos herdados", isCorrect: false },
+                        { text: "Impedir a herança da superclasse", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "De qual classe herda, mesmo sem escrever extends, toda classe em Java?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Main, a classe que inicia o programa", isCorrect: false },
+                        { text: "Object, a raiz de todas as classes", isCorrect: true },
+                        { text: "System, usada para imprimir no console", isCorrect: false },
+                        { text: "String, a classe de textos", isCorrect: false },
+                    ],
+                },
             ],
         },
         {
@@ -1227,6 +1648,26 @@ const MODULO_7: Modulo = {
                         { text: "Fazer o método rodar antes de todos os outros", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "O que é polimorfismo em Java?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Tratar subclasses diferentes por uma referência da superclasse", isCorrect: true },
+                        { text: "Ter dois ou mais métodos com o mesmo nome e parâmetros diferentes", isCorrect: false },
+                        { text: "Esconder os atributos com o modificador private", isCorrect: false },
+                        { text: "Criar uma classe que não pode ser instanciada", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "No polimorfismo, quem decide qual versão de um método sobrescrito roda?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O tipo da referência, em tempo de compilação", isCorrect: false },
+                        { text: "A ordem dos métodos dentro do arquivo", isCorrect: false },
+                        { text: "Sempre a versão original da superclasse", isCorrect: false },
+                        { text: "O objeto real, em tempo de execução", isCorrect: true },
+                    ],
+                },
             ],
         },
         {
@@ -1278,6 +1719,26 @@ const MODULO_7: Modulo = {
                         { text: "Uma classe pode estender várias classes, mas só uma interface", isCorrect: false },
                         { text: "Interfaces não podem declarar nenhum método", isCorrect: false },
                         { text: "Interfaces só funcionam com tipos primitivos", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que é um método abstrato?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um método sem corpo, implementado na subclasse", isCorrect: true },
+                        { text: "Um método com corpo que nenhuma subclasse pode chamar", isCorrect: false },
+                        { text: "Um método que cria objetos da própria classe base", isCorrect: false },
+                        { text: "Um método que existe apenas na classe raiz Object", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Uma interface, na prática, define:",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A cópia exata de outra classe já implementada", isCorrect: false },
+                        { text: "Um contrato de métodos que a classe fornece", isCorrect: true },
+                        { text: "Os dados privados de um único objeto criado", isCorrect: false },
+                        { text: "Um laço que percorre coleções de dados", isCorrect: false },
                     ],
                 },
             ],
@@ -1335,6 +1796,26 @@ const MODULO_8: Modulo = {
                         { text: "O último elemento adicionado à lista", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "Qual método da ArrayList lê o elemento em uma posição?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "size", isCorrect: false },
+                        { text: "add", isCorrect: false },
+                        { text: "get", isCorrect: true },
+                        { text: "remove", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que se costuma declarar 'List<String> x = new ArrayList<>()' em vez de ArrayList dos dois lados?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Programar para a interface List deixa o código flexível", isCorrect: true },
+                        { text: "Porque a ArrayList não pode ser usada na hora da criação", isCorrect: false },
+                        { text: "Porque a List é mais rápida que a ArrayList", isCorrect: false },
+                        { text: "Porque só assim a lista aceita strings", isCorrect: false },
+                    ],
+                },
             ],
         },
         {
@@ -1386,6 +1867,26 @@ const MODULO_8: Modulo = {
                         { text: "O tipo da chave usada para buscar", isCorrect: false },
                         { text: "O número máximo de pares no mapa", isCorrect: false },
                         { text: "O índice de cada elemento do mapa", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Em um Map, quais métodos inserem e recuperam um valor?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "put para inserir e get para recuperar", isCorrect: true },
+                        { text: "add para inserir e size para recuperar", isCorrect: false },
+                        { text: "set para inserir e find para recuperar", isCorrect: false },
+                        { text: "push para inserir e pop para recuperar", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Diferente de um Set, uma List permite:",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Associar cada chave a um valor", isCorrect: false },
+                        { text: "Impedir qualquer repetição", isCorrect: false },
+                        { text: "Guardar apenas um elemento", isCorrect: false },
+                        { text: "Guardar elementos repetidos", isCorrect: true },
                     ],
                 },
             ],
@@ -1441,6 +1942,26 @@ const MODULO_8: Modulo = {
                         { text: "O programa só falha ao rodar, nunca ao compilar", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "Sem generics, o que uma coleção guardaria, exigindo casts na leitura?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Object, ou seja, qualquer coisa", isCorrect: true },
+                        { text: "Apenas números inteiros do tipo int", isCorrect: false },
+                        { text: "Somente valores do tipo String", isCorrect: false },
+                        { text: "Nada, pois não compilaria", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Com List<String>, o que 'nomes.get(0)' devolve?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um Object que ainda precisa de um cast", isCorrect: false },
+                        { text: "Um número inteiro qualquer", isCorrect: false },
+                        { text: "Uma String, sem precisar de cast", isCorrect: true },
+                        { text: "Sempre o valor null", isCorrect: false },
+                    ],
+                },
             ],
         },
         {
@@ -1492,6 +2013,26 @@ const MODULO_8: Modulo = {
                         { text: "Apenas quando uma exceção é lançada", isCorrect: false },
                         { text: "Apenas quando nenhuma exceção é lançada", isCorrect: false },
                         { text: "Nunca, pois é um bloco apenas decorativo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que 'int r = 10 / 0;' provoca em Java?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Lança uma ArithmeticException", isCorrect: true },
+                        { text: "Devolve o valor zero normalmente", isCorrect: false },
+                        { text: "Devolve o valor infinito", isCorrect: false },
+                        { text: "Gera um erro de compilação", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Para que o bloco finally é especialmente indicado?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Lançar novas exceções de propósito no código", isCorrect: false },
+                        { text: "Liberar recursos, como fechar um arquivo", isCorrect: true },
+                        { text: "Conter o código que pode falhar", isCorrect: false },
+                        { text: "Ignorar a exceção capturada antes", isCorrect: false },
                     ],
                 },
             ],
@@ -1553,6 +2094,26 @@ const MODULO_9: Modulo = {
                         { text: "Impedir qualquer erro em tempo de execução", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "Qual é a ideia central por trás das expressões lambda?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Tratar um comportamento como um valor", isCorrect: true },
+                        { text: "Guardar textos longos em memória", isCorrect: false },
+                        { text: "Criar tipos primitivos novos", isCorrect: false },
+                        { text: "Substituir todas as classes por interfaces", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Antes das lambdas, o que era preciso para passar um comportamento a um método?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Nada, pois já bastava usar a seta -> da lambda", isCorrect: false },
+                        { text: "Escrever uma classe inteira para envolver", isCorrect: true },
+                        { text: "Declarar o método como estático na classe", isCorrect: false },
+                        { text: "Usar um laço for tradicional para repetir", isCorrect: false },
+                    ],
+                },
             ],
         },
         {
@@ -1606,6 +2167,26 @@ const MODULO_9: Modulo = {
                         { text: "Associar chaves a valores como em um Map", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "Como se cria uma stream a partir de uma coleção?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Chamando o método stream() sobre ela", isCorrect: true },
+                        { text: "Chamando o método size() sobre ela", isCorrect: false },
+                        { text: "Passando a coleção ao construtor de Stream", isCorrect: false },
+                        { text: "Declarando a coleção como final", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Em uma stream, quando as operações realmente executam?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Assim que a stream é criada com o stream()", isCorrect: false },
+                        { text: "Só quando uma operação terminal é chamada", isCorrect: true },
+                        { text: "A cada operação intermediária encadeada", isCorrect: false },
+                        { text: "Somente ao fim do programa inteiro", isCorrect: false },
+                    ],
+                },
             ],
         },
         {
@@ -1655,12 +2236,32 @@ const MODULO_9: Modulo = {
                         { text: "Uma forma de declarar variáveis de tipos primitivos", isCorrect: false },
                     ],
                 },
+                {
+                    statement: "Entre os temas do curso, o encapsulamento se refere a:",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Deixar os atributos private e usar métodos", isCorrect: true },
+                        { text: "Uma classe herdar atributos de outra com extends", isCorrect: false },
+                        { text: "Processar coleções com as operações filter e map", isCorrect: false },
+                        { text: "Repetir um bloco de código com o laço for", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "No resumo do curso, qual coleção garante elementos únicos, sem duplicatas?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A List", isCorrect: false },
+                        { text: "O array comum", isCorrect: false },
+                        { text: "O StringBuilder", isCorrect: false },
+                        { text: "O Set", isCorrect: true },
+                    ],
+                },
             ],
         },
     ],
 };
 
-const MODULOS: Modulo[] = [
+export const MODULOS: Modulo[] = [
     MODULO_1,
     MODULO_2,
     MODULO_3,
@@ -1739,9 +2340,13 @@ async function seed() {
     );
 }
 
-seed()
-    .then(() => process.exit(0))
-    .catch((e) => {
-        console.error("Falha no seed:", e);
-        process.exit(1);
-    });
+// Só semeia quando executado direto. Se for importado (ex.: sincronizar-questoes-trilha),
+// expõe MODULOS/NOME sem rodar o seed nem chamar process.exit.
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+    seed()
+        .then(() => process.exit(0))
+        .catch((e) => {
+            console.error("Falha no seed:", e);
+            process.exit(1);
+        });
+}

--- a/backend/scripts/seed-trilha-javascript.ts
+++ b/backend/scripts/seed-trilha-javascript.ts
@@ -5498,7 +5498,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Considere o código:\n\nlet nums = [1, 2, 3, 4];\nlet r = nums\n  .filter(function (n) { return n > 2; })\n  .map(function (n) { return n * 10; });\n\nQuanto vale `r`?",
+                        "statement": "Considere o código:\n\n```\nlet nums = [1, 2, 3, 4];\nlet r = nums\n  .filter(function (n) { return n > 2; })\n  .map(function (n) { return n * 10; });\n```\n\nQuanto vale `r`?",
                         "difficulty": "dificil",
                         "options": [
                             {

--- a/backend/scripts/seed-trilha-logica-de-programacao.ts
+++ b/backend/scripts/seed-trilha-logica-de-programacao.ts
@@ -1520,7 +1520,7 @@ const MODULOS: Modulo[] = [
                 ],
                 "questions": [
                     {
-                        "statement": "Qual é a saída no console deste código?\n\nlet nota = 7;\n\nif (nota >= 6) {\n  console.log(\"Aprovado\");\n}\n\nconsole.log(\"Fim\");",
+                        "statement": "Qual é a saída no console deste código?\n\n```\nlet nota = 7;\n\nif (nota >= 6) {\n  console.log(\"Aprovado\");\n}\n\nconsole.log(\"Fim\");\n```",
                         "difficulty": "facil",
                         "options": [
                             {
@@ -1542,7 +1542,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Qual é a saída no console deste código?\n\nlet idade = 12;\n\nif (idade >= 18) {\n  console.log(\"Maior de idade\");\n}\n\nconsole.log(\"Verificação concluída\");",
+                        "statement": "Qual é a saída no console deste código?\n\n```\nlet idade = 12;\n\nif (idade >= 18) {\n  console.log(\"Maior de idade\");\n}\n\nconsole.log(\"Verificação concluída\");\n```",
                         "difficulty": "facil",
                         "options": [
                             {
@@ -1564,7 +1564,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Qual é a saída deste código?\n\nlet x = 3;\n\nif (x > 5)\n  console.log(\"x é grande\");\n  console.log(\"sempre imprime\");",
+                        "statement": "Qual é a saída deste código?\n\n```\nlet x = 3;\n\nif (x > 5)\n  console.log(\"x é grande\");\n  console.log(\"sempre imprime\");\n```",
                         "difficulty": "medio",
                         "options": [
                             {
@@ -1586,7 +1586,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Qual é a saída deste código, e por quê?\n\nlet numero = 0;\n\nif (numero = 5) {\n  console.log(\"Entrou no if\");\n}",
+                        "statement": "Qual é a saída deste código, e por quê?\n\n```\nlet numero = 0;\n\nif (numero = 5) {\n  console.log(\"Entrou no if\");\n}\n```",
                         "difficulty": "dificil",
                         "options": [
                             {
@@ -1665,7 +1665,7 @@ const MODULOS: Modulo[] = [
                 ],
                 "questions": [
                     {
-                        "statement": "Qual é a saída no console?\n\nlet idade = 20;\n\nif (idade >= 18) {\n  console.log(\"Maior de idade\");\n} else {\n  console.log(\"Menor de idade\");\n}",
+                        "statement": "Qual é a saída no console?\n\n```\nlet idade = 20;\n\nif (idade >= 18) {\n  console.log(\"Maior de idade\");\n} else {\n  console.log(\"Menor de idade\");\n}\n```",
                         "difficulty": "facil",
                         "options": [
                             {
@@ -1687,7 +1687,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Qual é a saída no console?\n\nlet numero = 10;\n\nif (numero % 2 === 0) {\n  console.log(\"par\");\n} else {\n  console.log(\"ímpar\");\n}",
+                        "statement": "Qual é a saída no console?\n\n```\nlet numero = 10;\n\nif (numero % 2 === 0) {\n  console.log(\"par\");\n} else {\n  console.log(\"ímpar\");\n}\n```",
                         "difficulty": "facil",
                         "options": [
                             {
@@ -1709,7 +1709,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Qual é a saída no console?\n\nlet a = 6;\nlet b = 6;\n\nif (a >= b) {\n  console.log(a + \" é o maior\");\n} else {\n  console.log(b + \" é o maior\");\n}",
+                        "statement": "Qual é a saída no console?\n\n```\nlet a = 6;\nlet b = 6;\n\nif (a >= b) {\n  console.log(a + \" é o maior\");\n} else {\n  console.log(b + \" é o maior\");\n}\n```",
                         "difficulty": "medio",
                         "options": [
                             {
@@ -1753,7 +1753,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Qual é a saída deste código, e por quê?\n\nlet ativo = false;\n\nif (ativo = true) {\n  console.log(\"Conta ativa\");\n} else {\n  console.log(\"Conta inativa\");\n}",
+                        "statement": "Qual é a saída deste código, e por quê?\n\n```\nlet ativo = false;\n\nif (ativo = true) {\n  console.log(\"Conta ativa\");\n} else {\n  console.log(\"Conta inativa\");\n}\n```",
                         "difficulty": "dificil",
                         "options": [
                             {
@@ -1810,7 +1810,7 @@ const MODULOS: Modulo[] = [
                 ],
                 "questions": [
                     {
-                        "statement": "Qual é a saída?\n\nlet nota = 9;\n\nif (nota >= 9) {\n  console.log(\"Conceito A\");\n} else if (nota >= 7) {\n  console.log(\"Conceito B\");\n} else if (nota >= 5) {\n  console.log(\"Conceito C\");\n} else {\n  console.log(\"Conceito D\");\n}",
+                        "statement": "Qual é a saída?\n\n```\nlet nota = 9;\n\nif (nota >= 9) {\n  console.log(\"Conceito A\");\n} else if (nota >= 7) {\n  console.log(\"Conceito B\");\n} else if (nota >= 5) {\n  console.log(\"Conceito C\");\n} else {\n  console.log(\"Conceito D\");\n}\n```",
                         "difficulty": "facil",
                         "options": [
                             {
@@ -1832,7 +1832,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Qual é a saída?\n\nlet idade = 70;\n\nif (idade < 13) {\n  console.log(\"Criança\");\n} else if (idade < 18) {\n  console.log(\"Adolescente\");\n} else if (idade < 60) {\n  console.log(\"Adulto\");\n} else {\n  console.log(\"Idoso\");\n}",
+                        "statement": "Qual é a saída?\n\n```\nlet idade = 70;\n\nif (idade < 13) {\n  console.log(\"Criança\");\n} else if (idade < 18) {\n  console.log(\"Adolescente\");\n} else if (idade < 60) {\n  console.log(\"Adulto\");\n} else {\n  console.log(\"Idoso\");\n}\n```",
                         "difficulty": "facil",
                         "options": [
                             {
@@ -1854,7 +1854,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Qual é a saída?\n\nlet nota = 4;\n\nif (nota >= 9) {\n  console.log(\"Conceito A\");\n} else if (nota >= 7) {\n  console.log(\"Conceito B\");\n} else if (nota >= 5) {\n  console.log(\"Conceito C\");\n} else {\n  console.log(\"Conceito D\");\n}",
+                        "statement": "Qual é a saída?\n\n```\nlet nota = 4;\n\nif (nota >= 9) {\n  console.log(\"Conceito A\");\n} else if (nota >= 7) {\n  console.log(\"Conceito B\");\n} else if (nota >= 5) {\n  console.log(\"Conceito C\");\n} else {\n  console.log(\"Conceito D\");\n}\n```",
                         "difficulty": "medio",
                         "options": [
                             {
@@ -1876,7 +1876,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "No código abaixo, em que situação a mensagem \"Conceito A\" seria exibida?\n\nif (nota >= 5) {\n  console.log(\"Conceito C\");\n} else if (nota >= 7) {\n  console.log(\"Conceito B\");\n} else if (nota >= 9) {\n  console.log(\"Conceito A\");\n}",
+                        "statement": "No código abaixo, em que situação a mensagem \"Conceito A\" seria exibida?\n\n```\nif (nota >= 5) {\n  console.log(\"Conceito C\");\n} else if (nota >= 7) {\n  console.log(\"Conceito B\");\n} else if (nota >= 9) {\n  console.log(\"Conceito A\");\n}\n```",
                         "difficulty": "dificil",
                         "options": [
                             {
@@ -1898,7 +1898,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Se a cadeia de categorias por idade fosse escrita nesta ordem:\n\nif (idade < 60) {\n  console.log(\"Adulto\");\n} else if (idade < 18) {\n  console.log(\"Adolescente\");\n} else if (idade < 13) {\n  console.log(\"Criança\");\n} else {\n  console.log(\"Idoso\");\n}\n\nQual seria a saída para idade = 10?",
+                        "statement": "Se a cadeia de categorias por idade fosse escrita nesta ordem:\n\n```\nif (idade < 60) {\n  console.log(\"Adulto\");\n} else if (idade < 18) {\n  console.log(\"Adolescente\");\n} else if (idade < 13) {\n  console.log(\"Criança\");\n} else {\n  console.log(\"Idoso\");\n}\n```\n\nQual seria a saída para idade = 10?",
                         "difficulty": "medio",
                         "options": [
                             {
@@ -1955,7 +1955,7 @@ const MODULOS: Modulo[] = [
                 ],
                 "questions": [
                     {
-                        "statement": "Qual é a saída?\n\nlet a = 4;\nlet b = 4;\nlet c = 9;\n\nif (a >= b && a >= c) {\n  console.log(a + \" é o maior\");\n} else if (b >= a && b >= c) {\n  console.log(b + \" é o maior\");\n} else {\n  console.log(c + \" é o maior\");\n}",
+                        "statement": "Qual é a saída?\n\n```\nlet a = 4;\nlet b = 4;\nlet c = 9;\n\nif (a >= b && a >= c) {\n  console.log(a + \" é o maior\");\n} else if (b >= a && b >= c) {\n  console.log(b + \" é o maior\");\n} else {\n  console.log(c + \" é o maior\");\n}\n```",
                         "difficulty": "medio",
                         "options": [
                             {
@@ -1977,7 +1977,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Qual é a saída?\n\nlet estudante = false;\nlet idoso = false;\n\nif (estudante || idoso) {\n  console.log(\"Tem direito a meia-entrada\");\n} else {\n  console.log(\"Paga o valor cheio\");\n}",
+                        "statement": "Qual é a saída?\n\n```\nlet estudante = false;\nlet idoso = false;\n\nif (estudante || idoso) {\n  console.log(\"Tem direito a meia-entrada\");\n} else {\n  console.log(\"Paga o valor cheio\");\n}\n```",
                         "difficulty": "facil",
                         "options": [
                             {
@@ -1999,7 +1999,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Qual é a saída?\n\nlet bloqueado = true;\n\nif (!bloqueado) {\n  console.log(\"Acesso liberado\");\n} else {\n  console.log(\"Acesso negado\");\n}",
+                        "statement": "Qual é a saída?\n\n```\nlet bloqueado = true;\n\nif (!bloqueado) {\n  console.log(\"Acesso liberado\");\n} else {\n  console.log(\"Acesso negado\");\n}\n```",
                         "difficulty": "facil",
                         "options": [
                             {
@@ -2043,7 +2043,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Qual é a saída?\n\nlet idade = 16;\nlet comResponsavel = true;\n\nif (idade >= 18 || (idade >= 12 && comResponsavel)) {\n  console.log(\"Pode assistir o filme\");\n} else {\n  console.log(\"Não pode assistir\");\n}",
+                        "statement": "Qual é a saída?\n\n```\nlet idade = 16;\nlet comResponsavel = true;\n\nif (idade >= 18 || (idade >= 12 && comResponsavel)) {\n  console.log(\"Pode assistir o filme\");\n} else {\n  console.log(\"Não pode assistir\");\n}\n```",
                         "difficulty": "dificil",
                         "options": [
                             {
@@ -2100,7 +2100,7 @@ const MODULOS: Modulo[] = [
                 ],
                 "questions": [
                     {
-                        "statement": "Qual é a saída?\n\nlet dia = 5;\n\nswitch (dia) {\n  case 1:\n    console.log(\"Domingo\");\n    break;\n  case 5:\n    console.log(\"Quinta-feira\");\n    break;\n  default:\n    console.log(\"Dia inválido\");\n}",
+                        "statement": "Qual é a saída?\n\n```\nlet dia = 5;\n\nswitch (dia) {\n  case 1:\n    console.log(\"Domingo\");\n    break;\n  case 5:\n    console.log(\"Quinta-feira\");\n    break;\n  default:\n    console.log(\"Dia inválido\");\n}\n```",
                         "difficulty": "facil",
                         "options": [
                             {
@@ -2122,7 +2122,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Qual é a saída?\n\nlet opcao = 9;\n\nswitch (opcao) {\n  case 1:\n    console.log(\"Criar conta\");\n    break;\n  case 2:\n    console.log(\"Entrar\");\n    break;\n  default:\n    console.log(\"Opção inválida\");\n}",
+                        "statement": "Qual é a saída?\n\n```\nlet opcao = 9;\n\nswitch (opcao) {\n  case 1:\n    console.log(\"Criar conta\");\n    break;\n  case 2:\n    console.log(\"Entrar\");\n    break;\n  default:\n    console.log(\"Opção inválida\");\n}\n```",
                         "difficulty": "facil",
                         "options": [
                             {
@@ -2144,7 +2144,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Qual é a saída?\n\nlet numero = 2;\n\nswitch (numero) {\n  case 1:\n    console.log(\"um\");\n  case 2:\n    console.log(\"dois\");\n  case 3:\n    console.log(\"três\");\n  default:\n    console.log(\"outro\");\n}",
+                        "statement": "Qual é a saída?\n\n```\nlet numero = 2;\n\nswitch (numero) {\n  case 1:\n    console.log(\"um\");\n  case 2:\n    console.log(\"dois\");\n  case 3:\n    console.log(\"três\");\n  default:\n    console.log(\"outro\");\n}\n```",
                         "difficulty": "medio",
                         "options": [
                             {
@@ -2188,7 +2188,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Qual é a saída?\n\nlet letra = \"a\";\n\nswitch (letra) {\n  case \"a\":\n    console.log(\"Primeira\");\n  case \"b\":\n    console.log(\"Segunda\");\n    break;\n  case \"c\":\n    console.log(\"Terceira\");\n    break;\n  default:\n    console.log(\"Outra\");\n}",
+                        "statement": "Qual é a saída?\n\n```\nlet letra = \"a\";\n\nswitch (letra) {\n  case \"a\":\n    console.log(\"Primeira\");\n  case \"b\":\n    console.log(\"Segunda\");\n    break;\n  case \"c\":\n    console.log(\"Terceira\");\n    break;\n  default:\n    console.log(\"Outra\");\n}\n```",
                         "difficulty": "dificil",
                         "options": [
                             {
@@ -2316,7 +2316,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Considerando o código abaixo:\n\nfor (let i = 1; i <= 100; i++) {\n  console.log(i);\n}\n\nQuantos números esse código mostra no console?",
+                        "statement": "Considerando o código abaixo:\n\n```\nfor (let i = 1; i <= 100; i++) {\n  console.log(i);\n}\n```\n\nQuantos números esse código mostra no console?",
                         "difficulty": "medio",
                         "options": [
                             {
@@ -2439,7 +2439,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Considerando o código abaixo:\n\nlet i = 0;\nwhile (i < 3) {\n  console.log('Oi');\n  i = i + 1;\n}\n\nQuantas vezes a palavra 'Oi' aparece no console?",
+                        "statement": "Considerando o código abaixo:\n\n```\nlet i = 0;\nwhile (i < 3) {\n  console.log('Oi');\n  i = i + 1;\n}\n```\n\nQuantas vezes a palavra 'Oi' aparece no console?",
                         "difficulty": "medio",
                         "options": [
                             {
@@ -2461,7 +2461,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Considerando o código abaixo:\n\nlet n = 10;\nwhile (n > 0) {\n  console.log(n);\n}\n\nO que acontece quando esse código roda?",
+                        "statement": "Considerando o código abaixo:\n\n```\nlet n = 10;\nwhile (n > 0) {\n  console.log(n);\n}\n```\n\nO que acontece quando esse código roda?",
                         "difficulty": "medio",
                         "options": [
                             {
@@ -2483,7 +2483,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Considerando o código abaixo:\n\nlet i = 1;\nwhile (i <= 4) {\n  i = i + 1;\n}\nconsole.log(i);\n\nQual valor aparece no console?",
+                        "statement": "Considerando o código abaixo:\n\n```\nlet i = 1;\nwhile (i <= 4) {\n  i = i + 1;\n}\nconsole.log(i);\n```\n\nQual valor aparece no console?",
                         "difficulty": "dificil",
                         "options": [
                             {
@@ -2584,7 +2584,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Considerando o código abaixo, com n valendo 10:\n\nfor (let i = 0; i <= n; i++) {\n  console.log(i);\n}\n\nQuantas vezes esse laço executa?",
+                        "statement": "Considerando o código abaixo, com n valendo 10:\n\n```\nfor (let i = 0; i <= n; i++) {\n  console.log(i);\n}\n```\n\nQuantas vezes esse laço executa?",
                         "difficulty": "medio",
                         "options": [
                             {
@@ -2606,7 +2606,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Considerando o for a seguir:\n\nfor (let i = 1; i <= 5; i++) {\n  console.log(i);\n}\n\nCom qual valor de i a condição i <= 5 deixa de ser verdadeira, fazendo o laço parar?",
+                        "statement": "Considerando o for a seguir:\n\n```\nfor (let i = 1; i <= 5; i++) {\n  console.log(i);\n}\n```\n\nCom qual valor de i a condição i <= 5 deixa de ser verdadeira, fazendo o laço parar?",
                         "difficulty": "medio",
                         "options": [
                             {
@@ -2729,7 +2729,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Considerando o código abaixo:\n\nlet soma = 0;\nfor (let i = 1; i <= 4; i++) {\n  soma = soma + i;\n}\nconsole.log(soma);\n\nQual o valor de soma no final?",
+                        "statement": "Considerando o código abaixo:\n\n```\nlet soma = 0;\nfor (let i = 1; i <= 4; i++) {\n  soma = soma + i;\n}\nconsole.log(soma);\n```\n\nQual o valor de soma no final?",
                         "difficulty": "medio",
                         "options": [
                             {
@@ -2751,7 +2751,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Considerando o código abaixo:\n\nlet quantidade = 0;\nfor (let i = 1; i <= 10; i++) {\n  if (i % 2 !== 0) {\n    quantidade = quantidade + 1;\n  }\n}\nconsole.log(quantidade);\n\nQual o valor de quantidade no final?",
+                        "statement": "Considerando o código abaixo:\n\n```\nlet quantidade = 0;\nfor (let i = 1; i <= 10; i++) {\n  if (i % 2 !== 0) {\n    quantidade = quantidade + 1;\n  }\n}\nconsole.log(quantidade);\n```\n\nQual o valor de quantidade no final?",
                         "difficulty": "medio",
                         "options": [
                             {
@@ -2773,7 +2773,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "O código abaixo deveria somar os números de 1 até 5, mas tem um erro sutil na condição. Qual o valor de soma no final?\n\nlet soma = 0;\nfor (let i = 1; i < 5; i++) {\n  soma = soma + i;\n}\nconsole.log(soma);",
+                        "statement": "O código abaixo deveria somar os números de 1 até 5, mas tem um erro sutil na condição. Qual o valor de soma no final?\n\n```\nlet soma = 0;\nfor (let i = 1; i < 5; i++) {\n  soma = soma + i;\n}\nconsole.log(soma);\n```",
                         "difficulty": "dificil",
                         "options": [
                             {
@@ -2874,7 +2874,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Considerando o código abaixo:\n\nfor (let i = 1; i <= 5; i++) {\n  if (i === 3) {\n    break;\n  }\n  console.log(i);\n}\n\nO que aparece no console?",
+                        "statement": "Considerando o código abaixo:\n\n```\nfor (let i = 1; i <= 5; i++) {\n  if (i === 3) {\n    break;\n  }\n  console.log(i);\n}\n```\n\nO que aparece no console?",
                         "difficulty": "medio",
                         "options": [
                             {
@@ -2896,7 +2896,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Considerando o código abaixo:\n\nfor (let i = 1; i <= 5; i++) {\n  if (i === 3) {\n    continue;\n  }\n  console.log(i);\n}\n\nO que aparece no console?",
+                        "statement": "Considerando o código abaixo:\n\n```\nfor (let i = 1; i <= 5; i++) {\n  if (i === 3) {\n    continue;\n  }\n  console.log(i);\n}\n```\n\nO que aparece no console?",
                         "difficulty": "medio",
                         "options": [
                             {
@@ -2918,7 +2918,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Considerando o código abaixo:\n\nfor (let a = 1; a <= 4; a++) {\n  for (let b = 1; b <= 3; b++) {\n    console.log(a, b);\n  }\n}\n\nQuantas vezes o console.log de dentro executa, ao todo?",
+                        "statement": "Considerando o código abaixo:\n\n```\nfor (let a = 1; a <= 4; a++) {\n  for (let b = 1; b <= 3; b++) {\n    console.log(a, b);\n  }\n}\n```\n\nQuantas vezes o console.log de dentro executa, ao todo?",
                         "difficulty": "dificil",
                         "options": [
                             {
@@ -3020,7 +3020,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Considerando o código abaixo:\n\nfunction mostrarLinha() {\n  console.log(\"---\");\n}\n\nmostrarLinha();\nmostrarLinha();\nconsole.log(\"fim\");\n\nQuantas vezes o texto \"---\" aparece no console?",
+                        "statement": "Considerando o código abaixo:\n\n```\nfunction mostrarLinha() {\n  console.log(\"---\");\n}\n\nmostrarLinha();\nmostrarLinha();\nconsole.log(\"fim\");\n```\n\nQuantas vezes o texto \"---\" aparece no console?",
                         "difficulty": "medio",
                         "options": [
                             {
@@ -3064,7 +3064,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Considerando o código abaixo:\n\nfunction mostrarMensagem() {\n  console.log(\"Você me chamou!\");\n}\n\nconsole.log(\"Início do programa\");\n\nO que aparece no console quando esse código roda?",
+                        "statement": "Considerando o código abaixo:\n\n```\nfunction mostrarMensagem() {\n  console.log(\"Você me chamou!\");\n}\n\nconsole.log(\"Início do programa\");\n```\n\nO que aparece no console quando esse código roda?",
                         "difficulty": "dificil",
                         "options": [
                             {
@@ -3165,7 +3165,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Considerando o código abaixo:\n\nfunction subtrair(a, b) {\n  console.log(a - b);\n}\n\nsubtrair(10, 3);\n\nO que aparece no console?",
+                        "statement": "Considerando o código abaixo:\n\n```\nfunction subtrair(a, b) {\n  console.log(a - b);\n}\n\nsubtrair(10, 3);\n```\n\nO que aparece no console?",
                         "difficulty": "medio",
                         "options": [
                             {
@@ -3209,7 +3209,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Considerando o código abaixo:\n\nfunction saudar(nome) {\n  console.log(\"Oi, \" + nome);\n}\n\nsaudar();\n\nO que aparece no console quando saudar() é chamada sem nenhum argumento?",
+                        "statement": "Considerando o código abaixo:\n\n```\nfunction saudar(nome) {\n  console.log(\"Oi, \" + nome);\n}\n\nsaudar();\n```\n\nO que aparece no console quando saudar() é chamada sem nenhum argumento?",
                         "difficulty": "dificil",
                         "options": [
                             {
@@ -3288,7 +3288,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Considerando o código abaixo:\n\nfunction dobro(n) {\n  return n * 2;\n}\n\nconst valor = dobro(5);\nconsole.log(valor);\n\nO que aparece no console?",
+                        "statement": "Considerando o código abaixo:\n\n```\nfunction dobro(n) {\n  return n * 2;\n}\n\nconst valor = dobro(5);\nconsole.log(valor);\n```\n\nO que aparece no console?",
                         "difficulty": "facil",
                         "options": [
                             {
@@ -3310,7 +3310,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Considerando o código abaixo:\n\nfunction triplo(n) {\n  console.log(n * 3);\n}\n\nconst valor = triplo(4);\nconsole.log(valor);\n\nO que aparece no console, na ordem?",
+                        "statement": "Considerando o código abaixo:\n\n```\nfunction triplo(n) {\n  console.log(n * 3);\n}\n\nconst valor = triplo(4);\nconsole.log(valor);\n```\n\nO que aparece no console, na ordem?",
                         "difficulty": "medio",
                         "options": [
                             {
@@ -3332,7 +3332,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Considerando o código abaixo:\n\nfunction classificar(nota) {\n  if (nota >= 6) {\n    return \"aprovado\";\n  }\n  return \"reprovado\";\n}\n\nconsole.log(classificar(8));\n\nO que aparece no console?",
+                        "statement": "Considerando o código abaixo:\n\n```\nfunction classificar(nota) {\n  if (nota >= 6) {\n    return \"aprovado\";\n  }\n  return \"reprovado\";\n}\n\nconsole.log(classificar(8));\n```\n\nO que aparece no console?",
                         "difficulty": "medio",
                         "options": [
                             {
@@ -3354,7 +3354,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Considerando o código abaixo:\n\nfunction verificar(numero) {\n  if (numero > 0) {\n    return \"positivo\";\n    console.log(\"chequei o número\");\n  }\n  return \"não positivo\";\n}\n\nconsole.log(verificar(5));\n\nAlém do resultado devolvido, o que mais aparece no console?",
+                        "statement": "Considerando o código abaixo:\n\n```\nfunction verificar(numero) {\n  if (numero > 0) {\n    return \"positivo\";\n    console.log(\"chequei o número\");\n  }\n  return \"não positivo\";\n}\n\nconsole.log(verificar(5));\n```\n\nAlém do resultado devolvido, o que mais aparece no console?",
                         "difficulty": "dificil",
                         "options": [
                             {
@@ -3433,7 +3433,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Considerando o código abaixo:\n\nfunction calcular() {\n  const total = 100;\n  console.log(total);\n}\n\ncalcular();\nconsole.log(total);\n\nO que acontece quando esse código roda?",
+                        "statement": "Considerando o código abaixo:\n\n```\nfunction calcular() {\n  const total = 100;\n  console.log(total);\n}\n\ncalcular();\nconsole.log(total);\n```\n\nO que acontece quando esse código roda?",
                         "difficulty": "facil",
                         "options": [
                             {
@@ -3455,7 +3455,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Considerando o código abaixo:\n\nconst cidade = \"Recife\";\n\nfunction mostrarCidade() {\n  console.log(\"Cidade: \" + cidade);\n}\n\nmostrarCidade();\n\nO que aparece no console?",
+                        "statement": "Considerando o código abaixo:\n\n```\nconst cidade = \"Recife\";\n\nfunction mostrarCidade() {\n  console.log(\"Cidade: \" + cidade);\n}\n\nmostrarCidade();\n```\n\nO que aparece no console?",
                         "difficulty": "medio",
                         "options": [
                             {
@@ -3477,7 +3477,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Considerando o código abaixo:\n\nfunction contarOvelhas() {\n  const total = 5;\n  return total;\n}\n\nfunction contarPatos() {\n  const total = 12;\n  return total;\n}\n\nconsole.log(contarOvelhas());\nconsole.log(contarPatos());\n\nO que aparece no console?",
+                        "statement": "Considerando o código abaixo:\n\n```\nfunction contarOvelhas() {\n  const total = 5;\n  return total;\n}\n\nfunction contarPatos() {\n  const total = 12;\n  return total;\n}\n\nconsole.log(contarOvelhas());\nconsole.log(contarPatos());\n```\n\nO que aparece no console?",
                         "difficulty": "medio",
                         "options": [
                             {
@@ -3596,7 +3596,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Considerando as funções abaixo:\n\nfunction maiorDeDois(a, b) {\n  if (a > b) {\n    return a;\n  }\n  return b;\n}\n\nfunction maiorDeTres(a, b, c) {\n  const maiorEntreAeB = maiorDeDois(a, b);\n  return maiorDeDois(maiorEntreAeB, c);\n}\n\nO que maiorDeTres(7, 3, 5) devolve?",
+                        "statement": "Considerando as funções abaixo:\n\n```\nfunction maiorDeDois(a, b) {\n  if (a > b) {\n    return a;\n  }\n  return b;\n}\n\nfunction maiorDeTres(a, b, c) {\n  const maiorEntreAeB = maiorDeDois(a, b);\n  return maiorDeDois(maiorEntreAeB, c);\n}\n```\n\nO que maiorDeTres(7, 3, 5) devolve?",
                         "difficulty": "medio",
                         "options": [
                             {
@@ -3640,7 +3640,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Considerando o código abaixo:\n\nfunction dobro(n) {\n  return n * 2;\n}\n\nfunction quadruplo(n) {\n  return dobro(dobro(n));\n}\n\nconsole.log(quadruplo(3));\n\nO que aparece no console?",
+                        "statement": "Considerando o código abaixo:\n\n```\nfunction dobro(n) {\n  return n * 2;\n}\n\nfunction quadruplo(n) {\n  return dobro(dobro(n));\n}\n\nconsole.log(quadruplo(3));\n```\n\nO que aparece no console?",
                         "difficulty": "dificil",
                         "options": [
                             {
@@ -4036,7 +4036,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Qual é a saída deste código?\n\nlet numeros = [3, 6, 9];\nlet total = 0;\nfor (let n of numeros) {\n  total = total + n;\n}\nconsole.log(total);",
+                        "statement": "Qual é a saída deste código?\n\n```\nlet numeros = [3, 6, 9];\nlet total = 0;\nfor (let n of numeros) {\n  total = total + n;\n}\nconsole.log(total);\n```",
                         "difficulty": "medio",
                         "options": [
                             {
@@ -4080,7 +4080,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Qual é a saída deste código?\n\nlet idades = [15, 22, 17, 30, 16];\nlet menores = 0;\nfor (let i = 0; i < idades.length; i++) {\n  if (idades[i] < 18) {\n    menores = menores + 1;\n  }\n}\nconsole.log(menores);",
+                        "statement": "Qual é a saída deste código?\n\n```\nlet idades = [15, 22, 17, 30, 16];\nlet menores = 0;\nfor (let i = 0; i < idades.length; i++) {\n  if (idades[i] < 18) {\n    menores = menores + 1;\n  }\n}\nconsole.log(menores);\n```",
                         "difficulty": "dificil",
                         "options": [
                             {
@@ -4326,7 +4326,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Qual é a saída deste código?\n\nlet itens = [{ nome: \"caneta\", preco: 2 }, { nome: \"caderno\", preco: 15 }];\nlet total = 0;\nfor (let item of itens) {\n  total = total + item.preco;\n}\nconsole.log(total);",
+                        "statement": "Qual é a saída deste código?\n\n```\nlet itens = [{ nome: \"caneta\", preco: 2 }, { nome: \"caderno\", preco: 15 }];\nlet total = 0;\nfor (let item of itens) {\n  total = total + item.preco;\n}\nconsole.log(total);\n```",
                         "difficulty": "medio",
                         "options": [
                             {
@@ -4370,7 +4370,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Qual é a saída deste código?\n\nlet produtos = [\n  { nome: \"mouse\", estoque: 5 },\n  { nome: \"teclado\", estoque: 0 },\n  { nome: \"monitor\", estoque: 3 }\n];\nlet semEstoque = 0;\nfor (let produto of produtos) {\n  if (produto.estoque === 0) {\n    semEstoque = semEstoque + 1;\n  }\n}\nconsole.log(semEstoque);",
+                        "statement": "Qual é a saída deste código?\n\n```\nlet produtos = [\n  { nome: \"mouse\", estoque: 5 },\n  { nome: \"teclado\", estoque: 0 },\n  { nome: \"monitor\", estoque: 3 }\n];\nlet semEstoque = 0;\nfor (let produto of produtos) {\n  if (produto.estoque === 0) {\n    semEstoque = semEstoque + 1;\n  }\n}\nconsole.log(semEstoque);\n```",
                         "difficulty": "dificil",
                         "options": [
                             {

--- a/backend/scripts/seed-trilha-python.ts
+++ b/backend/scripts/seed-trilha-python.ts
@@ -2600,7 +2600,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Qual é a saída do código abaixo?\n\nestoque = {\"caderno\": \"cheio\", \"lapis\": \"baixo\"}\nfor item in estoque:\n    print(item)",
+                        "statement": "Qual é a saída do código abaixo?\n\n```\nestoque = {\"caderno\": \"cheio\", \"lapis\": \"baixo\"}\nfor item in estoque:\n    print(item)\n```",
                         "difficulty": "medio",
                         "options": [
                             {
@@ -2912,7 +2912,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Qual é a saída do código abaixo?\n\nprodutos = [\n    {\"nome\": \"Caneta\", \"preco\": 2.0},\n    {\"nome\": \"Caderno\", \"preco\": 15.0},\n    {\"nome\": \"Lapis\", \"preco\": 1.5},\n]\nbaratos = [produto[\"nome\"] for produto in produtos if produto[\"preco\"] < 5]\nprint(baratos)",
+                        "statement": "Qual é a saída do código abaixo?\n\n```\nprodutos = [\n    {\"nome\": \"Caneta\", \"preco\": 2.0},\n    {\"nome\": \"Caderno\", \"preco\": 15.0},\n    {\"nome\": \"Lapis\", \"preco\": 1.5},\n]\nbaratos = [produto[\"nome\"] for produto in produtos if produto[\"preco\"] < 5]\nprint(baratos)\n```",
                         "difficulty": "dificil",
                         "options": [
                             {
@@ -2996,7 +2996,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "O que este código imprime?\n\ndef triplo(n):\n    return n * 3\n\nprint(triplo(4))",
+                        "statement": "O que este código imprime?\n\n```\ndef triplo(n):\n    return n * 3\n\nprint(triplo(4))\n```",
                         "difficulty": "facil",
                         "options": [
                             {
@@ -3040,7 +3040,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Este código chama cumprimenta(\"Rio\") e depois faz print(resultado). O que a última linha imprime?\n\ndef cumprimenta(nome):\n    print(f\"Olá, {nome}\")\n\nresultado = cumprimenta(\"Rio\")\nprint(resultado)",
+                        "statement": "Este código chama cumprimenta(\"Rio\") e depois faz print(resultado). O que a última linha imprime?\n\n```\ndef cumprimenta(nome):\n    print(f\"Olá, {nome}\")\n\nresultado = cumprimenta(\"Rio\")\nprint(resultado)\n```",
                         "difficulty": "medio",
                         "options": [
                             {
@@ -3062,7 +3062,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "O que este código imprime?\n\ndef checar(n):\n    if n < 0:\n        return \"negativo\"\n    return \"positivo\"\n    print(\"depois do return\")\n\nprint(checar(-5))",
+                        "statement": "O que este código imprime?\n\n```\ndef checar(n):\n    if n < 0:\n        return \"negativo\"\n    return \"positivo\"\n    print(\"depois do return\")\n\nprint(checar(-5))\n```",
                         "difficulty": "dificil",
                         "options": [
                             {
@@ -3141,7 +3141,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "O que este código imprime?\n\ndef apresentar(nome, cidade):\n    print(f\"{nome} mora em {cidade}\")\n\napresentar(cidade=\"Recife\", nome=\"Bia\")",
+                        "statement": "O que este código imprime?\n\n```\ndef apresentar(nome, cidade):\n    print(f\"{nome} mora em {cidade}\")\n\napresentar(cidade=\"Recife\", nome=\"Bia\")\n```",
                         "difficulty": "facil",
                         "options": [
                             {
@@ -3185,7 +3185,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "O que este código imprime?\n\ndef multiplicar_tudo(*numeros):\n    resultado = 1\n    for n in numeros:\n        resultado *= n\n    return resultado\n\nprint(multiplicar_tudo(2, 3, 4))",
+                        "statement": "O que este código imprime?\n\n```\ndef multiplicar_tudo(*numeros):\n    resultado = 1\n    for n in numeros:\n        resultado *= n\n    return resultado\n\nprint(multiplicar_tudo(2, 3, 4))\n```",
                         "difficulty": "medio",
                         "options": [
                             {
@@ -3207,7 +3207,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "O que este código imprime?\n\ndef registrar(local, *valores):\n    print(local, valores)\n\nregistrar(\"SP\", 10, 20, 30)",
+                        "statement": "O que este código imprime?\n\n```\ndef registrar(local, *valores):\n    print(local, valores)\n\nregistrar(\"SP\", 10, 20, 30)\n```",
                         "difficulty": "dificil",
                         "options": [
                             {
@@ -3286,7 +3286,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "O que este código imprime, na ordem?\n\nx = 10\n\ndef mostrar():\n    x = 20\n    print(x)\n\nmostrar()\nprint(x)",
+                        "statement": "O que este código imprime, na ordem?\n\n```\nx = 10\n\ndef mostrar():\n    x = 20\n    print(x)\n\nmostrar()\nprint(x)\n```",
                         "difficulty": "facil",
                         "options": [
                             {
@@ -3352,7 +3352,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "O que este código imprime, na ordem?\n\ndef dobrar_lista(numeros):\n    novos = []\n    for n in numeros:\n        novos.append(n * 2)\n    return novos\n\nvalores = [1, 2, 3]\nresultado = dobrar_lista(valores)\nprint(valores)\nprint(resultado)",
+                        "statement": "O que este código imprime, na ordem?\n\n```\ndef dobrar_lista(numeros):\n    novos = []\n    for n in numeros:\n        novos.append(n * 2)\n    return novos\n\nvalores = [1, 2, 3]\nresultado = dobrar_lista(valores)\nprint(valores)\nprint(resultado)\n```",
                         "difficulty": "dificil",
                         "options": [
                             {
@@ -3497,7 +3497,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "O que este código imprime?\n\nfrom math import sqrt\n\ndef sqrt(x):\n    return \"raiz de \" + str(x)\n\nprint(sqrt(9))",
+                        "statement": "O que este código imprime?\n\n```\nfrom math import sqrt\n\ndef sqrt(x):\n    return \"raiz de \" + str(x)\n\nprint(sqrt(9))\n```",
                         "difficulty": "dificil",
                         "options": [
                             {
@@ -3744,7 +3744,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Considere o código:\n\nwith open(\"notas.txt\", \"w\") as arquivo:\n    arquivo.write(\"Ana\\n\")\n    arquivo.write(\"Bruno\\n\")\n\nwith open(\"notas.txt\", \"r\") as arquivo:\n    conteudo = arquivo.read()\n\nprint(conteudo)\n\nQual é a saída deste trecho?",
+                        "statement": "Considere o código:\n\n```\nwith open(\"notas.txt\", \"w\") as arquivo:\n    arquivo.write(\"Ana\\n\")\n    arquivo.write(\"Bruno\\n\")\n\nwith open(\"notas.txt\", \"r\") as arquivo:\n    conteudo = arquivo.read()\n\nprint(conteudo)\n```\n\nQual é a saída deste trecho?",
                         "difficulty": "medio",
                         "options": [
                             {
@@ -3889,7 +3889,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Considere o código:\n\nimport csv\n\nwith open(\"alunos.csv\", \"r\") as arquivo:\n    leitor = csv.reader(arquivo)\n    cabecalho = next(leitor)\n    for linha in leitor:\n        print(linha[0])\n\nO arquivo alunos.csv tem o cabeçalho nome,idade,cidade seguido pelas linhas de Ana, Bruno e Carla. Qual é a saída deste trecho?",
+                        "statement": "Considere o código:\n\n```\nimport csv\n\nwith open(\"alunos.csv\", \"r\") as arquivo:\n    leitor = csv.reader(arquivo)\n    cabecalho = next(leitor)\n    for linha in leitor:\n        print(linha[0])\n```\n\nO arquivo alunos.csv tem o cabeçalho nome,idade,cidade seguido pelas linhas de Ana, Bruno e Carla. Qual é a saída deste trecho?",
                         "difficulty": "medio",
                         "options": [
                             {
@@ -4034,7 +4034,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Considere o código:\n\ntry:\n    numeros = [10, 20, 30]\n    print(numeros[5])\nexcept IndexError:\n    print(\"indice invalido\")\nexcept ValueError:\n    print(\"valor invalido\")\nelse:\n    print(\"tudo certo\")\nfinally:\n    print(\"fim da tentativa\")\n\nQual é a saída deste trecho?",
+                        "statement": "Considere o código:\n\n```\ntry:\n    numeros = [10, 20, 30]\n    print(numeros[5])\nexcept IndexError:\n    print(\"indice invalido\")\nexcept ValueError:\n    print(\"valor invalido\")\nelse:\n    print(\"tudo certo\")\nfinally:\n    print(\"fim da tentativa\")\n```\n\nQual é a saída deste trecho?",
                         "difficulty": "medio",
                         "options": [
                             {
@@ -4179,7 +4179,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Considere o código:\n\nclass Produto:\n    def __init__(self, nome, preco):\n        self.nome = nome\n        self.preco = preco\n\np1 = Produto(\"Caderno\", 12.0)\np2 = Produto(\"Caneta\", 3.0)\np1.preco = 15.0\n\nprint(p1.preco, p2.preco)\n\nQual é a saída deste trecho?",
+                        "statement": "Considere o código:\n\n```\nclass Produto:\n    def __init__(self, nome, preco):\n        self.nome = nome\n        self.preco = preco\n\np1 = Produto(\"Caderno\", 12.0)\np2 = Produto(\"Caneta\", 3.0)\np1.preco = 15.0\n\nprint(p1.preco, p2.preco)\n```\n\nQual é a saída deste trecho?",
                         "difficulty": "medio",
                         "options": [
                             {
@@ -4324,7 +4324,7 @@ const MODULOS: Modulo[] = [
                         ]
                     },
                     {
-                        "statement": "Considere o código:\n\ntotal = 0\nvalidos = 0\nvalores = [\"10\", \"vinte\", \"30\"]\n\nfor texto in valores:\n    try:\n        numero = int(texto)\n    except ValueError:\n        print(\"ignorado\")\n    else:\n        total += numero\n        validos += 1\n\nprint(total, validos)\n\nQual é a saída deste trecho?",
+                        "statement": "Considere o código:\n\n```\ntotal = 0\nvalidos = 0\nvalores = [\"10\", \"vinte\", \"30\"]\n\nfor texto in valores:\n    try:\n        numero = int(texto)\n    except ValueError:\n        print(\"ignorado\")\n    else:\n        total += numero\n        validos += 1\n\nprint(total, validos)\n```\n\nQual é a saída deste trecho?",
                         "difficulty": "medio",
                         "options": [
                             {

--- a/backend/scripts/sincronizar-questoes-trilha.ts
+++ b/backend/scripts/sincronizar-questoes-trilha.ts
@@ -1,0 +1,132 @@
+// Insere no banco as questões novas de uma trilha já semeada, sem tocar nas existentes
+// (as respostas dos alunos referenciam as questões antigas por FK). O seed é idempotente
+// "pula se já tem aulas", então re-semear não adiciona nada; este script casa aula por
+// posição (módulo -> aula) e insere só as questões cujo enunciado ainda não está no banco.
+// Antes de inserir, roda um QC (5 questões por aula, 4 opções, 1 correta, sem enunciado
+// duplicado, correta não é a mais longa nas novas). Idempotente e com --dry.
+//
+// Rodar: docker compose exec -T backend node scripts/sincronizar-questoes-trilha.ts <java|cpp|go> [--dry]
+import { db } from "../db.ts";
+import { trails, modules, lessons, questions, questionOptions } from "../schema.ts";
+import { eq, asc } from "drizzle-orm";
+
+type Opcao = { text: string; isCorrect: boolean };
+type Questao = { statement: string; difficulty: "facil" | "medio" | "dificil"; options: Opcao[] };
+type Aula = { titulo: string; questions: Questao[] };
+type Modulo = { titulo: string; aulas: Aula[] };
+
+// QC do conteúdo do seed. `estruturais` (contagem/opções/duplicado) abortam; a regra de
+// "correta não é a mais longa" só vale para as questões novas (índice >= 3) e só avisa.
+function qc(MODULOS: Modulo[]): { estruturais: string[]; avisos: string[] } {
+    const estruturais: string[] = [];
+    const avisos: string[] = [];
+    MODULOS.forEach((m, mi) =>
+        m.aulas.forEach((a, li) => {
+            const loc = `M${mi + 1}.A${li + 1} "${a.titulo}"`;
+            if (a.questions.length !== 5) estruturais.push(`${loc}: ${a.questions.length} questões (esperado 5)`);
+            const vistos = new Set<string>();
+            a.questions.forEach((q, qi) => {
+                if (q.options.length !== 4) estruturais.push(`${loc} Q${qi + 1}: ${q.options.length} opções`);
+                const corretas = q.options.filter((o) => o.isCorrect);
+                if (corretas.length !== 1) estruturais.push(`${loc} Q${qi + 1}: ${corretas.length} corretas`);
+                if (vistos.has(q.statement)) estruturais.push(`${loc} Q${qi + 1}: enunciado duplicado`);
+                vistos.add(q.statement);
+                if (qi >= 3 && corretas.length === 1) {
+                    const lenC = corretas[0].text.length;
+                    const maxD = Math.max(...q.options.filter((o) => !o.isCorrect).map((o) => o.text.length));
+                    if (lenC > maxD) avisos.push(`${loc} Q${qi + 1}: correta é a mais longa (${lenC} vs ${maxD})`);
+                }
+            });
+        }),
+    );
+    return { estruturais, avisos };
+}
+
+async function main() {
+    const nome = process.argv.slice(2).find((a) => !a.startsWith("--"));
+    const dry = process.argv.includes("--dry");
+    if (!nome) {
+        console.error("uso: node scripts/sincronizar-questoes-trilha.ts <java|cpp|go> [--dry]");
+        process.exit(1);
+    }
+
+    const mod = await import(`./seed-trilha-${nome}.ts`);
+    const MODULOS: Modulo[] = mod.MODULOS;
+    const NOME: string = mod.NOME;
+    if (!MODULOS || !NOME) {
+        console.error(`seed-trilha-${nome}.ts não exporta MODULOS/NOME.`);
+        process.exit(1);
+    }
+
+    const { estruturais, avisos } = qc(MODULOS);
+    avisos.forEach((p) => console.warn("  aviso:", p));
+    if (estruturais.length) {
+        estruturais.forEach((p) => console.error("  QC:", p));
+        console.error(`Abortado: ${estruturais.length} problema(s) estrutural(is).`);
+        process.exit(1);
+    }
+
+    const [trilha] = await db.select().from(trails).where(eq(trails.name, NOME));
+    if (!trilha) {
+        console.error(`Trilha "${NOME}" não existe no banco (rode o seed antes).`);
+        process.exit(1);
+    }
+    const mods = await db
+        .select()
+        .from(modules)
+        .where(eq(modules.trailId, trilha.id))
+        .orderBy(asc(modules.position));
+
+    let inseridas = 0;
+    for (let mi = 0; mi < MODULOS.length; mi++) {
+        const dbmod = mods.find((m) => m.position === mi + 1);
+        if (!dbmod) {
+            console.warn(`módulo ${mi + 1} não encontrado no banco`);
+            continue;
+        }
+        const ls = await db
+            .select()
+            .from(lessons)
+            .where(eq(lessons.moduleId, dbmod.id))
+            .orderBy(asc(lessons.position));
+        for (let li = 0; li < MODULOS[mi].aulas.length; li++) {
+            const dblesson = ls.find((l) => l.position === li + 1);
+            if (!dblesson) {
+                console.warn(`aula ${mi + 1}.${li + 1} não encontrada no banco`);
+                continue;
+            }
+            const qs = await db
+                .select()
+                .from(questions)
+                .where(eq(questions.lessonId, dblesson.id))
+                .orderBy(asc(questions.position));
+            const existentes = new Set(qs.map((q) => q.statement));
+            let pos = qs.reduce((mx, q) => Math.max(mx, q.position), 0);
+            for (const q of MODULOS[mi].aulas[li].questions) {
+                if (existentes.has(q.statement)) continue;
+                pos++;
+                inseridas++;
+                if (dry) continue;
+                const [nova] = await db
+                    .insert(questions)
+                    .values({ lessonId: dblesson.id, statement: q.statement, difficulty: q.difficulty, position: pos })
+                    .returning();
+                await db.insert(questionOptions).values(
+                    q.options.map((o, k) => ({
+                        questionId: nova.id,
+                        text: o.text,
+                        isCorrect: o.isCorrect,
+                        position: k + 1,
+                    })),
+                );
+            }
+        }
+    }
+    console.log(`\n${dry ? "[DRY] " : ""}Trilha "${NOME}": questões inseridas: ${inseridas}`);
+    process.exit(0);
+}
+
+main().catch((e) => {
+    console.error("Falha ao sincronizar questões:", e);
+    process.exit(1);
+});

--- a/frontend/src/components/BlocosConteudo.tsx
+++ b/frontend/src/components/BlocosConteudo.tsx
@@ -151,13 +151,30 @@ export function BlocosConteudo({ blocks }: { blocks: Bloco[] }) {
 }
 
 // Texto curto com fórmulas ($...$ inline, $$...$$ em bloco), para enunciado e opções
-// de quiz. Sem <p> para não quebrar o layout inline dos rótulos.
+// de quiz. Sem <p> para não quebrar o layout inline dos rótulos. Código em cerca
+// (```...```) vira bloco com indentação preservada; código inline (`x`) fica inline.
 export function TextoMath({ children }: { children: string }) {
   return (
     <ReactMarkdown
       remarkPlugins={[remarkGfm, remarkMath]}
       rehypePlugins={[rehypeKatex]}
-      components={{ p: ({ children }) => <>{children}</> }}
+      components={{
+        p: ({ children }) => <>{children}</>,
+        pre: ({ children }) => (
+          <div className="codeblock" style={{ margin: '12px 0' }}>
+            <pre className="codeblock__code">{children}</pre>
+          </div>
+        ),
+        code: ({ children }) => {
+          const txt = Array.isArray(children) ? children.join('') : String(children ?? '');
+          // Multi-linha = bloco (dentro do <pre>, herda o estilo); senão, código inline.
+          return txt.includes('\n') ? (
+            <code>{children}</code>
+          ) : (
+            <code className="code-inline">{children}</code>
+          );
+        },
+      }}
     >
       {children}
     </ReactMarkdown>


### PR DESCRIPTION
Dois ajustes nas trilhas.

Questões por aula (Java, C++, Go): essas trilhas tinham só 3 questões por aula, e como concluir a aula exige 4 acertos, dava pra travar sem conseguir avançar. Cada aula ganhou mais 2 questões sobre o próprio conteúdo (168 no total), com as alternativas equilibradas.

Indentação do código no quiz: sem cerca de código, o markdown do enunciado colapsava os espaços e a indentação sumia, o que atrapalhava principalmente as questões de Python. Agora o código aparece como bloco, com a indentação preservada.

Após o deploy falta aplicar em produção: cercar os enunciados já existentes e inserir as questões novas nas trilhas já semeadas, sem alterar o que já está lá.
