### PR TITLE
feat: volta o botão de apoiar na navegação e no menu

### DIFF
--- a/frontend/src/components/UserMenu.tsx
+++ b/frontend/src/components/UserMenu.tsx
@@ -94,17 +94,14 @@ export function UserMenu({ initials, level, name, email }: UserMenuProps) {
           >
             Conquistas
           </button>
-          {/* 'Apoiar o projeto' oculto temporariamente; quem já é apoiador ainda acessa a assinatura. */}
-          {user?.apoiador && (
-            <button
-              type="button"
-              role="menuitem"
-              className="user-menu__item"
-              onClick={() => go('/apoie')}
-            >
-              Minha assinatura
-            </button>
-          )}
+          <button
+            type="button"
+            role="menuitem"
+            className="user-menu__item"
+            onClick={() => go('/apoie')}
+          >
+            {user?.apoiador ? 'Minha assinatura' : 'Apoiar o projeto'}
+          </button>
           {user?.role === 'admin' && (
             <button
               type="button"

--- a/frontend/src/data/nav.ts
+++ b/frontend/src/data/nav.ts
@@ -7,7 +7,7 @@ export const NAV_PRINCIPAL = [
   { label: 'Desafios', to: '/desafios' },
   { label: 'Ranking', to: '/ranking' },
   { label: 'Comunidade', to: '/comunidade' },
-  // 'Apoiar' oculto temporariamente; readicionar: { label: 'Apoiar', to: '/apoie' }
+  { label: 'Apoiar', to: '/apoie' },
 ];
 
 export const NAV_ESTUDIO = [


### PR DESCRIPTION
Volta os dois pontos de entrada do apoio que estavam escondidos desde o c28d0ab: o item 'Apoiar' na navegação principal e o 'Apoiar o projeto' no menu do usuário. Quem já é apoiador continua vendo 'Minha assinatura' no lugar.

Eles foram escondidos porque a cobrança ainda não estava de pé. Isso mudou: o AbacatePay está configurado em produção, com a chave de produção no `.env.prod` e o webhook já cadastrado no painel.

## O que muda

- `frontend/src/data/nav.ts`: readiciona `{ label: 'Apoiar', to: '/apoie' }` na navegação principal.
- `frontend/src/components/UserMenu.tsx`: volta ao botão único, com o rótulo saindo de `user?.apoiador`.

O diff é o inverso exato do c28d0ab, os arquivos voltaram ao conteúdo que tinham antes dele.

## Como testar

1. Com uma conta sem apoio: 'Apoiar' aparece na navegação e 'Apoiar o projeto' no menu do usuário.
2. Com uma conta apoiadora: o item do menu vira 'Minha assinatura'.
3. Em `/apoie`, gerar um Pix mensal e conferir que o QR code aparece.

Como o build de produção é feito na imagem do frontend, o botão só aparece no ar depois do deploy, não é algo que o restart do backend resolva.
