### PR TITLE
feat: página inicial pública com os números reais da plataforma

### DIFF
--- a/backend/src/controllers/TrailController.ts
+++ b/backend/src/controllers/TrailController.ts
@@ -28,7 +28,7 @@ import {
     atualizarLinguagem,
     excluirLinguagem,
 } from "../services/language.service.ts";
-import { calcularEstatisticas } from "../services/stats.service.ts";
+import { calcularEstatisticas, estatisticasPublicas } from "../services/stats.service.ts";
 import {
     listarConquistas,
     criarConquista,
@@ -390,6 +390,15 @@ export const submitQuiz = async (req: Request, res: Response, next: NextFunction
 export const getMyXp = async (req: Request, res: Response, next: NextFunction) => {
     try {
         res.json(await calcularEstatisticas(req.userId!));
+    } catch (err) {
+        next(err);
+    }
+};
+
+// Números da plataforma para a página inicial pública (sem login). Só agregados.
+export const getPublicStats = async (_req: Request, res: Response, next: NextFunction) => {
+    try {
+        res.json(await estatisticasPublicas());
     } catch (err) {
         next(err);
     }

--- a/backend/src/routes/trail.routes.ts
+++ b/backend/src/routes/trail.routes.ts
@@ -46,9 +46,13 @@ import {
     getCommunityAchievements,
     getRanking,
     getMyStreak,
+    getPublicStats,
 } from "../controllers/TrailController.ts";
 
 const router = Router();
+
+// Números da plataforma para a página inicial, antes de qualquer login.
+router.get("/estatisticas-publicas", getPublicStats);
 
 // Catálogo (admin cria, qualquer logado lê)
 router.post("/trails", autenticar, exigirAdmin, createTrail);

--- a/backend/src/services/stats.service.ts
+++ b/backend/src/services/stats.service.ts
@@ -1,5 +1,15 @@
 import { db } from "../../db.ts";
-import { lessonProgress, questionAnswers, challengeSubmissions } from "../../schema.ts";
+import {
+    lessonProgress,
+    questionAnswers,
+    challengeSubmissions,
+    trails,
+    lessons,
+    questions,
+    challenges,
+    simulados,
+    users,
+} from "../../schema.ts";
 import { eq, and, count, sum, gt } from "drizzle-orm";
 import { calcularXp, nivelPorXp } from "../domain/xp.ts";
 
@@ -30,4 +40,44 @@ export async function calcularEstatisticas(userId: string) {
         questionsCorrect,
         challengesCompleted,
     };
+}
+
+// Contagens agregadas para a página inicial, sem nenhum dado de usuário. Ficam
+// alguns minutos em memória para uma visita não virar sete count() no banco.
+export type EstatisticasPublicas = {
+    trilhas: number;
+    aulas: number;
+    desafios: number;
+    simulados: number;
+    questoes: number;
+    estudantes: number;
+    exerciciosResolvidos: number;
+};
+
+const CACHE_PUBLICO_MS = 5 * 60 * 1000;
+let cachePublico: { dados: EstatisticasPublicas; expiraEm: number } | null = null;
+
+export async function estatisticasPublicas(): Promise<EstatisticasPublicas> {
+    if (cachePublico && cachePublico.expiraEm > Date.now()) return cachePublico.dados;
+    const [trilhas, aulas, desafios, provas, questoesAula, estudantes, respostas] =
+        await Promise.all([
+            db.select({ n: count() }).from(trails),
+            db.select({ n: count() }).from(lessons).where(eq(lessons.published, true)),
+            db.select({ n: count() }).from(challenges).where(eq(challenges.published, true)),
+            db.select({ n: count() }).from(simulados),
+            db.select({ n: count() }).from(questions),
+            db.select({ n: count() }).from(users),
+            db.select({ n: count() }).from(questionAnswers),
+        ]);
+    const dados: EstatisticasPublicas = {
+        trilhas: Number(trilhas[0]?.n ?? 0),
+        aulas: Number(aulas[0]?.n ?? 0),
+        desafios: Number(desafios[0]?.n ?? 0),
+        simulados: Number(provas[0]?.n ?? 0),
+        questoes: Number(questoesAula[0]?.n ?? 0),
+        estudantes: Number(estudantes[0]?.n ?? 0),
+        exerciciosResolvidos: Number(respostas[0]?.n ?? 0),
+    };
+    cachePublico = { dados, expiraEm: Date.now() + CACHE_PUBLICO_MS };
+    return dados;
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,16 +2,15 @@ import { lazy, Suspense } from 'react';
 import { BrowserRouter, Routes, Route, Navigate, useParams } from 'react-router-dom';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
 import { ToastProvider } from './contexts/ToastContext';
-import { Login } from './pages/Login';
+import { Landing } from './pages/Landing';
 import { ComunicadoPrompt } from './components/ComunicadoPrompt';
 import { BottomNav } from './components/BottomNav';
 import { ConquistaToaster } from './components/ConquistaToaster';
 
-// Cada página vira um pedaço próprio do bundle, baixado só quando a rota abre.
-// Antes tudo vinha num arquivo só, então quem entrava baixava o app inteiro para
-// ver uma tela. O Login continua junto do pacote principal por ser a primeira
-// tela de quem chega deslogado. As páginas exportam por nome, e o lazy espera um
-// export default, daí a adaptação em cada linha.
+// Cada página é baixada só quando a rota abre. A Landing fica no pacote principal
+// por ser a primeira tela de quem chega. As páginas exportam por nome, e o lazy
+// espera um export default, daí a adaptação em cada linha.
+const Login = lazy(() => import('./pages/Login').then((m) => ({ default: m.Login })));
 const Register = lazy(() => import('./pages/Register').then((m) => ({ default: m.Register })));
 const Home = lazy(() => import('./pages/Home').then((m) => ({ default: m.Home })));
 const Trilhas = lazy(() => import('./pages/Trilhas').then((m) => ({ default: m.Trilhas })));
@@ -103,14 +102,14 @@ function AuthRoute({ children }: { children: React.JSX.Element }) {
 
   if (loading) return <div>Carregando...</div>;
 
-  return isAuthenticated ? children : <Navigate to="/" />;
+  return isAuthenticated ? children : <Navigate to="/entrar" />;
 }
 
 function PrivateRoute({ children }: { children: React.JSX.Element }) {
   const { isAuthenticated, user, loading } = useAuth();
 
   if (loading) return <div>Carregando...</div>;
-  if (!isAuthenticated) return <Navigate to="/" />;
+  if (!isAuthenticated) return <Navigate to="/entrar" />;
   if (!user?.username) return <Navigate to="/completar-perfil" replace />;
   return children;
 }
@@ -119,7 +118,7 @@ function AdminRoute({ children }: { children: React.JSX.Element }) {
   const { user, isAuthenticated, loading } = useAuth();
 
   if (loading) return <div>Carregando...</div>;
-  if (!isAuthenticated) return <Navigate to="/" />;
+  if (!isAuthenticated) return <Navigate to="/entrar" />;
   if (!user?.username) return <Navigate to="/completar-perfil" replace />;
   return user?.role === 'admin' ? children : <Navigate to="/home" />;
 }
@@ -146,7 +145,8 @@ function AppRoutes() {
       <ComunicadoPrompt />
       <Suspense fallback={<div className="lesson__loading">Carregando...</div>}>
         <Routes>
-          <Route path="/" element={isAuthenticated ? <Navigate to="/home" /> : <Login />} />
+          <Route path="/" element={isAuthenticated ? <Navigate to="/home" /> : <Landing />} />
+          <Route path="/entrar" element={isAuthenticated ? <Navigate to="/home" /> : <Login />} />
           <Route
             path="/cadastro"
             element={isAuthenticated ? <Navigate to="/home" /> : <Register />}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -7,4 +7,5 @@
 @import './styles/trilha-detalhe.css';
 @import './styles/comunidade.css';
 @import './styles/roadmap.css';
+@import './styles/landing.css';
 @import './styles/mobile.css';

--- a/frontend/src/pages/Landing/index.tsx
+++ b/frontend/src/pages/Landing/index.tsx
@@ -1,0 +1,358 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import api from '../../services/api';
+import { Logo } from '../../components/Logo';
+import { ThemeToggle } from '../../components/ThemeToggle';
+import {
+  Zap,
+  Flame,
+  Trophy,
+  BookOpen,
+  ClockExam,
+  Target,
+  ChevronRight,
+  Github,
+  Linkedin,
+  XSocial,
+} from '../../components/Icons';
+
+// Vêm do backend para a página nunca anunciar um número que envelheceu no código.
+type Estatisticas = {
+  trilhas: number;
+  aulas: number;
+  desafios: number;
+  simulados: number;
+  questoes: number;
+  estudantes: number;
+  exerciciosResolvidos: number;
+};
+
+const numero = new Intl.NumberFormat('pt-BR');
+
+// Arredonda para baixo e marca com "+": 1293 vira "1.200+", 142 vira "100+". Continua
+// verdadeiro, e a vitrine não muda de número a cada aluno novo que entra.
+function aproximado(n: number): string {
+  if (n < 10) return numero.format(n);
+  const passo = n >= 100 ? 100 : 10;
+  return `${numero.format(Math.floor(n / passo) * passo)}+`;
+}
+
+// Traço enquanto carrega e também quando o número é zero: numa vitrine, anunciar
+// "0 desafios" é pior do que não anunciar nada.
+function Numero({ valor }: { valor?: number }) {
+  if (!valor) return <span className="lp-stat__num lp-stat__num--vazio">--</span>;
+  return <span className="lp-stat__num">{aproximado(valor)}</span>;
+}
+
+const RECURSOS = [
+  {
+    icone: <Zap size={20} />,
+    titulo: 'Desafio do dia',
+    texto:
+      'Um problema novo a cada dia, resolvido no editor da própria plataforma. Roda seus testes na hora e conta XP na primeira vez que passa.',
+  },
+  {
+    icone: <Flame size={20} />,
+    titulo: 'Streak que segura o hábito',
+    texto:
+      'Cada dia de estudo mantém sua sequência viva. É o lembrete diário de que constância vale mais do que maratona.',
+  },
+  {
+    icone: <Trophy size={20} />,
+    titulo: 'Ranking e ligas',
+    texto:
+      'Seu XP te posiciona entre os outros estudantes e sobe as ligas, de Bronze até Diamante.',
+  },
+  {
+    icone: <BookOpen size={20} />,
+    titulo: 'Trilhas guiadas',
+    texto:
+      'Da lógica de programação ao Kubernetes, com aula, exemplo e quiz. Sem pular etapa e sem se perder na ordem.',
+  },
+  {
+    icone: <ClockExam size={20} />,
+    titulo: 'Simulados de certificação',
+    texto:
+      'Provas cronometradas no formato oficial, para AWS, Azure e mais. Ao errar, você vê a resolução passo a passo.',
+  },
+  {
+    icone: <Target size={20} />,
+    titulo: 'Progresso que dá para ver',
+    texto:
+      'Mapa de atividade do ano, XP por trilha, conquistas e meta semanal. Sua evolução em números, não em sensação.',
+  },
+];
+
+const PASSOS = [
+  {
+    n: '01',
+    titulo: 'Crie sua conta grátis',
+    texto: 'Leva menos de um minuto. Sem cartão de crédito, sem complicação.',
+  },
+  {
+    n: '02',
+    titulo: 'Escolha por onde começar',
+    texto: 'Siga um roadmap de carreira, uma trilha específica ou vá direto no desafio do dia.',
+  },
+  {
+    n: '03',
+    titulo: 'Volte amanhã',
+    texto: 'Mantenha o streak, junte XP e acompanhe a evolução subindo no ranking.',
+  },
+];
+
+// Tecnologias que têm trilha de verdade na plataforma.
+const TECNOLOGIAS = ['Python', 'JavaScript', 'Java', 'Go', 'Linux', 'Docker', 'Kubernetes', 'AWS'];
+
+export function Landing() {
+  const [stats, setStats] = useState<Estatisticas>();
+
+  useEffect(() => {
+    let ativo = true;
+    api
+      .get<Estatisticas>('/estatisticas-publicas')
+      .then(({ data }) => {
+        if (ativo) setStats(data);
+      })
+      .catch((e) => {
+        // A página se sustenta sem os números, então a visita não é interrompida.
+        console.error('Não foi possível carregar as estatísticas públicas', e);
+      });
+    return () => {
+      ativo = false;
+    };
+  }, []);
+
+  return (
+    <div className="lp">
+      <header className="lp-topbar">
+        <div className="lp-container lp-topbar__inner">
+          <Logo variant="solid" size={19} to="/" />
+          <nav className="lp-nav">
+            <a href="#recursos">Recursos</a>
+            <a href="#trilhas">Trilhas</a>
+            <a href="#como-funciona">Como funciona</a>
+          </nav>
+          <div className="lp-topbar__acoes">
+            <span className="lp-tema">
+              <ThemeToggle inline />
+            </span>
+            <Link className="lp-link-entrar" to="/entrar">
+              Entrar
+            </Link>
+            <Link className="btn btn--accent lp-btn-topo" to="/cadastro">
+              Começar grátis
+            </Link>
+          </div>
+        </div>
+      </header>
+
+      <main>
+        <section className="lp-hero">
+          <div className="lp-container lp-hero__inner">
+            <div className="lp-hero__texto">
+              <span className="lp-badge">
+                <Flame size={13} /> Um novo desafio todo dia
+              </span>
+              <h1 className="lp-h1">
+                Aprenda a programar resolvendo <span className="lp-h1__destaque">um desafio</span>{' '}
+                por dia.
+              </h1>
+              <p className="lp-lede">
+                A ensina.dev transforma o aprendizado de programação em hábito. Desafios diários,
+                trilhas guiadas, simulados de certificação e um ranking para te manter no ritmo, do
+                zero à sua primeira vaga.
+              </p>
+              <div className="lp-hero__ctas">
+                <Link className="btn btn--accent lp-btn-grande" to="/cadastro">
+                  Criar conta grátis <ChevronRight size={14} />
+                </Link>
+                <a className="btn lp-btn-secundario" href="#como-funciona">
+                  Ver como funciona
+                </a>
+              </div>
+              <p className="lp-hero__prova">
+                {stats ? (
+                  <>
+                    <strong>{aproximado(stats.estudantes)} alunos</strong> já estudam na ensina.dev
+                  </>
+                ) : (
+                  <>Comece hoje, de graça</>
+                )}
+              </p>
+            </div>
+
+            <div className="lp-mock" aria-hidden="true">
+              <div className="lp-mock__barra">
+                <span className="lp-mock__ponto" style={{ background: '#ff5f57' }} />
+                <span className="lp-mock__ponto" style={{ background: '#febc2e' }} />
+                <span className="lp-mock__ponto" style={{ background: '#28c840' }} />
+                <span className="lp-mock__arquivo">desafio-do-dia</span>
+              </div>
+              <div className="lp-mock__corpo">
+                <div className="lp-mock__tags">
+                  <span className="lp-tag lp-tag--facil">Fácil</span>
+                  <span className="lp-tag">+50 XP</span>
+                  <span className="lp-tag lp-tag--streak">
+                    <Flame size={12} /> 12 dias
+                  </span>
+                </div>
+                <h3 className="lp-mock__titulo">Soma de dois números</h3>
+                <pre className="lp-mock__codigo">
+                  <code>{`function soma(nums, alvo) {
+  const mapa = {};
+  for (let i = 0; i < nums.length; i++) {
+    // resolva aqui
+  }
+}`}</code>
+                </pre>
+                <span className="btn btn--accent lp-mock__botao">Resolver agora</span>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="lp-tecnologias" id="trilhas">
+          <div className="lp-container">
+            <p className="lp-olho lp-olho--centro">O que você aprende aqui</p>
+            <ul className="lp-tecnologias__lista">
+              {TECNOLOGIAS.map((t) => (
+                <li key={t}>{t}</li>
+              ))}
+            </ul>
+            <p className="lp-tecnologias__nota">
+              {stats ? (
+                <>
+                  e mais {numero.format(stats.trilhas - TECNOLOGIAS.length)} trilhas, de lógica de
+                  programação a machine learning
+                </>
+              ) : (
+                <>e muitas outras trilhas, de lógica de programação a machine learning</>
+              )}
+            </p>
+          </div>
+        </section>
+
+        <section className="lp-numeros">
+          <div className="lp-container lp-numeros__grade">
+            <div className="lp-stat">
+              <Numero valor={stats?.estudantes} />
+              <span className="lp-stat__rotulo">alunos</span>
+            </div>
+            <div className="lp-stat">
+              <Numero valor={stats?.aulas} />
+              <span className="lp-stat__rotulo">aulas publicadas</span>
+            </div>
+            <div className="lp-stat">
+              <Numero valor={stats?.desafios} />
+              <span className="lp-stat__rotulo">desafios de código</span>
+            </div>
+            <div className="lp-stat">
+              <Numero valor={stats?.simulados} />
+              <span className="lp-stat__rotulo">simulados de certificação</span>
+            </div>
+          </div>
+        </section>
+
+        <section className="lp-secao" id="recursos">
+          <div className="lp-container">
+            <p className="lp-olho lp-olho--centro">Por que ensina.dev</p>
+            <h2 className="lp-h2">Feito para criar o hábito de programar</h2>
+            <p className="lp-sub">
+              Tudo o que você precisa para sair da teoria e praticar de verdade, todos os dias.
+            </p>
+            <div className="lp-cards">
+              {RECURSOS.map((r) => (
+                <article className="lp-card" key={r.titulo}>
+                  <span className="lp-card__icone">{r.icone}</span>
+                  <h3 className="lp-card__titulo">{r.titulo}</h3>
+                  <p className="lp-card__texto">{r.texto}</p>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="lp-secao lp-secao--alt" id="como-funciona">
+          <div className="lp-container">
+            <p className="lp-olho lp-olho--centro">Como funciona</p>
+            <h2 className="lp-h2">Comece em 3 passos</h2>
+            <div className="lp-passos">
+              {PASSOS.map((p) => (
+                <article className="lp-passo" key={p.n}>
+                  <span className="lp-passo__n">{p.n}</span>
+                  <h3 className="lp-card__titulo">{p.titulo}</h3>
+                  <p className="lp-card__texto">{p.texto}</p>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="lp-secao">
+          <div className="lp-container">
+            <div className="lp-cta">
+              <h2 className="lp-cta__titulo">Seu próximo desafio começa hoje.</h2>
+              <p className="lp-cta__texto">
+                Crie sua conta grátis, resolva o desafio do dia e comece seu streak agora mesmo.
+              </p>
+              <Link className="btn lp-cta__botao" to="/cadastro">
+                Criar conta grátis
+              </Link>
+              <p className="lp-cta__nota">Sem cartão de crédito. Comece em segundos.</p>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <footer className="lp-rodape">
+        <div className="lp-container lp-rodape__grade">
+          <div className="lp-rodape__marca">
+            <Logo variant="solid" size={18} />
+            <p>
+              {stats ? (
+                <>
+                  {aproximado(stats.aulas)} aulas e {aproximado(stats.questoes)} questões para você
+                  praticar programação todo dia.
+                </>
+              ) : (
+                <>Aprenda a programar resolvendo um desafio por dia.</>
+              )}
+            </p>
+          </div>
+          <nav className="lp-rodape__col">
+            <h4>Plataforma</h4>
+            <a href="#recursos">Recursos</a>
+            <a href="#trilhas">Trilhas</a>
+            <a href="#como-funciona">Como funciona</a>
+          </nav>
+          <nav className="lp-rodape__col">
+            <h4>Conta</h4>
+            <Link to="/entrar">Entrar</Link>
+            <Link to="/cadastro">Criar conta</Link>
+            <Link to="/recuperar-senha">Recuperar senha</Link>
+          </nav>
+        </div>
+        <div className="lp-container lp-rodape__base">
+          <span>© {new Date().getFullYear()} ensina.dev. Todos os direitos reservados.</span>
+          <span className="lp-rodape__redes">
+            <a
+              href="https://github.com/jpavrdev"
+              target="_blank"
+              rel="noreferrer"
+              aria-label="GitHub"
+            >
+              <Github size={16} />
+            </a>
+            <a href="https://linkedin.com" target="_blank" rel="noreferrer" aria-label="LinkedIn">
+              <Linkedin size={16} />
+            </a>
+            <a href="https://x.com" target="_blank" rel="noreferrer" aria-label="X">
+              <XSocial size={16} />
+            </a>
+          </span>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/frontend/src/pages/OAuthCallback/index.tsx
+++ b/frontend/src/pages/OAuthCallback/index.tsx
@@ -37,7 +37,7 @@ export function OAuthCallback() {
             <div className="verify-icon verify-icon--erro">!</div>
             <h1 className="verify-title">Não foi possível entrar</h1>
             <p className="verify-text">Tente novamente pela tela de login.</p>
-            <Link className="btn btn--ghost btn--block" to="/">
+            <Link className="btn btn--ghost btn--block" to="/entrar">
               Voltar ao login
             </Link>
           </>

--- a/frontend/src/pages/PerfilPublico/index.tsx
+++ b/frontend/src/pages/PerfilPublico/index.tsx
@@ -131,7 +131,7 @@ export function PerfilPublico() {
             <Logo variant="solid" size={20} to="/" />
             <div className="topbar__spacer" />
             <ThemeToggle inline />
-            <Link className="btn btn--ghost" to="/">
+            <Link className="btn btn--ghost" to="/entrar">
               Entrar
             </Link>
           </header>

--- a/frontend/src/pages/RecuperarSenha/index.tsx
+++ b/frontend/src/pages/RecuperarSenha/index.tsx
@@ -73,7 +73,7 @@ export function RecuperarSenha() {
         <>
           <div className="auth__alert auth__alert--ok">{mensagem}</div>
           <p className="auth__foot">
-            <Link className="link" to="/">
+            <Link className="link" to="/entrar">
               Voltar ao login
             </Link>
           </p>
@@ -111,7 +111,7 @@ export function RecuperarSenha() {
           </div>
           <p className="auth__foot">
             Lembrou a senha?{' '}
-            <Link className="link" to="/">
+            <Link className="link" to="/entrar">
               Voltar ao login
             </Link>
           </p>

--- a/frontend/src/pages/RedefinirSenha/index.tsx
+++ b/frontend/src/pages/RedefinirSenha/index.tsx
@@ -65,7 +65,7 @@ export function RedefinirSenha() {
         <>
           <h2 className="auth__title">Senha redefinida!</h2>
           <p className="auth__subtitle">Já pode entrar com a sua nova senha.</p>
-          <Link className="btn btn--accent btn--block" to="/">
+          <Link className="btn btn--accent btn--block" to="/entrar">
             Ir para o login
           </Link>
         </>
@@ -104,7 +104,7 @@ export function RedefinirSenha() {
             </button>
           </form>
           <p className="auth__foot">
-            <Link className="link" to="/">
+            <Link className="link" to="/entrar">
               Voltar ao login
             </Link>
           </p>

--- a/frontend/src/pages/Register/index.tsx
+++ b/frontend/src/pages/Register/index.tsx
@@ -87,7 +87,7 @@ export function Register() {
         gender,
         phone: phone.trim(),
       });
-      navigate('/');
+      navigate('/entrar');
     } catch (e: unknown) {
       // Mapeia os erros conhecidos do backend (409) para o campo certo.
       const msg = mensagemErro(e, 'Erro ao criar conta. Tente novamente.');
@@ -226,7 +226,7 @@ export function Register() {
       </p>
       <p className="auth__foot">
         Já tem conta?{' '}
-        <Link className="link" to="/">
+        <Link className="link" to="/entrar">
           Entrar
         </Link>
       </p>

--- a/frontend/src/pages/VerifyEmail/index.tsx
+++ b/frontend/src/pages/VerifyEmail/index.tsx
@@ -51,7 +51,7 @@ export function VerifyEmail() {
             <div className="verify-icon verify-icon--ok">✓</div>
             <h1 className="verify-title">Email verificado!</h1>
             <p className="verify-text">{mensagem}</p>
-            <Link className="btn btn--accent btn--block" to="/">
+            <Link className="btn btn--accent btn--block" to="/entrar">
               Ir para o login
             </Link>
           </>
@@ -62,7 +62,7 @@ export function VerifyEmail() {
             <div className="verify-icon verify-icon--erro">!</div>
             <h1 className="verify-title">Não foi possível verificar</h1>
             <p className="verify-text">{mensagem}</p>
-            <Link className="btn btn--ghost btn--block" to="/">
+            <Link className="btn btn--ghost btn--block" to="/entrar">
               Voltar ao login
             </Link>
           </>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -61,7 +61,7 @@ api.interceptors.response.use(
       // Refresh falhou (refresh inválido/expirado): desloga
       fila = [];
       localStorage.clear();
-      window.location.href = '/';
+      window.location.href = '/entrar';
       return Promise.reject(err);
     } finally {
       isRefreshing = false;

--- a/frontend/src/styles/landing.css
+++ b/frontend/src/styles/landing.css
@@ -1,0 +1,595 @@
+/* Página inicial pública. O prefixo .lp- evita colisão com as telas de dentro
+   do app, e as cores saem de tokens.css, então o tema escuro vem de graça. */
+
+.lp {
+  min-height: 100%;
+  background: var(--bg);
+}
+.lp-container {
+  width: 100%;
+  max-width: 1320px;
+  margin: 0 auto;
+  padding: 0 40px;
+}
+
+/* ===================== TOPO ===================== */
+.lp-topbar {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  background: color-mix(in srgb, var(--bg) 88%, transparent);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--border);
+}
+.lp-topbar__inner {
+  display: flex;
+  align-items: center;
+  gap: 28px;
+  height: 68px;
+}
+/* Sem isso a barra espreme o logo e o botão, e os dois quebram em duas linhas. */
+.lp-topbar__inner > .logo,
+.lp-topbar__acoes {
+  flex-shrink: 0;
+}
+.lp-topbar__inner .logo__word,
+.lp-nav a,
+.lp-link-entrar,
+.lp-btn-topo {
+  white-space: nowrap;
+}
+.lp-nav {
+  display: flex;
+  align-items: center;
+  gap: 26px;
+  margin-left: 12px;
+}
+.lp-nav a {
+  color: var(--muted);
+  text-decoration: none;
+  font-size: 14.5px;
+  font-weight: 500;
+}
+.lp-nav a:hover {
+  color: var(--text);
+}
+.lp-topbar__acoes {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-left: auto;
+}
+.lp-link-entrar {
+  color: var(--text);
+  text-decoration: none;
+  font-size: 14.5px;
+  font-weight: 600;
+}
+.lp-link-entrar:hover {
+  color: var(--accent);
+}
+.lp-btn-topo {
+  height: 40px;
+  padding: 0 18px;
+  font-size: 14px;
+  text-decoration: none;
+}
+
+/* ===================== HERO ===================== */
+.lp-hero {
+  padding: 80px 0 92px;
+}
+.lp-hero__inner {
+  display: grid;
+  grid-template-columns: 1.05fr 1fr;
+  gap: 72px;
+  align-items: center;
+}
+.lp-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 13px;
+  font-weight: 600;
+}
+.lp-h1 {
+  margin: 22px 0 0;
+  font-size: 58px;
+  line-height: 1.06;
+  letter-spacing: -0.035em;
+  font-weight: 700;
+}
+.lp-h1__destaque {
+  color: var(--accent);
+}
+.lp-lede {
+  margin: 22px 0 0;
+  max-width: 34em;
+  color: var(--muted);
+  font-size: 16.5px;
+  line-height: 1.65;
+}
+.lp-hero__ctas {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 30px;
+}
+.lp-btn-grande {
+  height: 52px;
+  padding: 0 26px;
+  font-size: 15px;
+  text-decoration: none;
+}
+.lp-btn-secundario {
+  height: 52px;
+  padding: 0 26px;
+  font-size: 15px;
+  background: var(--surface);
+  border-color: var(--border-strong);
+  color: var(--text);
+  text-decoration: none;
+}
+.lp-btn-secundario:hover {
+  border-color: var(--accent);
+}
+.lp-hero__prova {
+  margin: 26px 0 0;
+  color: var(--muted);
+  font-size: 14px;
+}
+.lp-hero__prova strong {
+  color: var(--text);
+}
+
+/* Cartão ilustrativo do desafio do dia */
+.lp-mock {
+  border: 1px solid var(--border);
+  border-radius: var(--r-2xl);
+  background: var(--surface);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+.lp-mock__barra {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 40px;
+  padding: 0 16px;
+  background: var(--surface-2);
+  border-bottom: 1px solid var(--border);
+}
+.lp-mock__ponto {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+}
+.lp-mock__arquivo {
+  margin-left: 8px;
+  font-family: var(--font-code);
+  font-size: 12px;
+  color: var(--muted);
+}
+.lp-mock__corpo {
+  padding: 20px;
+}
+.lp-mock__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.lp-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: var(--surface-2);
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 600;
+}
+.lp-tag--facil {
+  background: var(--success-soft);
+  color: var(--success);
+}
+.lp-tag--streak {
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+.lp-mock__titulo {
+  margin: 14px 0 12px;
+  font-size: 19px;
+  letter-spacing: -0.02em;
+}
+.lp-mock__codigo {
+  margin: 0 0 16px;
+  padding: 16px;
+  border-radius: var(--r-lg);
+  background: var(--input);
+  border: 1px solid var(--border);
+  font-family: var(--font-code);
+  font-size: 12.5px;
+  line-height: 1.7;
+  color: var(--text);
+  overflow-x: auto;
+}
+.lp-mock__botao {
+  width: 100%;
+  height: 44px;
+  font-size: 14.5px;
+}
+
+/* ===================== TECNOLOGIAS ===================== */
+.lp-tecnologias {
+  padding: 8px 0 48px;
+}
+.lp-tecnologias__lista {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 14px 38px;
+  list-style: none;
+  margin: 20px 0 0;
+  padding: 0;
+}
+.lp-tecnologias__lista li {
+  color: var(--muted);
+  font-size: 21px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  opacity: 0.75;
+}
+.lp-tecnologias__nota {
+  margin: 18px 0 0;
+  text-align: center;
+  color: var(--muted);
+  font-size: 13.5px;
+}
+
+/* ===================== NÚMEROS ===================== */
+.lp-numeros {
+  padding: 8px 0 24px;
+}
+.lp-numeros__grade {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  border: 1px solid var(--border);
+  border-radius: var(--r-2xl);
+  background: var(--surface);
+  overflow: hidden;
+}
+.lp-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 30px 16px;
+  border-right: 1px solid var(--border);
+}
+.lp-stat:last-child {
+  border-right: 0;
+}
+.lp-stat__num {
+  font-size: 34px;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  color: var(--accent);
+}
+.lp-stat__num--vazio {
+  color: var(--muted);
+  opacity: 0.5;
+}
+.lp-stat__rotulo {
+  color: var(--muted);
+  font-size: 13.5px;
+  text-align: center;
+}
+
+/* ===================== SEÇÕES ===================== */
+.lp-secao {
+  padding: 76px 0;
+}
+.lp-secao--alt {
+  background: var(--surface-2);
+}
+.lp-olho {
+  color: var(--accent);
+  font-size: 12.5px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  margin: 0;
+}
+.lp-olho--centro {
+  text-align: center;
+}
+.lp-h2 {
+  margin: 14px 0 0;
+  text-align: center;
+  font-size: 36px;
+  line-height: 1.15;
+  letter-spacing: -0.03em;
+  font-weight: 700;
+}
+.lp-sub {
+  margin: 16px auto 0;
+  max-width: 34em;
+  text-align: center;
+  color: var(--muted);
+  font-size: 15.5px;
+  line-height: 1.6;
+}
+
+.lp-cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+  margin-top: 44px;
+}
+.lp-card {
+  padding: 26px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-2xl);
+  background: var(--surface);
+}
+.lp-card__icone {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  border-radius: var(--r-lg);
+  background: var(--accent-soft);
+  color: var(--accent);
+  margin-bottom: 16px;
+}
+.lp-card__titulo {
+  margin: 0 0 8px;
+  font-size: 17px;
+  letter-spacing: -0.02em;
+}
+.lp-card__texto {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14.5px;
+  line-height: 1.62;
+}
+
+.lp-passos {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+  margin-top: 44px;
+}
+.lp-passo {
+  padding: 26px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-2xl);
+  background: var(--surface);
+}
+.lp-passo__n {
+  display: block;
+  font-size: 34px;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  color: var(--border-strong);
+  margin-bottom: 12px;
+}
+
+/* ===================== CHAMADA FINAL ===================== */
+.lp-cta {
+  padding: 64px 32px;
+  border-radius: 24px;
+  background: linear-gradient(
+    135deg,
+    var(--accent),
+    color-mix(in srgb, var(--accent) 72%, #101a3a)
+  );
+  text-align: center;
+  color: #fff;
+}
+.lp-cta__titulo {
+  margin: 0;
+  font-size: 38px;
+  line-height: 1.15;
+  letter-spacing: -0.03em;
+  font-weight: 700;
+}
+.lp-cta__texto {
+  margin: 16px auto 0;
+  max-width: 32em;
+  font-size: 15.5px;
+  line-height: 1.6;
+  color: rgba(255, 255, 255, 0.86);
+}
+.lp-cta__botao {
+  margin-top: 28px;
+  height: 50px;
+  padding: 0 30px;
+  background: #fff;
+  color: var(--accent);
+  font-size: 15px;
+  text-decoration: none;
+}
+.lp-cta__botao:hover {
+  filter: brightness(0.96);
+}
+.lp-cta__nota {
+  margin: 16px 0 0;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+/* ===================== RODAPÉ ===================== */
+.lp-rodape {
+  border-top: 1px solid var(--border);
+  background: var(--surface);
+  padding: 52px 0 26px;
+}
+.lp-rodape__grade {
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr;
+  gap: 36px;
+}
+.lp-rodape__marca p {
+  margin: 14px 0 0;
+  max-width: 30em;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.6;
+}
+.lp-rodape__col {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.lp-rodape__col h4 {
+  margin: 0 0 4px;
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text);
+}
+.lp-rodape__col a {
+  color: var(--muted);
+  text-decoration: none;
+  font-size: 14px;
+}
+.lp-rodape__col a:hover {
+  color: var(--accent);
+}
+.lp-rodape__base {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-top: 40px;
+  padding-top: 22px;
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 13px;
+}
+.lp-rodape__redes {
+  display: flex;
+  gap: 12px;
+}
+.lp-rodape__redes a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--r-md);
+  border: 1px solid var(--border);
+  color: var(--muted);
+}
+.lp-rodape__redes a:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+/* ===================== TELAS MENORES ===================== */
+@media (max-width: 900px) {
+  /* A partir daqui a barra não comporta os atalhos junto com os botões. */
+  .lp-nav {
+    display: none;
+  }
+  .lp-container {
+    padding: 0 28px;
+  }
+  .lp-hero__inner {
+    grid-template-columns: 1fr;
+    gap: 40px;
+  }
+  .lp-h1 {
+    font-size: 40px;
+  }
+  .lp-cards,
+  .lp-passos {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .lp-numeros__grade {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .lp-stat:nth-child(2) {
+    border-right: 0;
+  }
+  .lp-stat:nth-child(-n + 2) {
+    border-bottom: 1px solid var(--border);
+  }
+  .lp-rodape__grade {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .lp-container {
+    padding: 0 18px;
+  }
+  .lp-topbar__inner {
+    gap: 10px;
+    height: 60px;
+  }
+  /* No telefone a barra fica apertada: o seletor de tema sai para "Entrar" e
+     "Começar grátis" caberem, que é o que a pessoa veio fazer. */
+  .lp-tema {
+    display: none;
+  }
+  .lp-btn-topo {
+    height: 38px;
+    padding: 0 14px;
+    font-size: 13.5px;
+  }
+  .lp-hero {
+    padding: 40px 0 52px;
+  }
+  .lp-h1 {
+    font-size: 33px;
+  }
+  .lp-lede {
+    font-size: 15.5px;
+  }
+  .lp-mock__codigo {
+    font-size: 11.5px;
+  }
+  .lp-stat__num {
+    font-size: 27px;
+  }
+  .lp-stat {
+    padding: 22px 10px;
+  }
+  .lp-h2 {
+    font-size: 27px;
+  }
+  .lp-cta__titulo {
+    font-size: 27px;
+  }
+  .lp-secao {
+    padding: 54px 0;
+  }
+  .lp-cards,
+  .lp-passos {
+    grid-template-columns: 1fr;
+  }
+  .lp-cta {
+    padding: 44px 22px;
+  }
+  .lp-hero__ctas .btn {
+    width: 100%;
+  }
+  .lp-rodape__grade {
+    grid-template-columns: 1fr;
+  }
+  .lp-tecnologias__lista {
+    gap: 10px 22px;
+  }
+  .lp-tecnologias__lista li {
+    font-size: 17px;
+  }
+}


### PR DESCRIPTION
Quem chegava no site caía direto no formulário de login, sem nenhuma explicação do que a ensina.dev faz. Agora a raiz mostra uma página de apresentação e o login passou para /entrar.

A página tem o hero com o cartão do desafio do dia, a faixa de tecnologias que têm trilha de verdade, os números da plataforma, seis recursos, os três passos para começar, a chamada final e o rodapé.

Os números vêm de /estatisticas-publicas, um endpoint novo sem login que conta no banco e guarda o resultado alguns minutos em memória. Assim a página nunca anuncia um valor que envelheceu no código. Aparecem arredondados para baixo com "+", que continua verdadeiro e não muda a cada aluno novo: em produção sai 1.200+ alunos, 1.800+ aulas, 100+ desafios e 10+ simulados. Número zerado vira traço em vez de anunciar vazio.

Ficaram de fora a faixa de logos de empresas e os depoimentos assinados que apareciam no layout de referência, porque não existe dado que sustente nenhum dos dois.

Com a raiz deixando de ser o login, os pontos que mandavam o usuário para lá passaram a apontar para /entrar: as guardas de rota, o logout por refresh expirado e as telas de verificação de email e de recuperação de senha. A página inicial entrou no pacote principal e o login virou carregamento sob demanda, já que a ordem se inverteu.

Conferido em telefone, tablet e tela larga, sem rolagem horizontal em nenhuma das larguras.
