### PR TITLE
fix: confirma o apoio sem depender do webhook do gateway

### DIFF
--- a/backend/db.ts
+++ b/backend/db.ts
@@ -9,4 +9,12 @@ const pool = new pg.Pool({
     ssl: env.DB_SSL ? { rejectUnauthorized: false } : false,
 });
 
+// Sem este handler o pool relança o erro como 'error' event sem ouvinte, o que
+// derruba o processo. Um restart do Postgres (deploy, recriação do container)
+// mata todas as conexões de uma vez e cai exatamente aqui. O pool abre conexão
+// nova na próxima consulta, então basta registrar e seguir.
+pool.on("error", (err) => {
+    console.error("Erro em conexão ociosa do pool do Postgres:", err.message);
+});
+
 export const db = drizzle(pool);

--- a/backend/scripts/reconciliar-apoios.ts
+++ b/backend/scripts/reconciliar-apoios.ts
@@ -1,0 +1,103 @@
+// Ativa os apoios que foram pagos no gateway mas continuam pendentes no banco.
+// Acontece quando o webhook do AbacatePay não chega: não cadastrado, fora do ar,
+// segredo trocado. A tela de apoio já confirma sozinha enquanto o QR está aberto,
+// mas cobrança paga depois disso (ou antes desta correção existir) fica presa e
+// só sai daqui.
+//
+// Idempotente: só mexe em linha pendente com paid_at nulo, e só quando o gateway
+// diz PAID. Rodar de novo não estende validade de ninguém.
+//
+// Rodar em prod: docker compose -f docker-compose.prod.yml run --rm -T --no-deps backend node scripts/reconciliar-apoios.ts
+import { and, eq, isNotNull, isNull } from "drizzle-orm";
+import { db } from "../db.ts";
+import { subscriptions, users } from "../schema.ts";
+import { PLANOS } from "../src/services/apoiador.service.ts";
+import { consultarPixQrCode, gatewayConfigurado } from "../src/services/abacatepay.client.ts";
+
+const reais = (cents: number) => `R$ ${(cents / 100).toFixed(2).replace(".", ",")}`;
+
+async function reconciliar() {
+    if (!gatewayConfigurado()) {
+        console.error("Sem ABACATEPAY_API_KEY: não há como consultar o gateway.");
+        process.exit(1);
+    }
+
+    const pendentes = await db
+        .select({
+            id: subscriptions.id,
+            plan: subscriptions.plan,
+            gatewayId: subscriptions.gatewayId,
+            amountCents: subscriptions.amountCents,
+            paidAt: subscriptions.paidAt,
+            expiresAt: subscriptions.expiresAt,
+            username: users.username,
+            email: users.email,
+        })
+        .from(subscriptions)
+        .innerJoin(users, eq(users.id, subscriptions.userId))
+        .where(
+            and(
+                eq(subscriptions.status, "pendente"),
+                isNull(subscriptions.paidAt),
+                isNotNull(subscriptions.gatewayId),
+            ),
+        );
+
+    if (pendentes.length === 0) {
+        console.log("Nenhuma cobrança pendente para conferir.");
+        return;
+    }
+
+    let ativadas = 0;
+    let recebido = 0;
+    for (const p of pendentes) {
+        const quem = p.username ?? p.email;
+        // Só cobrança de QRCode Pix tem consulta nesta rota; assinatura recorrente
+        // vem do /billing e depende do webhook.
+        if (!p.gatewayId!.startsWith("pix_char_")) {
+            console.log(`${quem}: ${p.gatewayId} não é QRCode Pix, pulando.`);
+            continue;
+        }
+        try {
+            const cobranca = await consultarPixQrCode(p.gatewayId!);
+            if (!cobranca.pago) {
+                console.log(`${quem}: ${p.plan} de ${reais(p.amountCents)} segue sem pagamento.`);
+                continue;
+            }
+            if (cobranca.amountCents !== p.amountCents) {
+                console.warn(
+                    `${quem}: valor divergente, cobramos ${reais(p.amountCents)} e o gateway registrou ${reais(cobranca.amountCents)}.`,
+                );
+            }
+            const pagoEm = cobranca.pagoEm ?? new Date();
+            const expiresAt = new Date(pagoEm.getTime() + PLANOS[p.plan].dias * 86400000);
+            const feito = await db
+                .update(subscriptions)
+                .set({ status: "ativa", paidAt: pagoEm, expiresAt })
+                .where(and(eq(subscriptions.id, p.id), isNull(subscriptions.paidAt)))
+                .returning({ id: subscriptions.id });
+            if (feito.length === 0) {
+                console.log(`${quem}: alguém confirmou antes, nada a fazer.`);
+                continue;
+            }
+            ativadas++;
+            recebido += p.amountCents;
+            console.log(
+                `${quem}: ${p.plan} de ${reais(p.amountCents)} pago em ${pagoEm.toISOString()}, apoio vale até ${expiresAt.toISOString()}.`,
+            );
+        } catch (err) {
+            console.error(`${quem}: falha ao consultar ${p.gatewayId}:`, err);
+        }
+    }
+
+    console.log(
+        `Concluído: ${pendentes.length} conferidas, ${ativadas} ativadas, ${reais(recebido)} reconhecidos.`,
+    );
+}
+
+reconciliar()
+    .then(() => process.exit(0))
+    .catch((e) => {
+        console.error("Falha ao reconciliar apoios:", e);
+        process.exit(1);
+    });

--- a/backend/src/services/abacatepay.client.ts
+++ b/backend/src/services/abacatepay.client.ts
@@ -5,6 +5,10 @@ export function gatewayConfigurado() {
     return Boolean(env.ABACATEPAY_API_KEY);
 }
 
+// Validade do QRCode Pix. Passado esse prazo a cobrança não pode mais ser paga,
+// então nem vale consultar o gateway sobre ela.
+export const PIX_TTL_SEGUNDOS = 1800;
+
 async function chamar(caminho: string, body: unknown) {
     const resposta = await fetch(`${env.ABACATEPAY_API_URL}${caminho}`, {
         method: "POST",
@@ -22,6 +26,36 @@ async function chamar(caminho: string, body: unknown) {
     return dados as Record<string, unknown>;
 }
 
+// Estado de um QRCode Pix já criado (v1). É como sabemos que o dinheiro entrou
+// sem depender do webhook: PENDING enquanto ninguém paga, PAID depois.
+export async function consultarPixQrCode(id: string) {
+    const resposta = await fetch(
+        `${env.ABACATEPAY_API_URL}/pixQrCode/check?id=${encodeURIComponent(id)}`,
+        { headers: { Authorization: `Bearer ${env.ABACATEPAY_API_KEY}` } },
+    );
+    const dados = await resposta.json().catch(() => null);
+    if (!resposta.ok) {
+        console.error(
+            "AbacatePay respondeu erro ao consultar cobrança:",
+            id,
+            resposta.status,
+            JSON.stringify(dados),
+        );
+        throw new AppError(
+            502,
+            "O gateway de pagamento não respondeu. Tente de novo em instantes.",
+        );
+    }
+    const d = ((dados as Record<string, unknown>)?.data ?? dados) as Record<string, unknown>;
+    return {
+        pago: String(d.status ?? "") === "PAID",
+        amountCents: Number(d.amount ?? 0),
+        // updatedAt é quando a cobrança virou PAID. Vale mais que a hora da
+        // reconciliação: é o instante em que o aluno pagou de verdade.
+        pagoEm: d.updatedAt ? new Date(String(d.updatedAt)) : null,
+    };
+}
+
 // QRCode Pix direto (v1): devolve o QR (imagem base64) e o copia-e-cola.
 // Sem customer de propósito: no Pix quem paga já se identifica no banco.
 export async function criarPixTransparente(
@@ -32,7 +66,7 @@ export async function criarPixTransparente(
     const r = await chamar("/pixQrCode/create", {
         amount: amountCents,
         description,
-        expiresIn: 1800,
+        expiresIn: PIX_TTL_SEGUNDOS,
         metadata,
     });
     const dados = (r.data ?? r) as Record<string, unknown>;

--- a/backend/src/services/apoiador.service.ts
+++ b/backend/src/services/apoiador.service.ts
@@ -1,4 +1,5 @@
-import { and, count, desc, eq, gt, inArray, or } from "drizzle-orm";
+import { randomUUID } from "node:crypto";
+import { and, count, desc, eq, gt, inArray, isNotNull, isNull, or } from "drizzle-orm";
 import { db } from "../../db.ts";
 import { subscriptions, users } from "../../schema.ts";
 import { AppError } from "../errors/AppError.ts";
@@ -7,6 +8,8 @@ import {
     gatewayConfigurado,
     criarPixTransparente,
     criarCheckoutAssinatura,
+    consultarPixQrCode,
+    PIX_TTL_SEGUNDOS,
 } from "./abacatepay.client.ts";
 
 export const PLANOS = {
@@ -47,7 +50,62 @@ export async function apoiadoresAtivos(): Promise<Set<string>> {
     return new Set(linhas.map((l) => l.userId));
 }
 
+// Marca o apoio como pago e calcula até quando vale. Renovação estende a partir
+// do vencimento atual; pagamento novo conta da data em que o dinheiro entrou.
+async function ativarAssinatura(
+    alvo: {
+        id: string;
+        plan: keyof typeof PLANOS;
+        paidAt: Date | null;
+        expiresAt: Date | null;
+    },
+    pagoEm: Date,
+    renovacao = false,
+) {
+    const base = renovacao && alvo.expiresAt && alvo.expiresAt > pagoEm ? alvo.expiresAt : pagoEm;
+    const expiresAt = new Date(base.getTime() + PLANOS[alvo.plan].dias * 86400000);
+    // Fora de renovação, exigir paid_at nulo torna a ativação idempotente: o
+    // webhook e a consulta ao gateway podem chegar juntos sem se atropelar.
+    const condicoes = [eq(subscriptions.id, alvo.id)];
+    if (!renovacao) condicoes.push(isNull(subscriptions.paidAt));
+    await db
+        .update(subscriptions)
+        .set({ status: "ativa", paidAt: alvo.paidAt ?? pagoEm, expiresAt })
+        .where(and(...condicoes));
+}
+
+// Pergunta ao gateway se as cobranças que ainda estão pendentes aqui já foram
+// pagas. O webhook é o caminho rápido, e este é o que garante que um webhook
+// perdido não deixe quem pagou sem o apoio. Só consulta cobrança que ainda pode
+// ser paga, para não bater no gateway a cada abertura da página.
+export async function confirmarPagamentosPendentes(userId: string) {
+    if (!gatewayConfigurado()) return;
+    const pendentes = await db
+        .select()
+        .from(subscriptions)
+        .where(
+            and(
+                eq(subscriptions.userId, userId),
+                eq(subscriptions.status, "pendente"),
+                isNull(subscriptions.paidAt),
+                isNotNull(subscriptions.gatewayId),
+                gt(subscriptions.createdAt, new Date(Date.now() - PIX_TTL_SEGUNDOS * 1000)),
+            ),
+        );
+    for (const pendente of pendentes) {
+        try {
+            const cobranca = await consultarPixQrCode(pendente.gatewayId!);
+            if (cobranca.pago) await ativarAssinatura(pendente, cobranca.pagoEm ?? new Date());
+        } catch (err) {
+            // Gateway fora do ar não pode derrubar a tela de apoio: a próxima
+            // consulta ou o webhook resolvem.
+            console.error("Falha ao confirmar cobrança no gateway:", pendente.gatewayId, err);
+        }
+    }
+}
+
 export async function statusApoio(userId: string) {
+    await confirmarPagamentosPendentes(userId);
     const [ativa] = await db
         .select({
             plan: subscriptions.plan,
@@ -82,6 +140,7 @@ export async function criarCobranca(userId: string, plan: "mensal" | "anual") {
             and(
                 eq(subscriptions.userId, userId),
                 eq(subscriptions.status, "pendente"),
+                isNotNull(subscriptions.gatewayId),
                 gt(subscriptions.createdAt, new Date(Date.now() - 3600000)),
             ),
         );
@@ -91,21 +150,24 @@ export async function criarCobranca(userId: string, plan: "mensal" | "anual") {
     if (!gatewayConfigurado()) {
         throw new AppError(503, "O apoio ainda não está disponível. Volte em breve!");
     }
-    const [pendente] = await db
-        .insert(subscriptions)
-        .values({ userId, plan, status: "pendente", amountCents: PLANOS[plan].valorCents })
-        .returning({ id: subscriptions.id });
-
+    // O id nasce aqui para viajar no metadata da cobrança, e a linha só é gravada
+    // depois que o gateway responde. Assim uma falha na criação do Pix não deixa
+    // pendência órfã, que além de sujar o histórico contaria contra o limite acima.
+    const id = randomUUID();
     const pix = await criarPixTransparente(PLANOS[plan].valorCents, PLANOS[plan].descricao, {
-        subscriptionId: pendente.id,
+        subscriptionId: id,
     });
-    await db
-        .update(subscriptions)
-        .set({ gatewayId: pix.gatewayId || null })
-        .where(eq(subscriptions.id, pendente.id));
+    await db.insert(subscriptions).values({
+        id,
+        userId,
+        plan,
+        status: "pendente",
+        amountCents: PLANOS[plan].valorCents,
+        gatewayId: pix.gatewayId || null,
+    });
 
     return {
-        subscriptionId: pendente.id,
+        subscriptionId: id,
         valorCents: PLANOS[plan].valorCents,
         brCode: pix.brCode,
         brCodeBase64: pix.brCodeBase64,
@@ -116,26 +178,21 @@ export async function criarAssinaturaRecorrente(userId: string) {
     if (!gatewayConfigurado() || !env.ABACATEPAY_PRODUCT_PIX_AUTO) {
         throw new AppError(503, "O Pix Automático ainda não está disponível. Use o plano mensal ou anual.");
     }
-    const [pendente] = await db
-        .insert(subscriptions)
-        .values({
-            userId,
-            plan: "pix_auto",
-            status: "pendente",
-            amountCents: PLANOS.pix_auto.valorCents,
-        })
-        .returning({ id: subscriptions.id });
-
+    const id = randomUUID();
     const checkout = await criarCheckoutAssinatura(
         env.ABACATEPAY_PRODUCT_PIX_AUTO,
         `${env.FRONTEND_URL}/apoie`,
         `${env.FRONTEND_URL}/apoie?pago=1`,
-        pendente.id,
+        id,
     );
-    await db
-        .update(subscriptions)
-        .set({ gatewayId: checkout.gatewayId || null })
-        .where(eq(subscriptions.id, pendente.id));
+    await db.insert(subscriptions).values({
+        id,
+        userId,
+        plan: "pix_auto",
+        status: "pendente",
+        amountCents: PLANOS.pix_auto.valorCents,
+        gatewayId: checkout.gatewayId || null,
+    });
 
     return { url: checkout.url };
 }
@@ -149,7 +206,15 @@ function extrairReferencias(payload: Record<string, unknown>): string[] {
         if (typeof o.subscriptionId === "string") refs.push(o.subscriptionId);
         if (typeof o.externalId === "string") refs.push(o.externalId);
         if (typeof o.id === "string") refs.push(o.id);
-        for (const chave of ["metadata", "data", "pixQrCode", "transparent", "checkout", "subscription", "billing"]) {
+        for (const chave of [
+            "metadata",
+            "data",
+            "pixQrCode",
+            "transparent",
+            "checkout",
+            "subscription",
+            "billing",
+        ]) {
             visitar(o[chave]);
         }
     };
@@ -187,22 +252,16 @@ export async function processarWebhook(payload: Record<string, unknown>) {
     }
 
     if (EVENTOS_PAGAMENTO.has(evento)) {
-        const agora = new Date();
-        if (alvo.paidAt && evento !== "subscription.renewed") {
+        const renovacao = evento === "subscription.renewed";
+        if (alvo.paidAt && !renovacao) {
             return { ok: true };
         }
-        // Renovação estende a partir do vencimento atual; pagamento novo começa agora.
-        const base =
-            alvo.expiresAt && alvo.expiresAt > agora && evento === "subscription.renewed"
-                ? alvo.expiresAt
-                : agora;
-        const expiresAt = new Date(base.getTime() + PLANOS[alvo.plan].dias * 86400000);
+        await ativarAssinatura(alvo, new Date(), renovacao);
+    } else if (evento === "subscription.cancelled") {
         await db
             .update(subscriptions)
-            .set({ status: "ativa", paidAt: alvo.paidAt ?? agora, expiresAt })
+            .set({ status: "cancelada" })
             .where(eq(subscriptions.id, alvo.id));
-    } else if (evento === "subscription.cancelled") {
-        await db.update(subscriptions).set({ status: "cancelada" }).where(eq(subscriptions.id, alvo.id));
     } else {
         console.warn("Webhook do gateway com evento não tratado:", evento);
     }
@@ -216,7 +275,6 @@ export async function definirAccent(userId: string, accent: string | null) {
     await db.update(users).set({ accent }).where(eq(users.id, userId));
     return { accent };
 }
-
 
 // Cancela o que estiver valendo: nada renova, e o período já pago segue até o fim.
 export async function cancelarApoio(userId: string) {
@@ -242,7 +300,6 @@ export async function cancelarApoio(userId: string) {
     return { ok: true, expiresAt: expiresAt ?? null, pixAuto };
 }
 
-
 export async function definirVeuFundo(userId: string, dim: number) {
     if (!(await apoiadorAtivo(userId))) {
         throw new AppError(403, "Imagem de fundo é um benefício de apoiador.");
@@ -250,7 +307,6 @@ export async function definirVeuFundo(userId: string, dim: number) {
     await db.update(users).set({ backgroundDim: dim }).where(eq(users.id, userId));
     return { backgroundDim: dim };
 }
-
 
 const TZ_SP = "America/Sao_Paulo";
 const diaSP = (d: Date) => d.toLocaleDateString("en-CA", { timeZone: TZ_SP });

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -12,4 +12,11 @@ ensinadev.com.br, www.ensinadev.com.br {
 	}
 
 	encode gzip
+
+	# Sem log de acesso não há como saber se um webhook de gateway chegou e foi
+	# recusado ou se nunca chegou. Vale o barulho no journal por isso.
+	log {
+		output stderr
+		format json
+	}
 }


### PR DESCRIPTION
Hotfix direto na `main`. Hoje cinco pessoas geraram cobrança de apoio e **duas pagaram**, R$ 5 e R$ 50, e as duas ficaram sem o apoio.

## O que aconteceu

A linha de `subscriptions` só virava `ativa` pelo webhook do AbacatePay. O webhook não estava chamando a plataforma, e não existia nenhum outro caminho para o dinheiro que entrou ser reconhecido. Confirmei pela API deles que as duas cobranças estão `PAID` no gateway.

Diagnosticar levou mais tempo do que devia porque o Caddy não registrava acesso, então não havia como distinguir "o gateway nunca chamou" de "chamou e tomou 401".

## A correção principal

A página de apoio **já pergunta o status a cada 4 segundos** enquanto o QR está na tela. O backend é que só olhava o próprio banco. Agora o status consulta o gateway quando existe cobrança que ainda pode ser paga:

- `consultarPixQrCode` no client, que lê `GET /pixQrCode/check`
- `confirmarPagamentosPendentes(userId)` chamado no início de `statusApoio`
- a janela é o TTL do próprio QR, 30 minutos, então quem não gerou cobrança agora não dispara chamada externa nenhuma

Com isso o apoio confirma em segundos **mesmo sem webhook**. O webhook continua sendo o caminho rápido, só deixa de ser o único.

A conta de validade saiu de dentro do `processarWebhook` e virou `ativarAssinatura`, usada pelos dois caminhos. Fora de renovação ela exige `paid_at` nulo, então webhook e consulta podem chegar juntos sem se atropelar nem estender a assinatura duas vezes.

## Para o que já ficou preso

`scripts/reconciliar-apoios.ts` varre as pendentes com cobrança no gateway, pergunta o estado de cada uma e ativa as pagas, usando o `updatedAt` do gateway como data do pagamento em vez de "agora". Idempotente: só toca em linha com `paid_at` nulo. É o que resolve as duas de hoje, que estão fora da janela de 30 minutos.

    docker compose -f docker-compose.prod.yml run --rm -T --no-deps backend node scripts/reconciliar-apoios.ts

## Três coisas que apareceram investigando

**A cobrança gravava a linha antes de chamar o gateway.** Duas das cinco de hoje ficaram órfãs, sem cobrança correspondente no gateway, porque a requisição morreu no meio (o backend foi recriado por um deploy segundos depois). Pior: órfã contava contra o limite de três cobranças por hora, então quem esbarrasse em falha do gateway três vezes ficava uma hora bloqueado com 429 sem nunca ter visto um QR code. Agora o id nasce antes para viajar no `metadata`, e a linha só é gravada depois que o gateway responde.

**O pool do Postgres não tinha handler de `error`.** Sem ele o pool relança como evento sem ouvinte e derruba o processo. Aconteceu hoje: o container do banco foi recriado, o backend morreu com `Unhandled 'error' event` e só voltou porque o Docker reinicia. Três segundos fora do ar e tudo em voo perdido.

**O Caddy não registrava acesso.** Passa a registrar, em JSON no stderr.

## Verificação

- 107 testes de integração passando, incluindo os 12 de apoio. Os que cobrem o caminho novo indiretamente: reentrega de webhook não estende a assinatura, rajada de pendentes ainda dá 429, cobrança sem gateway configurado ainda dá 503
- `tsc --noEmit` e eslint limpos
- `caddy validate` aceita o Caddyfile
- a leitura do `GET /pixQrCode/check` foi conferida contra o gateway real hoje, nas cinco cobranças: acertou os dois `PAID` e os três `PENDING`, e os campos `amount` e `updatedAt` batem

O que **não** tem teste automatizado é a consulta ao gateway dentro do `statusApoio`, porque os testes rodam sem `ABACATEPAY_API_KEY` de propósito (um deles verifica justamente o comportamento sem gateway) e o serviço já está carregado quando o servidor de teste sobe, o que impede o mock de módulo. O parsing da resposta é o mesmo já conferido contra o gateway real.

## Depois do merge

Ainda é preciso cadastrar o webhook no painel, em Integração > Webhook, apontando para `https://ensinadev.com.br/api/webhooks/abacatepay?webhookSecret=<segredo>`. Isso aqui garante que ninguém mais fique sem o apoio, mas o webhook é o que confirma na hora sem depender de a pessoa estar com a página aberta.