### PR TITLE
feat: primeiro passo na home e cadastro que explica o próximo passo

### DIFF
--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -28,6 +28,10 @@ import { NAV_PRINCIPAL as NAV } from '../../data/nav';
 
 const DIF_LABEL: Record<string, string> = { facil: 'Fácil', medio: 'Médio', dificil: 'Difícil' };
 
+// Trilha sugerida para quem ainda não começou nada. Se ela não existir, a home cai
+// na primeira trilha de nível iniciante que encontrar.
+const TRILHA_DE_ENTRADA = 'Lógica de Programação';
+
 // Resumo em texto puro do enunciado (primeiro bloco de texto, sem marcação).
 function resumoEnunciado(blocks: { type: string; value: string }[]): string {
   const texto = blocks.find((b) => b.type === 'text')?.value ?? '';
@@ -134,6 +138,15 @@ export function Home() {
   const mostrandoEmAndamento = emAndamento.length > 0;
   const listaTrilhas = (mostrandoEmAndamento ? emAndamento : disponiveis).slice(0, 4);
 
+  // Quem chega sem nenhum progresso cai numa grade de dezenas de trilhas sem saber
+  // por onde começar, e dois em cada três cadastros nunca abrem uma aula. Para esses,
+  // a home abre com um destino único: a trilha de entrada, direto na primeira aula.
+  const semProgresso = !carregando && disponiveis.length > 0 && disponiveis.every((t) => !t.done);
+  const trilhaInicial =
+    disponiveis.find((t) => t.name === TRILHA_DE_ENTRADA) ??
+    disponiveis.find((t) => t.level === 'Iniciante') ??
+    null;
+
   return (
     <div className="home-shell">
       <div className="home">
@@ -168,6 +181,27 @@ export function Home() {
         {/* Corpo */}
         <div className="home__body">
           <main className="home__main">
+            {/* Primeiro passo de quem ainda não começou */}
+            {semProgresso && trilhaInicial && (
+              <section className="inicio">
+                <span className="inicio__tag">Primeiros passos</span>
+                <h2 className="inicio__title">Nunca programou? Comece por aqui.</h2>
+                <p className="inicio__desc">
+                  <b>{trilhaInicial.name}</b> é o ponto de partida da plataforma, sem pré-requisito
+                  nenhum. São {trilhaInicial.lessons} aulas curtas, cada uma com um quiz no fim para
+                  fixar o que você acabou de ler.
+                </p>
+                <div className="inicio__acoes">
+                  <button className="inicio__btn" onClick={() => abrirTrilha(trilhaInicial.id)}>
+                    <Play size={15} /> Começar a primeira aula
+                  </button>
+                  <Link className="link" to="/trilhas">
+                    Prefiro escolher outra trilha
+                  </Link>
+                </div>
+              </section>
+            )}
+
             {/* Desafio do dia */}
             {desafioHoje && (
               <section>

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -31,6 +31,7 @@ const DIF_LABEL: Record<string, string> = { facil: 'Fácil', medio: 'Médio', di
 // Trilha sugerida para quem ainda não começou nada. Se ela não existir, a home cai
 // na primeira trilha de nível iniciante que encontrar.
 const TRILHA_DE_ENTRADA = 'Lógica de Programação';
+const CHAVE_DESTAQUE = '@App:primeiroPassoVisto';
 
 // Resumo em texto puro do enunciado (primeiro bloco de texto, sem marcação).
 function resumoEnunciado(blocks: { type: string; value: string }[]): string {
@@ -147,6 +148,25 @@ export function Home() {
     disponiveis.find((t) => t.level === 'Iniciante') ??
     null;
 
+  // O véu escurece o resto da home para a atenção cair no bloco. Some no primeiro
+  // clique (nele, fora dele ou no Esc) e não volta, para não virar obstáculo de quem
+  // só quer olhar a plataforma.
+  const [destaque, setDestaque] = useState(() => localStorage.getItem(CHAVE_DESTAQUE) !== '1');
+
+  function fecharDestaque() {
+    setDestaque(false);
+    localStorage.setItem(CHAVE_DESTAQUE, '1');
+  }
+
+  useEffect(() => {
+    if (!destaque) return;
+    function aoTeclar(e: KeyboardEvent) {
+      if (e.key === 'Escape') fecharDestaque();
+    }
+    window.addEventListener('keydown', aoTeclar);
+    return () => window.removeEventListener('keydown', aoTeclar);
+  }, [destaque]);
+
   return (
     <div className="home-shell">
       <div className="home">
@@ -183,23 +203,32 @@ export function Home() {
           <main className="home__main">
             {/* Primeiro passo de quem ainda não começou */}
             {semProgresso && trilhaInicial && (
-              <section className="inicio">
-                <span className="inicio__tag">Primeiros passos</span>
-                <h2 className="inicio__title">Nunca programou? Comece por aqui.</h2>
-                <p className="inicio__desc">
-                  <b>{trilhaInicial.name}</b> é o ponto de partida da plataforma, sem pré-requisito
-                  nenhum. São {trilhaInicial.lessons} aulas curtas, cada uma com um quiz no fim para
-                  fixar o que você acabou de ler.
-                </p>
-                <div className="inicio__acoes">
-                  <button className="inicio__btn" onClick={() => abrirTrilha(trilhaInicial.id)}>
-                    <Play size={15} /> Começar a primeira aula
-                  </button>
-                  <Link className="link" to="/trilhas">
-                    Prefiro escolher outra trilha
-                  </Link>
-                </div>
-              </section>
+              <>
+                {destaque && <div className="inicio__veu" onClick={fecharDestaque} />}
+                <section className={`inicio${destaque ? ' inicio--destaque' : ''}`}>
+                  <span className="inicio__tag">Primeiros passos</span>
+                  <h2 className="inicio__title">Nunca programou? Comece por aqui.</h2>
+                  <p className="inicio__desc">
+                    <b>{trilhaInicial.name}</b> é o ponto de partida da plataforma, sem
+                    pré-requisito nenhum. São {trilhaInicial.lessons} aulas curtas, cada uma com um
+                    quiz no fim para fixar o que você acabou de ler.
+                  </p>
+                  <div className="inicio__acoes">
+                    <button
+                      className="inicio__btn"
+                      onClick={() => {
+                        fecharDestaque();
+                        navigate(`/trilhas/${trilhaInicial.id}`);
+                      }}
+                    >
+                      Ver a trilha e começar
+                    </button>
+                    <Link className="link" to="/trilhas" onClick={fecharDestaque}>
+                      Prefiro escolher outra trilha
+                    </Link>
+                  </div>
+                </section>
+              </>
             )}
 
             {/* Desafio do dia */}

--- a/frontend/src/pages/Login/index.tsx
+++ b/frontend/src/pages/Login/index.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react';
-import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { Link, useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { AuthShell } from '../../components/auth/AuthShell';
 import { AuthBrand } from '../../components/auth/AuthBrand';
@@ -25,7 +25,13 @@ export function Login() {
   const [searchParams] = useSearchParams();
   const erroOAuth = ERROS_OAUTH[searchParams.get('erro') ?? ''] ?? '';
 
-  const [email, setEmail] = useState('');
+  // Quem acabou de se cadastrar chega aqui com o aviso de confirmar o email e com o
+  // endereço já preenchido; sem isso a pessoa cai numa tela de login sem entender por
+  // que foi parar nela.
+  const vindoDoCadastro = useLocation().state as { aviso?: string; email?: string } | null;
+  const [avisoCadastro, setAvisoCadastro] = useState(vindoDoCadastro?.aviso ?? '');
+
+  const [email, setEmail] = useState(vindoDoCadastro?.email ?? '');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const [submitting, setSubmitting] = useState(false);
@@ -37,6 +43,7 @@ export function Login() {
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setError('');
+    setAvisoCadastro('');
     setNaoVerificado(false);
     setReenvioMsg('');
     setSubmitting(true);
@@ -115,6 +122,8 @@ export function Login() {
       </div>
       <h2 className="auth__title">Bem-vindo de volta</h2>
       <p className="auth__subtitle">Continue de onde você parou.</p>
+
+      {avisoCadastro && <div className="auth__alert auth__alert--ok">{avisoCadastro}</div>}
 
       {(error || erroOAuth) && <div className="auth__alert">{error || erroOAuth}</div>}
 

--- a/frontend/src/pages/Register/index.tsx
+++ b/frontend/src/pages/Register/index.tsx
@@ -78,7 +78,7 @@ export function Register() {
 
     setSubmitting(true);
     try {
-      await api.post('/register', {
+      const { data } = await api.post('/register', {
         name,
         username,
         email: email.trim(),
@@ -87,7 +87,14 @@ export function Register() {
         gender,
         phone: phone.trim(),
       });
-      navigate('/entrar');
+      // Leva o aviso de confirmar o email junto: o login recusa quem ainda não
+      // confirmou, e sem esse texto a pessoa não entende por que voltou para cá.
+      navigate('/entrar', {
+        state: {
+          aviso: data?.mensagem ?? 'Conta criada. Verifique seu email para ativar o acesso.',
+          email: email.trim(),
+        },
+      });
     } catch (e: unknown) {
       // Mapeia os erros conhecidos do backend (409) para o campo certo.
       const msg = mensagemErro(e, 'Erro ao criar conta. Tente novamente.');

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1020,6 +1020,65 @@
   font-weight: 700;
 }
 
+/* Primeiro passo (home de quem ainda não começou nenhuma trilha) */
+.inicio {
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--r-xl);
+  padding: 22px;
+}
+.inicio__tag {
+  display: inline-block;
+  font-size: 11.5px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--accent);
+  background: var(--accent-soft);
+  border-radius: 99px;
+  padding: 4px 10px;
+}
+.inicio__title {
+  font-size: 20px;
+  font-weight: 700;
+  margin: 12px 0 0;
+}
+.inicio__desc {
+  font-size: 14px;
+  line-height: 1.65;
+  color: var(--muted);
+  margin: 8px 0 0;
+  max-width: 62ch;
+}
+.inicio__desc b {
+  color: var(--text);
+  font-weight: 600;
+}
+.inicio__acoes {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  flex-wrap: wrap;
+  margin-top: 18px;
+}
+.inicio__btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border: 0;
+  cursor: pointer;
+  font: inherit;
+  font-size: 14px;
+  font-weight: 600;
+  color: #fff;
+  background: var(--accent);
+  border-radius: var(--r-md);
+  padding: 11px 18px;
+}
+.inicio__btn:hover {
+  filter: brightness(1.08);
+}
+
 /* Cards da sidebar */
 .card {
   background: var(--surface);

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1027,6 +1027,32 @@
   border-radius: var(--r-xl);
   padding: 22px;
 }
+/* Véu que escurece o resto da home enquanto o bloco não recebe o primeiro clique. */
+.inicio__veu {
+  position: fixed;
+  inset: 0;
+  z-index: 400;
+  background: rgba(0, 0, 0, 0.58);
+  animation: inicio-veu 0.25s ease;
+}
+@keyframes inicio-veu {
+  from {
+    opacity: 0;
+  }
+}
+.inicio--destaque {
+  position: relative;
+  z-index: 401;
+  border-color: var(--accent);
+  box-shadow:
+    0 0 0 4px color-mix(in srgb, var(--accent) 28%, transparent),
+    0 22px 60px rgba(0, 0, 0, 0.4);
+}
+@media (prefers-reduced-motion: reduce) {
+  .inicio__veu {
+    animation: none;
+  }
+}
 .inicio__tag {
   display: inline-block;
   font-size: 11.5px;


### PR DESCRIPTION
## O problema

Levantei o funil em produção antes de mexer em qualquer coisa:

| | Usuários | % |
|---|---|---|
| Cadastrados | 1364 | |
| Abriram alguma aula | 336 | 25% |
| Responderam algum quiz | 317 | 23% |
| Fizeram algum desafio | 170 | 12% |
| Fizeram algum simulado | 35 | 3% |
| **Zero atividade** | **916** | **67%** |

1357 dos 1364 cadastros são de julho, então é o funil atual e não resíduo antigo.

Dois furos aparecem logo na entrada.

**1. Não existe destino óbvio.** Quem chega sem progresso vê "Desafio do dia" no topo, que é um problema de código, e abaixo uma grade de dezenas de trilhas. Quem nunca programou não sabe por onde começar.

**2. O cadastro não explica o que aconteceu.** Ao criar conta por email e senha, a pessoa é jogada na tela de login sem mensagem nenhuma. A API já respondia "Conta criada. Verifique seu email para ativar o acesso", mas o front descartava esse texto. A pessoa tentava entrar, tomava "Verifique seu email antes de entrar" e ficava sem entender.

## O que muda

**Primeiro passo na home.** Para quem não tem progresso em trilha nenhuma, a home abre com um bloco único apontando a trilha de entrada, em destaque, com o resto da página escurecido por um véu. O botão leva para a página de detalhes da trilha, onde a pessoa vê o que vai aprender, o tempo de leitura, os módulos, escolhe a linguagem e começa pelo botão de lá.

**Cadastro que explica.** O cadastro passa a levar o aviso e o email digitado para a tela de login, que mostra o aviso e já preenche o campo. Se ainda assim a pessoa tentar entrar sem confirmar, o fluxo de reenviar verificação que já existia continua valendo.

## Detalhes

- O bloco some sozinho assim que a pessoa tiver qualquer progresso. Nada é adicionado para usuário ativo.
- O véu some no primeiro clique, seja no botão, fora dele ou no Esc, e fica marcado em `localStorage` para não voltar em quem só quer olhar a plataforma.
- A trilha sugerida é `Lógica de Programação`. Se ela não existir na base, cai na primeira de nível iniciante; sem nenhuma, o bloco não renderiza.
- Enquanto as trilhas carregam, o bloco fica oculto, então não há piscada.
- Estilo só com tokens do tema, então funciona em claro e escuro. O véu respeita `prefers-reduced-motion`.

## Por que não um tour guiado de vários passos

O funil mostra que o problema não é "não sei onde clicar", e sim que não existe destino óbvio. Um tour de vários slides só alcança cadastro novo (não faz nada pelos 916 que já saíram), aparece uma vez no momento em que a pessoa quer explorar, e fica ancorado no layout, quebrando a cada mudança de tela. O destaque aqui é um passo só, sobre o bloco que já resolve a dúvida.

Esta é a primeira das quatro ideias que discutimos. As outras (rotear para um roadmap no cadastro, checklist de primeiros passos persistente e o tour completo) continuam na mesa.

## Testado localmente

Contas novas criadas em dev pelo cadastro real:

- a home de quem tem zero progresso abre com o bloco em destaque e o resto escurecido
- o botão abre os detalhes de Lógica de Programação, com o seletor JavaScript / Python
- voltando para a home, o véu não reaparece e o bloco continua
- o cadastro mostra "Conta criada. Verifique seu email para ativar o acesso" na tela de login, com o email já preenchido
- `tsc --noEmit` e eslint passando

## Nota

Indo direto para a aula, a versão anterior pulava a escolha entre JavaScript e Python, que só existe na página de detalhes. Foi o motivo de mudar o destino do botão.