### PR TITLE
feat: terminal Linux dentro das aulas

### DIFF
--- a/backend/app.ts
+++ b/backend/app.ts
@@ -12,6 +12,7 @@ import comunicadoRoutes from "./src/routes/comunicado.routes.ts";
 import certificateRoutes from "./src/routes/certificate.routes.ts";
 import apoioRoutes from "./src/routes/apoio.routes.ts";
 import comunidadeRoutes from "./src/routes/comunidade.routes.ts";
+import labRoutes from "./src/routes/lab.routes.ts";
 import { errorMiddleware } from "./src/middlewares/error.ts";
 import { apiLimiter } from "./src/middlewares/rateLimit.ts";
 import helmet from "helmet";
@@ -60,6 +61,7 @@ app.use(comunicadoRoutes);
 app.use(certificateRoutes);
 app.use(apoioRoutes);
 app.use(comunidadeRoutes);
+app.use(labRoutes);
 app.use(adminRoutes);
 
 app.get("/health", (_req, res) => res.json({ status: "ok" }));

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -1,8 +1,15 @@
 import { env } from "./src/config/env.ts";
+import http from "node:http";
 import { app } from "./app.ts";
+import { ligarTerminalLabs } from "./src/labs.ws.ts";
 
 const PORT = Number(env.PORT) || 3001;
 
-app.listen(PORT, "0.0.0.0", () => {
+// O servidor sai do app para o terminal dos labs poder assinar o upgrade de
+// WebSocket, que o Express sozinho não trata.
+const server = http.createServer(app);
+ligarTerminalLabs(server);
+
+server.listen(PORT, "0.0.0.0", () => {
     console.log(`Server is running on port ${PORT}`);
 });

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,6 +11,7 @@
             "dependencies": {
                 "@types/cookie-parser": "^1.4.10",
                 "@types/cors": "^2.8.19",
+                "@types/ws": "^8.18.1",
                 "argon2": "^0.45.1",
                 "bcrypt": "^6.0.0",
                 "cookie-parser": "^1.4.7",
@@ -24,6 +25,7 @@
                 "pdfkit": "^0.19.1",
                 "pg": "^8.21.0",
                 "qrcode": "^1.5.4",
+                "ws": "^8.21.1",
                 "zod": "^4.4.3"
             },
             "devDependencies": {
@@ -1366,6 +1368,15 @@
             "license": "MIT",
             "dependencies": {
                 "@types/http-errors": "*",
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/ws": {
+            "version": "8.18.1",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+            "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+            "license": "MIT",
+            "dependencies": {
                 "@types/node": "*"
             }
         },
@@ -4767,6 +4778,27 @@
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "license": "ISC"
+        },
+        "node_modules/ws": {
+            "version": "8.21.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+            "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/xtend": {
             "version": "4.0.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
     "dependencies": {
         "@types/cookie-parser": "^1.4.10",
         "@types/cors": "^2.8.19",
+        "@types/ws": "^8.18.1",
         "argon2": "^0.45.1",
         "bcrypt": "^6.0.0",
         "cookie-parser": "^1.4.7",
@@ -31,6 +32,7 @@
         "pdfkit": "^0.19.1",
         "pg": "^8.21.0",
         "qrcode": "^1.5.4",
+        "ws": "^8.21.1",
         "zod": "^4.4.3"
     },
     "devDependencies": {

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -20,6 +20,8 @@ const envSchema = z.object({
     OAUTH_CALLBACK_BASE: z.string().url().default("http://localhost:3001"),
     // Serviço interno que executa o código dos desafios em containers isolados.
     RUNNER_URL: z.string().url().default("http://runner:8080"),
+    // Serviço interno dos laboratórios de Linux (terminal por WebSocket).
+    LABS_URL: z.string().default("ws://labs:8090"),
     // Envio de email por SMTP (opcional). Sem host/user/pass, o backend só loga o link.
     SMTP_HOST: z.string().optional(),
     SMTP_PORT: z.string().default("587"),

--- a/backend/src/controllers/LabController.ts
+++ b/backend/src/controllers/LabController.ts
@@ -1,0 +1,10 @@
+import type { Request, Response, NextFunction } from "express";
+import { emitirTicket } from "../services/lab.service.ts";
+
+export const criarTicketLab = (req: Request, res: Response, next: NextFunction) => {
+    try {
+        res.json(emitirTicket(req.userId!));
+    } catch (err) {
+        next(err);
+    }
+};

--- a/backend/src/labs.ws.ts
+++ b/backend/src/labs.ws.ts
@@ -1,0 +1,67 @@
+import type { Server } from "node:http";
+import { WebSocketServer, WebSocket } from "ws";
+import { env } from "./config/env.ts";
+import { consumirTicket } from "./services/lab.service.ts";
+
+// Ponte entre o navegador e o serviço de labs. O backend fica no meio para
+// conferir de quem é a sessão: o serviço de labs não é exposto, e quem chega
+// nele já passou por aqui. Os bytes do terminal só atravessam.
+export function ligarTerminalLabs(server: Server) {
+    const wss = new WebSocketServer({ noServer: true });
+
+    server.on("upgrade", (req, socket, head) => {
+        const url = new URL(req.url ?? "/", "http://localhost");
+        if (url.pathname !== "/labs/terminal") return;
+
+        const userId = consumirTicket(url.searchParams.get("ticket") ?? "");
+        if (!userId) {
+            socket.write("HTTP/1.1 401 Unauthorized\r\n\r\n");
+            socket.destroy();
+            return;
+        }
+
+        wss.handleUpgrade(req, socket, head, (navegador) => {
+            const lab = new WebSocket(`${env.LABS_URL}/sessao`);
+            // O que o aluno digita antes do lab responder o handshake não pode
+            // sumir, senão a primeira tecla se perde.
+            const pendentes: Array<Buffer | string> = [];
+
+            navegador.on("message", (dados, ehBinario) => {
+                const carga = ehBinario ? (dados as Buffer) : dados.toString();
+                if (lab.readyState === WebSocket.OPEN) lab.send(carga);
+                else pendentes.push(carga);
+            });
+            lab.on("open", () => {
+                for (const p of pendentes) lab.send(p);
+                pendentes.length = 0;
+            });
+            lab.on("message", (dados, ehBinario) => {
+                if (navegador.readyState === WebSocket.OPEN)
+                    navegador.send(ehBinario ? (dados as Buffer) : dados.toString());
+            });
+
+            const fechar = () => {
+                if (lab.readyState === WebSocket.OPEN) lab.close();
+                if (navegador.readyState === WebSocket.OPEN) navegador.close();
+            };
+            navegador.on("close", fechar);
+            lab.on("close", fechar);
+            navegador.on("error", (e) => {
+                console.error("[labs] erro no socket do navegador:", e.message);
+                fechar();
+            });
+            lab.on("error", (e) => {
+                console.error("[labs] serviço de labs indisponível:", e.message);
+                if (navegador.readyState === WebSocket.OPEN) {
+                    navegador.send(
+                        JSON.stringify({
+                            tipo: "erro",
+                            mensagem: "O laboratório está indisponível. Tente de novo em instantes.",
+                        }),
+                    );
+                }
+                fechar();
+            });
+        });
+    });
+}

--- a/backend/src/middlewares/rateLimit.ts
+++ b/backend/src/middlewares/rateLimit.ts
@@ -69,6 +69,13 @@ export const apiLimiter = rateLimit({
     skip: (req) => process.env.NODE_ENV === "test" || req.path === "/health",
 });
 
+// Cada ticket vira um container de lab, então o teto segura quem fica abrindo
+// sessão sem usar. Folgado o bastante para reconectar depois de perder a rede.
+export const labTicketLimiter = criarLimiter(
+    30,
+    "Muitas aberturas de laboratório seguidas. Aguarde alguns minutos.",
+);
+
 export const desafioRunLimiter = criarLimiter(
     60,
     "Muitas execuções seguidas. Aguarde um instante e tente de novo.",

--- a/backend/src/routes/lab.routes.ts
+++ b/backend/src/routes/lab.routes.ts
@@ -1,0 +1,11 @@
+import { Router } from "express";
+import { autenticar } from "../middlewares/auth.ts";
+import { labTicketLimiter } from "../middlewares/rateLimit.ts";
+import { criarTicketLab } from "../controllers/LabController.ts";
+
+const router = Router();
+
+// Ticket de uso único para abrir o WebSocket do terminal.
+router.post("/labs/ticket", autenticar, labTicketLimiter, criarTicketLab);
+
+export default router;

--- a/backend/src/schemas/trail.schemas.ts
+++ b/backend/src/schemas/trail.schemas.ts
@@ -128,7 +128,7 @@ export const saveLessonStudioSchema = z.object({
     contentBlocks: z
         .array(
             z.object({
-                type: z.enum(["text", "code", "image", "video", "quote", "table"]),
+                type: z.enum(["text", "code", "image", "video", "quote", "table", "terminal"]),
                 value: z.string(),
             }),
         )

--- a/backend/src/services/lab.service.ts
+++ b/backend/src/services/lab.service.ts
@@ -1,0 +1,31 @@
+import { randomBytes } from "node:crypto";
+
+// O navegador não manda cabeçalho de Authorization ao abrir um WebSocket, então
+// o token do usuário não tem como viajar ali. O backend emite um ticket curto e
+// de uso único numa chamada HTTP normal (essa sim autenticada), e o WebSocket
+// abre com ele. Como vale segundos e queima no primeiro uso, aparecer em log de
+// acesso não compromete a conta.
+const VALIDADE_MS = 30 * 1000;
+
+type Ticket = { userId: string; expiraEm: number };
+const tickets = new Map<string, Ticket>();
+
+function limpar() {
+    const agora = Date.now();
+    for (const [chave, t] of tickets) if (t.expiraEm <= agora) tickets.delete(chave);
+}
+
+export function emitirTicket(userId: string): { ticket: string; validadeSegundos: number } {
+    limpar();
+    const ticket = randomBytes(32).toString("hex");
+    tickets.set(ticket, { userId, expiraEm: Date.now() + VALIDADE_MS });
+    return { ticket, validadeSegundos: VALIDADE_MS / 1000 };
+}
+
+export function consumirTicket(ticket: string): string | null {
+    limpar();
+    const registro = tickets.get(ticket);
+    if (!registro) return null;
+    tickets.delete(ticket);
+    return registro.expiraEm > Date.now() ? registro.userId : null;
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -55,6 +55,21 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
 
+  # Laboratórios de Linux: um container com shell por sessão de aluno.
+  # Fala com um daemon Docker SEPARADO, com userns-remap ligado, para que o root
+  # de dentro do lab seja um UID sem privilégio para o kernel do host. Ver
+  # labs/README.md para preparar esse daemon no servidor.
+  labs:
+    build:
+      context: ./labs
+    restart: unless-stopped
+    environment:
+      - MAX_SESSOES=${LAB_MAX_SESSOES:-20}
+      - LAB_TTL_MINUTOS=${LAB_TTL_MINUTOS:-45}
+      - LAB_DOCKER_HOST=unix:///var/run/docker-labs.sock
+    volumes:
+      - /var/run/docker-labs.sock:/var/run/docker-labs.sock
+
 volumes:
   pgdata:
   caddy_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,17 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     restart: unless-stopped
 
+  # Laboratórios de Linux: um container com shell por sessão, ligado ao navegador
+  # por WebSocket. A imagem lab-linux precisa existir (rode labs/build-images.sh).
+  labs:
+    build:
+      context: ./labs
+    environment:
+      - MAX_SESSOES=5
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    restart: unless-stopped
+
   frontend:
     build:
       context: ./frontend

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,8 @@
         "@codemirror/lang-python": "^6.2.1",
         "@codemirror/theme-one-dark": "^6.1.3",
         "@uiw/react-codemirror": "^4.25.11",
+        "@xterm/addon-fit": "^0.11.0",
+        "@xterm/xterm": "^6.0.0",
         "axios": "^1.18.1",
         "katex": "^0.18.1",
         "react": "^19.2.6",
@@ -1496,6 +1498,21 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
+      "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.0.0.tgz",
+      "integrity": "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==",
+      "license": "MIT",
+      "workspaces": [
+        "addons/*"
+      ]
     },
     "node_modules/acorn": {
       "version": "8.17.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,8 @@
     "@codemirror/lang-python": "^6.2.1",
     "@codemirror/theme-one-dark": "^6.1.3",
     "@uiw/react-codemirror": "^4.25.11",
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/xterm": "^6.0.0",
     "axios": "^1.18.1",
     "katex": "^0.18.1",
     "react": "^19.2.6",

--- a/frontend/src/components/BlocosConteudo.tsx
+++ b/frontend/src/components/BlocosConteudo.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, type ReactNode } from 'react';
+import { useMemo, useRef, lazy, Suspense, type ReactNode } from 'react';
 import ReactMarkdown, { type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
@@ -6,6 +6,9 @@ import rehypeKatex from 'rehype-katex';
 import { parseGrid } from '../utils/tabela';
 import { glossariar, criarMatcher } from './Glossario';
 import { useGlossario } from '../hooks/useGlossario';
+
+// O xterm pesa, e só as aulas com laboratório precisam dele.
+const TerminalLab = lazy(() => import('./TerminalLab').then((m) => ({ default: m.TerminalLab })));
 
 // Bloco genérico de conteúdo (aulas e desafios usam o mesmo formato).
 export interface Bloco {
@@ -128,6 +131,13 @@ export function BlocosConteudo({ blocks }: { blocks: Bloco[] }) {
               />
             </div>
           ) : null;
+        }
+        if (b.type === 'terminal') {
+          return (
+            <Suspense key={i} fallback={<div className="lesson__loading">Carregando...</div>}>
+              <TerminalLab />
+            </Suspense>
+          );
         }
         if (b.type === 'quote') {
           return <blockquote key={i}>{citacaoInline(b.value)}</blockquote>;

--- a/frontend/src/components/TerminalLab.tsx
+++ b/frontend/src/components/TerminalLab.tsx
@@ -1,0 +1,165 @@
+import { useEffect, useRef, useState } from 'react';
+import { Terminal } from '@xterm/xterm';
+import { FitAddon } from '@xterm/addon-fit';
+import '@xterm/xterm/css/xterm.css';
+import api from '../services/api';
+import { useTheme } from '../contexts/ThemeContext';
+
+type Estado = 'parado' | 'conectando' | 'ligado' | 'encerrado' | 'erro';
+
+// Terminal de verdade dentro da aula. O xterm só transporta tecla para lá e
+// caractere de volta; quem executa é um container descartável do outro lado.
+export function TerminalLab() {
+  const caixa = useRef<HTMLDivElement>(null);
+  const term = useRef<Terminal | null>(null);
+  const fit = useRef<FitAddon | null>(null);
+  const ws = useRef<WebSocket | null>(null);
+  const [estado, setEstado] = useState<Estado>('parado');
+  const [aviso, setAviso] = useState('');
+  const { theme } = useTheme();
+
+  useEffect(() => {
+    return () => {
+      ws.current?.close();
+      term.current?.dispose();
+    };
+  }, []);
+
+  async function iniciar() {
+    if (estado === 'conectando' || estado === 'ligado') return;
+    setAviso('');
+    setEstado('conectando');
+    try {
+      const { data } = await api.post<{ ticket: string }>('/labs/ticket');
+
+      const t = new Terminal({
+        fontFamily: 'var(--font-code), ui-monospace, monospace',
+        fontSize: 13,
+        cursorBlink: true,
+        convertEol: true,
+        theme:
+          theme === 'dark'
+            ? { background: '#0d1320', foreground: '#ecf1fa', cursor: '#2d6bf5' }
+            : { background: '#1b1726', foreground: '#f3efe6', cursor: '#2d6bf5' },
+      });
+      const f = new FitAddon();
+      t.loadAddon(f);
+      if (!caixa.current) return;
+      caixa.current.innerHTML = '';
+      t.open(caixa.current);
+      f.fit();
+      term.current = t;
+      fit.current = f;
+
+      const base = (api.defaults.baseURL ?? '').replace(/^http/, 'ws');
+      const socket = new WebSocket(`${base}/labs/terminal?ticket=${data.ticket}`);
+      ws.current = socket;
+
+      socket.onopen = () => {
+        setEstado('ligado');
+        socket.send(JSON.stringify({ tipo: 'resize', cols: t.cols, rows: t.rows }));
+        t.focus();
+      };
+      socket.onmessage = (ev) => {
+        const texto = String(ev.data);
+        // O serviço avisa por JSON quando fica pronto, quando dá erro e quando
+        // o tempo acaba. O resto é saída crua do shell.
+        if (texto.startsWith('{')) {
+          try {
+            const msg = JSON.parse(texto);
+            if (msg.tipo === 'erro') {
+              setAviso(msg.mensagem);
+              setEstado('erro');
+              return;
+            }
+            if (msg.tipo === 'fim') {
+              t.writeln(`\r\n\r\n[laboratório encerrado: ${msg.motivo}]`);
+              setEstado('encerrado');
+              return;
+            }
+            if (msg.tipo === 'pronto') {
+              setAviso(`Sessão de ${msg.ttlMinutos} minutos. Nada aqui é salvo.`);
+              return;
+            }
+          } catch {
+            // Não era controle, então é saída do shell e segue o fluxo normal.
+            t.write(texto);
+            return;
+          }
+          return;
+        }
+        t.write(texto);
+      };
+      socket.onclose = () => setEstado((e) => (e === 'erro' ? e : 'encerrado'));
+      socket.onerror = () => {
+        setAviso('Não foi possível conectar ao laboratório.');
+        setEstado('erro');
+      };
+
+      t.onData((d) => {
+        if (socket.readyState === WebSocket.OPEN) socket.send(d);
+      });
+
+      const aoRedimensionar = () => {
+        f.fit();
+        if (socket.readyState === WebSocket.OPEN)
+          socket.send(JSON.stringify({ tipo: 'resize', cols: t.cols, rows: t.rows }));
+      };
+      window.addEventListener('resize', aoRedimensionar);
+      socket.addEventListener('close', () => window.removeEventListener('resize', aoRedimensionar));
+    } catch {
+      setAviso('Não foi possível abrir o laboratório. Tente de novo em instantes.');
+      setEstado('erro');
+    }
+  }
+
+  function encerrar() {
+    ws.current?.close();
+    setEstado('encerrado');
+  }
+
+  return (
+    <div className="lab">
+      <div className="lab__barra">
+        <span className="lab__titulo">Laboratório</span>
+        <span className={`lab__estado lab__estado--${estado}`}>
+          {estado === 'ligado'
+            ? 'conectado'
+            : estado === 'conectando'
+              ? 'conectando...'
+              : estado === 'encerrado'
+                ? 'encerrado'
+                : estado === 'erro'
+                  ? 'erro'
+                  : 'desligado'}
+        </span>
+        {estado === 'ligado' ? (
+          <button className="btn btn--ghost lab__botao" type="button" onClick={encerrar}>
+            Encerrar
+          </button>
+        ) : (
+          <button
+            className="btn btn--accent lab__botao"
+            type="button"
+            onClick={iniciar}
+            disabled={estado === 'conectando'}
+          >
+            {estado === 'parado' ? 'Iniciar laboratório' : 'Reiniciar'}
+          </button>
+        )}
+      </div>
+      {aviso && <p className="lab__aviso">{aviso}</p>}
+      {estado === 'parado' ? (
+        <div className="lab__vazio">
+          <p>
+            Um terminal Linux de verdade, só seu, criado na hora e apagado ao fim. Pode usar
+            <code className="code-inline">sudo</code> à vontade: quebrar essa máquina não afeta
+            nada.
+          </p>
+        </div>
+      ) : (
+        <div className="lab__tela" ref={caixa} />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -8,4 +8,5 @@
 @import './styles/comunidade.css';
 @import './styles/roadmap.css';
 @import './styles/landing.css';
+@import './styles/lab.css';
 @import './styles/mobile.css';

--- a/frontend/src/pages/Estudio/index.tsx
+++ b/frontend/src/pages/Estudio/index.tsx
@@ -28,6 +28,7 @@ const BLOCO_TIPOS: { type: BlocoTipo; icon: string; label: string }[] = [
   { type: 'video', icon: '▷', label: 'Vídeo' },
   { type: 'quote', icon: '❝', label: 'Citação' },
   { type: 'table', icon: '▦', label: 'Tabela' },
+  { type: 'terminal', icon: '>_', label: 'Laboratório' },
 ];
 const BLOCO_LABEL: Record<BlocoTipo, string> = {
   text: 'Texto',
@@ -36,6 +37,7 @@ const BLOCO_LABEL: Record<BlocoTipo, string> = {
   video: 'Vídeo',
   quote: 'Citação',
   table: 'Tabela',
+  terminal: 'Laboratório',
 };
 const DIFFS: { value: QuestionDifficulty; label: string }[] = [
   { value: 'facil', label: 'Fácil' },
@@ -329,7 +331,10 @@ export function Estudio() {
               </span>
             )}
             {aula && (
-              <Link className="btn btn--ghost studio__btn" to={`/trilhas/${trailId}/aula/${aula.id}`}>
+              <Link
+                className="btn btn--ghost studio__btn"
+                to={`/trilhas/${trailId}/aula/${aula.id}`}
+              >
                 <Eye size={15} /> Pré-visualizar
               </Link>
             )}
@@ -475,7 +480,12 @@ export function Estudio() {
                         <Trash size={15} />
                       </button>
                     </div>
-                    {b.type === 'table' ? (
+                    {b.type === 'terminal' ? (
+                      <p className="studio__section-sub" style={{ margin: 0 }}>
+                        Terminal Linux para o aluno praticar. Não tem conteúdo a preencher: basta
+                        posicionar o bloco onde o laboratório deve aparecer na aula.
+                      </p>
+                    ) : b.type === 'table' ? (
                       <TabelaEditor value={b.value} onChange={(v) => setBloco(i, v)} />
                     ) : b.type === 'image' || b.type === 'video' ? (
                       <input

--- a/frontend/src/services/trails.ts
+++ b/frontend/src/services/trails.ts
@@ -151,7 +151,7 @@ export interface QuizQuestion {
   options: QuizOption[];
   answer?: QuizAnswerState | null;
 }
-export type BlocoTipo = 'text' | 'code' | 'image' | 'video' | 'quote' | 'table';
+export type BlocoTipo = 'text' | 'code' | 'image' | 'video' | 'quote' | 'table' | 'terminal';
 export interface Bloco {
   type: BlocoTipo;
   value: string;

--- a/frontend/src/styles/lab.css
+++ b/frontend/src/styles/lab.css
@@ -1,0 +1,82 @@
+/* Laboratório de Linux dentro da aula. O terminal em si é desenhado pelo xterm;
+   aqui fica só a moldura, que acompanha o visual dos blocos de código. */
+.lab {
+  border: 1px solid var(--border);
+  border-radius: var(--r-2xl);
+  background: var(--surface);
+  overflow: hidden;
+  margin: 0 0 26px;
+}
+.lab__barra {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  background: var(--surface-2);
+  border-bottom: 1px solid var(--border);
+}
+.lab__titulo {
+  font-weight: 600;
+  font-size: 14px;
+}
+.lab__estado {
+  font-family: var(--font-code);
+  font-size: 11.5px;
+  padding: 3px 9px;
+  border-radius: 999px;
+  background: var(--input);
+  color: var(--muted);
+  border: 1px solid var(--border);
+}
+.lab__estado--ligado {
+  color: var(--success);
+  border-color: color-mix(in srgb, var(--success) 45%, transparent);
+}
+.lab__estado--erro {
+  color: #d9536b;
+  border-color: color-mix(in srgb, #d9536b 45%, transparent);
+}
+.lab__botao {
+  margin-left: auto;
+  height: 36px;
+  padding: 0 16px;
+  font-size: 13.5px;
+  flex: none;
+}
+.lab__aviso {
+  margin: 0;
+  padding: 10px 16px;
+  font-size: 13px;
+  color: var(--muted);
+  border-bottom: 1px solid var(--border);
+}
+.lab__vazio {
+  padding: 26px 20px;
+}
+.lab__vazio p {
+  margin: 0;
+  max-width: 46em;
+  color: var(--muted);
+  font-size: 14.5px;
+  line-height: 1.65;
+}
+.lab__vazio code {
+  margin: 0 4px;
+}
+.lab__tela {
+  height: 420px;
+  padding: 12px;
+  background: #1b1726;
+}
+[data-theme='dark'] .lab__tela {
+  background: #0d1320;
+}
+@media (max-width: 640px) {
+  .lab__tela {
+    height: 320px;
+    padding: 8px;
+  }
+  .lab__barra {
+    flex-wrap: wrap;
+  }
+}

--- a/labs/Dockerfile
+++ b/labs/Dockerfile
@@ -1,0 +1,14 @@
+# node-pty é módulo nativo, então precisa de compilador na hora de instalar.
+FROM node:22-alpine AS deps
+RUN apk add --no-cache python3 make g++
+WORKDIR /app
+COPY package.json ./
+RUN npm install --omit=dev
+
+FROM node:22-alpine
+RUN apk add --no-cache docker-cli
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY package.json server.mjs ./
+EXPOSE 8090
+CMD ["node", "server.mjs"]

--- a/labs/README.md
+++ b/labs/README.md
@@ -1,0 +1,106 @@
+# Laboratórios de Linux
+
+Terminal de verdade dentro das aulas. Cada sessão ganha um container descartável
+com shell, ligado ao navegador por WebSocket. O aluno pode usar `sudo` à vontade:
+quebrar aquela máquina não afeta nada, porque ela é só dele e some no fim.
+
+```
+navegador (xterm.js)
+   |  WebSocket
+backend  (confere de quem é a sessão; o ticket vale 30s e queima no primeiro uso)
+   |  WebSocket
+labs     (único serviço que fala com o Docker)
+   |  docker run
+container do aluno  (sem rede, com limite de CPU, memória e PIDs, e TTL)
+```
+
+## Por que o lab não usa as mesmas travas do runner dos desafios
+
+O runner roda com `--cap-drop ALL` e `--security-opt no-new-privileges`. Num lab
+isso não serve: `no-new-privileges` mata o setuid, então o `sudo` para de
+funcionar, e sem capabilities metade do módulo de permissões deixa de rodar.
+
+Quem segura o host aqui é outra coisa: o **user namespace**. Com `userns-remap`,
+o UID 0 de dentro do container vira um UID alto e sem privilégio nenhum para o
+kernel do host. O aluno é root da caixa dele e ninguém lá fora.
+
+## Preparando o servidor
+
+O `userns-remap` é configuração do daemon inteiro, não de um container. Ligar no
+daemon principal remapearia dono de arquivo em todos os volumes e mexeria com
+backend, banco e Caddy de uma vez. Por isso os labs usam um **segundo daemon**.
+
+1. Crie o usuário do remap e as faixas de UID/GID:
+
+```bash
+adduser --system --group --no-create-home dockremap
+echo 'dockremap:500000:65536' >> /etc/subuid
+echo 'dockremap:500000:65536' >> /etc/subgid
+```
+
+2. Configure o daemon dos labs em `/etc/docker/daemon-labs.json`:
+
+```json
+{
+  "userns-remap": "dockremap",
+  "data-root": "/var/lib/docker-labs",
+  "hosts": ["unix:///var/run/docker-labs.sock"],
+  "iptables": false,
+  "bridge": "none"
+}
+```
+
+3. Suba como serviço próprio (`/etc/systemd/system/docker-labs.service`):
+
+```ini
+[Unit]
+Description=Docker daemon dos laboratorios
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/dockerd --config-file /etc/docker/daemon-labs.json
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+systemctl daemon-reload && systemctl enable --now docker-labs
+```
+
+4. Construa a imagem do lab **nesse** daemon:
+
+```bash
+LAB_DOCKER_HOST=unix:///var/run/docker-labs.sock bash labs/build-images.sh
+```
+
+Confira que o remap pegou: o processo dentro do lab tem que aparecer com UID alto
+no host.
+
+```bash
+DOCKER_HOST=unix:///var/run/docker-labs.sock docker run --rm lab-linux id
+# uid=1000(aluno) ... visto de dentro
+ps -eo user,cmd | grep bash
+# 500000 ... visto do host
+```
+
+## Ajustes
+
+| variável | padrão | o que faz |
+|---|---|---|
+| `MAX_SESSOES` | 20 | sessões simultâneas antes de recusar novas |
+| `LAB_TTL_MINUTOS` | 45 | tempo de vida da sessão |
+| `LAB_MEMORIA` | 256m | memória por lab |
+| `LAB_CPUS` | 0.5 | CPU por lab |
+| `LAB_DOCKER_HOST` | vazio | socket do daemon dos labs; vazio usa o padrão (só em dev) |
+
+Um shell parado custa de 10 a 20 MB, então o gargalo costuma ser CPU, não memória.
+
+## Limites conhecidos
+
+Sem rede dentro do lab, então `apt install` não funciona e as aulas de systemd,
+pacotes e rede pedem mais trabalho (systemd como PID 1 e egress por allowlist).
+Montar disco de verdade e labs de Kubernetes com vários nós ficam fora: para isso
+seria preciso microVM, que exige virtualização aninhada, algo que a Hostinger não
+oferece.

--- a/labs/build-images.sh
+++ b/labs/build-images.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Constrói a imagem do ambiente de lab no daemon que hospeda os labs.
+# Em produção, aponte para o daemon dedicado antes de rodar:
+#   LAB_DOCKER_HOST=unix:///var/run/docker-labs.sock bash labs/build-images.sh
+set -euo pipefail
+cd "$(dirname "$0")"
+
+if [ -n "${LAB_DOCKER_HOST:-}" ]; then
+    export DOCKER_HOST="$LAB_DOCKER_HOST"
+    echo "==> usando daemon $DOCKER_HOST"
+fi
+
+docker build -t lab-linux image
+
+echo "==> Imagem pronta: lab-linux"

--- a/labs/image/Dockerfile
+++ b/labs/image/Dockerfile
@@ -1,0 +1,32 @@
+# Ambiente do lab de Linux. Debian de propósito, não Alpine: a trilha ensina as
+# flags do GNU coreutils, e o busybox do Alpine aceita um conjunto diferente, o
+# que faria o aluno decorar comando que não funciona num servidor de verdade.
+FROM debian:12-slim
+
+# Ferramentas que as aulas usam. strace atende o módulo de syscalls; procps,
+# psmisc e lsof atendem o de processos e sinais.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    sudo bash coreutils findutils grep sed gawk diffutils \
+    less nano vim procps psmisc lsof file tree strace \
+    ca-certificates bash-completion \
+    && rm -rf /var/lib/apt/lists/*
+
+# O aluno não é root: o módulo de permissões precisa de alguém que apanhe do
+# "Permission denied" antes de resolver com sudo. O sudo é sem senha porque não
+# existe senha para ele saber, e a caixa é descartável de qualquer jeito.
+RUN useradd -m -s /bin/bash aluno \
+    && echo 'aluno ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/aluno \
+    && chmod 0440 /etc/sudoers.d/aluno
+
+# Um cenário mínimo para as aulas de navegação, busca e permissões terem o que
+# explorar já no primeiro comando.
+RUN mkdir -p /home/aluno/projeto/logs /home/aluno/projeto/config \
+    && printf 'erro: falha ao conectar\naviso: cache cheio\nerro: timeout\n' > /home/aluno/projeto/logs/app.log \
+    && printf 'porta=8080\ndebug=false\n' > /home/aluno/projeto/config/app.conf \
+    && printf 'Bem-vindo ao laboratorio.\n' > /home/aluno/leia-me.txt \
+    && chown -R aluno:aluno /home/aluno
+
+USER aluno
+WORKDIR /home/aluno
+ENV TERM=xterm-256color LANG=C.UTF-8
+CMD ["/bin/bash", "-l"]

--- a/labs/package-lock.json
+++ b/labs/package-lock.json
@@ -1,0 +1,51 @@
+{
+  "name": "labs",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "labs",
+      "dependencies": {
+        "node-pty": "^1.0.0",
+        "ws": "^8.18.0"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
+    "node_modules/node-pty": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
+      "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.1.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/labs/package.json
+++ b/labs/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "labs",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "node-pty": "^1.0.0",
+    "ws": "^8.18.0"
+  }
+}

--- a/labs/server.mjs
+++ b/labs/server.mjs
@@ -1,0 +1,144 @@
+// Serviço interno dos labs de Linux. Cada conexão WebSocket ganha um container
+// efêmero com um shell dentro, e o serviço liga o PTY desse container ao socket.
+// Só ele fala com o Docker; o backend público nunca toca o socket.
+//
+// Diferente do runner dos desafios, aqui o aluno PRECISA de sudo, então
+// no-new-privileges e cap-drop ALL não entram: eles quebrariam o setuid do sudo
+// e metade do módulo de permissões. O que segura o host é o user namespace do
+// daemon dedicado, onde o root de dentro é um UID alto sem poder nenhum fora.
+import http from 'node:http';
+import { WebSocketServer } from 'ws';
+import pty from 'node-pty';
+
+const MAX_SESSOES = Number(process.env.MAX_SESSOES || 20);
+const TTL_MS = Number(process.env.LAB_TTL_MINUTOS || 45) * 60 * 1000;
+const IMAGEM = process.env.LAB_IMAGEM || 'lab-linux';
+const MEMORIA = process.env.LAB_MEMORIA || '256m';
+const CPUS = process.env.LAB_CPUS || '0.5';
+// Socket do daemon dedicado aos labs. Vazio = daemon padrão (usado só em dev).
+const DOCKER_HOST = process.env.LAB_DOCKER_HOST || '';
+
+const sessoes = new Map();
+
+function argsDoContainer(nome) {
+    return [
+        'run',
+        '--rm',
+        '-i',
+        '--tty',
+        '--name',
+        nome,
+        '--hostname',
+        'lab',
+        // Sem rede o Docker não resolve o próprio hostname, e aí todo sudo cospe
+        // um aviso de "unable to resolve host" antes de funcionar.
+        '--add-host',
+        'lab:127.0.0.1',
+        // Sem rede: os módulos de comando, permissões e bash não precisam, e é o
+        // que impede a caixa de ser usada para alcançar qualquer outra coisa.
+        '--network',
+        'none',
+        '--memory',
+        MEMORIA,
+        '--memory-swap',
+        MEMORIA,
+        '--cpus',
+        CPUS,
+        '--pids-limit',
+        '256',
+        IMAGEM,
+    ];
+}
+
+function encerrar(sessao, motivo) {
+    if (sessao.encerrada) return;
+    sessao.encerrada = true;
+    clearTimeout(sessao.ttl);
+    sessoes.delete(sessao.id);
+    try {
+        sessao.proc.kill();
+    } catch (e) {
+        console.error('[labs] falha ao matar o pty:', e.message);
+    }
+    // O --rm cuida do container quando o processo morre, mas se o pty já tiver
+    // ido embora sem levar o docker junto, o rm garante que nada fica de pé.
+    try {
+        const env = DOCKER_HOST ? { ...process.env, DOCKER_HOST } : process.env;
+        pty.spawn('docker', ['rm', '-f', sessao.nome], { env }).on('exit', () => {});
+    } catch (e) {
+        console.error('[labs] falha ao remover o container:', e.message);
+    }
+    if (sessao.ws.readyState === sessao.ws.OPEN) {
+        sessao.ws.send(JSON.stringify({ tipo: 'fim', motivo }));
+        sessao.ws.close();
+    }
+    console.log(`[labs] sessão ${sessao.id} encerrada (${motivo}); ativas: ${sessoes.size}`);
+}
+
+function abrirSessao(ws) {
+    if (sessoes.size >= MAX_SESSOES) {
+        ws.send(JSON.stringify({ tipo: 'erro', mensagem: 'Todos os laboratórios estão ocupados. Tente em instantes.' }));
+        ws.close();
+        return;
+    }
+    const id = `${Date.now().toString(36)}-${sessoes.size}`;
+    const nome = `lab-${id}`;
+    const env = DOCKER_HOST ? { ...process.env, DOCKER_HOST } : process.env;
+    const proc = pty.spawn('docker', argsDoContainer(nome), {
+        name: 'xterm-256color',
+        cols: 80,
+        rows: 24,
+        env,
+    });
+
+    const sessao = { id, nome, proc, ws, encerrada: false };
+    sessao.ttl = setTimeout(() => encerrar(sessao, 'tempo esgotado'), TTL_MS);
+    sessoes.set(id, sessao);
+    console.log(`[labs] sessão ${id} aberta; ativas: ${sessoes.size}`);
+
+    proc.onData((d) => {
+        if (ws.readyState === ws.OPEN) ws.send(d);
+    });
+    proc.onExit(() => encerrar(sessao, 'shell encerrado'));
+
+    ws.on('message', (raw, ehBinario) => {
+        if (sessao.encerrada) return;
+        // Texto puro é tecla digitada. JSON com tipo é comando de controle, hoje
+        // só o redimensionamento da janela.
+        const texto = ehBinario ? null : raw.toString();
+        if (texto && texto.startsWith('{')) {
+            try {
+                const msg = JSON.parse(texto);
+                if (msg.tipo === 'resize') {
+                    proc.resize(Math.max(2, msg.cols | 0), Math.max(2, msg.rows | 0));
+                    return;
+                }
+            } catch (e) {
+                console.error('[labs] mensagem de controle inválida:', e.message);
+            }
+        }
+        proc.write(texto ?? raw.toString());
+    });
+
+    ws.on('close', () => encerrar(sessao, 'conexão fechada'));
+    ws.on('error', (e) => {
+        console.error('[labs] erro no websocket:', e.message);
+        encerrar(sessao, 'erro de conexão');
+    });
+
+    ws.send(JSON.stringify({ tipo: 'pronto', ttlMinutos: Math.round(TTL_MS / 60000) }));
+}
+
+const server = http.createServer((req, res) => {
+    if (req.url === '/health') {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ status: 'ok', sessoes: sessoes.size, max: MAX_SESSOES }));
+        return;
+    }
+    res.writeHead(404).end();
+});
+
+const wss = new WebSocketServer({ server, path: '/sessao' });
+wss.on('connection', abrirSessao);
+
+server.listen(8090, () => console.log('labs ouvindo em :8090'));


### PR DESCRIPTION
A trilha de Linux ensinava comando sem lugar nenhum para praticar. Agora a aula pode ter um laboratório: um terminal de verdade, criado na hora e apagado no fim, onde o aluno usa sudo à vontade porque a máquina é só dele.

Como funciona: o navegador pede um ticket numa chamada autenticada, abre o WebSocket com ele e o backend faz a ponte até o serviço de labs, que sobe um container por sessão. O ticket vale trinta segundos e queima no primeiro uso, porque WebSocket não carrega cabeçalho de autorização. O xterm no navegador só transporta tecla para lá e caractere de volta.

O ambiente é Debian, não Alpine, porque a trilha ensina as flags do GNU coreutils e o busybox aceita outro conjunto. O aluno entra como usuário comum com sudo sem senha, então o "Permission denied" acontece de verdade antes de ele resolver com sudo, que é o que as aulas de permissão precisam. Vem com um cenário pronto para o primeiro comando ter o que explorar.

O container roda sem rede, com limite de CPU, memória, processos e tempo de vida, e é removido quando a conexão cai. Diferente do executor dos desafios, aqui não entram cap-drop ALL nem no-new-privileges, que quebrariam o setuid do sudo e metade do módulo de permissões. Quem protege o host é o user namespace de um daemon Docker separado, descrito no labs/README.md: com ele, o root de dentro do lab é um UID sem privilégio nenhum de fora.

O laboratório entra pelo Estúdio como mais um tipo de bloco, então dá para posicionar onde fizer sentido na aula. O xterm só é baixado nas aulas que têm um, num pedaço separado do bundle.

Depois do merge falta preparar o daemon dedicado no servidor, seguindo o README. Sem ele o terminal funciona, mas o isolamento fica no nível do Docker comum, o que não basta com sudo liberado.

Fora do alcance por enquanto: aulas de systemd, pacotes e rede, que pedem egress liberado e systemd como PID 1, e montagem de disco de verdade.
