### PR TITLE
fix: fecha brechas de esgotamento de recurso no laboratório

### DIFF
--- a/backend/src/labs.ws.ts
+++ b/backend/src/labs.ws.ts
@@ -21,7 +21,11 @@ export function ligarTerminalLabs(server: Server) {
         }
 
         wss.handleUpgrade(req, socket, head, (navegador) => {
-            const lab = new WebSocket(`${env.LABS_URL}/sessao`);
+            // De quem é a sessão vai por cabeçalho na conexão interna, para o
+            // serviço de labs poder limitar uma sessão por aluno.
+            const lab = new WebSocket(`${env.LABS_URL}/sessao`, {
+                headers: { "x-user-id": userId },
+            });
             // O que o aluno digita antes do lab responder o handshake não pode
             // sumir, senão a primeira tecla se perde.
             const pendentes: Array<Buffer | string> = [];

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -64,8 +64,12 @@ services:
       context: ./labs
     restart: unless-stopped
     environment:
-      - MAX_SESSOES=${LAB_MAX_SESSOES:-20}
+      # Teto conservador de propósito: a máquina tem 2 vCPUs e o Postgres roda
+      # nela. Melhor recusar a sétima sessão do que deixar o site lento para os
+      # outros mil e trezentos alunos.
+      - MAX_SESSOES=${LAB_MAX_SESSOES:-6}
       - LAB_TTL_MINUTOS=${LAB_TTL_MINUTOS:-45}
+      - LAB_CPUS=${LAB_CPUS:-0.25}
       - LAB_DOCKER_HOST=unix:///var/run/docker-labs.sock
     volumes:
       - /var/run/docker-labs.sock:/var/run/docker-labs.sock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     build:
       context: ./labs
     environment:
-      - MAX_SESSOES=5
+      - MAX_SESSOES=3
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     restart: unless-stopped

--- a/labs/README.md
+++ b/labs/README.md
@@ -123,7 +123,34 @@ docker build -t lab-linux labs/image
 docker save lab-linux | DOCKER_HOST=unix:///var/run/docker-labs.sock docker load
 ```
 
-### 5. Confirme que o remap pegou
+### 5. Limite o disco dos labs
+
+Sem isso, um aluno enche o disco do servidor em cerca de um minuto e meio com um
+`dd`, e derruba o Postgres junto. Cota por container (`--storage-opt size=`) não
+resolve aqui: ela exige xfs com `pquota`, e a raiz é ext4. A saída é dar aos labs
+um disco próprio de tamanho fixo, num arquivo montado por loopback.
+
+```bash
+systemctl stop docker-labs
+fallocate -l 10G /var/lib/docker-labs.img
+mkfs.ext4 -q -F /var/lib/docker-labs.img
+mv /var/lib/docker-labs /var/lib/docker-labs.antigo
+mkdir -p /var/lib/docker-labs
+mount -o loop /var/lib/docker-labs.img /var/lib/docker-labs
+cp -a /var/lib/docker-labs.antigo/. /var/lib/docker-labs/ && rm -rf /var/lib/docker-labs.antigo
+echo '/var/lib/docker-labs.img /var/lib/docker-labs ext4 loop,defaults,nofail 0 0' >> /etc/fstab
+systemctl start docker-labs
+```
+
+Não use a opção `discard` na montagem: em arquivo de loopback ela perfura bloco a
+bloco e a escrita fica lenta a ponto de travar. O arquivo cresce até o teto de
+10 GB e para; para devolver ao host o que estiver livre, um `fstrim` periódico
+resolve (há um `fstrim-labs.timer` semanal no servidor).
+
+Confira que o teto pegou: dentro do lab, `df -h /` tem que mostrar o tamanho do
+loopback, não o disco do host.
+
+### 6. Confirme que o remap pegou
 
 É o teste que prova a segurança toda. De dentro o aluno é root; do host, ninguém.
 
@@ -139,13 +166,15 @@ docker rm -f t
 
 | variável | padrão | o que faz |
 |---|---|---|
-| `MAX_SESSOES` | 20 | sessões simultâneas antes de recusar novas |
+| `MAX_SESSOES` | 6 | sessões simultâneas antes de recusar novas (uma por aluno) |
 | `LAB_TTL_MINUTOS` | 45 | tempo de vida da sessão |
 | `LAB_MEMORIA` | 256m | memória por lab |
-| `LAB_CPUS` | 0.5 | CPU por lab |
+| `LAB_CPUS` | 0.25 | CPU por lab; o peso na disputa é baixo, então o app ganha do laboratório |
 | `LAB_DOCKER_HOST` | vazio | socket do daemon dos labs; vazio usa o padrão (só em dev) |
 
 Um shell parado custa de 10 a 20 MB, então o gargalo costuma ser CPU, não memória.
+O teto é conservador de propósito: a máquina tem 2 vCPUs e o Postgres roda nela.
+Melhor recusar a sétima sessão do que deixar o site lento para todo mundo.
 
 ## Limites conhecidos
 

--- a/labs/server.mjs
+++ b/labs/server.mjs
@@ -7,138 +7,180 @@
 // e metade do módulo de permissões. O que segura o host é o user namespace do
 // daemon dedicado, onde o root de dentro é um UID alto sem poder nenhum fora.
 import http from 'node:http';
+import { execFile } from 'node:child_process';
 import { WebSocketServer } from 'ws';
 import pty from 'node-pty';
 
-const MAX_SESSOES = Number(process.env.MAX_SESSOES || 20);
+const MAX_SESSOES = Number(process.env.MAX_SESSOES || 6);
 const TTL_MS = Number(process.env.LAB_TTL_MINUTOS || 45) * 60 * 1000;
 const IMAGEM = process.env.LAB_IMAGEM || 'lab-linux';
 const MEMORIA = process.env.LAB_MEMORIA || '256m';
-const CPUS = process.env.LAB_CPUS || '0.5';
+const CPUS = process.env.LAB_CPUS || '0.25';
 // Socket do daemon dedicado aos labs. Vazio = daemon padrão (usado só em dev).
 const DOCKER_HOST = process.env.LAB_DOCKER_HOST || '';
 
+const ambiente = DOCKER_HOST ? { ...process.env, DOCKER_HOST } : process.env;
 const sessoes = new Map();
+// Uma sessão por aluno, para uma conta só não ocupar todas as vagas.
+const porUsuario = new Map();
 
 function argsDoContainer(nome) {
-    return [
-        'run',
-        '--rm',
-        '-i',
-        '--tty',
-        '--name',
-        nome,
-        '--hostname',
-        'lab',
-        // Sem rede o Docker não resolve o próprio hostname, e aí todo sudo cospe
-        // um aviso de "unable to resolve host" antes de funcionar.
-        '--add-host',
-        'lab:127.0.0.1',
-        // Sem rede: os módulos de comando, permissões e bash não precisam, e é o
-        // que impede a caixa de ser usada para alcançar qualquer outra coisa.
-        '--network',
-        'none',
-        '--memory',
-        MEMORIA,
-        '--memory-swap',
-        MEMORIA,
-        '--cpus',
-        CPUS,
-        '--pids-limit',
-        '256',
-        IMAGEM,
-    ];
+  return [
+    'run', '--rm', '-i', '--tty',
+    '--name', nome,
+    '--hostname', 'lab',
+    // Sem rede o Docker não resolve o próprio hostname, e aí todo sudo cospe
+    // um aviso de "unable to resolve host" antes de funcionar.
+    '--add-host', 'lab:127.0.0.1',
+    // Sem rede: os módulos de comando, permissões e bash não precisam, e é o
+    // que impede a caixa de ser usada para alcançar qualquer outra coisa.
+    '--network', 'none',
+    '--memory', MEMORIA,
+    '--memory-swap', MEMORIA,
+    '--cpus', CPUS,
+    // Peso baixo na disputa por CPU. A máquina tem 2 vCPUs e o banco roda nela:
+    // com tudo ocupado, backend e Postgres ganham do laboratório, para um aluno
+    // sozinho não deixar o site lento para todo mundo.
+    '--cpu-shares', '256',
+    '--pids-limit', '256',
+    IMAGEM,
+    // O tempo de vida também vale de dentro. Se este serviço morrer ou for
+    // recriado num deploy, o container se encerra sozinho em vez de ficar
+    // rodando para sempre, porque o TTL daqui mora só na memória do processo.
+    'timeout', String(Math.round(TTL_MS / 1000)), '/bin/bash', '-l',
+  ];
+}
+
+// O --rm do Docker costuma chegar primeiro, então "não existe" e "remoção já em
+// andamento" são o caminho normal, não erro.
+const jaResolvido = /No such container|already in progress/i;
+
+function removerContainer(nome) {
+  execFile('docker', ['rm', '-f', nome], { env: ambiente }, (e) => {
+    if (e && !jaResolvido.test(e.message)) {
+      console.error('[labs] falha ao remover o container:', e.message);
+    }
+  });
+}
+
+// Um deploy recria este serviço, e os containers da execução anterior continuam
+// de pé sem ninguém para encerrá-los. Varre e limpa ao subir.
+function limparOrfaos() {
+  execFile('docker', ['ps', '-aq', '--filter', 'name=^lab-'], { env: ambiente }, (e, saida) => {
+    if (e) {
+      console.error('[labs] não foi possível procurar órfãos:', e.message);
+      return;
+    }
+    const ids = saida.split('\n').filter(Boolean);
+    if (ids.length === 0) return;
+    console.log(`[labs] removendo ${ids.length} laboratório(s) órfão(s) da execução anterior`);
+    execFile('docker', ['rm', '-f', ...ids], { env: ambiente }, (err) => {
+      if (err && !jaResolvido.test(err.message)) {
+        console.error('[labs] falha ao remover órfãos:', err.message);
+      }
+    });
+  });
 }
 
 function encerrar(sessao, motivo) {
-    if (sessao.encerrada) return;
-    sessao.encerrada = true;
-    clearTimeout(sessao.ttl);
-    sessoes.delete(sessao.id);
-    try {
-        sessao.proc.kill();
-    } catch (e) {
-        console.error('[labs] falha ao matar o pty:', e.message);
-    }
-    // O --rm cuida do container quando o processo morre, mas se o pty já tiver
-    // ido embora sem levar o docker junto, o rm garante que nada fica de pé.
-    try {
-        const env = DOCKER_HOST ? { ...process.env, DOCKER_HOST } : process.env;
-        pty.spawn('docker', ['rm', '-f', sessao.nome], { env }).on('exit', () => {});
-    } catch (e) {
-        console.error('[labs] falha ao remover o container:', e.message);
-    }
-    if (sessao.ws.readyState === sessao.ws.OPEN) {
-        sessao.ws.send(JSON.stringify({ tipo: 'fim', motivo }));
-        sessao.ws.close();
-    }
-    console.log(`[labs] sessão ${sessao.id} encerrada (${motivo}); ativas: ${sessoes.size}`);
+  if (sessao.encerrada) return;
+  sessao.encerrada = true;
+  clearTimeout(sessao.ttl);
+  sessoes.delete(sessao.id);
+  if (porUsuario.get(sessao.userId) === sessao) porUsuario.delete(sessao.userId);
+  try {
+    sessao.proc.kill();
+  } catch (e) {
+    console.error('[labs] falha ao matar o pty:', e.message);
+  }
+  removerContainer(sessao.nome);
+  if (sessao.ws.readyState === sessao.ws.OPEN) {
+    sessao.ws.send(JSON.stringify({ tipo: 'fim', motivo }));
+    sessao.ws.close();
+  }
+  console.log(`[labs] sessão ${sessao.id} encerrada (${motivo}); ativas: ${sessoes.size}`);
 }
 
-function abrirSessao(ws) {
-    if (sessoes.size >= MAX_SESSOES) {
-        ws.send(JSON.stringify({ tipo: 'erro', mensagem: 'Todos os laboratórios estão ocupados. Tente em instantes.' }));
-        ws.close();
-        return;
-    }
-    const id = `${Date.now().toString(36)}-${sessoes.size}`;
-    const nome = `lab-${id}`;
-    const env = DOCKER_HOST ? { ...process.env, DOCKER_HOST } : process.env;
-    const proc = pty.spawn('docker', argsDoContainer(nome), {
-        name: 'xterm-256color',
-        cols: 80,
-        rows: 24,
-        env,
-    });
+function abrirSessao(ws, req) {
+  // O backend só encaminha depois de conferir o ticket, e manda de quem é.
+  // Sem cabeçalho (conexão direta em dev), todos caem no mesmo balde.
+  const userId = String(req.headers['x-user-id'] || 'anonimo');
 
-    const sessao = { id, nome, proc, ws, encerrada: false };
-    sessao.ttl = setTimeout(() => encerrar(sessao, 'tempo esgotado'), TTL_MS);
-    sessoes.set(id, sessao);
-    console.log(`[labs] sessão ${id} aberta; ativas: ${sessoes.size}`);
+  // Recarregar a página não pode trancar o próprio acesso, então a sessão
+  // anterior do mesmo aluno é substituída em vez de a nova ser recusada.
+  const anterior = porUsuario.get(userId);
+  if (anterior) encerrar(anterior, 'substituída por uma nova sessão do mesmo aluno');
 
-    proc.onData((d) => {
-        if (ws.readyState === ws.OPEN) ws.send(d);
-    });
-    proc.onExit(() => encerrar(sessao, 'shell encerrado'));
+  if (sessoes.size >= MAX_SESSOES) {
+    ws.send(
+      JSON.stringify({
+        tipo: 'erro',
+        mensagem: 'Todos os laboratórios estão ocupados. Tente em instantes.',
+      }),
+    );
+    ws.close();
+    return;
+  }
 
-    ws.on('message', (raw, ehBinario) => {
-        if (sessao.encerrada) return;
-        // Texto puro é tecla digitada. JSON com tipo é comando de controle, hoje
-        // só o redimensionamento da janela.
-        const texto = ehBinario ? null : raw.toString();
-        if (texto && texto.startsWith('{')) {
-            try {
-                const msg = JSON.parse(texto);
-                if (msg.tipo === 'resize') {
-                    proc.resize(Math.max(2, msg.cols | 0), Math.max(2, msg.rows | 0));
-                    return;
-                }
-            } catch (e) {
-                console.error('[labs] mensagem de controle inválida:', e.message);
-            }
+  const id = `${Date.now().toString(36)}-${Math.round(Math.random() * 1e6).toString(36)}`;
+  const nome = `lab-${id}`;
+  const proc = pty.spawn('docker', argsDoContainer(nome), {
+    name: 'xterm-256color',
+    cols: 80,
+    rows: 24,
+    env: ambiente,
+  });
+
+  const sessao = { id, nome, userId, proc, ws, encerrada: false };
+  sessao.ttl = setTimeout(() => encerrar(sessao, 'tempo esgotado'), TTL_MS);
+  sessoes.set(id, sessao);
+  porUsuario.set(userId, sessao);
+  console.log(`[labs] sessão ${id} aberta; ativas: ${sessoes.size}`);
+
+  proc.onData((d) => {
+    if (ws.readyState === ws.OPEN) ws.send(d);
+  });
+  proc.onExit(() => encerrar(sessao, 'shell encerrado'));
+
+  ws.on('message', (raw, ehBinario) => {
+    if (sessao.encerrada) return;
+    // Texto puro é tecla digitada. JSON com tipo é comando de controle, hoje
+    // só o redimensionamento da janela.
+    const texto = ehBinario ? null : raw.toString();
+    if (texto && texto.startsWith('{')) {
+      try {
+        const msg = JSON.parse(texto);
+        if (msg.tipo === 'resize') {
+          proc.resize(Math.max(2, msg.cols | 0), Math.max(2, msg.rows | 0));
+          return;
         }
-        proc.write(texto ?? raw.toString());
-    });
+      } catch (e) {
+        console.error('[labs] mensagem de controle inválida:', e.message);
+      }
+    }
+    proc.write(texto ?? raw.toString());
+  });
 
-    ws.on('close', () => encerrar(sessao, 'conexão fechada'));
-    ws.on('error', (e) => {
-        console.error('[labs] erro no websocket:', e.message);
-        encerrar(sessao, 'erro de conexão');
-    });
+  ws.on('close', () => encerrar(sessao, 'conexão fechada'));
+  ws.on('error', (e) => {
+    console.error('[labs] erro no websocket:', e.message);
+    encerrar(sessao, 'erro de conexão');
+  });
 
-    ws.send(JSON.stringify({ tipo: 'pronto', ttlMinutos: Math.round(TTL_MS / 60000) }));
+  ws.send(JSON.stringify({ tipo: 'pronto', ttlMinutos: Math.round(TTL_MS / 60000) }));
 }
 
 const server = http.createServer((req, res) => {
-    if (req.url === '/health') {
-        res.writeHead(200, { 'content-type': 'application/json' });
-        res.end(JSON.stringify({ status: 'ok', sessoes: sessoes.size, max: MAX_SESSOES }));
-        return;
-    }
-    res.writeHead(404).end();
+  if (req.url === '/health') {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ status: 'ok', sessoes: sessoes.size, max: MAX_SESSOES }));
+    return;
+  }
+  res.writeHead(404).end();
 });
 
 const wss = new WebSocketServer({ server, path: '/sessao' });
 wss.on('connection', abrirSessao);
 
-server.listen(8090, () => console.log('labs ouvindo em :8090'));
+limparOrfaos();
+server.listen(8090, () => console.log(`labs ouvindo em :8090 (até ${MAX_SESSOES} sessões)`));


### PR DESCRIPTION
Ataquei o próprio laboratório para ver o que ele aguentava.

O isolamento se sustentou: user namespace confirmado (root dentro aparece como UID 501000 no host), seccomp ativo, nenhuma capability para o aluno comum, sem rede, e fork bomb contida pelo pids-limit. Nada disso compromete o host.

Apareceram três brechas de disponibilidade, todas exploráveis por qualquer aluno logado.

Um dd enchia o disco do servidor em cerca de um minuto e meio, o que derrubaria o Postgres junto. Cota por container não resolve aqui, porque exige xfs com pquota e a raiz é ext4. Os labs passam a ter um disco próprio de tamanho fixo montado por loopback, e o container agora enxerga esse teto no lugar do disco do host.

Uma conta sozinha ocupava todas as vagas, porque o serviço só conferia o total e nem recebia o usuário. O backend passa a informar de quem é a sessão, e vale uma por aluno. Abrir de novo substitui a anterior, para recarregar a página não trancar o próprio acesso.

Cada deploy abandonava as sessões ativas rodando para sempre, já que o tempo de vida morava só na memória do serviço. Agora ele varre e remove laboratórios de execuções anteriores ao subir, e o container se encerra sozinho pelo tempo mesmo sem ninguém para encerrá-lo.

Junto vai o teto de recursos, generoso demais para uma máquina de dois núcleos que também roda o banco: seis sessões em vez de vinte, um quarto de CPU em vez de meia, e peso baixo na disputa para backend e Postgres ganharem do laboratório quando apertar.

A parte de infraestrutura, que é o disco limitado e o timer semanal de limpeza, já está aplicada em produção e verificada. As mudanças de código entram com o merge.
