### PR TITLE
feat: trilhas de PHP, Ruby, Laravel e Ruby on Rails

### DIFF
--- a/backend/scripts/seed-detalhes-trilhas.ts
+++ b/backend/scripts/seed-detalhes-trilhas.ts
@@ -29,6 +29,42 @@ const DETALHES: Record<string, { whatYouLearn: string[]; prerequisites: string[]
         ],
         prerequisites: ["Lógica de programação (algoritmos, laços, condicionais)"],
     },
+    PHP: {
+        whatYouLearn: [
+            "Sintaxe, tipos e strings do PHP 8.5",
+            "Arrays, funções, controle de fluxo e o pipe operator",
+            "Orientação a objetos com enums, readonly e traits",
+            "PHP na web: formulários, sessões, PDO e autoload PSR-4",
+        ],
+        prerequisites: ["Lógica de programação (algoritmos, laços, condicionais)"],
+    },
+    Ruby: {
+        whatYouLearn: [
+            "A sintaxe do Ruby 4.0, onde tudo é objeto",
+            "Coleções, Enumerable, blocos e pattern matching",
+            "Classes, módulos, mixins e duck typing",
+            "Exceções, testes com Minitest e RSpec, e o Ruby moderno",
+        ],
+        prerequisites: ["Lógica de programação (algoritmos, laços, condicionais)"],
+    },
+    Laravel: {
+        whatYouLearn: [
+            "Rotas, controllers, validação e Blade com componentes",
+            "Eloquent: migrations, relacionamentos e como evitar o N+1",
+            "Autenticação com passkeys, gates, policies e APIs com Sanctum",
+            "Filas, cache, testes com Pest e as novidades do Laravel 13",
+        ],
+        prerequisites: ["PHP (orientação a objetos e composer)", "Noções de HTTP e SQL"],
+    },
+    "Ruby on Rails": {
+        whatYouLearn: [
+            "Rotas REST, controllers, views em ERB e o ciclo da requisição",
+            "Active Record: migrations, associações, escopos e validações",
+            "Hotwire com Turbo e Stimulus, sem virar dois projetos",
+            "Jobs e cache com a Solid Trifecta, testes e deploy com Kamal",
+        ],
+        prerequisites: ["Ruby (classes, blocos e gems)", "Noções de HTTP e SQL"],
+    },
     "Estatística e Probabilidade": {
         whatYouLearn: [
             "Estatística descritiva: média, mediana, desvio e distribuições",

--- a/backend/scripts/seed-trilha-laravel.ts
+++ b/backend/scripts/seed-trilha-laravel.ts
@@ -1,0 +1,3045 @@
+// Seed da trilha Laravel (Laravel 13). Conteúdo autoral.
+// A versão 13 saiu em março de 2026, exige PHP 8.3 e é a que a trilha ensina:
+// atributos do PHP no Eloquent e nos jobs, AI SDK, busca vetorial, JSON:API e Cache::touch.
+//
+// Idempotente e nao destrutivo: se a trilha ja tiver aulas, nao faz nada.
+//
+// Rodar em prod: docker compose -f docker-compose.prod.yml run --rm -T --no-deps backend node scripts/seed-trilha-laravel.ts
+import { db } from "../db.ts";
+import { trails, modules, lessons, questions, questionOptions } from "../schema.ts";
+import { eq } from "drizzle-orm";
+import { pathToFileURL } from "node:url";
+
+export const NOME = "Laravel";
+const LEVEL: "iniciante" | "intermediario" | "avancado" = "intermediario";
+const DESCRICAO =
+    "Laravel 13 do primeiro projeto ao deploy: rotas, controllers e validação, Blade com componentes, Eloquent com migrations e relacionamentos, autenticação com passkeys, gates e policies, APIs com resources e Sanctum, filas, cache, testes com Pest, e as novidades da versão 13 com atributos do PHP, SDK de IA e busca vetorial. O framework PHP mais usado do mundo.";
+const CARGA_HORARIA = 24;
+
+type Bloco = { type: "text" | "code" | "quote" | "table"; value: string };
+type Questao = {
+    statement: string;
+    difficulty: "facil" | "medio" | "dificil";
+    options: { text: string; isCorrect: boolean }[];
+};
+type Aula = { titulo: string; blocks: Bloco[]; questions: Questao[] };
+type Modulo = { titulo: string; aulas: Aula[] };
+
+const MODULO_1: Modulo = {
+    titulo: "Módulo 1 - O Laravel e o primeiro projeto",
+    aulas: [
+        {
+            titulo: "O que é Laravel e o que ele resolve",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Um framework com tudo dentro\n\nLaravel é um framework PHP criado por Taylor Otwell em 2011. Ele segue a filosofia de **baterias inclusas**: rotas, banco de dados, autenticação, filas, cache, email e testes vêm prontos e conversando entre si.\n\nA alternativa seria montar cada peça com bibliotecas separadas e cuidar da integração. Laravel troca essa liberdade por convenção e velocidade.",
+                },
+                {
+                    type: "text",
+                    value: "## O padrão MVC\n\nA organização segue MVC, com uma divisão de responsabilidade que aparece em toda a estrutura de pastas.",
+                },
+                {
+                    type: "table",
+                    value: '[["Camada", "Responsabilidade", "Onde fica"], ["Model", "dados e regra de negócio", "app/Models"], ["View", "o que a pessoa vê", "resources/views"], ["Controller", "recebe e responde", "app/Http/Controllers"], ["Route", "liga URL a controller", "routes/web.php"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Laravel 13\n\nEsta trilha usa o **Laravel 13**, lançado em 17 de março de 2026. Ele exige **PHP 8.3** no mínimo e traz três novidades grandes: configuração por atributos do PHP, o SDK de IA de primeira parte e busca vetorial nativa.\n\nO release foi desenhado para atualização tranquila: quem vinha do Laravel 12 encontra pouquíssima quebra.",
+                },
+                {
+                    type: "quote",
+                    value: "Laravel segue calendário anual: uma versão maior por ano, com correções por cerca de 18 meses e segurança por 24.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que a filosofia de baterias inclusas significa?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "O framework já traz as peças principais prontas",
+                            isCorrect: true,
+                        },
+                        { text: "O framework roda sem precisar de nenhum banco", isCorrect: false },
+                        {
+                            text: "As dependências são instaladas em tempo de execução",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O projeto é entregue com o servidor web embutido",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual a versão mínima de PHP exigida pelo Laravel 13?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "PHP 8.3", isCorrect: true },
+                        { text: "PHP 8.0, a mesma exigida pelo Laravel 10", isCorrect: false },
+                        { text: "PHP 8.5, a versão mais recente da linguagem", isCorrect: false },
+                        { text: "PHP 7.4, para manter a compatibilidade antiga", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Onde ficam os models em um projeto Laravel?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Em app/Models", isCorrect: true },
+                        { text: "Em resources/models, junto das views", isCorrect: false },
+                        { text: "Em database/models, perto das migrations", isCorrect: false },
+                        { text: "Em src/Model, seguindo o padrão PSR-4", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a responsabilidade do controller no MVC?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Receber a requisição e devolver a resposta", isCorrect: true },
+                        { text: "Guardar as regras de negócio da aplicação", isCorrect: false },
+                        { text: "Montar o HTML que será enviado ao navegador", isCorrect: false },
+                        { text: "Definir a estrutura das tabelas do banco", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quando o Laravel 13 foi lançado?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Em março de 2026", isCorrect: true },
+                        { text: "Em fevereiro de 2025, junto do Laravel 12", isCorrect: false },
+                        { text: "Em novembro de 2025, junto do PHP 8.5", isCorrect: false },
+                        { text: "Em janeiro de 2026, no começo do ano", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Instalando e criando o primeiro projeto",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O instalador\n\nO caminho oficial é o instalador global do Laravel, que faz mais que criar a pasta: ele pergunta qual starter kit você quer, qual banco usar e já roda as migrations.",
+                },
+                {
+                    type: "code",
+                    value: "composer global require laravel/installer\n\nlaravel new blog\n\ncd blog\nphp artisan serve\n# http://localhost:8000",
+                },
+                {
+                    type: "text",
+                    value: "## Ambiente completo\n\nPara não instalar PHP, banco e Redis na máquina, existem dois caminhos prontos:\n\n- **Laravel Herd**: aplicativo nativo para macOS e Windows, sem container\n- **Laravel Sail**: ambiente em Docker, definido por um docker-compose gerado pelo próprio framework",
+                },
+                {
+                    type: "code",
+                    value: "# Com Sail\nphp artisan sail:install\n./vendor/bin/sail up -d\n./vendor/bin/sail artisan migrate\n\n# Um apelido ajuda muito\nalias sail='./vendor/bin/sail'",
+                },
+                {
+                    type: "text",
+                    value: "## O que é criado\n\nO instalador já configura SQLite por padrão, o que permite rodar sem instalar banco nenhum. Trocar para MySQL ou PostgreSQL é uma questão de mudar variáveis no `.env`.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o comando `laravel new` faz além de criar a pasta?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Pergunta o starter kit e prepara o banco", isCorrect: true },
+                        { text: "Publica o projeto em um servidor de produção", isCorrect: false },
+                        { text: "Instala o PHP e o banco de dados na máquina", isCorrect: false },
+                        { text: "Cria o repositório Git remoto do projeto", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que é o Laravel Sail?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um ambiente de desenvolvimento em Docker", isCorrect: true },
+                        { text: "Um aplicativo nativo para macOS e Windows", isCorrect: false },
+                        { text: "O servidor de produção recomendado pelo time", isCorrect: false },
+                        { text: "Um gerenciador de versões do PHP instalado", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual comando sobe o servidor de desenvolvimento?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "php artisan serve", isCorrect: true },
+                        {
+                            text: "php artisan start, no padrão de outros frameworks",
+                            isCorrect: false,
+                        },
+                        { text: "composer run dev, definido no composer.json", isCorrect: false },
+                        { text: "laravel serve, pelo instalador global", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual banco o instalador configura por padrão?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "SQLite", isCorrect: true },
+                        { text: "MySQL, o mais usado em produção com Laravel", isCorrect: false },
+                        { text: "PostgreSQL, por causa da busca vetorial", isCorrect: false },
+                        { text: "Nenhum, é preciso escolher antes de criar", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a diferença entre Herd e Sail?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O Herd é nativo e o Sail usa containers", isCorrect: true },
+                        { text: "O Herd só funciona em Linux e o Sail em macOS", isCorrect: false },
+                        { text: "O Sail é pago e o Herd é gratuito para todos", isCorrect: false },
+                        { text: "O Herd instala em produção e o Sail no local", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "A estrutura de pastas",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Onde cada coisa mora\n\nA estrutura do Laravel é convenção pura: quem conhece um projeto conhece todos. Saber onde procurar poupa muito tempo.",
+                },
+                {
+                    type: "table",
+                    value: '[["Pasta", "O que guarda"], ["app/", "o código da aplicação"], ["routes/", "as rotas web, API e console"], ["resources/views/", "os templates Blade"], ["database/", "migrations, seeders e factories"], ["config/", "os arquivos de configuração"], ["public/", "o ponto de entrada e os assets"], ["storage/", "logs, cache e arquivos enviados"], ["tests/", "os testes automatizados"]]',
+                },
+                {
+                    type: "text",
+                    value: "## O ponto de entrada\n\nToda requisição entra por `public/index.php`. O servidor web aponta para a pasta `public`, e **só ela** fica exposta. O resto do projeto, incluindo o `.env` com as senhas, fica fora do alcance da web.\n\nApontar o servidor para a raiz do projeto em vez da pasta `public` é uma falha de segurança grave e infelizmente comum.",
+                },
+                {
+                    type: "text",
+                    value: "## O bootstrap enxuto\n\nDesde o Laravel 11 a configuração de middleware, exceções e rotas mora em `bootstrap/app.php`, em vez de espalhada por vários arquivos de kernel.",
+                },
+                {
+                    type: "code",
+                    value: "return Application::configure(basePath: dirname(__DIR__))\n    ->withRouting(\n        web: __DIR__.'/../routes/web.php',\n        commands: __DIR__.'/../routes/console.php',\n        health: '/up',\n    )\n    ->withMiddleware(function (Middleware $middleware) {\n        $middleware->append(GarantirAssinatura::class);\n    })\n    ->withExceptions(function (Exceptions $exceptions) {\n        //\n    })->create();",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual pasta o servidor web deve apontar?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "public", isCorrect: true },
+                        { text: "A raiz do projeto, onde fica o composer.json", isCorrect: false },
+                        { text: "A pasta app, onde está o código da aplicação", isCorrect: false },
+                        { text: "A pasta resources, com as views do projeto", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que apontar o servidor para a raiz é grave?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Expõe o .env e o código à web", isCorrect: true },
+                        { text: "Faz o site carregar bem mais devagar", isCorrect: false },
+                        { text: "Impede que as rotas sejam reconhecidas", isCorrect: false },
+                        { text: "Quebra o funcionamento das migrations", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Onde ficam as migrations?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Em database/migrations", isCorrect: true },
+                        { text: "Em app/Migrations, junto com os models", isCorrect: false },
+                        { text: "Em config/database, com a configuração", isCorrect: false },
+                        { text: "Em storage/migrations, geradas em execução", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que mudou no bootstrap desde o Laravel 11?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A configuração ficou em um arquivo só", isCorrect: true },
+                        { text: "O ponto de entrada mudou para app.php", isCorrect: false },
+                        { text: "As rotas passaram a ser geradas na hora", isCorrect: false },
+                        { text: "O bootstrap deixou de existir no projeto", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Onde ficam os templates Blade?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Em resources/views", isCorrect: true },
+                        { text: "Em public/views, junto dos assets do site", isCorrect: false },
+                        { text: "Em app/Views, no código da aplicação", isCorrect: false },
+                        { text: "Em templates, na raiz do projeto criado", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Artisan e o Tinker",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# A linha de comando do framework\n\nO **Artisan** é o console do Laravel. Ele gera código, roda migrations, limpa cache e executa tarefas. `php artisan list` mostra tudo que existe.",
+                },
+                {
+                    type: "code",
+                    value: "php artisan make:model Produto -mfsc\n# -m migration, -f factory, -s seeder, -c controller\n\nphp artisan make:controller PedidoController --resource\nphp artisan make:request GuardarPedidoRequest\nphp artisan make:middleware GarantirAssinatura\n\nphp artisan migrate\nphp artisan migrate:fresh --seed\nphp artisan route:list\nphp artisan optimize:clear",
+                },
+                {
+                    type: "text",
+                    value: "## Tinker\n\nO `tinker` abre um console com a aplicação carregada. Você conversa com os models, testa uma consulta e inspeciona resultado sem escrever rota nem controller. É a ferramenta mais subestimada do framework.",
+                },
+                {
+                    type: "code",
+                    value: 'php artisan tinker\n\n>>> User::count()\n=> 42\n>>> $u = User::factory()->create(["name" => "Ana"])\n>>> $u->posts()->create(["title" => "Primeiro"])\n>>> Produto::where("preco", ">", 100)->pluck("nome")',
+                },
+                {
+                    type: "text",
+                    value: "## Comandos próprios\n\nNo Laravel 13 os atributos do PHP substituem as propriedades de configuração, o que deixa o comando mais enxuto.",
+                },
+                {
+                    type: "code",
+                    value: "use Illuminate\\Console\\Attributes\\Description;\nuse Illuminate\\Console\\Attributes\\Signature;\n\n#[Signature('relatorio:mensal {mes}')]\n#[Description('Gera o relatório do mês informado')]\nclass RelatorioMensal extends Command\n{\n    public function handle(): int\n    {\n        $this->info('Gerando...');\n        return self::SUCCESS;\n    }\n}",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o Artisan é?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "A ferramenta de linha de comando do Laravel", isCorrect: true },
+                        { text: "O gerenciador de dependências do projeto PHP", isCorrect: false },
+                        { text: "O motor de templates usado nas views do site", isCorrect: false },
+                        { text: "O servidor web que atende as requisições", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o `tinker` permite fazer?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Conversar com a aplicação em um console", isCorrect: true },
+                        { text: "Gerar arquivos de código automaticamente", isCorrect: false },
+                        { text: "Rodar os testes automatizados do projeto", isCorrect: false },
+                        { text: "Publicar a aplicação em um servidor remoto", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `php artisan make:model Produto -m` cria além do model?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A migration da tabela", isCorrect: true },
+                        { text: "O controller com os métodos de recurso", isCorrect: false },
+                        { text: "A factory para gerar dados de teste", isCorrect: false },
+                        { text: "O seeder que popula a tabela criada", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual comando lista todas as rotas registradas?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "php artisan route:list", isCorrect: true },
+                        { text: "php artisan routes, no plural do recurso", isCorrect: false },
+                        { text: "php artisan list:routes, seguindo o padrão", isCorrect: false },
+                        { text: "php artisan show:routes com o filtro", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que os atributos trouxeram para comandos no Laravel 13?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Substituem as propriedades de configuração", isCorrect: true },
+                        { text: "Permitem que o comando rode em segundo plano", isCorrect: false },
+                        {
+                            text: "Fazem o comando ser registrado automaticamente",
+                            isCorrect: false,
+                        },
+                        { text: "Obrigam a declarar o retorno do método handle", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Configuração, .env e ambientes",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Configuração fora do código\n\nO Laravel segue o princípio de que **o que muda entre ambientes fica em variável de ambiente**, não em código. O arquivo `.env` guarda essas variáveis e **nunca vai para o Git**.\n\nO `.env.example`, sem valores reais, é o que vai versionado e serve de referência para quem clona o projeto.",
+                },
+                {
+                    type: "code",
+                    value: "APP_NAME=Loja\nAPP_ENV=local\nAPP_KEY=base64:...\nAPP_DEBUG=true\nAPP_URL=http://localhost\n\nDB_CONNECTION=pgsql\nDB_HOST=127.0.0.1\nDB_DATABASE=loja\nDB_USERNAME=postgres\nDB_PASSWORD=segredo\n\nQUEUE_CONNECTION=database\nCACHE_STORE=database",
+                },
+                {
+                    type: "text",
+                    value: "## env() só em config\n\nEsta é a regra mais importante e a mais violada: chame `env()` **apenas dentro de arquivos em `config/`**. Em qualquer outro lugar, use `config()`.\n\nO motivo é o cache. Em produção se roda `php artisan config:cache`, e a partir dali o `.env` deixa de ser lido. Um `env()` no controller passa a devolver `null` silenciosamente, e o bug aparece só em produção.",
+                },
+                {
+                    type: "code",
+                    value: "// config/servicos.php\nreturn [\n    'gateway' => [\n        'chave' => env('GATEWAY_KEY'),\n        'url' => env('GATEWAY_URL', 'https://api.exemplo.com'),\n    ],\n];\n\n// No controller ou service: sempre config()\n$chave = config('servicos.gateway.chave');",
+                },
+                {
+                    type: "quote",
+                    value: "APP_DEBUG=true em produção mostra a stack trace e as variáveis de ambiente na tela do erro. É como credenciais vazam.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O arquivo `.env` deve ir para o controle de versão?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Não, ele guarda segredos", isCorrect: true },
+                        { text: "Sim, para todo mundo ter a mesma configuração", isCorrect: false },
+                        { text: "Sim, mas apenas o de produção do projeto", isCorrect: false },
+                        {
+                            text: "Depende de o repositório ser privado ou público",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Onde `env()` pode ser chamado com segurança?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Apenas em arquivos dentro de config", isCorrect: true },
+                        { text: "Em qualquer lugar da aplicação, sem restrição", isCorrect: false },
+                        { text: "Apenas dentro dos controllers e dos models", isCorrect: false },
+                        { text: "Em qualquer lugar, menos dentro das views", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que acontece com `env()` depois de `config:cache`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Passa a devolver null fora de config", isCorrect: true },
+                        {
+                            text: "Continua funcionando normalmente em todo lugar",
+                            isCorrect: false,
+                        },
+                        { text: "Levanta uma exceção avisando do cache ativo", isCorrect: false },
+                        { text: "Recarrega o arquivo .env a cada chamada feita", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual o risco de `APP_DEBUG=true` em produção?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Vaza stack trace e variáveis de ambiente", isCorrect: true },
+                        { text: "Deixa a aplicação bem mais lenta ao responder", isCorrect: false },
+                        { text: "Impede que as filas processem os jobs na fila", isCorrect: false },
+                        {
+                            text: "Faz o cache de configuração parar de funcionar",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Para que serve o `.env.example`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Servir de referência sem valores reais", isCorrect: true },
+                        { text: "Guardar a configuração usada em produção", isCorrect: false },
+                        { text: "Ser lido quando o .env não existe no projeto", isCorrect: false },
+                        {
+                            text: "Listar as variáveis que já foram descontinuadas",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_2: Modulo = {
+    titulo: "Módulo 2 - Rotas, controllers e validação",
+    aulas: [
+        {
+            titulo: "Rotas e verbos HTTP",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Ligando URL a código\n\nUma rota associa um verbo HTTP e um caminho a um trecho de código. As rotas de página ficam em `routes/web.php` e as de API em `routes/api.php`.\n\nA diferença não é só organizacional: as rotas web passam por sessão e proteção CSRF; as de API, não.",
+                },
+                {
+                    type: "code",
+                    value: "use Illuminate\\Support\\Facades\\Route;\n\nRoute::get('/produtos', [ProdutoController::class, 'index']);\nRoute::post('/produtos', [ProdutoController::class, 'store']);\nRoute::get('/produtos/{produto}', [ProdutoController::class, 'show']);\nRoute::put('/produtos/{produto}', [ProdutoController::class, 'update']);\nRoute::delete('/produtos/{produto}', [ProdutoController::class, 'destroy']);\n\n// As sete rotas REST de uma vez\nRoute::resource('produtos', ProdutoController::class);",
+                },
+                {
+                    type: "table",
+                    value: '[["Verbo", "Caminho", "Ação", "Para que serve"], ["GET", "/produtos", "index", "listar"], ["GET", "/produtos/criar", "create", "formulário"], ["POST", "/produtos", "store", "gravar"], ["GET", "/produtos/{id}", "show", "ver um"], ["PUT", "/produtos/{id}", "update", "atualizar"], ["DELETE", "/produtos/{id}", "destroy", "remover"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Nomes de rota\n\nDar nome à rota evita espalhar URL pelo código. Se o caminho mudar, só a definição muda.",
+                },
+                {
+                    type: "code",
+                    value: "Route::get('/produtos/{produto}', [ProdutoController::class, 'show'])\n    ->name('produtos.show');\n\n// Nas views e controllers\nroute('produtos.show', $produto)\nredirect()->route('produtos.index')",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual a diferença entre routes/web.php e routes/api.php?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "As web têm sessão e proteção CSRF", isCorrect: true },
+                        { text: "As de API aceitam apenas o verbo GET e POST", isCorrect: false },
+                        { text: "As web são carregadas antes das de API sempre", isCorrect: false },
+                        { text: "As de API não podem ter parâmetros na URL", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `Route::resource` cria?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "As sete rotas REST de uma vez", isCorrect: true },
+                        { text: "Uma rota para cada verbo HTTP existente", isCorrect: false },
+                        { text: "Apenas as rotas de leitura do recurso", isCorrect: false },
+                        { text: "Um controller com os métodos já escritos", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual verbo e ação correspondem a remover um recurso?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "DELETE e destroy", isCorrect: true },
+                        { text: "POST e remove, no padrão de formulários", isCorrect: false },
+                        { text: "GET e delete, com o id na query string", isCorrect: false },
+                        { text: "PUT e destroy, atualizando o registro", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a vantagem de nomear uma rota?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A URL fica em um lugar só", isCorrect: true },
+                        { text: "A rota passa a responder bem mais rápido", isCorrect: false },
+                        { text: "O Laravel gera o controller automaticamente", isCorrect: false },
+                        { text: "A rota fica protegida contra acesso externo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual ação corresponde a `GET /produtos`?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "index", isCorrect: true },
+                        { text: "show, que exibe um recurso específico", isCorrect: false },
+                        { text: "create, que devolve o formulário vazio", isCorrect: false },
+                        { text: "store, que grava o recurso no banco", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Parâmetros, grupos e middleware nas rotas",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Parâmetros\n\nChaves na URL viram argumentos do método. Parâmetros opcionais levam interrogação e precisam de valor padrão. Restrições evitam que a rota case com o que não deveria.",
+                },
+                {
+                    type: "code",
+                    value: "Route::get('/posts/{post}/comentarios/{comentario}', function (int $post, int $comentario) {\n    //\n});\n\nRoute::get('/usuarios/{nome?}', function (?string $nome = 'visitante') {\n    return \"Olá, {$nome}\";\n});\n\n// Só aceita números\nRoute::get('/produtos/{id}', ...)->whereNumber('id');\nRoute::get('/perfil/{slug}', ...)->where('slug', '[a-z0-9-]+');",
+                },
+                {
+                    type: "text",
+                    value: "## Grupos\n\nGrupos aplicam prefixo, middleware, namespace e nome a várias rotas de uma vez. É o que mantém o arquivo de rotas legível quando o projeto cresce.",
+                },
+                {
+                    type: "code",
+                    value: "Route::middleware(['auth'])\n    ->prefix('painel')\n    ->name('painel.')\n    ->group(function () {\n        Route::get('/', [PainelController::class, 'index'])->name('index');\n        Route::resource('produtos', ProdutoController::class);\n    });\n\n// Gera /painel e a rota chamada painel.index",
+                },
+                {
+                    type: "text",
+                    value: "## Middleware\n\nO middleware fica **entre** a requisição e o controller. Ele pode barrar, alterar ou apenas observar. `auth` é o mais usado: barra quem não está logado antes de o controller rodar.",
+                },
+                {
+                    type: "code",
+                    value: "Route::get('/painel', ...)->middleware(['auth', 'verified']);\nRoute::get('/admin', ...)->middleware('can:administrar');\nRoute::post('/contato', ...)->middleware('throttle:5,1');  // 5 por minuto",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Como se torna um parâmetro de rota opcional?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Com interrogação e valor padrão", isCorrect: true },
+                        { text: "Com colchetes em volta do nome do parâmetro", isCorrect: false },
+                        { text: "Declarando duas rotas, com e sem o parâmetro", isCorrect: false },
+                        { text: "Com a palavra optional antes do nome dele", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que um grupo de rotas permite aplicar de uma vez?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Prefixo, middleware e nome", isCorrect: true },
+                        { text: "Apenas o middleware comum a todas elas", isCorrect: false },
+                        { text: "Somente o prefixo do caminho na URL", isCorrect: false },
+                        { text: "O controller que atende todas as rotas", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Onde o middleware roda?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Entre a requisição e o controller", isCorrect: true },
+                        { text: "Depois de o controller devolver a resposta", isCorrect: false },
+                        { text: "Dentro do controller, no começo do método", isCorrect: false },
+                        { text: "Apenas quando uma exceção é levantada", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o middleware `throttle:5,1` faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Limita a cinco requisições por minuto", isCorrect: true },
+                        { text: "Guarda a resposta em cache por cinco minutos", isCorrect: false },
+                        { text: "Espera cinco segundos antes de responder", isCorrect: false },
+                        {
+                            text: "Limita o corpo da requisição a cinco kilobytes",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Para que serve `whereNumber('id')` em uma rota?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Só casar quando o parâmetro for numérico", isCorrect: true },
+                        {
+                            text: "Converter o parâmetro para inteiro no controller",
+                            isCorrect: false,
+                        },
+                        { text: "Validar se o id existe na tabela do banco", isCorrect: false },
+                        { text: "Ordenar os resultados pelo campo informado", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Controllers e route model binding",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O controller\n\nO controller recebe a requisição, coordena o trabalho e devolve a resposta. Ele deve ser **fino**: regra de negócio pertence ao model ou a uma classe de serviço, não ao controller.",
+                },
+                {
+                    type: "code",
+                    value: "class ProdutoController extends Controller\n{\n    public function index()\n    {\n        return view('produtos.index', [\n            'produtos' => Produto::latest()->paginate(15),\n        ]);\n    }\n\n    public function show(Produto $produto)\n    {\n        return view('produtos.show', compact('produto'));\n    }\n}",
+                },
+                {
+                    type: "text",
+                    value: "## Route model binding\n\nRepare que `show` recebe um `Produto`, não um id. O Laravel vê o tipo declarado, busca o registro pela chave e **devolve 404 sozinho** se não existir.\n\nIsso elimina o `findOrFail` repetido em todo método e a verificação de nulo.",
+                },
+                {
+                    type: "code",
+                    value: "// Sem binding\npublic function show(int $id)\n{\n    $produto = Produto::findOrFail($id);\n    return view('produtos.show', compact('produto'));\n}\n\n// Com binding: o mesmo resultado\npublic function show(Produto $produto)\n{\n    return view('produtos.show', compact('produto'));\n}",
+                },
+                {
+                    type: "text",
+                    value: "## Buscando por outra coluna\n\nPara usar slug em vez de id na URL, declare no model qual coluna a rota usa.",
+                },
+                {
+                    type: "code",
+                    value: "class Produto extends Model\n{\n    public function getRouteKeyName(): string\n    {\n        return 'slug';\n    }\n}\n\n// Ou direto na rota\nRoute::get('/produtos/{produto:slug}', ...);",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o route model binding faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Busca o registro e injeta no método", isCorrect: true },
+                        { text: "Valida os dados enviados no formulário", isCorrect: false },
+                        { text: "Cria o registro quando ele não existe", isCorrect: false },
+                        { text: "Converte o parâmetro da rota em inteiro", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que acontece quando o registro não é encontrado no binding?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O Laravel devolve 404 sozinho", isCorrect: true },
+                        { text: "O parâmetro chega ao método com o valor nulo", isCorrect: false },
+                        { text: "É levantada uma exceção de tipo inválido", isCorrect: false },
+                        { text: "O método é chamado com um objeto vazio", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que o controller deve ser fino?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A regra de negócio pertence a outra camada", isCorrect: true },
+                        { text: "Porque ele é recriado a cada requisição nova", isCorrect: false },
+                        { text: "Porque o Laravel limita o tamanho dos métodos", isCorrect: false },
+                        { text: "Porque ele roda antes de qualquer middleware", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como fazer a rota buscar por slug em vez de id?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Com `getRouteKeyName` no model", isCorrect: true },
+                        { text: "Renomeando a coluna id para slug no banco", isCorrect: false },
+                        {
+                            text: "Passando o slug como segundo parâmetro da rota",
+                            isCorrect: false,
+                        },
+                        { text: "Usando findBySlug dentro do controller", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `Produto::latest()->paginate(15)` devolve?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Uma página com quinze registros recentes", isCorrect: true },
+                        { text: "Os quinze primeiros registros já cadastrados", isCorrect: false },
+                        { text: "Um array simples com todos os produtos", isCorrect: false },
+                        { text: "O último produto criado na tabela do banco", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Validação e Form Request",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Validando a entrada\n\nDado que vem do navegador nunca é confiável. O Laravel valida com uma lista de regras e, quando algo falha, **redireciona de volta com os erros e os valores digitados**, sem você escrever nada para isso.",
+                },
+                {
+                    type: "code",
+                    value: "public function store(Request $request)\n{\n    $dados = $request->validate([\n        'nome' => ['required', 'string', 'max:255'],\n        'email' => ['required', 'email', 'unique:usuarios,email'],\n        'preco' => ['required', 'numeric', 'min:0'],\n        'categoria_id' => ['required', 'exists:categorias,id'],\n        'tags' => ['array'],\n        'tags.*' => ['string', 'max:30'],\n    ]);\n\n    Produto::create($dados);\n\n    return redirect()->route('produtos.index')\n        ->with('sucesso', 'Produto cadastrado.');\n}",
+                },
+                {
+                    type: "text",
+                    value: "## Form Request\n\nQuando as regras crescem ou se repetem, elas ganham uma classe própria. O Form Request valida **antes** de o controller rodar, e junta autorização e validação no mesmo lugar.",
+                },
+                {
+                    type: "code",
+                    value: "class GuardarProdutoRequest extends FormRequest\n{\n    public function authorize(): bool\n    {\n        return $this->user()->can('criar-produto');\n    }\n\n    public function rules(): array\n    {\n        return [\n            'nome' => ['required', 'string', 'max:255'],\n            'preco' => ['required', 'numeric', 'min:0'],\n        ];\n    }\n\n    public function messages(): array\n    {\n        return ['preco.min' => 'O preço não pode ser negativo.'];\n    }\n}\n\n// No controller: o tipo declarado já valida\npublic function store(GuardarProdutoRequest $request)\n{\n    Produto::create($request->validated());\n}",
+                },
+                {
+                    type: "quote",
+                    value: "Use sempre validated() e nunca all() ao criar registros: validated() devolve só os campos que passaram pelas regras.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que acontece quando a validação falha em uma requisição web?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O usuário volta com os erros e o que digitou", isCorrect: true },
+                        {
+                            text: "A aplicação devolve um erro quinhentos ao navegador",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O controller roda mesmo assim com os dados vazios",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "A requisição é descartada sem nenhuma resposta",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Quando o Form Request é validado?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Antes de o controller rodar", isCorrect: true },
+                        { text: "Na primeira linha do método do controller", isCorrect: false },
+                        { text: "Depois que o controller devolve a resposta", isCorrect: false },
+                        { text: "Apenas quando o método validate é chamado", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual método do Form Request cuida da autorização?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "authorize", isCorrect: true },
+                        { text: "rules, junto com as regras de validação", isCorrect: false },
+                        { text: "can, herdado da classe base do framework", isCorrect: false },
+                        { text: "policy, ligando o request a uma política", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que usar `validated()` em vez de `all()`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Ele devolve só os campos que passaram", isCorrect: true },
+                        { text: "Ele converte os valores para o tipo correto", isCorrect: false },
+                        { text: "Ele executa a validação uma segunda vez", isCorrect: false },
+                        { text: "Ele remove os campos nulos do resultado", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que a regra `exists:categorias,id` verifica?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Que o valor existe naquela tabela", isCorrect: true },
+                        { text: "Que o valor ainda não existe na tabela", isCorrect: false },
+                        { text: "Que a tabela categorias tem registros", isCorrect: false },
+                        { text: "Que o campo foi enviado no formulário", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Respostas, redirects e tratamento de erros",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Devolvendo a resposta\n\nO controller pode devolver uma view, um redirecionamento, JSON ou um arquivo. O Laravel converte cada retorno na resposta HTTP adequada.",
+                },
+                {
+                    type: "code",
+                    value: "return view('produtos.index', compact('produtos'));\n\nreturn redirect()->route('produtos.index');\nreturn redirect()->back()->withErrors(['nome' => 'Já existe']);\nreturn redirect()->route('produtos.show', $produto)\n    ->with('sucesso', 'Salvo com sucesso');\n\nreturn response()->json(['ok' => true], 201);\nreturn response()->download($caminho);\nreturn response()->noContent();  // 204",
+                },
+                {
+                    type: "text",
+                    value: "## A sessão flash\n\n`with()` guarda um valor na sessão que vale **apenas para a próxima requisição**. É como mensagens de sucesso sobrevivem ao redirecionamento e desaparecem depois.",
+                },
+                {
+                    type: "code",
+                    value: "{{-- Na view --}}\n@if (session('sucesso'))\n    <div class=\"alerta\">{{ session('sucesso') }}</div>\n@endif",
+                },
+                {
+                    type: "text",
+                    value: "## Erros\n\nO Laravel transforma exceções em respostas. `abort()` interrompe com um código HTTP, e views em `resources/views/errors` personalizam cada página de erro.",
+                },
+                {
+                    type: "code",
+                    value: "abort(404);\nabort(403, 'Você não pode ver este pedido.');\nabort_if($pedido->user_id !== auth()->id(), 403);\nabort_unless($usuario->assinante, 402);\n\n// Personalizar: resources/views/errors/404.blade.php",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Quanto tempo um valor guardado com `with()` sobrevive?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Até a próxima requisição", isCorrect: true },
+                        { text: "Enquanto a sessão do usuário estiver aberta", isCorrect: false },
+                        { text: "Por vinte e quatro horas, como um cookie", isCorrect: false },
+                        {
+                            text: "Até que ele seja apagado manualmente do código",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que `abort(403)` faz?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Interrompe com o código HTTP informado", isCorrect: true },
+                        { text: "Registra o erro no log e continua a execução", isCorrect: false },
+                        { text: "Redireciona o usuário para a página inicial", isCorrect: false },
+                        { text: "Devolve um JSON com a mensagem de erro", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que acontece ao devolver um array de um controller?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O Laravel o converte em JSON", isCorrect: true },
+                        { text: "O array é impresso como texto simples", isCorrect: false },
+                        { text: "É levantada uma exceção de tipo inválido", isCorrect: false },
+                        { text: "O array é passado para a view padrão", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Onde ficam as views que personalizam páginas de erro?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Em resources/views/errors", isCorrect: true },
+                        { text: "Em public/errors, junto dos assets do site", isCorrect: false },
+                        { text: "Em app/Exceptions, com o handler de erros", isCorrect: false },
+                        { text: "Em config/errors, junto da configuração", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `abort_unless($condicao, 403)` faz?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Interrompe quando a condição é falsa", isCorrect: true },
+                        { text: "Interrompe quando a condição é verdadeira", isCorrect: false },
+                        { text: "Registra a condição no log da aplicação", isCorrect: false },
+                        { text: "Valida a condição e devolve o resultado", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_3: Modulo = {
+    titulo: "Módulo 3 - Blade e a camada de visão",
+    aulas: [
+        {
+            titulo: "Blade: sintaxe e diretivas",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O motor de templates\n\nO **Blade** compila os templates para PHP puro e guarda o resultado em cache. Você escreve uma sintaxe enxuta e o custo em execução é praticamente zero.\n\nA diferença mais importante para o PHP cru: `{{ }}` **escapa a saída automaticamente**, o que fecha a porta do XSS por padrão.",
+                },
+                {
+                    type: "code",
+                    value: "{{-- Escapado: o padrão e o certo --}}\n<h1>{{ $produto->nome }}</h1>\n\n{{-- Sem escapar: só para HTML que você mesmo gerou --}}\n<div>{!! $conteudoConfiavel !!}</div>\n\n{{-- Valor padrão quando vazio --}}\n<p>{{ $produto->descricao ?? 'Sem descrição' }}</p>",
+                },
+                {
+                    type: "table",
+                    value: '[["Diretiva", "Para que serve"], ["@if, @elseif, @else", "condicional"], ["@foreach, @forelse", "laço, com caso vazio"], ["@auth, @guest", "logado ou não"], ["@can, @cannot", "permissão"], ["@csrf", "campo do token"], ["@method(\'PUT\')", "verbo em formulário"]]',
+                },
+                {
+                    type: "code",
+                    value: "@forelse ($produtos as $produto)\n    <li>{{ $produto->nome }} ({{ $loop->iteration }} de {{ $loop->count }})</li>\n@empty\n    <li>Nenhum produto cadastrado.</li>\n@endforelse\n\n@auth\n    <p>Olá, {{ auth()->user()->name }}</p>\n@endauth",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que `{{ }}` faz com a saída no Blade?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Escapa o conteúdo automaticamente", isCorrect: true },
+                        { text: "Imprime o conteúdo exatamente como está", isCorrect: false },
+                        { text: "Converte o conteúdo para JSON antes de exibir", isCorrect: false },
+                        { text: "Executa o conteúdo como código PHP na hora", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quando usar `{!! !!}` em vez de `{{ }}`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Só com HTML que você mesmo gerou", isCorrect: true },
+                        { text: "Sempre que o valor tiver acentuação no texto", isCorrect: false },
+                        { text: "Quando o valor vier direto do banco de dados", isCorrect: false },
+                        { text: "Quando o texto for maior que uma linha", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `@forelse` oferece que `@foreach` não oferece?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um bloco para a coleção vazia", isCorrect: true },
+                        { text: "A contagem de itens já percorridos", isCorrect: false },
+                        { text: "A ordenação automática da coleção", isCorrect: false },
+                        { text: "A paginação dos itens exibidos", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que a variável `$loop` traz dentro de um foreach?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Informações como posição e total", isCorrect: true },
+                        { text: "Uma cópia do item que está sendo percorrido", isCorrect: false },
+                        { text: "A coleção completa que está sendo percorrida", isCorrect: false },
+                        { text: "A quantidade de laços aninhados no template", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O Blade custa desempenho em cada requisição?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Não, ele é compilado e fica em cache", isCorrect: true },
+                        { text: "Sim, o template é interpretado toda vez", isCorrect: false },
+                        { text: "Sim, mas só quando há muitas diretivas", isCorrect: false },
+                        {
+                            text: "Sim, por isso existe o Blade compilado à parte",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Layouts e componentes",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Não repetir a moldura\n\nToda página compartilha cabeçalho, menu e rodapé. O Blade resolve isso de duas formas, e a moderna é por **componentes**.",
+                },
+                {
+                    type: "code",
+                    value: "{{-- resources/views/components/layout.blade.php --}}\n<!DOCTYPE html>\n<html lang=\"pt-br\">\n<head>\n    <title>{{ $titulo ?? 'Loja' }}</title>\n    @vite(['resources/css/app.css', 'resources/js/app.js'])\n</head>\n<body>\n    <x-navegacao />\n    <main>{{ $slot }}</main>\n</body>\n</html>",
+                },
+                {
+                    type: "code",
+                    value: '{{-- Usando o layout --}}\n<x-layout titulo="Produtos">\n    <h1>Nossos produtos</h1>\n    @foreach ($produtos as $produto)\n        <x-card :produto="$produto" destaque />\n    @endforeach\n</x-layout>',
+                },
+                {
+                    type: "text",
+                    value: "## Passando dados\n\nAtributo sem dois-pontos passa **texto literal**. Com dois-pontos, o valor é interpretado como expressão PHP. Atributo sozinho, sem valor, vira `true`.\n\n## Componentes com classe\n\nQuando o componente precisa de lógica, ele ganha uma classe em `app/View/Components`, onde o construtor recebe os atributos.",
+                },
+                {
+                    type: "code",
+                    value: "class Card extends Component\n{\n    public function __construct(\n        public Produto $produto,\n        public bool $destaque = false,\n    ) {}\n\n    public function render(): View\n    {\n        return view('components.card');\n    }\n}",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que `{{ $slot }}` representa em um componente?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O conteúdo passado entre as tags", isCorrect: true },
+                        { text: "O título definido no atributo do componente", isCorrect: false },
+                        { text: "A variável padrão vinda do controller", isCorrect: false },
+                        { text: "O nome do arquivo do componente atual", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: 'Qual a diferença entre `titulo="X"` e `:titulo="$x"`?',
+                    difficulty: "medio",
+                    options: [
+                        { text: "Os dois-pontos interpretam como PHP", isCorrect: true },
+                        { text: "Os dois-pontos tornam o atributo obrigatório", isCorrect: false },
+                        { text: "Sem dois-pontos o atributo não é escapado", isCorrect: false },
+                        { text: "Com dois-pontos o valor vira uma constante", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que um atributo sem valor vira no componente?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O booleano true", isCorrect: true },
+                        { text: "Uma string vazia dentro do componente", isCorrect: false },
+                        { text: "O valor nulo, por não ter sido informado", isCorrect: false },
+                        { text: "Um erro avisando que falta o valor", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Onde ficam as classes de componentes?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Em app/View/Components", isCorrect: true },
+                        { text: "Em resources/views/components apenas", isCorrect: false },
+                        { text: "Em app/Http/Components, junto do controller", isCorrect: false },
+                        { text: "Em app/Components, na raiz da pasta app", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como se chama um componente `card` em uma view?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Com `<x-card />`", isCorrect: true },
+                        { text: "Com `@component('card')` e o fechamento", isCorrect: false },
+                        { text: "Com `@include('components.card')`", isCorrect: false },
+                        { text: "Com `{{ component('card') }}`", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Formulários, CSRF e o retorno dos erros",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O formulário completo\n\nTodo formulário POST precisa do token CSRF. O `@csrf` gera o campo escondido, e o middleware confere. Sem ele a requisição é recusada com 419.\n\nComo o HTML só entende GET e POST, `@method` gera o campo que o Laravel lê para tratar como PUT ou DELETE.",
+                },
+                {
+                    type: "code",
+                    value: '<form method="POST" action="{{ route(\'produtos.update\', $produto) }}">\n    @csrf\n    @method(\'PUT\')\n\n    <label for="nome">Nome</label>\n    <input id="nome" name="nome" value="{{ old(\'nome\', $produto->nome) }}">\n    @error(\'nome\')\n        <span class="erro">{{ $message }}</span>\n    @enderror\n\n    <button>Salvar</button>\n</form>',
+                },
+                {
+                    type: "text",
+                    value: "## old() e @error\n\nQuando a validação falha, o Laravel redireciona de volta. `old('campo')` recupera o que a pessoa tinha digitado, e `@error` exibe a mensagem do campo.\n\nSem `old()`, o formulário volta vazio depois de um erro, e quem preencheu tudo perde o trabalho. É o detalhe que mais separa formulário bem feito de formulário irritante.",
+                },
+                {
+                    type: "code",
+                    value: "{{-- Todos os erros de uma vez --}}\n@if ($errors->any())\n    <ul>\n        @foreach ($errors->all() as $erro)\n            <li>{{ $erro }}</li>\n        @endforeach\n    </ul>\n@endif",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que acontece com um POST sem o campo CSRF?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A requisição é recusada com 419", isCorrect: true },
+                        {
+                            text: "O formulário é enviado normalmente ao servidor",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O Laravel gera o token automaticamente no envio",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "A validação falha e o usuário volta ao formulário",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Para que serve `@method('PUT')`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Simular o verbo que o HTML não envia", isCorrect: true },
+                        {
+                            text: "Definir qual método do controller será chamado",
+                            isCorrect: false,
+                        },
+                        { text: "Validar o formulário antes de ele ser enviado", isCorrect: false },
+                        { text: "Trocar a rota de destino do formulário", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `old('nome')` recupera?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O valor digitado antes do erro", isCorrect: true },
+                        { text: "O valor que está gravado no banco de dados", isCorrect: false },
+                        { text: "O valor padrão definido na migration", isCorrect: false },
+                        { text: "O último valor salvo pelo mesmo usuário", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que a diretiva `@error` exibe?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "A mensagem de erro daquele campo", isCorrect: true },
+                        { text: "Todos os erros de validação do formulário", isCorrect: false },
+                        { text: "O erro mais recente da aplicação inteira", isCorrect: false },
+                        { text: "O log de exceções do sistema em execução", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que `old()` importa tanto para quem usa o formulário?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Sem ele o formulário volta vazio após o erro", isCorrect: true },
+                        { text: "Sem ele os erros não aparecem na tela", isCorrect: false },
+                        {
+                            text: "Sem ele o token CSRF deixa de ser gerado no campo",
+                            isCorrect: false,
+                        },
+                        { text: "Sem ele os campos ficam desabilitados", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Starter kits, Vite e assets",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Começando com o básico pronto\n\nOs **starter kits** do Laravel entregam autenticação, cadastro, recuperação de senha, verificação de email e telas de perfil funcionando. Você escolhe a pilha de front-end na criação do projeto.\n\nNo Laravel 13, os kits também expõem `/.well-known/passkey-endpoints`, exigido pela especificação do W3C para que dispositivos Apple descubram as passkeys da aplicação. O endpoint só aparece quando a opção de passkeys é ligada na instalação.",
+                },
+                {
+                    type: "table",
+                    value: '[["Pilha", "Como funciona", "Quando escolher"], ["Blade + Livewire", "componentes no servidor", "equipe de back-end"], ["React com Inertia", "SPA sem escrever API", "front-end em React"], ["Vue com Inertia", "SPA sem escrever API", "front-end em Vue"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Vite\n\nO **Vite** compila CSS e JavaScript. Em desenvolvimento ele atualiza o navegador na hora; em produção gera arquivos com hash no nome, o que resolve cache antigo de uma vez.",
+                },
+                {
+                    type: "code",
+                    value: "npm install\nnpm run dev      # desenvolvimento, com recarga automática\nnpm run build    # produção, com hash nos arquivos\n\n{{-- Na view: a diretiva resolve o caminho certo nos dois casos --}}\n@vite(['resources/css/app.css', 'resources/js/app.js'])",
+                },
+                {
+                    type: "quote",
+                    value: "Nunca aponte para o arquivo compilado na mão. A diretiva @vite escolhe o caminho certo em desenvolvimento e em produção.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que um starter kit entrega pronto?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Autenticação, cadastro e perfil", isCorrect: true },
+                        { text: "O banco de dados já modelado e populado", isCorrect: false },
+                        { text: "As rotas de API do projeto documentadas", isCorrect: false },
+                        { text: "O ambiente de produção configurado", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o Inertia permite?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Fazer uma SPA sem escrever uma API", isCorrect: true },
+                        { text: "Rodar componentes React dentro do Blade", isCorrect: false },
+                        { text: "Compilar o front-end sem usar o Node", isCorrect: false },
+                        { text: "Servir a aplicação sem servidor web", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que o Vite põe hash no nome dos arquivos?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Para o navegador não usar cache antigo", isCorrect: true },
+                        { text: "Para dificultar a leitura do código gerado", isCorrect: false },
+                        {
+                            text: "Para permitir vários arquivos com o mesmo nome",
+                            isCorrect: false,
+                        },
+                        { text: "Para identificar qual versão do Vite gerou", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o Laravel 13 acrescentou aos starter kits?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O endpoint de descoberta de passkeys", isCorrect: true },
+                        { text: "A autenticação de dois fatores por mensagem", isCorrect: false },
+                        { text: "O painel de administração já pronto", isCorrect: false },
+                        { text: "A integração automática com redes sociais", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que usar `@vite` em vez do caminho direto do arquivo?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Ela resolve o caminho nos dois ambientes", isCorrect: true },
+                        {
+                            text: "Ela compila o arquivo no momento da requisição",
+                            isCorrect: false,
+                        },
+                        { text: "Ela reduz o tamanho do arquivo enviado", isCorrect: false },
+                        { text: "Ela escapa o conteúdo antes de servir", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Livewire e Inertia: quando usar cada um",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Interatividade sem virar dois projetos\n\nUma aplicação com muita interação tradicionalmente vira duas: uma API em PHP e um front-end em JavaScript. Livewire e Inertia existem para evitar essa divisão, cada um de um jeito.",
+                },
+                {
+                    type: "text",
+                    value: "## Livewire\n\nO componente vive **no servidor**. A interação dispara uma requisição, o servidor recalcula o HTML e devolve só a diferença. Você escreve PHP e quase nenhum JavaScript.",
+                },
+                {
+                    type: "code",
+                    value: "class BuscaProdutos extends Component\n{\n    public string $termo = '';\n\n    public function render(): View\n    {\n        return view('livewire.busca-produtos', [\n            'produtos' => Produto::where('nome', 'like', \"%{$this->termo}%\")->get(),\n        ]);\n    }\n}\n\n{{-- A view: cada tecla atualiza a lista --}}\n<input wire:model.live=\"termo\" placeholder=\"Buscar...\">",
+                },
+                {
+                    type: "text",
+                    value: "## Inertia\n\nO componente vive **no navegador**, em React, Vue ou Svelte. O controller devolve `Inertia::render` com as props, e o Inertia cuida da navegação sem recarregar a página. Não existe API para escrever nem estado duplicado.",
+                },
+                {
+                    type: "code",
+                    value: "public function index()\n{\n    return Inertia::render('Produtos/Index', [\n        'produtos' => Produto::latest()->paginate(15),\n    ]);\n}",
+                },
+                {
+                    type: "table",
+                    value: '[["", "Livewire", "Inertia"], ["Onde o componente roda", "servidor", "navegador"], ["Linguagem principal", "PHP", "JavaScript"], ["Ida ao servidor", "a cada interação", "só na navegação"], ["Melhor para", "CRUD e painéis", "interfaces ricas"]]',
+                },
+            ],
+            questions: [
+                {
+                    statement: "Onde um componente Livewire executa?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "No servidor", isCorrect: true },
+                        { text: "No navegador, como um componente React", isCorrect: false },
+                        { text: "Nos dois lados, sincronizados a cada mudança", isCorrect: false },
+                        { text: "No banco de dados, junto das consultas", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o Inertia evita escrever?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Uma API separada para o front-end", isCorrect: true },
+                        { text: "Os componentes de interface da aplicação", isCorrect: false },
+                        { text: "As rotas e os controllers do projeto", isCorrect: false },
+                        { text: "As consultas ao banco de dados", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual o custo do modelo do Livewire?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Uma ida ao servidor a cada interação", isCorrect: true },
+                        { text: "A duplicação do estado entre as duas pontas", isCorrect: false },
+                        { text: "A necessidade de compilar o PHP no navegador", isCorrect: false },
+                        { text: "A perda do histórico de navegação do browser", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Em que caso o Inertia se encaixa melhor?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Interfaces ricas com equipe de front-end", isCorrect: true },
+                        {
+                            text: "Painéis administrativos simples, com muito CRUD",
+                            isCorrect: false,
+                        },
+                        { text: "Sites estáticos sem nenhuma interação", isCorrect: false },
+                        { text: "APIs consumidas por aplicativos móveis", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `wire:model.live` faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Sincroniza o campo com o servidor ao digitar", isCorrect: true },
+                        { text: "Valida o campo antes de enviar o formulário", isCorrect: false },
+                        {
+                            text: "Guarda o valor digitado no armazenamento local",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Envia o formulário quando o campo perde o foco",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_4: Modulo = {
+    titulo: "Módulo 4 - Eloquent e banco de dados",
+    aulas: [
+        {
+            titulo: "Migrations e o schema",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O banco versionado\n\nUma **migration** descreve uma mudança no banco em código PHP. Ela vai para o Git junto com a aplicação, e qualquer pessoa reconstrói o banco rodando um comando.\n\nO ganho é enorme: fim do arquivo SQL trocado por mensagem e do banco de produção diferente do de desenvolvimento.",
+                },
+                {
+                    type: "code",
+                    value: "public function up(): void\n{\n    Schema::create('produtos', function (Blueprint $table) {\n        $table->id();\n        $table->string('nome');\n        $table->string('slug')->unique();\n        $table->text('descricao')->nullable();\n        $table->decimal('preco', 10, 2);\n        $table->foreignId('categoria_id')->constrained();\n        $table->boolean('ativo')->default(true);\n        $table->timestamps();\n        $table->softDeletes();\n    });\n}\n\npublic function down(): void\n{\n    Schema::dropIfExists('produtos');\n}",
+                },
+                {
+                    type: "table",
+                    value: '[["Comando", "O que faz"], ["migrate", "aplica o que falta"], ["migrate:rollback", "desfaz o último lote"], ["migrate:fresh", "apaga tudo e aplica de novo"], ["migrate:status", "mostra o que já rodou"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Nunca edite uma migration já aplicada\n\nSe a migration já rodou em outro ambiente, editá-la não muda nada lá: o Laravel a considera aplicada. A alteração precisa vir em uma migration nova.\n\nO `migrate:fresh` apaga todas as tabelas. Em produção ele é destrutivo e não deve nem existir no processo de deploy.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que uma migration descreve?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Uma mudança na estrutura do banco", isCorrect: true },
+                        { text: "Os dados iniciais que a tabela vai ter", isCorrect: false },
+                        { text: "A consulta que o model executa no banco", isCorrect: false },
+                        { text: "A conexão com o servidor de banco de dados", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que não editar uma migration já aplicada?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Os ambientes onde ela rodou não recebem a mudança",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "O Laravel bloqueia a edição do arquivo depois de salvo",
+                            isCorrect: false,
+                        },
+                        { text: "O arquivo é removido depois de ser aplicado", isCorrect: false },
+                        { text: "A edição desfaz a migration automaticamente", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `migrate:fresh` faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Apaga todas as tabelas e aplica de novo", isCorrect: true },
+                        { text: "Aplica apenas as migrations que ainda faltam", isCorrect: false },
+                        { text: "Desfaz a última migration que foi aplicada", isCorrect: false },
+                        { text: "Recria apenas as tabelas que estão vazias", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `$table->timestamps()` cria?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "As colunas de criação e atualização", isCorrect: true },
+                        { text: "Uma coluna com a data de exclusão do registro", isCorrect: false },
+                        { text: "Um gatilho que registra toda alteração feita", isCorrect: false },
+                        { text: "Uma coluna única com a data e a hora atual", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `foreignId('categoria_id')->constrained()` faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Cria a coluna e a chave estrangeira", isCorrect: true },
+                        { text: "Cria apenas a coluna, sem nenhuma restrição", isCorrect: false },
+                        { text: "Cria um índice único na coluna informada", isCorrect: false },
+                        { text: "Copia os dados da tabela relacionada", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Models e o básico do Eloquent",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O ORM do Laravel\n\nO **Eloquent** implementa Active Record: cada model representa uma tabela e cada instância uma linha. A convenção liga `Produto` à tabela `produtos` sem configuração.",
+                },
+                {
+                    type: "code",
+                    value: "// Criando\n$p = Produto::create(['nome' => 'Caneca', 'preco' => 29.9]);\n\n// Lendo\nProduto::all();\nProduto::find(1);\nProduto::findOrFail(1);\nProduto::where('preco', '<', 100)->orderBy('nome')->get();\nProduto::where('ativo', true)->first();\nProduto::count();\n\n// Atualizando\n$p->update(['preco' => 34.9]);\n\n// Removendo\n$p->delete();",
+                },
+                {
+                    type: "text",
+                    value: "## Mass assignment\n\n`create()` e `update()` recebem um array, e sem proteção alguém poderia enviar um campo que não deveria, como `is_admin`. Por isso o Eloquent exige declarar o que é preenchível.",
+                },
+                {
+                    type: "code",
+                    value: "class Produto extends Model\n{\n    protected $fillable = ['nome', 'slug', 'preco', 'categoria_id'];\n\n    // Conversão automática de tipos ao ler e gravar\n    protected function casts(): array\n    {\n        return [\n            'ativo' => 'boolean',\n            'preco' => 'decimal:2',\n            'publicado_em' => 'datetime',\n            'configuracao' => 'array',\n        ];\n    }\n}",
+                },
+                {
+                    type: "text",
+                    value: "## Coleções\n\nConsultas devolvem uma `Collection`, não um array. Ela traz dezenas de métodos encadeáveis, muito além do que um array oferece.",
+                },
+                {
+                    type: "code",
+                    value: "Produto::all()\n    ->filter(fn ($p) => $p->preco > 50)\n    ->sortBy('nome')\n    ->groupBy('categoria_id')\n    ->map->nome;",
+                },
+            ],
+            questions: [
+                {
+                    statement: "A qual tabela o model `Produto` se liga por convenção?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "produtos", isCorrect: true },
+                        { text: "produto, no singular do nome da classe", isCorrect: false },
+                        { text: "tb_produtos, com o prefixo padrão", isCorrect: false },
+                        { text: "Nenhuma, é preciso declarar sempre", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que a propriedade `$fillable` protege?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Contra atribuição em massa indevida", isCorrect: true },
+                        { text: "Contra injeção de SQL nas consultas feitas", isCorrect: false },
+                        { text: "Contra a leitura de colunas sensíveis", isCorrect: false },
+                        { text: "Contra a exclusão acidental de registros", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que os casts fazem em um model?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Convertem os tipos ao ler e gravar", isCorrect: true },
+                        { text: "Validam os valores antes de gravar no banco", isCorrect: false },
+                        { text: "Definem os tipos das colunas na migration", isCorrect: false },
+                        { text: "Escondem colunas do resultado em JSON", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que uma consulta Eloquent devolve?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Uma Collection", isCorrect: true },
+                        { text: "Um array simples com os registros", isCorrect: false },
+                        { text: "Um objeto de resultado do driver do banco", isCorrect: false },
+                        { text: "Um gerador que precisa ser percorrido", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a diferença entre `find` e `findOrFail`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O segundo lança exceção quando não acha", isCorrect: true },
+                        { text: "O segundo procura em todas as tabelas ligadas", isCorrect: false },
+                        { text: "O primeiro só funciona com a chave primária", isCorrect: false },
+                        { text: "O primeiro devolve uma coleção de registros", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Atributos do PHP no Eloquent, novidade do Laravel 13",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Configuração na declaração\n\nAté o Laravel 12, configurar um model era preencher propriedades protegidas: `$table`, `$fillable`, `$hidden`, `$connection`. Funciona, mas espalha a configuração em várias propriedades soltas.\n\nO **Laravel 13** introduziu **atributos do PHP** como alternativa. A configuração passa a ficar na declaração da classe, visível de imediato. É adição, não substituição: as propriedades continuam funcionando.",
+                },
+                {
+                    type: "code",
+                    value: "use Illuminate\\Database\\Eloquent\\Attributes\\Fillable;\nuse Illuminate\\Database\\Eloquent\\Attributes\\Hidden;\nuse Illuminate\\Database\\Eloquent\\Attributes\\Table;\n\n#[Table('produtos')]\n#[Fillable(['nome', 'slug', 'preco'])]\n#[Hidden(['custo_interno'])]\nclass Produto extends Model\n{\n    //\n}",
+                },
+                {
+                    type: "table",
+                    value: '[["Atributo", "Substitui a propriedade"], ["#[Table]", "$table"], ["#[Fillable]", "$fillable"], ["#[Guarded]", "$guarded"], ["#[Hidden] e #[Visible]", "$hidden e $visible"], ["#[Appends]", "$appends"], ["#[Connection]", "$connection"], ["#[Touches]", "$touches"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Onde mais os atributos entraram\n\nO Laravel 13 levou os atributos para além do Eloquent: jobs de fila, comandos de console, form requests, resources de API, factories e seeders de teste ganharam versões em atributo.\n\nA escolha entre atributo e propriedade é de estilo. O importante é não misturar as duas formas no mesmo model, o que confunde quem lê depois.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que os atributos do Laravel 13 substituem nos models?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "As propriedades de configuração", isCorrect: true },
+                        { text: "Os métodos de relacionamento entre models", isCorrect: false },
+                        { text: "As regras de validação dos formulários", isCorrect: false },
+                        { text: "Os casts que convertem os tipos das colunas", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Os atributos são obrigatórios no Laravel 13?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Não, as propriedades continuam funcionando", isCorrect: true },
+                        {
+                            text: "Sim, as propriedades foram todas descontinuadas",
+                            isCorrect: false,
+                        },
+                        { text: "Sim, mas apenas em models criados do zero", isCorrect: false },
+                        { text: "Sim, exceto quando o model usa herança", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual atributo substitui a propriedade `$hidden`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "#[Hidden]", isCorrect: true },
+                        { text: "#[Guarded], que protege as colunas", isCorrect: false },
+                        { text: "#[Invisible], no padrão de nomes antigo", isCorrect: false },
+                        { text: "#[Protected], seguindo a visibilidade", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Além do Eloquent, onde os atributos entraram?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Em jobs, comandos e form requests", isCorrect: true },
+                        { text: "Apenas nas migrations e nos seeders", isCorrect: false },
+                        { text: "Somente nas rotas e nos middlewares", isCorrect: false },
+                        { text: "Nas views Blade e nos componentes", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que evitar misturar atributos e propriedades no mesmo model?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "A configuração fica espalhada e confunde", isCorrect: true },
+                        { text: "O Laravel ignora a segunda forma encontrada", isCorrect: false },
+                        { text: "As duas formas entram em conflito e falham", isCorrect: false },
+                        { text: "Os atributos deixam de ser lidos na herança", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Relacionamentos",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Ligando tabelas\n\nO Eloquent expressa relacionamento como método no model. Depois disso, você navega entre os dados como se fossem propriedades.",
+                },
+                {
+                    type: "table",
+                    value: '[["Relação", "Método", "Exemplo"], ["um para um", "hasOne e belongsTo", "usuário tem um perfil"], ["um para muitos", "hasMany e belongsTo", "post tem comentários"], ["muitos para muitos", "belongsToMany", "post tem tags"], ["através de", "hasManyThrough", "país tem posts via usuários"], ["polimórfica", "morphMany", "comentário em post ou vídeo"]]',
+                },
+                {
+                    type: "code",
+                    value: "class Post extends Model\n{\n    public function usuario(): BelongsTo\n    {\n        return $this->belongsTo(User::class);\n    }\n\n    public function comentarios(): HasMany\n    {\n        return $this->hasMany(Comentario::class);\n    }\n\n    public function tags(): BelongsToMany\n    {\n        return $this->belongsToMany(Tag::class);\n    }\n}\n\n// Usando\n$post->usuario->name;\n$post->comentarios;                      // a coleção\n$post->comentarios()->where('aprovado', true)->get();\n$post->tags()->attach($tag);\n$post->tags()->sync([1, 2, 3]);",
+                },
+                {
+                    type: "text",
+                    value: "## Propriedade ou método\n\nEsta distinção confunde no começo:\n\n- `$post->comentarios` é **propriedade** e devolve a coleção já carregada\n- `$post->comentarios()` é **método** e devolve o construtor de consulta, para continuar filtrando",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual método expressa que um post pertence a um usuário?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "belongsTo", isCorrect: true },
+                        { text: "hasOne, indicando que ele tem um usuário", isCorrect: false },
+                        { text: "hasMany, para a coleção de usuários", isCorrect: false },
+                        { text: "belongsToMany, ligando os dois lados", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a diferença entre `$post->tags` e `$post->tags()`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O segundo devolve o construtor de consulta", isCorrect: true },
+                        {
+                            text: "O primeiro executa uma consulta bem mais lenta",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O segundo devolve apenas a quantidade de itens",
+                            isCorrect: false,
+                        },
+                        { text: "O primeiro só funciona em relações simples", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual método usar para muitos para muitos?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "belongsToMany", isCorrect: true },
+                        { text: "hasManyThrough, passando pela tabela pivô", isCorrect: false },
+                        { text: "morphMany, que também liga vários registros", isCorrect: false },
+                        { text: "hasMany dos dois lados da relação", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `sync([1, 2, 3])` faz em uma relação?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Deixa exatamente esses vínculos e remove o resto",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Acrescenta os três aos vínculos que já existiam antes",
+                            isCorrect: false,
+                        },
+                        { text: "Remove os três dos vínculos existentes", isCorrect: false },
+                        { text: "Cria os registros que ainda não existem", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Para que serve uma relação polimórfica?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Ligar um model a mais de um tipo de dono", isCorrect: true },
+                        { text: "Ligar dois models pela tabela intermediária", isCorrect: false },
+                        { text: "Ligar models que estão em bancos diferentes", isCorrect: false },
+                        { text: "Ligar um model a ele mesmo em hierarquia", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Factories, seeders e o problema N+1",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Dados falsos com propósito\n\nA **factory** descreve como gerar um registro de mentira. Ela é essencial em teste e útil para popular o ambiente de desenvolvimento.",
+                },
+                {
+                    type: "code",
+                    value: "class ProdutoFactory extends Factory\n{\n    public function definition(): array\n    {\n        return [\n            'nome' => fake()->words(3, true),\n            'slug' => fake()->unique()->slug(),\n            'preco' => fake()->randomFloat(2, 10, 500),\n            'ativo' => true,\n        ];\n    }\n\n    public function inativo(): static\n    {\n        return $this->state(fn () => ['ativo' => false]);\n    }\n}\n\nProduto::factory()->count(50)->create();\nProduto::factory()->inativo()->create();\nUser::factory()->has(Post::factory()->count(3))->create();",
+                },
+                {
+                    type: "text",
+                    value: "# O problema N+1\n\nEste é o problema de desempenho mais comum em qualquer ORM. Ao percorrer uma lista acessando uma relação, cada item dispara uma consulta nova.\n\nCem posts viram **101 consultas**: uma para a lista e cem para os autores.",
+                },
+                {
+                    type: "code",
+                    value: "// N+1: uma consulta por post dentro do laço\n$posts = Post::all();\nforeach ($posts as $post) {\n    echo $post->usuario->name;\n}\n\n// Eager loading: duas consultas no total\n$posts = Post::with('usuario')->get();\n\n// Várias relações e aninhadas\nPost::with(['usuario', 'comentarios.usuario'])->get();\n\n// Só a contagem, sem carregar os registros\nPost::withCount('comentarios')->get();",
+                },
+                {
+                    type: "quote",
+                    value: "Ligue Model::preventLazyLoading() em desenvolvimento: o Laravel passa a lançar exceção quando um N+1 acontece, em vez de deixá-lo passar.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Para que serve uma factory?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Gerar registros de mentira para teste", isCorrect: true },
+                        { text: "Criar a estrutura das tabelas no banco", isCorrect: false },
+                        { text: "Validar os dados antes de gravar no banco", isCorrect: false },
+                        { text: "Definir os relacionamentos entre os models", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que caracteriza o problema N+1?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Uma consulta extra por item percorrido", isCorrect: true },
+                        { text: "Uma consulta que devolve registros repetidos", isCorrect: false },
+                        { text: "Um relacionamento declarado de forma errada", isCorrect: false },
+                        { text: "Uma tabela sem índice na chave estrangeira", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como se resolve o N+1 no Eloquent?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Com eager loading, usando `with`", isCorrect: true },
+                        { text: "Com um índice na coluna da chave estrangeira", isCorrect: false },
+                        {
+                            text: "Aumentando o limite de consultas por requisição",
+                            isCorrect: false,
+                        },
+                        { text: "Guardando o resultado da consulta em cache", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quantas consultas `Post::with('usuario')->get()` faz?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Duas", isCorrect: true },
+                        { text: "Uma para cada post encontrado na tabela", isCorrect: false },
+                        { text: "Uma só, com junção entre as duas tabelas", isCorrect: false },
+                        { text: "Três, sendo uma para contar os registros", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `preventLazyLoading()` faz em desenvolvimento?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Lança exceção quando ocorre um N+1", isCorrect: true },
+                        { text: "Carrega todas as relações automaticamente", isCorrect: false },
+                        { text: "Registra as consultas lentas em um arquivo", isCorrect: false },
+                        {
+                            text: "Desativa o carregamento de relações no projeto",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_5: Modulo = {
+    titulo: "Módulo 5 - Autenticação e autorização",
+    aulas: [
+        {
+            titulo: "Autenticação: sessão, guards e providers",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Duas perguntas diferentes\n\nEsta distinção organiza o módulo inteiro:\n\n- **Autenticação** responde *quem é você*\n- **Autorização** responde *o que você pode fazer*\n\nSão sistemas separados no Laravel, e confundir os dois leva a código que verifica login onde deveria verificar permissão.",
+                },
+                {
+                    type: "code",
+                    value: "// Tentando entrar\nif (Auth::attempt(['email' => $email, 'password' => $senha], $lembrar)) {\n    $request->session()->regenerate();\n    return redirect()->intended('/painel');\n}\n\nreturn back()->withErrors([\n    'email' => 'As credenciais não conferem.',\n])->onlyInput('email');\n\n// Saindo\nAuth::logout();\n$request->session()->invalidate();\n$request->session()->regenerateToken();",
+                },
+                {
+                    type: "text",
+                    value: "## Por que regenerar a sessão\n\n`session()->regenerate()` no login e `invalidate()` no logout não são detalhe: sem eles a aplicação fica vulnerável a fixação de sessão, em que o atacante planta um identificador e o reaproveita depois que a vítima entra.",
+                },
+                {
+                    type: "text",
+                    value: "## Guards e providers\n\nO **guard** define como o usuário é identificado em cada requisição: por sessão no navegador, por token em API. O **provider** define de onde os usuários vêm, normalmente uma tabela pelo Eloquent.\n\nEssa separação permite ter administradores e clientes em tabelas distintas, cada um com seu guard.",
+                },
+                {
+                    type: "code",
+                    value: "// config/auth.php\n'guards' => [\n    'web' => ['driver' => 'session', 'provider' => 'users'],\n    'admin' => ['driver' => 'session', 'provider' => 'admins'],\n],\n\n// Usando um guard específico\nAuth::guard('admin')->attempt($credenciais);\nRoute::middleware('auth:admin')->group(...);",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual a diferença entre autenticação e autorização?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Uma diz quem é, a outra diz o que pode", isCorrect: true },
+                        { text: "Uma vale para web e a outra apenas para API", isCorrect: false },
+                        { text: "Uma usa sessão e a outra usa sempre token", isCorrect: false },
+                        {
+                            text: "Uma roda no middleware e a outra no controller",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Por que chamar `session()->regenerate()` no login?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Para evitar fixação de sessão", isCorrect: true },
+                        {
+                            text: "Para que o usuário permaneça logado por mais tempo",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Para limpar os dados antigos guardados na sessão",
+                            isCorrect: false,
+                        },
+                        { text: "Para gerar o token CSRF do próximo formulário", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que um guard define?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Como o usuário é identificado na requisição", isCorrect: true },
+                        {
+                            text: "Quais permissões o usuário tem dentro do sistema",
+                            isCorrect: false,
+                        },
+                        { text: "De qual tabela os usuários são carregados", isCorrect: false },
+                        { text: "Quanto tempo a sessão permanece válida", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que um provider define?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "De onde os usuários vêm", isCorrect: true },
+                        { text: "Como a senha é criptografada no banco", isCorrect: false },
+                        {
+                            text: "Quais rotas exigem que o usuário esteja logado",
+                            isCorrect: false,
+                        },
+                        { text: "Qual middleware roda antes da autenticação", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `redirect()->intended()` faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Leva à página que o usuário tentou abrir", isCorrect: true },
+                        { text: "Leva sempre à página inicial da aplicação", isCorrect: false },
+                        {
+                            text: "Leva à página anterior no histórico do navegador",
+                            isCorrect: false,
+                        },
+                        { text: "Leva ao painel definido na configuração", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Passkeys e autenticação sem senha",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O problema da senha\n\nSenha é reutilizada entre sites, vaza em incidente e cai em phishing. As **passkeys** atacam a raiz disso: em vez de um segredo compartilhado, usam um par de chaves criptográficas.\n\nA chave privada nunca sai do dispositivo, e o servidor guarda só a pública. Não há o que vazar de útil, e phishing não funciona porque a chave é vinculada ao domínio.",
+                },
+                {
+                    type: "table",
+                    value: '[["", "Senha", "Passkey"], ["O servidor guarda", "hash do segredo", "a chave pública"], ["Risco de vazamento", "alto", "sem valor para o atacante"], ["Phishing", "funciona", "não funciona"], ["Reuso entre sites", "comum", "impossível"]]',
+                },
+                {
+                    type: "text",
+                    value: "## No Laravel 13\n\nOs starter kits trazem passkeys como opção na instalação. Quando ligada, a aplicação passa a expor `/.well-known/passkey-endpoints`, exigido pela especificação do W3C. Sem esse endpoint, dispositivos Apple não descobrem corretamente as passkeys do site.\n\nO fluxo tem duas etapas, ambas com desafio aleatório: **registro**, que grava a chave pública, e **autenticação**, em que o dispositivo assina o desafio e o servidor confere com a chave guardada.",
+                },
+                {
+                    type: "quote",
+                    value: "Mantenha um segundo caminho de entrada ao adotar passkey. Quem perde o dispositivo sem alternativa perde a conta.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o servidor guarda em uma autenticação por passkey?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A chave pública do usuário", isCorrect: true },
+                        { text: "O hash da senha escolhida no cadastro", isCorrect: false },
+                        { text: "A chave privada, protegida por criptografia", isCorrect: false },
+                        { text: "O dispositivo autorizado a fazer o acesso", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que phishing não funciona com passkey?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "A chave é vinculada ao domínio original", isCorrect: true },
+                        { text: "O usuário não digita nada durante o acesso", isCorrect: false },
+                        { text: "O navegador bloqueia sites desconhecidos", isCorrect: false },
+                        { text: "A chave expira poucos segundos após o uso", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Para que serve `/.well-known/passkey-endpoints`?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Permitir que dispositivos descubram as passkeys",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Guardar as chaves públicas de todos os usuários",
+                            isCorrect: false,
+                        },
+                        { text: "Validar o desafio enviado pelo servidor", isCorrect: false },
+                        { text: "Listar os dispositivos já autorizados", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quando esse endpoint é incluído no projeto?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Quando passkeys são ligadas na instalação", isCorrect: true },
+                        { text: "Sempre, em qualquer projeto do Laravel 13", isCorrect: false },
+                        { text: "Apenas quando o projeto usa o Inertia", isCorrect: false },
+                        { text: "Depois de publicar as rotas de autenticação", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Que cuidado tomar ao adotar passkey?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Manter um segundo caminho de entrada", isCorrect: true },
+                        { text: "Exigir senha forte junto com a passkey", isCorrect: false },
+                        { text: "Registrar a passkey em todos os navegadores", isCorrect: false },
+                        { text: "Trocar a chave pública a cada trinta dias", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Middleware próprio",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Interceptando a requisição\n\nUm middleware envolve o ciclo da requisição. Ele decide se ela segue, altera a requisição ou mexe na resposta depois que o controller termina.",
+                },
+                {
+                    type: "code",
+                    value: "class GarantirAssinatura\n{\n    public function handle(Request $request, Closure $next): Response\n    {\n        if (! $request->user()?->assinaturaAtiva()) {\n            return redirect()->route('planos')\n                ->with('aviso', 'Este recurso é para assinantes.');\n        }\n\n        return $next($request);\n    }\n}",
+                },
+                {
+                    type: "text",
+                    value: "## Antes e depois\n\nO código antes do `$next($request)` roda **antes** do controller. O que vem depois roda com a resposta já pronta, o que serve para acrescentar cabeçalho ou medir tempo.",
+                },
+                {
+                    type: "code",
+                    value: "public function handle(Request $request, Closure $next): Response\n{\n    $inicio = microtime(true);\n\n    $response = $next($request);   // o controller roda aqui\n\n    $duracao = microtime(true) - $inicio;\n    $response->headers->set('X-Duracao', (string) $duracao);\n\n    return $response;\n}",
+                },
+                {
+                    type: "text",
+                    value: "## Registrando\n\nDesde o Laravel 11 o registro fica em `bootstrap/app.php`. Você pode aplicar a todas as rotas, criar um apelido ou usar a classe direto na rota.",
+                },
+                {
+                    type: "code",
+                    value: "->withMiddleware(function (Middleware $middleware) {\n    $middleware->append(GarantirCabecalhos::class);   // todas as rotas\n    $middleware->alias(['assinante' => GarantirAssinatura::class]);\n})\n\n// Na rota\nRoute::get('/relatorios', ...)->middleware('assinante');",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que `$next($request)` faz em um middleware?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Passa a requisição adiante na cadeia", isCorrect: true },
+                        { text: "Encerra a requisição devolvendo a resposta", isCorrect: false },
+                        { text: "Reinicia o ciclo desde o primeiro middleware", isCorrect: false },
+                        { text: "Cria uma nova requisição a partir da atual", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Onde fica o código que roda depois do controller?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Depois da chamada a `$next`", isCorrect: true },
+                        { text: "Antes da chamada, no começo do handle", isCorrect: false },
+                        { text: "Em um método separado chamado terminate", isCorrect: false },
+                        { text: "Em um middleware registrado por último", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Onde os middlewares são registrados desde o Laravel 11?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Em bootstrap/app.php", isCorrect: true },
+                        { text: "No arquivo app/Http/Kernel.php do projeto", isCorrect: false },
+                        { text: "Em config/middleware.php, junto do resto", isCorrect: false },
+                        { text: "Diretamente no arquivo de rotas do projeto", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que um middleware pode fazer com a requisição?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Barrar, alterar ou deixar seguir", isCorrect: true },
+                        { text: "Apenas registrar informações em um log", isCorrect: false },
+                        { text: "Apenas barrar quem não estiver autenticado", isCorrect: false },
+                        { text: "Apenas alterar os cabeçalhos da resposta", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Para que serve dar um apelido a um middleware?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Usá-lo pelo nome curto nas rotas", isCorrect: true },
+                        { text: "Aplicá-lo automaticamente em todas as rotas", isCorrect: false },
+                        { text: "Executá-lo antes dos demais middlewares", isCorrect: false },
+                        { text: "Permitir que ele receba parâmetros na rota", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Gates e Policies",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Onde a permissão mora\n\nO Laravel oferece duas formas de autorizar, e a escolha depende de a regra girar em torno de um model ou não.\n\n- **Gate**: uma função solta, para permissão que não pertence a um model\n- **Policy**: uma classe por model, com um método por ação",
+                },
+                {
+                    type: "code",
+                    value: "// Gate: registrado em um service provider\nGate::define('ver-relatorios', function (User $user) {\n    return $user->cargo === 'gerente';\n});\n\n// Usando\nif (Gate::allows('ver-relatorios')) { }\nGate::authorize('ver-relatorios');   // lança 403 se negar",
+                },
+                {
+                    type: "code",
+                    value: "class PostPolicy\n{\n    public function view(?User $user, Post $post): bool\n    {\n        return $post->publicado || $user?->id === $post->user_id;\n    }\n\n    public function update(User $user, Post $post): bool\n    {\n        return $user->id === $post->user_id;\n    }\n\n    public function delete(User $user, Post $post): bool\n    {\n        return $user->id === $post->user_id || $user->admin;\n    }\n\n    // Roda antes de tudo: admin passa direto\n    public function before(User $user, string $ability): ?bool\n    {\n        return $user->admin ? true : null;\n    }\n}",
+                },
+                {
+                    type: "text",
+                    value: "## Usando em cada camada\n\nA mesma policy responde no controller, na view e na rota, o que evita a regra duplicada em três lugares diferentes.",
+                },
+                {
+                    type: "code",
+                    value: "// No controller\n$this->authorize('update', $post);\n\n// Na view: esconde o que a pessoa não pode fazer\n@can('update', $post)\n    <a href=\"{{ route('posts.edit', $post) }}\">Editar</a>\n@endcan\n\n// Na rota\nRoute::put('/posts/{post}', ...)->middleware('can:update,post');",
+                },
+                {
+                    type: "quote",
+                    value: "Esconder o botão na view é experiência, não segurança. A verificação no controller é o que realmente protege.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Quando usar Policy em vez de Gate?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Quando a regra gira em torno de um model", isCorrect: true },
+                        { text: "Quando a regra vale para o sistema inteiro", isCorrect: false },
+                        { text: "Quando a verificação acontece só na view", isCorrect: false },
+                        { text: "Quando existe mais de um guard configurado", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o método `before` de uma policy faz?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Roda antes e pode liberar tudo de uma vez", isCorrect: true },
+                        { text: "Prepara os dados que os outros métodos usam", isCorrect: false },
+                        { text: "Valida os argumentos recebidos pela policy", isCorrect: false },
+                        { text: "Registra a tentativa de acesso em um log", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `Gate::authorize` faz quando a permissão é negada?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Lança uma exceção que vira 403", isCorrect: true },
+                        { text: "Devolve falso para o código continuar", isCorrect: false },
+                        { text: "Redireciona para a página de login", isCorrect: false },
+                        { text: "Registra o erro e permite o acesso", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Esconder o botão com `@can` é suficiente para proteger a ação?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Não, é preciso verificar no servidor", isCorrect: true },
+                        { text: "Sim, o usuário não consegue clicar no botão", isCorrect: false },
+                        { text: "Sim, desde que a rota também tenha nome", isCorrect: false },
+                        { text: "Sim, o Blade bloqueia a requisição sozinho", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quantos métodos uma policy costuma ter?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um para cada ação do model", isCorrect: true },
+                        { text: "Um só, que recebe a ação como argumento", isCorrect: false },
+                        { text: "Dois, um para leitura e outro para escrita", isCorrect: false },
+                        { text: "Nenhum fixo, ela usa apenas o before", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "As defesas que o framework já dá",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Segurança por padrão\n\nBoa parte das falhas clássicas já vem fechada no Laravel. Vale saber **quais** e, principalmente, o que ainda desliga cada proteção sem querer.",
+                },
+                {
+                    type: "table",
+                    value: '[["Ataque", "A defesa do Laravel", "O que ainda abre a porta"], ["SQL injection", "consultas preparadas no Eloquent", "usar DB::raw com entrada do usuário"], ["XSS", "escape automático do Blade", "usar {!! !!} com dado externo"], ["CSRF", "middleware e token", "excluir a rota da verificação"], ["Mass assignment", "fillable e guarded", "guarded vazio no model"], ["Senha em texto", "hash automático no cast", "gravar sem passar pelo Hash"]]',
+                },
+                {
+                    type: "code",
+                    value: "// Perigoso: concatena entrada do usuário\nDB::select(\"SELECT * FROM users WHERE nome = '{$request->nome}'\");\n\n// Seguro: mesmo em consulta crua, use vínculo\nDB::select('SELECT * FROM users WHERE nome = ?', [$request->nome]);\n\n// Perigoso: abre o model inteiro para atribuição em massa\nprotected $guarded = [];\n\n// Seguro\nprotected $fillable = ['nome', 'email'];",
+                },
+                {
+                    type: "text",
+                    value: "## Senhas\n\nO model `User` já converte a senha em hash pelo cast, então `bcrypt()` manual costuma ser redundante. O algoritmo padrão é o bcrypt, configurável para argon2 em `config/hashing.php`.\n\n## Limitando tentativas\n\nO middleware `throttle` protege login e formulários públicos contra força bruta e abuso.",
+                },
+                {
+                    type: "code",
+                    value: "Route::post('/login', ...)->middleware('throttle:5,1');\n\n// Limite por usuário em vez de por IP\nRateLimiter::for('api', fn (Request $r) =>\n    Limit::perMinute(60)->by($r->user()?->id ?: $r->ip())\n);",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que ainda deixa a aplicação vulnerável a SQL injection?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Concatenar entrada do usuário em consulta crua", isCorrect: true },
+                        { text: "Usar o Eloquent para montar as consultas", isCorrect: false },
+                        {
+                            text: "Declarar todas as colunas na propriedade fillable",
+                            isCorrect: false,
+                        },
+                        { text: "Escapar a saída nas views com chaves duplas", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `protected $guarded = []` faz?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Abre todas as colunas para atribuição em massa", isCorrect: true },
+                        {
+                            text: "Protege todas as colunas contra a atribuição em massa",
+                            isCorrect: false,
+                        },
+                        { text: "Desativa a validação dos dados enviados", isCorrect: false },
+                        { text: "Esconde as colunas ao converter para JSON", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como o Blade protege contra XSS?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Escapando a saída de `{{ }}`", isCorrect: true },
+                        { text: "Removendo todas as tags HTML do conteúdo", isCorrect: false },
+                        { text: "Validando o conteúdo antes de exibir na tela", isCorrect: false },
+                        { text: "Bloqueando scripts pelo cabeçalho da resposta", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como se converte a senha em hash no model User?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Pelo cast, que já vem configurado", isCorrect: true },
+                        { text: "Chamando bcrypt manualmente antes de gravar", isCorrect: false },
+                        { text: "Por um gatilho criado na migration da tabela", isCorrect: false },
+                        {
+                            text: "Pelo middleware que trata o formulário de login",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Para que serve o middleware `throttle` no login?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Limitar tentativas e conter força bruta", isCorrect: true },
+                        { text: "Validar as credenciais antes do controller", isCorrect: false },
+                        { text: "Registrar cada tentativa de acesso em log", isCorrect: false },
+                        { text: "Bloquear acessos vindos de fora do país", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_6: Modulo = {
+    titulo: "Módulo 6 - APIs, filas e cache",
+    aulas: [
+        {
+            titulo: "API resources e JSON:API",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Controlando o que a API devolve\n\nDevolver o model direto expõe toda coluna, incluindo o que não deveria sair, e prende o formato da resposta à estrutura da tabela. O **API Resource** é a camada que traduz model em resposta.",
+                },
+                {
+                    type: "code",
+                    value: "class ProdutoResource extends JsonResource\n{\n    public function toArray(Request $request): array\n    {\n        return [\n            'id' => $this->id,\n            'nome' => $this->nome,\n            'preco' => (float) $this->preco,\n            'categoria' => CategoriaResource::make($this->whenLoaded('categoria')),\n            'criado_em' => $this->created_at->toIso8601String(),\n            'custo' => $this->when($request->user()?->admin, $this->custo_interno),\n        ];\n    }\n}\n\n// No controller\nreturn ProdutoResource::collection(\n    Produto::with('categoria')->paginate(15)\n);",
+                },
+                {
+                    type: "text",
+                    value: "`whenLoaded` só inclui a relação se ela foi carregada, o que evita N+1 escondido dentro do resource. `when` inclui o campo apenas quando a condição é verdadeira.\n\n## JSON:API no Laravel 13\n\nO **JSON:API** é uma especificação que padroniza o formato de resposta: onde ficam os dados, as relações, os links e os erros. Ela resolve a discussão de formato que toda equipe repete.\n\nO Laravel 13 trouxe **resources JSON:API de primeira parte**, cuidando da serialização, da inclusão de relações, dos campos esparsos, dos links e dos cabeçalhos exigidos.",
+                },
+                {
+                    type: "quote",
+                    value: "Campos esparsos deixam o cliente pedir só as colunas que quer, o que reduz tráfego sem precisar de um endpoint novo.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual o problema de devolver o model direto na API?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Expõe colunas e prende o formato à tabela", isCorrect: true },
+                        { text: "Deixa a resposta bem mais lenta ao serializar", isCorrect: false },
+                        { text: "Impede o uso de paginação nos resultados", isCorrect: false },
+                        { text: "Quebra a validação dos dados de entrada", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `whenLoaded` evita em um resource?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Disparar um N+1 ao serializar a relação", isCorrect: true },
+                        { text: "Devolver campos nulos para o cliente da API", isCorrect: false },
+                        {
+                            text: "Carregar o resource duas vezes na mesma resposta",
+                            isCorrect: false,
+                        },
+                        { text: "Expor a relação para usuários sem permissão", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que a especificação JSON:API padroniza?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O formato de dados, relações, links e erros", isCorrect: true },
+                        { text: "A forma de autenticar as requisições da API", isCorrect: false },
+                        { text: "O limite de requisições por minuto permitido", isCorrect: false },
+                        { text: "A versão do protocolo HTTP a ser usada", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o Laravel 13 acrescentou quanto a JSON:API?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Resources de primeira parte no framework", isCorrect: true },
+                        { text: "Um pacote externo recomendado pela equipe", isCorrect: false },
+                        { text: "A conversão automática de todo resource", isCorrect: false },
+                        { text: "Uma nova versão da especificação do formato", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que são campos esparsos?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O cliente pede só os campos que quer", isCorrect: true },
+                        {
+                            text: "Campos que ficam nulos na maior parte do tempo",
+                            isCorrect: false,
+                        },
+                        { text: "Campos que só aparecem para administradores", isCorrect: false },
+                        { text: "Campos calculados que não existem na tabela", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Autenticação de API com Sanctum",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Dois cenários, uma ferramenta\n\nO **Sanctum** atende os dois casos mais comuns de API sem a complexidade do OAuth:\n\n- **Token de API**: para aplicativo móvel ou integração de terceiro\n- **SPA no mesmo domínio**: usa cookie de sessão, sem token nenhum",
+                },
+                {
+                    type: "code",
+                    value: "// Emitindo um token com escopos\n$token = $usuario->createToken('app-movel', ['pedidos:ler'])->plainTextToken;\n\n// O cliente envia no cabeçalho\n// Authorization: Bearer 1|abc123...\n\nRoute::middleware('auth:sanctum')->group(function () {\n    Route::get('/pedidos', [PedidoController::class, 'index']);\n});\n\n// Verificando o escopo\nif ($request->user()->tokenCan('pedidos:ler')) { }\n\n// Revogando\n$usuario->tokens()->delete();               // todos\n$request->user()->currentAccessToken()->delete();   // só o atual",
+                },
+                {
+                    type: "text",
+                    value: "## O token só aparece uma vez\n\n`plainTextToken` é a única oportunidade de ver o valor: o banco guarda apenas o hash. Se o cliente perder, o caminho é emitir outro e revogar o anterior.\n\n## SPA no mesmo domínio\n\nNesse modo o Sanctum usa a sessão normal, com cookie `HttpOnly`. É mais seguro que guardar token em `localStorage`, que fica exposto a qualquer XSS na página.",
+                },
+                {
+                    type: "code",
+                    value: "// O cliente busca o cookie CSRF antes do login\naxios.get('/sanctum/csrf-cookie').then(() => {\n    axios.post('/login', { email, password });\n});",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Quais dois cenários o Sanctum atende?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Token de API e SPA no mesmo domínio", isCorrect: true },
+                        { text: "Login social e autenticação de dois fatores", isCorrect: false },
+                        { text: "Sessão web e autenticação por certificado", isCorrect: false },
+                        { text: "OAuth completo e chaves de acesso fixas", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quantas vezes o valor do token pode ser lido?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Uma só, na criação", isCorrect: true },
+                        { text: "Quantas vezes quiser, consultando o banco", isCorrect: false },
+                        { text: "Duas, na criação e na primeira autenticação", isCorrect: false },
+                        { text: "Enquanto o token estiver dentro da validade", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que o modo SPA é mais seguro que guardar token no navegador?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O cookie HttpOnly não é lido por JavaScript", isCorrect: true },
+                        {
+                            text: "O cookie é criptografado com uma chave rotativa",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "A sessão expira em poucos minutos de inatividade",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O token guardado ocupa espaço no armazenamento",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que `tokenCan` verifica?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Se o token tem determinado escopo", isCorrect: true },
+                        { text: "Se o token ainda está dentro da validade", isCorrect: false },
+                        { text: "Se o usuário do token está ativo no sistema", isCorrect: false },
+                        { text: "Se o token foi emitido pelo mesmo domínio", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o banco guarda do token emitido?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Apenas o hash dele", isCorrect: true },
+                        { text: "O valor completo, para poder ser reenviado", isCorrect: false },
+                        {
+                            text: "O valor criptografado com a chave da aplicação",
+                            isCorrect: false,
+                        },
+                        { text: "Apenas os escopos, sem guardar o valor", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Filas e jobs",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Tirando o lento do caminho\n\nEnviar email, gerar PDF ou chamar uma API externa dentro da requisição faz o usuário esperar por algo que não precisa acontecer agora. A **fila** empurra esse trabalho para segundo plano e a resposta sai na hora.",
+                },
+                {
+                    type: "code",
+                    value: "use Illuminate\\Queue\\Attributes\\Backoff;\nuse Illuminate\\Queue\\Attributes\\Queue;\nuse Illuminate\\Queue\\Attributes\\Tries;\n\n#[Queue('emails')]\n#[Tries(3)]\n#[Backoff([10, 30, 60])]\nclass EnviarBoasVindas implements ShouldQueue\n{\n    use Queueable;\n\n    public function __construct(public User $usuario) {}\n\n    public function handle(): void\n    {\n        Mail::to($this->usuario)->send(new BoasVindas($this->usuario));\n    }\n\n    public function failed(?Throwable $e): void\n    {\n        Log::error('Falhou o email de boas-vindas', ['id' => $this->usuario->id]);\n    }\n}\n\n// Despachando\nEnviarBoasVindas::dispatch($usuario);\nEnviarBoasVindas::dispatch($usuario)->delay(now()->addMinutes(10));",
+                },
+                {
+                    type: "text",
+                    value: "Os atributos `#[Queue]`, `#[Tries]` e `#[Backoff]` são a forma do **Laravel 13**, no lugar das propriedades `$queue`, `$tries` e `$backoff`.\n\n## O worker\n\nA fila só anda se houver um processo consumindo. Em produção ele fica sob um supervisor que o reinicia se cair.",
+                },
+                {
+                    type: "code",
+                    value: "php artisan queue:work --queue=emails,padrao --tries=3\nphp artisan queue:failed          # lista as que falharam\nphp artisan queue:retry all       # tenta de novo\n\n# Depois de todo deploy, para o worker recarregar o código\nphp artisan queue:restart",
+                },
+                {
+                    type: "quote",
+                    value: "O worker carrega o código na memória ao subir. Sem queue:restart no deploy, ele segue rodando a versão antiga por tempo indefinido.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual o ganho de mandar um trabalho para a fila?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "A resposta ao usuário sai na hora", isCorrect: true },
+                        { text: "O trabalho passa a ser executado mais rápido", isCorrect: false },
+                        { text: "O servidor consome bem menos memória no total", isCorrect: false },
+                        { text: "O trabalho deixa de poder falhar na execução", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o atributo `#[Tries(3)]` define?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Quantas tentativas o job terá", isCorrect: true },
+                        { text: "Quantos jobs rodam ao mesmo tempo na fila", isCorrect: false },
+                        { text: "Quantos segundos ele espera antes de rodar", isCorrect: false },
+                        { text: "Quantas filas diferentes ele pode usar", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que rodar `queue:restart` no deploy?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O worker segue com o código antigo em memória", isCorrect: true },
+                        {
+                            text: "A fila precisa ser esvaziada antes de cada deploy",
+                            isCorrect: false,
+                        },
+                        { text: "Os jobs pendentes são perdidos sem o comando", isCorrect: false },
+                        { text: "O comando recria a tabela de jobs no banco", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o método `failed` de um job faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Roda quando todas as tentativas se esgotam", isCorrect: true },
+                        {
+                            text: "Roda a cada tentativa do job que não deu certo",
+                            isCorrect: false,
+                        },
+                        { text: "Impede que o job seja tentado de novo", isCorrect: false },
+                        { text: "Registra o job na lista de pendentes", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que acontece se não houver worker rodando?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Os jobs ficam parados na fila", isCorrect: true },
+                        { text: "Eles são executados na própria requisição", isCorrect: false },
+                        { text: "Eles são descartados depois de um tempo", isCorrect: false },
+                        { text: "A aplicação recusa novos despachos de job", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Cache e o Cache::touch do Laravel 13",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Guardando o que custa caro\n\nCache troca processamento por memória: o resultado caro é calculado uma vez e reaproveitado. O Laravel abstrai vários drivers pela mesma interface, então trocar de Redis para banco é mudar uma variável no `.env`.",
+                },
+                {
+                    type: "code",
+                    value: "Cache::put('produtos.destaque', $produtos, now()->addHour());\nCache::get('produtos.destaque');\nCache::forget('produtos.destaque');\n\n// Calcula só se não estiver em cache\n$produtos = Cache::remember('produtos.destaque', 3600, function () {\n    return Produto::where('destaque', true)->with('categoria')->get();\n});\n\n// Sem expiração\nCache::rememberForever('config.taxas', fn () => Taxa::all());",
+                },
+                {
+                    type: "text",
+                    value: "## Cache::touch, novidade do Laravel 13\n\nEstender a validade de um item exigia buscar o valor e gravá-lo de novo, o que trafega o dado inteiro entre a aplicação e o servidor de cache sem necessidade.\n\nO **Laravel 13** trouxe `Cache::touch()`, que **estende o TTL sem buscar nem regravar o valor**. Em item grande a diferença é grande, e é exatamente o que se quer em sessão ativa ou trava distribuída.",
+                },
+                {
+                    type: "code",
+                    value: "// Antes: puxava e regravava o valor inteiro\n$valor = Cache::get($chave);\nCache::put($chave, $valor, now()->addHour());\n\n// Laravel 13: só o prazo muda\nCache::touch($chave, now()->addHour());",
+                },
+                {
+                    type: "text",
+                    value: "## Invalidação\n\nA parte difícil de cache não é guardar, é saber quando descartar. Duas estratégias funcionam bem: apagar a chave no evento que muda o dado, ou pôr um identificador de versão na própria chave.",
+                },
+                {
+                    type: "code",
+                    value: "// Apagar no evento do model\nprotected static function booted(): void\n{\n    static::saved(fn () => Cache::forget('produtos.destaque'));\n    static::deleted(fn () => Cache::forget('produtos.destaque'));\n}\n\n// Ou versionar a chave\nCache::remember(\"produto.{$id}.v{$produto->updated_at->timestamp}\", 3600, ...);",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que `Cache::remember` faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Devolve do cache ou calcula e guarda", isCorrect: true },
+                        { text: "Guarda o valor sem nunca deixá-lo expirar", isCorrect: false },
+                        { text: "Apaga a chave depois de ela ser lida uma vez", isCorrect: false },
+                        { text: "Renova o prazo de validade a cada leitura", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `Cache::touch` do Laravel 13 faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Estende o prazo sem buscar o valor", isCorrect: true },
+                        { text: "Cria a chave quando ela ainda não existe", isCorrect: false },
+                        { text: "Verifica se a chave está presente no cache", isCorrect: false },
+                        { text: "Copia a chave para outro driver configurado", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual o ganho do `touch` em um item grande?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Evita trafegar o valor de ida e volta", isCorrect: true },
+                        { text: "Diminui o espaço ocupado pelo item no cache", isCorrect: false },
+                        { text: "Permite guardar o item por tempo indefinido", isCorrect: false },
+                        { text: "Comprime o valor antes de gravá-lo de novo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a parte difícil de trabalhar com cache?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Saber quando descartar o que está guardado", isCorrect: true },
+                        { text: "Escolher o driver certo para cada ambiente", isCorrect: false },
+                        { text: "Definir o tempo de expiração de cada chave", isCorrect: false },
+                        { text: "Serializar objetos complexos antes de guardar", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que versionar a chave com `updated_at` resolve?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "A chave muda sozinha quando o dado muda", isCorrect: true },
+                        { text: "O cache passa a ocupar bem menos memória", isCorrect: false },
+                        { text: "As chaves antigas são apagadas na hora", isCorrect: false },
+                        { text: "O valor é recalculado a cada requisição", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Events, listeners e notificações",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Desacoplando o que acontece depois\n\nQuando um pedido é criado, várias coisas precisam acontecer: email ao cliente, aviso ao estoque, registro no relatório. Pôr tudo no controller o transforma em um emaranhado que cresce a cada regra nova.\n\nO **evento** anuncia que algo aconteceu. Os **listeners** reagem, sem que quem disparou saiba quem está ouvindo.",
+                },
+                {
+                    type: "code",
+                    value: "class PedidoCriado\n{\n    use Dispatchable, SerializesModels;\n\n    public function __construct(public Pedido $pedido) {}\n}\n\nclass EnviarConfirmacao implements ShouldQueue\n{\n    public function handle(PedidoCriado $evento): void\n    {\n        Mail::to($evento->pedido->cliente)->send(new Confirmacao($evento->pedido));\n    }\n}\n\n// No controller: uma linha, e o resto acontece\nPedidoCriado::dispatch($pedido);",
+                },
+                {
+                    type: "text",
+                    value: "Um listener que implementa `ShouldQueue` vai para a fila sozinho. O controller devolve a resposta e o trabalho pesado acontece depois.\n\n## Notificações\n\nA **notificação** é uma mensagem com vários canais possíveis: email, banco de dados, Slack, SMS. A mesma classe escolhe por onde vai, e o usuário pode ter preferências.",
+                },
+                {
+                    type: "code",
+                    value: "class PedidoEnviado extends Notification implements ShouldQueue\n{\n    use Queueable;\n\n    public function __construct(public Pedido $pedido) {}\n\n    public function via(object $notifiable): array\n    {\n        return $notifiable->prefere_email ? ['mail', 'database'] : ['database'];\n    }\n\n    public function toMail(object $notifiable): MailMessage\n    {\n        return (new MailMessage)\n            ->subject('Seu pedido saiu para entrega')\n            ->line(\"O pedido {$this->pedido->numero} está a caminho.\")\n            ->action('Acompanhar', route('pedidos.show', $this->pedido));\n    }\n\n    public function toArray(object $notifiable): array\n    {\n        return ['pedido_id' => $this->pedido->id];\n    }\n}\n\n$usuario->notify(new PedidoEnviado($pedido));",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Que problema o sistema de eventos resolve?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O acúmulo de responsabilidades no controller", isCorrect: true },
+                        { text: "A lentidão das consultas feitas ao banco", isCorrect: false },
+                        {
+                            text: "A duplicação de rotas que apontam o mesmo caminho",
+                            isCorrect: false,
+                        },
+                        { text: "A falta de validação nos dados recebidos", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que acontece quando um listener implementa `ShouldQueue`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Ele passa a rodar em segundo plano", isCorrect: true },
+                        { text: "Ele é executado antes dos outros listeners", isCorrect: false },
+                        { text: "Ele é executado uma vez a cada minuto", isCorrect: false },
+                        { text: "Ele passa a ignorar as falhas silenciosamente", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o método `via` de uma notificação define?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Por quais canais ela será enviada", isCorrect: true },
+                        { text: "Qual template de email será usado no envio", isCorrect: false },
+                        { text: "Quando a notificação deve ser disparada", isCorrect: false },
+                        { text: "Quais usuários vão receber a mensagem", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quem dispara o evento sabe quem vai reagir a ele?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Não, e essa é a vantagem", isCorrect: true },
+                        { text: "Sim, os listeners são informados na chamada", isCorrect: false },
+                        { text: "Sim, o evento carrega a lista de ouvintes", isCorrect: false },
+                        { text: "Depende de o listener estar em uma fila", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o canal `database` de uma notificação faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Grava a notificação em uma tabela", isCorrect: true },
+                        { text: "Envia um email usando o servidor configurado", isCorrect: false },
+                        { text: "Guarda a mensagem no cache da aplicação", isCorrect: false },
+                        { text: "Publica a mensagem em uma fila de eventos", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_7: Modulo = {
+    titulo: "Módulo 7 - Testes, IA e produção",
+    aulas: [
+        {
+            titulo: "Testes com Pest e PHPUnit",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Testar é rápido no Laravel\n\nO framework traz uma base de teste com banco de teste, autenticação simulada e asserções de HTTP. Escrever teste no Laravel custa pouco, o que remove a desculpa mais comum para não escrever.\n\nO **PHPUnit** é a base, e o **Pest** é uma camada por cima com sintaxe enxuta. Os dois rodam juntos no mesmo projeto.",
+                },
+                {
+                    type: "code",
+                    value: "// Pest\nit('lista os produtos ativos', function () {\n    Produto::factory()->count(3)->create(['ativo' => true]);\n    Produto::factory()->create(['ativo' => false]);\n\n    $this->get('/produtos')\n        ->assertOk()\n        ->assertViewHas('produtos', fn ($p) => $p->count() === 3);\n});\n\nit('impede que outro usuário edite o post', function () {\n    $post = Post::factory()->create();\n    $intruso = User::factory()->create();\n\n    $this->actingAs($intruso)\n        ->put(\"/posts/{$post->id}\", ['titulo' => 'invadido'])\n        ->assertForbidden();\n});",
+                },
+                {
+                    type: "table",
+                    value: '[["Asserção", "Verifica"], ["assertOk e assertStatus", "o código HTTP da resposta"], ["assertRedirect", "para onde redirecionou"], ["assertSee", "que o texto aparece na página"], ["assertDatabaseHas", "que a linha existe no banco"], ["assertForbidden", "que o acesso foi negado"]]',
+                },
+                {
+                    type: "text",
+                    value: "## RefreshDatabase\n\nA trait `RefreshDatabase` roda cada teste dentro de uma transação e desfaz tudo ao final. Assim um teste nunca deixa lixo para o próximo, e a ordem de execução deixa de importar.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual a relação entre Pest e PHPUnit?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O Pest é uma camada sobre o PHPUnit", isCorrect: true },
+                        { text: "São ferramentas concorrentes e incompatíveis", isCorrect: false },
+                        { text: "O PHPUnit é uma extensão do Pest no Laravel", isCorrect: false },
+                        { text: "O Pest substitui o PHPUnit por completo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `RefreshDatabase` faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Desfaz as mudanças ao fim de cada teste", isCorrect: true },
+                        { text: "Recria o banco inteiro antes de cada teste", isCorrect: false },
+                        { text: "Copia o banco de produção para o de teste", isCorrect: false },
+                        { text: "Popula o banco com os seeders do projeto", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `actingAs($usuario)` faz em um teste?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Executa a requisição como aquele usuário", isCorrect: true },
+                        { text: "Cria um usuário novo no banco de teste", isCorrect: false },
+                        { text: "Verifica se o usuário consegue fazer login", isCorrect: false },
+                        { text: "Concede todas as permissões ao usuário", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `assertDatabaseHas` verifica?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Que a linha existe na tabela", isCorrect: true },
+                        { text: "Que a tabela informada existe no banco", isCorrect: false },
+                        { text: "Que a consulta devolveu algum resultado", isCorrect: false },
+                        { text: "Que a conexão com o banco está ativa", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que a ordem dos testes deixa de importar com RefreshDatabase?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Cada teste começa com o banco no mesmo estado", isCorrect: true },
+                        { text: "Os testes passam a rodar todos em paralelo", isCorrect: false },
+                        {
+                            text: "O framework ordena os testes por ordem alfabética",
+                            isCorrect: false,
+                        },
+                        { text: "Os dados criados ficam isolados por usuário", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "O Laravel AI SDK",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# IA como parte do framework\n\nAté o Laravel 12, integrar um modelo de linguagem significava escolher um pacote da comunidade e amarrar o código ao provedor escolhido. Trocar de provedor depois era reescrever.\n\nO **Laravel 13** trouxe o **AI SDK de primeira parte**: uma API única para geração de texto, agentes que chamam ferramentas, embeddings, áudio, imagens e integração com bancos vetoriais.",
+                },
+                {
+                    type: "table",
+                    value: '[["Recurso do SDK", "Para que serve"], ["Geração de texto", "resumir, classificar, redigir"], ["Agentes com ferramentas", "o modelo chama funções suas"], ["Embeddings", "transformar texto em vetor"], ["Áudio e imagem", "transcrever e gerar"], ["Vector stores", "guardar e buscar por embedding"]]',
+                },
+                {
+                    type: "text",
+                    value: "## O ganho da API única\n\nComo a interface é do framework e não do provedor, trocar de modelo é configuração. O código da aplicação continua igual, e dá para comparar provedores sem reescrever nada.\n\n## O que não muda\n\nO SDK facilita a chamada, não os cuidados. Continua valendo tratar a saída do modelo como **entrada não confiável**: validar antes de gravar, escapar antes de exibir, e nunca deixar o modelo decidir sozinho uma ação irreversível.",
+                },
+                {
+                    type: "quote",
+                    value: "Chamada a modelo é lenta e pode falhar. Mande para a fila e trate o tempo esgotado, como você faria com qualquer API externa.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o Laravel AI SDK trouxe no Laravel 13?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Uma API única do framework para IA", isCorrect: true },
+                        { text: "Um modelo de linguagem embutido no framework", isCorrect: false },
+                        { text: "A substituição dos pacotes da comunidade", isCorrect: false },
+                        { text: "Um painel para treinar modelos próprios", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a vantagem da API ser do framework?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Trocar de provedor vira configuração", isCorrect: true },
+                        { text: "As respostas do modelo ficam mais precisas", isCorrect: false },
+                        { text: "O custo por requisição diminui bastante", isCorrect: false },
+                        { text: "O modelo passa a rodar no próprio servidor", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que são embeddings?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Texto transformado em vetor numérico", isCorrect: true },
+                        { text: "Trechos de texto guardados em cache", isCorrect: false },
+                        { text: "Instruções fixas enviadas ao modelo", isCorrect: false },
+                        { text: "Respostas prontas para perguntas comuns", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como tratar a saída de um modelo de linguagem?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Como entrada não confiável", isCorrect: true },
+                        { text: "Como dado já validado pelo provedor", isCorrect: false },
+                        { text: "Como HTML pronto para ser exibido", isCorrect: false },
+                        { text: "Como valor constante que pode ir ao banco", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que mandar chamadas de IA para a fila?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Elas são lentas e podem falhar", isCorrect: true },
+                        { text: "As filas reduzem o custo de cada chamada", isCorrect: false },
+                        { text: "O SDK só funciona dentro de um job", isCorrect: false },
+                        { text: "Assim as respostas ficam guardadas em cache", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Busca vetorial e semântica",
+            blocks: [
+                {
+                    type: "text",
+                    value: '# Buscar por sentido, não por palavra\n\nA busca tradicional casa **caracteres**: procurar por "sapato" não encontra "calçado". A busca semântica compara **significado**, e para isso o texto vira um vetor de números, o embedding.\n\nTextos com sentido parecido ficam próximos nesse espaço, e a busca vira uma questão de encontrar os vetores mais próximos do vetor da pergunta.',
+                },
+                {
+                    type: "table",
+                    value: '[["", "Busca por texto", "Busca semântica"], ["Compara", "caracteres e palavras", "significado"], ["Acha sinônimo", "não", "sim"], ["Erro de digitação", "atrapalha", "tolera bem"], ["Custo", "baixo", "gera embedding e compara vetores"]]',
+                },
+                {
+                    type: "text",
+                    value: "## No Laravel 13\n\nO Laravel 13 trouxe **suporte nativo a consulta vetorial**, com fluxo de embeddings e busca por similaridade. A base recomendada é **PostgreSQL com a extensão pgvector**, e dá para gerar o embedding a partir de uma string e buscar por similaridade sem sair do framework.\n\n## Quando usar cada uma\n\nBusca semântica não substitui a tradicional: ela custa mais e não é boa em correspondência exata, como código de produto ou CPF. O padrão que funciona é **híbrido**, combinando as duas e ordenando pelos dois sinais.",
+                },
+                {
+                    type: "quote",
+                    value: "Embedding tem validade: se o texto do registro mudar, o vetor precisa ser gerado de novo, senão a busca aponta para o conteúdo antigo.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que a busca semântica compara?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O significado do texto", isCorrect: true },
+                        { text: "Os caracteres presentes nas duas frases", isCorrect: false },
+                        { text: "A quantidade de palavras em comum", isCorrect: false },
+                        { text: "A ordem exata em que as palavras aparecem", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual banco o Laravel 13 recomenda para busca vetorial?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "PostgreSQL com pgvector", isCorrect: true },
+                        { text: "MySQL com a extensão de texto completo", isCorrect: false },
+                        { text: "SQLite, que já vem no projeto criado", isCorrect: false },
+                        { text: "Redis, pela velocidade em memória", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Em que caso a busca tradicional continua melhor?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Em correspondência exata, como um código", isCorrect: true },
+                        { text: "Quando o usuário digita palavras com erro", isCorrect: false },
+                        { text: "Quando existem muitos sinônimos possíveis", isCorrect: false },
+                        { text: "Quando a base tem milhões de registros", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que acontece se o texto mudar e o embedding não for regerado?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "A busca passa a apontar para o conteúdo antigo", isCorrect: true },
+                        {
+                            text: "A consulta vetorial deixa de devolver resultado",
+                            isCorrect: false,
+                        },
+                        { text: "O banco recalcula o vetor automaticamente", isCorrect: false },
+                        { text: "O registro some dos resultados da busca", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que é uma busca híbrida?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Combinar a busca por texto e a semântica", isCorrect: true },
+                        { text: "Buscar em dois bancos de dados diferentes", isCorrect: false },
+                        { text: "Alternar entre as duas conforme o horário", isCorrect: false },
+                        { text: "Usar dois modelos de embedding ao mesmo tempo", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Preparando para produção",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Os comandos de otimização\n\nEm desenvolvimento o Laravel relê configuração, rotas e views a cada requisição, o que é ótimo para trabalhar e ruim para servir. Em produção tudo isso vira cache.",
+                },
+                {
+                    type: "code",
+                    value: "php artisan optimize\n# equivale a config:cache, route:cache, view:cache e event:cache\n\ncomposer install --no-dev --optimize-autoloader\nnpm run build\nphp artisan migrate --force\nphp artisan queue:restart\n\n# Para desfazer o cache\nphp artisan optimize:clear",
+                },
+                {
+                    type: "text",
+                    value: "## O que quebra com o cache ligado\n\nDuas armadilhas conhecidas:\n\n- `env()` fora de `config/` devolve `null` depois de `config:cache`\n- `route:cache` não funciona com rota que usa closure. Toda rota precisa apontar para um controller",
+                },
+                {
+                    type: "table",
+                    value: '[["Configuração", "Em produção"], ["APP_DEBUG", "false, sem exceção"], ["APP_ENV", "production"], ["Servidor apontando para", "a pasta public"], ["Fila", "worker sob supervisor"], ["Agendador", "uma entrada de cron por minuto"]]',
+                },
+                {
+                    type: "text",
+                    value: "## O agendador\n\nO Laravel tem agendamento próprio, definido em código. O sistema operacional só precisa de **uma** entrada de cron chamando o `schedule:run` a cada minuto, e o framework decide o que roda.",
+                },
+                {
+                    type: "code",
+                    value: "// routes/console.php\nSchedule::command('relatorio:diario')->dailyAt('03:00');\nSchedule::job(new LimparTemporarios)->hourly();\nSchedule::command('backup:run')->weekly()->withoutOverlapping();\n\n# No cron do servidor, uma linha só\n* * * * * cd /var/www/app && php artisan schedule:run >> /dev/null 2>&1",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que `php artisan optimize` faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Gera cache de configuração, rotas e views", isCorrect: true },
+                        {
+                            text: "Compila o PHP do projeto para código de máquina",
+                            isCorrect: false,
+                        },
+                        { text: "Remove os pacotes de desenvolvimento", isCorrect: false },
+                        { text: "Otimiza as consultas feitas ao banco", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que impede o uso de `route:cache`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Rotas que usam closure em vez de controller", isCorrect: true },
+                        { text: "Rotas que recebem parâmetros na URL", isCorrect: false },
+                        { text: "Rotas registradas dentro de um grupo", isCorrect: false },
+                        {
+                            text: "Rotas que estejam protegidas por algum middleware",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Quantas entradas de cron o agendador do Laravel precisa?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Uma, chamando schedule:run por minuto", isCorrect: true },
+                        { text: "Uma para cada tarefa agendada no projeto", isCorrect: false },
+                        { text: "Nenhuma, o framework agenda por conta própria", isCorrect: false },
+                        { text: "Duas, uma para as filas e outra para tarefas", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual deve ser o valor de `APP_DEBUG` em produção?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "false", isCorrect: true },
+                        { text: "true, para facilitar achar os problemas", isCorrect: false },
+                        { text: "O mesmo valor usado em desenvolvimento", isCorrect: false },
+                        { text: "Depende de a aplicação ser pública ou interna", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Para que serve `withoutOverlapping` em uma tarefa agendada?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Impedir que ela rode em cima de si mesma", isCorrect: true },
+                        {
+                            text: "Impedir que duas tarefas rodem no mesmo minuto",
+                            isCorrect: false,
+                        },
+                        { text: "Garantir que ela rode mesmo se falhar antes", isCorrect: false },
+                        { text: "Executá-la em uma fila separada das outras", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Deploy e o projeto final",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Colocando no ar\n\nO deploy de uma aplicação Laravel segue sempre a mesma sequência, e automatizá-la evita o passo esquecido que derruba o site.",
+                },
+                {
+                    type: "code",
+                    value: 'php artisan down --render="errors::503"\n\ngit pull origin main\ncomposer install --no-dev --optimize-autoloader\nnpm ci && npm run build\nphp artisan migrate --force\nphp artisan optimize\nphp artisan queue:restart\n\nphp artisan up',
+                },
+                {
+                    type: "text",
+                    value: "## As opções de hospedagem\n\n- **Laravel Cloud** e **Forge**: soluções oficiais, cuidam de servidor, filas e certificado\n- **VPS com Nginx e PHP-FPM**: mais barato e mais trabalho\n- **Docker**: reprodutível, e é o caminho para orquestração\n\nEm qualquer uma, o essencial é o mesmo: apontar o servidor para `public`, ter worker de fila supervisionado e o cron do agendador.",
+                },
+                {
+                    type: "text",
+                    value: "## O projeto final\n\nPara fechar a trilha, construa uma **loja simples** que exercite cada módulo:\n\n1. Migrations e models para produtos, categorias e pedidos\n2. Rotas de recurso com Form Requests validando a entrada\n3. Views em Blade com componentes e um layout compartilhado\n4. Autenticação por starter kit, com policies protegendo o painel\n5. Uma API de produtos com resources e autenticação por Sanctum\n6. Email de confirmação de pedido em fila, disparado por evento\n7. Testes cobrindo o fluxo de compra e as regras de permissão\n\nCada item corresponde a um módulo desta trilha.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Para que serve `php artisan down`?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Pôr a aplicação em manutenção", isCorrect: true },
+                        { text: "Desligar o servidor web da máquina", isCorrect: false },
+                        { text: "Parar os workers de fila em execução", isCorrect: false },
+                        { text: "Desfazer a última migration aplicada", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que usar `--force` no migrate durante o deploy?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Em produção o comando pede confirmação", isCorrect: true },
+                        { text: "Para aplicar as migrations fora de ordem", isCorrect: false },
+                        { text: "Para recriar as tabelas que já existem", isCorrect: false },
+                        { text: "Para ignorar as migrations que falharem", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que é essencial em qualquer hospedagem de Laravel?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Servidor apontando para public e worker de fila",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Um banco PostgreSQL com a extensão vetorial ligada",
+                            isCorrect: false,
+                        },
+                        { text: "Um servidor Nginx, que é o único suportado", isCorrect: false },
+                        { text: "Um container Docker para cada serviço usado", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que `npm ci` em vez de `npm install` no deploy?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Ele respeita o lock e não o altera", isCorrect: true },
+                        { text: "Ele instala bem mais rápido as dependências", isCorrect: false },
+                        {
+                            text: "Ele instala também os pacotes de desenvolvimento",
+                            isCorrect: false,
+                        },
+                        { text: "Ele já executa o build depois de instalar", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual o último passo antes de `php artisan up`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Reiniciar os workers de fila", isCorrect: true },
+                        { text: "Rodar os testes automatizados do projeto", isCorrect: false },
+                        { text: "Limpar todo o cache da aplicação", isCorrect: false },
+                        { text: "Fazer o backup do banco de dados", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+export const MODULOS: Modulo[] = [
+    MODULO_1,
+    MODULO_2,
+    MODULO_3,
+    MODULO_4,
+    MODULO_5,
+    MODULO_6,
+    MODULO_7,
+];
+
+async function seed() {
+    let [trilha] = await db.select().from(trails).where(eq(trails.name, NOME));
+    if (!trilha) {
+        [trilha] = await db
+            .insert(trails)
+            .values({
+                name: NOME,
+                trailLevel: LEVEL,
+                description: DESCRICAO,
+                workloadHours: CARGA_HORARIA,
+            })
+            .returning();
+        console.log("Trilha criada: " + NOME);
+    } else {
+        const existentes = await db.select().from(lessons).where(eq(lessons.trailId, trilha.id));
+        if (existentes.length > 0) {
+            console.log("Trilha já tem aulas, nada a fazer: " + NOME);
+            return;
+        }
+        await db
+            .update(trails)
+            .set({ workloadHours: CARGA_HORARIA, description: DESCRICAO, trailLevel: LEVEL })
+            .where(eq(trails.id, trilha.id));
+    }
+
+    let totalAulas = 0;
+    let totalQuestoes = 0;
+    for (let mi = 0; mi < MODULOS.length; mi++) {
+        const m = MODULOS[mi];
+        const [mod] = await db
+            .insert(modules)
+            .values({ trailId: trilha.id, title: m.titulo, position: mi + 1 })
+            .returning();
+        for (let li = 0; li < m.aulas.length; li++) {
+            const a = m.aulas[li];
+            const [lesson] = await db
+                .insert(lessons)
+                .values({
+                    trailId: trilha.id,
+                    moduleId: mod.id,
+                    title: a.titulo,
+                    content: null,
+                    contentBlocks: a.blocks,
+                    position: li + 1,
+                    published: true,
+                })
+                .returning();
+            for (let qi = 0; qi < a.questions.length; qi++) {
+                const q = a.questions[qi];
+                const [questao] = await db
+                    .insert(questions)
+                    .values({
+                        lessonId: lesson.id,
+                        statement: q.statement,
+                        difficulty: q.difficulty,
+                        position: qi + 1,
+                    })
+                    .returning();
+                await db.insert(questionOptions).values(
+                    q.options.map((o, k) => ({
+                        questionId: questao.id,
+                        text: o.text,
+                        isCorrect: o.isCorrect,
+                        position: k + 1,
+                    })),
+                );
+            }
+            totalAulas++;
+            totalQuestoes += a.questions.length;
+        }
+    }
+    console.log(
+        "Seed concluído: " +
+            MODULOS.length +
+            " módulos, " +
+            totalAulas +
+            " aulas, " +
+            totalQuestoes +
+            " questões.",
+    );
+}
+
+// Só semeia quando executado direto. Importado, expõe MODULOS/NOME sem rodar nada.
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+    seed()
+        .then(() => process.exit(0))
+        .catch((e) => {
+            console.error("Falha no seed:", e);
+            process.exit(1);
+        });
+}

--- a/backend/scripts/seed-trilha-php.ts
+++ b/backend/scripts/seed-trilha-php.ts
@@ -1,0 +1,3235 @@
+// Seed da trilha PHP (PHP 8.5). Conteúdo autoral.
+// A versão 8.5 saiu em novembro de 2025 e é a que a trilha ensina: pipe operator,
+// array_first e array_last, stack trace em erro fatal e filtros que lançam exceção.
+//
+// Idempotente e nao destrutivo: se a trilha ja tiver aulas, nao faz nada.
+//
+// Rodar em prod: docker compose -f docker-compose.prod.yml run --rm -T --no-deps backend node scripts/seed-trilha-php.ts
+import { db } from "../db.ts";
+import { trails, modules, lessons, questions, questionOptions } from "../schema.ts";
+import { eq } from "drizzle-orm";
+import { pathToFileURL } from "node:url";
+
+export const NOME = "PHP";
+const LEVEL: "iniciante" | "intermediario" | "avancado" = "iniciante";
+const DESCRICAO =
+    "PHP 8.5 do zero ao uso real: sintaxe e tipos, strings e arrays, controle de fluxo e funções, orientação a objetos com enums e propriedades readonly, tratamento de erros e exceções, e o PHP na web com formulários, sessões, PDO e autoload PSR-4. A linguagem por trás do WordPress, do Laravel e de boa parte dos sites que existem.";
+const CARGA_HORARIA = 20;
+
+type Bloco = { type: "text" | "code" | "quote" | "table"; value: string };
+type Questao = {
+    statement: string;
+    difficulty: "facil" | "medio" | "dificil";
+    options: { text: string; isCorrect: boolean }[];
+};
+type Aula = { titulo: string; blocks: Bloco[]; questions: Questao[] };
+type Modulo = { titulo: string; aulas: Aula[] };
+
+const MODULO_1: Modulo = {
+    titulo: "Módulo 1 - Primeiros passos com PHP",
+    aulas: [
+        {
+            titulo: "O que é PHP e onde ele roda",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O que é PHP\n\nPHP é uma linguagem criada em 1995 para escrever páginas dinâmicas. A sigla hoje significa **PHP: Hypertext Preprocessor**, e o nome já entrega o propósito original: um programa que roda no servidor e devolve HTML pronto para o navegador.\n\nDesde então a linguagem mudou muito. O PHP moderno tem tipagem, orientação a objetos completa, enums, e um desempenho que não lembra em nada a fama que ele carregou por anos. Esta trilha usa o **PHP 8.5**, lançado em novembro de 2025.",
+                },
+                {
+                    type: "text",
+                    value: "## Onde o PHP é usado\n\nO PHP roda em boa parte da web. WordPress, que sozinho move uma fatia enorme dos sites do mundo, é PHP. Também são PHP a Wikipedia, o Slack no back-end e uma quantidade grande de sistemas internos de empresas.\n\nO uso típico é **no servidor**: o código roda antes de a página chegar ao navegador, monta o HTML, conversa com o banco e devolve a resposta. Diferente do JavaScript, que roda no navegador da pessoa, o PHP nunca é visto por quem acessa o site.",
+                },
+                {
+                    type: "table",
+                    value: '[["Onde roda", "Linguagem típica", "Quem enxerga o código"], ["No servidor", "PHP, Python, Java", "Ninguém de fora"], ["No navegador", "JavaScript", "Qualquer pessoa"]]',
+                },
+                {
+                    type: "quote",
+                    value: "PHP roda no servidor e devolve HTML pronto. Quem acessa o site recebe o resultado, nunca o código.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Onde o código PHP é executado em uma aplicação web tradicional?",
+                    difficulty: "facil",
+                    options: [
+                        {
+                            text: "No servidor, antes de a resposta chegar ao navegador",
+                            isCorrect: true,
+                        },
+                        { text: "No navegador de quem acessa o site", isCorrect: false },
+                        { text: "No banco de dados, junto com as consultas", isCorrect: false },
+                        {
+                            text: "Na placa de vídeo do computador de quem acessa o site",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que a sigla PHP significa hoje?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "PHP: Hypertext Preprocessor", isCorrect: true },
+                        { text: "Personal Hardware Processor", isCorrect: false },
+                        { text: "Public Hosting Protocol", isCorrect: false },
+                        { text: "Página HTML Programável", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual destes sistemas conhecidos é escrito em PHP?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "WordPress", isCorrect: true },
+                        { text: "Photoshop", isCorrect: false },
+                        { text: "Android", isCorrect: false },
+                        { text: "Excel", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual versão do PHP esta trilha usa?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "PHP 8.5", isCorrect: true },
+                        { text: "PHP 5.6", isCorrect: false },
+                        { text: "PHP 7.0", isCorrect: false },
+                        { text: "PHP 4.4", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que o visitante de um site nunca vê o código PHP?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Porque ele é executado no servidor e só o resultado é enviado",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Porque o navegador esconde o código de propósito",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Porque o PHP é criptografado pelo servidor antes de ser enviado",
+                            isCorrect: false,
+                        },
+                        { text: "Porque o código fica salvo no banco de dados", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Instalando o PHP 8.5 e o primeiro script",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Colocando o PHP para rodar\n\nPara escrever PHP você precisa do interpretador instalado. No Linux e no macOS ele costuma vir pelo gerenciador de pacotes; no Windows, pelo site oficial ou por pacotes como Laragon e XAMPP.\n\nConfira a versão instalada no terminal:",
+                },
+                {
+                    type: "code",
+                    value: "php --version\n# PHP 8.5.8 (cli) (built: Jul  2 2026)",
+                },
+                {
+                    type: "text",
+                    value: "## O primeiro script\n\nTodo arquivo PHP começa com a tag de abertura `<?php`. Tudo que vier depois dela é código; tudo fora dela é enviado como está.\n\nCrie um arquivo `ola.php`:",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\necho "Olá, mundo!";\necho PHP_EOL;\necho "Rodando em PHP " . PHP_VERSION;',
+                },
+                {
+                    type: "text",
+                    value: "Rode com `php ola.php`. O `echo` imprime, o ponto junta textos e `PHP_EOL` é a quebra de linha do sistema.\n\n## O servidor embutido\n\nO PHP traz um servidor web próprio, ótimo para estudar sem instalar nada além:\n\n```\nphp -S localhost:8000\n```\n\nAbra `http://localhost:8000/ola.php` no navegador e o mesmo script vira uma página.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual tag abre um bloco de código PHP?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "<?php", isCorrect: true },
+                        { text: "<php>", isCorrect: false },
+                        { text: "<script php>", isCorrect: false },
+                        { text: "{{ php }}", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o comando `php -S localhost:8000` faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Sobe o servidor web embutido do PHP", isCorrect: true },
+                        { text: "Instala o PHP na versão 8000", isCorrect: false },
+                        { text: "Salva o script em um servidor remoto", isCorrect: false },
+                        { text: "Compila o projeto para um executável", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual instrução imprime um texto na saída?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "echo", isCorrect: true },
+                        { text: "print_page", isCorrect: false },
+                        { text: "write", isCorrect: false },
+                        { text: "output", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Para que serve a constante `PHP_EOL`?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Dá a quebra de linha correta do sistema operacional",
+                            isCorrect: true,
+                        },
+                        { text: "Marca o fim do arquivo PHP", isCorrect: false },
+                        { text: "Encerra a execução do script", isCorrect: false },
+                        {
+                            text: "Guarda a versão do PHP instalada no sistema operacional",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Como se conhece a versão do PHP instalada pelo terminal?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Com `php --version`", isCorrect: true },
+                        { text: "Com `php --check`", isCorrect: false },
+                        { text: "Abrindo o arquivo php.ini", isCorrect: false },
+                        { text: "Com `version php`", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Variáveis, tipos e saída",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Variáveis\n\nToda variável em PHP começa com cifrão. Não se declara o tipo: ele vem do valor atribuído, e pode mudar durante a execução.\n\nOs nomes diferenciam maiúsculas de minúsculas, então `$nome` e `$Nome` são variáveis distintas.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\n$nome = "Ana";\n$idade = 28;\n$altura = 1.67;\n$estudante = true;\n\necho "$nome tem $idade anos.";',
+                },
+                {
+                    type: "text",
+                    value: "## Os tipos básicos\n\nO PHP tem quatro tipos escalares e alguns compostos. A função `gettype()` mostra o tipo de um valor, e `var_dump()` mostra tipo e conteúdo, o que ajuda muito a depurar.",
+                },
+                {
+                    type: "table",
+                    value: '[["Tipo", "Exemplo", "O que guarda"], ["string", "\\"Ana\\"", "texto"], ["int", "28", "número inteiro"], ["float", "1.67", "número com casas decimais"], ["bool", "true", "verdadeiro ou falso"], ["array", "[1, 2, 3]", "uma lista de valores"], ["null", "null", "ausência de valor"]]',
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\n$idade = 28;\nvar_dump($idade);   // int(28)\nvar_dump("28");     // string(2) "28"\nvar_dump($idade == "28");  // bool(true)',
+                },
+            ],
+            questions: [
+                {
+                    statement: "Como se escreve o nome de uma variável em PHP?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Começando com cifrão, como em `$nome`", isCorrect: true },
+                        { text: "Começando com arroba, como em `@nome`", isCorrect: false },
+                        { text: "Com a palavra `var` na frente", isCorrect: false },
+                        { text: "Sem nenhum símbolo, apenas `nome`", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Precisa declarar o tipo de uma variável ao criá-la?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Não, o tipo vem do valor atribuído", isCorrect: true },
+                        { text: "Sim, sempre antes do nome", isCorrect: false },
+                        { text: "Sim, mas só para números", isCorrect: false },
+                        { text: "Sim, usando a palavra `type` antes do nome", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual função mostra o tipo e o conteúdo de uma variável?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "var_dump()", isCorrect: true },
+                        { text: "show()", isCorrect: false },
+                        { text: "print_type()", isCorrect: false },
+                        { text: "describe()", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "As variáveis `$total` e `$Total` são a mesma coisa?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Não, o nome diferencia maiúsculas de minúsculas",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Sim, o PHP ignora maiúsculas no nome de variáveis",
+                            isCorrect: false,
+                        },
+                        { text: "Sim, desde que estejam no mesmo arquivo", isCorrect: false },
+                        { text: "Depende da versão do PHP instalada", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual tipo representa a ausência de valor?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "null", isCorrect: true },
+                        { text: "void", isCorrect: false },
+                        { text: "empty", isCorrect: false },
+                        { text: "zero", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "PHP dentro do HTML",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Misturando código e marcação\n\nO PHP nasceu para gerar HTML, então ele pode ser aberto e fechado várias vezes no mesmo arquivo. Tudo que estiver fora das tags é enviado sem alteração.\n\nEssa mistura é a forma mais direta de montar uma página dinâmica.",
+                },
+                {
+                    type: "code",
+                    value: '<?php $usuario = "Ana"; ?>\n<!DOCTYPE html>\n<html lang="pt-br">\n<body>\n    <h1>Bem-vinda, <?= $usuario ?></h1>\n</body>\n</html>',
+                },
+                {
+                    type: "text",
+                    value: "## A tag curta de eco\n\n`<?= $valor ?>` é atalho para `<?php echo $valor; ?>`. É a forma recomendada dentro de HTML porque deixa a marcação legível.\n\n## Escapando a saída\n\nJogar conteúdo vindo do usuário direto no HTML é como uma página é invadida. A função `htmlspecialchars()` transforma os caracteres perigosos em entidades, e deve ser usada em tudo que veio de fora.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\n$comentario = \'<script>alert("invadido")</script>\';\n\n// Errado: executa o script no navegador de quem visitar\necho $comentario;\n\n// Certo: aparece como texto na tela\necho htmlspecialchars($comentario, ENT_QUOTES, "UTF-8");',
+                },
+                {
+                    type: "quote",
+                    value: "Todo dado que veio de fora passa por htmlspecialchars antes de virar HTML. Sem exceção.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que `<?= $nome ?>` faz?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "É atalho para `<?php echo $nome; ?>`", isCorrect: true },
+                        { text: "Declara a variável `$nome` como texto", isCorrect: false },
+                        { text: "Comenta o trecho de código", isCorrect: false },
+                        { text: "Importa o arquivo `$nome`", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Para que serve `htmlspecialchars()`?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Escapa caracteres para que o texto não vire HTML executável",
+                            isCorrect: true,
+                        },
+                        { text: "Remove todo o HTML de uma string", isCorrect: false },
+                        { text: "Converte a string para maiúsculas", isCorrect: false },
+                        {
+                            text: "Comprime o HTML da página inteira para ela carregar mais rápido",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "O que acontece com o texto que está fora das tags PHP em um arquivo `.php`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "É enviado ao navegador sem alteração", isCorrect: true },
+                        { text: "É ignorado por completo pelo interpretador", isCorrect: false },
+                        { text: "Gera um erro de sintaxe", isCorrect: false },
+                        { text: "É executado como código PHP", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Imprimir direto no HTML um comentário digitado pelo usuário abre qual risco?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Execução de script malicioso no navegador de quem visita",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Perda de desempenho ao carregar a página a cada visita nova",
+                            isCorrect: false,
+                        },
+                        { text: "Erro de sintaxe no arquivo PHP", isCorrect: false },
+                        { text: "Corrupção do banco de dados", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Um arquivo PHP pode abrir e fechar as tags mais de uma vez?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Sim, quantas vezes forem necessárias", isCorrect: true },
+                        { text: "Não, só uma vez por arquivo", isCorrect: false },
+                        { text: "Só em arquivos com a extensão .phtml", isCorrect: false },
+                        { text: "Apenas se o arquivo não tiver HTML", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Composer e o ecossistema",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O gerenciador de pacotes\n\nO **Composer** é a ferramenta que instala e organiza bibliotecas de terceiros em um projeto PHP. Ele é para o PHP o que o npm é para o JavaScript.\n\nO catálogo de pacotes se chama **Packagist**, e é de onde o Composer baixa quase tudo.",
+                },
+                {
+                    type: "code",
+                    value: "# Inicia um projeto novo\ncomposer init\n\n# Instala uma biblioteca\ncomposer require monolog/monolog\n\n# Instala tudo que o projeto declara\ncomposer install",
+                },
+                {
+                    type: "text",
+                    value: "## Os dois arquivos\n\n`composer.json` declara o que o projeto quer. `composer.lock` grava as versões exatas que foram instaladas.\n\nO `.lock` é o que garante que a sua máquina e o servidor rodem exatamente as mesmas versões, e por isso ele **vai para o controle de versão**. A pasta `vendor/`, onde o código baixado fica, não vai.",
+                },
+                {
+                    type: "table",
+                    value: '[["Arquivo ou pasta", "O que é", "Vai para o Git"], ["composer.json", "o que o projeto pede", "sim"], ["composer.lock", "as versões exatas instaladas", "sim"], ["vendor/", "o código baixado", "não"]]',
+                },
+                {
+                    type: "quote",
+                    value: "composer install respeita o .lock e instala as versões travadas. composer update ignora o .lock e busca versões novas.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual é a função do Composer em um projeto PHP?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Gerenciar as bibliotecas de terceiros", isCorrect: true },
+                        { text: "Compilar o PHP para binário", isCorrect: false },
+                        { text: "Servir as páginas prontas para o navegador", isCorrect: false },
+                        { text: "Formatar o código-fonte", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "A pasta `vendor/` deve ir para o controle de versão?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Não, ela é recriada pelo Composer", isCorrect: true },
+                        { text: "Sim, senão o projeto não roda", isCorrect: false },
+                        { text: "Sim, mas apenas o conteúdo de bin/", isCorrect: false },
+                        { text: "Só quando o projeto usa Git", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual comando instala as versões exatas já travadas no projeto?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "composer install", isCorrect: true },
+                        { text: "composer update", isCorrect: false },
+                        { text: "composer refresh", isCorrect: false },
+                        { text: "composer lock", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Onde ficam publicados os pacotes PHP que o Composer baixa?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "No Packagist", isCorrect: true },
+                        { text: "No npm", isCorrect: false },
+                        { text: "No PyPI", isCorrect: false },
+                        { text: "No Maven Central", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a diferença entre `composer.json` e `composer.lock`?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "O json declara o que se quer e o lock grava o que foi instalado",
+                            isCorrect: true,
+                        },
+                        { text: "O json é do projeto e o lock é do servidor", isCorrect: false },
+                        { text: "O lock declara e o json apenas documenta", isCorrect: false },
+                        {
+                            text: "São o mesmo arquivo, escrito em dois formatos diferentes de texto",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_2: Modulo = {
+    titulo: "Módulo 2 - Tipos, strings e operadores",
+    aulas: [
+        {
+            titulo: "Os tipos escalares e a conversão entre eles",
+            blocks: [
+                {
+                    type: "text",
+                    value: '# Tipagem dinâmica com conversão automática\n\nO PHP converte tipos sozinho quando a operação pede. Somar `"5"` com `5` dá `10`, porque a string vira número na hora.\n\nIsso é prático e é também a origem de muito bug. Entender quando a conversão acontece é o que separa código previsível de código que falha em produção.',
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\nvar_dump(5 + "5");      // int(10)\nvar_dump("abc" == 0);   // bool(false) no PHP 8, era true no PHP 7\nvar_dump((int) "12kg"); // int(12)\nvar_dump((int) "kg12"); // int(0)',
+                },
+                {
+                    type: "text",
+                    value: "## Conversão explícita\n\nQuando você quer o controle, converte na mão com um cast ou com as funções `intval()`, `floatval()`, `strval()` e `boolval()`.\n\nUma novidade do **PHP 8.5**: casts fora do formato canônico, como `(boolean)` e `(integer)`, foram marcados como obsoletos. Use as formas curtas `(bool)` e `(int)`.",
+                },
+                {
+                    type: "table",
+                    value: '[["Valor", "Vira false quando convertido para bool"], ["0 e 0.0", "sim"], ["\\"\\" e \\"0\\"", "sim"], ["array vazio", "sim"], ["null", "sim"], ["\\"false\\"", "não, string não vazia é true"]]',
+                },
+            ],
+            questions: [
+                {
+                    statement: 'Qual o resultado de `5 + "5"` em PHP?',
+                    difficulty: "facil",
+                    options: [
+                        { text: "O inteiro 10", isCorrect: true },
+                        { text: 'A string "55"', isCorrect: false },
+                        { text: "Um erro de tipo", isCorrect: false },
+                        { text: "O float 5.5", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: 'O que `(int) "12kg"` devolve?',
+                    difficulty: "medio",
+                    options: [
+                        { text: "12", isCorrect: true },
+                        { text: "0", isCorrect: false },
+                        { text: "Um erro fatal", isCorrect: false },
+                        { text: 'A string "12"', isCorrect: false },
+                    ],
+                },
+                {
+                    statement: 'A string `"false"` convertida para bool dá qual valor?',
+                    difficulty: "dificil",
+                    options: [
+                        { text: "true, porque não está vazia", isCorrect: true },
+                        { text: "false, pelo conteúdo da palavra", isCorrect: false },
+                        { text: "null, por ser ambígua", isCorrect: false },
+                        { text: "Depende do strict_types", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quais casts o PHP 8.5 marcou como obsoletos?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Os não canônicos, como `(boolean)` e `(integer)`",
+                            isCorrect: true,
+                        },
+                        { text: "Todos os casts explícitos", isCorrect: false },
+                        {
+                            text: "Os casts para array e para object dentro de funções",
+                            isCorrect: false,
+                        },
+                        { text: "Os casts dentro de funções", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual destes valores é convertido para `false`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um array vazio", isCorrect: true },
+                        { text: 'A string "0.0"', isCorrect: false },
+                        { text: "O número -1", isCorrect: false },
+                        { text: 'A string " "', isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Strings: aspas, interpolação e heredoc",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Aspas simples e duplas não são a mesma coisa\n\nEm aspas **duplas**, o PHP substitui variáveis pelo valor e entende sequências de escape como `\\n`. Em aspas **simples**, o texto sai literal.\n\nEssa é uma das primeiras pegadinhas de quem começa.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\n$nome = "Ana";\n\necho "Olá, $nome";   // Olá, Ana\necho \'Olá, $nome\';   // Olá, $nome\n\n// Chaves deixam claro onde a variável termina\necho "Olá, {$nome}s";',
+                },
+                {
+                    type: "text",
+                    value: "## Concatenar e formatar\n\nO ponto junta strings. Para montar texto com valores no meio, `sprintf()` costuma ficar mais legível que uma sequência de pontos.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\n$preco = 19.9;\necho "Total: R$ " . number_format($preco, 2, ",", ".");\n\nprintf("Você pagou %.2f reais por %d itens", $preco, 3);',
+                },
+                {
+                    type: "text",
+                    value: "## Heredoc e nowdoc\n\nPara blocos longos, o heredoc mantém a interpolação e dispensa escapar aspas. O nowdoc, com o marcador entre aspas simples, é a versão literal.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\n$nome = "Ana";\n\n$html = <<<HTML\n    <p>Olá, $nome</p>\n    <p>Seja bem-vinda.</p>\n    HTML;\n\necho $html;',
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual a diferença entre aspas simples e duplas?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "As duplas substituem variáveis pelo valor", isCorrect: true },
+                        { text: "As simples são bem mais rápidas de digitar", isCorrect: false },
+                        { text: "As simples aceitam quebras de linha", isCorrect: false },
+                        { text: "Não há diferença prática entre elas", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `echo 'Olá, $nome';` imprime?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Olá, $nome", isCorrect: true },
+                        { text: "Olá, Ana", isCorrect: false },
+                        { text: "Um erro de sintaxe", isCorrect: false },
+                        { text: "Olá, seguido de nada", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual operador junta duas strings em PHP?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "O ponto", isCorrect: true },
+                        { text: "O mais", isCorrect: false },
+                        { text: "O e comercial", isCorrect: false },
+                        { text: "As duas barras", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: 'Para que servem as chaves em `"{$nome}s"`?',
+                    difficulty: "medio",
+                    options: [
+                        { text: "Delimitar onde o nome da variável termina", isCorrect: true },
+                        { text: "Transformar a variável em um array de texto", isCorrect: false },
+                        { text: "Escapar o cifrão da variável", isCorrect: false },
+                        { text: "Chamar uma função com o valor", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que diferencia o nowdoc do heredoc?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O nowdoc não interpola variáveis", isCorrect: true },
+                        { text: "O nowdoc não aceita quebras de linha", isCorrect: false },
+                        { text: "O heredoc só funciona dentro de classes", isCorrect: false },
+                        {
+                            text: "O nowdoc precisa ser fechado com ponto e vírgula",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Operadores e as duas comparações",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O igual solto e o igual estrito\n\nPHP tem duas comparações de igualdade, e escolher a errada é fonte clássica de bug.\n\n- `==` compara **valores**, convertendo tipos se precisar\n- `===` compara **valor e tipo**, sem conversão nenhuma\n\nA regra prática é simples: use `===` por padrão e só recorra a `==` quando a conversão for exatamente o que você quer.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\nvar_dump(0 == "0");        // true\nvar_dump(0 === "0");       // false\nvar_dump(null == false);   // true\nvar_dump(null === false);  // false\nvar_dump([1,2] == [1,2]);  // true',
+                },
+                {
+                    type: "text",
+                    value: "## Aritméticos, lógicos e o spaceship\n\nAlém dos operadores usuais, o PHP tem o `<=>`, chamado de spaceship, que devolve -1, 0 ou 1. Ele é a base para escrever comparadores de ordenação.",
+                },
+                {
+                    type: "table",
+                    value: '[["Operador", "O que faz", "Exemplo"], ["**", "potência", "2 ** 3 dá 8"], ["%", "resto da divisão", "7 % 2 dá 1"], ["intdiv()", "divisão inteira", "intdiv(7, 2) dá 3"], ["<=>", "compara e devolve -1, 0 ou 1", "1 <=> 2 dá -1"], ["&&", "e lógico", "true && false dá false"]]',
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual a diferença entre `==` e `===`?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "O `===` também compara o tipo", isCorrect: true },
+                        { text: "O `===` é mais rápido de executar", isCorrect: false },
+                        { text: "O `==` só funciona com números", isCorrect: false },
+                        { text: "O `===` só funciona com objetos", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: 'Qual o resultado de `0 === "0"`?',
+                    difficulty: "medio",
+                    options: [
+                        { text: "false", isCorrect: true },
+                        { text: "true", isCorrect: false },
+                        { text: "null", isCorrect: false },
+                        { text: "Um erro de tipo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o operador `<=>` devolve?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "-1, 0 ou 1, conforme a comparação", isCorrect: true },
+                        { text: "Sempre true ou false", isCorrect: false },
+                        { text: "A diferença entre os dois valores", isCorrect: false },
+                        { text: "O maior dos dois valores", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual expressão dá o resto da divisão de 7 por 2?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "7 % 2", isCorrect: true },
+                        { text: "7 / 2", isCorrect: false },
+                        { text: "7 ** 2", isCorrect: false },
+                        { text: "intdiv(7, 2)", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual comparação usar por padrão em código novo?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O `===`, por não converter tipos", isCorrect: true },
+                        { text: "O `==`, por ser mais flexível", isCorrect: false },
+                        { text: "Tanto faz, o resultado é o mesmo", isCorrect: false },
+                        { text: "O `<=>`, por ser mais completo", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Null, coalescência e nullsafe",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Lidando com a ausência de valor\n\n`null` significa que não há valor. Acessar uma chave que não existe, ou um método de algo nulo, é um dos erros mais comuns em qualquer linguagem.\n\nO PHP tem três ferramentas que resolvem isso sem encher o código de `if`.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\n$dados = ["nome" => "Ana"];\n\n// Coalescência: usa o segundo se o primeiro for null ou não existir\n$cidade = $dados["cidade"] ?? "não informada";\n\n// Atribuição por coalescência: só atribui se ainda for null\n$dados["ativo"] ??= true;\n\necho $cidade;  // não informada',
+                },
+                {
+                    type: "text",
+                    value: "## O operador nullsafe\n\nEm cadeias de objetos, `?->` interrompe a chamada e devolve `null` em vez de estourar erro quando o objeto do meio é nulo.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\n// Sem nullsafe: quebra se getEndereco() devolver null\n$cidade = $usuario->getEndereco()->cidade;\n\n// Com nullsafe: devolve null e segue a vida\n$cidade = $usuario?->getEndereco()?->cidade;\n\n// Combinando com a coalescência\n$cidade = $usuario?->getEndereco()?->cidade ?? "sem cidade";',
+                },
+                {
+                    type: "quote",
+                    value: "O ?? trata valor ausente. O ?-> trata objeto ausente. Juntos eles cobrem quase todo caso de null no dia a dia.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o operador `??` faz?",
+                    difficulty: "facil",
+                    options: [
+                        {
+                            text: "Devolve o segundo valor se o primeiro for null ou inexistente",
+                            isCorrect: true,
+                        },
+                        { text: "Compara dois valores e devolve o maior", isCorrect: false },
+                        { text: "Converte o valor para booleano", isCorrect: false },
+                        {
+                            text: "Lança uma exceção sempre que o primeiro valor for nulo ou ausente",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que `?->` faz quando o objeto é nulo?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Interrompe a cadeia e devolve null", isCorrect: true },
+                        { text: "Lança um erro fatal", isCorrect: false },
+                        { text: "Cria um objeto vazio automaticamente", isCorrect: false },
+                        { text: "Devolve uma string vazia", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `$config['tema'] ??= 'claro';` faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Atribui o valor só se a chave ainda for nula", isCorrect: true },
+                        {
+                            text: "Sempre sobrescreve a chave com o valor informado",
+                            isCorrect: false,
+                        },
+                        { text: "Remove a chave quando ela existe", isCorrect: false },
+                        { text: "Compara a chave com a string informada", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a vantagem de `??` sobre um `if` que testa `isset`?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Resolve o caso em uma linha, sem aviso de índice indefinido",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Executa bem mais rápido do que o isset em qualquer situação de uso",
+                            isCorrect: false,
+                        },
+                        { text: "Funciona apenas com arrays", isCorrect: false },
+                        { text: "Dispensa a declaração da variável", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Em `$u?->perfil()?->nome ?? 'anônimo'`, o que acontece se `$u` for null?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O resultado é a string anônimo", isCorrect: true },
+                        { text: "O script para com erro fatal", isCorrect: false },
+                        { text: "O resultado é null", isCorrect: false },
+                        { text: "O método perfil é chamado mesmo assim", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Constantes, match e o ternário",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Valores que não mudam\n\nConstantes guardam valores fixos. Diferente de variáveis, não levam cifrão e não podem ser reatribuídas.\n\nUse `const` dentro de classes e no topo de arquivos, e `define()` quando o nome ou o valor for calculado em tempo de execução.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\nconst TAXA = 0.05;\nconst MOEDA = "BRL";\n\ndefine("AMBIENTE", getenv("APP_ENV") ?: "local");\n\necho TAXA;      // 0.05\necho AMBIENTE;  // local',
+                },
+                {
+                    type: "text",
+                    value: "## O ternário e a forma curta\n\nO ternário resolve um `if` de uma linha. A forma curta `?:` devolve o primeiro valor quando ele é verdadeiro.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\n$status = $ativo ? "ativo" : "inativo";\n\n// Forma curta: usa $apelido se não for vazio\n$exibir = $apelido ?: $nome;',
+                },
+                {
+                    type: "text",
+                    value: "## match, o irmão estrito do switch\n\nO `match` compara com `===`, devolve um valor e não precisa de `break`. Se nada casar, ele lança `UnhandledMatchError` em vez de seguir em silêncio, o que evita bug esquecido.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\n$faixa = match(true) {\n    $idade < 13 => "criança",\n    $idade < 18 => "adolescente",\n    $idade < 60 => "adulto",\n    default => "idoso",\n};\n\n$sigla = match($estado) {\n    "São Paulo" => "SP",\n    "Rio de Janeiro" => "RJ",\n    default => "??",\n};',
+                },
+            ],
+            questions: [
+                {
+                    statement: "Como se escreve o uso de uma constante?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Sem cifrão, apenas pelo nome", isCorrect: true },
+                        { text: "Com cifrão, como uma variável", isCorrect: false },
+                        { text: "Com dois-pontos na frente", isCorrect: false },
+                        { text: "Entre chaves duplas", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual comparação o `match` usa?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A estrita, com `===`", isCorrect: true },
+                        { text: "A solta, com `==`", isCorrect: false },
+                        { text: "Comparação de texto apenas", isCorrect: false },
+                        { text: "A mesma do operador `<=>`", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "O que acontece quando nenhum braço do `match` casa e não há `default`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "É lançado um UnhandledMatchError", isCorrect: true },
+                        { text: "O resultado é null em silêncio", isCorrect: false },
+                        { text: "O primeiro braço é usado", isCorrect: false },
+                        { text: "O script continua sem retornar nada", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O `match` precisa de `break` em cada braço?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Não, ele não tem o efeito cascata do switch", isCorrect: true },
+                        { text: "Sim, igual ao switch", isCorrect: false },
+                        { text: "Só quando há mais de três braços", isCorrect: false },
+                        {
+                            text: "Só quando o valor comparado for do tipo string",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "O que `$apelido ?: $nome` devolve quando `$apelido` é uma string vazia?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O valor de `$nome`", isCorrect: true },
+                        { text: "A string vazia mesmo assim", isCorrect: false },
+                        { text: "O valor null", isCorrect: false },
+                        { text: "Um erro de operador inválido", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_3: Modulo = {
+    titulo: "Módulo 3 - Controle de fluxo e funções",
+    aulas: [
+        {
+            titulo: "Condicionais: if, else e a sintaxe alternativa",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Decidindo o caminho\n\nO `if` executa um bloco quando a condição é verdadeira. `elseif` acrescenta condições e `else` cobre o resto.\n\nO PHP avalia a condição convertendo para booleano, então valores como `0`, string vazia e array vazio contam como falso.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\n$nota = 7.5;\n\nif ($nota >= 9) {\n    echo "Excelente";\n} elseif ($nota >= 6) {\n    echo "Aprovado";\n} else {\n    echo "Reprovado";\n}',
+                },
+                {
+                    type: "text",
+                    value: "## A sintaxe alternativa\n\nDentro de HTML, chaves espalhadas atrapalham a leitura. O PHP aceita uma forma com dois-pontos e palavra de fechamento, bem mais legível na marcação.",
+                },
+                {
+                    type: "code",
+                    value: '<?php if ($logado): ?>\n    <p>Olá de novo</p>\n<?php else: ?>\n    <a href="/entrar">Entrar</a>\n<?php endif; ?>',
+                },
+                {
+                    type: "quote",
+                    value: "Em arquivos de template, prefira a sintaxe alternativa. Em arquivos só de lógica, prefira as chaves.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual palavra o PHP usa para uma condição adicional dentro do if?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "elseif", isCorrect: true },
+                        { text: "elif", isCorrect: false },
+                        { text: "else if not", isCorrect: false },
+                        { text: "orif", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como se fecha um `if` na sintaxe alternativa?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Com `endif;`", isCorrect: true },
+                        { text: "Com uma chave", isCorrect: false },
+                        { text: "Com `end;`", isCorrect: false },
+                        { text: "Com `fi;`", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Um array vazio dentro de um `if` é avaliado como o quê?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Falso", isCorrect: true },
+                        { text: "Verdadeiro", isCorrect: false },
+                        { text: "Null", isCorrect: false },
+                        { text: "Gera erro de conversão", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Onde a sintaxe alternativa é mais indicada?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Em arquivos que misturam PHP com HTML", isCorrect: true },
+                        { text: "Em arquivos apenas de classes", isCorrect: false },
+                        { text: "Em scripts que rodam na linha de comando", isCorrect: false },
+                        { text: "Em arquivos de configuração", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "O que acontece quando nenhuma condição do if é verdadeira e não há else?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Nada é executado e o script continua", isCorrect: true },
+                        { text: "O script para com erro", isCorrect: false },
+                        { text: "O primeiro bloco do if roda mesmo assim", isCorrect: false },
+                        { text: "O PHP emite um aviso", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Laços: while, for e foreach",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Repetindo instruções\n\nO PHP tem quatro laços. A escolha depende do que você sabe antes de começar:\n\n- `for`: você sabe quantas vezes vai repetir\n- `while`: repete enquanto uma condição valer\n- `do while`: igual ao while, mas executa pelo menos uma vez\n- `foreach`: percorre arrays e objetos, e é o mais usado no dia a dia",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\nfor ($i = 1; $i <= 3; $i++) {\n    echo "Volta $i\\n";\n}\n\n$sobrando = 3;\nwhile ($sobrando > 0) {\n    echo "Faltam $sobrando\\n";\n    $sobrando--;\n}',
+                },
+                {
+                    type: "text",
+                    value: "## foreach, o laço do PHP\n\nEle percorre cada item sem você controlar índice. Com `=>` você pega também a chave.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\n$notas = ["Ana" => 9.5, "Bruno" => 7.0];\n\nforeach ($notas as $aluno => $nota) {\n    echo "$aluno tirou $nota\\n";\n}\n\n// Alterando os itens: o & passa por referência\nforeach ($valores as &$v) {\n    $v = $v * 2;\n}\nunset($v);  // sempre libere a referência depois',
+                },
+                {
+                    type: "text",
+                    value: "## Interrompendo\n\n`break` sai do laço e `continue` pula para a próxima volta. Ambos aceitam um número para atravessar laços aninhados, mas usar mais de um nível costuma ser sinal de que o código pede uma função.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual laço é feito para percorrer arrays?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "foreach", isCorrect: true },
+                        { text: "for", isCorrect: false },
+                        { text: "while", isCorrect: false },
+                        { text: "do while", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual laço garante ao menos uma execução do bloco?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "do while", isCorrect: true },
+                        { text: "while", isCorrect: false },
+                        { text: "for", isCorrect: false },
+                        { text: "foreach sobre arrays", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `continue` faz dentro de um laço?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Pula para a próxima repetição", isCorrect: true },
+                        { text: "Encerra o laço por completo", isCorrect: false },
+                        { text: "Reinicia o laço do começo", isCorrect: false },
+                        { text: "Repete a volta atual do laço de novo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Em `foreach ($notas as $aluno => $nota)`, o que `$aluno` recebe?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A chave de cada item", isCorrect: true },
+                        { text: "A posição numérica do item", isCorrect: false },
+                        { text: "O valor de cada item", isCorrect: false },
+                        { text: "O tamanho do array", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que se usa `unset($v)` depois de um foreach com `&$v`?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Para desfazer a referência que sobra apontando ao último item",
+                            isCorrect: true,
+                        },
+                        { text: "Para liberar memória do array inteiro", isCorrect: false },
+                        { text: "Porque o PHP exige isso em todo foreach", isCorrect: false },
+                        {
+                            text: "Para reiniciar o ponteiro interno do array percorrido no laço",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Funções: parâmetros e retorno",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Agrupando comportamento\n\nUma função guarda um trecho de lógica com nome. Ela recebe parâmetros, faz o trabalho e devolve um valor com `return`.\n\nParâmetros podem ter valor padrão, e nesse caso ficam opcionais na chamada. Os opcionais vêm sempre depois dos obrigatórios.",
+                },
+                {
+                    type: "code",
+                    value: "<?php\n\nfunction calcularTotal(float $preco, int $quantidade, float $desconto = 0.0): float\n{\n    $bruto = $preco * $quantidade;\n    return $bruto - ($bruto * $desconto);\n}\n\necho calcularTotal(19.90, 3);        // 59.7\necho calcularTotal(19.90, 3, 0.10);  // 53.73",
+                },
+                {
+                    type: "text",
+                    value: "## Escopo\n\nO que é criado dentro da função só existe lá dentro. Uma função **não enxerga** variáveis de fora, ao contrário do que acontece em várias outras linguagens.\n\nSe a função precisa de um dado, ele entra como parâmetro. Essa restrição é uma vantagem: deixa claro do que a função depende.",
+                },
+                {
+                    type: "code",
+                    value: "<?php\n\n$total = 100;\n\nfunction mostrar(): void\n{\n    echo $total;  // Warning: variável indefinida\n}\n\nfunction mostrarCerto(int $total): void\n{\n    echo $total;  // funciona\n}",
+                },
+                {
+                    type: "text",
+                    value: "## Quantidade variável de argumentos\n\nO operador `...`, chamado de spread, recolhe o que sobrou em um array.",
+                },
+                {
+                    type: "code",
+                    value: "<?php\n\nfunction somar(int ...$numeros): int\n{\n    return array_sum($numeros);\n}\n\necho somar(1, 2, 3);  // 6",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que uma função devolve quando não tem `return`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "null", isCorrect: true },
+                        { text: "Zero", isCorrect: false },
+                        { text: "Uma string vazia", isCorrect: false },
+                        { text: "O último valor calculado", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Uma função enxerga uma variável criada fora dela?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Não, o escopo é isolado", isCorrect: true },
+                        { text: "Sim, todas as variáveis do arquivo", isCorrect: false },
+                        { text: "Sim, desde que sejam do mesmo tipo", isCorrect: false },
+                        { text: "Apenas quando declarada como const", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Onde ficam os parâmetros com valor padrão na assinatura?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Depois dos obrigatórios", isCorrect: true },
+                        { text: "Antes dos obrigatórios", isCorrect: false },
+                        { text: "Em qualquer posição", isCorrect: false },
+                        { text: "Sempre no meio da lista", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `int ...$numeros` significa em uma assinatura?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "A função aceita vários inteiros e os recebe como array",
+                            isCorrect: true,
+                        },
+                        { text: "A função aceita apenas três inteiros", isCorrect: false },
+                        { text: "O parâmetro é passado por referência", isCorrect: false },
+                        {
+                            text: "Os valores informados são convertidos para string antes",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que declarar `: void` no retorno de uma função significa?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Que ela não devolve valor algum", isCorrect: true },
+                        { text: "Que ela devolve null explicitamente", isCorrect: false },
+                        { text: "Que ela pode devolver qualquer tipo", isCorrect: false },
+                        { text: "Que o retorno é opcional", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Tipos em funções e strict_types",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Declarando tipos\n\nDesde o PHP 7 é possível declarar o tipo de cada parâmetro e do retorno. Isso documenta a função e permite que o interpretador reclame quando algo errado chega.\n\nO PHP moderno aceita também **tipos de união**, com a barra vertical, e o tipo `never` para funções que nunca retornam.",
+                },
+                {
+                    type: "code",
+                    value: "<?php\n\nfunction buscar(int|string $id): ?Usuario\n{\n    // ?Usuario quer dizer: um Usuario ou null\n    return $this->repo->find($id);\n}\n\nfunction abortar(string $motivo): never\n{\n    throw new RuntimeException($motivo);\n}",
+                },
+                {
+                    type: "text",
+                    value: '## O modo estrito\n\nPor padrão o PHP **converte** o argumento para o tipo declarado quando consegue. Passar `"5"` para um parâmetro `int` funciona, e vira `5`.\n\nCom `declare(strict_types=1);` na primeira linha do arquivo, essa conversão deixa de acontecer e o tipo errado vira `TypeError`.',
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\ndeclare(strict_types=1);\n\nfunction dobrar(int $n): int\n{\n    return $n * 2;\n}\n\necho dobrar(5);    // 10\necho dobrar("5");  // TypeError: precisa ser int, string informada',
+                },
+                {
+                    type: "quote",
+                    value: "declare(strict_types=1) vale só para o arquivo onde está escrito, e precisa ser a primeira instrução dele.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que `?Usuario` significa como tipo de retorno?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um Usuario ou null", isCorrect: true },
+                        { text: "Um Usuario opcional na chamada", isCorrect: false },
+                        { text: "Um array de Usuario", isCorrect: false },
+                        { text: "Um Usuario passado por referência", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que muda com `declare(strict_types=1);`?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "O PHP para de converter os argumentos e exige o tipo exato",
+                            isCorrect: true,
+                        },
+                        { text: "Todas as variáveis passam a exigir tipo", isCorrect: false },
+                        { text: "O código passa a rodar mais rápido", isCorrect: false },
+                        {
+                            text: "Todas as funções do arquivo ficam obrigadas a declarar retorno",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Onde a instrução `declare(strict_types=1);` precisa ficar?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Como primeira instrução do arquivo", isCorrect: true },
+                        { text: "Em qualquer lugar antes da primeira função", isCorrect: false },
+                        { text: "No arquivo de configuração do projeto", isCorrect: false },
+                        { text: "Dentro de cada função que quer o modo estrito", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o tipo de retorno `never` indica?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Que a função nunca devolve, por lançar exceção ou encerrar",
+                            isCorrect: true,
+                        },
+                        { text: "Que a função devolve null sempre", isCorrect: false },
+                        { text: "Que a função não pode ser chamada", isCorrect: false },
+                        {
+                            text: "Que o retorno da função é sempre ignorado por quem a chama",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        'Sem strict_types, o que acontece ao passar `"5"` para um parâmetro `int`?',
+                    difficulty: "medio",
+                    options: [
+                        { text: "O valor é convertido para o inteiro 5", isCorrect: true },
+                        { text: "É lançado um TypeError", isCorrect: false },
+                        { text: "O valor chega como string mesmo assim", isCorrect: false },
+                        { text: "A função recebe null", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Argumentos nomeados, arrow functions e o pipe do PHP 8.5",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Argumentos nomeados\n\nEm vez de depender da ordem, você pode nomear o argumento na chamada. Isso deixa a chamada legível e permite pular opcionais do meio.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\nfunction criarUsuario(\n    string $nome,\n    bool $ativo = true,\n    bool $admin = false,\n    string $idioma = "pt-br",\n): Usuario { /* ... */ }\n\n// Sem nomear: o leitor não sabe o que é cada true\ncriarUsuario("Ana", true, false, "en");\n\n// Nomeando: claro, e sem repetir os padrões\ncriarUsuario(nome: "Ana", idioma: "en");',
+                },
+                {
+                    type: "text",
+                    value: "## Funções anônimas e arrow functions\n\nUma função anônima é um valor: pode ser guardada em variável e passada adiante. A **arrow function** é a forma curta, de uma expressão só, e captura as variáveis de fora automaticamente.",
+                },
+                {
+                    type: "code",
+                    value: "<?php\n\n$taxa = 0.1;\n\n// Anônima: precisa declarar o que captura com use\n$comTaxa = function (float $v) use ($taxa): float {\n    return $v + ($v * $taxa);\n};\n\n// Arrow: captura sozinha, corpo de uma expressão\n$comTaxaCurta = fn (float $v): float => $v + ($v * $taxa);\n\necho $comTaxaCurta(100.0);  // 110",
+                },
+                {
+                    type: "text",
+                    value: "## O pipe operator, novidade do PHP 8.5\n\nO `|>` encadeia chamadas passando o resultado de uma para a próxima. Ele resolve a leitura de dentro para fora que as funções aninhadas impõem.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\n$texto = "  Olá, Mundo!  ";\n\n// Antes: lê-se de dentro para fora\n$antes = ucfirst(strtolower(trim($texto)));\n\n// Com o pipe do PHP 8.5: lê-se na ordem em que acontece\n$depois = $texto\n    |> trim(...)\n    |> strtolower(...)\n    |> ucfirst(...);',
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual a vantagem dos argumentos nomeados?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Deixam a chamada legível e permitem pular opcionais",
+                            isCorrect: true,
+                        },
+                        { text: "Fazem a função executar mais rápido", isCorrect: false },
+                        {
+                            text: "Dispensam a declaração de tipos nos parâmetros da função",
+                            isCorrect: false,
+                        },
+                        { text: "Permitem chamar a função sem argumentos", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que a arrow function faz automaticamente?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Captura as variáveis do escopo de fora", isCorrect: true },
+                        { text: "Declara os tipos dos parâmetros sozinha", isCorrect: false },
+                        { text: "Executa de forma assíncrona", isCorrect: false },
+                        { text: "Devolve sempre um array", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o operador `|>` do PHP 8.5 faz?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Passa o resultado de uma chamada para a próxima",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Compara dois valores e devolve o resultado booleano",
+                            isCorrect: false,
+                        },
+                        { text: "Concatena duas strings", isCorrect: false },
+                        { text: "Executa duas funções em paralelo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como uma função anônima acessa uma variável de fora?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Declarando-a em `use`", isCorrect: true },
+                        { text: "Automaticamente, como a arrow function", isCorrect: false },
+                        { text: "Passando-a como parâmetro obrigatório", isCorrect: false },
+                        { text: "Declarando-a como global no arquivo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual problema de leitura o pipe operator resolve?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "A leitura de dentro para fora das funções aninhadas",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "A falta de declaração de tipos nos parâmetros da função",
+                            isCorrect: false,
+                        },
+                        { text: "A repetição de argumentos padrão", isCorrect: false },
+                        { text: "O escopo isolado das funções", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_4: Modulo = {
+    titulo: "Módulo 4 - Arrays e coleções",
+    aulas: [
+        {
+            titulo: "Arrays indexados e associativos",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O array faz tudo em PHP\n\nO array do PHP não é só uma lista. Ele é um **mapa ordenado**: guarda pares de chave e valor mantendo a ordem de inserção. Por isso ele serve de lista, dicionário, pilha e fila ao mesmo tempo.\n\nQuando você não informa a chave, o PHP usa números a partir de zero.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\n// Indexado: chaves 0, 1, 2\n$cores = ["azul", "verde", "vermelho"];\n\n// Associativo: você escolhe as chaves\n$usuario = [\n    "nome" => "Ana",\n    "idade" => 28,\n    "ativo" => true,\n];\n\necho $cores[0];          // azul\necho $usuario["nome"];   // Ana',
+                },
+                {
+                    type: "text",
+                    value: "## Adicionando e removendo\n\nColchetes vazios acrescentam no fim. `unset()` remove uma chave, mas **não reordena** as que sobraram, o que surpreende quem espera uma lista contínua.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\n$cores = ["azul", "verde"];\n$cores[] = "vermelho";        // vira a chave 2\n$usuario["email"] = "a@b.c";  // acrescenta a chave\n\nunset($cores[0]);\nvar_dump(array_keys($cores)); // [1, 2], o zero não voltou\n\n$cores = array_values($cores); // renumera do zero',
+                },
+                {
+                    type: "table",
+                    value: '[["Função", "O que faz"], ["count()", "quantos itens tem"], ["in_array()", "diz se um valor existe"], ["array_key_exists()", "diz se uma chave existe"], ["array_keys()", "devolve só as chaves"], ["array_values()", "devolve os valores e renumera"]]',
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o array do PHP é, na prática?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um mapa ordenado de chave e valor", isCorrect: true },
+                        { text: "Uma lista de tamanho fixo", isCorrect: false },
+                        { text: "Uma estrutura só de números", isCorrect: false },
+                        { text: "Um objeto de propriedades fixas e ordenadas", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a primeira chave de um array indexado?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Zero", isCorrect: true },
+                        { text: "Um", isCorrect: false },
+                        { text: "A string vazia", isCorrect: false },
+                        { text: "Depende da configuração", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `$lista[] = 'novo';` faz?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Acrescenta o valor no fim do array", isCorrect: true },
+                        { text: "Substitui o array inteiro", isCorrect: false },
+                        { text: "Insere no começo do array", isCorrect: false },
+                        { text: "Cria uma chave chamada novo no array", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Depois de `unset($lista[0])`, o que acontece com as chaves restantes?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Continuam as mesmas, sem renumeração", isCorrect: true },
+                        { text: "São renumeradas de novo a partir de zero", isCorrect: false },
+                        { text: "Todas viram strings", isCorrect: false },
+                        { text: "O array inteiro é esvaziado", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual função devolve os valores renumerando as chaves?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "array_values()", isCorrect: true },
+                        { text: "array_keys()", isCorrect: false },
+                        { text: "array_reindex()", isCorrect: false },
+                        { text: "sort()", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Transformando: map, filter e reduce",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Trabalhando o array inteiro de uma vez\n\nEm vez de escrever um `foreach` para cada transformação, o PHP oferece funções que recebem outra função e aplicam a regra em todo o array.\n\nAs três principais respondem a perguntas diferentes:\n\n- `array_map`: transformar cada item\n- `array_filter`: manter só alguns itens\n- `array_reduce`: reduzir tudo a um valor só",
+                },
+                {
+                    type: "code",
+                    value: "<?php\n\n$precos = [10.0, 25.5, 8.0, 42.0];\n\n// Transformar: aplica 10% de desconto em cada um\n$comDesconto = array_map(fn (float $p) => $p * 0.9, $precos);\n\n// Filtrar: mantém só os acima de 10\n$caros = array_filter($precos, fn (float $p) => $p > 10);\n\n// Reduzir: soma tudo\n$total = array_reduce($precos, fn ($acc, $p) => $acc + $p, 0.0);\n\necho $total;  // 85.5",
+                },
+                {
+                    type: "text",
+                    value: "## A pegadinha do array_filter\n\n`array_filter` **preserva as chaves originais**. Se você filtrar `[0 => a, 1 => b, 2 => c]` e sobrar só o item 2, o resultado tem a chave 2, não a zero. Passar o resultado direto para `json_encode` gera um objeto em vez de uma lista.\n\nA correção é envolver com `array_values()`.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\n$nums = [1, 5, 10];\n$grandes = array_filter($nums, fn ($n) => $n > 4);\n\necho json_encode($grandes);\n// {"1":5,"2":10}  vira objeto, não lista\n\necho json_encode(array_values($grandes));\n// [5,10]  agora sim',
+                },
+                {
+                    type: "quote",
+                    value: "array_filter sem array_values é a causa mais comum de uma API PHP devolver objeto onde deveria devolver lista.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que `array_map` faz?",
+                    difficulty: "facil",
+                    options: [
+                        {
+                            text: "Aplica uma função a cada item e devolve o novo array",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Remove do array original os itens que não passam num teste",
+                            isCorrect: false,
+                        },
+                        { text: "Junta todos os itens em um valor só", isCorrect: false },
+                        { text: "Ordena os itens pelo valor", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `array_reduce` devolve?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um único valor acumulado", isCorrect: true },
+                        { text: "Um array do mesmo tamanho", isCorrect: false },
+                        { text: "Um array com metade dos itens", isCorrect: false },
+                        { text: "A quantidade de itens", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que acontece com as chaves depois de `array_filter`?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "São preservadas, mesmo com buracos na sequência",
+                            isCorrect: true,
+                        },
+                        { text: "São renumeradas a partir de zero", isCorrect: false },
+                        { text: "Viram strings automaticamente", isCorrect: false },
+                        {
+                            text: "São descartadas junto com os itens que foram removidos",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Por que `json_encode` pode devolver objeto depois de um filtro?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Porque as chaves deixaram de ser uma sequência a partir de zero",
+                            isCorrect: true,
+                        },
+                        { text: "Porque o filtro converte o array em objeto", isCorrect: false },
+                        {
+                            text: "Porque a função json_encode não aceita arrays que foram filtrados",
+                            isCorrect: false,
+                        },
+                        { text: "Porque o PHP perde a ordem dos itens", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual função corrige as chaves depois de filtrar?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "array_values()", isCorrect: true },
+                        { text: "array_keys()", isCorrect: false },
+                        { text: "sort()", isCorrect: false },
+                        { text: "array_reset_keys()", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Ordenação e busca",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Uma família grande de funções de ordenação\n\nO PHP tem várias funções de ordenar, e o nome de cada uma segue um padrão que vale decorar:\n\n- começa com `a`: preserva a associação entre chave e valor\n- começa com `k`: ordena pelas chaves\n- termina com `sort` e começa com `r`: ordem decrescente\n- começa com `u`: você fornece a regra de comparação",
+                },
+                {
+                    type: "table",
+                    value: '[["Função", "Ordena por", "Preserva as chaves"], ["sort()", "valor, crescente", "não"], ["rsort()", "valor, decrescente", "não"], ["asort()", "valor, crescente", "sim"], ["ksort()", "chave, crescente", "sim"], ["usort()", "sua regra", "não"]]',
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\n$notas = ["Ana" => 9.5, "Bruno" => 7.0, "Carla" => 8.2];\n\nasort($notas);   // por nota, mantendo os nomes\nksort($notas);   // por nome\n\n// Regra própria: do maior para o menor\nuasort($notas, fn ($a, $b) => $b <=> $a);',
+                },
+                {
+                    type: "text",
+                    value: "## Buscando\n\n`in_array` diz se um valor existe e `array_search` devolve a chave dele. Ambos aceitam um terceiro parâmetro para comparação estrita, e vale sempre passar `true`: sem ele, `in_array(0, ['a','b'])` chega a devolver resultados inesperados por conversão de tipo.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\n$cores = ["azul", "verde", "vermelho"];\n\nvar_dump(in_array("verde", $cores, true));   // bool(true)\nvar_dump(array_search("verde", $cores, true)); // int(1)\n\n// Sem o terceiro parâmetro a comparação é solta\nvar_dump(in_array(0, $cores));       // depende da conversão\nvar_dump(in_array(0, $cores, true)); // bool(false), previsível',
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que a função `asort()` preserva que a `sort()` não preserva?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A ligação entre cada chave e seu valor", isCorrect: true },
+                        { text: "A ordem original dos itens", isCorrect: false },
+                        { text: "O tipo de cada valor", isCorrect: false },
+                        { text: "A quantidade original de itens do array", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `ksort()` ordena?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "As chaves do array", isCorrect: true },
+                        { text: "Os valores do array", isCorrect: false },
+                        { text: "Apenas as chaves numéricas", isCorrect: false },
+                        { text: "Os itens em ordem aleatória", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Para que serve o prefixo `u` em `usort`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Indica que você fornece a regra de comparação", isCorrect: true },
+                        { text: "Indica ordem decrescente", isCorrect: false },
+                        { text: "Indica que as chaves são preservadas", isCorrect: false },
+                        {
+                            text: "Indica ordenação sem diferenciar maiúsculas e acentos",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Por que passar `true` como terceiro argumento de `in_array`?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Para comparar também o tipo e evitar surpresa de conversão",
+                            isCorrect: true,
+                        },
+                        { text: "Para tornar a busca mais rápida", isCorrect: false },
+                        {
+                            text: "Para que a busca alcance também os arrays aninhados no valor",
+                            isCorrect: false,
+                        },
+                        { text: "Para devolver a chave em vez de booleano", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `array_search` devolve quando encontra o valor?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A chave correspondente", isCorrect: true },
+                        { text: "O próprio valor procurado", isCorrect: false },
+                        { text: "A quantidade de ocorrências", isCorrect: false },
+                        { text: "Sempre o booleano true", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Novidades do PHP 8.5, spread e destructuring",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# array_first e array_last\n\nPegar o primeiro ou o último item de um array sempre exigiu contorno em PHP: `reset()` e `end()` mexem no ponteiro interno, e `$arr[0]` só funciona se as chaves forem numéricas a partir de zero.\n\nO **PHP 8.5** resolveu isso com duas funções diretas.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\n$notas = ["Ana" => 9.5, "Bruno" => 7.0, "Carla" => 8.2];\n\n// PHP 8.5\n$primeira = array_first($notas);  // 9.5\n$ultima = array_last($notas);     // 8.2\n\n// Como se fazia antes, com efeito colateral no ponteiro\n$primeira = reset($notas);\n$ultima = end($notas);',
+                },
+                {
+                    type: "text",
+                    value: "## Spread para juntar arrays\n\nO `...` espalha um array dentro de outro. Desde o PHP 8.1 ele funciona também com chaves de texto.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\n$padroes = ["tema" => "claro", "idioma" => "pt-br"];\n$doUsuario = ["tema" => "escuro"];\n\n// O que vem depois vence em caso de chave repetida\n$config = [...$padroes, ...$doUsuario];\n// ["tema" => "escuro", "idioma" => "pt-br"]',
+                },
+                {
+                    type: "text",
+                    value: "## Destructuring\n\nDesmontar um array em variáveis separadas evita uma sequência de acessos por índice. Com chaves de texto, você escolhe o que quer.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\n[$primeiro, $segundo] = ["a", "b"];\n\n$usuario = ["nome" => "Ana", "idade" => 28, "cidade" => "Recife"];\n["nome" => $nome, "cidade" => $cidade] = $usuario;\n\necho "$nome mora em $cidade";\n\n// Em foreach, direto na assinatura\nforeach ($pedidos as ["id" => $id, "total" => $total]) {\n    echo "Pedido $id: $total\\n";\n}',
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que `array_first()` do PHP 8.5 devolve?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "O primeiro valor do array", isCorrect: true },
+                        { text: "A primeira chave do array", isCorrect: false },
+                        { text: "O array sem o primeiro item", isCorrect: false },
+                        { text: "A quantidade de itens", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual problema de `reset()` e `end()` as novas funções evitam?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Elas mexem no ponteiro interno do array", isCorrect: true },
+                        {
+                            text: "Elas não funcionam com chaves de texto no array",
+                            isCorrect: false,
+                        },
+                        { text: "Elas são muito mais lentas", isCorrect: false },
+                        { text: "Elas devolvem a chave em vez do valor", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Em `[...$a, ...$b]`, quem vence quando a mesma chave de texto aparece nos dois?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O valor do que vem depois", isCorrect: true },
+                        { text: "O valor do que vem antes", isCorrect: false },
+                        { text: "As duas viram um array aninhado", isCorrect: false },
+                        { text: "O PHP lança um erro de chave duplicada", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `['nome' => $n] = $usuario;` faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Coloca o valor da chave nome dentro de `$n`", isCorrect: true },
+                        { text: "Cria a chave nome no array", isCorrect: false },
+                        { text: "Renomeia a chave nome para n dentro do array", isCorrect: false },
+                        { text: "Remove a chave nome do array", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "É possível desmontar o array direto na assinatura do foreach?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Sim, informando as chaves entre colchetes", isCorrect: true },
+                        { text: "Não, só dentro do corpo do laço", isCorrect: false },
+                        { text: "Só com arrays de chaves numéricas em ordem", isCorrect: false },
+                        { text: "Só a partir do PHP 8.5", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Arrays multidimensionais e JSON",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Arrays dentro de arrays\n\nUm array pode guardar outros arrays, e é assim que se representa uma tabela, uma lista de registros ou uma configuração aninhada.\n\nO acesso encadeia os colchetes.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\n$alunos = [\n    ["nome" => "Ana", "notas" => [9.5, 8.0]],\n    ["nome" => "Bruno", "notas" => [7.0, 6.5]],\n];\n\necho $alunos[0]["nome"];       // Ana\necho $alunos[0]["notas"][1];   // 8\n\nforeach ($alunos as $aluno) {\n    $media = array_sum($aluno["notas"]) / count($aluno["notas"]);\n    printf("%s: %.1f\\n", $aluno["nome"], $media);\n}',
+                },
+                {
+                    type: "text",
+                    value: "## Convertendo para JSON\n\n`json_encode()` transforma array em texto JSON e `json_decode()` faz o caminho de volta. O segundo parâmetro `true` do decode pede array associativo em vez de objeto.\n\nDuas flags valem sempre em API pública: `JSON_UNESCAPED_UNICODE`, para acentos não virarem códigos, e `JSON_THROW_ON_ERROR`, para falha virar exceção em vez de `false` silencioso.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\n$dados = ["nome" => "Ana", "cidade" => "São Paulo"];\n\n$json = json_encode($dados, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);\necho $json;  // {"nome":"Ana","cidade":"São Paulo"}\n\n$devolta = json_decode($json, true);\necho $devolta["cidade"];  // São Paulo',
+                },
+                {
+                    type: "table",
+                    value: '[["Flag", "Para que serve"], ["JSON_UNESCAPED_UNICODE", "mantém acentos legíveis"], ["JSON_UNESCAPED_SLASHES", "não escapa a barra em URLs"], ["JSON_PRETTY_PRINT", "quebra linhas para leitura"], ["JSON_THROW_ON_ERROR", "erro vira exceção"]]',
+                },
+            ],
+            questions: [
+                {
+                    statement:
+                        "Como se acessa a segunda nota do primeiro aluno em `$alunos[0]['notas']`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Com `$alunos[0]['notas'][1]`", isCorrect: true },
+                        { text: "Com `$alunos[0]['notas'][2]`", isCorrect: false },
+                        { text: "Com `$alunos[1]['notas'][0]`", isCorrect: false },
+                        { text: "Com `$alunos['notas'][0][1]`", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o segundo parâmetro `true` de `json_decode` faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Devolve array associativo em vez de objeto", isCorrect: true },
+                        { text: "Valida o JSON antes de converter", isCorrect: false },
+                        { text: "Mantém os acentos sem escapar", isCorrect: false },
+                        {
+                            text: "Formata o resultado do JSON com quebras de linha",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Para que serve a flag `JSON_THROW_ON_ERROR`?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Fazer a falha virar exceção em vez de retorno falso",
+                            isCorrect: true,
+                        },
+                        { text: "Impedir que o JSON tenha erros", isCorrect: false },
+                        {
+                            text: "Registrar o erro da conversão em um arquivo de log próprio",
+                            isCorrect: false,
+                        },
+                        { text: "Ignorar chaves inválidas em silêncio", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Sem `JSON_UNESCAPED_UNICODE`, o que acontece com acentos?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Viram sequências de escape no texto gerado", isCorrect: true },
+                        { text: "São removidos do resultado", isCorrect: false },
+                        { text: "Geram um erro de codificação", isCorrect: false },
+                        {
+                            text: "São convertidos para as letras equivalentes sem acento",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual função transforma um array PHP em texto JSON?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "json_encode()", isCorrect: true },
+                        { text: "json_decode()", isCorrect: false },
+                        { text: "serialize()", isCorrect: false },
+                        { text: "json_parse()", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_5: Modulo = {
+    titulo: "Módulo 5 - Orientação a objetos",
+    aulas: [
+        {
+            titulo: "Classes, propriedades e métodos",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Do array ao objeto\n\nArrays associativos servem para dados soltos, mas não garantem nada: qualquer chave pode faltar, qualquer tipo pode entrar.\n\nUma **classe** define a forma de um dado e o comportamento que anda junto com ele. O objeto é uma instância dessa forma.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\nclass Produto\n{\n    public string $nome;\n    public float $preco;\n\n    public function __construct(string $nome, float $preco)\n    {\n        $this->nome = $nome;\n        $this->preco = $preco;\n    }\n\n    public function precoComDesconto(float $percentual): float\n    {\n        return $this->preco * (1 - $percentual);\n    }\n}\n\n$camisa = new Produto("Camisa", 79.90);\necho $camisa->precoComDesconto(0.10);  // 71.91',
+                },
+                {
+                    type: "text",
+                    value: "## O `$this` e a seta\n\nDentro da classe, `$this` aponta para o objeto atual. A seta `->` acessa propriedades e métodos, tanto dentro quanto fora.\n\n## Visibilidade\n\nTrês níveis controlam quem enxerga o quê. A regra prática: comece com `private` e só abra o que precisa ser usado de fora.",
+                },
+                {
+                    type: "table",
+                    value: '[["Modificador", "Quem enxerga"], ["public", "qualquer código"], ["protected", "a própria classe e as filhas"], ["private", "só a própria classe"]]',
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que `$this` representa dentro de uma classe?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "O objeto sobre o qual o método foi chamado", isCorrect: true },
+                        { text: "A classe em si, não a instância", isCorrect: false },
+                        {
+                            text: "O último objeto que foi criado durante o script",
+                            isCorrect: false,
+                        },
+                        { text: "A classe pai da hierarquia", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual método é executado ao criar o objeto com `new`?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "__construct", isCorrect: true },
+                        { text: "__init", isCorrect: false },
+                        { text: "__new", isCorrect: false },
+                        { text: "__initialize", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quem enxerga uma propriedade `protected`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A própria classe e as classes filhas", isCorrect: true },
+                        { text: "Somente a própria classe", isCorrect: false },
+                        { text: "Qualquer código do projeto", isCorrect: false },
+                        { text: "Apenas as classes do mesmo arquivo PHP", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual visibilidade adotar por padrão ao criar uma propriedade?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "private, abrindo só o necessário", isCorrect: true },
+                        { text: "public, para facilitar o acesso", isCorrect: false },
+                        { text: "protected, para permitir herança", isCorrect: false },
+                        { text: "Nenhuma, deixando o padrão da linguagem", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a vantagem de uma classe sobre um array associativo?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Ela garante a forma do dado e reúne o comportamento",
+                            isCorrect: true,
+                        },
+                        { text: "Ela ocupa menos memória sempre", isCorrect: false },
+                        {
+                            text: "Ela é convertida para JSON de forma totalmente automática",
+                            isCorrect: false,
+                        },
+                        { text: "Ela dispensa a declaração de tipos", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Construtor promovido, readonly e getters",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Menos repetição no construtor\n\nDeclarar a propriedade, receber no construtor e atribuir é a mesma informação escrita três vezes. Desde o PHP 8.0 a **promoção de propriedades** resolve isso: basta pôr a visibilidade no parâmetro.",
+                },
+                {
+                    type: "code",
+                    value: "<?php\n\n// Antes\nclass Produto\n{\n    private string $nome;\n    private float $preco;\n\n    public function __construct(string $nome, float $preco)\n    {\n        $this->nome = $nome;\n        $this->preco = $preco;\n    }\n}\n\n// Com promoção: mesma coisa, uma vez só\nclass Produto\n{\n    public function __construct(\n        private string $nome,\n        private float $preco,\n    ) {}\n}",
+                },
+                {
+                    type: "text",
+                    value: "## readonly\n\nUma propriedade `readonly` só pode ser escrita uma vez, dentro do escopo da própria classe. Depois disso qualquer tentativa de mudança vira erro.\n\nIsso dá objetos imutáveis quase de graça, e imutabilidade elimina uma classe inteira de bug: o valor não muda pelas costas de quem está usando.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\nfinal class Cpf\n{\n    public function __construct(\n        public readonly string $numero,\n    ) {\n        if (strlen($numero) !== 11) {\n            throw new InvalidArgumentException("CPF precisa de 11 dígitos");\n        }\n    }\n}\n\n$cpf = new Cpf("12345678901");\necho $cpf->numero;        // funciona\n$cpf->numero = "outro";   // Error: não pode modificar readonly',
+                },
+                {
+                    type: "quote",
+                    value: "Validar no construtor e marcar readonly significa que, se o objeto existe, ele é válido. Nenhum método precisa checar de novo.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que a promoção de propriedades no construtor evita?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Declarar e atribuir a mesma propriedade duas vezes",
+                            isCorrect: true,
+                        },
+                        { text: "Precisar declarar tipos nos parâmetros", isCorrect: false },
+                        {
+                            text: "A necessidade de usar `new` para criar um objeto novo",
+                            isCorrect: false,
+                        },
+                        { text: "Ter mais de um parâmetro no construtor", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quantas vezes uma propriedade `readonly` pode ser escrita?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Uma só, no escopo da própria classe", isCorrect: true },
+                        { text: "Quantas vezes quiser, de dentro da classe", isCorrect: false },
+                        { text: "Nenhuma, ela é sempre nula", isCorrect: false },
+                        { text: "Uma por método da classe", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "O que acontece ao tentar alterar uma propriedade readonly já preenchida?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "É lançado um Error", isCorrect: true },
+                        { text: "O valor é alterado com um aviso", isCorrect: false },
+                        { text: "A alteração é ignorada em silêncio", isCorrect: false },
+                        { text: "A propriedade volta ao valor padrão", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Validar no construtor e usar readonly garante o quê?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Que todo objeto existente está em estado válido",
+                            isCorrect: true,
+                        },
+                        { text: "Que o objeto ocupa menos memória", isCorrect: false },
+                        { text: "Que a classe não pode ser estendida", isCorrect: false },
+                        {
+                            text: "Que os métodos da classe passam a executar mais rápido",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Onde a visibilidade é escrita na promoção de propriedades?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "No próprio parâmetro do construtor", isCorrect: true },
+                        { text: "Em uma linha separada acima do construtor", isCorrect: false },
+                        { text: "Depois do corpo do construtor", isCorrect: false },
+                        { text: "No nome da classe", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Herança, classes abstratas e interfaces",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Herança\n\nUma classe pode estender outra e receber suas propriedades e métodos. A filha pode substituir um método, e chama a versão do pai com `parent::`.\n\nO PHP tem **herança simples**: cada classe estende no máximo uma.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\nabstract class Funcionario\n{\n    public function __construct(protected string $nome, protected float $salarioBase) {}\n\n    // Sem corpo: cada filha é obrigada a implementar\n    abstract public function calcularSalario(): float;\n\n    public function descrever(): string\n    {\n        return "{$this->nome}: " . number_format($this->calcularSalario(), 2);\n    }\n}\n\nclass Vendedor extends Funcionario\n{\n    public function __construct(string $nome, float $base, private float $comissao)\n    {\n        parent::__construct($nome, $base);\n    }\n\n    public function calcularSalario(): float\n    {\n        return $this->salarioBase + $this->comissao;\n    }\n}',
+                },
+                {
+                    type: "text",
+                    value: "## Classe abstrata x interface\n\nA **classe abstrata** é uma classe incompleta: pode ter código pronto e obriga as filhas a preencher o que falta. A **interface** é só um contrato de assinaturas, sem implementação.\n\nA diferença que decide qual usar: uma classe estende **uma** abstrata, mas implementa **quantas** interfaces quiser.",
+                },
+                {
+                    type: "code",
+                    value: "<?php\n\ninterface Notificavel\n{\n    public function enviar(string $mensagem): bool;\n}\n\ninterface Registravel\n{\n    public function registrar(): void;\n}\n\nclass EmailService implements Notificavel, Registravel\n{\n    public function enviar(string $mensagem): bool { /* ... */ return true; }\n    public function registrar(): void { /* ... */ }\n}",
+                },
+                {
+                    type: "table",
+                    value: '[["", "Classe abstrata", "Interface"], ["Tem código pronto", "sim", "não"], ["Tem propriedades", "sim", "não"], ["Quantas por classe", "uma", "várias"], ["Instanciável", "não", "não"]]',
+                },
+            ],
+            questions: [
+                {
+                    statement: "Quantas classes uma classe PHP pode estender?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Uma", isCorrect: true },
+                        { text: "Quantas quiser", isCorrect: false },
+                        { text: "Duas, no máximo", isCorrect: false },
+                        { text: "Nenhuma", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `parent::` faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Chama a versão do método na classe pai", isCorrect: true },
+                        { text: "Cria uma instância da classe pai", isCorrect: false },
+                        { text: "Impede a filha de sobrescrever o método", isCorrect: false },
+                        { text: "Aponta para a interface implementada", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Um método `abstract` tem corpo?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Não, só a assinatura, e a filha é obrigada a implementar",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Sim, com corpo, e a classe filha não pode alterá-lo depois",
+                            isCorrect: false,
+                        },
+                        { text: "Sim, mas o corpo é ignorado", isCorrect: false },
+                        { text: "Depende da visibilidade declarada", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a diferença prática que decide entre abstrata e interface?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Interfaces podem ser várias por classe, abstrata só uma",
+                            isCorrect: true,
+                        },
+                        { text: "Interfaces executam mais rápido", isCorrect: false },
+                        {
+                            text: "Abstratas não podem declarar métodos públicos nem privados",
+                            isCorrect: false,
+                        },
+                        { text: "Interfaces permitem propriedades tipadas", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "É possível criar um objeto direto de uma classe abstrata?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Não, ela precisa ser estendida", isCorrect: true },
+                        { text: "Sim, como qualquer classe", isCorrect: false },
+                        { text: "Sim, se todos os métodos tiverem corpo", isCorrect: false },
+                        { text: "Só dentro da própria classe", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Traits, static e constantes de classe",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Traits: reaproveitar sem herdar\n\nComo o PHP tem herança simples, sobra o problema de compartilhar um comportamento entre classes que não têm parentesco. O **trait** resolve: é um bloco de métodos que a classe absorve com `use`.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\ntrait RegistraLog\n{\n    public function log(string $mensagem): void\n    {\n        $agora = date("Y-m-d H:i:s");\n        echo "[$agora] " . static::class . ": $mensagem\\n";\n    }\n}\n\nclass Pedido\n{\n    use RegistraLog;\n}\n\nclass Usuario\n{\n    use RegistraLog;\n}\n\n(new Pedido())->log("criado");  // [2026-07-30 09:00:00] Pedido: criado',
+                },
+                {
+                    type: "text",
+                    value: "## static: o que pertence à classe\n\nPropriedades e métodos `static` pertencem à classe, não a cada objeto. Acessa-se com `::` sem precisar instanciar.\n\nUsar `static` com moderação: estado estático é global disfarçado, e dificulta teste.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\nclass Config\n{\n    public const VERSAO = "1.0";\n    private static array $valores = [];\n\n    public static function set(string $chave, mixed $valor): void\n    {\n        self::$valores[$chave] = $valor;\n    }\n\n    public static function get(string $chave): mixed\n    {\n        return self::$valores[$chave] ?? null;\n    }\n}\n\nConfig::set("tema", "escuro");\necho Config::get("tema");  // escuro\necho Config::VERSAO;       // 1.0',
+                },
+                {
+                    type: "quote",
+                    value: "self:: aponta para a classe onde o código foi escrito. static:: aponta para a classe que foi realmente chamada, respeitando herança.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Que problema o trait resolve?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Compartilhar comportamento entre classes sem parentesco",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Permitir a herança múltipla de estado entre várias classes",
+                            isCorrect: false,
+                        },
+                        { text: "Substituir o uso de interfaces", isCorrect: false },
+                        { text: "Criar objetos sem construtor", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como se acessa um membro `static`?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Com `::` a partir do nome da classe", isCorrect: true },
+                        { text: "Com `->` a partir de um objeto criado", isCorrect: false },
+                        { text: "Com `=>` dentro de um array", isCorrect: false },
+                        { text: "Com `parent::` apenas", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual palavra-chave a classe usa para absorver um trait?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "use", isCorrect: true },
+                        { text: "extends", isCorrect: false },
+                        { text: "implements", isCorrect: false },
+                        { text: "include", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a diferença entre `self::` e `static::`?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "O static respeita a classe realmente chamada na herança",
+                            isCorrect: true,
+                        },
+                        { text: "O self é mais rápido de resolver", isCorrect: false },
+                        {
+                            text: "O static só pode ser usado dentro de métodos declarados abstratos",
+                            isCorrect: false,
+                        },
+                        { text: "O self funciona apenas em traits", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que usar estado `static` com moderação?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Ele é estado global disfarçado e dificulta os testes",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Ele consome muito mais memória que uma propriedade comum",
+                            isCorrect: false,
+                        },
+                        { text: "Ele não funciona com herança", isCorrect: false },
+                        { text: "Ele exige PHP 8.5 ou superior", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Enums",
+            blocks: [
+                {
+                    type: "text",
+                    value: '# O fim das constantes soltas\n\nAntes, um conjunto fixo de valores virava constante de classe ou string mágica espalhada pelo código. Nada impedia alguém de passar `"pendnete"` com erro de digitação.\n\nO **enum**, do PHP 8.1, cria um tipo com valores fechados. O que não é um caso do enum não passa pela assinatura.',
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\nenum StatusPedido: string\n{\n    case Pendente = "pendente";\n    case Pago = "pago";\n    case Enviado = "enviado";\n    case Cancelado = "cancelado";\n}\n\nfunction atualizar(StatusPedido $status): void\n{\n    echo $status->value;\n}\n\natualizar(StatusPedido::Pago);   // pago\natualizar("pago");                // TypeError',
+                },
+                {
+                    type: "text",
+                    value: "## Enum com comportamento\n\nEnums aceitam métodos e podem implementar interfaces. Isso permite guardar junto do caso a regra que depende dele, em vez de espalhar `match` pelo sistema.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\nenum StatusPedido: string\n{\n    case Pendente = "pendente";\n    case Pago = "pago";\n    case Cancelado = "cancelado";\n\n    public function rotulo(): string\n    {\n        return match($this) {\n            self::Pendente => "Aguardando pagamento",\n            self::Pago => "Pagamento confirmado",\n            self::Cancelado => "Pedido cancelado",\n        };\n    }\n\n    public function podeCancelar(): bool\n    {\n        return $this === self::Pendente;\n    }\n}\n\necho StatusPedido::Pendente->rotulo();',
+                },
+                {
+                    type: "text",
+                    value: "## Puro e atrelado\n\nUm enum **puro** só tem os casos. Um enum **atrelado**, com `: string` ou `: int`, guarda um valor por caso, o que é o que você grava no banco.\n\nO atrelado ganha `from()`, que lança exceção se o valor não existir, e `tryFrom()`, que devolve `null`. Todo enum tem `cases()`, que lista tudo.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\n$status = StatusPedido::from("pago");        // StatusPedido::Pago\n$status = StatusPedido::tryFrom("invalido"); // null, sem exceção\n\nforeach (StatusPedido::cases() as $caso) {\n    echo $caso->name . " = " . $caso->value . "\\n";\n}',
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual problema o enum resolve?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Impedir que valores fora do conjunto entrem no código",
+                            isCorrect: true,
+                        },
+                        { text: "Reduzir o uso de memória das constantes", isCorrect: false },
+                        { text: "Permitir herança múltipla", isCorrect: false },
+                        {
+                            text: "Converter os valores para JSON de forma totalmente automática",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual a diferença entre `from()` e `tryFrom()`?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "O tryFrom devolve null em vez de lançar exceção",
+                            isCorrect: true,
+                        },
+                        { text: "O from aceita apenas inteiros", isCorrect: false },
+                        { text: "O tryFrom só funciona em enums puros", isCorrect: false },
+                        {
+                            text: "O from lista todos os casos existentes dentro do enum",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que `StatusPedido::cases()` devolve?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Todos os casos do enum", isCorrect: true },
+                        { text: "Apenas o primeiro caso", isCorrect: false },
+                        { text: "Os valores em formato de string", isCorrect: false },
+                        { text: "A quantidade de casos declarados", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que diferencia um enum atrelado de um puro?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O atrelado guarda um valor por caso", isCorrect: true },
+                        { text: "O atrelado não aceita métodos", isCorrect: false },
+                        { text: "O puro pode implementar interfaces", isCorrect: false },
+                        { text: "O puro aceita mais de cinquenta casos", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a vantagem de pôr um método dentro do enum?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "A regra fica junto do caso, sem match espalhado no sistema",
+                            isCorrect: true,
+                        },
+                        { text: "O enum passa a aceitar valores novos", isCorrect: false },
+                        {
+                            text: "Os casos deixam de exigir um tipo declarado nas assinaturas",
+                            isCorrect: false,
+                        },
+                        { text: "O enum pode ser instanciado com new", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_6: Modulo = {
+    titulo: "Módulo 6 - Erros, exceções e qualidade",
+    aulas: [
+        {
+            titulo: "Erros, avisos e o que o PHP faz com eles",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Nem todo problema para o script\n\nO PHP classifica problemas em níveis. Alguns interrompem tudo, outros só avisam e a execução continua, o que costuma ser pior: o bug segue escondido.\n\nNo PHP 8 muita coisa que era aviso virou erro, e isso foi bom: falhar cedo é melhor que produzir resultado errado em silêncio.",
+                },
+                {
+                    type: "table",
+                    value: '[["Nível", "Para o script", "Exemplo"], ["Fatal error", "sim", "chamar função que não existe"], ["Warning", "não", "abrir arquivo inexistente"], ["Notice", "não", "usar variável indefinida"], ["Deprecated", "não", "usar recurso obsoleto"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Configurando o que aparece\n\nEm desenvolvimento você quer ver tudo. Em produção, o oposto: nada de erro na tela do usuário, tudo no log.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\n// Desenvolvimento\nini_set("display_errors", "1");\nerror_reporting(E_ALL);\n\n// Produção\nini_set("display_errors", "0");\nini_set("log_errors", "1");\nini_set("error_log", "/var/log/php/app.log");',
+                },
+                {
+                    type: "quote",
+                    value: "Erro na tela em produção vaza caminho de arquivo, versão e às vezes credencial. Em produção, log sempre, tela nunca.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual nível de problema interrompe a execução do script?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Fatal error", isCorrect: true },
+                        { text: "Warning", isCorrect: false },
+                        { text: "Notice", isCorrect: false },
+                        { text: "Deprecated notice", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que exibir erros em produção é perigoso?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Vaza caminhos, versões e às vezes credenciais", isCorrect: true },
+                        { text: "Deixa o site mais lento", isCorrect: false },
+                        { text: "Impede o log de funcionar", isCorrect: false },
+                        {
+                            text: "Consome memória demais do servidor de produção",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que `error_reporting(E_ALL)` faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Manda reportar todos os níveis de problema", isCorrect: true },
+                        {
+                            text: "Interrompe o script já no primeiro aviso emitido",
+                            isCorrect: false,
+                        },
+                        { text: "Desliga o relatório de erros", isCorrect: false },
+                        { text: "Grava os erros em um arquivo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que um Warning pode ser pior que um erro fatal?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "O script continua e produz resultado errado sem ninguém notar",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Ele acaba consumindo bem mais memória do que um erro fatal comum",
+                            isCorrect: false,
+                        },
+                        { text: "Ele não aparece nos logs do servidor", isCorrect: false },
+                        { text: "Ele impede o uso de exceções", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que mudou no PHP 8 quanto aos níveis de erro?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Vários avisos passaram a ser erros", isCorrect: true },
+                        { text: "Todos os erros viraram avisos", isCorrect: false },
+                        { text: "Os níveis foram unificados em um só", isCorrect: false },
+                        { text: "Os avisos deixaram de existir", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Exceções: try, catch e finally",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Interrompendo com contexto\n\nUma exceção é um objeto que representa uma falha. Quando lançada, ela interrompe o fluxo e sobe pela pilha de chamadas até alguém tratá-la.\n\nA vantagem sobre devolver `false`: a exceção carrega mensagem, código e o rastro de onde nasceu.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\nfunction dividir(float $a, float $b): float\n{\n    if ($b === 0.0) {\n        throw new InvalidArgumentException("Divisão por zero");\n    }\n    return $a / $b;\n}\n\ntry {\n    echo dividir(10, 0);\n} catch (InvalidArgumentException $e) {\n    echo "Falhou: " . $e->getMessage();\n} finally {\n    echo "Isto roda sempre";\n}',
+                },
+                {
+                    type: "text",
+                    value: "## A ordem dos catch importa\n\nO PHP usa o primeiro `catch` compatível. Se o mais genérico vier primeiro, os específicos abaixo nunca rodam. Vá do mais específico ao mais genérico.\n\nUm `catch` pode tratar vários tipos com a barra vertical.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\ntry {\n    processar();\n} catch (ArquivoNaoEncontrado | PermissaoNegada $e) {\n    echo "Problema de arquivo: " . $e->getMessage();\n} catch (RuntimeException $e) {\n    echo "Erro de execução";\n} catch (Throwable $e) {\n    // Throwable pega exceções e erros do PHP\n    echo "Algo inesperado";\n}',
+                },
+                {
+                    type: "table",
+                    value: '[["Método", "O que devolve"], ["getMessage()", "a mensagem da falha"], ["getCode()", "o código numérico"], ["getFile() e getLine()", "onde foi lançada"], ["getPrevious()", "a exceção anterior encadeada"], ["getTraceAsString()", "o rastro em texto"]]',
+                },
+            ],
+            questions: [
+                {
+                    statement: "Quando o bloco `finally` é executado?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Sempre, com ou sem exceção", isCorrect: true },
+                        { text: "Só quando uma exceção é lançada", isCorrect: false },
+                        { text: "Só quando nada dá errado", isCorrect: false },
+                        { text: "Apenas se não houver `catch`", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Em que ordem os blocos `catch` devem ser escritos?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Do tipo mais específico para o mais genérico", isCorrect: true },
+                        {
+                            text: "Do tipo mais genérico para o tipo mais específico",
+                            isCorrect: false,
+                        },
+                        { text: "Em ordem alfabética dos tipos", isCorrect: false },
+                        { text: "A ordem não faz diferença", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual método devolve a mensagem de uma exceção?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "getMessage()", isCorrect: true },
+                        { text: "getText()", isCorrect: false },
+                        { text: "getErrorText()", isCorrect: false },
+                        { text: "message()", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `Throwable` alcança que `Exception` não alcança?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Também os erros internos do PHP, como TypeError",
+                            isCorrect: true,
+                        },
+                        { text: "Apenas as exceções que você criou", isCorrect: false },
+                        { text: "Somente os avisos e notices", isCorrect: false },
+                        {
+                            text: "Apenas as exceções lançadas dentro de um finally",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual a vantagem de lançar exceção em vez de devolver `false`?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "A exceção carrega mensagem e o rastro de onde nasceu",
+                            isCorrect: true,
+                        },
+                        { text: "A exceção é sempre mais rápida", isCorrect: false },
+                        {
+                            text: "O `false` não pode ser retornado por uma função tipada",
+                            isCorrect: false,
+                        },
+                        { text: "A exceção dispensa o uso de try", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Exceções próprias e hierarquia",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Criando o seu tipo de falha\n\nUma exceção própria é uma classe que estende `Exception`. Ela deixa o `catch` preciso: você trata o que sabe tratar e deixa o resto subir.\n\nO padrão que funciona bem é uma exceção base por domínio, e as específicas abaixo dela.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\nclass PagamentoException extends Exception {}\n\nclass SaldoInsuficiente extends PagamentoException\n{\n    public function __construct(\n        public readonly float $faltam,\n    ) {\n        parent::__construct("Faltam R$ " . number_format($faltam, 2));\n    }\n}\n\nclass CartaoRecusado extends PagamentoException {}\n\ntry {\n    cobrar($pedido);\n} catch (SaldoInsuficiente $e) {\n    avisarCliente($e->faltam);\n} catch (PagamentoException $e) {\n    // pega CartaoRecusado e qualquer outra do domínio\n    registrarFalha($e);\n}',
+                },
+                {
+                    type: "text",
+                    value: "## Encadeando\n\nO terceiro parâmetro do construtor recebe a exceção anterior. Isso preserva a causa original enquanto você lança uma de nível mais alto, e é o que permite entender a origem no log.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\ntry {\n    $this->gateway->cobrar($valor);\n} catch (ConnectionException $e) {\n    throw new PagamentoException(\n        "Não foi possível cobrar agora",\n        previous: $e,\n    );\n}\n\n// Mais tarde, no log\necho $e->getPrevious()?->getMessage();',
+                },
+                {
+                    type: "quote",
+                    value: "Capture o específico, trate o que sabe tratar, e deixe subir o que você não sabe. Um catch genérico que engole tudo esconde bug.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Uma exceção própria estende qual classe, no caso mais comum?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Exception", isCorrect: true },
+                        { text: "Error", isCorrect: false },
+                        { text: "Throwable diretamente", isCorrect: false },
+                        { text: "stdClass", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a vantagem de uma exceção base por domínio?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Permite capturar o domínio inteiro com um catch só",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Faz as exceções daquele domínio ocuparem menos memória",
+                            isCorrect: false,
+                        },
+                        { text: "Dispensa o uso de try nos chamadores", isCorrect: false },
+                        { text: "Impede que a exceção suba na pilha", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o parâmetro `previous` guarda?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A exceção original que causou esta", isCorrect: true },
+                        { text: "A mensagem em outro idioma", isCorrect: false },
+                        { text: "O código numérico da falha", isCorrect: false },
+                        { text: "O nome do arquivo onde ela ocorreu", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que evitar um `catch (Throwable)` que apenas ignora?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Ele engole bugs reais e some com o rastro do problema",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Ele acaba deixando a execução do script bem mais lenta",
+                            isCorrect: false,
+                        },
+                        { text: "Ele não compila em PHP 8.5", isCorrect: false },
+                        { text: "Ele impede o uso de finally", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como se recupera a exceção encadeada?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Com `getPrevious()`", isCorrect: true },
+                        { text: "Com `getParent()`", isCorrect: false },
+                        { text: "Com `getCause()`", isCorrect: false },
+                        { text: "Com `getRootCause()`", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Depuração e o stack trace do PHP 8.5",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Enxergando onde quebrou\n\nAté o PHP 8.4, um erro fatal mostrava apenas a mensagem e a linha. Descobrir **qual caminho** levou até ali exigia instalar extensão ou espalhar log pelo código.\n\nO **PHP 8.5** passou a incluir o **stack trace nos erros fatais**, o que reduz muito o tempo de diagnóstico em produção.",
+                },
+                {
+                    type: "code",
+                    value: "PHP Fatal error:  Uncaught TypeError: dobrar(): Argument #1 ($n)\nmust be of type int, string given in /app/calc.php:6\nStack trace:\n#0 /app/relatorio.php(14): dobrar('abc')\n#1 /app/index.php(3): gerarRelatorio()\n#2 {main}",
+                },
+                {
+                    type: "text",
+                    value: "## Handlers globais\n\nVocê pode registrar uma função que trata qualquer exceção não capturada, e outra para erros. É assim que se manda tudo para um log estruturado em vez de deixar na tela.\n\nOutra novidade do 8.5: `get_exception_handler()` e `get_error_handler()` permitem **descobrir qual handler está registrado**, o que antes era impossível e atrapalhava bibliotecas que precisavam encadear.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\nset_exception_handler(function (Throwable $e): void {\n    error_log(sprintf(\n        "[%s] %s em %s:%d",\n        $e::class,\n        $e->getMessage(),\n        $e->getFile(),\n        $e->getLine(),\n    ));\n    http_response_code(500);\n    echo "Erro interno. Tente novamente.";\n});\n\n// PHP 8.5: dá para saber o que já está registrado\n$atual = get_exception_handler();',
+                },
+                {
+                    type: "text",
+                    value: "## Ferramentas de depuração\n\n`var_dump()` serve para uma olhada rápida. Para trabalho sério, o **Xdebug** permite parar a execução e inspecionar variáveis passo a passo, o que é infinitamente mais produtivo que espalhar `echo` pelo código.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o PHP 8.5 passou a incluir nos erros fatais?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O stack trace da execução", isCorrect: true },
+                        { text: "O valor de todas as variáveis", isCorrect: false },
+                        { text: "A sugestão de correção do erro", isCorrect: false },
+                        { text: "O tempo de execução do script", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Para que serve `set_exception_handler()`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Tratar qualquer exceção que não foi capturada", isCorrect: true },
+                        { text: "Impedir que exceções sejam lançadas", isCorrect: false },
+                        { text: "Registrar exceções somente em desenvolvimento", isCorrect: false },
+                        { text: "Converter avisos em exceções", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `get_exception_handler()` do PHP 8.5 permite?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Descobrir qual handler está registrado no momento",
+                            isCorrect: true,
+                        },
+                        { text: "Remover o handler registrado", isCorrect: false },
+                        { text: "Executar o handler manualmente", isCorrect: false },
+                        {
+                            text: "Listar todas as exceções que já foram lançadas antes",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual ferramenta permite parar a execução e inspecionar variáveis?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "O Xdebug", isCorrect: true },
+                        { text: "O Composer", isCorrect: false },
+                        { text: "O var_dump", isCorrect: false },
+                        { text: "O Packagist", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que o stack trace no erro fatal reduz o tempo de diagnóstico?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Mostra o caminho de chamadas que levou até a falha",
+                            isCorrect: true,
+                        },
+                        { text: "Impede que o erro aconteça de novo", isCorrect: false },
+                        {
+                            text: "Corrige o tipo do argumento de forma totalmente automática",
+                            isCorrect: false,
+                        },
+                        { text: "Envia o erro para o desenvolvedor por email", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "PSR, atributos e ferramentas de qualidade",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Os padrões da comunidade\n\nAs **PSR** são recomendações publicadas pelo PHP-FIG que padronizam como o código PHP é escrito e organizado. Seguir PSR é o que faz bibliotecas de autores diferentes se encaixarem.",
+                },
+                {
+                    type: "table",
+                    value: '[["Padrão", "Do que trata"], ["PSR-1 e PSR-12", "estilo e formatação do código"], ["PSR-4", "onde cada classe fica no disco"], ["PSR-3", "interface de log"], ["PSR-7", "objetos de requisição e resposta HTTP"], ["PSR-11", "container de injeção de dependência"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Atributos\n\nAtributos são metadados escritos na própria declaração, entre `#[` e `]`. Frameworks os leem por reflexão para configurar comportamento sem arquivo separado.\n\nO PHP 8.5 acrescentou o atributo `#[\\NoDiscard]`, que faz o interpretador avisar quando o retorno de uma função é ignorado, útil para funções cujo resultado não deveria ser descartado.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\n#[Attribute]\nclass Rota\n{\n    public function __construct(\n        public string $caminho,\n        public string $metodo = "GET",\n    ) {}\n}\n\nclass UsuarioController\n{\n    #[Rota("/usuarios", metodo: "GET")]\n    public function listar(): array { return []; }\n}',
+                },
+                {
+                    type: "text",
+                    value: "## O trio de qualidade\n\nTrês ferramentas aparecem em quase todo projeto PHP sério:\n\n- **PHPStan** ou **Psalm**: análise estática, encontra bug sem rodar o código\n- **PHP CS Fixer** ou **PHP_CodeSniffer**: formatam conforme a PSR-12\n- **PHPUnit** ou **Pest**: testes automatizados",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que as PSR padronizam?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Como o código PHP é escrito e organizado", isCorrect: true },
+                        { text: "A velocidade de execução do interpretador", isCorrect: false },
+                        { text: "O formato do banco de dados", isCorrect: false },
+                        { text: "As versões suportadas do PHP", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual PSR trata de onde cada classe fica no disco?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A PSR-4", isCorrect: true },
+                        { text: "A PSR-12", isCorrect: false },
+                        { text: "A PSR-3", isCorrect: false },
+                        { text: "A PSR-7", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como um atributo é escrito em PHP?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Entre `#[` e `]` antes da declaração", isCorrect: true },
+                        { text: "Como comentário iniciado por duas barras", isCorrect: false },
+                        { text: "Dentro de um bloco `attribute { }`", isCorrect: false },
+                        { text: "Como string no construtor da classe", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Que tipo de problema o PHPStan encontra?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Bugs detectáveis sem executar o código", isCorrect: true },
+                        { text: "Somente erros de formatação", isCorrect: false },
+                        {
+                            text: "Apenas as falhas de conexão com o banco de dados",
+                            isCorrect: false,
+                        },
+                        { text: "Somente problemas de desempenho", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Para que serve o atributo `#[\\NoDiscard]` do PHP 8.5?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Avisar quando o retorno de uma função é ignorado",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Impedir que a mesma função seja chamada duas vezes",
+                            isCorrect: false,
+                        },
+                        { text: "Descartar o retorno automaticamente", isCorrect: false },
+                        { text: "Marcar a função como obsoleta", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_7: Modulo = {
+    titulo: "Módulo 7 - PHP na web",
+    aulas: [
+        {
+            titulo: "Da requisição à resposta",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O que acontece quando alguém acessa uma página\n\nO navegador manda uma requisição HTTP ao servidor. O servidor identifica que é um arquivo PHP, chama o interpretador, e o interpretador executa o script do zero, monta a saída e devolve.\n\nA parte que mais surpreende quem vem de outras linguagens: **cada requisição começa do nada**. Nenhuma variável sobrevive entre uma e outra. É por isso que existem sessões e banco de dados.",
+                },
+                {
+                    type: "text",
+                    value: "## As superglobais\n\nO PHP entrega os dados da requisição em arrays disponíveis em qualquer escopo.",
+                },
+                {
+                    type: "table",
+                    value: '[["Superglobal", "O que traz"], ["$_GET", "dados da query string da URL"], ["$_POST", "dados enviados no corpo do formulário"], ["$_SERVER", "informações do servidor e da requisição"], ["$_SESSION", "dados guardados entre requisições"], ["$_COOKIE", "cookies enviados pelo navegador"], ["$_FILES", "arquivos que subiram no formulário"]]',
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\n$metodo = $_SERVER["REQUEST_METHOD"];  // GET, POST...\n$caminho = $_SERVER["REQUEST_URI"];\n\nif ($metodo === "POST") {\n    processarFormulario();\n}\n\n// Definindo a resposta\nhttp_response_code(201);\nheader("Content-Type: application/json");\necho json_encode(["ok" => true]);',
+                },
+                {
+                    type: "quote",
+                    value: "Cabeçalhos precisam ser enviados antes de qualquer saída. Um espaço em branco antes de <?php já quebra o header().",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que acontece com as variáveis PHP entre duas requisições?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Nada sobrevive, cada requisição começa do zero", isCorrect: true },
+                        { text: "Permanecem na memória do servidor", isCorrect: false },
+                        { text: "São salvas em disco automaticamente", isCorrect: false },
+                        {
+                            text: "Continuam apenas quando forem declaradas constantes",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual superglobal traz os dados da query string da URL?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "$_GET", isCorrect: true },
+                        { text: "$_POST", isCorrect: false },
+                        { text: "$_SERVER", isCorrect: false },
+                        { text: "$_SESSION", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Onde se descobre o método HTTP da requisição?",
+                    difficulty: "medio",
+                    options: [
+                        { text: 'Em `$_SERVER["REQUEST_METHOD"]`', isCorrect: true },
+                        { text: 'Em `$_GET["method"]`', isCorrect: false },
+                        { text: 'Em `$_POST["method"]`', isCorrect: false },
+                        { text: "Na constante global HTTP_METHOD", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que `header()` falha se houver saída antes dele?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Os cabeçalhos precisam ir antes do corpo da resposta",
+                            isCorrect: true,
+                        },
+                        { text: "Porque a função só roda em servidores Apache", isCorrect: false },
+                        {
+                            text: "Porque o PHP limita a um único cabeçalho por requisição",
+                            isCorrect: false,
+                        },
+                        { text: "Porque a saída apaga os cabeçalhos definidos", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual superglobal traz os arquivos enviados por um formulário?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "$_FILES", isCorrect: true },
+                        { text: "$_POST", isCorrect: false },
+                        { text: "$_UPLOAD", isCorrect: false },
+                        { text: "$_REQUEST", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Formulários, validação e segurança",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Nunca confie no que chega\n\nTodo dado vindo do navegador pode ter sido alterado. Validação no HTML ajuda a experiência, mas não protege nada: qualquer pessoa envia uma requisição direta sem passar pelo formulário.\n\nA validação que vale é a do servidor.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\n$erros = [];\n\n$nome = trim($_POST["nome"] ?? "");\n$email = trim($_POST["email"] ?? "");\n$idade = filter_input(INPUT_POST, "idade", FILTER_VALIDATE_INT);\n\nif ($nome === "") {\n    $erros[] = "Informe o nome";\n}\nif (!filter_var($email, FILTER_VALIDATE_EMAIL)) {\n    $erros[] = "Email inválido";\n}\nif ($idade === false || $idade < 18) {\n    $erros[] = "Idade precisa ser 18 ou mais";\n}\n\nif ($erros === []) {\n    salvar($nome, $email, $idade);\n}',
+                },
+                {
+                    type: "text",
+                    value: "## Filtros com exceção, novidade do 8.5\n\nAs funções `filter_var` e `filter_input` sempre devolveram `false` quando a validação falhava, o que se confunde com o valor booleano `false` legítimo. O **PHP 8.5** acrescentou a opção de **lançar exceção** em vez de devolver `false`, deixando o erro impossível de ignorar.",
+                },
+                {
+                    type: "text",
+                    value: "## As três defesas obrigatórias\n\nTrês ataques clássicos entram por formulário, e cada um tem sua defesa:\n\n- **XSS**: escapar a saída com `htmlspecialchars()`\n- **SQL injection**: usar consultas preparadas, nunca concatenar\n- **CSRF**: gerar um token por sessão e conferir no envio",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\n// Gerando o token no formulário\n$_SESSION["csrf"] ??= bin2hex(random_bytes(32));\n?>\n<form method="post">\n    <input type="hidden" name="csrf" value="<?= $_SESSION["csrf"] ?>">\n    <input type="text" name="nome">\n    <button>Enviar</button>\n</form>\n<?php\n\n// Conferindo no recebimento\nif (!hash_equals($_SESSION["csrf"], $_POST["csrf"] ?? "")) {\n    http_response_code(419);\n    exit("Token inválido");\n}',
+                },
+            ],
+            questions: [
+                {
+                    statement: "Por que a validação no HTML não é suficiente?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Qualquer um envia requisição sem passar pelo formulário",
+                            isCorrect: true,
+                        },
+                        { text: "Porque o HTML não valida números", isCorrect: false },
+                        { text: "Porque ela deixa a página lenta", isCorrect: false },
+                        {
+                            text: "Porque o navegador de quem acessa pode estar desatualizado",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual função valida o formato de um email?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "filter_var com FILTER_VALIDATE_EMAIL", isCorrect: true },
+                        { text: "check_email()", isCorrect: false },
+                        { text: "is_email()", isCorrect: false },
+                        { text: "preg_match com o padrão FILTER_EMAIL pronto", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a defesa contra SQL injection?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Usar consultas preparadas", isCorrect: true },
+                        { text: "Escapar a saída com htmlspecialchars", isCorrect: false },
+                        { text: "Validar o token CSRF", isCorrect: false },
+                        { text: "Usar apenas requisições POST", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o token CSRF protege?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Impede que outro site envie o formulário em nome do usuário",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Impede que scripts vindos de outro site rodem dentro da página",
+                            isCorrect: false,
+                        },
+                        { text: "Impede consultas SQL maliciosas", isCorrect: false },
+                        { text: "Impede o envio de arquivos grandes", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o PHP 8.5 acrescentou às funções de filtro?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "A opção de lançar exceção em vez de devolver false",
+                            isCorrect: true,
+                        },
+                        { text: "Suporte a validação de CPF", isCorrect: false },
+                        { text: "Filtros escritos em JSON", isCorrect: false },
+                        {
+                            text: "A validação automática de formulários HTML inteiros",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Sessões, cookies e login",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Guardando estado entre requisições\n\nComo cada requisição começa do zero, é preciso um mecanismo para lembrar quem está navegando.\n\nO **cookie** guarda um valor no navegador e vai junto em cada requisição. A **sessão** guarda os dados no servidor e manda ao navegador apenas um identificador. Dados sensíveis vão para a sessão, nunca para o cookie.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\nsession_start();\n\n// Guardando\n$_SESSION["usuario_id"] = 42;\n$_SESSION["nome"] = "Ana";\n\n// Lendo em outra página, depois de session_start()\nif (isset($_SESSION["usuario_id"])) {\n    echo "Olá, " . $_SESSION["nome"];\n}\n\n// Encerrando\nsession_destroy();',
+                },
+                {
+                    type: "text",
+                    value: "## Senhas\n\nSenha nunca é guardada como texto e nunca é criptografada de forma reversível. Ela vira um **hash**, e o PHP já traz as funções certas: `password_hash()` e `password_verify()`.\n\nO algoritmo padrão do PHP hoje é o bcrypt, e `PASSWORD_DEFAULT` acompanha automaticamente quando a recomendação mudar.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\n// No cadastro\n$hash = password_hash($senhaDigitada, PASSWORD_DEFAULT);\n// grave $hash no banco\n\n// No login\nif (password_verify($senhaDigitada, $hashDoBanco)) {\n    session_regenerate_id(true);  // evita fixação de sessão\n    $_SESSION["usuario_id"] = $usuario->id;\n} else {\n    $erro = "Email ou senha incorretos";\n}',
+                },
+                {
+                    type: "quote",
+                    value: "Diga apenas email ou senha incorretos. Dizer qual dos dois errou entrega ao atacante quais emails existem no sistema.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Onde ficam guardados os dados de uma sessão?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "No servidor, com o identificador no navegador", isCorrect: true },
+                        {
+                            text: "No navegador, dentro do próprio cookie de sessão",
+                            isCorrect: false,
+                        },
+                        { text: "No banco de dados, sempre", isCorrect: false },
+                        { text: "Na URL de cada página", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual função gera o hash de uma senha?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "password_hash()", isCorrect: true },
+                        { text: "md5()", isCorrect: false },
+                        { text: "encrypt()", isCorrect: false },
+                        { text: "hash_password()", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que chamar `session_regenerate_id(true)` no login?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Para evitar que um identificador anterior continue válido",
+                            isCorrect: true,
+                        },
+                        { text: "Para tornar a sessão mais rápida", isCorrect: false },
+                        { text: "Para aumentar o tempo de expiração", isCorrect: false },
+                        {
+                            text: "Para permitir vários logins simultâneos com o mesmo usuário",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que precisa ser chamado antes de usar `$_SESSION`?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "session_start()", isCorrect: true },
+                        { text: "session_open()", isCorrect: false },
+                        { text: "session_init()", isCorrect: false },
+                        { text: "start_session()", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Por que a mensagem de erro do login não deve dizer qual campo errou?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Revelaria ao atacante quais emails existem no sistema",
+                            isCorrect: true,
+                        },
+                        { text: "Deixaria a resposta mais lenta", isCorrect: false },
+                        {
+                            text: "Quebraria a validação do formulário de entrada no site",
+                            isCorrect: false,
+                        },
+                        { text: "Impediria o uso de sessões", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Banco de dados com PDO",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Uma interface para vários bancos\n\nO **PDO** é a camada padrão de acesso a banco do PHP. Ele fala com MySQL, PostgreSQL, SQLite e outros pela mesma interface, o que reduz o retrabalho ao trocar de banco.\n\nA conexão pede uma DSN, usuário e senha, e vale configurar três opções sempre.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\n$pdo = new PDO(\n    "mysql:host=localhost;dbname=loja;charset=utf8mb4",\n    $usuario,\n    $senha,\n    [\n        // erro vira exceção em vez de retorno falso\n        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,\n        // resultados como array associativo\n        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,\n        // consultas preparadas de verdade, não emuladas\n        PDO::ATTR_EMULATE_PREPARES => false,\n    ],\n);',
+                },
+                {
+                    type: "text",
+                    value: "## Consultas preparadas\n\nConcatenar valor dentro de SQL é como um banco é invadido. Na consulta preparada, o SQL vai primeiro com marcadores, e os valores depois: o banco nunca confunde dado com comando.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\n// NUNCA faça isto\n$sql = "SELECT * FROM usuarios WHERE email = \'$email\'";\n\n// Faça isto: marcadores nomeados\n$stmt = $pdo->prepare("SELECT * FROM usuarios WHERE email = :email");\n$stmt->execute(["email" => $email]);\n$usuario = $stmt->fetch();\n\n// Vários registros\n$stmt = $pdo->prepare("SELECT * FROM produtos WHERE preco < :teto");\n$stmt->execute(["teto" => 100]);\n$produtos = $stmt->fetchAll();\n\n// Inserindo e pegando o id gerado\n$stmt = $pdo->prepare("INSERT INTO produtos (nome, preco) VALUES (:nome, :preco)");\n$stmt->execute(["nome" => "Caneca", "preco" => 29.9]);\n$id = $pdo->lastInsertId();',
+                },
+                {
+                    type: "text",
+                    value: "## Transações\n\nQuando várias escritas precisam valer juntas ou não valer nenhuma, envolva em transação. O `catch` desfaz tudo com `rollBack()`.",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n\n$pdo->beginTransaction();\ntry {\n    $pdo->prepare("UPDATE contas SET saldo = saldo - :v WHERE id = :id")\n        ->execute(["v" => 100, "id" => 1]);\n    $pdo->prepare("UPDATE contas SET saldo = saldo + :v WHERE id = :id")\n        ->execute(["v" => 100, "id" => 2]);\n    $pdo->commit();\n} catch (Throwable $e) {\n    $pdo->rollBack();\n    throw $e;\n}',
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o PDO oferece em relação aos bancos de dados?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Uma interface única para bancos diferentes", isCorrect: true },
+                        { text: "Um banco de dados embutido no PHP", isCorrect: false },
+                        { text: "A criação automática de tabelas", isCorrect: false },
+                        {
+                            text: "A tradução do SQL para a linguagem de outro banco",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Por que a consulta preparada impede SQL injection?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "O SQL vai antes dos valores, então dado nunca vira comando",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Ela remove todos os caracteres especiais de cada valor enviado",
+                            isCorrect: false,
+                        },
+                        { text: "Ela criptografa a consulta enviada", isCorrect: false },
+                        { text: "Ela limita o tamanho de cada valor", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `PDO::ERRMODE_EXCEPTION` faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Faz erros de banco virarem exceções", isCorrect: true },
+                        { text: "Impede que erros aconteçam", isCorrect: false },
+                        { text: "Registra os erros do banco em arquivo", isCorrect: false },
+                        { text: "Devolve false em vez de erro", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual método devolve todos os registros de uma consulta?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "fetchAll()", isCorrect: true },
+                        { text: "fetch()", isCorrect: false },
+                        { text: "getAll()", isCorrect: false },
+                        { text: "rowCount()", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Para que serve uma transação?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Garantir que várias escritas valham juntas ou nenhuma",
+                            isCorrect: true,
+                        },
+                        { text: "Deixar as consultas mais rápidas", isCorrect: false },
+                        {
+                            text: "Permitir consultas em vários bancos de dados diferentes",
+                            isCorrect: false,
+                        },
+                        { text: "Guardar o resultado em cache", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Autoload PSR-4 e o projeto final",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Namespaces e autoload\n\nEm um projeto com dezenas de classes, dar `require` em cada arquivo é inviável. O **namespace** organiza as classes em pastas lógicas, e o **autoload** carrega o arquivo só quando a classe é usada pela primeira vez.\n\nA **PSR-4** define a regra: o namespace espelha o caminho da pasta.",
+                },
+                {
+                    type: "code",
+                    value: '{\n    "autoload": {\n        "psr-4": {\n            "App\\\\": "src/"\n        }\n    }\n}',
+                },
+                {
+                    type: "code",
+                    value: "<?php\n// src/Model/Produto.php\n\nnamespace App\\Model;\n\nclass Produto\n{\n    public function __construct(\n        public readonly string $nome,\n        public readonly float $preco,\n    ) {}\n}",
+                },
+                {
+                    type: "code",
+                    value: '<?php\n// index.php\n\nrequire __DIR__ . "/vendor/autoload.php";\n\nuse App\\Model\\Produto;\n\n$p = new Produto("Caneca", 29.90);\necho $p->nome;',
+                },
+                {
+                    type: "text",
+                    value: "## O projeto final\n\nPara fechar a trilha, monte um **catálogo de produtos** que junte tudo:\n\n1. Estrutura PSR-4 com `composer.json` e a pasta `src/`\n2. Uma classe `Produto` com propriedades readonly e um enum `Categoria`\n3. Um repositório com PDO e SQLite, usando consultas preparadas\n4. Uma página que lista os produtos, com `htmlspecialchars()` na saída\n5. Um formulário de cadastro com validação no servidor e token CSRF\n6. Tratamento de erro com exceções próprias e um handler global\n\nCada item corresponde a um módulo desta trilha. Se algum passo travar, o módulo dele é onde voltar.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que a PSR-4 define?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Que o namespace espelha o caminho das pastas", isCorrect: true },
+                        {
+                            text: "Como formatar as chaves e a indentação do código",
+                            isCorrect: false,
+                        },
+                        { text: "Como escrever mensagens de log", isCorrect: false },
+                        { text: "Quais versões do PHP suportar", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o autoload evita?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Escrever um require para cada classe usada", isCorrect: true },
+                        { text: "Escrever o namespace no topo de cada classe", isCorrect: false },
+                        { text: "Instalar pacotes com o Composer", isCorrect: false },
+                        { text: "Declarar tipos nos parâmetros", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Qual arquivo precisa ser incluído para o autoload do Composer funcionar?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "vendor/autoload.php", isCorrect: true },
+                        { text: "composer.json", isCorrect: false },
+                        { text: "vendor/composer.php", isCorrect: false },
+                        { text: "src/autoload.php", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Para que serve a palavra `use` no topo de um arquivo?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Importar uma classe de outro namespace", isCorrect: true },
+                        { text: "Absorver um trait na classe", isCorrect: false },
+                        { text: "Declarar o namespace no topo do arquivo", isCorrect: false },
+                        { text: "Carregar uma extensão do PHP", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quando o autoload carrega o arquivo de uma classe?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Na primeira vez em que a classe é usada", isCorrect: true },
+                        { text: "No início da execução, todas de uma vez", isCorrect: false },
+                        { text: "Ao rodar composer install", isCorrect: false },
+                        { text: "Somente quando a classe é instanciada com new", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+export const MODULOS: Modulo[] = [
+    MODULO_1,
+    MODULO_2,
+    MODULO_3,
+    MODULO_4,
+    MODULO_5,
+    MODULO_6,
+    MODULO_7,
+];
+
+async function seed() {
+    let [trilha] = await db.select().from(trails).where(eq(trails.name, NOME));
+    if (!trilha) {
+        [trilha] = await db
+            .insert(trails)
+            .values({
+                name: NOME,
+                trailLevel: LEVEL,
+                description: DESCRICAO,
+                workloadHours: CARGA_HORARIA,
+            })
+            .returning();
+        console.log("Trilha criada: " + NOME);
+    } else {
+        const existentes = await db.select().from(lessons).where(eq(lessons.trailId, trilha.id));
+        if (existentes.length > 0) {
+            console.log("Trilha já tem aulas, nada a fazer: " + NOME);
+            return;
+        }
+        await db
+            .update(trails)
+            .set({ workloadHours: CARGA_HORARIA, description: DESCRICAO, trailLevel: LEVEL })
+            .where(eq(trails.id, trilha.id));
+    }
+
+    let totalAulas = 0;
+    let totalQuestoes = 0;
+    for (let mi = 0; mi < MODULOS.length; mi++) {
+        const m = MODULOS[mi];
+        const [mod] = await db
+            .insert(modules)
+            .values({ trailId: trilha.id, title: m.titulo, position: mi + 1 })
+            .returning();
+        for (let li = 0; li < m.aulas.length; li++) {
+            const a = m.aulas[li];
+            const [lesson] = await db
+                .insert(lessons)
+                .values({
+                    trailId: trilha.id,
+                    moduleId: mod.id,
+                    title: a.titulo,
+                    content: null,
+                    contentBlocks: a.blocks,
+                    position: li + 1,
+                    published: true,
+                })
+                .returning();
+            for (let qi = 0; qi < a.questions.length; qi++) {
+                const q = a.questions[qi];
+                const [questao] = await db
+                    .insert(questions)
+                    .values({
+                        lessonId: lesson.id,
+                        statement: q.statement,
+                        difficulty: q.difficulty,
+                        position: qi + 1,
+                    })
+                    .returning();
+                await db.insert(questionOptions).values(
+                    q.options.map((o, k) => ({
+                        questionId: questao.id,
+                        text: o.text,
+                        isCorrect: o.isCorrect,
+                        position: k + 1,
+                    })),
+                );
+            }
+            totalAulas++;
+            totalQuestoes += a.questions.length;
+        }
+    }
+    console.log(
+        "Seed concluído: " +
+            MODULOS.length +
+            " módulos, " +
+            totalAulas +
+            " aulas, " +
+            totalQuestoes +
+            " questões.",
+    );
+}
+
+// Só semeia quando executado direto. Importado, expõe MODULOS/NOME sem rodar nada.
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+    seed()
+        .then(() => process.exit(0))
+        .catch((e) => {
+            console.error("Falha no seed:", e);
+            process.exit(1);
+        });
+}

--- a/backend/scripts/seed-trilha-rails.ts
+++ b/backend/scripts/seed-trilha-rails.ts
@@ -1,0 +1,3008 @@
+// Seed da trilha Ruby on Rails (Rails 8.1). Conteúdo autoral.
+// A versão 8.1 saiu em outubro de 2025 e é a que a trilha ensina: Active Job
+// Continuations, associações depreciadas, Structured Event Reporting e o CI local com bin/ci.
+//
+// Idempotente e nao destrutivo: se a trilha ja tiver aulas, nao faz nada.
+//
+// Rodar em prod: docker compose -f docker-compose.prod.yml run --rm -T --no-deps backend node scripts/seed-trilha-rails.ts
+import { db } from "../db.ts";
+import { trails, modules, lessons, questions, questionOptions } from "../schema.ts";
+import { eq } from "drizzle-orm";
+import { pathToFileURL } from "node:url";
+
+export const NOME = "Ruby on Rails";
+const LEVEL: "iniciante" | "intermediario" | "avancado" = "intermediario";
+const DESCRICAO =
+    "Ruby on Rails 8.1 do primeiro app ao deploy: rotas REST, controllers e views em ERB, Active Record com migrations, associações e escopos, autenticação nativa e segurança, Hotwire com Turbo e Stimulus, jobs e cache com a Solid Trifecta, testes com Minitest e deploy com Kamal. O framework que definiu boa parte do que hoje se espera de uma aplicação web.";
+const CARGA_HORARIA = 24;
+
+type Bloco = { type: "text" | "code" | "quote" | "table"; value: string };
+type Questao = {
+    statement: string;
+    difficulty: "facil" | "medio" | "dificil";
+    options: { text: string; isCorrect: boolean }[];
+};
+type Aula = { titulo: string; blocks: Bloco[]; questions: Questao[] };
+type Modulo = { titulo: string; aulas: Aula[] };
+
+const MODULO_1: Modulo = {
+    titulo: "Módulo 1 - O Rails e o primeiro app",
+    aulas: [
+        {
+            titulo: "O que é Rails e as duas doutrinas",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O framework que definiu uma época\n\nO **Ruby on Rails** foi criado por David Heinemeier Hansson em 2004, extraído do Basecamp. Ele popularizou ideias que hoje parecem óbvias: migrations, geradores, MVC no servidor e teste como parte do projeto.\n\nGitHub, Shopify, Airbnb e Basecamp rodam Rails em escala grande até hoje.",
+                },
+                {
+                    type: "text",
+                    value: "## Convenção sobre configuração\n\nA primeira doutrina: se você seguir as convenções, quase nada precisa ser configurado. Um model `Produto` fala com a tabela `produtos`, o controller `ProdutosController` renderiza `app/views/produtos`.\n\nO ganho não é digitar menos, é que **todo projeto Rails se parece**. Quem chega em um projeto novo já sabe onde procurar.",
+                },
+                {
+                    type: "text",
+                    value: "## Não se repita\n\nA segunda: cada pedaço de conhecimento mora em um lugar só. A estrutura da tabela está na migration, e o model a descobre sozinho. Nada de declarar as colunas de novo no código.",
+                },
+                {
+                    type: "table",
+                    value: '[["Convenção", "Exemplo"], ["Model no singular", "Produto"], ["Tabela no plural", "produtos"], ["Controller no plural", "ProdutosController"], ["Views por controller", "app/views/produtos"], ["Chave estrangeira", "categoria_id"]]',
+                },
+                {
+                    type: "text",
+                    value: "Esta trilha usa o **Rails 8.1**, lançado em outubro de 2025, com Ruby 4.0.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que a convenção sobre configuração garante?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Que quase nada precisa ser configurado", isCorrect: true },
+                        { text: "Que o código roda mais rápido em produção", isCorrect: false },
+                        { text: "Que as configurações ficam em um arquivo só", isCorrect: false },
+                        { text: "Que o framework aceita qualquer estrutura", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Com qual tabela o model `Produto` fala por convenção?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "produtos", isCorrect: true },
+                        { text: "produto, no mesmo singular do model", isCorrect: false },
+                        { text: "tb_produto, com prefixo padrão do Rails", isCorrect: false },
+                        { text: "Nenhuma, é preciso declarar sempre", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o princípio de não se repetir defende?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Cada conhecimento em um lugar só", isCorrect: true },
+                        { text: "Que o código nunca tenha linhas duplicadas", isCorrect: false },
+                        { text: "Que cada classe tenha uma responsabilidade", isCorrect: false },
+                        { text: "Que os testes cubram todos os caminhos", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual o maior ganho de todo projeto Rails ser parecido?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Quem chega já sabe onde procurar", isCorrect: true },
+                        { text: "O framework consegue otimizar melhor o código", isCorrect: false },
+                        { text: "Os projetos podem compartilhar o mesmo banco", isCorrect: false },
+                        {
+                            text: "As gems funcionam sem precisar de configuração",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Como o model descobre as colunas da tabela?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Ele lê o schema do banco sozinho", isCorrect: true },
+                        { text: "Pelas propriedades declaradas na classe", isCorrect: false },
+                        { text: "Por um arquivo de mapeamento em config", isCorrect: false },
+                        { text: "Pelos atributos definidos na migration", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "rails new e a estrutura do projeto",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Criando a aplicação\n\nO comando `rails new` monta o projeto inteiro: estrutura de pastas, dependências, banco configurado, testes e até o Git iniciado.",
+                },
+                {
+                    type: "code",
+                    value: "gem install rails\nrails new loja\n\n# Escolhendo o banco e dispensando o que não vai usar\nrails new loja --database=postgresql\nrails new api --api --skip-test\n\ncd loja\nbin/rails server\n# http://localhost:3000",
+                },
+                {
+                    type: "table",
+                    value: '[["Pasta", "O que guarda"], ["app/", "models, views, controllers e jobs"], ["config/", "rotas, banco e ambientes"], ["db/", "migrations, schema e seeds"], ["test/", "os testes da aplicação"], ["bin/", "os executáveis do projeto"], ["public/", "arquivos servidos como estão"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Dentro de app\n\nA pasta `app` cresceu ao longo das versões e hoje separa bem as responsabilidades: `models`, `views`, `controllers`, `helpers`, `jobs`, `mailers` e `javascript`.\n\n## bin, não gem\n\nUse sempre `bin/rails` em vez de `rails`. O executável em `bin` respeita as versões travadas no `Gemfile.lock`, enquanto o comando global usa a versão instalada no sistema, que pode ser outra.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que `rails new` cria além da estrutura de pastas?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Dependências, banco configurado e Git", isCorrect: true },
+                        { text: "Apenas as pastas vazias do projeto novo", isCorrect: false },
+                        { text: "O servidor de produção já configurado", isCorrect: false },
+                        { text: "Os models e controllers do domínio", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que usar `bin/rails` em vez de `rails`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Ele respeita as versões travadas do projeto", isCorrect: true },
+                        { text: "Ele executa os comandos bem mais rápido", isCorrect: false },
+                        { text: "Ele funciona sem o Ruby estar instalado", isCorrect: false },
+                        { text: "Ele mostra mais detalhes na saída do terminal", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que a opção `--api` faz no `rails new`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Cria o projeto sem a camada de views", isCorrect: true },
+                        { text: "Cria apenas as rotas de API do projeto", isCorrect: false },
+                        { text: "Configura a autenticação por token", isCorrect: false },
+                        { text: "Gera a documentação dos endpoints", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Onde ficam as migrations em um projeto Rails?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Em db/migrate", isCorrect: true },
+                        { text: "Em app/migrations, junto dos models", isCorrect: false },
+                        { text: "Em config/database, com a configuração", isCorrect: false },
+                        { text: "Em lib/migrations, fora da pasta app", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual comando sobe o servidor de desenvolvimento?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "bin/rails server", isCorrect: true },
+                        { text: "bin/rails start, no padrão de outros", isCorrect: false },
+                        { text: "bin/rails serve, com um e no fim", isCorrect: false },
+                        { text: "bin/rails run, executando a aplicação", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "O ciclo de uma requisição",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Do navegador à resposta\n\nEntender esse caminho é o que permite saber onde procurar quando algo não funciona. Toda requisição em Rails segue os mesmos passos.",
+                },
+                {
+                    type: "table",
+                    value: '[["Passo", "O que acontece", "Onde fica"], ["1", "o roteador escolhe a ação", "config/routes.rb"], ["2", "o middleware processa", "Rack"], ["3", "a ação do controller roda", "app/controllers"], ["4", "o model conversa com o banco", "app/models"], ["5", "a view monta o HTML", "app/views"], ["6", "o layout envolve a view", "app/views/layouts"]]',
+                },
+                {
+                    type: "code",
+                    value: "# 1. A rota\nget '/produtos/:id', to: 'produtos#show'\n\n# 3. O controller\nclass ProdutosController < ApplicationController\n  def show\n    @produto = Produto.find(params[:id])   # 4. o model\n  end\n  # 5. renderiza app/views/produtos/show.html.erb sozinho\nend",
+                },
+                {
+                    type: "text",
+                    value: "## Renderização implícita\n\nRepare que a ação `show` não diz o que renderizar. O Rails procura a view com o mesmo nome da ação e a usa. Você só escreve `render` quando quer fugir da convenção.\n\n## As variáveis com arroba\n\nVariáveis de instância definidas no controller ficam visíveis na view. É assim que o dado atravessa do controller para o HTML.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual é o primeiro passo do ciclo de uma requisição?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "O roteador escolhe qual ação chamar", isCorrect: true },
+                        { text: "O controller busca o registro no banco", isCorrect: false },
+                        { text: "A view monta o HTML da resposta", isCorrect: false },
+                        { text: "O model valida os dados recebidos", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que a ação renderiza quando não há `render` explícito?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A view com o mesmo nome da ação", isCorrect: true },
+                        { text: "A view index do mesmo controller", isCorrect: false },
+                        { text: "Uma resposta vazia com o código 204", isCorrect: false },
+                        { text: "O layout padrão da aplicação, sem view", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como um dado chega do controller até a view?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Por variável de instância, com arroba", isCorrect: true },
+                        { text: "Por variável local declarada na ação", isCorrect: false },
+                        { text: "Por parâmetro passado ao método render", isCorrect: false },
+                        { text: "Por uma variável global da aplicação", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Onde ficam definidas as rotas?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Em config/routes.rb", isCorrect: true },
+                        { text: "Em app/routes.rb, junto dos controllers", isCorrect: false },
+                        { text: "Em config/application.rb, na configuração", isCorrect: false },
+                        { text: "Em cada controller, no topo da classe", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que envolve a view depois que ela é montada?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O layout da aplicação", isCorrect: true },
+                        { text: "O middleware que trata a resposta", isCorrect: false },
+                        { text: "O helper do controller correspondente", isCorrect: false },
+                        { text: "O roteador, que monta a resposta final", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Console e geradores",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O console\n\n`bin/rails console` abre um irb com a aplicação carregada. É onde se testa uma consulta, inspeciona um registro e entende por que algo não funciona.\n\nO modo sandbox desfaz tudo ao sair, o que permite experimentar sem medo.",
+                },
+                {
+                    type: "code",
+                    value: 'bin/rails console\n\n>> Produto.count\n>> p = Produto.new(nome: "Caneca")\n>> p.valid?\n>> p.errors.full_messages\n>> Produto.where("preco > ?", 100).to_sql\n\n# Desfaz tudo ao sair\nbin/rails console --sandbox',
+                },
+                {
+                    type: "text",
+                    value: "## Geradores\n\nOs geradores criam a estrutura repetitiva. O `scaffold` faz o CRUD completo de uma vez, útil para aprender e para protótipo, mas raro em código de produção: ele gera mais do que a maioria dos casos precisa.",
+                },
+                {
+                    type: "code",
+                    value: "bin/rails generate model Produto nome:string preco:decimal categoria:references\nbin/rails generate controller Produtos index show\nbin/rails generate migration AdicionaAtivoAProdutos ativo:boolean\nbin/rails generate scaffold Pedido total:decimal status:string\n\n# Desfazendo o que um gerador criou\nbin/rails destroy model Produto",
+                },
+                {
+                    type: "table",
+                    value: '[["Comando", "O que faz"], ["bin/rails routes", "lista todas as rotas"], ["bin/rails db:migrate", "aplica as migrations"], ["bin/rails db:seed", "popula com dados iniciais"], ["bin/rails test", "roda os testes"], ["bin/rails stats", "conta linhas por camada"]]',
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que `bin/rails console --sandbox` faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Desfaz as alterações ao sair", isCorrect: true },
+                        { text: "Abre o console sem carregar a aplicação", isCorrect: false },
+                        { text: "Impede que consultas sejam executadas", isCorrect: false },
+                        {
+                            text: "Conecta no banco de teste em vez do de desenvolvimento",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que o gerador `scaffold` cria?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O CRUD completo do recurso", isCorrect: true },
+                        { text: "Apenas o model e a migration dele", isCorrect: false },
+                        { text: "Somente as rotas e o controller vazio", isCorrect: false },
+                        { text: "As views, sem o controller correspondente", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que o scaffold é raro em código de produção?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Ele gera mais do que a maioria precisa", isCorrect: true },
+                        { text: "Ele não segue as convenções do framework", isCorrect: false },
+                        { text: "Ele deixa a aplicação mais lenta ao iniciar", isCorrect: false },
+                        { text: "Ele não funciona com banco PostgreSQL", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `categoria:references` gera na migration?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A coluna categoria_id com chave estrangeira", isCorrect: true },
+                        { text: "Uma coluna de texto com o nome da categoria", isCorrect: false },
+                        { text: "Uma tabela intermediária entre as duas", isCorrect: false },
+                        { text: "Um índice único na coluna categoria", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual comando lista todas as rotas do projeto?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "bin/rails routes", isCorrect: true },
+                        { text: "bin/rails routes:list, com o subcomando", isCorrect: false },
+                        { text: "bin/rails show:routes, exibindo a tabela", isCorrect: false },
+                        { text: "bin/rails config:routes, lendo o arquivo", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Configuração, ambientes e credentials",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Três ambientes\n\nRails nasce com `development`, `test` e `production`, cada um com sua configuração em `config/environments`. A diferença mais visível é o recarregamento: em desenvolvimento o código é relido a cada requisição; em produção ele é carregado uma vez.",
+                },
+                {
+                    type: "table",
+                    value: '[["", "development", "production"], ["Recarrega o código", "sim", "não"], ["Mostra erro detalhado", "sim", "não"], ["Cache", "desligado", "ligado"], ["Assets", "compilados na hora", "pré-compilados"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Credentials\n\nRails não usa arquivo `.env` por padrão. Ele guarda os segredos em um arquivo **criptografado** que vai para o Git, e a chave que o abre fica fora dele.\n\nA vantagem sobre o `.env`: os segredos ficam versionados junto com o código, então não existe o problema de alguém não ter a variável nova. O risco todo se concentra na `master.key`, que **nunca** pode ir para o repositório.",
+                },
+                {
+                    type: "code",
+                    value: "# Abre o editor do arquivo criptografado\nbin/rails credentials:edit\n\n# Por ambiente\nbin/rails credentials:edit --environment production",
+                },
+                {
+                    type: "code",
+                    value: "# config/credentials.yml.enc, depois de descriptografado\nsecret_key_base: abc123...\n\ngateway:\n  chave: sk_live_xyz\n  url: https://api.gateway.com\n\n# No código\nRails.application.credentials.gateway[:chave]\nRails.application.credentials.dig(:gateway, :url)",
+                },
+                {
+                    type: "text",
+                    value: "O **Rails 8.1** acrescentou a busca de credenciais por linha de comando, integrada ao Kamal, o que permite ao deploy obter segredos sem que eles fiquem no servidor.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual a diferença mais visível entre development e production?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O recarregamento do código a cada requisição", isCorrect: true },
+                        {
+                            text: "A quantidade de memória que o processo Ruby consome",
+                            isCorrect: false,
+                        },
+                        { text: "A versão do Rails usada em cada ambiente", isCorrect: false },
+                        { text: "O banco de dados usado por cada um deles", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como o Rails guarda os segredos por padrão?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Em um arquivo criptografado versionado", isCorrect: true },
+                        { text: "Em um arquivo .env fora do controle de versão", isCorrect: false },
+                        {
+                            text: "Em variáveis de ambiente do sistema operacional",
+                            isCorrect: false,
+                        },
+                        { text: "Em uma tabela do banco de dados da aplicação", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual arquivo nunca pode ir para o repositório?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A master.key", isCorrect: true },
+                        { text: "O credentials.yml.enc, que tem os segredos", isCorrect: false },
+                        { text: "O database.yml, com a conexão do banco", isCorrect: false },
+                        { text: "O arquivo de ambiente de produção", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a vantagem das credentials sobre um arquivo .env?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Os segredos ficam versionados com o código", isCorrect: true },
+                        {
+                            text: "Elas podem ser lidas sem precisar de nenhuma chave",
+                            isCorrect: false,
+                        },
+                        { text: "Elas são carregadas bem mais rápido", isCorrect: false },
+                        { text: "Elas funcionam sem precisar de deploy", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o Rails 8.1 acrescentou às credentials?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A busca por linha de comando com o Kamal", isCorrect: true },
+                        { text: "A criptografia por chave assimétrica", isCorrect: false },
+                        {
+                            text: "Um arquivo separado para cada segredo guardado",
+                            isCorrect: false,
+                        },
+                        { text: "A rotação automática da chave mestra", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_2: Modulo = {
+    titulo: "Módulo 2 - Rotas, controllers e views",
+    aulas: [
+        {
+            titulo: "Rotas RESTful e resources",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O roteador\n\nO arquivo `config/routes.rb` liga URL e verbo HTTP a uma ação de controller. Rails empurra você para o desenho REST, e `resources` gera as sete rotas de uma vez.",
+                },
+                {
+                    type: "code",
+                    value: "Rails.application.routes.draw do\n  root 'produtos#index'\n\n  resources :produtos\n\n  # Só algumas\n  resources :categorias, only: [:index, :show]\n\n  # Rotas extras dentro do recurso\n  resources :pedidos do\n    member { post :cancelar }      # /pedidos/1/cancelar\n    collection { get :pendentes }  # /pedidos/pendentes\n  end\n\n  # Aninhado, e raso para não gerar URL longa demais\n  resources :posts, shallow: true do\n    resources :comentarios\n  end\nend",
+                },
+                {
+                    type: "table",
+                    value: '[["Verbo", "Caminho", "Ação", "Helper"], ["GET", "/produtos", "index", "produtos_path"], ["GET", "/produtos/new", "new", "new_produto_path"], ["POST", "/produtos", "create", "produtos_path"], ["GET", "/produtos/:id", "show", "produto_path"], ["PATCH", "/produtos/:id", "update", "produto_path"], ["DELETE", "/produtos/:id", "destroy", "produto_path"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Os helpers de caminho\n\nCada rota gera um método que monta a URL. Usar `produto_path(@produto)` em vez de escrever a URL na mão significa que mudar o caminho é mexer em um lugar só.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Quantas rotas `resources :produtos` gera?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Sete", isCorrect: true },
+                        { text: "Quatro, uma para cada verbo HTTP", isCorrect: false },
+                        { text: "Duas, apenas index e show do recurso", isCorrect: false },
+                        { text: "Uma para cada ação do controller", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a diferença entre `member` e `collection`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Member tem id na URL e collection não", isCorrect: true },
+                        { text: "Member aceita apenas o verbo GET na rota", isCorrect: false },
+                        { text: "Collection só funciona em rotas aninhadas", isCorrect: false },
+                        { text: "Member gera o helper e collection não gera", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Para que serve a opção `shallow: true`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Evitar URLs aninhadas longas demais", isCorrect: true },
+                        { text: "Impedir que o recurso tenha rotas aninhadas", isCorrect: false },
+                        { text: "Gerar apenas as rotas de leitura do recurso", isCorrect: false },
+                        { text: "Criar rotas sem os helpers de caminho", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a vantagem de usar `produto_path` em vez da URL escrita?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Mudar o caminho é mexer em um lugar só", isCorrect: true },
+                        { text: "O helper valida se o registro existe antes", isCorrect: false },
+                        { text: "A URL gerada fica menor e mais legível", isCorrect: false },
+                        { text: "O helper adiciona o token CSRF na URL", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual verbo e ação correspondem a atualizar um recurso?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "PATCH e update", isCorrect: true },
+                        { text: "POST e update, no padrão dos formulários", isCorrect: false },
+                        { text: "PUT e edit, que abre o formulário", isCorrect: false },
+                        { text: "GET e update, com os dados na query", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Controllers e strong parameters",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# A ação do controller\n\nO controller busca os dados, decide o que fazer e escolhe a resposta. As sete ações REST cobrem o CRUD e são a espinha dorsal de quase todo controller Rails.",
+                },
+                {
+                    type: "code",
+                    value: "class ProdutosController < ApplicationController\n  before_action :set_produto, only: %i[show edit update destroy]\n\n  def index\n    @produtos = Produto.order(created_at: :desc).page(params[:page])\n  end\n\n  def create\n    @produto = Produto.new(produto_params)\n\n    if @produto.save\n      redirect_to @produto, notice: 'Produto criado.'\n    else\n      render :new, status: :unprocessable_entity\n    end\n  end\n\n  private\n\n  def set_produto\n    @produto = Produto.find(params[:id])\n  end\n\n  def produto_params\n    params.require(:produto).permit(:nome, :preco, :categoria_id)\n  end\nend",
+                },
+                {
+                    type: "text",
+                    value: "## Strong parameters\n\nO método `produto_params` não é enfeite: sem ele, alguém poderia enviar um campo que não deveria, como `admin: true`, e o `Product.new` aceitaria.\n\n`require` exige que a chave exista e `permit` lista o que pode passar. Tudo fora da lista é descartado, e o Rails registra um aviso no log.",
+                },
+                {
+                    type: "text",
+                    value: "## O status na falha\n\n`status: :unprocessable_entity` no `render` da falha é obrigatório desde que o Turbo virou padrão: sem o código 422, o Turbo não sabe que houve erro e não substitui o formulário na tela.",
+                },
+                {
+                    type: "code",
+                    value: "before_action :autenticar\nbefore_action :set_produto, only: %i[edit update]\nafter_action :registrar_acesso, only: :show\nskip_before_action :verify_authenticity_token, only: :webhook",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que os strong parameters protegem?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Contra atribuição em massa indevida", isCorrect: true },
+                        { text: "Contra injeção de SQL nas consultas feitas", isCorrect: false },
+                        { text: "Contra requisições vindas de outros sites", isCorrect: false },
+                        { text: "Contra o envio de arquivos muito grandes", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a diferença entre `require` e `permit`?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Require exige a chave e permit lista o que passa",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Require valida o tipo e permit valida o valor enviado",
+                            isCorrect: false,
+                        },
+                        { text: "Require é para criar e permit para atualizar", isCorrect: false },
+                        { text: "Não há diferença, os dois filtram os campos", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que usar `status: :unprocessable_entity` ao renderizar erro?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Sem o 422 o Turbo não mostra o formulário com erros",
+                            isCorrect: true,
+                        },
+                        { text: "Porque o Rails exige um status em todo render", isCorrect: false },
+                        {
+                            text: "Para que o navegador não guarde a página no cache dele",
+                            isCorrect: false,
+                        },
+                        { text: "Para que o log registre a falha de validação", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `before_action` faz?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Roda um método antes das ações", isCorrect: true },
+                        { text: "Roda um método depois de cada ação", isCorrect: false },
+                        { text: "Valida os parâmetros antes de salvar", isCorrect: false },
+                        { text: "Registra a ação no log da aplicação", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que acontece com um campo não listado no `permit`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Ele é descartado e o Rails avisa no log", isCorrect: true },
+                        { text: "A requisição inteira é recusada com erro", isCorrect: false },
+                        { text: "O campo é gravado com o valor nulo", isCorrect: false },
+                        { text: "O campo é aceito, mas gera uma exceção", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Views, ERB e helpers",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# ERB\n\nAs views usam **ERB**: HTML com Ruby embutido. Duas tags fazem quase tudo:\n\n- `<%= %>` executa **e imprime** o resultado\n- `<% %>` executa **sem imprimir**, para laços e condicionais",
+                },
+                {
+                    type: "code",
+                    value: "<h1><%= @produto.nome %></h1>\n\n<% if @produtos.any? %>\n  <ul>\n    <% @produtos.each do |produto| %>\n      <li><%= link_to produto.nome, produto %></li>\n    <% end %>\n  </ul>\n<% else %>\n  <p>Nenhum produto cadastrado.</p>\n<% end %>",
+                },
+                {
+                    type: "text",
+                    value: "## O escape é automático\n\nO ERB do Rails **escapa a saída sozinho**. Para inserir HTML confiável é preciso pedir explicitamente com `raw` ou `html_safe`, e essa inversão é o que fecha a porta do XSS por padrão.",
+                },
+                {
+                    type: "code",
+                    value: '<%= "<b>negrito</b>" %>        <%# vira texto, não negrito %>\n<%= raw "<b>negrito</b>" %>    <%# vira negrito de verdade %>',
+                },
+                {
+                    type: "table",
+                    value: '[["Helper", "Para que serve"], ["link_to", "gera uma tag de link"], ["form_with", "gera um formulário"], ["image_tag", "gera a tag de imagem"], ["number_to_currency", "formata como moeda"], ["time_ago_in_words", "diz há quanto tempo foi"], ["truncate", "corta o texto no tamanho"]]',
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual a diferença entre `<%= %>` e `<% %>`?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "O primeiro imprime o resultado", isCorrect: true },
+                        { text: "O primeiro só funciona dentro de laços", isCorrect: false },
+                        { text: "O segundo escapa o conteúdo impresso", isCorrect: false },
+                        { text: "O segundo executa mais rápido na renderização", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O ERB do Rails escapa a saída por padrão?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Sim, é preciso pedir para não escapar", isCorrect: true },
+                        { text: "Não, é preciso escapar manualmente sempre", isCorrect: false },
+                        { text: "Só quando o valor vem de um formulário", isCorrect: false },
+                        { text: "Só em produção, não em desenvolvimento", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que o escape automático fecha a porta do XSS?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O caminho seguro é o padrão, e não a exceção", isCorrect: true },
+                        { text: "Porque ele remove todo HTML do conteúdo", isCorrect: false },
+                        { text: "Porque ele valida o texto antes de exibir", isCorrect: false },
+                        {
+                            text: "Porque ele bloqueia os scripts pelo cabeçalho da resposta",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que `link_to produto.nome, produto` gera?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um link para a página do produto", isCorrect: true },
+                        { text: "Um formulário para editar o produto", isCorrect: false },
+                        { text: "Um botão que remove o produto do banco", isCorrect: false },
+                        { text: "Uma imagem com o nome do produto", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como se insere HTML confiável em uma view?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Com `raw` ou `html_safe`", isCorrect: true },
+                        { text: "Com aspas duplas em volta do conteúdo", isCorrect: false },
+                        { text: "Com a tag `<% %>` em vez da com igual", isCorrect: false },
+                        { text: "Com o helper `escape` antes do valor", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Layouts, partials e formulários",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Layout\n\nO layout é a moldura de todas as páginas. O `yield` marca onde a view da ação entra.",
+                },
+                {
+                    type: "code",
+                    value: '<!-- app/views/layouts/application.html.erb -->\n<!DOCTYPE html>\n<html lang="pt-br">\n  <head>\n    <title><%= content_for(:title) || "Loja" %></title>\n    <%= csrf_meta_tags %>\n    <%= stylesheet_link_tag :app %>\n    <%= javascript_importmap_tags %>\n  </head>\n  <body>\n    <%= render "shared/navegacao" %>\n    <%= yield %>\n  </body>\n</html>',
+                },
+                {
+                    type: "text",
+                    value: "## Partials\n\nUm arquivo começando por sublinhado é uma **partial**, um pedaço reaproveitável. Renderizar uma coleção é tão comum que o Rails tem atalho para isso.",
+                },
+                {
+                    type: "code",
+                    value: '<%= render "produto", produto: @produto %>\n\n<%# Coleção: chama a partial uma vez por item %>\n<%= render partial: "produto", collection: @produtos %>\n\n<%# Atalho: o Rails infere a partial pelo nome da classe %>\n<%= render @produtos %>',
+                },
+                {
+                    type: "text",
+                    value: "## form_with\n\nO `form_with` monta o formulário a partir do model. Ele escolhe sozinho a URL e o verbo: se o registro é novo, faz POST para criar; se já existe, faz PATCH para atualizar. O token CSRF entra automaticamente.",
+                },
+                {
+                    type: "code",
+                    value: "<%= form_with model: @produto do |form| %>\n  <% if @produto.errors.any? %>\n    <ul>\n      <% @produto.errors.full_messages.each do |mensagem| %>\n        <li><%= mensagem %></li>\n      <% end %>\n    </ul>\n  <% end %>\n\n  <%= form.label :nome %>\n  <%= form.text_field :nome %>\n\n  <%= form.label :preco %>\n  <%= form.number_field :preco, step: 0.01 %>\n\n  <%= form.collection_select :categoria_id, Categoria.all, :id, :nome %>\n\n  <%= form.submit %>\n<% end %>",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que `yield` marca no layout?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Onde a view da ação entra", isCorrect: true },
+                        { text: "Onde as partials serão renderizadas", isCorrect: false },
+                        { text: "Onde o JavaScript será carregado", isCorrect: false },
+                        { text: "Onde o layout termina o processamento", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como se identifica uma partial pelo nome do arquivo?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Ele começa com sublinhado", isCorrect: true },
+                        { text: "Ele termina com a extensão .partial", isCorrect: false },
+                        { text: "Ele fica em uma pasta chamada partials", isCorrect: false },
+                        { text: "Ele começa com a palavra shared", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como o `form_with` decide entre criar e atualizar?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Pelo registro ser novo ou já existir", isCorrect: true },
+                        { text: "Pela ação do controller que renderizou a view", isCorrect: false },
+                        { text: "Pelo verbo informado na opção method", isCorrect: false },
+                        { text: "Pela rota que foi usada para chegar na página", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `render @produtos` faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Renderiza a partial uma vez por item", isCorrect: true },
+                        { text: "Converte a coleção em JSON na resposta", isCorrect: false },
+                        { text: "Renderiza a view index do controller", isCorrect: false },
+                        { text: "Imprime os produtos como texto simples", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O `form_with` inclui o token CSRF automaticamente?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Sim, sem precisar declarar", isCorrect: true },
+                        { text: "Não, é preciso chamar um helper à parte", isCorrect: false },
+                        { text: "Só quando o formulário usa o verbo POST", isCorrect: false },
+                        { text: "Só quando a proteção está ligada na rota", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Flash, redirect e render",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Duas formas de responder\n\nA distinção entre `render` e `redirect_to` confunde muito no começo:\n\n- `render` monta uma view **na mesma requisição**, sem mudar a URL\n- `redirect_to` devolve um redirecionamento e o navegador **faz outra requisição**",
+                },
+                {
+                    type: "code",
+                    value: "def create\n  @produto = Produto.new(produto_params)\n\n  if @produto.save\n    # Sucesso: redireciona, para o F5 não reenviar o formulário\n    redirect_to @produto, notice: 'Produto criado com sucesso.'\n  else\n    # Falha: renderiza, para manter o que foi digitado e os erros\n    render :new, status: :unprocessable_entity\n  end\nend",
+                },
+                {
+                    type: "text",
+                    value: "Essa escolha tem motivo. No sucesso, redirecionar evita que recarregar a página reenvie o formulário e crie um registro duplicado. Na falha, renderizar preserva o objeto em memória com os valores digitados e os erros de validação.",
+                },
+                {
+                    type: "text",
+                    value: "## Flash\n\nO `flash` guarda uma mensagem que sobrevive **exatamente um** redirecionamento e some depois. `flash.now` vale só para a renderização atual, e é o que se usa junto com `render`.",
+                },
+                {
+                    type: "code",
+                    value: "redirect_to @produto, notice: 'Salvo.'\nredirect_to produtos_path, alert: 'Não foi possível salvar.'\n\n# Com render, use flash.now\nflash.now[:alert] = 'Confira os campos.'\nrender :new, status: :unprocessable_entity\n\n<%# No layout %>\n<% flash.each do |tipo, mensagem| %>\n  <div class=\"flash <%= tipo %>\"><%= mensagem %></div>\n<% end %>",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual a diferença entre `render` e `redirect_to`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O redirect faz o navegador pedir de novo", isCorrect: true },
+                        { text: "O render é bem mais rápido de executar", isCorrect: false },
+                        { text: "O redirect só funciona dentro de create", isCorrect: false },
+                        { text: "O render não pode passar variáveis à view", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que redirecionar depois de salvar com sucesso?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Para que recarregar não reenvie o formulário", isCorrect: true },
+                        {
+                            text: "Para que a mensagem de sucesso apareça na tela",
+                            isCorrect: false,
+                        },
+                        { text: "Porque o Rails exige redirect em toda criação", isCorrect: false },
+                        { text: "Para que o registro seja gravado no banco", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Por que renderizar em vez de redirecionar quando a validação falha?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Para manter o que foi digitado e os erros", isCorrect: true },
+                        { text: "Para que a URL da página não seja alterada", isCorrect: false },
+                        { text: "Porque o redirect apagaria o registro criado", isCorrect: false },
+                        { text: "Para que o status da resposta seja 422", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quanto tempo uma mensagem em `flash` sobrevive?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um redirecionamento", isCorrect: true },
+                        { text: "Enquanto a sessão do usuário estiver aberta", isCorrect: false },
+                        { text: "Até que ela seja apagada explicitamente", isCorrect: false },
+                        { text: "Por cinco minutos a partir da definição", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quando usar `flash.now` em vez de `flash`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Quando a resposta é um render", isCorrect: true },
+                        { text: "Quando a mensagem for de alerta e não aviso", isCorrect: false },
+                        { text: "Quando houver mais de uma mensagem na tela", isCorrect: false },
+                        { text: "Quando a ação for de criação de registro", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_3: Modulo = {
+    titulo: "Módulo 3 - Active Record",
+    aulas: [
+        {
+            titulo: "Migrations e o schema",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O banco em código\n\nCada **migration** descreve uma mudança no banco. Elas rodam em ordem e o resultado acumulado fica registrado em `db/schema.rb`, que é a fonte de verdade da estrutura atual.",
+                },
+                {
+                    type: "code",
+                    value: "class CreateProdutos < ActiveRecord::Migration[8.1]\n  def change\n    create_table :produtos do |t|\n      t.string :nome, null: false\n      t.string :slug, null: false, index: { unique: true }\n      t.text :descricao\n      t.decimal :preco, precision: 10, scale: 2, null: false\n      t.references :categoria, null: false, foreign_key: true\n      t.boolean :ativo, default: true, null: false\n\n      t.timestamps\n    end\n  end\nend",
+                },
+                {
+                    type: "text",
+                    value: "## O método change\n\nO `change` sabe desfazer a maior parte das operações sozinho: o inverso de `create_table` é `drop_table`. Quando a operação não é reversível, como remover uma coluna com dados, escreva `up` e `down` separados.",
+                },
+                {
+                    type: "code",
+                    value: "bin/rails db:migrate\nbin/rails db:rollback\nbin/rails db:rollback STEP=3\nbin/rails db:migrate:status\nbin/rails db:prepare      # cria, migra e popula se precisar",
+                },
+                {
+                    type: "text",
+                    value: "## O schema é ordenado por coluna no Rails 8.1\n\nUma mudança pequena e prática do 8.1: as colunas em `db/schema.rb` agora saem **em ordem alfabética**. Isso reduz o conflito de merge que aparecia sempre que duas pessoas acrescentavam coluna na mesma tabela.",
+                },
+                {
+                    type: "quote",
+                    value: "Nunca edite uma migration já aplicada em outro ambiente. Lá ela consta como executada, e a alteração nunca chega.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que `db/schema.rb` representa?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A estrutura atual do banco", isCorrect: true },
+                        { text: "A lista de migrations que ainda faltam", isCorrect: false },
+                        { text: "Os dados iniciais que a aplicação usa", isCorrect: false },
+                        { text: "A configuração de conexão com o banco", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o método `change` permite?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O Rails inferir como desfazer a migration", isCorrect: true },
+                        { text: "Alterar uma migration que já foi aplicada", isCorrect: false },
+                        { text: "Rodar a migration sem tocar no schema", isCorrect: false },
+                        { text: "Aplicar a mudança em todos os ambientes", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quando escrever `up` e `down` em vez de `change`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Quando a operação não é reversível sozinha", isCorrect: true },
+                        { text: "Quando a migration altera mais de uma tabela", isCorrect: false },
+                        { text: "Quando a tabela já tem dados gravados", isCorrect: false },
+                        { text: "Quando a migration cria uma chave estrangeira", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que mudou no schema.rb no Rails 8.1?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "As colunas saem em ordem alfabética", isCorrect: true },
+                        { text: "O arquivo passou a ser gerado em formato SQL", isCorrect: false },
+                        { text: "As migrations aplicadas deixaram de constar", isCorrect: false },
+                        {
+                            text: "O arquivo deixou de ir para o controle de versão",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual problema a ordenação alfabética do schema reduz?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O conflito de merge entre pessoas diferentes", isCorrect: true },
+                        { text: "O tempo que a migration leva para rodar", isCorrect: false },
+                        { text: "O tamanho do arquivo gerado pelo Rails", isCorrect: false },
+                        {
+                            text: "A quantidade de índices que são criados na tabela",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Models e a interface de consulta",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Active Record\n\nO padrão Active Record dá nome ao ORM: cada objeto é uma linha e sabe se salvar. O model não declara as colunas, ele as descobre lendo o schema.",
+                },
+                {
+                    type: "code",
+                    value: "Produto.create(nome: 'Caneca', preco: 29.9)\nProduto.find(1)\nProduto.find_by(slug: 'caneca')\nProduto.where(ativo: true)\nProduto.where('preco > ?', 100)\nProduto.where(preco: 10..100)\nProduto.order(created_at: :desc).limit(10)\nProduto.count\nProduto.sum(:preco)\nProduto.group(:categoria_id).count",
+                },
+                {
+                    type: "text",
+                    value: "## As consultas são preguiçosas\n\n`Produto.where(ativo: true)` **não** consulta o banco. Ele devolve uma `ActiveRecord::Relation`, que só executa quando alguém precisa do resultado: ao percorrer, ao chamar `to_a`, `first` ou `count`.\n\nÉ isso que permite montar a consulta em partes, encadeando condições conforme os filtros que chegaram.",
+                },
+                {
+                    type: "code",
+                    value: "consulta = Produto.all\nconsulta = consulta.where(categoria_id: params[:categoria]) if params[:categoria].present?\nconsulta = consulta.where('preco <= ?', params[:teto]) if params[:teto].present?\nconsulta = consulta.order(:nome)\n\n@produtos = consulta   # o banco só é consultado na view",
+                },
+                {
+                    type: "table",
+                    value: '[["Método", "Quando não encontra"], ["find", "levanta RecordNotFound"], ["find_by", "devolve nil"], ["find_by!", "levanta RecordNotFound"], ["where", "devolve relação vazia"], ["first", "devolve nil"]]',
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que `Produto.where(ativo: true)` devolve?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Uma relação ainda não executada", isCorrect: true },
+                        { text: "Um array com os registros encontrados", isCorrect: false },
+                        { text: "O primeiro registro que casa com a condição", isCorrect: false },
+                        { text: "A quantidade de registros que atendem", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quando a consulta chega ao banco?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Quando o resultado é realmente necessário", isCorrect: true },
+                        { text: "No momento em que o where é chamado", isCorrect: false },
+                        { text: "Sempre no fim da ação do controller", isCorrect: false },
+                        { text: "Quando o model é carregado pela aplicação", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a diferença entre `find` e `find_by`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O find levanta exceção quando não acha", isCorrect: true },
+                        { text: "O find_by aceita apenas a chave primária", isCorrect: false },
+                        { text: "O find devolve vários registros de uma vez", isCorrect: false },
+                        { text: "O find_by executa a consulta bem mais rápido", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como o model conhece as colunas da tabela?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Lendo o schema do banco", isCorrect: true },
+                        { text: "Por atributos declarados dentro da classe", isCorrect: false },
+                        { text: "Por um arquivo de mapeamento em config", isCorrect: false },
+                        { text: "Pela migration que criou a tabela", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que a preguiça da relação é útil?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Permite montar a consulta em partes", isCorrect: true },
+                        { text: "Reduz a quantidade de memória usada", isCorrect: false },
+                        { text: "Guarda o resultado em cache automaticamente", isCorrect: false },
+                        {
+                            text: "Evita que a consulta seja executada duas vezes",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Validações e callbacks",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Validando no model\n\nAs validações rodam antes de salvar. `save` devolve `false` quando alguma falha, e `save!` levanta exceção. Os erros ficam em `errors`, prontos para a view exibir.",
+                },
+                {
+                    type: "code",
+                    value: "class Produto < ApplicationRecord\n  validates :nome, presence: true, length: { maximum: 255 }\n  validates :slug, presence: true, uniqueness: true\n  validates :preco, numericality: { greater_than_or_equal_to: 0 }\n  validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }\n  validates :status, inclusion: { in: %w[rascunho publicado] }\n\n  validate :preco_promocional_menor\n\n  private\n\n  def preco_promocional_menor\n    return if preco_promocional.blank? || preco.blank?\n\n    if preco_promocional >= preco\n      errors.add(:preco_promocional, 'precisa ser menor que o preço')\n    end\n  end\nend",
+                },
+                {
+                    type: "text",
+                    value: "## A validação de unicidade tem uma armadilha\n\n`uniqueness: true` faz uma consulta antes de gravar. Entre a consulta e a gravação, outra requisição pode inserir o mesmo valor. A única garantia real é um **índice único no banco**, e a validação existe para dar mensagem amigável, não para garantir.",
+                },
+                {
+                    type: "text",
+                    value: "## Callbacks\n\nCallbacks rodam em momentos do ciclo de vida do registro. São úteis e viciantes: callback demais transforma um `save` simples em uma cascata difícil de seguir e de testar.",
+                },
+                {
+                    type: "code",
+                    value: "before_validation :gerar_slug\nafter_create_commit :notificar_equipe\nbefore_destroy :impedir_se_tiver_pedidos\n\n# Prefira after_commit a after_save quando envolve algo externo:\n# after_save roda dentro da transação, e um email disparado ali\n# pode sair mesmo se a transação for desfeita depois.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que `save` devolve quando uma validação falha?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "false", isCorrect: true },
+                        { text: "Uma exceção de registro inválido", isCorrect: false },
+                        { text: "O registro com os erros preenchidos", isCorrect: false },
+                        { text: "O valor nil, sem gravar nada", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que `uniqueness: true` não garante unicidade?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Outra requisição pode gravar entre a consulta e o insert",
+                            isCorrect: true,
+                        },
+                        { text: "Porque ela só funciona com colunas de texto", isCorrect: false },
+                        {
+                            text: "Porque ela acaba sendo ignorada quando existe índice na coluna",
+                            isCorrect: false,
+                        },
+                        { text: "Porque ela só roda quando o registro é novo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que garante unicidade de verdade?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um índice único no banco", isCorrect: true },
+                        { text: "A validação declarada dentro do model", isCorrect: false },
+                        { text: "Um callback antes de salvar o registro", isCorrect: false },
+                        { text: "A verificação feita dentro do controller", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual o risco de usar muitos callbacks?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um save vira uma cascata difícil de seguir", isCorrect: true },
+                        {
+                            text: "As validações do model deixam de ser executadas",
+                            isCorrect: false,
+                        },
+                        { text: "O registro é gravado mais de uma vez", isCorrect: false },
+                        { text: "Os callbacks rodam em ordem aleatória", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Por que preferir `after_commit` a `after_save` para efeito externo?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O after_save roda dentro da transação", isCorrect: true },
+                        { text: "O after_commit executa bem mais rápido", isCorrect: false },
+                        { text: "O after_save não recebe o registro salvo", isCorrect: false },
+                        { text: "O after_commit roda antes da validação", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Associações",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Ligando os models\n\nAs associações declaram como as tabelas se relacionam. A partir delas, o Rails gera dezenas de métodos e cuida das consultas.",
+                },
+                {
+                    type: "code",
+                    value: "class Usuario < ApplicationRecord\n  has_many :posts, dependent: :destroy\n  has_one :perfil, dependent: :destroy\n  has_many :comentarios, through: :posts\nend\n\nclass Post < ApplicationRecord\n  belongs_to :usuario\n  has_many :comentarios, dependent: :destroy\n  has_many :tags, through: :post_tags\n  has_many :post_tags\nend",
+                },
+                {
+                    type: "table",
+                    value: '[["Associação", "Onde fica a chave estrangeira"], ["belongs_to", "na própria tabela"], ["has_one", "na tabela do outro"], ["has_many", "na tabela do outro"], ["has_many through", "em uma tabela intermediária"]]',
+                },
+                {
+                    type: "text",
+                    value: "## belongs_to é obrigatório por padrão\n\nDesde o Rails 5, `belongs_to` exige que a associação exista: salvar um post sem usuário falha na validação. Para permitir o vínculo vazio, declare `optional: true`.\n\n## dependent, e o cuidado com ele\n\n`dependent: :destroy` apaga os filhos junto e **executa os callbacks de cada um**, um por um. Em uma tabela com muitos registros isso fica lento; `dependent: :delete_all` é rápido, mas pula os callbacks.",
+                },
+                {
+                    type: "code",
+                    value: "usuario.posts.create(titulo: 'Olá')\nusuario.posts.count\nusuario.posts.where(publicado: true)\npost.usuario.nome\npost.tags << tag",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Onde fica a chave estrangeira em um `belongs_to`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Na própria tabela do model", isCorrect: true },
+                        { text: "Na tabela do model associado a ele", isCorrect: false },
+                        { text: "Em uma tabela intermediária entre as duas", isCorrect: false },
+                        { text: "Em nenhuma, a ligação é feita em memória", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que mudou no `belongs_to` desde o Rails 5?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Ele passou a ser obrigatório por padrão", isCorrect: true },
+                        { text: "Ele deixou de gerar métodos no model", isCorrect: false },
+                        { text: "Ele passou a exigir um índice na coluna", isCorrect: false },
+                        { text: "Ele passou a apagar o registro associado", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a diferença entre `dependent: :destroy` e `:delete_all`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O destroy roda os callbacks de cada filho", isCorrect: true },
+                        { text: "O delete_all apaga também o registro pai", isCorrect: false },
+                        { text: "O destroy apaga apenas o primeiro registro", isCorrect: false },
+                        { text: "O delete_all só funciona com has_one", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Para que serve `has_many through`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Ligar dois models por uma tabela intermediária", isCorrect: true },
+                        { text: "Ligar um model a ele mesmo em hierarquia", isCorrect: false },
+                        {
+                            text: "Ligar models que estão em bancos de dados distintos",
+                            isCorrect: false,
+                        },
+                        { text: "Ligar um model a vários tipos de dono", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como permitir que um `belongs_to` fique vazio?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Com `optional: true`", isCorrect: true },
+                        { text: "Com `null: true` na declaração da associação", isCorrect: false },
+                        { text: "Removendo a validação de presença do model", isCorrect: false },
+                        { text: "Com `allow_nil: true` na associação", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Escopos, N+1 e associações depreciadas",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Escopos\n\nUm escopo dá nome a uma consulta e a torna encadeável. Ele evita que a mesma condição se espalhe por vários controllers.",
+                },
+                {
+                    type: "code",
+                    value: "class Produto < ApplicationRecord\n  scope :ativos, -> { where(ativo: true) }\n  scope :baratos, -> { where('preco < ?', 50) }\n  scope :recentes, -> { order(created_at: :desc) }\n  scope :da_categoria, ->(id) { where(categoria_id: id) if id.present? }\n\n  # Aplicado a todas as consultas: use com muito cuidado\n  # default_scope { where(deletado: false) }\nend\n\nProduto.ativos.baratos.recentes.limit(10)",
+                },
+                {
+                    type: "text",
+                    value: "## O problema N+1\n\nO problema de desempenho mais comum em Rails. Percorrer uma lista acessando uma associação dispara uma consulta por item.\n\nO Rails traz um detector embutido: com `strict_loading`, acessar uma associação não carregada levanta exceção em vez de disparar a consulta escondida.",
+                },
+                {
+                    type: "code",
+                    value: "# N+1: uma consulta por post\n@posts = Post.all\n@posts.each { |post| puts post.usuario.nome }\n\n# includes: duas consultas no total\n@posts = Post.includes(:usuario)\n\n# Aninhado e com contagem\nPost.includes(comentarios: :usuario)\nPost.left_joins(:comentarios).group(:id).select('posts.*, COUNT(comentarios.id) AS total')",
+                },
+                {
+                    type: "text",
+                    value: "## Associações depreciadas, novidade do Rails 8.1\n\nRemover uma associação de um model grande é arriscado: nunca se sabe quem ainda a usa. O **Rails 8.1** permite **marcar a associação como depreciada**, e o framework passa a avisar, ou levantar erro, quando alguém a usa.\n\nIsso transforma uma remoção às cegas em um processo com evidência: marca, observa os avisos por um tempo, e só então remove.",
+                },
+                {
+                    type: "code",
+                    value: "class Usuario < ApplicationRecord\n  has_many :pedidos_antigos, deprecated: true\nend",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Para que serve um escopo?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Dar nome a uma consulta reaproveitável", isCorrect: true },
+                        { text: "Limitar quais colunas podem ser lidas", isCorrect: false },
+                        { text: "Definir quem pode acessar o registro", isCorrect: false },
+                        { text: "Validar os dados antes de gravar no banco", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quantas consultas `Post.includes(:usuario)` faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Duas", isCorrect: true },
+                        { text: "Uma para cada post encontrado na tabela", isCorrect: false },
+                        { text: "Uma só, com junção entre as duas tabelas", isCorrect: false },
+                        { text: "Três, contando a de contagem dos registros", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `strict_loading` faz?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Levanta erro ao acessar associação não carregada",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Carrega todas as associações do model antecipadamente",
+                            isCorrect: false,
+                        },
+                        { text: "Registra as consultas lentas em um arquivo", isCorrect: false },
+                        { text: "Impede que o model faça qualquer consulta", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o Rails 8.1 permite fazer com uma associação?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Marcá-la como depreciada e observar o uso", isCorrect: true },
+                        { text: "Renomeá-la sem quebrar o código existente", isCorrect: false },
+                        { text: "Carregá-la sempre junto com o registro", isCorrect: false },
+                        { text: "Movê-la para outro model automaticamente", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que `default_scope` pede cuidado?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Ele se aplica a todas as consultas do model", isCorrect: true },
+                        { text: "Ele não pode ser encadeado com outros escopos", isCorrect: false },
+                        { text: "Ele deixa as consultas bem mais lentas", isCorrect: false },
+                        { text: "Ele só funciona em models sem associações", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_4: Modulo = {
+    titulo: "Módulo 4 - Autenticação, segurança e mailers",
+    aulas: [
+        {
+            titulo: "O gerador de autenticação",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Autenticação sem gem\n\nPor muitos anos autenticação em Rails significava instalar o Devise. Desde o Rails 8 existe um **gerador nativo** que entrega o essencial com código no seu projeto, que você lê e altera à vontade.",
+                },
+                {
+                    type: "code",
+                    value: "bin/rails generate authentication\n\n# Gera, entre outros:\n#   app/models/user.rb e session.rb\n#   app/controllers/sessions_controller.rb\n#   app/controllers/concerns/authentication.rb\n#   as views de login e de recuperação de senha\n#   as migrations de users e sessions",
+                },
+                {
+                    type: "text",
+                    value: "## has_secure_password\n\nO coração da autenticação é `has_secure_password`, que usa a gem bcrypt. Ele acrescenta os campos virtuais de senha, a validação de confirmação e o método `authenticate`.\n\nA senha nunca é guardada: o banco tem apenas `password_digest`, o hash.",
+                },
+                {
+                    type: "code",
+                    value: "class User < ApplicationRecord\n  has_secure_password\n  normalizes :email, with: ->(e) { e.strip.downcase }\n  validates :email, presence: true, uniqueness: true\nend\n\n# No controller de sessão\nif user = User.authenticate_by(email: params[:email], password: params[:password])\n  start_new_session_for user\n  redirect_to after_authentication_url\nelse\n  redirect_to new_session_path, alert: 'Email ou senha incorretos.'\nend",
+                },
+                {
+                    type: "quote",
+                    value: "authenticate_by leva o mesmo tempo quando o email não existe e quando a senha está errada, o que impede descobrir emails cadastrados pelo tempo de resposta.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o gerador de autenticação do Rails 8 entrega?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Código no seu projeto, para ler e alterar", isCorrect: true },
+                        { text: "Uma gem instalada com as rotas prontas", isCorrect: false },
+                        { text: "Um serviço externo de autenticação ligado", isCorrect: false },
+                        { text: "Apenas as migrations das tabelas usadas", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `has_secure_password` acrescenta ao model?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Campos virtuais, validação e authenticate", isCorrect: true },
+                        { text: "As rotas de login e de logout do sistema", isCorrect: false },
+                        { text: "A tabela de sessões usada pela aplicação", isCorrect: false },
+                        { text: "O controller que trata o formulário de acesso", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o banco guarda da senha?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Apenas o hash, em password_digest", isCorrect: true },
+                        { text: "A senha criptografada e reversível", isCorrect: false },
+                        { text: "A senha em texto, protegida por permissão", isCorrect: false },
+                        { text: "Nada, a senha fica só na sessão do usuário", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que `authenticate_by` leva o mesmo tempo nos dois casos?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Para não revelar quais emails existem", isCorrect: true },
+                        {
+                            text: "Para que a resposta chegue mais rápido ao usuário",
+                            isCorrect: false,
+                        },
+                        { text: "Porque o bcrypt tem tempo fixo de execução", isCorrect: false },
+                        { text: "Para permitir várias tentativas simultâneas", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual gem o `has_secure_password` usa por baixo?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "bcrypt", isCorrect: true },
+                        { text: "devise, que cuida da autenticação", isCorrect: false },
+                        { text: "openssl, para o hash das senhas", isCorrect: false },
+                        { text: "jwt, para gerar o token de sessão", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Sessões, cookies e as proteções do Rails",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Guardando quem está logado\n\nA sessão guarda dados entre requisições. Por padrão o Rails a guarda em um **cookie assinado**: o conteúdo fica no navegador, mas assinado com a chave secreta, então alterá-lo invalida a sessão.",
+                },
+                {
+                    type: "code",
+                    value: "session[:user_id] = user.id\nsession[:user_id]\nreset_session      # no login e no logout\n\n# Cookies\ncookies[:tema] = { value: 'escuro', expires: 1.year.from_now }\ncookies.signed[:user_id] = user.id      # assinado\ncookies.encrypted[:token] = valor       # criptografado",
+                },
+                {
+                    type: "text",
+                    value: "## O que o Rails já protege\n\nBoa parte das falhas clássicas vem fechada por padrão. Vale saber quais são e o que ainda as desliga.",
+                },
+                {
+                    type: "table",
+                    value: '[["Ataque", "A defesa", "O que ainda abre a porta"], ["CSRF", "token em todo formulário", "pular a verificação na ação"], ["XSS", "escape automático no ERB", "usar html_safe com dado externo"], ["SQL injection", "consultas com vínculo", "interpolar string no where"], ["Mass assignment", "strong parameters", "permitir campo demais"]]',
+                },
+                {
+                    type: "code",
+                    value: "# Perigoso: interpola a entrada do usuário\nProduto.where(\"nome = '#{params[:nome]}'\")\n\n# Seguro: com vínculo\nProduto.where('nome = ?', params[:nome])\nProduto.where(nome: params[:nome])",
+                },
+                {
+                    type: "text",
+                    value: "O `reset_session` no login e no logout evita fixação de sessão. É o mesmo cuidado que existe em qualquer framework, e continua sendo esquecido com frequência.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Onde o Rails guarda a sessão por padrão?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Em um cookie assinado no navegador", isCorrect: true },
+                        { text: "Em uma tabela do banco de dados da aplicação", isCorrect: false },
+                        { text: "Em arquivos dentro da pasta tmp do projeto", isCorrect: false },
+                        {
+                            text: "Na memória do servidor que atende a requisição",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que acontece se alguém alterar o cookie de sessão?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A assinatura não confere e a sessão cai", isCorrect: true },
+                        { text: "O conteúdo alterado passa a valer normalmente", isCorrect: false },
+                        { text: "O servidor recria a sessão com o valor novo", isCorrect: false },
+                        { text: "O navegador recusa o envio do cookie alterado", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual consulta abre a porta para SQL injection?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A que interpola a entrada dentro da string", isCorrect: true },
+                        { text: "A que usa hash de condições no where", isCorrect: false },
+                        { text: "A que usa ponto de interrogação como vínculo", isCorrect: false },
+                        { text: "A que encadeia vários escopos do model", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Para que serve `reset_session` no login?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Evitar fixação de sessão", isCorrect: true },
+                        { text: "Limpar as mensagens flash pendentes", isCorrect: false },
+                        { text: "Renovar o token CSRF do formulário", isCorrect: false },
+                        { text: "Encerrar as outras sessões do usuário", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a diferença entre `cookies.signed` e `cookies.encrypted`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O criptografado também esconde o conteúdo", isCorrect: true },
+                        { text: "O assinado dura mais tempo no navegador", isCorrect: false },
+                        { text: "O criptografado só funciona com HTTPS", isCorrect: false },
+                        { text: "O assinado pode guardar objetos completos", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Autorização: quem pode fazer o quê",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Depois de saber quem é\n\nAutenticação diz quem é a pessoa. **Autorização** diz o que ela pode fazer, e o Rails não traz uma solução pronta para isso: você escreve, ou usa uma gem como Pundit ou CanCanCan.\n\nA forma mais simples e que resolve a maioria dos casos é escopar a consulta pelo usuário.",
+                },
+                {
+                    type: "code",
+                    value: "# Frágil: qualquer id passa, e o dono não é conferido\ndef show\n  @post = Post.find(params[:id])\nend\n\n# Sólido: quem não é dono recebe 404, não 403\ndef show\n  @post = Current.user.posts.find(params[:id])\nend",
+                },
+                {
+                    type: "text",
+                    value: "Escopar pela associação resolve o problema na origem: o registro de outra pessoa simplesmente não existe naquela consulta. E devolver 404 em vez de 403 tem uma vantagem: não confirma ao curioso que aquele id existe.\n\n## Quando a regra cresce\n\nCom mais de um papel e regras por ação, uma classe de política organiza melhor. O padrão do Pundit é uma classe por model, com um método por ação, e é fácil de escrever à mão.",
+                },
+                {
+                    type: "code",
+                    value: "class PostPolicy\n  def initialize(usuario, post)\n    @usuario = usuario\n    @post = post\n  end\n\n  def editar?\n    @post.usuario_id == @usuario.id || @usuario.admin?\n  end\nend\n\n# No controller\nhead :forbidden unless PostPolicy.new(Current.user, @post).editar?",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O Rails traz uma solução pronta de autorização?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Não, você escreve ou usa uma gem", isCorrect: true },
+                        { text: "Sim, o gerador de autenticação já inclui", isCorrect: false },
+                        { text: "Sim, pelo sistema de políticas do framework", isCorrect: false },
+                        { text: "Sim, pelas permissões definidas nas rotas", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a vantagem de escopar a consulta pelo usuário?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "O registro de outra pessoa não existe na consulta",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "A consulta ao banco fica bem mais rápida de executar",
+                            isCorrect: false,
+                        },
+                        { text: "O Rails valida a permissão automaticamente", isCorrect: false },
+                        { text: "Os registros ficam ordenados pelo dono", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que devolver 404 em vez de 403 pode ser melhor?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Não confirma que aquele id existe", isCorrect: true },
+                        { text: "É o código correto para acesso negado", isCorrect: false },
+                        { text: "Faz o navegador guardar menos em cache", isCorrect: false },
+                        { text: "Permite que o usuário tente de novo depois", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual o padrão de uma classe de política?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Uma classe por model, um método por ação", isCorrect: true },
+                        { text: "Uma classe por usuário, com todas as regras", isCorrect: false },
+                        { text: "Um método por controller da aplicação", isCorrect: false },
+                        { text: "Uma classe única com todas as permissões", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que diferencia autenticação de autorização?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Uma diz quem é, a outra o que pode fazer", isCorrect: true },
+                        { text: "Uma usa cookie e a outra usa sempre token", isCorrect: false },
+                        { text: "Uma roda no model e a outra no controller", isCorrect: false },
+                        { text: "Uma vale para web e a outra apenas para API", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Action Mailer",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Enviando email\n\nUm mailer se parece com um controller: cada método monta um email e existe uma view correspondente, em HTML e em texto puro.",
+                },
+                {
+                    type: "code",
+                    value: 'class PedidoMailer < ApplicationMailer\n  def confirmacao(pedido)\n    @pedido = pedido\n    @url = pedido_url(@pedido)\n\n    mail(\n      to: @pedido.cliente.email,\n      subject: "Pedido #{@pedido.numero} confirmado",\n    )\n  end\nend\n\n# Envia agora, segurando a requisição\nPedidoMailer.confirmacao(pedido).deliver_now\n\n# Manda para a fila: o certo em quase todo caso\nPedidoMailer.confirmacao(pedido).deliver_later',
+                },
+                {
+                    type: "text",
+                    value: "## deliver_now e deliver_later\n\nA diferença importa muito. `deliver_now` conversa com o servidor de email **dentro da requisição**: se ele estiver lento, o usuário espera; se estiver fora do ar, a requisição falha.\n\n`deliver_later` põe o envio na fila e devolve a resposta na hora. É a escolha padrão.",
+                },
+                {
+                    type: "text",
+                    value: "## URL em email\n\nEm email use sempre `_url`, nunca `_path`. O caminho relativo não funciona fora do site, e a base é configurada por ambiente.",
+                },
+                {
+                    type: "code",
+                    value: "# config/environments/production.rb\nconfig.action_mailer.default_url_options = { host: 'loja.com.br', protocol: 'https' }\n\n# Em desenvolvimento, o letter_opener abre o email no navegador\n# em vez de enviar de verdade",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual a diferença entre `deliver_now` e `deliver_later`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O later manda o envio para a fila", isCorrect: true },
+                        { text: "O later agenda o email para o dia seguinte", isCorrect: false },
+                        { text: "O now envia para vários destinatários juntos", isCorrect: false },
+                        { text: "O later só funciona no ambiente de produção", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual o risco de usar `deliver_now` na requisição?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O usuário espera pelo servidor de email", isCorrect: true },
+                        { text: "O email pode ser enviado mais de uma vez", isCorrect: false },
+                        { text: "A mensagem chega sem a formatação correta", isCorrect: false },
+                        { text: "O email é gravado no banco antes de sair", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que usar `_url` em vez de `_path` em um email?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O caminho relativo não funciona fora do site", isCorrect: true },
+                        { text: "O helper de path não existe dentro do mailer", isCorrect: false },
+                        { text: "O Rails bloqueia caminhos relativos em emails", isCorrect: false },
+                        { text: "A URL completa é mais fácil de rastrear", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Com o que um mailer se parece na estrutura?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Com um controller, com views próprias", isCorrect: true },
+                        { text: "Com um model, com validações e callbacks", isCorrect: false },
+                        { text: "Com um job, com apenas um método perform", isCorrect: false },
+                        { text: "Com um helper, sem views correspondentes", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Onde se configura a base das URLs dos emails?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "No arquivo de ambiente, em config", isCorrect: true },
+                        { text: "No próprio mailer, em cada método", isCorrect: false },
+                        { text: "Nas credentials criptografadas do projeto", isCorrect: false },
+                        { text: "No arquivo de rotas da aplicação", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Active Storage e uploads",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Arquivos anexados\n\nO **Active Storage** cuida de upload: guarda o arquivo em disco, S3 ou outro serviço, registra os metadados no banco e gera variações de imagem sob demanda.",
+                },
+                {
+                    type: "code",
+                    value: "bin/rails active_storage:install\nbin/rails db:migrate\n\nclass Produto < ApplicationRecord\n  has_one_attached :foto\n  has_many_attached :galeria\n\n  validates :foto, content_type: %w[image/png image/jpeg],\n                   size: { less_than: 5.megabytes }\nend",
+                },
+                {
+                    type: "code",
+                    value: "<%= form.file_field :foto %>\n\n<%= image_tag produto.foto.variant(resize_to_limit: [400, 400]) if produto.foto.attached? %>\n\n<%# Sempre confira attached? antes de usar %>\n<% if produto.foto.attached? %>\n  <%= image_tag produto.foto %>\n<% end %>",
+                },
+                {
+                    type: "text",
+                    value: "## Os serviços\n\nO arquivo `config/storage.yml` define onde os arquivos ficam, e cada ambiente escolhe um serviço. Assim desenvolvimento usa disco local e produção usa S3, sem mudar uma linha do código.",
+                },
+                {
+                    type: "quote",
+                    value: "Valide sempre o tipo e o tamanho do que sobe. Aceitar qualquer arquivo de qualquer tamanho é convite para encher o disco e para servir conteúdo malicioso.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o Active Storage guarda no banco?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Os metadados do arquivo, não o conteúdo", isCorrect: true },
+                        { text: "O arquivo inteiro, em uma coluna binária", isCorrect: false },
+                        { text: "Apenas o nome original do arquivo enviado", isCorrect: false },
+                        { text: "O endereço público de onde ele é servido", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `variant` faz com uma imagem?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Gera uma versão transformada sob demanda", isCorrect: true },
+                        {
+                            text: "Substitui o arquivo original pelo redimensionado",
+                            isCorrect: false,
+                        },
+                        { text: "Cria todas as variações no momento do upload", isCorrect: false },
+                        { text: "Comprime a imagem antes de guardá-la", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que conferir `attached?` antes de exibir?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O registro pode não ter arquivo anexado", isCorrect: true },
+                        { text: "O arquivo pode estar em outro serviço", isCorrect: false },
+                        { text: "A variação pode ainda não estar pronta", isCorrect: false },
+                        { text: "O Rails exige a verificação em toda view", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Onde se define em qual serviço os arquivos ficam?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Em config/storage.yml", isCorrect: true },
+                        { text: "No model, junto do has_one_attached", isCorrect: false },
+                        { text: "Nas credentials criptografadas do projeto", isCorrect: false },
+                        { text: "No controller que recebe o upload", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que validar tipo e tamanho do arquivo?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Para não encher o disco nem servir algo malicioso",
+                            isCorrect: true,
+                        },
+                        { text: "Porque o Active Storage exige as validações", isCorrect: false },
+                        { text: "Para que a variação seja gerada corretamente", isCorrect: false },
+                        {
+                            text: "Para que o upload do arquivo fique mais rápido de concluir",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_5: Modulo = {
+    titulo: "Módulo 5 - Hotwire e o front-end",
+    aulas: [
+        {
+            titulo: "A filosofia do Hotwire",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# HTML pela rede\n\nO caminho comum para uma interface interativa é uma API JSON no servidor e um framework JavaScript no navegador. Isso funciona, e cobra um preço: duas aplicações, duas linguagens, o mesmo modelo de dados descrito duas vezes.\n\nO **Hotwire** propõe o contrário: o servidor continua mandando **HTML**, e um pouco de JavaScript troca só os pedaços que mudaram.",
+                },
+                {
+                    type: "table",
+                    value: '[["", "SPA com API", "Hotwire"], ["O servidor manda", "JSON", "HTML"], ["Onde a view vive", "no navegador", "no servidor"], ["Modelo de dados", "descrito duas vezes", "um só"], ["JavaScript", "muito", "pouco"]]',
+                },
+                {
+                    type: "text",
+                    value: "## As três peças\n\n- **Turbo**: intercepta links e formulários e troca partes da página sem recarregar\n- **Stimulus**: acrescenta comportamento ao HTML que já veio pronto\n- **Native**: reaproveita as mesmas telas em aplicativo móvel\n\nO Turbo faz a maior parte do trabalho, e boa parte dele **sem você escrever nada**.",
+                },
+                {
+                    type: "quote",
+                    value: "Hotwire não é para toda interface. Editor de texto rico, mapa interativo e planilha continuam pedindo um framework JavaScript de verdade.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o servidor manda em uma aplicação Hotwire?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "HTML", isCorrect: true },
+                        { text: "JSON, consumido por um framework no cliente", isCorrect: false },
+                        { text: "XML, convertido depois pelo navegador", isCorrect: false },
+                        { text: "Código JavaScript que monta a página", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual o principal custo do modelo de SPA com API?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O modelo de dados é descrito duas vezes", isCorrect: true },
+                        { text: "O servidor precisa de bem mais memória", isCorrect: false },
+                        { text: "As páginas demoram mais para carregar", isCorrect: false },
+                        { text: "A aplicação não funciona sem JavaScript", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual peça do Hotwire troca partes da página?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O Turbo", isCorrect: true },
+                        { text: "O Stimulus, que reage aos eventos", isCorrect: false },
+                        { text: "O Native, que atende os aplicativos", isCorrect: false },
+                        { text: "O Propshaft, que serve os arquivos", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Para que serve o Stimulus?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Acrescentar comportamento ao HTML pronto", isCorrect: true },
+                        { text: "Substituir partes da página sem recarregar", isCorrect: false },
+                        { text: "Gerar o HTML das páginas no servidor", isCorrect: false },
+                        { text: "Compilar os arquivos de JavaScript do projeto", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Em qual caso o Hotwire não é a melhor escolha?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Em um editor de texto rico ou um mapa", isCorrect: true },
+                        { text: "Em um painel administrativo com muitos CRUDs", isCorrect: false },
+                        { text: "Em um site com formulários e listagens", isCorrect: false },
+                        { text: "Em uma aplicação com autenticação por sessão", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Turbo Drive e Turbo Frames",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Turbo Drive\n\nO **Turbo Drive** vem ligado por padrão. Ele intercepta cliques em links e envios de formulário, busca a página nova em segundo plano e troca só o `body`, mantendo o `head` e o JavaScript já carregado.\n\nO efeito é uma navegação bem mais rápida sem que você escreva nada. O preço é que **a página não recarrega de verdade**, então código que rodava uma vez no carregamento precisa ouvir os eventos do Turbo.",
+                },
+                {
+                    type: "code",
+                    value: '<%# Desligando o Turbo em um link específico %>\n<%= link_to "Baixar PDF", relatorio_path, data: { turbo: false } %>\n\n<%# Confirmação antes de agir %>\n<%= button_to "Excluir", produto_path(@produto), method: :delete,\n      data: { turbo_confirm: "Tem certeza?" } %>',
+                },
+                {
+                    type: "text",
+                    value: "## Turbo Frames\n\nUm **frame** é um pedaço independente da página. Links e formulários dentro dele afetam **apenas ele**: o servidor devolve a página inteira e o Turbo extrai o frame de mesmo id.\n\nÉ como se faz edição no lugar, paginação parcial e modal, sem uma linha de JavaScript.",
+                },
+                {
+                    type: "code",
+                    value: '<%# A listagem %>\n<%= turbo_frame_tag dom_id(produto) do %>\n  <h3><%= produto.nome %></h3>\n  <%= link_to "Editar", edit_produto_path(produto) %>\n<% end %>\n\n<%# edit.html.erb: o mesmo id, e só ele é trocado %>\n<%= turbo_frame_tag dom_id(@produto) do %>\n  <%= render "form", produto: @produto %>\n<% end %>',
+                },
+                {
+                    type: "text",
+                    value: "## O erro clássico\n\nSe a resposta não tiver um frame com o **mesmo id**, o Turbo não sabe o que colocar e o conteúdo some, sem erro visível no console. Quando um frame fica em branco, a primeira coisa a conferir é se os dois ids batem.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o Turbo Drive substitui a cada navegação?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O body, mantendo o head", isCorrect: true },
+                        { text: "A página inteira, incluindo o head", isCorrect: false },
+                        { text: "Apenas os frames declarados na página", isCorrect: false },
+                        { text: "Somente os formulários que estão na tela", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que muda para o JavaScript com o Turbo Drive ligado?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "A página não recarrega, é preciso ouvir os eventos",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "O JavaScript da página deixa de funcionar na aplicação",
+                            isCorrect: false,
+                        },
+                        { text: "Os scripts são recarregados a cada navegação", isCorrect: false },
+                        { text: "O código precisa ser escrito em Stimulus", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que um Turbo Frame delimita?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um pedaço independente da página", isCorrect: true },
+                        { text: "Uma janela modal aberta sobre a página", isCorrect: false },
+                        { text: "Uma área que não pode ser atualizada", isCorrect: false },
+                        { text: "Um formulário com validação própria", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que acontece quando a resposta não tem o frame de mesmo id?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O conteúdo some sem erro visível", isCorrect: true },
+                        { text: "A página inteira é recarregada no lugar", isCorrect: false },
+                        { text: "O Turbo levanta uma exceção no console", isCorrect: false },
+                        { text: "O frame anterior permanece como estava", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como se desliga o Turbo em um link específico?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Com `data: { turbo: false }`", isCorrect: true },
+                        { text: "Com a opção `remote: false` no link", isCorrect: false },
+                        { text: "Removendo o Turbo do importmap do projeto", isCorrect: false },
+                        { text: "Com `data: { disable: true }` no link", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Turbo Streams",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Alterando vários pontos de uma vez\n\nO frame troca **um** pedaço. O **Turbo Stream** vai além: ele envia uma lista de operações, cada uma mirando um elemento diferente da página.\n\nCriar um comentário, por exemplo, precisa acrescentar o item na lista, limpar o formulário e atualizar o contador. Um stream faz os três em uma resposta.",
+                },
+                {
+                    type: "table",
+                    value: '[["Ação", "O que faz com o alvo"], ["append e prepend", "acrescenta dentro, no fim ou no começo"], ["replace", "troca o elemento inteiro"], ["update", "troca só o conteúdo de dentro"], ["remove", "remove o elemento"], ["before e after", "insere fora, antes ou depois"]]',
+                },
+                {
+                    type: "code",
+                    value: '<%# create.turbo_stream.erb %>\n<%= turbo_stream.append "comentarios" do %>\n  <%= render @comentario %>\n<% end %>\n\n<%= turbo_stream.update "contador", @post.comentarios.count %>\n\n<%= turbo_stream.replace "formulario_comentario" do %>\n  <%= render "form", comentario: Comentario.new %>\n<% end %>',
+                },
+                {
+                    type: "text",
+                    value: "## Streams por difusão\n\nA parte mais interessante: o model pode transmitir a atualização para **todo mundo que está vendo a página**, por WebSocket, sem que ninguém recarregue nada.\n\nÉ assim que se faz notificação ao vivo, chat e placar em tempo real com pouquíssimo código.",
+                },
+                {
+                    type: "code",
+                    value: 'class Comentario < ApplicationRecord\n  belongs_to :post\n  broadcasts_to :post\nend\n\n<%# Na view, para ouvir o canal %>\n<%= turbo_stream_from @post %>\n<div id="comentarios"><%= render @post.comentarios %></div>',
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que um Turbo Stream permite que um frame não permite?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Alterar vários pontos da página de uma vez", isCorrect: true },
+                        {
+                            text: "Trocar o conteúdo sem precisar recarregar a página",
+                            isCorrect: false,
+                        },
+                        { text: "Enviar formulários sem usar JavaScript", isCorrect: false },
+                        { text: "Manter o estado do formulário ao navegar", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a diferença entre `replace` e `update`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O replace troca o elemento inteiro", isCorrect: true },
+                        { text: "O update funciona apenas dentro de frames", isCorrect: false },
+                        { text: "O replace só aceita conteúdo em texto", isCorrect: false },
+                        { text: "O update remove o elemento antes de inserir", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `broadcasts_to` faz em um model?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Transmite a atualização a quem está vendo", isCorrect: true },
+                        { text: "Envia uma notificação por email aos usuários", isCorrect: false },
+                        { text: "Registra a alteração no log da aplicação", isCorrect: false },
+                        { text: "Guarda a alteração em cache para depois", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Que tecnologia leva o stream por difusão até o navegador?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "WebSocket", isCorrect: true },
+                        { text: "Requisições repetidas em curto intervalo", isCorrect: false },
+                        { text: "O cabeçalho de atualização do HTTP", isCorrect: false },
+                        { text: "Um arquivo servido pelo Propshaft", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `turbo_stream_from @post` faz na view?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Assina o canal de atualizações daquele registro",
+                            isCorrect: true,
+                        },
+                        { text: "Renderiza o post usando um stream", isCorrect: false },
+                        { text: "Cria um frame com o id do registro", isCorrect: false },
+                        {
+                            text: "Envia o post que foi criado para os outros usuários",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Stimulus",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# JavaScript que acompanha o HTML\n\nO **Stimulus** parte de uma premissa diferente da dos frameworks modernos: o HTML já veio pronto do servidor, e o JavaScript só acrescenta comportamento.\n\nEle não monta a página nem guarda estado. Ele conecta elementos a controladores por atributos no próprio HTML, o que deixa a ligação visível para quem lê a marcação.",
+                },
+                {
+                    type: "code",
+                    value: '// app/javascript/controllers/copiar_controller.js\nimport { Controller } from "@hotwired/stimulus"\n\nexport default class extends Controller {\n  static targets = ["origem", "aviso"]\n  static values = { mensagem: String }\n\n  copiar() {\n    navigator.clipboard.writeText(this.origemTarget.value)\n    this.avisoTarget.textContent = this.mensagemValue\n  }\n}',
+                },
+                {
+                    type: "code",
+                    value: '<div data-controller="copiar" data-copiar-mensagem-value="Copiado!">\n  <input data-copiar-target="origem" value="ABC-123" readonly>\n  <button data-action="click->copiar#copiar">Copiar</button>\n  <span data-copiar-target="aviso"></span>\n</div>',
+                },
+                {
+                    type: "table",
+                    value: '[["Atributo", "Para que serve"], ["data-controller", "liga o elemento ao controlador"], ["data-action", "liga um evento a um método"], ["data-*-target", "dá nome a um elemento interno"], ["data-*-value", "passa um dado do HTML"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Por que isso combina com o Turbo\n\nO Stimulus reconecta os controladores sozinho quando o Turbo troca um pedaço da página. Sem ele, todo trecho substituído perderia o comportamento e seria preciso religar na mão.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual a premissa do Stimulus?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O HTML já vem pronto do servidor", isCorrect: true },
+                        {
+                            text: "O JavaScript monta toda a interface no cliente",
+                            isCorrect: false,
+                        },
+                        { text: "O estado da aplicação vive no navegador", isCorrect: false },
+                        { text: "Cada componente cuida do próprio HTML", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `data-action` liga?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um evento a um método do controlador", isCorrect: true },
+                        { text: "Um elemento ao controlador correspondente", isCorrect: false },
+                        { text: "Um valor vindo do HTML ao JavaScript", isCorrect: false },
+                        { text: "Um alvo nomeado dentro do controlador", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Para que serve `data-*-target`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Dar nome a um elemento interno", isCorrect: true },
+                        { text: "Definir qual controlador cuida do elemento", isCorrect: false },
+                        { text: "Passar um valor do HTML para o JavaScript", isCorrect: false },
+                        { text: "Indicar qual evento dispara a ação", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "O que acontece com os controladores quando o Turbo troca um trecho?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O Stimulus os reconecta sozinho", isCorrect: true },
+                        {
+                            text: "Eles param de funcionar até recarregar a página",
+                            isCorrect: false,
+                        },
+                        { text: "É preciso religá-los manualmente no código", isCorrect: false },
+                        { text: "Eles continuam ligados ao elemento antigo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O Stimulus guarda o estado da aplicação?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Não, ele só acrescenta comportamento", isCorrect: true },
+                        { text: "Sim, em uma árvore de estado central", isCorrect: false },
+                        { text: "Sim, em valores dentro de cada controlador", isCorrect: false },
+                        { text: "Sim, sincronizado com o servidor", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Propshaft, importmap e assets",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Servindo CSS e JavaScript\n\nO Rails 8 trocou o Sprockets pelo **Propshaft**, bem mais simples: ele acrescenta um hash ao nome do arquivo e o serve. Sem compilação, sem pré-processamento embutido.\n\nO hash resolve cache: quando o conteúdo muda, o nome muda, e o navegador busca a versão nova sem precisar de instrução.",
+                },
+                {
+                    type: "text",
+                    value: "## Importmap\n\nO **importmap** permite usar bibliotecas JavaScript **sem empacotador e sem Node**. Ele declara um mapa de nome para URL, e o navegador resolve os imports por conta própria.\n\nIsso é possível porque navegadores modernos entendem módulos ES nativamente. Para muitos projetos, isso elimina toda a etapa de build do front-end.",
+                },
+                {
+                    type: "code",
+                    value: 'bin/importmap pin @hotwired/stimulus\nbin/importmap pin chart.js --download\n\n# config/importmap.rb\npin "application"\npin "@hotwired/turbo-rails", to: "turbo.min.js"\npin_all_from "app/javascript/controllers", under: "controllers"',
+                },
+                {
+                    type: "table",
+                    value: '[["", "Importmap", "Empacotador"], ["Precisa de Node", "não", "sim"], ["Etapa de build", "nenhuma", "sim"], ["Bom para", "a maioria dos projetos", "front-end pesado"], ["Compilar TypeScript", "não faz", "faz"]]',
+                },
+                {
+                    type: "text",
+                    value: "Quando o projeto precisa de TypeScript, JSX ou de uma árvore grande de dependências, o Rails também aceita esbuild, Vite ou Webpack pelo `jsbundling-rails`.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o Propshaft faz com os arquivos?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Acrescenta um hash ao nome e os serve", isCorrect: true },
+                        { text: "Compila e minifica o CSS e o JavaScript", isCorrect: false },
+                        { text: "Empacota tudo em um arquivo único", isCorrect: false },
+                        { text: "Converte TypeScript para JavaScript", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o importmap dispensa?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O empacotador e o Node", isCorrect: true },
+                        { text: "As bibliotecas JavaScript de terceiros", isCorrect: false },
+                        { text: "A declaração dos imports no código", isCorrect: false },
+                        { text: "O servidor de assets em produção", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que o importmap funciona sem build?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Os navegadores entendem módulos nativamente", isCorrect: true },
+                        { text: "O Rails compila os módulos antes no servidor", isCorrect: false },
+                        { text: "As bibliotecas já vêm pré-compiladas", isCorrect: false },
+                        { text: "O Propshaft resolve os imports antes", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Para que serve o hash no nome do arquivo?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Fazer o navegador buscar a versão nova", isCorrect: true },
+                        { text: "Impedir que o arquivo seja lido diretamente", isCorrect: false },
+                        { text: "Identificar qual versão do Rails o gerou", isCorrect: false },
+                        { text: "Permitir vários arquivos com o mesmo nome", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quando usar um empacotador em vez de importmap?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Com TypeScript, JSX ou muitas dependências", isCorrect: true },
+                        { text: "Sempre que o projeto usar o Hotwire", isCorrect: false },
+                        { text: "Quando a aplicação tiver mais de uma página", isCorrect: false },
+                        { text: "Quando o CSS precisar de pré-processador", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_6: Modulo = {
+    titulo: "Módulo 6 - Jobs, cache e a Solid Trifecta",
+    aulas: [
+        {
+            titulo: "Active Job e Solid Queue",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Trabalho em segundo plano\n\nO **Active Job** é a interface do Rails para trabalho assíncrono. Ela é agnóstica: o mesmo job roda no Solid Queue, no Sidekiq ou em outro adaptador, sem mudar o código.",
+                },
+                {
+                    type: "code",
+                    value: "class ProcessarRelatorioJob < ApplicationJob\n  queue_as :relatorios\n  retry_on Net::OpenTimeout, wait: :polynomially_longer, attempts: 5\n  discard_on ActiveRecord::RecordNotFound\n\n  def perform(relatorio)\n    relatorio.processar!\n  end\nend\n\nProcessarRelatorioJob.perform_later(relatorio)\nProcessarRelatorioJob.set(wait: 1.hour).perform_later(relatorio)",
+                },
+                {
+                    type: "text",
+                    value: "## Passe o registro, não o objeto inteiro\n\nO Active Job serializa os argumentos. Passar um model funciona porque o `GlobalID` guarda apenas o identificador e recarrega o registro na hora de executar.\n\nEssa é a razão do `discard_on RecordNotFound`: se o registro foi apagado entre o enfileiramento e a execução, não há o que fazer, e o job deve ser descartado em vez de tentar para sempre.",
+                },
+                {
+                    type: "text",
+                    value: "## Solid Queue\n\nO **Solid Queue** virou o adaptador padrão no Rails 8. Ele usa o **banco de dados relacional** como fila, em vez de exigir Redis.\n\nA troca tem lógica: uma peça a menos na infraestrutura, backup junto com o banco, e desempenho mais que suficiente para a grande maioria dos projetos.",
+                },
+                {
+                    type: "code",
+                    value: "# config/environments/production.rb\nconfig.active_job.queue_adapter = :solid_queue\n\n# Rodando o supervisor de filas\nbin/jobs start",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o Active Job oferece?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Uma interface única para vários adaptadores", isCorrect: true },
+                        {
+                            text: "Um servidor de filas que vem embutido no framework",
+                            isCorrect: false,
+                        },
+                        { text: "A execução paralela de todos os jobs", isCorrect: false },
+                        { text: "O agendamento de tarefas por horário", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que é guardado ao passar um model como argumento?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Apenas o identificador, pelo GlobalID", isCorrect: true },
+                        { text: "O objeto inteiro, serializado em JSON", isCorrect: false },
+                        { text: "Uma cópia do registro no momento do envio", isCorrect: false },
+                        { text: "A consulta que recupera aquele registro", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que usar `discard_on RecordNotFound`?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "O registro pode ter sido apagado antes de executar",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Porque o job não consegue mais acessar o banco de dados",
+                            isCorrect: false,
+                        },
+                        { text: "Para que o job seja tentado mais vezes", isCorrect: false },
+                        { text: "Porque o GlobalID expira depois de um tempo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o Solid Queue usa como armazenamento?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O banco de dados relacional", isCorrect: true },
+                        { text: "O Redis, como a maioria dos adaptadores", isCorrect: false },
+                        { text: "Arquivos na pasta tmp da aplicação", isCorrect: false },
+                        { text: "A memória do processo que executa", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a vantagem de usar o banco como fila?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Uma peça a menos na infraestrutura", isCorrect: true },
+                        { text: "Os jobs passam a executar bem mais rápido", isCorrect: false },
+                        { text: "A fila deixa de precisar de um supervisor", isCorrect: false },
+                        { text: "Os jobs podem ser executados em paralelo", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Active Job Continuations, novidade do Rails 8.1",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O problema do job longo\n\nUm job que roda por horas é frágil: um deploy, um reinício de container ou uma falha no meio derruba tudo, e a próxima tentativa **começa do zero**.\n\nA saída clássica era quebrar o trabalho em vários jobs menores encadeados, cada um enfileirando o próximo. Funciona e espalha a lógica por várias classes.",
+                },
+                {
+                    type: "text",
+                    value: "## As continuations\n\nO **Rails 8.1** trouxe o **Active Job Continuations**: o job declara etapas, e o framework guarda em qual delas ele estava. Depois de um reinício, ele **retoma da última etapa concluída** em vez de recomeçar.\n\nA lógica continua em uma classe só, e o job passa a sobreviver a deploy.",
+                },
+                {
+                    type: "code",
+                    value: "class MigrarContasJob < ApplicationJob\n  include ActiveJob::Continuable\n\n  def perform\n    step :normalizar_emails\n    step :recalcular_saldos\n    step :notificar_usuarios\n  end\n\n  private\n\n  def normalizar_emails\n    Usuario.find_each { |u| u.update!(email: u.email.strip.downcase) }\n  end\n\n  def recalcular_saldos\n    Conta.find_each(&:recalcular!)\n  end\n\n  def notificar_usuarios\n    Usuario.find_each { |u| AvisoMailer.migracao(u).deliver_later }\n  end\nend",
+                },
+                {
+                    type: "quote",
+                    value: "Cada etapa precisa ser idempotente: ela pode ser interrompida no meio e executada de novo desde o começo dela.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual o problema de um job muito longo?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um reinício faz a tentativa recomeçar do zero", isCorrect: true },
+                        { text: "Ele ocupa memória demais no servidor", isCorrect: false },
+                        {
+                            text: "Ele impede que os outros jobs da fila sejam executados",
+                            isCorrect: false,
+                        },
+                        { text: "Ele não pode acessar o banco de dados", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o Active Job Continuations permite?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Retomar da última etapa concluída", isCorrect: true },
+                        { text: "Executar as etapas todas em paralelo", isCorrect: false },
+                        { text: "Cancelar o job no meio da execução", isCorrect: false },
+                        { text: "Agendar cada etapa para um horário", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como era resolvido antes das continuations?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Quebrando em vários jobs encadeados", isCorrect: true },
+                        { text: "Aumentando o tempo limite de execução", isCorrect: false },
+                        { text: "Executando o job fora da fila normal", isCorrect: false },
+                        { text: "Guardando o progresso em uma tabela", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Que cuidado cada etapa exige?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Ser idempotente, para rodar de novo sem estragar",
+                            isCorrect: true,
+                        },
+                        { text: "Ter um tempo limite definido no código", isCorrect: false },
+                        {
+                            text: "Devolver algum valor para a etapa seguinte executar",
+                            isCorrect: false,
+                        },
+                        { text: "Ser executada em uma fila diferente", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o job precisa incluir para usar continuations?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "ActiveJob::Continuable", isCorrect: true },
+                        { text: "ActiveJob::Retryable, para as tentativas", isCorrect: false },
+                        { text: "ActiveJob::Steps, com as etapas", isCorrect: false },
+                        { text: "ActiveJob::Resumable, para retomar", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Cache e Solid Cache",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Guardando o que custa caro\n\nO Rails oferece cache em vários níveis. O mais usado é o **cache de fragmento**, que guarda um pedaço de HTML já renderizado.",
+                },
+                {
+                    type: "code",
+                    value: '<%# A chave inclui o registro: se ele mudar, a chave muda %>\n<% cache @produto do %>\n  <div class="card">\n    <h3><%= @produto.nome %></h3>\n    <p><%= number_to_currency(@produto.preco) %></p>\n  </div>\n<% end %>\n\n<%# Aninhado: o de fora é invalidado quando um de dentro muda %>\n<% cache [@categoria, @produtos.maximum(:updated_at)] do %>\n  <%= render @produtos %>\n<% end %>',
+                },
+                {
+                    type: "text",
+                    value: "## Invalidação por chave\n\nO Rails usa **cache key baseada no registro**: a chave inclui a classe, o id e o `updated_at`. Quando o registro muda, a chave muda e o fragmento antigo simplesmente deixa de ser procurado.\n\nIsso resolve a parte mais difícil de cache, que é saber quando descartar: você nunca apaga nada, apenas deixa de usar.",
+                },
+                {
+                    type: "code",
+                    value: "Rails.cache.fetch(\"produtos/destaque\", expires_in: 1.hour) do\n  Produto.destaque.includes(:categoria).to_a\nend\n\nRails.cache.write('chave', valor, expires_in: 5.minutes)\nRails.cache.read('chave')\nRails.cache.delete('chave')",
+                },
+                {
+                    type: "text",
+                    value: "## Solid Cache\n\nAssim como a fila, o cache padrão do Rails 8 usa o **banco de dados**. O **Solid Cache** troca memória por disco, o que parece contraintuitivo mas tem lógica: disco hoje é rápido e barato, e permite um cache **muito maior** do que caberia em memória, com retenção de dias em vez de minutos.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o cache de fragmento guarda?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Um pedaço de HTML já renderizado", isCorrect: true },
+                        { text: "O resultado de uma consulta ao banco", isCorrect: false },
+                        { text: "A página inteira, pronta para servir", isCorrect: false },
+                        { text: "Os arquivos de CSS e JavaScript", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que a chave de cache de um registro inclui?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A classe, o id e a data de atualização", isCorrect: true },
+                        { text: "Apenas o id do registro que está em questão", isCorrect: false },
+                        { text: "O conteúdo completo do fragmento", isCorrect: false },
+                        { text: "O nome da view que foi renderizada", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como o fragmento antigo é invalidado?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "A chave muda e ele deixa de ser procurado", isCorrect: true },
+                        { text: "Um callback do model apaga a chave antiga", isCorrect: false },
+                        { text: "O Rails limpa o cache a cada implantação", isCorrect: false },
+                        { text: "A chave expira depois de um tempo fixo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Onde o Solid Cache guarda os dados?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "No banco de dados, em disco", isCorrect: true },
+                        { text: "Na memória do processo da aplicação", isCorrect: false },
+                        { text: "No Redis, como era antes do Rails 8", isCorrect: false },
+                        { text: "Em arquivos dentro da pasta tmp", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a vantagem de um cache em disco?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Cabe muito mais e retém por mais tempo", isCorrect: true },
+                        { text: "Ele responde bem mais rápido que a memória", isCorrect: false },
+                        { text: "Ele dispensa a definição de expiração", isCorrect: false },
+                        {
+                            text: "Ele é replicado automaticamente entre servidores",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Action Cable e Solid Cable",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Comunicação nos dois sentidos\n\nO **Action Cable** integra WebSocket ao Rails. Diferente do HTTP, em que o navegador sempre pergunta primeiro, o WebSocket mantém a conexão aberta e permite que o **servidor** envie quando quiser.\n\nÉ o que sustenta chat, notificação ao vivo e os Turbo Streams por difusão.",
+                },
+                {
+                    type: "code",
+                    value: "class ComentariosChannel < ApplicationCable::Channel\n  def subscribed\n    post = Post.find(params[:post_id])\n    stream_for post\n  end\nend\n\n# Enviando do servidor\nComentariosChannel.broadcast_to(post, html: render_comentario(comentario))",
+                },
+                {
+                    type: "text",
+                    value: "## Na prática você quase não escreve isso\n\nCom Turbo Streams, o `broadcasts_to` no model já cuida do canal, da assinatura e do envio. Escrever um channel à mão só é necessário quando o caso foge do padrão.\n\n## Solid Cable\n\nA terceira peça da trifecta. Ele usa o **banco** para distribuir as mensagens entre os processos, em vez do Redis. Com Solid Queue, Solid Cache e Solid Cable, uma aplicação Rails completa roda com **apenas um banco relacional** como dependência de infraestrutura.",
+                },
+                {
+                    type: "table",
+                    value: '[["Peça", "Substitui", "Para que serve"], ["Solid Queue", "Sidekiq com Redis", "filas de jobs"], ["Solid Cache", "Memcached ou Redis", "cache"], ["Solid Cable", "Redis do Action Cable", "WebSocket entre processos"]]',
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o WebSocket permite que o HTTP comum não permite?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O servidor enviar sem ser perguntado", isCorrect: true },
+                        { text: "O envio de arquivos grandes ao servidor", isCorrect: false },
+                        { text: "A conexão sem passar por autenticação", isCorrect: false },
+                        { text: "A compressão automática das mensagens", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que sustenta os Turbo Streams por difusão?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O Action Cable", isCorrect: true },
+                        { text: "O Active Job, executando em segundo plano", isCorrect: false },
+                        { text: "O Propshaft, servindo os arquivos", isCorrect: false },
+                        { text: "O Solid Cache, guardando as mensagens", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quando é preciso escrever um channel à mão?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Quando o caso foge do padrão do Turbo", isCorrect: true },
+                        { text: "Sempre que a aplicação usar WebSocket", isCorrect: false },
+                        { text: "Quando o model tiver mais de uma associação", isCorrect: false },
+                        { text: "Quando o Solid Cable estiver configurado", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que as três peças da Solid Trifecta permitem?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Rodar tudo com apenas um banco relacional", isCorrect: true },
+                        {
+                            text: "Dispensar por completo o servidor web da aplicação",
+                            isCorrect: false,
+                        },
+                        { text: "Executar a aplicação sem nenhum job", isCorrect: false },
+                        { text: "Servir os assets sem o Propshaft", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o Solid Cable substitui?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O Redis usado pelo Action Cable", isCorrect: true },
+                        { text: "O próprio Action Cable do framework", isCorrect: false },
+                        { text: "O servidor de WebSocket em produção", isCorrect: false },
+                        { text: "O adaptador de fila da aplicação", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Structured Event Reporting, novidade do Rails 8.1",
+            blocks: [
+                {
+                    type: "text",
+                    value: '# O problema do log em texto\n\nLog tradicional é texto solto. Para responder "quantos pedidos falharam por saldo insuficiente na última hora" é preciso escrever uma expressão regular em cima de frases escritas por pessoas diferentes.\n\nO **evento estruturado** inverte isso: em vez de uma frase, você emite um **nome e um conjunto de campos**, e a ferramenta de observabilidade consulta como se fosse banco.',
+                },
+                {
+                    type: "code",
+                    value: "# Em vez disto\nRails.logger.info \"Pedido #{pedido.id} falhou: saldo insuficiente\"\n\n# Rails 8.1: nome e campos\nRails.event.notify('pedido.falhou', {\n  pedido_id: pedido.id,\n  motivo: 'saldo_insuficiente',\n  valor_cents: pedido.total_cents,\n})",
+                },
+                {
+                    type: "text",
+                    value: "## O que o Rails 8.1 trouxe\n\nUma **interface unificada** para emitir esses eventos, com assinantes que decidem o destino. O mesmo evento pode ir para o log em desenvolvimento e para a ferramenta de observabilidade em produção, sem mudar o código que o emite.\n\nAntes, cada projeto inventava a própria convenção, ou dependia de gems que não conversavam entre si.",
+                },
+                {
+                    type: "text",
+                    value: "## O que registrar\n\nEmita evento no que **importa para o negócio**: pedido criado, pagamento recusado, assinatura cancelada. Não registre dado pessoal nem segredo: log costuma ir para serviços de terceiros e ficar guardado por meses.",
+                },
+                {
+                    type: "quote",
+                    value: "Nunca coloque senha, token ou número de cartão em evento ou log. Uma vez emitido, o dado sai do seu controle.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual o problema do log em texto solto?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Consultar exige interpretar frases livres", isCorrect: true },
+                        {
+                            text: "Ele ocupa mais espaço em disco que o estruturado",
+                            isCorrect: false,
+                        },
+                        { text: "Ele não pode ser enviado a serviços externos", isCorrect: false },
+                        { text: "Ele é gravado apenas em desenvolvimento", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que um evento estruturado emite?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um nome e um conjunto de campos", isCorrect: true },
+                        { text: "Uma frase formatada com os dados dentro", isCorrect: false },
+                        { text: "Um registro gravado na tabela de log", isCorrect: false },
+                        { text: "Uma métrica numérica com um rótulo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o Rails 8.1 acrescentou nessa área?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Uma interface unificada para emitir eventos", isCorrect: true },
+                        { text: "Uma ferramenta de observabilidade embutida", isCorrect: false },
+                        { text: "A substituição do logger padrão do framework", isCorrect: false },
+                        { text: "O envio automático dos logs para a nuvem", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quem decide o destino de um evento emitido?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Os assinantes configurados", isCorrect: true },
+                        { text: "O próprio código que emite o evento", isCorrect: false },
+                        { text: "O ambiente em que a aplicação está rodando", isCorrect: false },
+                        { text: "A ferramenta de observabilidade contratada", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que nunca deve ir em um evento ou log?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Senha, token ou número de cartão", isCorrect: true },
+                        { text: "O identificador do registro envolvido", isCorrect: false },
+                        { text: "O motivo pelo qual a operação falhou", isCorrect: false },
+                        { text: "O horário em que o evento aconteceu", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_7: Modulo = {
+    titulo: "Módulo 7 - Testes, CI e deploy",
+    aulas: [
+        {
+            titulo: "Testes com Minitest",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Teste faz parte do projeto\n\nRails cria a pasta `test` no `rails new` e gera um arquivo de teste a cada gerador. A ferramenta padrão é o **Minitest**, e o RSpec é a alternativa popular.",
+                },
+                {
+                    type: "code",
+                    value: "class ProdutoTest < ActiveSupport::TestCase\n  test 'exige nome' do\n    produto = Produto.new(preco: 10)\n    assert_not produto.valid?\n    assert_includes produto.errors[:nome], 'não pode ficar em branco'\n  end\n\n  test 'escopo ativos traz só os ativos' do\n    assert_equal 2, Produto.ativos.count\n  end\nend\n\nclass ProdutosControllerTest < ActionDispatch::IntegrationTest\n  test 'lista os produtos' do\n    get produtos_url\n    assert_response :success\n    assert_select 'h1', 'Produtos'\n  end\n\n  test 'cria um produto válido' do\n    assert_difference('Produto.count', 1) do\n      post produtos_url, params: { produto: { nome: 'Caneca', preco: 29.9 } }\n    end\n    assert_redirected_to produto_url(Produto.last)\n  end\nend",
+                },
+                {
+                    type: "table",
+                    value: '[["Tipo de teste", "O que cobre"], ["model", "validações, escopos e regras"], ["integration", "a requisição inteira"], ["system", "o navegador de verdade"], ["mailer", "o email gerado"], ["job", "o trabalho em segundo plano"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Fixtures\n\nRails carrega os arquivos de `test/fixtures` no banco de teste antes da suíte. Cada teste roda dentro de uma transação que é desfeita ao final, então nenhum deixa lixo para o próximo.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual a ferramenta de teste padrão do Rails?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Minitest", isCorrect: true },
+                        { text: "RSpec, a mais popular na comunidade", isCorrect: false },
+                        { text: "Cucumber, com cenários em texto", isCorrect: false },
+                        { text: "Capybara, que dirige o navegador", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que um teste de integração cobre?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A requisição inteira, da rota à resposta", isCorrect: true },
+                        { text: "Apenas as validações declaradas no model", isCorrect: false },
+                        { text: "O comportamento do JavaScript na página", isCorrect: false },
+                        { text: "A comunicação com serviços externos", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que são as fixtures?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Dados carregados no banco antes da suíte", isCorrect: true },
+                        { text: "Métodos auxiliares usados pelos testes", isCorrect: false },
+                        {
+                            text: "Os arquivos que definem quais testes serão rodados",
+                            isCorrect: false,
+                        },
+                        { text: "As asserções disponíveis em cada tipo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que um teste não deixa lixo para o próximo?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Cada um roda em transação desfeita no fim", isCorrect: true },
+                        {
+                            text: "O banco de teste inteiro é recriado a cada teste",
+                            isCorrect: false,
+                        },
+                        { text: "As fixtures são recarregadas entre eles", isCorrect: false },
+                        { text: "Os testes rodam em ordem alfabética fixa", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `assert_difference('Produto.count', 1)` verifica?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Que o bloco criou exatamente um registro", isCorrect: true },
+                        { text: "Que a tabela tem ao menos um registro", isCorrect: false },
+                        { text: "Que a contagem foi consultada uma vez", isCorrect: false },
+                        { text: "Que o produto criado é diferente do anterior", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "System tests",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Testando como quem usa\n\nOs **system tests** abrem um navegador de verdade e interagem com a página: clicam, preenchem, esperam. Eles usam Capybara e Selenium, e o Rails já configura tudo no `rails new`.\n\nSão os únicos que provam que o JavaScript funciona, e é por isso que são indispensáveis em aplicação com Hotwire.",
+                },
+                {
+                    type: "code",
+                    value: "class CadastroDeProdutoTest < ApplicationSystemTestCase\n  test 'cadastra um produto pelo formulário' do\n    login_as usuarios(:ana)\n\n    visit produtos_path\n    click_on 'Novo produto'\n\n    fill_in 'Nome', with: 'Caneca esmaltada'\n    fill_in 'Preço', with: '39.90'\n    select 'Cozinha', from: 'Categoria'\n    click_on 'Salvar'\n\n    assert_text 'Produto criado com sucesso'\n    assert_selector 'h1', text: 'Caneca esmaltada'\n  end\nend",
+                },
+                {
+                    type: "text",
+                    value: "## O custo e o cuidado\n\nSystem tests são **lentos**: cada um sobe um navegador. A recomendação é cobrir os caminhos principais e deixar o detalhe para testes de model e integração.\n\nO problema clássico é a **instabilidade**: o teste falha às vezes porque verificou antes de a página terminar de atualizar. A solução não é `sleep`, é usar as asserções do Capybara, que já esperam pelo elemento por um tempo antes de falhar.",
+                },
+                {
+                    type: "quote",
+                    value: "Um teste que falha de vez em quando é pior que teste nenhum: a equipe aprende a ignorar a suíte vermelha.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que um system test usa que os outros não usam?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um navegador de verdade", isCorrect: true },
+                        { text: "Uma cópia do banco de produção", isCorrect: false },
+                        { text: "As fixtures carregadas na suíte", isCorrect: false },
+                        { text: "Um servidor separado para a API", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que system tests são indispensáveis com Hotwire?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "São os únicos que provam que o JavaScript funciona",
+                            isCorrect: true,
+                        },
+                        { text: "São os únicos que testam as rotas do projeto", isCorrect: false },
+                        { text: "São os mais rápidos de escrever e manter", isCorrect: false },
+                        {
+                            text: "São exigidos pelo próprio framework a partir do Rails 8",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual o principal custo dos system tests?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Eles são lentos para executar", isCorrect: true },
+                        { text: "Eles exigem um banco de dados separado", isCorrect: false },
+                        { text: "Eles não funcionam em ambiente de CI", isCorrect: false },
+                        { text: "Eles precisam ser escritos em JavaScript", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como resolver a instabilidade de um system test?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Usar as asserções que esperam pelo elemento", isCorrect: true },
+                        {
+                            text: "Acrescentar uma pausa antes de cada verificação",
+                            isCorrect: false,
+                        },
+                        { text: "Rodar o teste várias vezes até ele passar", isCorrect: false },
+                        { text: "Desligar o JavaScript durante a execução", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que um teste instável é pior que nenhum?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "A equipe aprende a ignorar a suíte vermelha", isCorrect: true },
+                        { text: "Ele consome tempo de execução da CI", isCorrect: false },
+                        { text: "Ele impede que outros testes sejam escritos", isCorrect: false },
+                        { text: "Ele deixa o banco de teste inconsistente", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Local CI com bin/ci, novidade do Rails 8.1",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# A CI que roda na sua máquina\n\nO conjunto de verificações antes de subir código costuma viver no arquivo do serviço de CI, em YAML. O resultado é que rodar tudo localmente exige lembrar cada comando na ordem certa, e o que roda na sua máquina nunca é exatamente o que roda no servidor.\n\nO **Rails 8.1** trouxe um **CI local declarativo**: um `config/ci.rb` descreve os passos, e `bin/ci` executa a mesma sequência em qualquer lugar.",
+                },
+                {
+                    type: "code",
+                    value: "# config/ci.rb\nCI.run do\n  step 'Setup', 'bin/setup --skip-server'\n  step 'Estilo do Ruby', 'bin/rubocop'\n  step 'Segurança das gems', 'bin/bundler-audit'\n  step 'Análise estática', 'bin/brakeman --quiet'\n  step 'Testes', 'bin/rails test'\n  step 'Testes de sistema', 'bin/rails test:system'\nend",
+                },
+                {
+                    type: "code",
+                    value: "bin/ci",
+                },
+                {
+                    type: "text",
+                    value: '## O ganho\n\nO mesmo arquivo vira a definição para o serviço de CI e para a máquina de quem desenvolve. Não existe mais a divergência entre "passou aqui" e "quebrou no servidor", e quem chega no projeto descobre em um arquivo só o que precisa passar.\n\nO Rails 8.1 já traz na geração os passos de RuboCop, do **Brakeman**, que procura falhas de segurança no código, e do bundler-audit, que confere se alguma gem tem vulnerabilidade conhecida.',
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o `config/ci.rb` do Rails 8.1 descreve?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Os passos de verificação do projeto", isCorrect: true },
+                        { text: "As dependências que o projeto precisa", isCorrect: false },
+                        { text: "Os ambientes em que ele pode rodar", isCorrect: false },
+                        { text: "As rotas que serão testadas na suíte", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual problema o CI local resolve?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "A divergência entre o que roda local e no servidor",
+                            isCorrect: true,
+                        },
+                        { text: "A lentidão dos testes de sistema na suíte", isCorrect: false },
+                        { text: "A falta de um serviço de CI contratado", isCorrect: false },
+                        {
+                            text: "A necessidade de escrever mais testes automatizados",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que o Brakeman verifica?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Falhas de segurança no código", isCorrect: true },
+                        { text: "O estilo do código conforme o guia", isCorrect: false },
+                        { text: "Se as gems têm vulnerabilidade conhecida", isCorrect: false },
+                        { text: "Se os testes cobrem todas as linhas", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o bundler-audit confere?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Se alguma gem tem vulnerabilidade conhecida", isCorrect: true },
+                        {
+                            text: "Se as gems do projeto estão na versão mais recente",
+                            isCorrect: false,
+                        },
+                        { text: "Se o Gemfile.lock está sincronizado", isCorrect: false },
+                        { text: "Se as gems são compatíveis entre si", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual comando executa a sequência definida?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "bin/ci", isCorrect: true },
+                        { text: "bin/rails ci, como subcomando", isCorrect: false },
+                        { text: "bin/rails test:all, rodando tudo", isCorrect: false },
+                        { text: "bin/setup, que prepara o ambiente", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Deploy com Kamal",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Do container ao servidor\n\nO **Kamal** é a ferramenta de deploy que acompanha o Rails 8. Ele constrói a imagem Docker, envia para os servidores, sobe a versão nova sem derrubar a antiga e refaz o caminho se algo falhar.\n\nA proposta é deixar hospedar em uma VPS tão simples quanto usar uma plataforma gerenciada, sem o custo dela.",
+                },
+                {
+                    type: "code",
+                    value: "# config/deploy.yml\nservice: loja\nimage: minhaconta/loja\n\nservers:\n  web:\n    - 192.168.0.1\n\nproxy:\n  ssl: true\n  host: loja.com.br\n\nenv:\n  secret:\n    - RAILS_MASTER_KEY\n    - DATABASE_URL",
+                },
+                {
+                    type: "code",
+                    value: "kamal setup      # primeira vez: prepara o servidor\nkamal deploy     # constrói, envia e troca a versão\nkamal rollback   # volta para a versão anterior\nkamal app logs -f\nkamal app exec 'bin/rails db:migrate'",
+                },
+                {
+                    type: "text",
+                    value: "## Duas mudanças do Rails 8.1\n\nO **Kamal 2.8** passou a usar um **registro local por padrão**, o que dispensa configurar um registro de imagens externo para começar.\n\nE a busca de credenciais por linha de comando permite ao deploy obter os segredos de um gerenciador na hora, em vez de deixá-los em arquivo no servidor.",
+                },
+                {
+                    type: "table",
+                    value: '[["Comando", "O que faz"], ["kamal setup", "prepara o servidor na primeira vez"], ["kamal deploy", "publica a versão nova"], ["kamal rollback", "volta para a anterior"], ["kamal app logs", "acompanha os logs"], ["kamal app exec", "roda um comando no container"]]',
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o Kamal faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Constrói a imagem e publica nos servidores", isCorrect: true },
+                        { text: "Cria os servidores em um provedor de nuvem", isCorrect: false },
+                        { text: "Monitora a aplicação depois de publicada", isCorrect: false },
+                        { text: "Gera os arquivos de configuração do Nginx", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `kamal rollback` faz?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Volta para a versão anterior", isCorrect: true },
+                        { text: "Desfaz a última migration aplicada", isCorrect: false },
+                        { text: "Remove a aplicação do servidor", isCorrect: false },
+                        { text: "Reinicia o container em execução", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a proposta do Kamal?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Tornar a VPS tão simples quanto uma plataforma", isCorrect: true },
+                        {
+                            text: "Substituir o Docker durante a construção da imagem",
+                            isCorrect: false,
+                        },
+                        { text: "Hospedar a aplicação sem nenhum servidor", isCorrect: false },
+                        { text: "Automatizar a criação dos testes de deploy", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que mudou no Kamal 2.8?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Ele passou a usar um registro local por padrão", isCorrect: true },
+                        {
+                            text: "Ele deixou de precisar do Docker instalado na máquina",
+                            isCorrect: false,
+                        },
+                        { text: "Ele passou a criar os servidores sozinho", isCorrect: false },
+                        { text: "Ele trocou o proxy embutido por Nginx", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como o Kamal evita derrubar a aplicação no deploy?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Sobe a versão nova antes de retirar a antiga", isCorrect: true },
+                        {
+                            text: "Coloca a aplicação inteira em modo de manutenção",
+                            isCorrect: false,
+                        },
+                        { text: "Faz o deploy fora do horário de pico", isCorrect: false },
+                        { text: "Publica em um servidor de cada vez", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Projeto final e para onde ir",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Juntando tudo\n\nPara fechar a trilha, construa um **quadro de tarefas colaborativo**. Ele exercita cada módulo desta trilha:\n\n1. Models de projeto, tarefa e comentário, com migrations e associações\n2. Rotas de recurso, controllers com strong parameters e views em ERB\n3. Validações, escopos e resolução de N+1 com includes\n4. Autenticação pelo gerador nativo, com consultas escopadas pelo usuário\n5. Hotwire: Turbo Frames na edição no lugar e Turbo Streams por difusão nos comentários\n6. Um job em Solid Queue para o resumo diário por email\n7. Testes de model, de integração e um system test do fluxo principal\n8. `bin/ci` verde e deploy com Kamal",
+                },
+                {
+                    type: "text",
+                    value: "O item 5 é o que mais ensina: quando um comentário de outra pessoa aparece na sua tela sem recarregar nada, fica claro o que o Hotwire propõe.",
+                },
+                {
+                    type: "text",
+                    value: "## Para onde ir depois\n\nRails é vasto, e alguns caminhos naturais a partir daqui:\n\n- **Aprofundar Active Record**: consultas complexas, `explain` e índices\n- **Desempenho**: perfilamento, cache em camadas e o custo real de cada consulta\n- **Rails como API**: modo `--api` com autenticação por token, para aplicativo móvel\n- **Ler o código do Rails**: ele é Ruby legível, e entender como o framework faz o que faz muda a forma de escrever o seu próprio código",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que resolve o N+1 no Active Record?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Carregar as associações com includes", isCorrect: true },
+                        { text: "Criar um índice na coluna estrangeira", isCorrect: false },
+                        { text: "Guardar a consulta em cache de fragmento", isCorrect: false },
+                        { text: "Usar um escopo em vez de where direto", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual peça do Hotwire faz o comentário aparecer sem recarregar?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O Turbo Stream por difusão", isCorrect: true },
+                        { text: "O Turbo Frame com o id do comentário", isCorrect: false },
+                        { text: "O Stimulus, ouvindo o evento de criação", isCorrect: false },
+                        { text: "O Turbo Drive, ao trocar o body da página", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a forma mais simples de autorizar o acesso a um registro?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Escopar a consulta pelo usuário atual", isCorrect: true },
+                        { text: "Comparar o id do dono dentro da view", isCorrect: false },
+                        { text: "Criar uma política para cada model do projeto", isCorrect: false },
+                        { text: "Usar um middleware antes do controller", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual tipo de teste cobre o fluxo principal com JavaScript?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O system test", isCorrect: true },
+                        { text: "O teste de integração da requisição", isCorrect: false },
+                        { text: "O teste de model, com as validações", isCorrect: false },
+                        { text: "O teste de job, em segundo plano", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que ler o código-fonte do Rails ajuda?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Ele é Ruby legível e ensina a escrever melhor", isCorrect: true },
+                        { text: "Ele mostra quais gems devem ser instaladas", isCorrect: false },
+                        {
+                            text: "Ele substitui a leitura da documentação oficial",
+                            isCorrect: false,
+                        },
+                        { text: "Ele permite alterar o framework no projeto", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+export const MODULOS: Modulo[] = [
+    MODULO_1,
+    MODULO_2,
+    MODULO_3,
+    MODULO_4,
+    MODULO_5,
+    MODULO_6,
+    MODULO_7,
+];
+
+async function seed() {
+    let [trilha] = await db.select().from(trails).where(eq(trails.name, NOME));
+    if (!trilha) {
+        [trilha] = await db
+            .insert(trails)
+            .values({
+                name: NOME,
+                trailLevel: LEVEL,
+                description: DESCRICAO,
+                workloadHours: CARGA_HORARIA,
+            })
+            .returning();
+        console.log("Trilha criada: " + NOME);
+    } else {
+        const existentes = await db.select().from(lessons).where(eq(lessons.trailId, trilha.id));
+        if (existentes.length > 0) {
+            console.log("Trilha já tem aulas, nada a fazer: " + NOME);
+            return;
+        }
+        await db
+            .update(trails)
+            .set({ workloadHours: CARGA_HORARIA, description: DESCRICAO, trailLevel: LEVEL })
+            .where(eq(trails.id, trilha.id));
+    }
+
+    let totalAulas = 0;
+    let totalQuestoes = 0;
+    for (let mi = 0; mi < MODULOS.length; mi++) {
+        const m = MODULOS[mi];
+        const [mod] = await db
+            .insert(modules)
+            .values({ trailId: trilha.id, title: m.titulo, position: mi + 1 })
+            .returning();
+        for (let li = 0; li < m.aulas.length; li++) {
+            const a = m.aulas[li];
+            const [lesson] = await db
+                .insert(lessons)
+                .values({
+                    trailId: trilha.id,
+                    moduleId: mod.id,
+                    title: a.titulo,
+                    content: null,
+                    contentBlocks: a.blocks,
+                    position: li + 1,
+                    published: true,
+                })
+                .returning();
+            for (let qi = 0; qi < a.questions.length; qi++) {
+                const q = a.questions[qi];
+                const [questao] = await db
+                    .insert(questions)
+                    .values({
+                        lessonId: lesson.id,
+                        statement: q.statement,
+                        difficulty: q.difficulty,
+                        position: qi + 1,
+                    })
+                    .returning();
+                await db.insert(questionOptions).values(
+                    q.options.map((o, k) => ({
+                        questionId: questao.id,
+                        text: o.text,
+                        isCorrect: o.isCorrect,
+                        position: k + 1,
+                    })),
+                );
+            }
+            totalAulas++;
+            totalQuestoes += a.questions.length;
+        }
+    }
+    console.log(
+        "Seed concluído: " +
+            MODULOS.length +
+            " módulos, " +
+            totalAulas +
+            " aulas, " +
+            totalQuestoes +
+            " questões.",
+    );
+}
+
+// Só semeia quando executado direto. Importado, expõe MODULOS/NOME sem rodar nada.
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+    seed()
+        .then(() => process.exit(0))
+        .catch((e) => {
+            console.error("Falha no seed:", e);
+            process.exit(1);
+        });
+}

--- a/backend/scripts/seed-trilha-ruby.ts
+++ b/backend/scripts/seed-trilha-ruby.ts
@@ -1,0 +1,3274 @@
+// Seed da trilha Ruby (Ruby 4.0). Conteúdo autoral.
+// A versão 4.0 saiu em dezembro de 2025 e é a que a trilha ensina: ZJIT, Set e
+// Pathname no core, Ractor::Port e operadores lógicos no começo da linha.
+//
+// Idempotente e nao destrutivo: se a trilha ja tiver aulas, nao faz nada.
+//
+// Rodar em prod: docker compose -f docker-compose.prod.yml run --rm -T --no-deps backend node scripts/seed-trilha-ruby.ts
+import { db } from "../db.ts";
+import { trails, modules, lessons, questions, questionOptions } from "../schema.ts";
+import { eq } from "drizzle-orm";
+import { pathToFileURL } from "node:url";
+
+export const NOME = "Ruby";
+const LEVEL: "iniciante" | "intermediario" | "avancado" = "iniciante";
+const DESCRICAO =
+    "Ruby 4.0 do zero ao uso real: tudo é objeto, coleções e Enumerable, blocos e iteradores, pattern matching, classes com módulos e mixins, exceções e testes com Minitest e RSpec, e o Ruby moderno com YJIT, ZJIT e Ractor. A linguagem por trás do Rails, do GitHub e do Shopify.";
+const CARGA_HORARIA = 20;
+
+type Bloco = { type: "text" | "code" | "quote" | "table"; value: string };
+type Questao = {
+    statement: string;
+    difficulty: "facil" | "medio" | "dificil";
+    options: { text: string; isCorrect: boolean }[];
+};
+type Aula = { titulo: string; blocks: Bloco[]; questions: Questao[] };
+type Modulo = { titulo: string; aulas: Aula[] };
+
+const MODULO_1: Modulo = {
+    titulo: "Módulo 1 - Primeiros passos com Ruby",
+    aulas: [
+        {
+            titulo: "O que é Ruby e por que ele existe",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Uma linguagem feita para pessoas\n\nRuby foi criada por Yukihiro Matsumoto, o Matz, e lançada em 1995. O objetivo declarado dele era incomum: fazer uma linguagem que desse **prazer de programar**, otimizada para quem escreve e lê o código, não para o computador.\n\nEssa escolha aparece em tudo. Ruby aceita várias formas de dizer a mesma coisa e o código costuma parecer com uma frase em inglês.",
+                },
+                {
+                    type: "code",
+                    value: '3.times { puts "Olá" }\n\n[1, 2, 3].each { |n| puts n * 2 }\n\nputs "adulto" if idade >= 18\n\n5.downto(1) { |n| puts n }',
+                },
+                {
+                    type: "text",
+                    value: "## Onde Ruby é usado\n\nO grande impulso veio do **Ruby on Rails**, lançado em 2004, que virou referência de produtividade em aplicações web. GitHub, Shopify, Airbnb e Basecamp nasceram em Rails.\n\nFora da web, Ruby aparece em automação, ferramentas de linha de comando e em toda ferramenta que usa Gemfile ou Rakefile.\n\nEsta trilha usa o **Ruby 4.0**, lançado em dezembro de 2025.",
+                },
+                {
+                    type: "quote",
+                    value: "Ruby é interpretada, de tipagem dinâmica e forte, e totalmente orientada a objetos: até um número é objeto.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual foi o objetivo declarado de quem criou o Ruby?",
+                    difficulty: "facil",
+                    options: [
+                        {
+                            text: "Fazer uma linguagem que desse prazer de programar",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Fazer a linguagem mais rápida do mundo em cálculos",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Substituir o C em programação de sistemas operacionais",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Criar uma linguagem só para desenvolvimento de jogos",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual framework popularizou o Ruby na web?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Ruby on Rails", isCorrect: true },
+                        { text: "Django, com sua estrutura de aplicativos", isCorrect: false },
+                        { text: "Spring, com sua injeção de dependência", isCorrect: false },
+                        { text: "Laravel, com seu sistema de rotas", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual versão do Ruby esta trilha usa?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Ruby 4.0", isCorrect: true },
+                        { text: "Ruby 2.7", isCorrect: false },
+                        { text: "Ruby 3.1", isCorrect: false },
+                        { text: "Ruby 1.9", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como se classifica a tipagem do Ruby?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Dinâmica e forte", isCorrect: true },
+                        { text: "Estática e fraca, verificada na compilação", isCorrect: false },
+                        { text: "Estática e forte, declarada em cada variável", isCorrect: false },
+                        { text: "Dinâmica e fraca, com conversão automática", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: 'O que `3.times { puts "Olá" }` demonstra sobre o Ruby?',
+                    difficulty: "medio",
+                    options: [
+                        { text: "Que até um número é um objeto com métodos", isCorrect: true },
+                        {
+                            text: "Que os laços precisam sempre de uma variável contadora",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Que o Ruby converte números em texto automaticamente",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Que a linguagem executa o bloco em paralelo por padrão",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Instalando o Ruby 4.0 e o irb",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Gerenciadores de versão\n\nQuase todo sistema traz uma versão antiga de Ruby, e projetos diferentes pedem versões diferentes. Por isso a comunidade usa gerenciadores como **rbenv**, **asdf** ou **mise**, que instalam várias versões e trocam entre elas por projeto.",
+                },
+                {
+                    type: "code",
+                    value: "# Com rbenv\nrbenv install 4.0.6\nrbenv global 4.0.6\n\nruby --version\n# ruby 4.0.6 (2026-07-14)\n\n# Fixando a versão de um projeto\necho '4.0.6' > .ruby-version",
+                },
+                {
+                    type: "text",
+                    value: "## O irb\n\nO **irb** é o console interativo do Ruby. Você digita uma expressão e vê o resultado na hora, o que faz dele o melhor lugar para testar uma ideia antes de escrevê-la em arquivo.",
+                },
+                {
+                    type: "code",
+                    value: 'irb\n\nirb(main):001> 2 + 2\n=> 4\nirb(main):002> "ruby".upcase\n=> "RUBY"\nirb(main):003> [3, 1, 2].sort\n=> [1, 2, 3]',
+                },
+                {
+                    type: "text",
+                    value: "## O primeiro arquivo\n\nSalve como `ola.rb` e rode com `ruby ola.rb`. Ruby não exige ponto e vírgula no fim das linhas, nem uma função principal para começar.",
+                },
+                {
+                    type: "code",
+                    value: 'nome = "Ana"\nputs "Olá, #{nome}!"\nputs "Rodando em Ruby #{RUBY_VERSION}"',
+                },
+            ],
+            questions: [
+                {
+                    statement: "Para que serve um gerenciador como o rbenv?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Instalar e alternar entre versões do Ruby", isCorrect: true },
+                        {
+                            text: "Instalar as bibliotecas que o projeto declara no Gemfile",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Compilar o código Ruby para um executável nativo",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Formatar o código conforme o guia de estilo oficial",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que é o irb?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "O console interativo do Ruby", isCorrect: true },
+                        { text: "O compilador oficial da linguagem Ruby", isCorrect: false },
+                        { text: "O gerenciador de pacotes usado pelo Rails", isCorrect: false },
+                        { text: "O servidor web embutido na instalação", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Ruby exige ponto e vírgula no fim de cada linha?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Não, ele é opcional", isCorrect: true },
+                        { text: "Sim, em todas as linhas de código", isCorrect: false },
+                        { text: "Sim, mas apenas dentro de classes", isCorrect: false },
+                        {
+                            text: "Sim, somente em arquivos com mais de uma linha",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Para que serve o arquivo `.ruby-version`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Fixar a versão que o projeto usa", isCorrect: true },
+                        { text: "Listar as gems que o projeto precisa instalar", isCorrect: false },
+                        {
+                            text: "Guardar as configurações do console interativo",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Definir quais arquivos serão executados primeiro",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Como se interpola uma variável dentro de uma string?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Com `#{}` dentro de aspas duplas", isCorrect: true },
+                        { text: "Com `${}` dentro de aspas duplas ou simples", isCorrect: false },
+                        { text: "Com `%{}` em qualquer tipo de aspas", isCorrect: false },
+                        { text: "Com `<%= %>` dentro de aspas simples", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Tudo é objeto",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Sem exceções\n\nEm muitas linguagens existem tipos primitivos, que não são objetos e não têm métodos. Em Ruby isso não existe: **todo valor é objeto**, e todo objeto responde a métodos.\n\nNúmeros, textos, `true`, `false` e até `nil` são objetos com métodos próprios.",
+                },
+                {
+                    type: "code",
+                    value: '42.class          # => Integer\n"texto".class     # => String\ntrue.class        # => TrueClass\nnil.class         # => NilClass\n42.even?          # => true\n-7.abs            # => 7\nnil.to_a          # => []',
+                },
+                {
+                    type: "text",
+                    value: "## Chamando métodos\n\nO ponto chama o método. Parênteses são opcionais quando não há ambiguidade, e a comunidade costuma omiti-los em chamadas sem argumento.\n\n## nil e o que é falso\n\nRuby tem uma regra rara e muito útil: **só `nil` e `false` são falsos**. Zero é verdadeiro, string vazia é verdadeira, array vazio é verdadeiro. Isso elimina uma classe inteira de bug que existe em outras linguagens.",
+                },
+                {
+                    type: "table",
+                    value: '[["Valor", "Em Ruby", "Em muitas outras linguagens"], ["0", "verdadeiro", "falso"], ["\\"\\"", "verdadeiro", "falso"], ["[]", "verdadeiro", "falso"], ["nil", "falso", "falso"], ["false", "falso", "falso"]]',
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que é objeto em Ruby?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Todo valor, sem exceção", isCorrect: true },
+                        {
+                            text: "Apenas as instâncias de classes que você define",
+                            isCorrect: false,
+                        },
+                        { text: "Somente os valores criados com a palavra new", isCorrect: false },
+                        { text: "Tudo, menos os números e os valores booleanos", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quais valores são falsos em Ruby?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Apenas nil e false", isCorrect: true },
+                        { text: "O nil, o false, o zero e a string vazia", isCorrect: false },
+                        { text: "O zero, a string vazia e o array vazio", isCorrect: false },
+                        { text: "O nil, o zero e qualquer coleção sem itens", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `0` vale dentro de um `if` em Ruby?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Verdadeiro", isCorrect: true },
+                        { text: "Falso, como na maioria das linguagens", isCorrect: false },
+                        { text: "Depende de estar em aspas ou não", isCorrect: false },
+                        { text: "Gera um aviso de conversão implícita", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `nil.class` devolve?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "NilClass", isCorrect: true },
+                        { text: "Um erro de método não encontrado", isCorrect: false },
+                        { text: "O valor nil de novo, sem classe", isCorrect: false },
+                        { text: "Object, a classe raiz da hierarquia", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Os parênteses na chamada de um método são obrigatórios?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Não, são opcionais", isCorrect: true },
+                        { text: "Sim, sempre que houver argumentos ou não", isCorrect: false },
+                        { text: "Sim, mas apenas em métodos de classe", isCorrect: false },
+                        { text: "Sim, apenas quando o método devolve valor", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Variáveis, símbolos e constantes",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O nome diz o escopo\n\nEm Ruby, o **primeiro caractere do nome** determina o tipo da variável. Não existe palavra-chave de declaração: você escreve o nome e o Ruby entende o alcance dele.",
+                },
+                {
+                    type: "table",
+                    value: '[["Forma", "Tipo", "Alcance"], ["nome", "local", "o bloco ou método atual"], ["@nome", "de instância", "o objeto"], ["@@nome", "de classe", "a classe e as filhas"], ["$nome", "global", "o programa inteiro"], ["Nome", "constante", "avisa ao ser mudada"]]',
+                },
+                {
+                    type: "code",
+                    value: "PI = 3.14159      # constante: muda com aviso, não com erro\n\nclass Contador\n  @@total = 0     # de classe, compartilhada\n\n  def initialize\n    @valor = 0    # de instância, uma por objeto\n    @@total += 1\n  end\nend",
+                },
+                {
+                    type: "text",
+                    value: "## Atribuição múltipla e o splat\n\nRuby desmonta coleções direto na atribuição, e o `*` recolhe o que sobrar.",
+                },
+                {
+                    type: "code",
+                    value: "a, b = 1, 2\na, b = b, a          # troca sem variável auxiliar\n\nprimeiro, *resto = [1, 2, 3, 4]\n# primeiro => 1, resto => [2, 3, 4]",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o `@` no começo do nome indica?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Uma variável de instância", isCorrect: true },
+                        { text: "Uma variável global do programa inteiro", isCorrect: false },
+                        { text: "Uma constante que não pode ser alterada", isCorrect: false },
+                        { text: "Uma variável local do método atual", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que acontece ao reatribuir uma constante em Ruby?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O Ruby emite um aviso, mas permite", isCorrect: true },
+                        { text: "O programa para com um erro fatal na hora", isCorrect: false },
+                        { text: "A atribuição é ignorada em completo silêncio", isCorrect: false },
+                        { text: "A constante vira uma variável local comum", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como se declara uma variável em Ruby?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Basta atribuir um valor a um nome", isCorrect: true },
+                        { text: "Usando a palavra-chave var antes do nome", isCorrect: false },
+                        { text: "Declarando o tipo antes do nome da variável", isCorrect: false },
+                        { text: "Usando a palavra let seguida do nome", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `a, b = b, a` faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Troca os valores das duas", isCorrect: true },
+                        { text: "Copia o valor de b para as duas variáveis", isCorrect: false },
+                        { text: "Cria um array com os dois valores dentro", isCorrect: false },
+                        { text: "Gera um erro de atribuição múltipla inválida", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Em `primeiro, *resto = [1, 2, 3, 4]`, o que `resto` recebe?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O array [2, 3, 4]", isCorrect: true },
+                        { text: "O último elemento do array, que é o 4", isCorrect: false },
+                        { text: "O array completo, com os quatro valores", isCorrect: false },
+                        { text: "Um array vazio, porque o splat vem depois", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Gems, Bundler e o Gemfile",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Bibliotecas em Ruby\n\nUma **gem** é uma biblioteca empacotada. O comando `gem` instala uma de cada vez, mas em projeto ninguém faz assim: usa-se o **Bundler**, que resolve as versões de todas as dependências juntas.",
+                },
+                {
+                    type: "code",
+                    value: "gem install rubocop\n\n# Em projeto, o caminho é o Bundler\nbundle init          # cria o Gemfile\nbundle add rspec     # acrescenta e instala\nbundle install       # instala o que o Gemfile declara\nbundle exec rspec    # roda usando as versões travadas",
+                },
+                {
+                    type: "text",
+                    value: "## Gemfile e Gemfile.lock\n\nO `Gemfile` declara o que o projeto quer, com restrições de versão. O `Gemfile.lock` grava as versões exatas resolvidas, e é ele que garante que todo mundo rode o mesmo código.",
+                },
+                {
+                    type: "code",
+                    value: 'source "https://rubygems.org"\nruby "4.0.6"\n\ngem "rails", "~> 8.1.0"\ngem "pg"\n\ngroup :development, :test do\n  gem "rubocop", require: false\n  gem "debug"\nend',
+                },
+                {
+                    type: "quote",
+                    value: "O operador ~> aceita atualizações de correção mas não de versão maior. Em ~> 8.1.0 entram 8.1.1 e 8.1.9, não entra 8.2.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que é uma gem?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Uma biblioteca Ruby empacotada", isCorrect: true },
+                        { text: "Um arquivo de configuração do projeto Ruby", isCorrect: false },
+                        { text: "Um comando interno do console interativo", isCorrect: false },
+                        { text: "Um formato de banco de dados usado no Rails", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o Bundler resolve que o `gem install` não resolve?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "As versões de todas as dependências juntas", isCorrect: true },
+                        {
+                            text: "A instalação de gems em sistemas operacionais antigos",
+                            isCorrect: false,
+                        },
+                        { text: "A compilação das gems escritas na linguagem C", isCorrect: false },
+                        {
+                            text: "A publicação de uma gem nova no repositório oficial",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que `~> 8.1.0` permite?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Atualizações de correção dentro da 8.1", isCorrect: true },
+                        {
+                            text: "Qualquer versão acima da 8.1.0, incluindo a 9.0",
+                            isCorrect: false,
+                        },
+                        { text: "Somente a versão 8.1.0 exata, sem atualização", isCorrect: false },
+                        { text: "Qualquer versão da linha 8, incluindo a 8.2", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o `Gemfile.lock` guarda?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "As versões exatas já resolvidas", isCorrect: true },
+                        { text: "As restrições de versão que o projeto declara", isCorrect: false },
+                        { text: "O código-fonte das gems que foram instaladas", isCorrect: false },
+                        { text: "A lista de gems disponíveis no RubyGems", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Para que serve `bundle exec` antes de um comando?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Rodar com as versões travadas do projeto", isCorrect: true },
+                        { text: "Instalar a gem antes de executar o comando", isCorrect: false },
+                        {
+                            text: "Executar o comando em segundo plano no terminal",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Atualizar as gems para as versões mais recentes",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_2: Modulo = {
+    titulo: "Módulo 2 - Tipos e coleções",
+    aulas: [
+        {
+            titulo: "Números e strings",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Números\n\n`Integer` não tem limite de tamanho em Ruby: ele cresce conforme a necessidade, sem estouro. `Float` segue o padrão de ponto flutuante, com as imprecisões de sempre, e para dinheiro existe `BigDecimal`.",
+                },
+                {
+                    type: "code",
+                    value: '2 ** 100        # => 1267650600228229401496703205376\n7 / 2           # => 3, divisão inteira\n7.0 / 2         # => 3.5\n7.fdiv(2)       # => 3.5\n0.1 + 0.2       # => 0.30000000000000004\n\nrequire "bigdecimal/util"\n("0.1".to_d + "0.2".to_d).to_s  # => "0.3"',
+                },
+                {
+                    type: "text",
+                    value: "## Strings\n\nAspas duplas interpolam e entendem escapes; aspas simples são literais. Strings em Ruby são **mutáveis** por padrão, o que surpreende quem vem de outras linguagens.",
+                },
+                {
+                    type: "code",
+                    value: 'nome = "ana silva"\n\nnome.upcase        # => "ANA SILVA"\nnome.capitalize    # => "Ana silva"\nnome.split(" ")    # => ["ana", "silva"]\nnome.sub("ana", "Ana")   # troca a primeira ocorrência\nnome.gsub("a", "@")      # troca todas\nnome.length        # => 9\nnome.include?("silva")   # => true',
+                },
+                {
+                    type: "text",
+                    value: "## O ponto de exclamação\n\nMuitos métodos vêm em par: `upcase` devolve uma cópia alterada e `upcase!` altera o objeto original. O `!` avisa que o método é destrutivo, e é convenção da linguagem, não regra do interpretador.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual o limite de tamanho de um Integer em Ruby?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Não existe limite fixo", isCorrect: true },
+                        {
+                            text: "Sessenta e quatro bits, como na maioria das linguagens",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Trinta e dois bits, com estouro silencioso acima disso",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Depende da arquitetura do processador da máquina",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual o resultado de `7 / 2` em Ruby?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "3", isCorrect: true },
+                        { text: "3.5, com a conversão automática para float", isCorrect: false },
+                        { text: "Um erro de divisão entre tipos diferentes", isCorrect: false },
+                        { text: "4, com o resultado arredondado para cima", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o `!` no fim de um método costuma indicar?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Que ele altera o próprio objeto", isCorrect: true },
+                        { text: "Que ele devolve verdadeiro ou falso apenas", isCorrect: false },
+                        { text: "Que ele lança uma exceção quando falha", isCorrect: false },
+                        { text: "Que ele é um método privado da classe", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a diferença entre `sub` e `gsub`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O gsub troca todas as ocorrências", isCorrect: true },
+                        {
+                            text: "O sub trabalha apenas com expressões regulares",
+                            isCorrect: false,
+                        },
+                        { text: "O gsub devolve um array em vez de uma string", isCorrect: false },
+                        { text: "O sub altera o objeto original da string", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que usar BigDecimal para dinheiro?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Float acumula erro de arredondamento", isCorrect: true },
+                        {
+                            text: "BigDecimal executa os cálculos bem mais rápido",
+                            isCorrect: false,
+                        },
+                        { text: "Float não aceita valores acima de mil reais", isCorrect: false },
+                        { text: "BigDecimal converte a moeda automaticamente", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Symbol e por que ele existe",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Um nome, não um texto\n\nUm **Symbol** parece uma string curta com dois-pontos na frente, mas o propósito é outro. String representa **conteúdo**; Symbol representa **identidade**, um nome usado como rótulo.\n\nA diferença prática: cada string nova ocupa um espaço novo na memória, enquanto o mesmo símbolo é sempre o mesmo objeto.",
+                },
+                {
+                    type: "code",
+                    value: '"nome".object_id == "nome".object_id   # => false, dois objetos\n:nome.object_id == :nome.object_id     # => true, o mesmo objeto\n\n:nome.class     # => Symbol\n:nome.to_s      # => "nome"\n"nome".to_sym   # => :nome',
+                },
+                {
+                    type: "text",
+                    value: "## Onde símbolos aparecem\n\nEles são a escolha padrão para chaves de hash, nomes de métodos e opções de configuração. Em toda parte onde o valor é um rótulo fixo do programa, e não um dado que veio do usuário.",
+                },
+                {
+                    type: "code",
+                    value: 'usuario = { nome: "Ana", idade: 28 }\n# equivale a { :nome => "Ana", :idade => 28 }\n\nusuario[:nome]      # => "Ana"\n\n[3, 1, 2].map(&:to_s)   # => ["3", "1", "2"]\n\nobjeto.respond_to?(:salvar)',
+                },
+                {
+                    type: "quote",
+                    value: "Regra prática: dado que veio de fora é String. Rótulo escrito no seu código é Symbol.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que um Symbol representa?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um nome ou rótulo, não conteúdo", isCorrect: true },
+                        { text: "Um texto curto com no máximo dez caracteres", isCorrect: false },
+                        { text: "Um número inteiro identificando o objeto", isCorrect: false },
+                        {
+                            text: "Uma constante global visível em todo o programa",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Duas ocorrências do mesmo símbolo são o mesmo objeto?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Sim, sempre", isCorrect: true },
+                        {
+                            text: "Não, cada uma ocupa memória nova como as strings",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Só quando estiverem no mesmo arquivo de código",
+                            isCorrect: false,
+                        },
+                        { text: "Só depois que o coletor de lixo é executado", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: 'O que `{ nome: "Ana" }` cria como chave?',
+                    difficulty: "medio",
+                    options: [
+                        { text: "O símbolo :nome", isCorrect: true },
+                        { text: 'A string "nome", com o valor entre aspas', isCorrect: false },
+                        { text: "Uma constante chamada nome dentro do hash", isCorrect: false },
+                        { text: "Um método chamado nome no objeto criado", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quando usar String em vez de Symbol?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Quando o valor é dado vindo de fora", isCorrect: true },
+                        { text: "Quando o valor é uma chave de hash do sistema", isCorrect: false },
+                        { text: "Quando o valor é o nome de um método a chamar", isCorrect: false },
+                        {
+                            text: "Quando o valor precisa ser comparado com outro",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que `&:to_s` faz em `map(&:to_s)`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Chama o método to_s em cada item", isCorrect: true },
+                        { text: "Converte o símbolo em uma string comum antes", isCorrect: false },
+                        {
+                            text: "Cria um bloco vazio que não faz nada com o item",
+                            isCorrect: false,
+                        },
+                        { text: "Compara cada item com o símbolo informado", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Array",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Listas ordenadas\n\nO Array guarda itens em ordem, aceita tipos misturados e cresce sozinho. Índices negativos contam do fim, o que economiza muito cálculo.",
+                },
+                {
+                    type: "code",
+                    value: "nums = [1, 2, 3, 4, 5]\n\nnums[0]        # => 1\nnums[-1]       # => 5, o último\nnums[1..3]     # => [2, 3, 4]\nnums.first(2)  # => [1, 2]\nnums.last      # => 5\n\nnums << 6           # acrescenta no fim\nnums.push(7)        # o mesmo\nnums.unshift(0)     # acrescenta no começo\nnums.pop            # remove e devolve o último",
+                },
+                {
+                    type: "text",
+                    value: "## Métodos que resolvem quase tudo\n\nO Array traz uma biblioteca enorme pronta. Vale conhecer os que aparecem toda hora.",
+                },
+                {
+                    type: "table",
+                    value: '[["Método", "O que faz"], ["sum, min, max", "soma, menor e maior"], ["sort, reverse", "ordena e inverte"], ["uniq", "remove repetidos"], ["compact", "remove os nil"], ["flatten", "achata arrays aninhados"], ["join(sep)", "vira string com separador"]]',
+                },
+                {
+                    type: "code",
+                    value: '[3, 1, 3, nil, 2].compact.uniq.sort   # => [1, 2, 3]\n[[1, 2], [3]].flatten                 # => [1, 2, 3]\n["a", "b"].join("-")                  # => "a-b"\n\n# Operações de conjunto\n[1, 2, 3] & [2, 3, 4]   # => [2, 3], interseção\n[1, 2] | [2, 3]         # => [1, 2, 3], união\n[1, 2, 3] - [2]         # => [1, 3], diferença',
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que `nums[-1]` devolve?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "O último item do array", isCorrect: true },
+                        { text: "Um erro de índice fora do intervalo válido", isCorrect: false },
+                        { text: "O primeiro item, contando de trás para frente", isCorrect: false },
+                        { text: "O valor nil, porque o índice é negativo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `uniq` faz?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Remove os itens repetidos", isCorrect: true },
+                        { text: "Ordena os itens e remove os valores nulos", isCorrect: false },
+                        { text: "Devolve apenas o primeiro item do array", isCorrect: false },
+                        { text: "Junta os itens em uma única string de texto", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `compact` remove de um array?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Os valores nil", isCorrect: true },
+                        {
+                            text: "Os valores repetidos que aparecem mais de uma vez",
+                            isCorrect: false,
+                        },
+                        { text: "Os arrays aninhados dentro do array principal", isCorrect: false },
+                        { text: "Os valores falsos, incluindo o false e o nil", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `[1, 2, 3] & [2, 3, 4]` devolve?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "[2, 3]", isCorrect: true },
+                        { text: "[1, 2, 3, 4], que é a união dos dois arrays", isCorrect: false },
+                        {
+                            text: "[1, 4], que são os itens exclusivos de cada um",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "true, porque existem itens em comum entre eles",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que `<<` faz em um array?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Acrescenta um item no fim", isCorrect: true },
+                        { text: "Compara o array com o valor da direita", isCorrect: false },
+                        { text: "Remove o último item e o devolve", isCorrect: false },
+                        { text: "Insere o item na primeira posição", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Hash",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Pares de chave e valor\n\nO Hash guarda pares e mantém a ordem de inserção. As chaves costumam ser símbolos, mas podem ser qualquer objeto.",
+                },
+                {
+                    type: "code",
+                    value: 'usuario = { nome: "Ana", idade: 28, ativo: true }\n\nusuario[:nome]              # => "Ana"\nusuario[:cidade]            # => nil\nusuario.fetch(:cidade, "?") # => "?", com padrão\nusuario.fetch(:cidade)      # KeyError, avisa em vez de esconder\n\nusuario[:email] = "a@b.c"\nusuario.delete(:ativo)\nusuario.key?(:nome)         # => true',
+                },
+                {
+                    type: "text",
+                    value: "## Percorrendo\n\nO `each` de um hash entrega chave e valor. Os métodos de transformação também existem em versão específica de hash.",
+                },
+                {
+                    type: "code",
+                    value: 'usuario.each do |chave, valor|\n  puts "#{chave}: #{valor}"\nend\n\nusuario.keys        # => [:nome, :idade]\nusuario.values      # => ["Ana", 28]\nusuario.transform_values(&:to_s)\nusuario.select { |_, v| v.is_a?(String) }\nusuario.merge(cidade: "Recife")',
+                },
+                {
+                    type: "quote",
+                    value: "Prefira fetch a colchetes quando a chave é obrigatória: colchetes devolvem nil e o erro só aparece muito depois.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que `hash[:inexistente]` devolve?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "nil", isCorrect: true },
+                        { text: "Um KeyError avisando que a chave não existe", isCorrect: false },
+                        { text: "Uma string vazia como valor padrão do hash", isCorrect: false },
+                        { text: "O primeiro valor guardado dentro do hash", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a vantagem de `fetch` sobre os colchetes?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Ele avisa quando a chave não existe", isCorrect: true },
+                        {
+                            text: "Ele funciona com chaves de qualquer tipo de objeto",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Ele devolve o valor bem mais rápido que os colchetes",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Ele mantém a ordem de inserção dos pares no hash",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O Hash mantém a ordem em que os pares foram inseridos?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Sim, mantém", isCorrect: true },
+                        {
+                            text: "Não, a ordem é sempre aleatória a cada execução",
+                            isCorrect: false,
+                        },
+                        { text: "Não, os pares ficam ordenados pelas chaves", isCorrect: false },
+                        { text: "Só quando as chaves usadas forem símbolos", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `each` de um hash entrega ao bloco?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "A chave e o valor", isCorrect: true },
+                        { text: "Apenas o valor de cada par guardado no hash", isCorrect: false },
+                        { text: "Um array com todos os pares de uma só vez", isCorrect: false },
+                        { text: "Apenas as chaves, na ordem de inserção delas", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `merge` faz com dois hashes?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Devolve um novo com os dois juntos", isCorrect: true },
+                        {
+                            text: "Altera o primeiro hash acrescentando o segundo",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Devolve apenas as chaves comuns aos dois hashes",
+                            isCorrect: false,
+                        },
+                        { text: "Compara os dois e devolve verdadeiro ou falso", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Range e o Set, agora no core do Ruby 4.0",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Range\n\nUm Range representa um intervalo. Dois pontos incluem o fim, três pontos excluem. Ele é preguiçoso: `(1..1_000_000)` não cria um milhão de objetos.",
+                },
+                {
+                    type: "code",
+                    value: '(1..5).to_a        # => [1, 2, 3, 4, 5]\n(1...5).to_a       # => [1, 2, 3, 4]\n(\'a\'..\'e\').to_a    # => ["a", "b", "c", "d", "e"]\n\n(1..10).include?(7)   # => true\n(1..10).step(3).to_a  # => [1, 4, 7, 10]\n\n# Muito usado em case\ncase idade\nwhen 0..12 then "criança"\nwhen 13..17 then "adolescente"\nelse "adulto"\nend',
+                },
+                {
+                    type: "text",
+                    value: '# Set\n\nUm Set é uma coleção **sem repetição** e com busca rápida. Até o Ruby 3.x ele morava na biblioteca padrão e exigia `require "set"`.\n\nNo **Ruby 4.0** o Set foi promovido a **classe do core**, disponível sem require, e ganhou uma forma de inspeção nova: `Set[1, 2, 3]`.',
+                },
+                {
+                    type: "code",
+                    value: "# Ruby 4.0: sem require\ns = Set[1, 2, 3]\ns << 3\ns.size          # => 3, o repetido não entrou\ns.include?(2)   # => true, e a busca é rápida\n\na = Set[1, 2, 3]\nb = Set[3, 4]\na | b           # => Set[1, 2, 3, 4]\na & b           # => Set[3]\na - b           # => Set[1, 2]",
+                },
+                {
+                    type: "text",
+                    value: "Junto do Set, o **Pathname** também virou classe do core no Ruby 4.0, deixando de ser gem padrão. O `SortedSet`, por outro lado, foi removido: quem precisar dele instala a gem separada.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual a diferença entre `1..5` e `1...5`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Os três pontos excluem o fim", isCorrect: true },
+                        { text: "Os três pontos excluem o começo do intervalo", isCorrect: false },
+                        { text: "Os três pontos criam um intervalo de texto", isCorrect: false },
+                        {
+                            text: "Não existe diferença prática entre as duas formas",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que mudou com o Set no Ruby 4.0?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Ele virou classe do core, sem require", isCorrect: true },
+                        {
+                            text: "Ele passou a aceitar valores repetidos na coleção",
+                            isCorrect: false,
+                        },
+                        { text: "Ele foi removido e virou uma gem separada", isCorrect: false },
+                        { text: "Ele deixou de manter a ordem de inserção", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que caracteriza um Set?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Não guardar valores repetidos", isCorrect: true },
+                        { text: "Guardar os itens sempre em ordem crescente", isCorrect: false },
+                        { text: "Aceitar apenas números inteiros como itens", isCorrect: false },
+                        { text: "Ter um tamanho máximo definido na criação", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que aconteceu com o SortedSet no Ruby 4.0?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Foi removido e virou gem separada", isCorrect: true },
+                        {
+                            text: "Foi promovido a classe do core junto com o Set",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Passou a ser o comportamento padrão de todo Set",
+                            isCorrect: false,
+                        },
+                        { text: "Foi renomeado para OrderedSet dentro do core", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Um Range de um a um milhão cria um milhão de objetos?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Não, ele é preguiçoso", isCorrect: true },
+                        {
+                            text: "Sim, todos são criados no momento da declaração",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Sim, mas apenas quando o range é uma constante",
+                            isCorrect: false,
+                        },
+                        { text: "Depende da memória disponível na máquina", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_3: Modulo = {
+    titulo: "Módulo 3 - Controle de fluxo e blocos",
+    aulas: [
+        {
+            titulo: "Condicionais e o valor de retorno",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Tudo devolve valor\n\nEm Ruby quase toda construção é uma **expressão**, e não uma instrução: ela devolve valor. Um `if` inteiro pode ser atribuído a uma variável, o que dispensa a repetição de atribuições dentro de cada braço.",
+                },
+                {
+                    type: "code",
+                    value: 'faixa = if idade < 13\n          "criança"\n        elsif idade < 18\n          "adolescente"\n        else\n          "adulto"\n        end\n\n# O método devolve a última expressão avaliada, sem precisar de return\ndef par?(n)\n  n % 2 == 0\nend',
+                },
+                {
+                    type: "text",
+                    value: "## unless e os modificadores\n\n`unless` é o `if` negado, e existe para evitar a leitura truncada de `if !condicao`. Ambos podem vir no fim da linha, o que se lê quase como uma frase.",
+                },
+                {
+                    type: "code",
+                    value: 'puts "Bem-vinda" if logada\nputs "Faça login" unless logada\n\nreturn if lista.empty?\n\n# O ternário existe, para casos curtos\nstatus = ativo ? "ativo" : "inativo"',
+                },
+                {
+                    type: "quote",
+                    value: "Use unless só com condição simples. unless com && ou || vira quebra-cabeça para quem lê depois.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que um `if` devolve em Ruby?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O valor do braço executado", isCorrect: true },
+                        { text: "Sempre o valor booleano verdadeiro ou falso", isCorrect: false },
+                        { text: "O valor nil, porque if é uma instrução", isCorrect: false },
+                        { text: "A condição que foi avaliada por último", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que um método devolve sem a palavra `return`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A última expressão avaliada", isCorrect: true },
+                        { text: "O valor nil, como na maioria das linguagens", isCorrect: false },
+                        { text: "O primeiro valor calculado dentro do método", isCorrect: false },
+                        {
+                            text: "Um erro avisando que falta o retorno explícito",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Para que serve o `unless`?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "É o if com a condição negada", isCorrect: true },
+                        { text: "É um laço que repete até a condição ser falsa", isCorrect: false },
+                        { text: "É o if que só funciona no fim de uma linha", isCorrect: false },
+                        { text: "É a forma de tratar exceções sem usar rescue", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: 'O que `puts "oi" if ativo` faz?',
+                    difficulty: "facil",
+                    options: [
+                        { text: "Imprime apenas quando ativo é verdadeiro", isCorrect: true },
+                        { text: "Imprime sempre e depois avalia a condição", isCorrect: false },
+                        {
+                            text: "Atribui o resultado da condição à variável ativo",
+                            isCorrect: false,
+                        },
+                        { text: "Gera um erro por falta do bloco end no fim", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quando evitar o `unless`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Com condições compostas por e ou ou", isCorrect: true },
+                        { text: "Sempre que ele estiver no fim de uma linha", isCorrect: false },
+                        { text: "Quando a condição envolver números inteiros", isCorrect: false },
+                        { text: "Quando houver um else no mesmo bloco", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "case e pattern matching",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O case clássico\n\nO `case` do Ruby compara com o operador `===`, que cada classe define do seu jeito. Por isso ele aceita intervalo, expressão regular e classe no `when`, sem sintaxe especial.",
+                },
+                {
+                    type: "code",
+                    value: 'case valor\nwhen Integer then "número inteiro"\nwhen 1..10 then "está entre um e dez"\nwhen /^\\d+$/ then "texto só de dígitos"\nwhen String then "outro texto"\nelse "não sei"\nend',
+                },
+                {
+                    type: "text",
+                    value: "## case/in: pattern matching\n\nDesde o Ruby 3.0 existe o `case/in`, que **desmonta** a estrutura enquanto compara. Ele brilha ao tratar JSON e respostas de API, onde antes era preciso uma sequência de acessos e verificações.",
+                },
+                {
+                    type: "code",
+                    value: 'resposta = { status: "ok", dados: { id: 7, nome: "Ana" } }\n\ncase resposta\nin { status: "ok", dados: { id: Integer => id, nome: String => nome } }\n  puts "Usuário #{id} chamado #{nome}"\nin { status: "erro", mensagem: String => msg }\n  puts "Falhou: #{msg}"\nelse\n  puts "Formato desconhecido"\nend',
+                },
+                {
+                    type: "text",
+                    value: "O `in` casa a forma e já cria as variáveis. Se nenhum padrão casar e não houver `else`, o Ruby levanta `NoMatchingPatternError`, o que evita seguir em silêncio com dado inesperado.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual operador o `case` clássico usa na comparação?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O `===`", isCorrect: true },
+                        {
+                            text: "O `==`, igual à comparação comum entre valores",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O `equal?`, que compara a identidade do objeto",
+                            isCorrect: false,
+                        },
+                        { text: "O `eql?`, que compara valor e também o tipo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o `case/in` faz além de comparar?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Desmonta a estrutura e cria variáveis", isCorrect: true },
+                        {
+                            text: "Executa todos os braços que casarem com o valor",
+                            isCorrect: false,
+                        },
+                        { text: "Converte o valor para hash antes de comparar", isCorrect: false },
+                        { text: "Ordena as chaves do hash antes da comparação", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "O que acontece quando nenhum padrão do `case/in` casa e não há `else`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "É levantado um NoMatchingPatternError", isCorrect: true },
+                        {
+                            text: "O resultado é nil e a execução segue normalmente",
+                            isCorrect: false,
+                        },
+                        { text: "O primeiro padrão é usado como valor padrão", isCorrect: false },
+                        { text: "O Ruby emite apenas um aviso no terminal", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que o `case` aceita `when Integer` sem sintaxe especial?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Porque a classe define o operador de comparação",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Porque o Ruby converte a classe em texto antes",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Porque existe um tratamento especial para classes",
+                            isCorrect: false,
+                        },
+                        { text: "Porque o when sempre compara o tipo do valor", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Em que situação o pattern matching mais ajuda?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Ao tratar dados aninhados como JSON", isCorrect: true },
+                        { text: "Ao comparar dois números inteiros simples", isCorrect: false },
+                        { text: "Ao percorrer um array de valores repetidos", isCorrect: false },
+                        { text: "Ao definir constantes no topo de uma classe", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Laços e iteradores",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Ruby prefere iteradores\n\nO `while` e o `for` existem, mas raramente aparecem em código Ruby. A comunidade usa **iteradores**: métodos que recebem um bloco e cuidam da repetição.\n\nO motivo não é estilo apenas. O iterador diz **o quê** você quer, enquanto o laço diz **como** percorrer, e o primeiro erra menos.",
+                },
+                {
+                    type: "code",
+                    value: "# Existe, mas quase não se usa\ni = 0\nwhile i < 3\n  puts i\n  i += 1\nend\n\n# O jeito Ruby\n3.times { |i| puts i }\n[1, 2, 3].each { |n| puts n }\n1.upto(3) { |n| puts n }\n5.downto(1) { |n| puts n }\n(1..10).step(2) { |n| puts n }",
+                },
+                {
+                    type: "table",
+                    value: '[["Iterador", "O que faz"], ["each", "percorre item a item"], ["each_with_index", "entrega item e posição"], ["times", "repete n vezes"], ["upto e downto", "conta para cima ou para baixo"], ["loop", "repete até um break"]]',
+                },
+                {
+                    type: "code",
+                    value: '%w[a b c].each_with_index do |letra, i|\n  puts "#{i}: #{letra}"\nend\n\n# next pula, break sai\n(1..10).each do |n|\n  next if n.odd?\n  break if n > 6\n  puts n\nend',
+                },
+            ],
+            questions: [
+                {
+                    statement: "Por que a comunidade Ruby prefere iteradores a laços?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Eles dizem o quê, não como percorrer", isCorrect: true },
+                        {
+                            text: "Eles executam bem mais rápido que os laços comuns",
+                            isCorrect: false,
+                        },
+                        { text: "Eles são a única forma de percorrer um array", isCorrect: false },
+                        {
+                            text: "Eles permitem alterar a coleção durante o percurso",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que `each_with_index` entrega ao bloco?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "O item e a posição dele", isCorrect: true },
+                        { text: "Apenas a posição de cada item da coleção", isCorrect: false },
+                        { text: "O item e o total de itens da coleção", isCorrect: false },
+                        { text: "Apenas o item, como faz o each comum", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `next` faz dentro de um bloco?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Pula para a próxima repetição", isCorrect: true },
+                        {
+                            text: "Encerra a repetição por completo naquele ponto",
+                            isCorrect: false,
+                        },
+                        { text: "Reinicia a repetição desde o primeiro item", isCorrect: false },
+                        { text: "Devolve o valor atual e encerra o método", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `%w[a b c]` cria?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um array de strings", isCorrect: true },
+                        { text: "Um array de símbolos com os mesmos nomes", isCorrect: false },
+                        { text: "Uma string única com as três letras juntas", isCorrect: false },
+                        { text: "Um hash com as letras como chaves e valores", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `5.downto(1)` faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Conta de cinco até um", isCorrect: true },
+                        { text: "Conta de um até cinco, na ordem crescente", isCorrect: false },
+                        { text: "Divide o número cinco pelo valor informado", isCorrect: false },
+                        { text: "Repete o bloco cinco vezes sem contador", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Blocos, yield e o bloco explícito",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O bloco é a marca do Ruby\n\nUm **bloco** é um trecho de código passado a um método. Entre chaves quando cabe em uma linha, entre `do` e `end` quando tem mais.\n\nTodo método pode receber um bloco, mesmo sem declarar nada. Ele executa o bloco com `yield`.",
+                },
+                {
+                    type: "code",
+                    value: 'def duas_vezes\n  yield\n  yield\nend\n\nduas_vezes { puts "oi" }\n# oi\n# oi\n\ndef com_valor\n  yield 10\n  yield 20\nend\n\ncom_valor { |n| puts n * 2 }   # 20 e 40',
+                },
+                {
+                    type: "text",
+                    value: "## Verificando e recebendo\n\n`block_given?` diz se veio bloco, e evita o erro de chamar `yield` sem ter recebido um. Para guardar o bloco ou repassá-lo, declare com `&`, o que o transforma em um objeto `Proc`.",
+                },
+                {
+                    type: "code",
+                    value: 'def talvez\n  return "sem bloco" unless block_given?\n  yield\nend\n\ndef guardando(&bloco)\n  @callback = bloco    # agora é um objeto\n  bloco.call(5)\nend\n\ndef repassando(&bloco)\n  [1, 2, 3].each(&bloco)\nend',
+                },
+                {
+                    type: "text",
+                    value: "## O padrão que blocos permitem\n\nO uso mais elegante é garantir que algo seja fechado, aconteça o que acontecer. É assim que o próprio Ruby entrega arquivos.",
+                },
+                {
+                    type: "code",
+                    value: 'File.open("dados.txt") do |arquivo|\n  puts arquivo.read\nend\n# o arquivo é fechado sozinho, mesmo se der erro\n\ndef medindo\n  inicio = Time.now\n  resultado = yield\n  puts "Levou #{Time.now - inicio}s"\n  resultado\nend',
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que `yield` faz dentro de um método?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Executa o bloco recebido", isCorrect: true },
+                        { text: "Devolve o valor e encerra o método na hora", isCorrect: false },
+                        { text: "Cria um bloco novo dentro do próprio método", isCorrect: false },
+                        { text: "Interrompe a execução até o bloco terminar", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como saber se um bloco foi passado ao método?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Com `block_given?`", isCorrect: true },
+                        {
+                            text: "Com `has_block?`, que devolve verdadeiro ou falso",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Verificando se a variável bloco não está vazia",
+                            isCorrect: false,
+                        },
+                        { text: "Não é possível saber antes de chamar o yield", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o `&` faz em `def metodo(&bloco)`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Transforma o bloco em um objeto Proc", isCorrect: true },
+                        {
+                            text: "Torna o bloco obrigatório na chamada do método",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Executa o bloco antes do corpo do método rodar",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Passa o bloco por referência em vez de por cópia",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual a vantagem de `File.open` com bloco?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O arquivo é fechado mesmo se der erro", isCorrect: true },
+                        {
+                            text: "O arquivo é lido bem mais rápido do que sem bloco",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O conteúdo é convertido para array automaticamente",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O arquivo pode ser aberto por vários processos",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Quando usar `do` e `end` em vez de chaves?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Quando o bloco tem mais de uma linha", isCorrect: true },
+                        { text: "Quando o bloco recebe mais de um argumento", isCorrect: false },
+                        {
+                            text: "Quando o método devolve um valor para o chamador",
+                            isCorrect: false,
+                        },
+                        { text: "Quando o bloco está dentro de outro bloco", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Proc e lambda",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Guardando comportamento em variável\n\nBlocos não são objetos: você não pode guardá-los em uma variável. `Proc` e `lambda` são a versão objeto de um bloco, e podem ser passados adiante.\n\nElas parecem iguais e têm **duas diferenças que importam**.",
+                },
+                {
+                    type: "code",
+                    value: "quadrado = ->(n) { n * n }     # lambda, forma curta\ndobro = lambda { |n| n * 2 }   # lambda, forma longa\ntriplo = Proc.new { |n| n * 3 }\n\nquadrado.call(4)   # => 16\nquadrado.(4)       # => 16\nquadrado[4]        # => 16",
+                },
+                {
+                    type: "text",
+                    value: "## Diferença 1: argumentos\n\nA **lambda é rigorosa**: erra a quantidade de argumentos e ela levanta `ArgumentError`. A **Proc é tolerante**: preenche o que falta com `nil` e ignora o que sobra.\n\n## Diferença 2: o return\n\nO `return` dentro de uma lambda sai só da lambda. Dentro de uma Proc, ele sai do **método inteiro** que a contém, o que costuma surpreender.",
+                },
+                {
+                    type: "code",
+                    value: "l = ->(a, b) { [a, b] }\nl.call(1)        # ArgumentError\n\np = Proc.new { |a, b| [a, b] }\np.call(1)        # => [1, nil], sem reclamar\n\ndef teste_lambda\n  l = -> { return 10 }\n  l.call\n  20               # devolve 20\nend\n\ndef teste_proc\n  p = Proc.new { return 10 }\n  p.call\n  20               # nunca chega aqui, devolve 10\nend",
+                },
+                {
+                    type: "quote",
+                    value: "Na dúvida, use lambda. O comportamento rigoroso avisa o erro cedo, e o return se comporta como se espera.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que acontece ao chamar uma lambda com argumentos a menos?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Ela levanta ArgumentError", isCorrect: true },
+                        { text: "Ela preenche os que faltam com o valor nil", isCorrect: false },
+                        { text: "Ela devolve nil sem executar o corpo dela", isCorrect: false },
+                        { text: "Ela usa os valores da chamada anterior a essa", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `return` faz dentro de uma Proc?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Sai do método que a contém", isCorrect: true },
+                        {
+                            text: "Sai apenas da Proc e segue o método normalmente",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Levanta um erro avisando que return é inválido",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Devolve o valor para a variável da Proc apenas",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual a forma curta de criar uma lambda?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Com `->`", isCorrect: true },
+                        { text: "Com `Proc.new` seguido do bloco de código", isCorrect: false },
+                        { text: "Com `def` sem informar o nome do método", isCorrect: false },
+                        { text: "Com `&` na frente do bloco entre chaves", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como se executa uma lambda guardada em `f`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Com `f.call`", isCorrect: true },
+                        { text: "Com `f` sozinho, como se fosse uma variável", isCorrect: false },
+                        { text: "Com `f.run`, que executa o corpo do bloco", isCorrect: false },
+                        { text: "Com `yield f`, passando a lambda adiante", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual usar por padrão, entre Proc e lambda?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Lambda, pelo comportamento previsível", isCorrect: true },
+                        {
+                            text: "Proc, por ser mais tolerante com os argumentos",
+                            isCorrect: false,
+                        },
+                        { text: "Proc, porque ela executa bem mais rápido", isCorrect: false },
+                        {
+                            text: "Tanto faz, as duas se comportam do mesmo jeito",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_4: Modulo = {
+    titulo: "Módulo 4 - Enumerable e métodos",
+    aulas: [
+        {
+            titulo: "Enumerable: map, select e reduce",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O módulo que dá superpoderes\n\n`Enumerable` é um módulo com dezenas de métodos de transformação. Array, Hash, Range e Set o incluem, e é por isso que todos eles respondem aos mesmos métodos.\n\nQualquer classe sua também pode incluí-lo: basta implementar `each`.",
+                },
+                {
+                    type: "code",
+                    value: "nums = [1, 2, 3, 4, 5, 6]\n\nnums.map { |n| n * 2 }         # => [2, 4, 6, 8, 10, 12]\nnums.select { |n| n.even? }    # => [2, 4, 6]\nnums.reject { |n| n.even? }    # => [1, 3, 5]\nnums.reduce(0) { |soma, n| soma + n }   # => 21\nnums.sum                       # => 21, atalho do reduce",
+                },
+                {
+                    type: "table",
+                    value: '[["Método", "Devolve"], ["map", "um item novo para cada original"], ["select e reject", "os que passam ou não no teste"], ["find", "o primeiro que passa"], ["reduce", "um valor acumulado"], ["group_by", "hash agrupando por critério"], ["partition", "dois arrays, passou e não passou"]]',
+                },
+                {
+                    type: "code",
+                    value: 'pessoas = [\n  { nome: "Ana", idade: 28 },\n  { nome: "Bruno", idade: 17 },\n  { nome: "Carla", idade: 34 },\n]\n\npessoas.group_by { |p| p[:idade] >= 18 }\npessoas.partition { |p| p[:idade] >= 18 }\npessoas.sum { |p| p[:idade] }        # => 79\npessoas.max_by { |p| p[:idade] }     # a Carla\npessoas.sort_by { |p| p[:nome] }',
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que um objeto precisa implementar para incluir Enumerable?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O método each", isCorrect: true },
+                        { text: "Os métodos map, select e reduce completos", isCorrect: false },
+                        { text: "O método to_a que converte para array", isCorrect: false },
+                        { text: "Um método chamado size devolvendo o total", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a diferença entre `map` e `select`?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "O map transforma, o select filtra", isCorrect: true },
+                        { text: "O map filtra os itens e o select transforma", isCorrect: false },
+                        {
+                            text: "O map devolve um valor só e o select devolve vários",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O map altera o original e o select devolve cópia",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que `reduce` devolve?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um valor acumulado", isCorrect: true },
+                        { text: "Uma coleção do mesmo tamanho da original", isCorrect: false },
+                        { text: "Apenas o primeiro item que passa no teste", isCorrect: false },
+                        { text: "Um hash agrupando os itens por critério", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `partition` devolve?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Dois arrays, o que passou e o que não", isCorrect: true },
+                        { text: "Um hash com os itens agrupados por critério", isCorrect: false },
+                        { text: "Apenas os itens que passaram na condição", isCorrect: false },
+                        { text: "O array original dividido ao meio em tamanho", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que Array, Hash e Range respondem aos mesmos métodos?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Todos incluem o módulo Enumerable", isCorrect: true },
+                        {
+                            text: "Todos herdam da mesma classe pai chamada Object",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O Ruby copia os métodos entre as classes internas",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Cada um implementa os métodos por conta própria",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Métodos: argumentos e retorno",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Definindo métodos\n\nO `def` cria um método. Não há declaração de tipo, e o retorno é a última expressão avaliada.",
+                },
+                {
+                    type: "code",
+                    value: 'def saudacao(nome, saudacao = "Olá")\n  "#{saudacao}, #{nome}!"\nend\n\nsaudacao("Ana")            # => "Olá, Ana!"\nsaudacao("Ana", "E aí")    # => "E aí, Ana!"',
+                },
+                {
+                    type: "text",
+                    value: "## Argumentos variáveis\n\nO `*` recolhe os posicionais que sobraram em um array, e o `**` recolhe os nomeados em um hash.",
+                },
+                {
+                    type: "code",
+                    value: 'def somar(*numeros)\n  numeros.sum\nend\nsomar(1, 2, 3)      # => 6\n\ndef configurar(**opcoes)\n  opcoes\nend\nconfigurar(tema: "escuro", idioma: "pt")\n\ndef tudo(obrigatorio, *resto, **opcoes, &bloco)\n  # a ordem dos tipos de argumento é fixa\nend',
+                },
+                {
+                    type: "text",
+                    value: "## Devolvendo mais de um valor\n\nO método devolve um array e a atribuição múltipla o desmonta na chamada, o que dá a impressão de vários retornos.",
+                },
+                {
+                    type: "code",
+                    value: "def divisao_com_resto(a, b)\n  [a / b, a % b]\nend\n\nquociente, resto = divisao_com_resto(7, 2)\n# quociente => 3, resto => 1",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que um método devolve quando não há `return`?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "A última expressão avaliada", isCorrect: true },
+                        {
+                            text: "O valor nil, como acontece em outras linguagens",
+                            isCorrect: false,
+                        },
+                        { text: "O primeiro argumento recebido pelo método", isCorrect: false },
+                        { text: "Um erro pedindo o retorno explícito no corpo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `*numeros` recolhe em uma assinatura?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Os argumentos posicionais que sobraram", isCorrect: true },
+                        { text: "Os argumentos nomeados passados na chamada", isCorrect: false },
+                        { text: "O bloco de código passado junto ao método", isCorrect: false },
+                        {
+                            text: "Apenas o primeiro argumento, ignorando o resto",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que `**opcoes` recolhe?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Os argumentos nomeados, em um hash", isCorrect: true },
+                        { text: "Os argumentos posicionais, em um array comum", isCorrect: false },
+                        { text: "O bloco passado ao método na forma de Proc", isCorrect: false },
+                        { text: "Todos os argumentos, sem distinção de tipo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como um método Ruby devolve dois valores?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Devolvendo um array com os dois", isCorrect: true },
+                        { text: "Usando dois comandos return em sequência", isCorrect: false },
+                        {
+                            text: "Declarando dois tipos de retorno na assinatura",
+                            isCorrect: false,
+                        },
+                        { text: "Não é possível devolver mais de um valor", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Um argumento com valor padrão é obrigatório na chamada?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Não, ele vira opcional", isCorrect: true },
+                        {
+                            text: "Sim, o padrão só vale dentro do corpo do método",
+                            isCorrect: false,
+                        },
+                        { text: "Sim, mas pode receber o valor nil na chamada", isCorrect: false },
+                        { text: "Depende de ele vir antes ou depois dos outros", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Argumentos nomeados e a legibilidade da chamada",
+            blocks: [
+                {
+                    type: "text",
+                    value: '# Quando a ordem atrapalha\n\nUma chamada como `criar("Ana", true, false, 3)` não diz nada a quem lê. Argumentos **nomeados** resolvem isso: o nome vai na chamada e a ordem deixa de importar.',
+                },
+                {
+                    type: "code",
+                    value: 'def criar_usuario(nome:, ativo: true, admin: false)\n  { nome: nome, ativo: ativo, admin: admin }\nend\n\ncriar_usuario(nome: "Ana")\ncriar_usuario(nome: "Bruno", admin: true)\ncriar_usuario(admin: true, nome: "Carla")   # a ordem não importa\n\ncriar_usuario(ativo: false)   # ArgumentError: falta nome',
+                },
+                {
+                    type: "text",
+                    value: "O nomeado **sem valor padrão é obrigatório**, e o Ruby avisa pelo nome quando ele falta. Isso é bem melhor que o erro genérico de quantidade dos posicionais.\n\n## Passando um hash pronto\n\nO `**` também funciona na chamada, espalhando um hash como argumentos nomeados.",
+                },
+                {
+                    type: "code",
+                    value: 'dados = { nome: "Ana", admin: true }\ncriar_usuario(**dados)\n\n# Novidade do Ruby 4.0: *nil não chama mais nil.to_a\ndef metodo(*args) = args\nmetodo(*nil)   # => []',
+                },
+                {
+                    type: "quote",
+                    value: "Regra prática: até dois argumentos, posicional. Três ou mais, nomeados. O ganho de leitura compensa a digitação.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Um argumento nomeado sem valor padrão é obrigatório?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Sim, e o erro diz qual faltou", isCorrect: true },
+                        { text: "Não, ele recebe nil quando não é informado", isCorrect: false },
+                        { text: "Não, o Ruby usa o valor do argumento anterior", isCorrect: false },
+                        {
+                            text: "Depende de haver outros nomeados na assinatura",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "A ordem dos argumentos nomeados importa na chamada?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Não, cada um vai pelo nome", isCorrect: true },
+                        { text: "Sim, precisa seguir a ordem da assinatura", isCorrect: false },
+                        { text: "Sim, mas apenas quando houver valor padrão", isCorrect: false },
+                        { text: "Sim, os obrigatórios vêm sempre primeiro", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `**dados` faz em uma chamada de método?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Espalha o hash como nomeados", isCorrect: true },
+                        { text: "Passa o hash inteiro como um único argumento", isCorrect: false },
+                        { text: "Converte o hash em array antes de passar", isCorrect: false },
+                        { text: "Duplica os valores do hash antes da chamada", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a vantagem do erro de um nomeado obrigatório?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Ele diz o nome do que faltou", isCorrect: true },
+                        { text: "Ele interrompe a execução bem mais cedo", isCorrect: false },
+                        { text: "Ele sugere um valor padrão para o argumento", isCorrect: false },
+                        { text: "Ele lista todos os argumentos do método", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que mudou no Ruby 4.0 quanto a `*nil`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Ele não chama mais nil.to_a", isCorrect: true },
+                        {
+                            text: "Ele passou a levantar um erro de tipo inválido",
+                            isCorrect: false,
+                        },
+                        { text: "Ele agora converte o nil em um array vazio", isCorrect: false },
+                        {
+                            text: "Ele deixou de ser aceito na chamada de métodos",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Convenções de nome: interrogação e exclamação",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O nome conta o que o método faz\n\nRuby não tem palavras-chave para isso, mas a comunidade segue duas convenções tão firmes que parecem regra da linguagem.\n\n- Método terminado em `?` **pergunta** e devolve verdadeiro ou falso\n- Método terminado em `!` **avisa de um perigo**, quase sempre alterar o próprio objeto",
+                },
+                {
+                    type: "code",
+                    value: 'nums = [3, 1, 2]\n\nnums.empty?      # => false\nnums.include?(2) # => true\n\nordenado = nums.sort   # devolve cópia, nums intacto\nnums.sort!             # altera nums no lugar\n\ntexto = "olá"\ntexto.upcase           # => "OLÁ", texto continua "olá"\ntexto.upcase!          # texto agora é "OLÁ"',
+                },
+                {
+                    type: "text",
+                    value: "## O detalhe do bang\n\nOs métodos com `!` costumam devolver `nil` quando **não houve mudança**. Encadear direto neles é um erro clássico.",
+                },
+                {
+                    type: "code",
+                    value: "a = [1, 2, 3]\na.sort!          # => [1, 2, 3], já estava ordenado\na.uniq!          # => nil, não havia repetido\n\n# Erro clássico: encadear em cima de um bang\nresultado = lista.uniq!.sort   # NoMethodError quando uniq! devolve nil\n\n# Certo\nresultado = lista.uniq.sort",
+                },
+                {
+                    type: "text",
+                    value: "## Nos seus métodos\n\nSiga a convenção. Um `salvar!` que levanta exceção ao falhar e um `salvar` que devolve `false` é exatamente o que o Rails faz, e quem lê já sabe o que esperar.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que um método terminado em `?` devolve por convenção?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Verdadeiro ou falso", isCorrect: true },
+                        { text: "Uma cópia alterada do objeto original", isCorrect: false },
+                        { text: "O valor nil quando a resposta é negativa", isCorrect: false },
+                        { text: "Um número indicando o total encontrado", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o `!` no fim do nome costuma avisar?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Que o método altera o objeto", isCorrect: true },
+                        { text: "Que o método é privado dentro da classe", isCorrect: false },
+                        { text: "Que o método devolve sempre um booleano", isCorrect: false },
+                        { text: "Que o método precisa receber um bloco", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `uniq!` devolve quando não há repetidos?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "nil", isCorrect: true },
+                        { text: "O array original, sem nenhuma alteração feita", isCorrect: false },
+                        {
+                            text: "Um array vazio, indicando que nada foi removido",
+                            isCorrect: false,
+                        },
+                        { text: "Um erro avisando que não havia o que remover", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que `lista.uniq!.sort` é arriscado?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O uniq! pode devolver nil e quebrar a cadeia", isCorrect: true },
+                        { text: "O sort não funciona depois de um método bang", isCorrect: false },
+                        {
+                            text: "A ordem dos dois métodos está sempre invertida",
+                            isCorrect: false,
+                        },
+                        { text: "O uniq! não aceita ser encadeado com outros", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Essas convenções são impostas pelo interpretador?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Não, são acordo da comunidade", isCorrect: true },
+                        { text: "Sim, o Ruby verifica o retorno de cada método", isCorrect: false },
+                        { text: "Sim, mas apenas para os métodos com o bang", isCorrect: false },
+                        { text: "Sim, e o código não roda se forem quebradas", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Encadeando transformações",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Um pipeline de dados\n\nComo quase todo método de Enumerable devolve uma coleção, dá para encadear transformações e ler o processo na ordem em que ele acontece.",
+                },
+                {
+                    type: "code",
+                    value: 'pedidos = [\n  { cliente: "Ana", total: 150.0, status: :pago },\n  { cliente: "Bruno", total: 80.0, status: :pendente },\n  { cliente: "Ana", total: 200.0, status: :pago },\n  { cliente: "Carla", total: 50.0, status: :pago },\n]\n\ntotal_por_cliente = pedidos\n  .select { |p| p[:status] == :pago }\n  .group_by { |p| p[:cliente] }\n  .transform_values { |lista| lista.sum { |p| p[:total] } }\n  .sort_by { |_, total| -total }\n  .to_h\n\n# => { "Ana" => 350.0, "Carla" => 50.0 }',
+                },
+                {
+                    type: "text",
+                    value: "## O custo de encadear\n\nCada elo cria uma coleção nova. Para milhares de itens isso pesa, e o `lazy` resolve: ele avalia sob demanda e para assim que tem o que precisa.",
+                },
+                {
+                    type: "code",
+                    value: "# Sem lazy: mapeia um milhão de itens e depois pega cinco\n(1..1_000_000).map { |n| n * 2 }.select(&:even?).first(5)\n\n# Com lazy: processa só o necessário para chegar aos cinco\n(1..1_000_000).lazy.map { |n| n * 2 }.select(&:even?).first(5)",
+                },
+                {
+                    type: "text",
+                    value: "## then, para quebrar a cadeia\n\nQuando o próximo passo não é um método da coleção, `then` mantém a leitura linear em vez de obrigar uma variável no meio.",
+                },
+                {
+                    type: "code",
+                    value: 'resultado = numeros\n  .map { |n| n * 2 }\n  .sum\n  .then { |total| "Total: #{total}" }',
+                },
+            ],
+            questions: [
+                {
+                    statement: "Por que dá para encadear métodos de Enumerable?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Porque cada um devolve uma coleção nova", isCorrect: true },
+                        {
+                            text: "Porque o Ruby guarda o resultado em uma variável",
+                            isCorrect: false,
+                        },
+                        { text: "Porque eles alteram sempre a coleção original", isCorrect: false },
+                        {
+                            text: "Porque o interpretador junta as chamadas em uma",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que o `lazy` muda em uma cadeia?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Avalia sob demanda, só o necessário", isCorrect: true },
+                        { text: "Executa toda a cadeia em segundo plano", isCorrect: false },
+                        {
+                            text: "Guarda o resultado em cache para a próxima vez",
+                            isCorrect: false,
+                        },
+                        { text: "Ordena a coleção antes de aplicar os métodos", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual o custo de uma cadeia longa sem lazy?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Cada elo cria uma coleção intermediária", isCorrect: true },
+                        {
+                            text: "A ordem dos itens da coleção acaba se perdendo",
+                            isCorrect: false,
+                        },
+                        { text: "Os métodos passam a alterar o objeto original", isCorrect: false },
+                        {
+                            text: "O resultado final vira sempre um array simples",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Para que serve o `then` em uma cadeia?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Aplicar algo que não é método da coleção", isCorrect: true },
+                        { text: "Executar o próximo passo apenas se der certo", isCorrect: false },
+                        { text: "Interromper a cadeia e devolver o valor atual", isCorrect: false },
+                        { text: "Repetir a última transformação mais uma vez", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `transform_values` faz em um hash?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Aplica um bloco a cada valor", isCorrect: true },
+                        { text: "Aplica um bloco a cada chave do hash", isCorrect: false },
+                        { text: "Troca as chaves pelos valores correspondentes", isCorrect: false },
+                        { text: "Remove os valores que não passam no teste", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_5: Modulo = {
+    titulo: "Módulo 5 - Classes, módulos e objetos",
+    aulas: [
+        {
+            titulo: "Classes e initialize",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Definindo um tipo\n\nA classe descreve o que um objeto guarda e o que ele sabe fazer. O método `initialize` roda quando você chama `new`, e é onde as variáveis de instância nascem.",
+                },
+                {
+                    type: "code",
+                    value: 'class Produto\n  def initialize(nome, preco)\n    @nome = nome\n    @preco = preco\n  end\n\n  def descricao\n    "#{@nome}: R$ #{format(\'%.2f\', @preco)}"\n  end\n\n  def com_desconto(percentual)\n    @preco * (1 - percentual)\n  end\nend\n\ncamisa = Produto.new("Camisa", 79.9)\nputs camisa.descricao\nputs camisa.com_desconto(0.1)',
+                },
+                {
+                    type: "text",
+                    value: "## Visibilidade\n\nTodo método é público por padrão. `private` e `protected` mudam isso para tudo que vier depois, o que é diferente de outras linguagens onde se marca método a método.",
+                },
+                {
+                    type: "code",
+                    value: 'class Conta\n  def sacar(valor)\n    return "saldo insuficiente" unless saldo_suficiente?(valor)\n    @saldo -= valor\n  end\n\n  private\n\n  # daqui para baixo, tudo é privado\n  def saldo_suficiente?(valor)\n    @saldo >= valor\n  end\nend',
+                },
+                {
+                    type: "quote",
+                    value: "Em Ruby, método privado não pode ser chamado com receptor explícito. Nem self.metodo funciona, salvo em atribuição.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual método roda quando você chama `new`?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "initialize", isCorrect: true },
+                        { text: "constructor, como em várias outras linguagens", isCorrect: false },
+                        { text: "new, definido dentro do corpo da classe", isCorrect: false },
+                        { text: "create, chamado logo depois da alocação", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a visibilidade padrão de um método em Ruby?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Público", isCorrect: true },
+                        { text: "Privado, até que se declare o contrário", isCorrect: false },
+                        { text: "Protegido, visível apenas para as subclasses", isCorrect: false },
+                        { text: "Depende de o método começar com maiúscula", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como o `private` funciona em Ruby?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Vale para tudo que vier depois dele", isCorrect: true },
+                        { text: "Vale apenas para o método logo abaixo dele", isCorrect: false },
+                        { text: "Precisa ser repetido em cada método privado", isCorrect: false },
+                        { text: "Recebe os nomes dos métodos entre parênteses", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Onde as variáveis de instância costumam nascer?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Dentro do initialize", isCorrect: true },
+                        { text: "No topo da classe, antes de qualquer método", isCorrect: false },
+                        { text: "Fora da classe, junto com as constantes", isCorrect: false },
+                        { text: "Em um bloco especial chamado attributes", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Um método privado pode ser chamado com receptor explícito?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Não, salvo em atribuição", isCorrect: true },
+                        { text: "Sim, desde que seja com a palavra self", isCorrect: false },
+                        {
+                            text: "Sim, desde que a chamada esteja na mesma classe",
+                            isCorrect: false,
+                        },
+                        { text: "Sim, desde que o objeto seja da mesma classe", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "attr_reader, attr_writer e attr_accessor",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Métodos de acesso sem repetição\n\nVariáveis de instância são privadas ao objeto: ninguém de fora lê `@nome` diretamente. Escrever um método para cada leitura e escrita seria repetitivo, e o Ruby gera esses métodos para você.",
+                },
+                {
+                    type: "code",
+                    value: 'class Produto\n  attr_reader :nome            # só leitura\n  attr_writer :estoque         # só escrita\n  attr_accessor :preco         # leitura e escrita\n\n  def initialize(nome, preco)\n    @nome = nome\n    @preco = preco\n    @estoque = 0\n  end\nend\n\np = Produto.new("Caneca", 29.9)\np.nome           # => "Caneca"\np.preco = 34.9   # funciona, tem writer\np.nome = "outro" # NoMethodError, só tem reader',
+                },
+                {
+                    type: "text",
+                    value: "## O que isso gera\n\n`attr_reader :nome` equivale exatamente a escrever o método abaixo. Nada de mágico, apenas geração de código.",
+                },
+                {
+                    type: "code",
+                    value: "def nome\n  @nome\nend\n\n# attr_writer :nome gera:\ndef nome=(valor)\n  @nome = valor\nend",
+                },
+                {
+                    type: "text",
+                    value: "## Quando não usar accessor\n\n`attr_accessor` para tudo transforma o objeto em um saco de dados aberto e destrói o encapsulamento. Exponha só o que precisa mesmo ser lido ou escrito de fora, e prefira métodos com nome de intenção a um writer cru.",
+                },
+                {
+                    type: "code",
+                    value: '# Em vez de expor o saldo para escrita\nattr_accessor :saldo   # qualquer um sobrescreve\n\n# Prefira a operação com nome e regra\nattr_reader :saldo\n\ndef depositar(valor)\n  raise ArgumentError, "valor precisa ser positivo" unless valor.positive?\n  @saldo += valor\nend',
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que `attr_reader :nome` gera?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Um método de leitura para @nome", isCorrect: true },
+                        {
+                            text: "Os métodos de leitura e de escrita ao mesmo tempo",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Uma variável de instância chamada nome na classe",
+                            isCorrect: false,
+                        },
+                        { text: "Uma constante com o valor atual do atributo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual gera leitura e escrita de uma vez?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "attr_accessor", isCorrect: true },
+                        { text: "attr_reader, que também aceita atribuição", isCorrect: false },
+                        { text: "attr_writer, que gera os dois métodos", isCorrect: false },
+                        { text: "attr_both, específico para os dois casos", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como se chama o método gerado por `attr_writer :preco`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "preco=", isCorrect: true },
+                        { text: "set_preco, no padrão de outras linguagens", isCorrect: false },
+                        { text: "write_preco, seguindo o nome do gerador", isCorrect: false },
+                        { text: "preco!, com o bang indicando alteração", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que evitar `attr_accessor` em tudo?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Ele abre o objeto e mata o encapsulamento", isCorrect: true },
+                        {
+                            text: "Ele consome mais memória do que os outros dois",
+                            isCorrect: false,
+                        },
+                        { text: "Ele não funciona quando a classe tem herança", isCorrect: false },
+                        { text: "Ele impede que a classe defina outros métodos", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "É possível ler `@nome` de fora do objeto sem accessor?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Não, variável de instância é do objeto", isCorrect: true },
+                        { text: "Sim, basta usar o ponto seguido do nome dela", isCorrect: false },
+                        { text: "Sim, desde que a classe não tenha herança", isCorrect: false },
+                        { text: "Sim, com a variável declarada como constante", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Herança e super",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Estendendo uma classe\n\nO `<` estabelece herança. A filha recebe tudo da mãe e pode substituir métodos. O `super` chama a versão da classe mãe.\n\nRuby tem **herança simples**: uma classe só herda de uma outra. O que compartilha comportamento entre classes distantes são os módulos.",
+                },
+                {
+                    type: "code",
+                    value: "class Funcionario\n  attr_reader :nome\n\n  def initialize(nome, salario_base)\n    @nome = nome\n    @salario_base = salario_base\n  end\n\n  def salario\n    @salario_base\n  end\nend\n\nclass Vendedor < Funcionario\n  def initialize(nome, salario_base, comissao)\n    super(nome, salario_base)\n    @comissao = comissao\n  end\n\n  def salario\n    super + @comissao\n  end\nend",
+                },
+                {
+                    type: "text",
+                    value: "## super com e sem parênteses\n\nEsta é uma pegadinha frequente:\n\n- `super` sem nada repassa **os mesmos argumentos** que o método recebeu\n- `super()` com parênteses vazios chama **sem argumento nenhum**\n- `super(a, b)` chama com o que você informar\n\nA diferença entre as duas primeiras formas já causou muito bug silencioso.",
+                },
+                {
+                    type: "code",
+                    value: 'class Base\n  def cumprimentar(nome = "mundo")\n    "Olá, #{nome}"\n  end\nend\n\nclass Filha < Base\n  def cumprimentar(nome)\n    super       # passa nome adiante\n  end\n\n  def outra(nome)\n    super()     # chama sem argumento, usa o padrão\n  end\nend',
+                },
+                {
+                    type: "text",
+                    value: "## A cadeia de ancestrais\n\n`ancestors` mostra a ordem exata em que o Ruby procura um método. Ela inclui classes e módulos, e é a resposta para qualquer dúvida de qual versão será chamada.",
+                },
+                {
+                    type: "code",
+                    value: "Vendedor.ancestors\n# => [Vendedor, Funcionario, Object, Kernel, BasicObject]",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual símbolo estabelece herança em Ruby?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "O sinal de menor", isCorrect: true },
+                        {
+                            text: "A palavra extends, antes do nome da classe mãe",
+                            isCorrect: false,
+                        },
+                        { text: "A palavra inherits, seguida do nome da mãe", isCorrect: false },
+                        {
+                            text: "Os dois pontos, como em várias outras linguagens",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que `super` sem parênteses faz?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Repassa os mesmos argumentos recebidos", isCorrect: true },
+                        { text: "Chama o método da mãe sem argumento nenhum", isCorrect: false },
+                        { text: "Chama o initialize da classe mãe, sempre", isCorrect: false },
+                        { text: "Devolve a instância da classe mãe do objeto", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `super()` com parênteses vazios faz?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Chama sem argumento algum", isCorrect: true },
+                        {
+                            text: "Repassa os mesmos argumentos que o método recebeu",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Faz exatamente o mesmo que o super sem parênteses",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Levanta um erro por faltar os argumentos exigidos",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Quantas classes uma classe Ruby pode herdar?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Uma", isCorrect: true },
+                        { text: "Quantas forem necessárias no projeto", isCorrect: false },
+                        { text: "Duas, sendo uma delas abstrata", isCorrect: false },
+                        { text: "Nenhuma, Ruby não tem herança de classes", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `ancestors` devolve?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A ordem de busca de métodos", isCorrect: true },
+                        { text: "Apenas as classes mães, sem os módulos", isCorrect: false },
+                        { text: "Os métodos herdados de cada classe da cadeia", isCorrect: false },
+                        { text: "As classes filhas que estendem esta classe", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Módulos: namespace e mixin",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Duas funções em uma construção\n\nO módulo serve para duas coisas bem diferentes.\n\n**Namespace**: agrupar classes relacionadas e evitar choque de nomes.\n\n**Mixin**: guardar métodos que várias classes vão absorver, resolvendo o que a herança simples não resolve.",
+                },
+                {
+                    type: "code",
+                    value: "# Como namespace\nmodule Financeiro\n  class Conta; end\n  class Fatura; end\nend\n\nFinanceiro::Conta.new",
+                },
+                {
+                    type: "code",
+                    value: '# Como mixin\nmodule Auditavel\n  def registrar(acao)\n    puts "[#{Time.now}] #{self.class}: #{acao}"\n  end\nend\n\nmodule Exportavel\n  def exportar\n    to_h.to_json\n  end\nend\n\nclass Pedido\n  include Auditavel\n  include Exportavel\nend\n\nPedido.new.registrar("criado")',
+                },
+                {
+                    type: "text",
+                    value: "## include, extend e prepend\n\nSão três formas de absorver um módulo, e a diferença está em **onde** os métodos entram.",
+                },
+                {
+                    type: "table",
+                    value: '[["Forma", "Os métodos viram", "Ficam"], ["include", "de instância", "depois da classe"], ["extend", "de classe", "no objeto"], ["prepend", "de instância", "antes da classe"]]',
+                },
+                {
+                    type: "code",
+                    value: 'module Registro\n  def salvar\n    puts "registrando antes"\n    super\n  end\nend\n\nclass Documento\n  prepend Registro\n\n  def salvar\n    puts "salvando"\n  end\nend\n\nDocumento.new.salvar\n# registrando antes\n# salvando',
+                },
+            ],
+            questions: [
+                {
+                    statement: "Quais são os dois usos de um módulo?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Namespace e mixin de métodos", isCorrect: true },
+                        { text: "Herança múltipla e sobrecarga de operadores", isCorrect: false },
+                        { text: "Definição de tipos e validação de argumentos", isCorrect: false },
+                        { text: "Agrupar constantes e controlar a visibilidade", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `include` faz com os métodos do módulo?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Torna métodos de instância da classe", isCorrect: true },
+                        {
+                            text: "Torna métodos de classe, chamados sem instância",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Copia os métodos para dentro do arquivo da classe",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Deixa os métodos disponíveis apenas no initialize",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual a diferença de `prepend` para `include`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Ele entra antes da classe na busca", isCorrect: true },
+                        {
+                            text: "Ele torna os métodos do módulo métodos de classe",
+                            isCorrect: false,
+                        },
+                        { text: "Ele copia o módulo em vez de referenciá-lo", isCorrect: false },
+                        {
+                            text: "Ele impede que a classe sobrescreva os métodos",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que `extend` faz em uma classe?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Torna os métodos do módulo de classe", isCorrect: true },
+                        { text: "Torna os métodos do módulo de instância", isCorrect: false },
+                        { text: "Estende a classe com herança do módulo", isCorrect: false },
+                        {
+                            text: "Adiciona o módulo à lista de ancestrais no fim",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Como se acessa a classe Conta dentro do módulo Financeiro?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Com `Financeiro::Conta`", isCorrect: true },
+                        { text: "Com `Financeiro.Conta`, usando o ponto", isCorrect: false },
+                        { text: "Com `Financeiro->Conta`, usando a seta", isCorrect: false },
+                        { text: "Com `Conta` apenas, o módulo é transparente", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Duck typing, Comparable e Enumerable",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Se anda como pato\n\nRuby não pergunta o tipo de um objeto, pergunta se ele **responde ao método**. Isso é o duck typing, e é o que torna a linguagem tão flexível: qualquer objeto que implemente o método certo serve.\n\nO efeito prático é que você programa contra comportamento, não contra classe.",
+                },
+                {
+                    type: "code",
+                    value: 'def imprimir(saida, texto)\n  saida.puts(texto)   # serve qualquer coisa que saiba puts\nend\n\nimprimir($stdout, "vai para a tela")\nimprimir(File.open("log.txt", "w"), "vai para o arquivo")\nimprimir(StringIO.new, "vai para a memória")',
+                },
+                {
+                    type: "text",
+                    value: "## Comparable\n\nImplemente `<=>` e inclua `Comparable`: a classe ganha `<`, `<=`, `>`, `>=`, `==`, `between?` e `clamp` de graça.",
+                },
+                {
+                    type: "code",
+                    value: 'class Versao\n  include Comparable\n  attr_reader :partes\n\n  def initialize(texto)\n    @partes = texto.split(".").map(&:to_i)\n  end\n\n  def <=>(outra)\n    partes <=> outra.partes\n  end\nend\n\nVersao.new("4.0.6") > Versao.new("3.4.8")   # => true\n[Versao.new("2.0"), Versao.new("1.9")].sort',
+                },
+                {
+                    type: "text",
+                    value: "## Enumerable\n\nO mesmo vale para coleções: implemente `each` e inclua `Enumerable` para ganhar `map`, `select`, `sort`, `sum` e dezenas de outros.",
+                },
+                {
+                    type: "code",
+                    value: 'class Turma\n  include Enumerable\n\n  def initialize(alunos)\n    @alunos = alunos\n  end\n\n  def each(&bloco)\n    @alunos.each(&bloco)\n  end\nend\n\nturma = Turma.new(["Ana", "Bruno", "Carla"])\nturma.map(&:upcase)\nturma.select { |a| a.start_with?("A") }\nturma.sort',
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o duck typing significa na prática?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Importa o método, não a classe do objeto", isCorrect: true },
+                        { text: "Importa a classe declarada na assinatura", isCorrect: false },
+                        { text: "Os tipos são verificados antes de executar", isCorrect: false },
+                        { text: "Todo objeto precisa herdar da mesma classe", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que uma classe precisa para incluir Comparable?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Implementar o método `<=>`", isCorrect: true },
+                        { text: "Implementar os métodos de maior e de menor", isCorrect: false },
+                        { text: "Herdar de uma classe que já seja comparável", isCorrect: false },
+                        {
+                            text: "Definir o método igual com dois sinais de igual",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que a classe ganha ao incluir Comparable?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Os operadores de comparação e o between?", isCorrect: true },
+                        { text: "Os métodos map, select e sum de uma só vez", isCorrect: false },
+                        { text: "A capacidade de ser convertida em array", isCorrect: false },
+                        { text: "A ordenação automática de suas instâncias", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que uma classe precisa para incluir Enumerable?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Implementar o método `each`", isCorrect: true },
+                        { text: "Implementar o método map com um bloco", isCorrect: false },
+                        { text: "Herdar diretamente da classe Array do Ruby", isCorrect: false },
+                        {
+                            text: "Guardar os itens em um array interno chamado items",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual a vantagem de programar contra comportamento?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Qualquer objeto compatível passa a servir", isCorrect: true },
+                        { text: "O código executa bem mais rápido em produção", isCorrect: false },
+                        { text: "O interpretador consegue verificar os tipos", isCorrect: false },
+                        { text: "As classes ficam com menos métodos definidos", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_6: Modulo = {
+    titulo: "Módulo 6 - Erros, testes e ferramentas",
+    aulas: [
+        {
+            titulo: "Exceções: raise, rescue e ensure",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Sinalizando falha\n\n`raise` levanta uma exceção e `rescue` a captura. O `ensure` roda sempre, com ou sem erro, e é onde vai a limpeza.",
+                },
+                {
+                    type: "code",
+                    value: 'def dividir(a, b)\n  raise ArgumentError, "divisor não pode ser zero" if b.zero?\n  a / b\nend\n\nbegin\n  dividir(10, 0)\nrescue ArgumentError => e\n  puts "Falhou: #{e.message}"\nrescue StandardError => e\n  puts "Outro problema: #{e.class}"\nelse\n  puts "Deu certo"     # roda só se não houve exceção\nensure\n  puts "Sempre roda"\nend',
+                },
+                {
+                    type: "text",
+                    value: "## rescue no método inteiro\n\nDentro de um método, `def` já funciona como `begin`. Não precisa envolver o corpo.",
+                },
+                {
+                    type: "code",
+                    value: 'def carregar(caminho)\n  File.read(caminho)\nrescue Errno::ENOENT\n  ""     # arquivo não existe, devolve vazio\nend',
+                },
+                {
+                    type: "text",
+                    value: "## O erro clássico do rescue solto\n\n`rescue` sem classe captura `StandardError`, o que é o certo. **Nunca capture `Exception`**: ela inclui coisas que não são erro de aplicação, como a interrupção pelo teclado e a falta de memória, e capturá-las impede até de encerrar o programa.",
+                },
+                {
+                    type: "code",
+                    value: "# Certo: pega erros de aplicação\nrescue => e\n\n# Errado: pega até Ctrl+C e falta de memória\nrescue Exception => e",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Quando o bloco `ensure` é executado?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Sempre, com ou sem exceção", isCorrect: true },
+                        { text: "Apenas quando uma exceção foi levantada", isCorrect: false },
+                        { text: "Apenas quando nenhuma exceção acontece", isCorrect: false },
+                        { text: "Somente se não houver nenhum bloco rescue", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que um `rescue` sem classe captura?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "StandardError e as filhas dela", isCorrect: true },
+                        { text: "Exception, ou seja, absolutamente tudo", isCorrect: false },
+                        { text: "Apenas as exceções definidas por você", isCorrect: false },
+                        { text: "Nada, ele precisa da classe explícita", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que nunca capturar `Exception`?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Ela inclui interrupção do teclado e falta de memória",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Ela é bem mais lenta do que capturar um StandardError",
+                            isCorrect: false,
+                        },
+                        { text: "Ela só existe em versões antigas do Ruby", isCorrect: false },
+                        {
+                            text: "Ela impede o uso do bloco ensure no mesmo begin",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement:
+                        "Precisa envolver o corpo de um método com `begin` para usar `rescue`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Não, o def já funciona como begin", isCorrect: true },
+                        { text: "Sim, sempre, senão o rescue não é reconhecido", isCorrect: false },
+                        { text: "Sim, exceto quando o método tem uma linha só", isCorrect: false },
+                        { text: "Sim, mas apenas em métodos de classe", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quando o bloco `else` de um begin roda?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Só quando não houve exceção", isCorrect: true },
+                        { text: "Sempre depois de o rescue ter capturado", isCorrect: false },
+                        { text: "Quando nenhum rescue casou com a exceção", isCorrect: false },
+                        { text: "Antes do ensure, mesmo se houve exceção", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Exceções próprias e hierarquia",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Criando o seu tipo de erro\n\nUma exceção própria é uma classe que herda de `StandardError`. Herdar de `Exception` direto é o erro comum: as suas exceções passariam a escapar de um `rescue` normal.",
+                },
+                {
+                    type: "code",
+                    value: "module Pagamento\n  Erro = Class.new(StandardError)\n\n  class SaldoInsuficiente < Erro\n    attr_reader :faltam\n\n    def initialize(faltam)\n      @faltam = faltam\n      super(\"Faltam R$ #{format('%.2f', faltam)}\")\n    end\n  end\n\n  CartaoRecusado = Class.new(Erro)\nend\n\nbegin\n  cobrar(pedido)\nrescue Pagamento::SaldoInsuficiente => e\n  avisar_cliente(e.faltam)\nrescue Pagamento::Erro => e\n  registrar(e)      # pega qualquer erro do domínio\nend",
+                },
+                {
+                    type: "text",
+                    value: "## Repassando com contexto\n\nRelevantar preserva a causa original no `cause`, sem que você precise fazer nada. Isso mantém o rastro completo no log.",
+                },
+                {
+                    type: "code",
+                    value: 'begin\n  gateway.cobrar(valor)\nrescue Net::OpenTimeout\n  raise Pagamento::Erro, "gateway não respondeu"\nend\n\n# Mais tarde\nputs e.cause.class    # => Net::OpenTimeout',
+                },
+                {
+                    type: "text",
+                    value: "## retry\n\nDentro de um `rescue`, `retry` executa o bloco `begin` de novo. É útil para falha transitória, mas exige um limite: sem contador vira laço infinito.",
+                },
+                {
+                    type: "code",
+                    value: "tentativas = 0\nbegin\n  tentativas += 1\n  api.buscar\nrescue Net::OpenTimeout\n  retry if tentativas < 3\n  raise\nend",
+                },
+            ],
+            questions: [
+                {
+                    statement: "De qual classe uma exceção própria deve herdar?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "StandardError", isCorrect: true },
+                        { text: "Exception, a raiz de toda a hierarquia", isCorrect: false },
+                        { text: "RuntimeError, que é a exceção mais comum", isCorrect: false },
+                        { text: "Error, definida no núcleo da linguagem", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que acontece se a sua exceção herdar de `Exception`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Ela escapa de um rescue comum", isCorrect: true },
+                        {
+                            text: "Ela deixa de aceitar uma mensagem no construtor",
+                            isCorrect: false,
+                        },
+                        { text: "Ela passa a ser capturada duas vezes seguidas", isCorrect: false },
+                        { text: "Ela não pode mais ser levantada com o raise", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `retry` faz dentro de um rescue?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Executa o bloco begin de novo", isCorrect: true },
+                        { text: "Levanta a mesma exceção mais uma vez seguida", isCorrect: false },
+                        {
+                            text: "Pula para o bloco ensure sem executar mais nada",
+                            isCorrect: false,
+                        },
+                        { text: "Devolve o controle para o método que chamou", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual o risco de usar `retry` sem contador?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um laço infinito de tentativas", isCorrect: true },
+                        {
+                            text: "A exceção original acaba se perdendo no caminho",
+                            isCorrect: false,
+                        },
+                        { text: "O bloco ensure deixa de ser executado no fim", isCorrect: false },
+                        { text: "As tentativas passam a rodar em paralelo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o `cause` de uma exceção guarda?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A exceção que estava sendo tratada", isCorrect: true },
+                        { text: "A mensagem original antes de ser reescrita", isCorrect: false },
+                        { text: "O arquivo e a linha em que ela foi levantada", isCorrect: false },
+                        { text: "A lista de todos os rescue que já tentaram", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Testes com Minitest",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O teste que vem junto\n\nO **Minitest** faz parte da biblioteca padrão do Ruby: não precisa instalar nada. Um teste é uma classe que herda de `Minitest::Test`, com métodos começando por `test_`.",
+                },
+                {
+                    type: "code",
+                    value: 'require "minitest/autorun"\nrequire_relative "../lib/calculadora"\n\nclass TestCalculadora < Minitest::Test\n  def setup\n    @calc = Calculadora.new\n  end\n\n  def test_soma_dois_numeros\n    assert_equal 4, @calc.somar(2, 2)\n  end\n\n  def test_divisao_por_zero_levanta_erro\n    assert_raises(ArgumentError) { @calc.dividir(1, 0) }\n  end\n\n  def test_lista_comeca_vazia\n    assert_empty @calc.historico\n  end\nend',
+                },
+                {
+                    type: "table",
+                    value: '[["Asserção", "Verifica"], ["assert_equal a, b", "que a é igual a b"], ["assert / refute", "verdadeiro ou falso"], ["assert_nil", "que o valor é nil"], ["assert_raises", "que a exceção foi levantada"], ["assert_includes", "que a coleção tem o item"]]',
+                },
+                {
+                    type: "text",
+                    value: "## setup e teardown\n\n`setup` roda antes de **cada** teste e `teardown` depois. Cada teste começa do zero, o que evita a dependência de ordem, um dos problemas mais chatos de suíte de testes.",
+                },
+                {
+                    type: "code",
+                    value: "ruby test/test_calculadora.rb\n\n# Ou pelo rake, com todos de uma vez\nrake test",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Onde o Minitest está disponível?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Na biblioteca padrão do Ruby", isCorrect: true },
+                        { text: "Em uma gem que precisa ser instalada à parte", isCorrect: false },
+                        { text: "Apenas dentro de projetos criados com o Rails", isCorrect: false },
+                        {
+                            text: "No console interativo irb, como comando embutido",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Como o Minitest identifica um método de teste?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Pelo prefixo `test_` no nome", isCorrect: true },
+                        { text: "Por uma anotação escrita acima do método", isCorrect: false },
+                        { text: "Pela presença de qualquer asserção no corpo", isCorrect: false },
+                        { text: "Pela ordem em que ele aparece na classe", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quando o `setup` é executado?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Antes de cada teste da classe", isCorrect: true },
+                        { text: "Uma vez só, antes de todos os testes", isCorrect: false },
+                        { text: "Depois de cada teste ter terminado", isCorrect: false },
+                        { text: "Apenas quando algum teste falha na execução", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual asserção verifica que uma exceção foi levantada?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "assert_raises", isCorrect: true },
+                        { text: "assert_error, informando a classe esperada", isCorrect: false },
+                        { text: "assert_throws, com o bloco entre chaves", isCorrect: false },
+                        { text: "assert_exception, seguido do tipo do erro", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que cada teste começa do zero?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Para nenhum depender da ordem de execução", isCorrect: true },
+                        { text: "Para os testes rodarem bem mais rápido", isCorrect: false },
+                        { text: "Para economizar memória durante a suíte", isCorrect: false },
+                        {
+                            text: "Porque o Ruby recarrega as classes a cada teste",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "RSpec e o estilo de especificação",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Descrevendo comportamento\n\nO **RSpec** é a alternativa mais usada ao Minitest. Ele troca asserções por uma linguagem que descreve comportamento, e a saída da suíte vira quase uma documentação do sistema.",
+                },
+                {
+                    type: "code",
+                    value: 'require "rails_helper"\n\nRSpec.describe Calculadora do\n  subject(:calc) { described_class.new }\n\n  describe "#somar" do\n    it "soma dois números positivos" do\n      expect(calc.somar(2, 2)).to eq(4)\n    end\n\n    it "aceita números negativos" do\n      expect(calc.somar(-1, -1)).to eq(-2)\n    end\n  end\n\n  describe "#dividir" do\n    context "quando o divisor é zero" do\n      it "levanta ArgumentError" do\n        expect { calc.dividir(1, 0) }.to raise_error(ArgumentError)\n      end\n    end\n  end\nend',
+                },
+                {
+                    type: "table",
+                    value: '[["Construção", "Para que serve"], ["describe", "agrupa por classe ou método"], ["context", "agrupa por situação"], ["it", "um comportamento esperado"], ["let", "valor criado sob demanda"], ["before", "preparação antes de cada it"]]',
+                },
+                {
+                    type: "text",
+                    value: "## let é preguiçoso\n\n`let` só cria o valor quando ele é usado pela primeira vez no exemplo, e depois guarda. `let!` força a criação antes de cada exemplo. Confundir os dois gera testes que passam sozinhos e falham na suíte.",
+                },
+                {
+                    type: "code",
+                    value: 'let(:usuario) { User.create(nome: "Ana") }   # criado quando usado\nlet!(:admin) { User.create(admin: true) }   # criado sempre',
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o RSpec troca em relação ao Minitest?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Asserções por descrição de comportamento", isCorrect: true },
+                        { text: "A linguagem Ruby por uma linguagem própria", isCorrect: false },
+                        { text: "Os testes unitários por testes de integração", isCorrect: false },
+                        { text: "A execução em série pela execução paralela", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a diferença entre `describe` e `context`?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Context agrupa por situação, describe por unidade",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Context roda os exemplos em ordem sempre aleatória",
+                            isCorrect: false,
+                        },
+                        { text: "Describe aceita apenas o nome de uma classe", isCorrect: false },
+                        { text: "Não existe diferença técnica entre os dois", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quando o `let` cria o valor?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Na primeira vez em que é usado", isCorrect: true },
+                        { text: "Antes de cada exemplo, sempre que declarado", isCorrect: false },
+                        { text: "Uma vez só, antes de todos os exemplos", isCorrect: false },
+                        { text: "Depois que o exemplo termina de executar", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `let!` faz de diferente?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Cria o valor antes de cada exemplo", isCorrect: true },
+                        { text: "Cria o valor apenas uma vez para toda a suíte", isCorrect: false },
+                        { text: "Impede que o valor seja alterado no exemplo", isCorrect: false },
+                        { text: "Levanta erro quando o valor não é usado", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como se testa que um bloco levanta exceção no RSpec?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Com `expect { }.to raise_error`", isCorrect: true },
+                        { text: "Com `assert_raises` seguido da classe do erro", isCorrect: false },
+                        { text: "Com `expect().to be_error` no valor devolvido", isCorrect: false },
+                        { text: "Com `it_raises` no lugar do it comum", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "RuboCop, debug e boas práticas",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O guia de estilo automatizado\n\nO **RuboCop** verifica estilo e problemas comuns segundo o guia de estilo da comunidade. Ele corrige boa parte sozinho, o que encerra discussão de formatação em revisão de código.",
+                },
+                {
+                    type: "code",
+                    value: "bundle add rubocop --group development\n\nrubocop                # aponta os problemas\nrubocop -a             # corrige o que é seguro\nrubocop -A             # corrige até o que é arriscado\nrubocop --regenerate-todo   # congela o que já existe",
+                },
+                {
+                    type: "text",
+                    value: "O `.rubocop_todo.yml` é o que torna a adoção viável em projeto grande: ele registra as violações atuais como aceitas, e a partir dali só o código novo precisa passar.",
+                },
+                {
+                    type: "text",
+                    value: "## O debugger\n\nA gem `debug` faz parte da distribuição padrão desde o Ruby 3.1. Coloque `binding.break` onde quiser parar e inspecione o estado, o que é muito melhor que espalhar `puts` pelo código.",
+                },
+                {
+                    type: "code",
+                    value: 'require "debug"\n\ndef calcular(pedido)\n  binding.break     # para aqui e abre o console\n  pedido.itens.sum(&:total)\nend\n\n# No console: n avança, s entra no método, c continua, p imprime',
+                },
+                {
+                    type: "table",
+                    value: '[["Ferramenta", "Para que serve"], ["RuboCop", "estilo e problemas comuns"], ["debug", "parar e inspecionar o estado"], ["Bundler", "resolver as dependências"], ["Rake", "automatizar tarefas do projeto"], ["YARD", "gerar documentação do código"]]',
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o RuboCop verifica?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Estilo e problemas comuns do código", isCorrect: true },
+                        { text: "Se os testes do projeto estão todos passando", isCorrect: false },
+                        { text: "Se as gems declaradas estão desatualizadas", isCorrect: false },
+                        { text: "Se o código roda na versão instalada do Ruby", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Para que serve o `.rubocop_todo.yml`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Registrar as violações atuais como aceitas", isCorrect: true },
+                        {
+                            text: "Listar as regras que ainda serão implementadas",
+                            isCorrect: false,
+                        },
+                        { text: "Guardar as correções que o RuboCop já aplicou", isCorrect: false },
+                        { text: "Definir quais arquivos serão sempre ignorados", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `binding.break` faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Para a execução e abre o console", isCorrect: true },
+                        { text: "Encerra o programa naquele ponto do código", isCorrect: false },
+                        { text: "Imprime o valor de todas as variáveis locais", isCorrect: false },
+                        {
+                            text: "Marca um ponto para o RuboCop verificar depois",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual a diferença entre `rubocop -a` e `rubocop -A`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O maiúsculo corrige também o arriscado", isCorrect: true },
+                        {
+                            text: "O maiúsculo corrige todos os arquivos do projeto",
+                            isCorrect: false,
+                        },
+                        { text: "O minúsculo apenas aponta, sem corrigir nada", isCorrect: false },
+                        {
+                            text: "O maiúsculo grava as correções no arquivo todo",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "A gem `debug` precisa ser instalada à parte?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Não, ela vem na distribuição padrão", isCorrect: true },
+                        { text: "Sim, ela precisa ser adicionada ao Gemfile", isCorrect: false },
+                        { text: "Sim, mas apenas em projetos que usam o Rails", isCorrect: false },
+                        { text: "Sim, ela é distribuída junto com o RuboCop", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_7: Modulo = {
+    titulo: "Módulo 7 - O Ruby moderno",
+    aulas: [
+        {
+            titulo: "O que mudou no Ruby 4.0",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Um salto de versão maior\n\nO **Ruby 4.0** saiu em 25 de dezembro de 2025, mantendo a tradição de lançar no Natal. Apesar do número, não é uma quebra como foi a passagem do 1.8 para o 1.9: a maior parte do código de Ruby 3 continua rodando.\n\nO que ele traz de mais visível é um compilador novo, mudanças no core e uma reformulação de Ractor.",
+                },
+                {
+                    type: "table",
+                    value: '[["Novidade", "O que é"], ["ZJIT", "compilador novo escrito em Rust"], ["Set no core", "sem precisar de require"], ["Pathname no core", "deixou de ser gem padrão"], ["Ruby::Box", "isolamento experimental"], ["Ractor::Port", "nova comunicação entre Ractors"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Mudanças de sintaxe\n\nDuas mudanças pequenas e úteis:\n\nOperadores lógicos no **começo da linha** agora continuam a linha anterior, do mesmo jeito que o ponto já fazia. Isso deixa condições longas legíveis sem barra invertida.",
+                },
+                {
+                    type: "code",
+                    value: "# Ruby 4.0: o operador no começo continua a linha de cima\nif usuario.ativo?\n   && usuario.confirmado?\n   && !usuario.bloqueado?\n  liberar\nend\n\n# O splat de nil não chama mais nil.to_a\ndef metodo(*args) = args\nmetodo(*nil)   # => []",
+                },
+                {
+                    type: "text",
+                    value: "## O que saiu\n\n`SortedSet` foi removido do core e virou gem separada. A biblioteca `cgi` deixou as gems padrão, restando apenas `cgi/escape`. Em Ractor, os métodos `yield`, `take`, `close_incoming` e `close_outgoing` foram removidos.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Quando o Ruby 4.0 foi lançado?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Em dezembro de 2025", isCorrect: true },
+                        { text: "Em janeiro de 2026, no começo do ano", isCorrect: false },
+                        { text: "Em julho de 2026, junto com o patch 4.0.6", isCorrect: false },
+                        { text: "Em dezembro de 2024, um ano antes disso", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O Ruby 4.0 quebra a compatibilidade com o Ruby 3?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Não na maior parte do código", isCorrect: true },
+                        { text: "Sim, exige a reescrita de quase todo o código", isCorrect: false },
+                        { text: "Sim, a sintaxe de blocos mudou por completo", isCorrect: false },
+                        { text: "Sim, todas as gems precisam ser reescritas", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que mudou com operadores no começo da linha?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Eles continuam a linha anterior", isCorrect: true },
+                        { text: "Eles passaram a exigir parênteses em volta", isCorrect: false },
+                        { text: "Eles deixaram de funcionar fora de condições", isCorrect: false },
+                        { text: "Eles agora precisam de barra invertida no fim", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que aconteceu com o `SortedSet` no Ruby 4.0?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Foi removido e virou gem à parte", isCorrect: true },
+                        { text: "Foi promovido a classe do core da linguagem", isCorrect: false },
+                        { text: "Foi renomeado para OrderedSet dentro do core", isCorrect: false },
+                        { text: "Passou a ser o comportamento padrão do Set", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual classe deixou de ser gem padrão e virou core?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Pathname", isCorrect: true },
+                        { text: "CGI, que perdeu apenas parte dos módulos", isCorrect: false },
+                        { text: "OpenStruct, junto com o Set nesta versão", isCorrect: false },
+                        { text: "JSON, que ganhou desempenho no core novo", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "YJIT e ZJIT",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Compilando em tempo de execução\n\nRuby interpreta o código, e um **JIT** compila os trechos mais executados para código de máquina durante a execução. O ganho aparece em aplicação de vida longa, como um servidor web, e não em script curto.\n\nO Ruby 4.0 traz **dois** JITs.",
+                },
+                {
+                    type: "table",
+                    value: '[["", "YJIT", "ZJIT"], ["Desde", "Ruby 3.1", "Ruby 4.0"], ["Escrito em", "Rust", "Rust"], ["Maturidade", "usado em produção", "experimental"], ["Velocidade", "a mais rápida hoje", "acima do interpretador"]]',
+                },
+                {
+                    type: "code",
+                    value: "# Ligando pela linha de comando\nruby --yjit app.rb\nruby --zjit app.rb\n\n# Ou por variável de ambiente\nRUBY_YJIT_ENABLE=1 ruby app.rb\n\n# Em código, com as opções novas do 4.0\nRubyVM::YJIT.enable(mem_size: 128, call_threshold: 30)",
+                },
+                {
+                    type: "text",
+                    value: "## Qual usar\n\nO **YJIT** é a escolha para produção: está maduro e é usado no Shopify e no GitHub em escala. O **ZJIT** é o projeto novo, com uma arquitetura diferente, e a própria equipe recomenda experimentar sem colocar em produção ainda.\n\nJIT custa memória: ele guarda o código compilado. Em container com pouca RAM, meça antes de ligar.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que um JIT faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Compila trechos quentes durante a execução", isCorrect: true },
+                        { text: "Compila o programa inteiro antes de executar", isCorrect: false },
+                        {
+                            text: "Interpreta o código linha a linha, mais rápido",
+                            isCorrect: false,
+                        },
+                        { text: "Traduz o Ruby para outra linguagem de script", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual JIT é recomendado para produção hoje?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O YJIT", isCorrect: true },
+                        { text: "O ZJIT, por ser o mais recente dos dois", isCorrect: false },
+                        { text: "Os dois juntos, ligados ao mesmo tempo", isCorrect: false },
+                        { text: "Nenhum, os dois seguem experimentais", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Em que tipo de programa o JIT compensa mais?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Aplicação de vida longa, como um servidor", isCorrect: true },
+                        { text: "Script curto de automação de tarefas simples", isCorrect: false },
+                        { text: "Programa que roda uma vez e encerra rápido", isCorrect: false },
+                        { text: "Qualquer programa, o ganho é sempre o mesmo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Em que linguagem o ZJIT foi escrito?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Rust", isCorrect: true },
+                        { text: "C, como o interpretador principal do Ruby", isCorrect: false },
+                        { text: "Ruby, usando metaprogramação avançada", isCorrect: false },
+                        { text: "Go, pela facilidade com concorrência", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual o custo de ligar um JIT?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Mais consumo de memória", isCorrect: true },
+                        { text: "Uma inicialização bem mais lenta do programa", isCorrect: false },
+                        { text: "A perda de compatibilidade com gems antigas", isCorrect: false },
+                        { text: "A impossibilidade de usar o debugger padrão", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Concorrência: threads, Fiber e Ractor",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O GVL e o que ele impede\n\nO Ruby tem um **Global VM Lock**: uma trava que permite apenas uma thread executando código Ruby por vez em um processo. O efeito é decisivo:\n\n- Para tarefa que **espera** rede ou disco, threads ajudam muito, porque a trava é liberada durante a espera\n- Para tarefa que **calcula**, threads não dão ganho algum",
+                },
+                {
+                    type: "code",
+                    value: 'urls = ["a.com", "b.com", "c.com"]\n\n# Threads ajudam: o tempo é de espera de rede\nresultados = urls.map do |url|\n  Thread.new { buscar(url) }\nend.map(&:value)',
+                },
+                {
+                    type: "text",
+                    value: "## Fiber\n\nA `Fiber` é uma corrotina: ela pausa e retoma sob controle explícito, sem paralelismo. É a base do `async` em Ruby e de servidores que atendem muitas conexões com pouca memória.",
+                },
+                {
+                    type: "text",
+                    value: "## Ractor\n\nO **Ractor** é a resposta ao GVL: cada um tem sua própria trava, então dois Ractors executam código Ruby **de verdade ao mesmo tempo**. O preço é o isolamento: eles não compartilham objetos mutáveis, e a comunicação é por troca de mensagens.\n\nO Ruby 4.0 reformulou essa comunicação. `Ractor.yield` e `Ractor#take` foram removidos, e no lugar entrou o `Ractor::Port`, junto com `Ractor#join` e `Ractor#value`.",
+                },
+                {
+                    type: "code",
+                    value: '# Ruby 4.0\nr = Ractor.new do\n  (1..1_000_000).sum\nend\n\nr.value    # espera e devolve o resultado\n\nporta = Ractor::Port.new\nRactor.new(porta) { |p| p.send("pronto") }\nputs porta.receive',
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o GVL impede?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Duas threads executando Ruby ao mesmo tempo", isCorrect: true },
+                        { text: "A criação de mais de uma thread por processo", isCorrect: false },
+                        {
+                            text: "O uso de threads em operações de entrada e saída",
+                            isCorrect: false,
+                        },
+                        { text: "A comunicação entre threads do mesmo programa", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Em que caso threads ajudam de verdade em Ruby?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Quando a tarefa espera rede ou disco", isCorrect: true },
+                        { text: "Quando a tarefa faz cálculo pesado de números", isCorrect: false },
+                        {
+                            text: "Quando o programa roda em uma máquina com um núcleo",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Quando as tarefas precisam compartilhar objetos",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que torna o Ractor diferente da thread?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Cada um tem a própria trava e roda em paralelo", isCorrect: true },
+                        { text: "Ele executa bem mais rápido a mesma tarefa", isCorrect: false },
+                        {
+                            text: "Ele compartilha todos os objetos com os outros",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Ele roda em outro processo do sistema operacional",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual o preço do paralelismo real do Ractor?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O isolamento entre eles", isCorrect: true },
+                        { text: "O consumo bem maior de memória por Ractor", isCorrect: false },
+                        { text: "A perda de compatibilidade com o debugger", isCorrect: false },
+                        { text: "A necessidade de ligar um JIT antes de usar", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que substituiu `Ractor#take` no Ruby 4.0?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O Ractor::Port e o método value", isCorrect: true },
+                        { text: "O método receive, que já existia antes", isCorrect: false },
+                        { text: "O bloco passado na criação do Ractor", isCorrect: false },
+                        { text: "Nada, o take continua sendo o recomendado", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Ruby::Box, o experimento de namespaces",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O problema que ele ataca\n\nRuby permite reabrir qualquer classe e mudar seu comportamento, o famoso **monkey patch**. Isso é poderoso e perigoso: duas gems podem alterar a mesma classe de formas incompatíveis, e não há como isolar uma da outra.\n\nOutro caso: usar duas versões da mesma gem no mesmo processo é simplesmente impossível hoje.",
+                },
+                {
+                    type: "code",
+                    value: '# Monkey patch: vale para o programa inteiro\nclass String\n  def gritar\n    upcase + "!"\n  end\nend\n\n"oi".gritar   # => "OI!"',
+                },
+                {
+                    type: "text",
+                    value: "## O que o Ruby::Box propõe\n\nO **Ruby::Box**, experimental no Ruby 4.0, cria um espaço isolado onde definições, monkey patches, variáveis globais e de classe ficam contidos. O que acontece dentro da caixa não vaza para fora.\n\nEle é experimental de verdade: a API pode mudar e não deve ir para produção. Vale conhecer porque, se amadurecer, muda como bibliotecas convivem em Ruby.",
+                },
+                {
+                    type: "quote",
+                    value: "Ruby::Box isola definições, monkey patches e variáveis globais. É experimental no 4.0 e a API ainda pode mudar.",
+                },
+                {
+                    type: "text",
+                    value: "## Refinements, a alternativa que já existe\n\nEnquanto isso, quem precisa de monkey patch com escopo limitado usa **refinements**: a alteração vale só nos arquivos que a ativarem com `using`.",
+                },
+                {
+                    type: "code",
+                    value: 'module Gritante\n  refine String do\n    def gritar\n      upcase + "!"\n    end\n  end\nend\n\n# Em outro arquivo\nusing Gritante\n"oi".gritar    # funciona aqui\n\n# Em um arquivo sem o using, o método não existe',
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que é um monkey patch?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Reabrir uma classe e alterar seu comportamento", isCorrect: true },
+                        {
+                            text: "Criar uma classe nova que herda de outra existente",
+                            isCorrect: false,
+                        },
+                        { text: "Corrigir um erro encontrado dentro de uma gem", isCorrect: false },
+                        { text: "Incluir um módulo dentro de uma classe pronta", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Que problema o Ruby::Box ataca?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O alcance global de alterações e patches", isCorrect: true },
+                        { text: "A lentidão do interpretador ao carregar gems", isCorrect: false },
+                        { text: "A falta de tipagem estática na linguagem", isCorrect: false },
+                        { text: "O consumo de memória de aplicações grandes", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual o status do Ruby::Box no Ruby 4.0?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Experimental, com API sujeita a mudança", isCorrect: true },
+                        { text: "Estável e recomendado para uso em produção", isCorrect: false },
+                        { text: "Obsoleto, substituído pelos refinements", isCorrect: false },
+                        { text: "Disponível apenas com uma gem instalada", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que os refinements permitem?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Limitar um patch aos arquivos que o ativam", isCorrect: true },
+                        {
+                            text: "Alterar uma classe em todo o programa de uma vez",
+                            isCorrect: false,
+                        },
+                        { text: "Criar classes novas dentro de outro namespace", isCorrect: false },
+                        { text: "Executar código isolado em outro processo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como se ativa um refinement em um arquivo?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Com a palavra `using`", isCorrect: true },
+                        { text: "Com a palavra include, como em um módulo", isCorrect: false },
+                        { text: "Com a palavra require no topo do arquivo", isCorrect: false },
+                        { text: "Com a palavra refine dentro da classe", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Projeto final e para onde ir",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Juntando tudo\n\nPara fechar a trilha, escreva um **gerenciador de tarefas de linha de comando**. Ele exercita cada módulo:\n\n1. Uma classe `Tarefa` com `attr_reader` e validação no `initialize`\n2. Um módulo `Persistivel` incluído por quem sabe salvar em JSON\n3. Uma classe `ListaDeTarefas` que inclui `Enumerable` implementando `each`\n4. Filtros e relatórios com `select`, `group_by` e `sum`\n5. Exceções próprias herdando de `StandardError`\n6. Testes com Minitest cobrindo o caminho feliz e os erros\n7. RuboCop passando sem violação\n\nCada passo corresponde a um módulo desta trilha.",
+                },
+                {
+                    type: "code",
+                    value: 'class Tarefa\n  include Comparable\n  attr_reader :titulo, :prioridade, :feita\n\n  PRIORIDADES = %i[baixa media alta].freeze\n\n  def initialize(titulo:, prioridade: :media)\n    raise ArgumentError, "título vazio" if titulo.to_s.strip.empty?\n    raise ArgumentError, "prioridade inválida" unless PRIORIDADES.include?(prioridade)\n\n    @titulo = titulo\n    @prioridade = prioridade\n    @feita = false\n  end\n\n  def concluir! = @feita = true\n\n  def <=>(outra)\n    PRIORIDADES.index(outra.prioridade) <=> PRIORIDADES.index(prioridade)\n  end\nend',
+                },
+                {
+                    type: "text",
+                    value: "## Para onde ir depois\n\nO caminho natural é o **Ruby on Rails**, que é onde a maior parte do Ruby profissional acontece. A trilha de Rails desta plataforma continua exatamente daqui.\n\nFora da web, vale olhar **Sinatra** para APIs pequenas, **Jekyll** para sites estáticos e a escrita de gems próprias, que é como se contribui com a comunidade.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que uma classe precisa para ser comparável com `<`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Incluir Comparable e definir `<=>`", isCorrect: true },
+                        { text: "Definir os métodos de maior e menor na classe", isCorrect: false },
+                        { text: "Herdar de uma classe base que já compare", isCorrect: false },
+                        { text: "Incluir Enumerable e implementar o each", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Para que serve o `freeze` em uma constante de array?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Impedir que o conteúdo seja alterado", isCorrect: true },
+                        { text: "Guardar o array em cache para acesso rápido", isCorrect: false },
+                        { text: "Converter o array em um Set sem repetição", isCorrect: false },
+                        { text: "Tornar a constante visível em outros arquivos", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `def concluir! = @feita = true` demonstra?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A definição de método em uma linha", isCorrect: true },
+                        { text: "A criação de um atributo com valor padrão", isCorrect: false },
+                        { text: "A definição de um método privado da classe", isCorrect: false },
+                        { text: "A atribuição de um bloco a um método", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual o caminho natural depois desta trilha?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Ruby on Rails", isCorrect: true },
+                        {
+                            text: "Sinatra, por ser bem mais completo que o Rails",
+                            isCorrect: false,
+                        },
+                        { text: "Jekyll, que é o framework web mais usado", isCorrect: false },
+                        { text: "Escrever gems, antes de qualquer framework", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que validar no `initialize`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Para que todo objeto criado esteja válido", isCorrect: true },
+                        { text: "Para que o objeto ocupe menos memória depois", isCorrect: false },
+                        { text: "Porque o Ruby exige validação no construtor", isCorrect: false },
+                        { text: "Para permitir que a classe seja comparável", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+export const MODULOS: Modulo[] = [
+    MODULO_1,
+    MODULO_2,
+    MODULO_3,
+    MODULO_4,
+    MODULO_5,
+    MODULO_6,
+    MODULO_7,
+];
+
+async function seed() {
+    let [trilha] = await db.select().from(trails).where(eq(trails.name, NOME));
+    if (!trilha) {
+        [trilha] = await db
+            .insert(trails)
+            .values({
+                name: NOME,
+                trailLevel: LEVEL,
+                description: DESCRICAO,
+                workloadHours: CARGA_HORARIA,
+            })
+            .returning();
+        console.log("Trilha criada: " + NOME);
+    } else {
+        const existentes = await db.select().from(lessons).where(eq(lessons.trailId, trilha.id));
+        if (existentes.length > 0) {
+            console.log("Trilha já tem aulas, nada a fazer: " + NOME);
+            return;
+        }
+        await db
+            .update(trails)
+            .set({ workloadHours: CARGA_HORARIA, description: DESCRICAO, trailLevel: LEVEL })
+            .where(eq(trails.id, trilha.id));
+    }
+
+    let totalAulas = 0;
+    let totalQuestoes = 0;
+    for (let mi = 0; mi < MODULOS.length; mi++) {
+        const m = MODULOS[mi];
+        const [mod] = await db
+            .insert(modules)
+            .values({ trailId: trilha.id, title: m.titulo, position: mi + 1 })
+            .returning();
+        for (let li = 0; li < m.aulas.length; li++) {
+            const a = m.aulas[li];
+            const [lesson] = await db
+                .insert(lessons)
+                .values({
+                    trailId: trilha.id,
+                    moduleId: mod.id,
+                    title: a.titulo,
+                    content: null,
+                    contentBlocks: a.blocks,
+                    position: li + 1,
+                    published: true,
+                })
+                .returning();
+            for (let qi = 0; qi < a.questions.length; qi++) {
+                const q = a.questions[qi];
+                const [questao] = await db
+                    .insert(questions)
+                    .values({
+                        lessonId: lesson.id,
+                        statement: q.statement,
+                        difficulty: q.difficulty,
+                        position: qi + 1,
+                    })
+                    .returning();
+                await db.insert(questionOptions).values(
+                    q.options.map((o, k) => ({
+                        questionId: questao.id,
+                        text: o.text,
+                        isCorrect: o.isCorrect,
+                        position: k + 1,
+                    })),
+                );
+            }
+            totalAulas++;
+            totalQuestoes += a.questions.length;
+        }
+    }
+    console.log(
+        "Seed concluído: " +
+            MODULOS.length +
+            " módulos, " +
+            totalAulas +
+            " aulas, " +
+            totalQuestoes +
+            " questões.",
+    );
+}
+
+// Só semeia quando executado direto. Importado, expõe MODULOS/NOME sem rodar nada.
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+    seed()
+        .then(() => process.exit(0))
+        .catch((e) => {
+            console.error("Falha no seed:", e);
+            process.exit(1);
+        });
+}


### PR DESCRIPTION
Quatro trilhas novas, e as **duas primeiras de framework** da plataforma. Até aqui o catálogo tinha linguagens soltas e uma trilha genérica de "APIs e Frameworks"; agora existe o caminho completo de duas stacks, da linguagem ao framework.

## As versões, que foi o primeiro trabalho

Confirmei cada uma na fonte oficial antes de escrever, e **duas fogem do que se esperaria**:

| Stack | Versão | Lançamento | Observação |
|---|---|---|---|
| PHP | **8.5** | 20/11/2025 | patch atual 8.5.8 |
| Ruby | **4.0** | 25/12/2025 | **não existe 3.5**, foi direto para a 4.0 |
| Laravel | **13** | 17/03/2026 | exige **PHP 8.3** no mínimo |
| Rails | **8.1** | out/2025 | patch atual 8.1.3.1 |

Material publicado em 2025 ainda ensina Ruby 3.4 e Laravel 12, então esse era o risco real de escrever de memória.

## O que cada trilha cobre

Todas seguem o formato atual: **7 módulos, 35 aulas, 175 questões, 5 por aula**.

**PHP**, iniciante, 20 horas. Sintaxe e tipos, strings e arrays, funções, orientação a objetos com enums e readonly, exceções, e o PHP na web com formulários, sessões, PDO e autoload PSR-4. As novidades da 8.5 entram onde fazem sentido: o pipe operator no módulo de funções, `array_first` e `array_last` no de arrays, o stack trace em erro fatal no de depuração.

**Ruby**, iniciante, 20 horas. Tudo é objeto, coleções e Enumerable, blocos e iteradores, pattern matching, classes com módulos e mixins, exceções e testes com Minitest e RSpec. O módulo 7 é sobre o Ruby 4.0: ZJIT ao lado do YJIT, Set e Pathname promovidos ao core, a reformulação de Ractor e o Ruby::Box.

**Laravel**, intermediário, 24 horas. Rotas e validação, Blade com componentes, Eloquent com relacionamentos e o N+1, autenticação com passkeys, gates e policies, APIs com resources e Sanctum, filas e cache, testes com Pest. As novidades da 13 aparecem nos módulos onde pertencem: atributos do PHP no Eloquent e nos jobs, o AI SDK, busca vetorial com pgvector, JSON:API e o `Cache::touch`.

**Ruby on Rails**, intermediário, 24 horas. Rotas REST, Active Record, autenticação pelo gerador nativo, Hotwire com Turbo e Stimulus, a Solid Trifecta, testes e deploy com Kamal. Da 8.1: Active Job Continuations, associações depreciadas, Structured Event Reporting e o CI local com `bin/ci`.

## Decisões de conteúdo

**Ensinar a armadilha, não só o caminho feliz.** Cada trilha insiste nos pontos onde a documentação é clara mas a prática engana: `==` contra `===` em PHP, `array_filter` sem `array_values` virando objeto no JSON, Proc contra lambda no `return`, `env()` fora de `config` depois do `config:cache`, `uniqueness: true` que não garante unicidade sem índice, frame do Turbo que some quando os ids não batem.

**As quatro emitem certificado.** Preenchi `workloadHours`, o que Go, Java e C++ ainda não fazem: 14 trilhas em produção não emitem certificado por falta desse campo.

**Ficam fora de roadmap**, como as demais trilhas de linguagem. O roadmap de back-end continua apontando para "Lógica & uma linguagem" e "APIs e Frameworks".

## Verificado em dev

- 4 trilhas, 28 módulos, 140 aulas, 700 questões, 5 questões em toda aula
- toda questão com 4 alternativas e exatamente uma correta: **0 fora do padrão**
- nenhuma alternativa correta é a mais longa do grupo, em nenhuma das 700
- sem emoji e sem travessão nas 140 aulas
- `seed-detalhes-trilhas` e `seed-conquistas-trilhas` rodados: 4 conquistas criadas
- `tsc --noEmit`, eslint e prettier limpos

## Para rodar em produção

    node scripts/seed-trilha-php.ts
    node scripts/seed-trilha-ruby.ts
    node scripts/seed-trilha-laravel.ts
    node scripts/seed-trilha-rails.ts
    node scripts/seed-detalhes-trilhas.ts
    node scripts/seed-conquistas-trilhas.ts

Todos idempotentes, e nenhum roadmap é alterado.