### PR TITLE
feat: trilhas de TypeScript, React e Spring Boot

### DIFF
--- a/backend/scripts/seed-detalhes-trilhas.ts
+++ b/backend/scripts/seed-detalhes-trilhas.ts
@@ -29,6 +29,33 @@ const DETALHES: Record<string, { whatYouLearn: string[]; prerequisites: string[]
         ],
         prerequisites: ["Lógica de programação (algoritmos, laços, condicionais)"],
     },
+    TypeScript: {
+        whatYouLearn: [
+            "Por que tipos existem e como o TypeScript checa antes de rodar",
+            "União e narrowing, interfaces, generics e restrições",
+            "Utility types, conditional e mapped types, e quando parar",
+            "Validação na fronteira, configuração do compilador e migração",
+        ],
+        prerequisites: ["JavaScript (funções, objetos, módulos e assíncrono)"],
+    },
+    React: {
+        whatYouLearn: [
+            "JSX, componentes, props e estado com useState e useReducer",
+            "Efeitos, e os quatro casos em que não se deve usar efeito",
+            "Composição, hooks próprios, context e as Actions do React 19",
+            "Desempenho com o React Compiler, testes e Server Components",
+        ],
+        prerequisites: ["JavaScript moderno (arrow functions, destructuring, módulos)"],
+    },
+    "Spring Boot": {
+        whatYouLearn: [
+            "Injeção de dependência, auto-configuração e starters",
+            "REST com validação, tratamento de erros e paginação",
+            "JPA com relacionamentos, transações, migrations e o N+1",
+            "Security com JWT, testes com Testcontainers e observabilidade",
+        ],
+        prerequisites: ["Java (orientação a objetos, coleções e exceções)", "Noções de HTTP e SQL"],
+    },
     PHP: {
         whatYouLearn: [
             "Sintaxe, tipos e strings do PHP 8.5",

--- a/backend/scripts/seed-trilha-react.ts
+++ b/backend/scripts/seed-trilha-react.ts
@@ -1,0 +1,3260 @@
+// Seed da trilha React (React 19.2). Conteúdo autoral.
+// A linha 19.2 começou em outubro de 2025 e é a que a trilha ensina: Actions,
+// useActionState e useOptimistic, ref como prop, useEffectEvent, Activity e o
+// React Compiler 1.0.
+//
+// Idempotente e nao destrutivo: se a trilha ja tiver aulas, nao faz nada.
+//
+// Rodar em prod: docker compose -f docker-compose.prod.yml run --rm -T --no-deps backend node scripts/seed-trilha-react.ts
+import { db } from "../db.ts";
+import { trails, modules, lessons, questions, questionOptions } from "../schema.ts";
+import { eq } from "drizzle-orm";
+import { pathToFileURL } from "node:url";
+
+export const NOME = "React";
+const LEVEL: "iniciante" | "intermediario" | "avancado" = "intermediario";
+const DESCRICAO =
+    "React 19.2 do primeiro componente ao deploy: JSX, props e estado, efeitos e o que não deveria ser efeito, composição com hooks próprios e context, as Actions do React 19 com useActionState e useOptimistic, desempenho com o React Compiler, testes com Testing Library e Server Components. A biblioteca de interface mais usada do mundo.";
+const CARGA_HORARIA = 24;
+
+type Bloco = { type: "text" | "code" | "quote" | "table"; value: string };
+type Questao = {
+    statement: string;
+    difficulty: "facil" | "medio" | "dificil";
+    options: { text: string; isCorrect: boolean }[];
+};
+type Aula = { titulo: string; blocks: Bloco[]; questions: Questao[] };
+type Modulo = { titulo: string; aulas: Aula[] };
+
+const MODULO_1: Modulo = {
+    titulo: "Módulo 1 - React do zero",
+    aulas: [
+        {
+            titulo: "O que é React e o que ele resolve",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Descrever, não manipular\n\nAntes do React, atualizar uma tela era **dizer ao navegador o que mudar**: achar o elemento, trocar o texto, remover a classe, esconder o outro. Com muitos estados possíveis, a quantidade de combinações explode e a tela sai de sincronia com os dados.\n\nO React inverte isso: você **descreve como a tela deveria estar** para um determinado estado, e ele calcula o que precisa mudar no navegador.",
+                },
+                {
+                    type: "code",
+                    value: '// Manipulando: você diz cada passo\nconst el = document.getElementById("contador");\nel.textContent = valor;\nif (valor > 10) el.classList.add("alerta");\nelse el.classList.remove("alerta");\n\n// Descrevendo: você diz como deve ficar\nfunction Contador({ valor }) {\n  return <span className={valor > 10 ? "alerta" : ""}>{valor}</span>;\n}',
+                },
+                {
+                    type: "text",
+                    value: "## Componentes\n\nA unidade do React é o **componente**: uma função que recebe dados e devolve o que aparece na tela. Componentes se compõem, e é assim que uma interface grande é montada a partir de peças pequenas.\n\n## A versão\n\nEsta trilha usa o **React 19.2**, cuja linha começou em outubro de 2025. O React 19 trouxe as Actions e mudanças que simplificaram bastante o dia a dia, e o **React Compiler** chegou à versão 1.0.",
+                },
+                {
+                    type: "quote",
+                    value: "Você descreve o resultado para cada estado. Quem decide o que mudar no navegador é o React, não o seu código.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual a diferença central entre React e manipular o DOM na mão?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Você descreve o resultado, não os passos", isCorrect: true },
+                        {
+                            text: "O React executa a página bem mais rápido sempre",
+                            isCorrect: false,
+                        },
+                        { text: "O React dispensa o uso de HTML na aplicação", isCorrect: false },
+                        { text: "O React roda no servidor em vez do navegador", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que é um componente em React?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Uma função que devolve o que aparece na tela", isCorrect: true },
+                        { text: "Um arquivo com o HTML de uma página inteira", isCorrect: false },
+                        {
+                            text: "Uma classe que herda de uma classe base do React",
+                            isCorrect: false,
+                        },
+                        { text: "Um objeto com os dados que a tela vai exibir", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual versão do React esta trilha usa?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "React 19.2", isCorrect: true },
+                        { text: "React 16.8", isCorrect: false },
+                        { text: "React 17.0", isCorrect: false },
+                        { text: "React 18.2", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que manipular o DOM na mão fica difícil de manter?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "A quantidade de combinações de estado explode", isCorrect: true },
+                        {
+                            text: "O navegador limita quantas alterações são feitas",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O JavaScript não consegue acessar todos os elementos",
+                            isCorrect: false,
+                        },
+                        { text: "O HTML precisa ser reescrito a cada alteração", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como uma interface grande é montada em React?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Compondo componentes pequenos", isCorrect: true },
+                        {
+                            text: "Escrevendo um componente com toda a tela dentro",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Separando o HTML, o CSS e o JavaScript em arquivos",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Gerando o HTML a partir de um arquivo de modelo",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Criando o projeto com Vite",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O ponto de partida\n\nO **Vite** é a ferramenta padrão para começar um projeto React hoje. Ele sobe um servidor de desenvolvimento que atualiza a tela na hora e gera o build de produção.",
+                },
+                {
+                    type: "code",
+                    value: "npm create vite@latest minha-app -- --template react-ts\ncd minha-app\nnpm install\nnpm run dev\n# http://localhost:5173",
+                },
+                {
+                    type: "text",
+                    value: "O template `react-ts` já vem com TypeScript configurado, e é o que a maioria dos projetos usa. Vale começar assim mesmo sem saber TypeScript ainda: os tipos ajudam antes de você entender todos eles.\n\n## A estrutura\n\nO projeto gerado é pequeno de propósito. `index.html` é o ponto de entrada, `src/main.tsx` conecta o React à página e `src/App.tsx` é o primeiro componente.",
+                },
+                {
+                    type: "code",
+                    value: '// src/main.tsx\nimport { StrictMode } from "react";\nimport { createRoot } from "react-dom/client";\nimport App from "./App";\n\ncreateRoot(document.getElementById("root")!).render(\n  <StrictMode>\n    <App />\n  </StrictMode>,\n);',
+                },
+                {
+                    type: "text",
+                    value: "## StrictMode\n\nO `StrictMode` só existe em desenvolvimento e **monta cada componente duas vezes** de propósito. Isso assusta quem vê um `console.log` aparecer duplicado, mas é um recurso: ele revela efeitos que não são seguros para rodar mais de uma vez.\n\nEm produção nada disso acontece. Se um bug some ao remover o StrictMode, o bug é real e continua lá.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual ferramenta é o padrão para criar projeto React hoje?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "O Vite", isCorrect: true },
+                        {
+                            text: "O Create React App, mantido pela equipe do React",
+                            isCorrect: false,
+                        },
+                        { text: "O Webpack, configurado manualmente no projeto", isCorrect: false },
+                        { text: "O Parcel, que dispensa qualquer configuração", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o `StrictMode` faz em desenvolvimento?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Monta cada componente duas vezes", isCorrect: true },
+                        { text: "Impede que erros de tipo passem despercebidos", isCorrect: false },
+                        {
+                            text: "Bloqueia o uso de recursos que serão removidos",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Executa os componentes em modo somente leitura",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Por que o StrictMode monta duas vezes?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Para revelar efeitos que não podem repetir", isCorrect: true },
+                        { text: "Para medir o tempo de renderização de cada um", isCorrect: false },
+                        {
+                            text: "Para garantir que o estado inicial esteja correto",
+                            isCorrect: false,
+                        },
+                        { text: "Para comparar o resultado das duas montagens", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O StrictMode afeta o comportamento em produção?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Não, ele só existe em desenvolvimento", isCorrect: true },
+                        {
+                            text: "Sim, ele deixa a aplicação um pouco mais lenta",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Sim, ele mantém a montagem dupla dos componentes",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Sim, ele bloqueia recursos considerados inseguros",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Se um bug some ao remover o StrictMode, o que isso significa?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O bug é real e continua no código", isCorrect: true },
+                        {
+                            text: "O StrictMode estava criando o problema sozinho",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O componente precisa ser reescrito como classe",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O bug só acontece no ambiente de desenvolvimento",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "JSX",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# HTML dentro do JavaScript\n\nO **JSX** parece HTML, mas é JavaScript. Cada tag vira uma chamada de função que o React usa para montar a tela.\n\nComo é JavaScript, algumas palavras mudam: `class` já existe na linguagem, então vira `className`; `for` vira `htmlFor`.",
+                },
+                {
+                    type: "code",
+                    value: 'const nome = "Ana";\nconst logado = true;\n\nfunction Saudacao() {\n  return (\n    <div className="caixa">\n      <h1>Olá, {nome}</h1>\n      {logado && <p>Bem-vinda de volta</p>}\n      <p>{logado ? "Sair" : "Entrar"}</p>\n    </div>\n  );\n}',
+                },
+                {
+                    type: "text",
+                    value: "## Chaves\n\nAs chaves saem do JSX e entram no JavaScript. Dentro delas vale qualquer **expressão**, mas não instrução: um `if` solto não funciona, e por isso condicional em JSX usa `&&` ou o ternário.",
+                },
+                {
+                    type: "table",
+                    value: '[["Em HTML", "Em JSX", "Por quê"], ["class", "className", "class é palavra reservada"], ["for", "htmlFor", "for é palavra reservada"], ["onclick", "onClick", "eventos em camelCase"], ["style=\'cor\'", "style={{ cor: \'x\' }}", "recebe um objeto"], ["<br>", "<br />", "toda tag precisa fechar"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Um elemento raiz\n\nUm componente devolve **um** elemento. Para devolver vários sem criar uma `div` a mais, use o fragmento, que não vira nada no HTML final.",
+                },
+                {
+                    type: "code",
+                    value: "return (\n  <>\n    <h1>Título</h1>\n    <p>Texto</p>\n  </>\n);",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o JSX é, tecnicamente?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "JavaScript que vira chamadas de função", isCorrect: true },
+                        { text: "HTML interpretado direto pelo navegador", isCorrect: false },
+                        { text: "Um formato de modelo compilado no servidor", isCorrect: false },
+                        { text: "Uma linguagem de marcação própria do React", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que `class` vira `className` em JSX?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "class é palavra reservada do JavaScript", isCorrect: true },
+                        { text: "Porque o React usa classes CSS diferentes", isCorrect: false },
+                        { text: "Porque o nome em HTML foi descontinuado", isCorrect: false },
+                        { text: "Para diferenciar de componentes de classe", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que pode ir dentro das chaves no JSX?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Qualquer expressão JavaScript", isCorrect: true },
+                        { text: "Qualquer instrução, incluindo if e for", isCorrect: false },
+                        { text: "Apenas variáveis já declaradas antes", isCorrect: false },
+                        { text: "Somente texto e números, sem funções", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Para que serve o fragmento `<>`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Devolver vários elementos sem criar um a mais", isCorrect: true },
+                        {
+                            text: "Agrupar componentes que compartilham o mesmo estado",
+                            isCorrect: false,
+                        },
+                        { text: "Marcar um trecho que não será renderizado", isCorrect: false },
+                        { text: "Criar um componente sem precisar de nome", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como se escreve estilo em linha no JSX?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Passando um objeto para style", isCorrect: true },
+                        { text: "Passando uma string com o CSS dentro", isCorrect: false },
+                        { text: "Usando o atributo css em vez de style", isCorrect: false },
+                        { text: "Importando o arquivo de CSS no componente", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Componentes e props",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Passando dados para baixo\n\nAs **props** são os argumentos de um componente. Elas descem de quem usa para quem é usado, e **não podem ser alteradas** por quem recebe: o componente lê e devolve a tela, sem mexer no que veio.",
+                },
+                {
+                    type: "code",
+                    value: 'type Props = {\n  nome: string;\n  preco: number;\n  emPromocao?: boolean;\n};\n\nfunction Card({ nome, preco, emPromocao = false }: Props) {\n  return (\n    <div className={emPromocao ? "card card--promo" : "card"}>\n      <h3>{nome}</h3>\n      <p>{preco.toFixed(2)}</p>\n    </div>\n  );\n}\n\n// Usando\n<Card nome="Caneca" preco={29.9} emPromocao />',
+                },
+                {
+                    type: "text",
+                    value: 'Repare em duas coisas: o valor entre chaves é JavaScript, então `preco={29.9}` passa um número enquanto `preco="29.9"` passaria texto. E `emPromocao` sozinho equivale a `emPromocao={true}`.\n\n## Fluxo em uma direção\n\nDados descem por props. Quando um componente filho precisa avisar o pai de algo, o pai passa uma **função** como prop, e o filho a chama. É o padrão mais importante do React.',
+                },
+                {
+                    type: "code",
+                    value: "function Lista({ itens, aoSelecionar }) {\n  return (\n    <ul>\n      {itens.map((item) => (\n        <li key={item.id} onClick={() => aoSelecionar(item)}>\n          {item.nome}\n        </li>\n      ))}\n    </ul>\n  );\n}\n\n// O pai decide o que fazer\n<Lista itens={produtos} aoSelecionar={(p) => setSelecionado(p)} />",
+                },
+                {
+                    type: "quote",
+                    value: "Props descem, eventos sobem. Quem tem o estado é quem decide o que fazer com o evento.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O componente pode alterar as props que recebe?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Não, elas são somente leitura", isCorrect: true },
+                        { text: "Sim, desde que avise o componente pai depois", isCorrect: false },
+                        { text: "Sim, quando elas forem objetos ou arrays", isCorrect: false },
+                        { text: "Sim, mas apenas dentro de um efeito", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: 'Qual a diferença entre `preco={29.9}` e `preco="29.9"`?',
+                    difficulty: "medio",
+                    options: [
+                        { text: "O primeiro passa número e o segundo texto", isCorrect: true },
+                        { text: "O primeiro é avaliado e o segundo é ignorado", isCorrect: false },
+                        { text: "O segundo é convertido para número pelo React", isCorrect: false },
+                        { text: "Não há diferença, o React trata os dois igual", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como um filho avisa o pai de um evento?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Chamando uma função recebida por prop", isCorrect: true },
+                        {
+                            text: "Alterando diretamente o estado do componente pai",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Emitindo um evento que sobe pela árvore sozinho",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Usando uma variável global compartilhada entre eles",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que `emPromocao` sozinho na tag significa?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O mesmo que passar o valor true", isCorrect: true },
+                        { text: "Que a prop foi declarada mas está vazia", isCorrect: false },
+                        { text: "Que a prop recebe o valor padrão declarado", isCorrect: false },
+                        { text: "Que a prop será preenchida pelo componente", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Em qual direção os dados fluem em React?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "De cima para baixo, por props", isCorrect: true },
+                        { text: "De baixo para cima, do filho para o pai", isCorrect: false },
+                        { text: "Nos dois sentidos, de forma automática", isCorrect: false },
+                        { text: "Entre componentes irmãos, diretamente", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Listas e chaves",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Renderizando uma coleção\n\nListas em React saem de um `map` sobre um array. Cada item precisa de uma prop `key`, e essa é a fonte de um dos bugs mais comuns de quem começa.",
+                },
+                {
+                    type: "code",
+                    value: "function ListaProdutos({ produtos }) {\n  return (\n    <ul>\n      {produtos.map((p) => (\n        <li key={p.id}>{p.nome}</li>\n      ))}\n    </ul>\n  );\n}",
+                },
+                {
+                    type: "text",
+                    value: "## Por que a chave importa\n\nA `key` diz ao React **qual item é qual** entre uma renderização e outra. Com ela, inserir um item no começo da lista move os existentes; sem ela, o React compara por posição e pode reaproveitar o elemento errado.\n\nO efeito aparece quando os itens têm estado interno: um campo de texto preenchido acaba associado à linha errada depois de uma remoção.",
+                },
+                {
+                    type: "code",
+                    value: "// Errado: o índice muda quando a lista muda\n{itens.map((item, i) => <Linha key={i} item={item} />)}\n\n// Certo: um identificador estável do próprio dado\n{itens.map((item) => <Linha key={item.id} item={item} />)}",
+                },
+                {
+                    type: "table",
+                    value: '[["Chave", "Quando serve"], ["id do banco", "sempre, é a melhor opção"], ["slug ou código único", "quando não há id numérico"], ["índice do array", "só em lista fixa que nunca reordena"], ["Math.random()", "nunca, muda a cada renderização"]]',
+                },
+                {
+                    type: "text",
+                    value: "A última linha merece destaque: uma chave aleatória faz o React descartar e recriar todos os itens a cada renderização, perdendo estado e desempenho.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Para que serve a prop `key` em uma lista?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Dizer ao React qual item é qual entre renderizações",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Definir a ordem em que os itens serão exibidos",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Identificar o item no momento em que ele for clicado na tela",
+                            isCorrect: false,
+                        },
+                        { text: "Guardar o valor do item para uso posterior", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quando usar o índice como chave é aceitável?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Em lista fixa que nunca reordena", isCorrect: true },
+                        { text: "Sempre, é o padrão recomendado pela equipe", isCorrect: false },
+                        { text: "Quando os itens não têm identificador próprio", isCorrect: false },
+                        { text: "Quando a lista tem poucos itens dentro dela", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que acontece ao usar `Math.random()` como chave?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Todos os itens são recriados a cada renderização",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "As chaves ficam garantidamente únicas na lista",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O React avisa no console e usa o índice no lugar",
+                            isCorrect: false,
+                        },
+                        { text: "Os itens perdem a ordem original do array", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quando o bug de chave errada mais aparece?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Quando os itens têm estado interno", isCorrect: true },
+                        { text: "Quando a lista tem mais de cem itens", isCorrect: false },
+                        { text: "Quando os itens são componentes simples", isCorrect: false },
+                        { text: "Quando a lista é renderizada uma vez só", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a melhor chave para uma lista vinda do banco?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "O id do registro", isCorrect: true },
+                        { text: "A posição do item dentro do array", isCorrect: false },
+                        { text: "O nome exibido em cada um dos itens", isCorrect: false },
+                        { text: "Um número gerado no momento da renderização", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_2: Modulo = {
+    titulo: "Módulo 2 - Estado e eventos",
+    aulas: [
+        {
+            titulo: "useState",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Dados que mudam\n\nProps vêm de fora e não mudam. O **estado** é o dado que pertence ao componente e muda com o tempo. Alterar o estado faz o React renderizar de novo.",
+                },
+                {
+                    type: "code",
+                    value: 'import { useState } from "react";\n\nfunction Contador() {\n  const [valor, setValor] = useState(0);\n\n  return (\n    <button onClick={() => setValor(valor + 1)}>\n      Cliquei {valor} vezes\n    </button>\n  );\n}',
+                },
+                {
+                    type: "text",
+                    value: "O `useState` devolve uma tupla: o valor atual e a função que o altera. O argumento é o valor **inicial**, usado só na primeira renderização.\n\n## Atualizar a partir do anterior\n\nQuando o valor novo depende do antigo, passe uma **função** para o setter. Isso evita o bug de somar duas vezes e obter apenas um.",
+                },
+                {
+                    type: "code",
+                    value: "// Errado: as duas leem o mesmo valor antigo\nsetValor(valor + 1);\nsetValor(valor + 1);   // resultado: soma um, não dois\n\n// Certo: cada uma recebe o resultado da anterior\nsetValor((v) => v + 1);\nsetValor((v) => v + 1);   // resultado: soma dois",
+                },
+                {
+                    type: "text",
+                    value: "## Nunca altere o estado no lugar\n\nO React compara a referência para saber se algo mudou. Alterar um array ou objeto existente não muda a referência, e a tela não atualiza. Sempre crie um valor novo.",
+                },
+                {
+                    type: "code",
+                    value: '// Errado: a referência é a mesma, o React não vê mudança\nitens.push(novo);\nsetItens(itens);\n\n// Certo: um array novo\nsetItens([...itens, novo]);\nsetItens(itens.filter((i) => i.id !== id));\nsetUsuario({ ...usuario, nome: "Ana" });',
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o `useState` devolve?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "O valor atual e a função que o altera", isCorrect: true },
+                        { text: "Apenas o valor guardado no estado atual", isCorrect: false },
+                        { text: "Um objeto com o valor e o valor anterior", isCorrect: false },
+                        { text: "Uma função que lê e escreve o valor", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quando o argumento do `useState` é usado?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Só na primeira renderização", isCorrect: true },
+                        { text: "Em toda renderização do componente", isCorrect: false },
+                        { text: "Sempre que o componente recebe props novas", isCorrect: false },
+                        { text: "Quando o estado volta a ser indefinido", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Por que passar uma função ao setter quando o valor depende do anterior?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Cada chamada recebe o resultado da anterior", isCorrect: true },
+                        { text: "A função executa bem mais rápido que o valor", isCorrect: false },
+                        {
+                            text: "O React exige função quando há mais de um setter",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "A função evita que o componente renderize de novo",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Por que alterar um array com `push` não atualiza a tela?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "A referência continua a mesma e o React não vê mudança",
+                            isCorrect: true,
+                        },
+                        { text: "O push não é permitido dentro de componentes", isCorrect: false },
+                        {
+                            text: "O array precisa ser convertido para um objeto antes disso",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O setter precisa ser chamado duas vezes seguidas",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Como se acrescenta um item a um array em estado?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Criando um array novo com espalhamento", isCorrect: true },
+                        { text: "Chamando push e depois o setter do estado", isCorrect: false },
+                        { text: "Alterando o array e forçando a renderização", isCorrect: false },
+                        { text: "Usando concat direto dentro do JSX", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Eventos e formulários controlados",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Eventos\n\nEventos em JSX são props em camelCase que recebem uma função. Repare que se passa a **função**, não a chamada dela.",
+                },
+                {
+                    type: "code",
+                    value: "// Certo: passa a função\n<button onClick={salvar}>Salvar</button>\n\n// Certo: função anônima quando precisa de argumento\n<button onClick={() => remover(item.id)}>Remover</button>\n\n// Errado: chama na hora da renderização\n<button onClick={remover(item.id)}>Remover</button>",
+                },
+                {
+                    type: "text",
+                    value: "## Formulário controlado\n\nNo **componente controlado**, o valor do campo vem do estado e cada digitação o atualiza. O estado vira a única fonte da verdade, e é isso que permite validar, formatar e habilitar o botão conforme o conteúdo.",
+                },
+                {
+                    type: "code",
+                    value: 'function Formulario() {\n  const [email, setEmail] = useState("");\n  const [aceito, setAceito] = useState(false);\n\n  function enviar(e: React.FormEvent) {\n    e.preventDefault();\n    console.log({ email, aceito });\n  }\n\n  return (\n    <form onSubmit={enviar}>\n      <input\n        type="email"\n        value={email}\n        onChange={(e) => setEmail(e.target.value)}\n      />\n      <input\n        type="checkbox"\n        checked={aceito}\n        onChange={(e) => setAceito(e.target.checked)}\n      />\n      <button disabled={!email || !aceito}>Enviar</button>\n    </form>\n  );\n}',
+                },
+                {
+                    type: "text",
+                    value: "O `e.preventDefault()` no submit impede o comportamento padrão do navegador de recarregar a página.\n\nUm detalhe que confunde: caixas de seleção usam `checked` e `e.target.checked`, não `value`.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que se passa para uma prop de evento?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A função, não a chamada dela", isCorrect: true },
+                        { text: "A chamada da função com os argumentos", isCorrect: false },
+                        { text: "O nome da função entre aspas simples", isCorrect: false },
+                        { text: "Um objeto descrevendo o que fazer", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que acontece com `onClick={remover(id)}`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "A função é chamada na renderização", isCorrect: true },
+                        { text: "A função é chamada apenas ao clicar no botão", isCorrect: false },
+                        { text: "O React avisa que a sintaxe está errada", isCorrect: false },
+                        { text: "O argumento é ignorado e a função não roda", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que caracteriza um formulário controlado?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O valor do campo vir do estado", isCorrect: true },
+                        { text: "O formulário ser validado antes do envio", isCorrect: false },
+                        { text: "Os campos serem preenchidos automaticamente", isCorrect: false },
+                        { text: "O envio ser bloqueado até tudo estar correto", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Para que serve `e.preventDefault()` no submit?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Impedir que a página recarregue", isCorrect: true },
+                        { text: "Impedir que o formulário seja enviado vazio", isCorrect: false },
+                        { text: "Cancelar o evento quando há erro de validação", isCorrect: false },
+                        {
+                            text: "Evitar que o clique dispare duas vezes seguidas",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual prop uma caixa de seleção usa?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "checked, e não value", isCorrect: true },
+                        { text: "value, como qualquer outro campo", isCorrect: false },
+                        { text: "selected, indicando a marcação", isCorrect: false },
+                        { text: "state, ligado direto ao useState", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "O estado é uma foto, não uma variável",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O que mais confunde no React\n\nDentro de uma renderização, o estado é um valor **fixo**. Chamar o setter não altera a variável que já está na tela: ele agenda uma renderização nova, com um valor novo.\n\nÉ por isso que o `console.log` logo depois do setter mostra o valor antigo, e isso não é bug.",
+                },
+                {
+                    type: "code",
+                    value: "function Exemplo() {\n  const [n, setN] = useState(0);\n\n  function clicar() {\n    setN(n + 1);\n    console.log(n);   // mostra o valor ANTIGO, sempre\n  }\n\n  return <button onClick={clicar}>{n}</button>;\n}",
+                },
+                {
+                    type: "text",
+                    value: "## Cada renderização tem seu próprio estado\n\nA função do componente roda de novo a cada renderização, e as variáveis dela são novas. O `n` de dentro de `clicar` pertence à renderização em que aquele clique foi registrado, e não muda depois.\n\nEsse comportamento se chama **closure sobre o estado**, e explica quase todo comportamento estranho envolvendo `setTimeout` e efeitos.",
+                },
+                {
+                    type: "code",
+                    value: "function Alerta() {\n  const [n, setN] = useState(0);\n\n  function avisarDepois() {\n    setTimeout(() => {\n      alert(n);   // mostra o n de QUANDO foi clicado\n    }, 3000);\n  }\n\n  return (\n    <>\n      <button onClick={() => setN(n + 1)}>{n}</button>\n      <button onClick={avisarDepois}>Avisar em 3s</button>\n    </>\n  );\n}",
+                },
+                {
+                    type: "quote",
+                    value: "Estado é uma foto do momento da renderização. Se você precisa do valor mais recente dentro de um callback, use a forma de função do setter.",
+                },
+            ],
+            questions: [
+                {
+                    statement:
+                        "Por que o `console.log` logo depois do setter mostra o valor antigo?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O estado é fixo dentro daquela renderização", isCorrect: true },
+                        {
+                            text: "O setter demora alguns milissegundos para aplicar",
+                            isCorrect: false,
+                        },
+                        { text: "O console mostra o valor de forma assíncrona", isCorrect: false },
+                        {
+                            text: "O React guarda o log antes de atualizar o valor",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que chamar o setter faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Agenda uma renderização nova", isCorrect: true },
+                        { text: "Altera a variável de estado imediatamente", isCorrect: false },
+                        { text: "Força a atualização da tela na mesma hora", isCorrect: false },
+                        { text: "Guarda o valor para a próxima função chamada", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual valor um `setTimeout` enxerga do estado?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O da renderização em que foi criado", isCorrect: true },
+                        { text: "O mais recente no momento em que dispara", isCorrect: false },
+                        { text: "O valor inicial passado ao useState", isCorrect: false },
+                        { text: "Sempre o valor indefinido, por ser assíncrono", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como esse comportamento se chama?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Closure sobre o estado", isCorrect: true },
+                        { text: "Renderização assíncrona dos componentes", isCorrect: false },
+                        { text: "Congelamento do estado pelo StrictMode", isCorrect: false },
+                        { text: "Atraso de propagação entre componentes", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como obter o valor mais recente dentro de um callback?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Usando a forma de função do setter", isCorrect: true },
+                        { text: "Declarando o estado fora do componente", isCorrect: false },
+                        { text: "Chamando o setter duas vezes seguidas", isCorrect: false },
+                        { text: "Lendo o valor direto do elemento na tela", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Levantando o estado",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Quando dois componentes precisam do mesmo dado\n\nEstado vive dentro de um componente e não é visível pelos irmãos. Quando dois precisam do mesmo dado, ele **sobe** para o pai comum mais próximo, que passa o valor e a função de alterar para os dois.",
+                },
+                {
+                    type: "code",
+                    value: 'function Painel() {\n  const [filtro, setFiltro] = useState("");\n\n  return (\n    <>\n      <Busca valor={filtro} aoMudar={setFiltro} />\n      <Resultados filtro={filtro} />\n    </>\n  );\n}\n\nfunction Busca({ valor, aoMudar }) {\n  return <input value={valor} onChange={(e) => aoMudar(e.target.value)} />;\n}\n\nfunction Resultados({ filtro }) {\n  const visiveis = produtos.filter((p) => p.nome.includes(filtro));\n  return <ul>{visiveis.map((p) => <li key={p.id}>{p.nome}</li>)}</ul>;\n}',
+                },
+                {
+                    type: "text",
+                    value: "## Onde o estado deve morar\n\nA regra: no componente **mais próximo** que precisa dele. Subir demais faz o pai renderizar por mudanças que não lhe dizem respeito; deixar embaixo demais impede o compartilhamento.\n\n## Estado que não deveria existir\n\nO erro mais comum de modelagem é guardar em estado algo que **pode ser calculado**. Isso cria duas fontes da verdade que precisam ser sincronizadas, e uma delas sempre fica para trás.",
+                },
+                {
+                    type: "code",
+                    value: "// Errado: o total precisa ser atualizado junto, sempre\nconst [itens, setItens] = useState([]);\nconst [total, setTotal] = useState(0);\n\n// Certo: o total é derivado, e nunca fica errado\nconst [itens, setItens] = useState([]);\nconst total = itens.reduce((s, i) => s + i.preco, 0);",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que fazer quando dois componentes irmãos precisam do mesmo dado?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Subir o estado para o pai comum", isCorrect: true },
+                        { text: "Passar o dado direto entre os dois irmãos", isCorrect: false },
+                        { text: "Duplicar o estado em cada um dos dois", isCorrect: false },
+                        { text: "Guardar o dado em uma variável global", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Onde o estado deve morar?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "No componente mais próximo que precisa dele", isCorrect: true },
+                        { text: "Sempre no componente raiz da aplicação", isCorrect: false },
+                        { text: "No componente que exibe o dado na tela", isCorrect: false },
+                        {
+                            text: "Em um arquivo separado, com todo o estado global",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual o problema de guardar em estado algo que pode ser calculado?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Cria duas fontes da verdade para sincronizar", isCorrect: true },
+                        { text: "Consome bem mais memória no navegador", isCorrect: false },
+                        { text: "Impede que o componente use outros estados", isCorrect: false },
+                        {
+                            text: "Faz o componente renderizar duas vezes seguidas",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual o custo de subir o estado alto demais?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "O pai renderiza por mudanças que não lhe importam",
+                            isCorrect: true,
+                        },
+                        { text: "Os filhos deixam de receber as props corretas", isCorrect: false },
+                        {
+                            text: "O estado acaba sendo compartilhado sem nenhum controle",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "A aplicação perde o estado ao trocar de página",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Como o total de uma lista deve ser obtido?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Calculado a partir dos itens na renderização", isCorrect: true },
+                        { text: "Guardado em um estado próprio e atualizado", isCorrect: false },
+                        { text: "Calculado dentro de um efeito após a mudança", isCorrect: false },
+                        { text: "Recebido do servidor a cada alteração feita", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "useReducer",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Quando o useState não dá mais conta\n\nCom vários estados que mudam juntos, a lógica de atualização se espalha por muitos handlers. O **useReducer** junta tudo em uma função só, que recebe o estado atual e uma ação e devolve o estado novo.",
+                },
+                {
+                    type: "code",
+                    value: 'type Estado = { itens: Item[]; carregando: boolean; erro: string | null };\n\ntype Acao =\n  | { tipo: "carregando" }\n  | { tipo: "sucesso"; itens: Item[] }\n  | { tipo: "erro"; mensagem: string }\n  | { tipo: "remover"; id: number };\n\nfunction redutor(estado: Estado, acao: Acao): Estado {\n  switch (acao.tipo) {\n    case "carregando":\n      return { ...estado, carregando: true, erro: null };\n    case "sucesso":\n      return { itens: acao.itens, carregando: false, erro: null };\n    case "erro":\n      return { ...estado, carregando: false, erro: acao.mensagem };\n    case "remover":\n      return { ...estado, itens: estado.itens.filter((i) => i.id !== acao.id) };\n  }\n}\n\nconst [estado, despachar] = useReducer(redutor, {\n  itens: [], carregando: false, erro: null,\n});\n\ndespachar({ tipo: "remover", id: 3 });',
+                },
+                {
+                    type: "text",
+                    value: "## Quando vale a troca\n\n- Vários campos que mudam juntos e precisam ficar consistentes\n- A mesma transição acontece em lugares diferentes da tela\n- Você quer testar a lógica de estado sem renderizar nada\n\nO redutor é uma **função pura**: mesma entrada, mesma saída, sem efeito colateral. Isso o torna trivial de testar, e é uma vantagem que o `useState` não oferece.",
+                },
+                {
+                    type: "code",
+                    value: 'test("remover tira o item da lista", () => {\n  const antes = { itens: [{ id: 1 }, { id: 2 }], carregando: false, erro: null };\n  const depois = redutor(antes, { tipo: "remover", id: 1 });\n  expect(depois.itens).toHaveLength(1);\n});',
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o `useReducer` junta em um lugar só?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A lógica de atualização do estado", isCorrect: true },
+                        { text: "Todos os estados usados pelo componente", isCorrect: false },
+                        { text: "Os efeitos que dependem daquele estado", isCorrect: false },
+                        { text: "As props recebidas do componente pai", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que um redutor recebe e devolve?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Estado atual e ação, devolve o estado novo", isCorrect: true },
+                        { text: "Apenas a ação, e devolve um valor booleano", isCorrect: false },
+                        { text: "O estado antigo, e altera ele no lugar", isCorrect: false },
+                        { text: "As props, e devolve o componente renderizado", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que um redutor é fácil de testar?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Ele é uma função pura, sem efeito colateral", isCorrect: true },
+                        { text: "Ele roda fora do ciclo de renderização", isCorrect: false },
+                        { text: "Ele é executado apenas uma vez por ação", isCorrect: false },
+                        {
+                            text: "Ele é chamado direto pelo React, sem receber props",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Quando trocar `useState` por `useReducer`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Quando vários campos mudam juntos", isCorrect: true },
+                        { text: "Quando o estado é usado por mais de um filho", isCorrect: false },
+                        { text: "Quando o componente tem mais de um efeito", isCorrect: false },
+                        { text: "Quando o estado vem de uma chamada de API", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como se dispara uma mudança com useReducer?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Despachando uma ação", isCorrect: true },
+                        { text: "Chamando o setter com o valor novo", isCorrect: false },
+                        { text: "Alterando o estado dentro do redutor", isCorrect: false },
+                        { text: "Renderizando o componente novamente", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_3: Modulo = {
+    titulo: "Módulo 3 - Efeitos e dados",
+    aulas: [
+        {
+            titulo: "useEffect: o que é e o que não é",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Sincronizar com o mundo de fora\n\nO `useEffect` existe para **sincronizar o componente com algo externo ao React**: uma conexão, uma assinatura, o título da página, uma API do navegador.\n\nEle **não** é um gancho de ciclo de vida, e não é onde você reage a cliques. A maior parte do mau uso de efeito vem de tratá-lo como um lugar para colocar lógica que aconteceria de qualquer jeito.",
+                },
+                {
+                    type: "code",
+                    value: "useEffect(() => {\n  document.title = `${naoLidas} mensagens`;\n}, [naoLidas]);\n\nuseEffect(() => {\n  const conexao = criarConexao(salaId);\n  conexao.conectar();\n  return () => conexao.desconectar();\n}, [salaId]);",
+                },
+                {
+                    type: "text",
+                    value: "## Quando ele roda\n\nO efeito roda **depois** de a tela ser pintada, e de novo sempre que alguma dependência muda. A função devolvida é a **limpeza**, e roda antes da próxima execução e ao desmontar o componente.",
+                },
+                {
+                    type: "table",
+                    value: '[["Dependências", "Quando o efeito roda"], ["sem array", "depois de toda renderização"], ["array vazio", "uma vez, ao montar"], ["[a, b]", "ao montar e quando a ou b mudam"]]',
+                },
+                {
+                    type: "quote",
+                    value: "Se o efeito não sincroniza com nada fora do React, ele provavelmente não deveria ser um efeito.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Para que o `useEffect` existe?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Sincronizar com algo externo ao React", isCorrect: true },
+                        { text: "Executar código quando o componente é montado", isCorrect: false },
+                        { text: "Reagir a cliques e outras ações do usuário", isCorrect: false },
+                        { text: "Calcular valores derivados de outros estados", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quando o efeito roda em relação à pintura da tela?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Depois de a tela ser pintada", isCorrect: true },
+                        { text: "Antes de a tela ser pintada pelo navegador", isCorrect: false },
+                        { text: "Ao mesmo tempo em que a tela é montada", isCorrect: false },
+                        { text: "Somente quando o componente é desmontado", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que a função devolvida pelo efeito faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Limpa antes da próxima execução e ao desmontar", isCorrect: true },
+                        {
+                            text: "Devolve o valor que foi calculado para o componente",
+                            isCorrect: false,
+                        },
+                        { text: "Reexecuta o efeito quando algo muda", isCorrect: false },
+                        { text: "Cancela o efeito antes de ele começar", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quando um efeito com array vazio roda?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Uma vez, ao montar", isCorrect: true },
+                        { text: "Depois de toda renderização do componente", isCorrect: false },
+                        { text: "Sempre que qualquer estado muda de valor", isCorrect: false },
+                        { text: "Apenas quando o componente é desmontado", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que indica que algo não deveria ser um efeito?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Não sincronizar com nada fora do React", isCorrect: true },
+                        { text: "Depender de mais de uma variável de estado", isCorrect: false },
+                        { text: "Precisar de uma função de limpeza no fim", isCorrect: false },
+                        { text: "Ser executado toda vez que a tela renderiza", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Dependências e limpeza",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O array de dependências\n\nEle lista tudo que o efeito **lê** de dentro do componente: estado, props e funções. O linter do React aponta o que falta, e ignorar esse aviso é a origem de bugs muito difíceis de achar.",
+                },
+                {
+                    type: "code",
+                    value: "// O efeito lê salaId e tema, então os dois entram\nuseEffect(() => {\n  const c = criarConexao(salaId, tema);\n  c.conectar();\n  return () => c.desconectar();\n}, [salaId, tema]);",
+                },
+                {
+                    type: "text",
+                    value: "## Não remova dependência, remova a necessidade\n\nQuando o efeito reexecuta demais, a tentação é apagar itens do array. Isso não resolve: o efeito passa a ler valores velhos, e o bug fica pior porque some do array a pista do que estava errado.\n\nO caminho certo é **mudar o efeito** para depender de menos coisas: mover a função para dentro, extrair o que não precisa reagir, ou usar `useEffectEvent`.",
+                },
+                {
+                    type: "code",
+                    value: "// Problema: a função é recriada a cada renderização,\n// então o efeito roda a cada renderização\nfunction Chat({ salaId }) {\n  function criar() { return criarConexao(salaId); }\n\n  useEffect(() => {\n    const c = criar();\n    c.conectar();\n    return () => c.desconectar();\n  }, [criar]);   // criar muda sempre\n}\n\n// Solução: mover a função para dentro do efeito\nuseEffect(() => {\n  const c = criarConexao(salaId);\n  c.conectar();\n  return () => c.desconectar();\n}, [salaId]);",
+                },
+                {
+                    type: "text",
+                    value: "## A limpeza não é opcional\n\nTodo efeito que **abre** algo precisa fechar: assinatura, temporizador, ouvinte de evento, conexão. Sem limpeza, o StrictMode revela o problema em desenvolvimento duplicando a montagem, e em produção ele aparece como vazamento de memória.",
+                },
+                {
+                    type: "code",
+                    value: 'useEffect(() => {\n  const id = setInterval(tick, 1000);\n  return () => clearInterval(id);\n}, []);\n\nuseEffect(() => {\n  window.addEventListener("resize", aoRedimensionar);\n  return () => window.removeEventListener("resize", aoRedimensionar);\n}, []);',
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que deve entrar no array de dependências?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Tudo que o efeito lê do componente", isCorrect: true },
+                        { text: "Apenas os estados usados dentro do efeito", isCorrect: false },
+                        { text: "Somente as props recebidas do componente pai", isCorrect: false },
+                        { text: "Os valores que mudam com mais frequência", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que acontece ao remover uma dependência necessária?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O efeito passa a ler valores velhos", isCorrect: true },
+                        { text: "O efeito deixa de rodar por completo", isCorrect: false },
+                        { text: "O React avisa com um erro na renderização", isCorrect: false },
+                        { text: "O componente deixa de ser atualizado na tela", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que uma função declarada no componente causa reexecução?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Ela é recriada a cada renderização", isCorrect: true },
+                        { text: "Ela não pode ser usada dentro de um efeito", isCorrect: false },
+                        { text: "Ela é chamada antes do efeito ser montado", isCorrect: false },
+                        { text: "Ela altera o estado ao ser declarada", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que todo efeito que abre algo precisa fazer?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Fechar na função de limpeza", isCorrect: true },
+                        { text: "Declarar o recurso fora do componente", isCorrect: false },
+                        { text: "Executar apenas uma vez ao montar", isCorrect: false },
+                        { text: "Guardar a referência em um estado", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como o StrictMode ajuda a achar limpeza faltando?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Ele monta e desmonta duas vezes em desenvolvimento",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Ele avisa no console do navegador sobre o efeito incompleto",
+                            isCorrect: false,
+                        },
+                        { text: "Ele impede o efeito de rodar sem a limpeza", isCorrect: false },
+                        { text: "Ele mede a memória usada por cada efeito", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "useEffectEvent, novidade do React 19.2",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O dilema das dependências\n\nExiste um caso em que o array de dependências e a lógica se contradizem: o efeito precisa **ler** um valor, mas não deveria **reagir** a ele.\n\nO exemplo clássico é uma conexão de chat que mostra uma notificação com o tema atual. O efeito deve reconectar quando a sala muda, mas trocar o tema não deveria derrubar a conexão.",
+                },
+                {
+                    type: "code",
+                    value: 'function Chat({ salaId, tema }) {\n  useEffect(() => {\n    const c = criarConexao(salaId);\n    c.on("conectado", () => {\n      mostrarNotificacao("Conectado!", tema);\n    });\n    c.conectar();\n    return () => c.desconectar();\n  }, [salaId, tema]);\n  // tema no array: trocar o tema reconecta o chat, e não deveria\n  // tema fora do array: a notificação usa um tema velho\n}',
+                },
+                {
+                    type: "text",
+                    value: "## A solução do 19.2\n\nO `useEffectEvent` separa a parte que é **evento** da parte que é sincronização. O que está dentro dele sempre enxerga os valores mais recentes, e **não entra** no array de dependências.",
+                },
+                {
+                    type: "code",
+                    value: 'import { useEffect, useEffectEvent } from "react";\n\nfunction Chat({ salaId, tema }) {\n  const aoConectar = useEffectEvent(() => {\n    mostrarNotificacao("Conectado!", tema);   // tema sempre atual\n  });\n\n  useEffect(() => {\n    const c = criarConexao(salaId);\n    c.on("conectado", () => aoConectar());\n    c.conectar();\n    return () => c.desconectar();\n  }, [salaId]);   // só salaId: trocar o tema não reconecta\n}',
+                },
+                {
+                    type: "quote",
+                    value: "A regra: o que o efeito sincroniza entra nas dependências. O que ele apenas dispara vai para um effect event.",
+                },
+                {
+                    type: "text",
+                    value: "## O limite\n\nUm effect event só pode ser chamado **de dentro de um efeito**, e nunca passado para outro componente como prop. Ele não é um substituto geral para `useCallback`.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Que problema o `useEffectEvent` resolve?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Ler um valor sem reagir a ele no efeito", isCorrect: true },
+                        { text: "Executar o efeito antes da tela ser pintada", isCorrect: false },
+                        { text: "Evitar que o efeito rode na montagem inicial", isCorrect: false },
+                        { text: "Permitir efeitos assíncronos sem limpeza", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que é passado ao effect event entra no array de dependências?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Não, ele fica fora do array", isCorrect: true },
+                        { text: "Sim, ele entra como qualquer outro valor", isCorrect: false },
+                        { text: "Sim, mas apenas quando muda de valor", isCorrect: false },
+                        { text: "Depende de o valor ser prop ou estado", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quais valores um effect event enxerga?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Sempre os mais recentes", isCorrect: true },
+                        { text: "Os da renderização em que foi criado", isCorrect: false },
+                        { text: "Apenas os que estão no array de dependências", isCorrect: false },
+                        { text: "Os valores iniciais do componente", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Onde um effect event pode ser chamado?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Apenas de dentro de um efeito", isCorrect: true },
+                        { text: "Em qualquer lugar do componente que o criou", isCorrect: false },
+                        { text: "Em componentes filhos, passado como prop", isCorrect: false },
+                        { text: "Dentro de um handler de clique também", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a regra para decidir onde algo vai?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "O que sincroniza vai nas dependências, o que dispara não",
+                            isCorrect: true,
+                        },
+                        { text: "Tudo que é função vai para um effect event", isCorrect: false },
+                        {
+                            text: "As props vão nas dependências e os estados não vão nunca",
+                            isCorrect: false,
+                        },
+                        { text: "O que muda com frequência fica fora do array", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Quando não usar efeito",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# A maior parte dos efeitos não deveria existir\n\nEsta é a lição que mais melhora código React na prática. Quatro casos cobrem quase todo uso desnecessário de `useEffect`.",
+                },
+                {
+                    type: "text",
+                    value: "## 1. Calcular a partir de props ou estado\n\nSe o valor pode ser calculado durante a renderização, calcule. Um efeito que atualiza estado a partir de outro estado causa **duas renderizações** e cria um valor que pode ficar desatualizado.",
+                },
+                {
+                    type: "code",
+                    value: "// Errado\nconst [total, setTotal] = useState(0);\nuseEffect(() => {\n  setTotal(itens.reduce((s, i) => s + i.preco, 0));\n}, [itens]);\n\n// Certo\nconst total = itens.reduce((s, i) => s + i.preco, 0);",
+                },
+                {
+                    type: "text",
+                    value: "## 2. Reagir a uma ação do usuário\n\nSe algo acontece **porque a pessoa clicou**, o código pertence ao handler do clique, não a um efeito que observa a mudança de estado.",
+                },
+                {
+                    type: "code",
+                    value: '// Errado: o efeito não sabe por que o carrinho mudou\nuseEffect(() => {\n  if (carrinho.length > 0) registrarAnalytics("item_adicionado");\n}, [carrinho]);\n\n// Certo: a intenção está no lugar onde ela acontece\nfunction adicionar(item) {\n  setCarrinho([...carrinho, item]);\n  registrarAnalytics("item_adicionado");\n}',
+                },
+                {
+                    type: "text",
+                    value: "## 3. Resetar estado quando a prop muda\n\nO caminho mais limpo é dar uma `key` diferente ao componente: o React o descarta e cria outro, com o estado zerado.\n\n## 4. Inicializar algo uma vez\n\nSe é inicialização da aplicação e não do componente, o lugar é fora do componente, no módulo.",
+                },
+                {
+                    type: "code",
+                    value: "// Reset por key: sem efeito nenhum\n<PerfilUsuario key={usuarioId} usuarioId={usuarioId} />",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que fazer com um valor que pode ser calculado?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Calcular durante a renderização", isCorrect: true },
+                        { text: "Guardar em estado e atualizar com um efeito", isCorrect: false },
+                        { text: "Calcular dentro de um efeito com dependências", isCorrect: false },
+                        { text: "Memorizar o resultado com useMemo sempre", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Onde colocar código que acontece por causa de um clique?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "No handler do clique", isCorrect: true },
+                        { text: "Em um efeito que observa a mudança de estado", isCorrect: false },
+                        { text: "Em um efeito com array de dependências vazio", isCorrect: false },
+                        { text: "Em uma função chamada durante a renderização", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual o custo de um efeito que atualiza estado derivado?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Duas renderizações e um valor que pode atrasar", isCorrect: true },
+                        {
+                            text: "Uma renderização a mais, sem nenhum outro efeito",
+                            isCorrect: false,
+                        },
+                        { text: "A perda do estado quando a prop muda", isCorrect: false },
+                        { text: "A necessidade de uma função de limpeza", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a forma mais limpa de resetar o estado de um componente?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Dar a ele uma key diferente", isCorrect: true },
+                        { text: "Chamar os setters dentro de um efeito", isCorrect: false },
+                        { text: "Desmontar e montar o componente na mão", isCorrect: false },
+                        { text: "Passar o valor inicial de novo por prop", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Onde inicializar algo que é da aplicação, não do componente?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Fora do componente, no módulo", isCorrect: true },
+                        { text: "Em um efeito com dependências vazias", isCorrect: false },
+                        { text: "No componente raiz da aplicação inteira", isCorrect: false },
+                        { text: "Em um hook próprio chamado uma vez", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Buscando dados",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O caso de uso mais comum, e o mais cheio de armadilha\n\nBuscar dados com `useEffect` funciona, e exige cuidados que quase todo tutorial curto ignora: condição de corrida, estado de carregamento, tratamento de erro e cancelamento.",
+                },
+                {
+                    type: "code",
+                    value: "function Perfil({ usuarioId }) {\n  const [dados, setDados] = useState(null);\n  const [carregando, setCarregando] = useState(true);\n  const [erro, setErro] = useState(null);\n\n  useEffect(() => {\n    let cancelado = false;\n    setCarregando(true);\n    setErro(null);\n\n    buscarUsuario(usuarioId)\n      .then((r) => {\n        if (!cancelado) setDados(r);\n      })\n      .catch((e) => {\n        if (!cancelado) setErro(e.message);\n      })\n      .finally(() => {\n        if (!cancelado) setCarregando(false);\n      });\n\n    return () => {\n      cancelado = true;\n    };\n  }, [usuarioId]);\n\n  if (carregando) return <p>Carregando...</p>;\n  if (erro) return <p>Erro: {erro}</p>;\n  return <h1>{dados.nome}</h1>;\n}",
+                },
+                {
+                    type: "text",
+                    value: "## A condição de corrida\n\nSe o `usuarioId` muda antes de a primeira resposta chegar, duas requisições ficam no ar. A que responder por último vence, e pode ser a **antiga**. A variável `cancelado` na limpeza resolve isso: a resposta que chega depois de o efeito ser limpo é descartada.\n\n## A recomendação atual\n\nA própria documentação do React sugere não escrever isso à mão. Uma biblioteca de busca de dados resolve cache, revalidação, deduplicação de requisições e estados de carregamento, que é bem mais do que o efeito acima faz.",
+                },
+                {
+                    type: "quote",
+                    value: "Escrever a busca à mão uma vez ensina os problemas. Escrever em todo componente do projeto repete os mesmos bugs em cada tela.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que é uma condição de corrida ao buscar dados?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Uma resposta antiga chegar depois da nova", isCorrect: true },
+                        {
+                            text: "Duas requisições saírem ao mesmo tempo do navegador",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O servidor demorar demais para responder à chamada",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O componente desmontar antes de a resposta chegar",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Como a variável `cancelado` resolve o problema?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Descarta a resposta que chega após a limpeza", isCorrect: true },
+                        { text: "Interrompe a requisição no meio do caminho", isCorrect: false },
+                        { text: "Impede que uma segunda requisição seja feita", isCorrect: false },
+                        { text: "Guarda a ordem em que as respostas chegaram", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quantos estados a busca à mão costuma exigir?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Três: dados, carregando e erro", isCorrect: true },
+                        { text: "Um só, com os dados que foram recebidos", isCorrect: false },
+                        { text: "Dois, os dados e o indicador de carregamento", isCorrect: false },
+                        { text: "Nenhum, o efeito já cuida de tudo sozinho", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que a documentação do React recomenda para busca de dados?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Usar uma biblioteca em vez de escrever à mão", isCorrect: true },
+                        { text: "Escrever sempre com useEffect e três estados", isCorrect: false },
+                        {
+                            text: "Buscar os dados no componente raiz da aplicação",
+                            isCorrect: false,
+                        },
+                        { text: "Fazer a busca antes de montar o componente", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que uma biblioteca de dados resolve além da requisição?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Cache, revalidação e deduplicação", isCorrect: true },
+                        { text: "A validação dos tipos da resposta recebida", isCorrect: false },
+                        { text: "A renderização dos dados na tela do usuário", isCorrect: false },
+                        { text: "O tratamento dos erros de rede do navegador", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_4: Modulo = {
+    titulo: "Módulo 4 - Composição e reuso",
+    aulas: [
+        {
+            titulo: "Composição com children",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# A prop especial\n\nO que fica **entre** as tags de um componente chega nele como a prop `children`. É o mecanismo mais simples e mais poderoso de reuso do React.",
+                },
+                {
+                    type: "code",
+                    value: 'function Card({ titulo, children }) {\n  return (\n    <section className="card">\n      <h3>{titulo}</h3>\n      <div className="card__corpo">{children}</div>\n    </section>\n  );\n}\n\n<Card titulo="Resumo">\n  <p>Qualquer conteúdo aqui dentro.</p>\n  <Botao>Ver mais</Botao>\n</Card>',
+                },
+                {
+                    type: "text",
+                    value: "## Composição contra configuração\n\nA alternativa a `children` seria uma prop para cada variação: `temBotao`, `textoBotao`, `aoClicarBotao`. Isso cresce sem limite e acaba em um componente com vinte props que ninguém entende.\n\nCom composição, quem usa decide o conteúdo, e o componente cuida só da estrutura.",
+                },
+                {
+                    type: "code",
+                    value: '// Configuração: cresce a cada caso novo\n<Modal titulo="X" temRodape textoConfirmar="Salvar" aoConfirmar={f} />\n\n// Composição: o componente não precisa prever nada\n<Modal>\n  <Modal.Titulo>X</Modal.Titulo>\n  <Modal.Corpo>...</Modal.Corpo>\n  <Modal.Rodape>\n    <Botao onClick={f}>Salvar</Botao>\n  </Modal.Rodape>\n</Modal>',
+                },
+                {
+                    type: "text",
+                    value: "## Vários espaços\n\nQuando o componente precisa de mais de um lugar para conteúdo, props que recebem JSX resolvem sem precisar de nada especial.",
+                },
+                {
+                    type: "code",
+                    value: 'function Layout({ cabecalho, lateral, children }) {\n  return (\n    <div className="layout">\n      <header>{cabecalho}</header>\n      <aside>{lateral}</aside>\n      <main>{children}</main>\n    </div>\n  );\n}\n\n<Layout cabecalho={<Menu />} lateral={<Filtros />}>\n  <Conteudo />\n</Layout>',
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que a prop `children` contém?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "O que está entre as tags do componente", isCorrect: true },
+                        { text: "Os componentes filhos declarados no arquivo", isCorrect: false },
+                        { text: "As props que não foram usadas no componente", isCorrect: false },
+                        { text: "Os elementos que o componente vai renderizar", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual o problema de configurar tudo por props?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O componente acumula props sem limite", isCorrect: true },
+                        { text: "As props ficam difíceis de tipar corretamente", isCorrect: false },
+                        {
+                            text: "O componente renderiza mais vezes que o necessário",
+                            isCorrect: false,
+                        },
+                        { text: "As props precisam ser passadas em ordem fixa", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que a composição resolve?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Quem usa decide o conteúdo, o componente a estrutura",
+                            isCorrect: true,
+                        },
+                        { text: "O componente passa a renderizar mais rápido", isCorrect: false },
+                        { text: "As props deixam de precisar de valor padrão", isCorrect: false },
+                        {
+                            text: "O estado passa a ser compartilhado entre os dois componentes",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Como passar conteúdo para mais de um espaço?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Com props que recebem JSX", isCorrect: true },
+                        { text: "Com vários children separados por vírgula", isCorrect: false },
+                        { text: "Com um array de elementos na prop children", isCorrect: false },
+                        { text: "Com um componente para cada espaço da tela", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que se passa em `cabecalho={<Menu />}`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um elemento React como valor da prop", isCorrect: true },
+                        { text: "O nome do componente a ser renderizado", isCorrect: false },
+                        { text: "Uma função que devolve o componente Menu", isCorrect: false },
+                        { text: "Uma string com o JSX do componente", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Hooks próprios",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Extraindo lógica com estado\n\nUm **hook próprio** é uma função que começa com `use` e chama outros hooks. Ele extrai lógica com estado para ser reaproveitada, o que componentes não conseguem fazer.\n\nO que se compartilha é a **lógica**, não o estado: cada componente que usa o hook tem a sua própria cópia.",
+                },
+                {
+                    type: "code",
+                    value: 'function useLocalStorage<T>(chave: string, inicial: T) {\n  const [valor, setValor] = useState<T>(() => {\n    const salvo = localStorage.getItem(chave);\n    return salvo ? JSON.parse(salvo) : inicial;\n  });\n\n  useEffect(() => {\n    localStorage.setItem(chave, JSON.stringify(valor));\n  }, [chave, valor]);\n\n  return [valor, setValor] as const;\n}\n\n// Em qualquer componente\nconst [tema, setTema] = useLocalStorage("tema", "claro");',
+                },
+                {
+                    type: "text",
+                    value: "Repare no `useState` com função: passar uma função faz o cálculo do valor inicial rodar **uma vez só**, em vez de a cada renderização. Ler do `localStorage` a cada renderização seria desperdício.\n\n## As regras dos hooks\n\nDuas regras que o React exige, e o linter verifica:\n\n1. Chamar hooks apenas no **topo** do componente ou de outro hook, nunca dentro de `if`, laço ou função aninhada\n2. Chamar hooks apenas de **componentes** ou de outros hooks, nunca de funções comuns",
+                },
+                {
+                    type: "code",
+                    value: "// Errado: a ordem dos hooks muda entre renderizações\nif (ativo) {\n  const [x, setX] = useState(0);\n}\n\n// Certo: a condição vai para dentro\nconst [x, setX] = useState(0);\nif (ativo) { /* usa x */ }",
+                },
+                {
+                    type: "text",
+                    value: "A razão da primeira regra: o React identifica cada hook pela **ordem** em que foi chamado. Se a ordem muda, o estado de um hook acaba entregue a outro.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que um hook próprio compartilha entre componentes?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "A lógica, não o estado", isCorrect: true },
+                        { text: "O estado, sincronizado entre todos eles", isCorrect: false },
+                        { text: "Os dois, lógica e estado ao mesmo tempo", isCorrect: false },
+                        { text: "Apenas os efeitos declarados dentro dele", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como um hook próprio precisa se chamar?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Começando com use", isCorrect: true },
+                        { text: "Terminando com Hook no fim do nome", isCorrect: false },
+                        { text: "Com a primeira letra sempre em maiúscula", isCorrect: false },
+                        { text: "Com o prefixo react no começo do nome", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que hooks não podem ser chamados dentro de `if`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O React os identifica pela ordem de chamada", isCorrect: true },
+                        {
+                            text: "Porque o React proíbe condicionais nos componentes",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Porque o estado ficaria indefinido na condição",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Porque o linter não consegue analisar o código",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que passar uma função ao `useState` faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O cálculo inicial roda uma vez só", isCorrect: true },
+                        {
+                            text: "O estado passa a ser calculado a cada renderização",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O valor inicial é recalculado quando as props mudam",
+                            isCorrect: false,
+                        },
+                        { text: "A função é chamada sempre que o estado é lido", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "De onde um hook pode ser chamado?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "De componentes ou de outros hooks", isCorrect: true },
+                        { text: "De qualquer função do projeto", isCorrect: false },
+                        { text: "Apenas de componentes, nunca de hooks", isCorrect: false },
+                        { text: "De funções auxiliares do mesmo arquivo", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Context",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Quando passar props cansa\n\nPassar um dado por cinco níveis de componentes que não o usam é chamado de **prop drilling**. O `Context` resolve isso: um valor fica disponível para toda a árvore abaixo, sem passar por quem não precisa.",
+                },
+                {
+                    type: "code",
+                    value: 'const TemaContext = createContext<"claro" | "escuro">("claro");\n\nfunction App() {\n  const [tema, setTema] = useState<"claro" | "escuro">("claro");\n\n  return (\n    <TemaContext value={tema}>\n      <Pagina />\n    </TemaContext>\n  );\n}\n\n// Em qualquer profundidade\nfunction Botao() {\n  const tema = use(TemaContext);\n  return <button className={tema}>Clique</button>;\n}',
+                },
+                {
+                    type: "text",
+                    value: "Duas mudanças do React 19 aparecem acima: o próprio contexto vira o provedor, dispensando `<TemaContext.Provider>`, e `use()` substitui `useContext()`.\n\n## Context não é gerenciador de estado\n\nEste é o mal-entendido mais comum. O contexto **transporta** um valor; ele não guarda nem otimiza nada. Quando o valor muda, **todo componente que o consome renderiza**, mesmo que use só uma parte dele.\n\nPor isso vale separar contextos por frequência de mudança, em vez de um único contexto com tudo dentro.",
+                },
+                {
+                    type: "code",
+                    value: "// Problema: quem só quer o tema renderiza quando o usuário muda\n<AppContext value={{ tema, usuario, carrinho }}>\n\n// Melhor: contextos separados\n<TemaContext value={tema}>\n  <UsuarioContext value={usuario}>\n    <CarrinhoContext value={carrinho}>",
+                },
+                {
+                    type: "quote",
+                    value: "Use context para o que muda pouco e é lido por muitos: tema, idioma, usuário logado. Para estado que muda toda hora, ele custa caro.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Que problema o Context resolve?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Passar props por níveis que não as usam", isCorrect: true },
+                        { text: "Guardar o estado global da aplicação inteira", isCorrect: false },
+                        { text: "Compartilhar estado entre componentes irmãos", isCorrect: false },
+                        { text: "Evitar que os componentes renderizem demais", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que acontece quando o valor de um contexto muda?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Todos os consumidores renderizam de novo", isCorrect: true },
+                        { text: "Apenas quem usa a parte alterada renderiza", isCorrect: false },
+                        { text: "O React compara e atualiza só o necessário", isCorrect: false },
+                        { text: "Somente o componente provedor é renderizado", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que mudou no Context com o React 19?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O contexto virou o próprio provedor", isCorrect: true },
+                        { text: "O contexto passou a guardar estado sozinho", isCorrect: false },
+                        { text: "O provedor passou a exigir um valor padrão", isCorrect: false },
+                        {
+                            text: "O contexto deixou de aceitar objetos como valor",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Por que separar contextos por frequência de mudança?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Para não renderizar quem não usa o que mudou", isCorrect: true },
+                        { text: "Para reduzir o tamanho do código do provedor", isCorrect: false },
+                        {
+                            text: "Porque o React limita o tamanho de cada contexto",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Para que cada contexto tenha seu próprio estado",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Para que tipo de dado o Context é adequado?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O que muda pouco e é lido por muitos", isCorrect: true },
+                        { text: "O que muda a cada digitação em um campo", isCorrect: false },
+                        { text: "O que é usado por um componente só", isCorrect: false },
+                        { text: "O que precisa ser guardado entre sessões", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Refs",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Guardar algo sem renderizar\n\nO `useRef` guarda um valor que **sobrevive entre renderizações** e cujo `.current` pode ser alterado **sem** disparar renderização.\n\nSão dois usos bem diferentes: acessar um elemento do DOM e guardar um valor mutável que não afeta a tela.",
+                },
+                {
+                    type: "code",
+                    value: "function Campo() {\n  const inputRef = useRef<HTMLInputElement>(null);\n\n  function focar() {\n    inputRef.current?.focus();\n  }\n\n  return (\n    <>\n      <input ref={inputRef} />\n      <button onClick={focar}>Focar</button>\n    </>\n  );\n}",
+                },
+                {
+                    type: "code",
+                    value: "// Guardando um valor mutável: o id do temporizador\nfunction Cronometro() {\n  const idRef = useRef<number | null>(null);\n\n  function iniciar() {\n    idRef.current = setInterval(tick, 1000);\n  }\n\n  function parar() {\n    if (idRef.current) clearInterval(idRef.current);\n  }\n}",
+                },
+                {
+                    type: "table",
+                    value: '[["", "useState", "useRef"], ["Renderiza ao mudar", "sim", "não"], ["Sobrevive à renderização", "sim", "sim"], ["Ler durante a renderização", "sim", "não deve"], ["Para que serve", "o que aparece na tela", "o que não aparece"]]',
+                },
+                {
+                    type: "text",
+                    value: "## A regra que evita bug\n\nNão leia nem escreva `ref.current` **durante a renderização**. Como alterá-lo não dispara renderização, o valor lido pode não corresponder ao que está na tela, e o React não garante consistência nesse caso. Use dentro de handlers e efeitos.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que acontece ao alterar `ref.current`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Nada renderiza de novo", isCorrect: true },
+                        { text: "O componente renderiza como com um estado", isCorrect: false },
+                        { text: "O React agenda uma renderização para depois", isCorrect: false },
+                        { text: "Apenas o elemento referenciado é atualizado", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quais são os dois usos de uma ref?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Acessar o DOM e guardar valor mutável", isCorrect: true },
+                        {
+                            text: "Guardar estado e compartilhar entre componentes",
+                            isCorrect: false,
+                        },
+                        { text: "Otimizar renderizações e memorizar funções", isCorrect: false },
+                        { text: "Criar efeitos e cancelar requisições", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que não ler `ref.current` durante a renderização?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "O valor pode não corresponder ao que está na tela",
+                            isCorrect: true,
+                        },
+                        { text: "A leitura dispara uma renderização adicional", isCorrect: false },
+                        {
+                            text: "O React proíbe a leitura e avisa com um erro no console",
+                            isCorrect: false,
+                        },
+                        { text: "A ref ainda não foi preenchida nesse momento", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Onde uma ref deve ser usada?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Em handlers e efeitos", isCorrect: true },
+                        { text: "Diretamente no corpo do componente", isCorrect: false },
+                        { text: "Dentro do JSX que será renderizado", isCorrect: false },
+                        { text: "Em qualquer lugar, sem restrição alguma", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual valor uma ref de elemento tem antes da montagem?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "null", isCorrect: true },
+                        { text: "O elemento vazio criado pelo React", isCorrect: false },
+                        { text: "Um objeto com o current indefinido", isCorrect: false },
+                        { text: "O valor padrão passado ao useRef", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "ref como prop, novidade do React 19",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O fim do forwardRef\n\nAté o React 18, `ref` não era uma prop comum: passá-la a um componente próprio não funcionava, e era preciso envolver tudo em `forwardRef`.\n\nO **React 19** mudou isso: `ref` virou uma prop como qualquer outra, e o `forwardRef` deixou de ser necessário em componentes função.",
+                },
+                {
+                    type: "code",
+                    value: "// Antes do React 19\nconst Input = forwardRef<HTMLInputElement, Props>((props, ref) => {\n  return <input ref={ref} {...props} />;\n});\n\n// React 19: ref é só mais uma prop\nfunction Input({ ref, ...props }: Props & { ref?: Ref<HTMLInputElement> }) {\n  return <input ref={ref} {...props} />;\n}",
+                },
+                {
+                    type: "text",
+                    value: "## Limpeza na ref de callback\n\nOutra melhoria do 19: uma `ref` em forma de função pode devolver uma **função de limpeza**, que roda quando o elemento sai da tela. Antes, o React chamava a função com `null` no desmonte, o que exigia uma verificação em todo lugar.",
+                },
+                {
+                    type: "code",
+                    value: "<div\n  ref={(node) => {\n    const observador = new ResizeObserver(medir);\n    observador.observe(node);\n    return () => observador.disconnect();   // React 19\n  }}\n/>",
+                },
+                {
+                    type: "text",
+                    value: "## useImperativeHandle\n\nQuando o componente quer expor **ações** em vez do elemento cru, `useImperativeHandle` define o que a ref enxerga. Use com parcimônia: expor um elemento inteiro dá a quem usa poder demais sobre o interior do componente.",
+                },
+                {
+                    type: "code",
+                    value: 'type Acoes = { focar: () => void; limpar: () => void };\n\nfunction Campo({ ref }: { ref?: Ref<Acoes> }) {\n  const input = useRef<HTMLInputElement>(null);\n\n  useImperativeHandle(ref, () => ({\n    focar: () => input.current?.focus(),\n    limpar: () => { if (input.current) input.current.value = ""; },\n  }));\n\n  return <input ref={input} />;\n}',
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o React 19 mudou quanto à `ref`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Ela virou uma prop comum", isCorrect: true },
+                        { text: "Ela passou a ser criada automaticamente", isCorrect: false },
+                        { text: "Ela deixou de funcionar em componentes função", isCorrect: false },
+                        {
+                            text: "Ela passou a exigir o uso de useImperativeHandle",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que o `forwardRef` fazia?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Permitia repassar a ref para o elemento interno",
+                            isCorrect: true,
+                        },
+                        { text: "Criava a referência usada pelo componente pai", isCorrect: false },
+                        { text: "Guardava o valor da ref entre renderizações", isCorrect: false },
+                        {
+                            text: "Convertia a ref em uma prop comum do componente",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que uma ref de callback pode devolver no React 19?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Uma função de limpeza", isCorrect: true },
+                        { text: "O elemento que foi referenciado por ela", isCorrect: false },
+                        { text: "Um valor booleano indicando sucesso", isCorrect: false },
+                        { text: "A referência do componente pai da árvore", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como era o desmonte de uma ref de callback antes?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "A função era chamada com null", isCorrect: true },
+                        { text: "A função simplesmente não era mais chamada", isCorrect: false },
+                        { text: "O React removia a referência em silêncio", isCorrect: false },
+                        { text: "Era preciso chamar a limpeza manualmente", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Para que serve `useImperativeHandle`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Expor ações em vez do elemento cru", isCorrect: true },
+                        { text: "Criar uma ref dentro do próprio componente", isCorrect: false },
+                        { text: "Repassar a ref recebida para outro componente", isCorrect: false },
+                        { text: "Executar comandos quando a ref é acessada", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_5: Modulo = {
+    titulo: "Módulo 5 - React 19: Actions e Suspense",
+    aulas: [
+        {
+            titulo: "Actions e useActionState",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O padrão que se repetia em todo formulário\n\nAntes do React 19, enviar um formulário exigia sempre a mesma sequência escrita à mão: estado de enviando, estado de erro, `preventDefault`, `try` e `finally`. Cinco linhas de cerimônia para cada formulário do projeto.\n\nAs **Actions** transformam isso em um recurso do framework. Uma função assíncrona passada para `action` recebe os dados do formulário, e o React cuida do resto.",
+                },
+                {
+                    type: "code",
+                    value: 'function Perfil() {\n  const [erro, submeter, enviando] = useActionState(\n    async (_anterior: string | null, dados: FormData) => {\n      try {\n        await salvarNome(dados.get("nome") as string);\n        return null;\n      } catch (e) {\n        return e instanceof Error ? e.message : "falhou";\n      }\n    },\n    null,\n  );\n\n  return (\n    <form action={submeter}>\n      <input name="nome" />\n      <button disabled={enviando}>Salvar</button>\n      {erro && <p className="erro">{erro}</p>}\n    </form>\n  );\n}',
+                },
+                {
+                    type: "text",
+                    value: "O `useActionState` devolve três coisas: o **estado** devolvido pela ação, a **função** para passar ao formulário e um booleano de **pendente**.\n\nRepare no que sumiu: não há `useState` para enviando, não há `preventDefault`, e o campo é lido pelo `name` em vez de estado controlado.",
+                },
+                {
+                    type: "table",
+                    value: '[["Antes", "Com Actions"], ["useState para enviando", "vem no terceiro retorno"], ["useState para erro", "é o valor devolvido pela ação"], ["onSubmit com preventDefault", "action recebe a função"], ["estado por campo", "FormData pelo name"]]',
+                },
+                {
+                    type: "text",
+                    value: "## O formulário se limpa sozinho\n\nQuando a ação termina sem erro, o React reinicia o formulário. É o comportamento esperado na maioria dos casos, e evita mais um trecho de código repetido.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o `useActionState` devolve?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O estado, a função de envio e o pendente", isCorrect: true },
+                        {
+                            text: "Apenas a função que será passada ao formulário",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O estado do formulário e os erros de validação",
+                            isCorrect: false,
+                        },
+                        { text: "Os dados enviados e o resultado da requisição", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que a prop `action` de um formulário recebe no React 19?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Uma função, que pode ser assíncrona", isCorrect: true },
+                        { text: "A URL para onde os dados serão enviados", isCorrect: false },
+                        { text: "O nome da rota que trata o formulário", isCorrect: false },
+                        { text: "Um objeto com a configuração do envio", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que deixa de ser necessário com Actions?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O preventDefault e o estado de enviando", isCorrect: true },
+                        { text: "A validação de todos os campos antes do envio", isCorrect: false },
+                        { text: "O tratamento de erro dentro da função", isCorrect: false },
+                        { text: "Os nomes nos campos do formulário", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como os campos são lidos em uma Action?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Pelo FormData, usando o name de cada um", isCorrect: true },
+                        { text: "Por estados controlados, um para cada campo", isCorrect: false },
+                        { text: "Por refs apontando para cada elemento", isCorrect: false },
+                        { text: "Pelo id declarado em cada um dos campos", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que acontece com o formulário quando a ação termina bem?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O React o reinicia sozinho", isCorrect: true },
+                        { text: "Ele mantém os valores que foram digitados", isCorrect: false },
+                        { text: "Ele é desmontado e montado de novo na tela", isCorrect: false },
+                        {
+                            text: "Ele fica desabilitado até a próxima renderização",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "useOptimistic",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Responder antes de o servidor responder\n\nQuando alguém curte um post, esperar a resposta do servidor para mudar o coração deixa a interface lenta. A **atualização otimista** mostra o resultado esperado na hora e corrige depois, se der errado.\n\nEscrever isso à mão exige guardar o valor anterior e desfazer no erro. O `useOptimistic` faz o desfazer sozinho.",
+                },
+                {
+                    type: "code",
+                    value: "function Curtidas({ post }) {\n  const [otimista, curtirOtimista] = useOptimistic(\n    post.curtidas,\n    (atual: number, delta: number) => atual + delta,\n  );\n\n  async function curtir() {\n    curtirOtimista(1);        // a tela muda agora\n    await enviarCurtida(post.id);   // se falhar, volta sozinho\n  }\n\n  return <button onClick={curtir}>{otimista} curtidas</button>;\n}",
+                },
+                {
+                    type: "text",
+                    value: "## Como o desfazer funciona\n\nO valor otimista vale **enquanto a ação está pendente**. Quando ela termina, o React descarta o valor otimista e volta a mostrar o estado real. Se a ação deu certo e o estado real foi atualizado, a transição é imperceptível; se falhou, o valor antigo reaparece.\n\nIsso significa que você não escreve nenhum código de rollback.",
+                },
+                {
+                    type: "quote",
+                    value: "Use atualização otimista onde a falha é rara e o custo dela é baixo. Em transferência de dinheiro, mostre o resultado só depois da confirmação.",
+                },
+                {
+                    type: "text",
+                    value: "## Em listas\n\nO padrão mais comum é acrescentar um item que ainda está sendo enviado, marcado visualmente como pendente.",
+                },
+                {
+                    type: "code",
+                    value: 'const [mensagens, adicionarOtimista] = useOptimistic(\n  mensagensReais,\n  (atuais: Msg[], nova: string) => [\n    ...atuais,\n    { id: "temp", texto: nova, enviando: true },\n  ],\n);\n\n{mensagens.map((m) => (\n  <li key={m.id} className={m.enviando ? "pendente" : ""}>\n    {m.texto}\n  </li>\n))}',
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que é uma atualização otimista?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Mostrar o resultado esperado antes da resposta", isCorrect: true },
+                        {
+                            text: "Enviar a requisição antes de o usuário confirmar",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Guardar a alteração para enviar tudo de uma vez",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Repetir a requisição quando ela falha na primeira",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Por quanto tempo o valor otimista vale?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Enquanto a ação estiver pendente", isCorrect: true },
+                        { text: "Até que o componente seja desmontado da tela", isCorrect: false },
+                        {
+                            text: "Por alguns segundos, definidos na configuração",
+                            isCorrect: false,
+                        },
+                        { text: "Até que outra atualização otimista aconteça", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quem escreve o código que desfaz a alteração no erro?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Ninguém, o React descarta o valor sozinho", isCorrect: true },
+                        { text: "O desenvolvedor, dentro do bloco catch", isCorrect: false },
+                        { text: "A própria função passada ao useOptimistic", isCorrect: false },
+                        { text: "O componente pai, ao receber o erro", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Onde a atualização otimista não é adequada?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Quando o custo de errar é alto, como em pagamento",
+                            isCorrect: true,
+                        },
+                        { text: "Em listas com muitos itens sendo exibidos", isCorrect: false },
+                        {
+                            text: "Quando a requisição demora apenas poucos milissegundos",
+                            isCorrect: false,
+                        },
+                        { text: "Em formulários com mais de um campo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que a segunda função passada ao `useOptimistic` faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Calcula o valor otimista a partir do atual", isCorrect: true },
+                        {
+                            text: "Envia a requisição para o servidor da aplicação",
+                            isCorrect: false,
+                        },
+                        { text: "Decide se a atualização deve ser desfeita", isCorrect: false },
+                        { text: "Valida os dados antes de exibir na tela", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "useFormStatus e componentes de formulário",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O botão que sabe do formulário\n\nUm botão de envio precisa se desabilitar enquanto o formulário está sendo enviado. Passar essa informação por prop funciona, e obriga todo formulário a repassar o mesmo dado.\n\nO `useFormStatus` deixa o componente **perguntar** o estado do formulário pai, sem receber prop nenhuma.",
+                },
+                {
+                    type: "code",
+                    value: 'import { useFormStatus } from "react-dom";\n\nfunction BotaoEnviar({ children }) {\n  const { pending } = useFormStatus();\n\n  return (\n    <button disabled={pending}>\n      {pending ? "Enviando..." : children}\n    </button>\n  );\n}\n\n// Em qualquer formulário, sem passar nada\n<form action={submeter}>\n  <input name="email" />\n  <BotaoEnviar>Cadastrar</BotaoEnviar>\n</form>',
+                },
+                {
+                    type: "text",
+                    value: "## A regra que confunde\n\nO `useFormStatus` só funciona em um componente que está **dentro** do formulário. Chamá-lo no mesmo componente que renderiza o `<form>` devolve sempre `pending: false`, porque não há formulário pai.\n\nEsse é o erro mais comum com esse hook, e a mensagem não é óbvia.",
+                },
+                {
+                    type: "code",
+                    value: "// Errado: o hook está no mesmo componente do form\nfunction Formulario() {\n  const { pending } = useFormStatus();   // sempre false\n  return <form action={f}><button disabled={pending} /></form>;\n}\n\n// Certo: o hook está em um filho\nfunction Formulario() {\n  return <form action={f}><BotaoEnviar /></form>;\n}",
+                },
+                {
+                    type: "text",
+                    value: "O hook também entrega `data`, `method` e `action`, o que permite construir indicadores mais ricos sem acoplar nada ao formulário específico.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o `useFormStatus` permite?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um filho saber o estado do formulário pai", isCorrect: true },
+                        { text: "O formulário conhecer o estado de cada campo", isCorrect: false },
+                        { text: "Validar o formulário antes de ele ser enviado", isCorrect: false },
+                        {
+                            text: "Cancelar o envio de um formulário em andamento",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Onde o `useFormStatus` precisa ser chamado?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Em um componente dentro do formulário", isCorrect: true },
+                        { text: "No mesmo componente que renderiza o form", isCorrect: false },
+                        { text: "No componente pai do formulário na árvore", isCorrect: false },
+                        { text: "Em qualquer lugar da aplicação, sem restrição", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que acontece ao chamá-lo no componente do próprio `<form>`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O pending fica sempre falso", isCorrect: true },
+                        { text: "O React lança um erro avisando do problema", isCorrect: false },
+                        {
+                            text: "O hook devolve o estado do formulário mesmo assim",
+                            isCorrect: false,
+                        },
+                        { text: "O formulário deixa de ser enviado ao servidor", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a alternativa que o hook substitui?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Passar o estado de envio por prop", isCorrect: true },
+                        { text: "Guardar o estado do formulário em um contexto", isCorrect: false },
+                        { text: "Usar uma ref apontando para o formulário", isCorrect: false },
+                        { text: "Consultar o DOM para saber se está enviando", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "De qual pacote o `useFormStatus` vem?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "react-dom", isCorrect: true },
+                        { text: "react, junto dos outros hooks", isCorrect: false },
+                        { text: "react-form, um pacote separado", isCorrect: false },
+                        { text: "react-router, com o roteamento", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "use() e Suspense",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Um hook que quebra as regras\n\nO `use()` do React 19 lê o valor de uma promessa ou de um contexto. Diferente dos outros hooks, ele **pode ser chamado dentro de condicionais e laços**, o que o torna bem mais flexível.",
+                },
+                {
+                    type: "code",
+                    value: 'import { use, Suspense } from "react";\n\nfunction Comentarios({ promessa }: { promessa: Promise<Comentario[]> }) {\n  const comentarios = use(promessa);   // suspende até resolver\n  return <ul>{comentarios.map((c) => <li key={c.id}>{c.texto}</li>)}</ul>;\n}\n\nfunction Pagina() {\n  const promessa = buscarComentarios();\n\n  return (\n    <Suspense fallback={<p>Carregando comentários...</p>}>\n      <Comentarios promessa={promessa} />\n    </Suspense>\n  );\n}',
+                },
+                {
+                    type: "text",
+                    value: "## O que é suspender\n\nQuando o `use()` encontra uma promessa não resolvida, o componente **suspende**: o React sobe até o `Suspense` mais próximo e mostra o `fallback`. Quando a promessa resolve, ele renderiza o conteúdo real.\n\nO ganho é que o estado de carregamento sai do componente. Não há `if (carregando)` espalhado, e o local do indicador é uma decisão de quem monta a tela.",
+                },
+                {
+                    type: "code",
+                    value: "// Vários limites: cada parte revela quando estiver pronta\n<Suspense fallback={<EsqueletoPerfil />}>\n  <Perfil />\n  <Suspense fallback={<EsqueletoPosts />}>\n    <Posts />\n  </Suspense>\n</Suspense>",
+                },
+                {
+                    type: "text",
+                    value: "## O cuidado com a promessa\n\nCriar a promessa **dentro** do componente que a consome causa um laço: ele suspende, renderiza de novo, cria outra promessa, suspende outra vez. A promessa precisa vir de fora, de um framework com cache ou de uma biblioteca de dados.\n\nÉ por isso que `use()` com promessa aparece pouco em aplicações puramente cliente, e é natural em frameworks que integram busca de dados.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que diferencia o `use()` dos outros hooks?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Ele pode ser chamado dentro de condicionais", isCorrect: true },
+                        { text: "Ele só funciona em componentes de servidor", isCorrect: false },
+                        { text: "Ele não precisa ser importado do React", isCorrect: false },
+                        {
+                            text: "Ele devolve sempre o mesmo valor entre renderizações",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que acontece quando um componente suspende?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "O React mostra o fallback do Suspense mais próximo",
+                            isCorrect: true,
+                        },
+                        { text: "O componente é desmontado até o dado chegar", isCorrect: false },
+                        {
+                            text: "A renderização da página inteira é interrompida",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O React tenta renderizar de novo depois de um tempo",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual o ganho do Suspense sobre um estado de carregando?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O estado de carregamento sai do componente", isCorrect: true },
+                        { text: "Os dados chegam bem mais rápido ao componente", isCorrect: false },
+                        { text: "O componente deixa de precisar tratar erros", isCorrect: false },
+                        { text: "O React guarda o resultado em cache sozinho", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Qual o problema de criar a promessa dentro do componente que a consome?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Ele entra em laço, criando uma promessa nova a cada vez",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "A promessa acaba nunca sendo resolvida pelo React em si",
+                            isCorrect: false,
+                        },
+                        { text: "O componente perde o estado a cada suspensão", isCorrect: false },
+                        {
+                            text: "O Suspense deixa de mostrar o conteúdo de espera",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Onde `use()` com promessa se encaixa melhor?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Em frameworks que integram busca de dados", isCorrect: true },
+                        {
+                            text: "Em qualquer aplicação React do lado do cliente",
+                            isCorrect: false,
+                        },
+                        { text: "Em componentes que fazem várias requisições", isCorrect: false },
+                        { text: "Em aplicações sem nenhum roteamento definido", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Metadados e recursos no documento",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Título e meta dentro do componente\n\nAntes do React 19, mudar o título da página ou uma meta tag exigia uma biblioteca ou um efeito mexendo no `document`. O React 19 passou a **entender** essas tags dentro de qualquer componente e movê-las para o `<head>` sozinho.",
+                },
+                {
+                    type: "code",
+                    value: 'function PaginaProduto({ produto }) {\n  return (\n    <article>\n      <title>{produto.nome} | Loja</title>\n      <meta name="description" content={produto.resumo} />\n      <link rel="canonical" href={`/produtos/${produto.slug}`} />\n\n      <h1>{produto.nome}</h1>\n      <p>{produto.descricao}</p>\n    </article>\n  );\n}',
+                },
+                {
+                    type: "text",
+                    value: 'As tags acima aparecem no meio do JSX e vão parar no `<head>` do documento. O componente que sabe o nome do produto é o mesmo que declara o título, o que elimina a sincronização manual entre os dois.\n\n## Folhas de estilo e scripts\n\nO mesmo vale para `<link rel="stylesheet">` e `<script async>`. O React cuida de **não duplicar**: se dois componentes declararem a mesma folha, ela é carregada uma vez só, e a ordem respeita a precedência informada.',
+                },
+                {
+                    type: "code",
+                    value: '<link rel="stylesheet" href="/editor.css" precedence="default" />\n<script async src="https://analytics.exemplo.com/s.js" />',
+                },
+                {
+                    type: "text",
+                    value: "## Pré-carregamento\n\nO React 19 também expõe funções para avisar o navegador do que virá, o que reduz o tempo até a tela ficar pronta.",
+                },
+                {
+                    type: "code",
+                    value: 'import { preload, preconnect, prefetchDNS } from "react-dom";\n\npreconnect("https://api.exemplo.com");\npreload("/fonte.woff2", { as: "font" });',
+                },
+            ],
+            questions: [
+                {
+                    statement:
+                        "O que o React 19 faz com uma tag `<title>` dentro de um componente?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Move para o head do documento", isCorrect: true },
+                        { text: "Renderiza como texto no corpo da página", isCorrect: false },
+                        { text: "Ignora a tag e avisa no console do navegador", isCorrect: false },
+                        { text: "Exige que ela esteja no componente raiz", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que era preciso antes do React 19 para mudar o título?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Uma biblioteca ou um efeito mexendo no document",
+                            isCorrect: true,
+                        },
+                        { text: "Declarar o título no arquivo HTML de entrada", isCorrect: false },
+                        {
+                            text: "Passar o título por prop até chegar ao componente raiz",
+                            isCorrect: false,
+                        },
+                        { text: "Usar um componente especial do próprio React", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "O que acontece se dois componentes declararem a mesma folha de estilo?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Ela é carregada uma vez só", isCorrect: true },
+                        {
+                            text: "As duas são carregadas, na ordem em que aparecem",
+                            isCorrect: false,
+                        },
+                        { text: "O React avisa sobre a duplicação no console", isCorrect: false },
+                        { text: "Apenas a do componente mais externo é usada", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Para que serve o atributo `precedence` em uma folha de estilo?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Definir a ordem em que ela entra no head", isCorrect: true },
+                        {
+                            text: "Indicar a prioridade de carregamento no navegador",
+                            isCorrect: false,
+                        },
+                        { text: "Marcar a folha como obrigatória para a página", isCorrect: false },
+                        { text: "Escolher qual folha vence em caso de conflito", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que a função `preconnect` faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Avisa o navegador para preparar a conexão", isCorrect: true },
+                        { text: "Faz a requisição antes de o componente montar", isCorrect: false },
+                        { text: "Guarda a resposta em cache para o próximo uso", isCorrect: false },
+                        { text: "Verifica se o servidor está disponível", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_6: Modulo = {
+    titulo: "Módulo 6 - Desempenho",
+    aulas: [
+        {
+            titulo: "Como o React re-renderiza",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# A regra principal\n\nQuando o estado de um componente muda, **ele e todos os seus descendentes** renderizam de novo. Não importa se as props dos filhos mudaram.\n\nIsso assusta quando dito assim, e na prática costuma ser barato: renderizar é executar funções e comparar objetos, não mexer no navegador. O React só toca no DOM naquilo que realmente mudou.",
+                },
+                {
+                    type: "table",
+                    value: '[["Etapa", "O que acontece", "Custo"], ["Render", "as funções rodam e devolvem JSX", "baixo"], ["Reconciliação", "o React compara com o anterior", "baixo"], ["Commit", "o DOM é alterado", "o mais caro"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Otimizar cedo demais custa mais que não otimizar\n\nEnvolver tudo em `memo` e `useCallback` acrescenta comparações e complexidade em troca de ganho nenhum na maior parte dos casos. A ordem certa é: **medir primeiro**.\n\nO React DevTools tem um perfilador que mostra o que renderizou, quantas vezes e quanto tempo levou. Sem esse dado, otimização é chute.",
+                },
+                {
+                    type: "quote",
+                    value: "Renderizar não é o mesmo que atualizar o DOM. A maior parte dos problemas de desempenho em React é trabalho pesado dentro do render, não a quantidade de renderizações.",
+                },
+                {
+                    type: "text",
+                    value: "## Os problemas reais mais comuns\n\n- Cálculo pesado feito a cada renderização, sem memorização\n- Lista com milhares de itens renderizados de uma vez\n- Contexto com valor novo a cada renderização do provedor\n- Componente que renderiza a árvore inteira por um estado que deveria estar mais embaixo",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que acontece quando o estado de um componente muda?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Ele e seus descendentes renderizam de novo", isCorrect: true },
+                        {
+                            text: "Apenas ele renderiza, os filhos ficam como estão",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Somente os filhos cujas props mudaram renderizam",
+                            isCorrect: false,
+                        },
+                        { text: "A aplicação inteira é renderizada novamente", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual etapa é a mais cara?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O commit, quando o DOM é alterado", isCorrect: true },
+                        { text: "O render, quando as funções são executadas", isCorrect: false },
+                        { text: "A reconciliação, ao comparar as árvores", isCorrect: false },
+                        { text: "As três custam praticamente o mesmo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a ordem certa ao otimizar?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Medir primeiro, otimizar depois", isCorrect: true },
+                        { text: "Memorizar tudo e medir o ganho no fim", isCorrect: false },
+                        { text: "Otimizar os componentes maiores primeiro", isCorrect: false },
+                        { text: "Reduzir a quantidade de componentes na tela", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual costuma ser o problema real de desempenho?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Trabalho pesado dentro do render", isCorrect: true },
+                        { text: "A quantidade de componentes que renderizam", isCorrect: false },
+                        { text: "O tamanho do arquivo JavaScript carregado", isCorrect: false },
+                        { text: "O número de estados declarados no componente", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual ferramenta mostra o que renderizou e quanto custou?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O perfilador do React DevTools", isCorrect: true },
+                        { text: "O console do navegador, com avisos do React", isCorrect: false },
+                        { text: "O relatório gerado pelo build de produção", isCorrect: false },
+                        { text: "O StrictMode, contando as renderizações", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "memo, useMemo e useCallback",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# As três ferramentas de memorização\n\nElas resolvem problemas diferentes, e confundi-las é comum.",
+                },
+                {
+                    type: "table",
+                    value: '[["Ferramenta", "Memoriza", "Evita"], ["memo", "o componente", "renderizar com as mesmas props"], ["useMemo", "um valor calculado", "recalcular a cada renderização"], ["useCallback", "uma função", "recriar a função a cada renderização"]]',
+                },
+                {
+                    type: "code",
+                    value: "// memo: só renderiza se as props mudarem\nconst Linha = memo(function Linha({ item, aoClicar }) {\n  return <li onClick={() => aoClicar(item.id)}>{item.nome}</li>;\n});\n\n// useMemo: cálculo caro que não precisa repetir\nconst ordenados = useMemo(\n  () => itens.slice().sort((a, b) => a.nome.localeCompare(b.nome)),\n  [itens],\n);\n\n// useCallback: função estável para passar a um filho memorizado\nconst aoClicar = useCallback((id: number) => {\n  setSelecionado(id);\n}, []);",
+                },
+                {
+                    type: "text",
+                    value: "## A armadilha do memo\n\n`memo` compara props por referência. Se o pai passa um objeto, um array ou uma função criada durante a renderização, a referência é nova toda vez e o `memo` **nunca funciona**.\n\nÉ por isso que `memo` e `useCallback` costumam andar juntos: sozinho, o `memo` no exemplo abaixo não evita nada.",
+                },
+                {
+                    type: "code",
+                    value: "// O memo não adianta: aoClicar é uma função nova a cada renderização\n<Linha item={item} aoClicar={() => selecionar(item.id)} />\n\n// Agora sim: a referência de aoClicar é estável\nconst aoClicar = useCallback((id) => selecionar(id), []);\n<Linha item={item} aoClicar={aoClicar} />",
+                },
+                {
+                    type: "quote",
+                    value: "Memorizar tem custo: a comparação, a memória e o código a mais. Só vale quando o perfilador mostrou que aquele ponto é o problema.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o `memo` memoriza?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "O componente, pelas props recebidas", isCorrect: true },
+                        { text: "O valor calculado dentro do componente", isCorrect: false },
+                        { text: "A função passada como prop ao componente", isCorrect: false },
+                        { text: "O estado guardado dentro do componente", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como o `memo` compara as props?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Por referência", isCorrect: true },
+                        { text: "Por valor, campo a campo do objeto", isCorrect: false },
+                        { text: "Por uma comparação profunda das estruturas", isCorrect: false },
+                        { text: "Pela quantidade de props recebidas", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que `memo` e `useCallback` costumam andar juntos?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Sem função estável, o memo nunca evita renderização",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Porque o useCallback exige um componente memorizado",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Porque os dois precisam do mesmo array de dependências",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Porque o memo não funciona com componentes função",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que o `useMemo` evita?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Recalcular um valor a cada renderização", isCorrect: true },
+                        { text: "Renderizar o componente mais de uma vez", isCorrect: false },
+                        { text: "Recriar as funções passadas aos filhos", isCorrect: false },
+                        { text: "Buscar os dados no servidor repetidamente", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual o custo de memorizar?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A comparação, a memória e o código a mais", isCorrect: true },
+                        {
+                            text: "Uma renderização extra no primeiro carregamento",
+                            isCorrect: false,
+                        },
+                        { text: "A perda do estado quando as props mudam", isCorrect: false },
+                        {
+                            text: "A necessidade de declarar todas as dependências",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "O React Compiler",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Memorização automática\n\nA maior crítica ao React sempre foi a quantidade de `memo`, `useMemo` e `useCallback` que um projeto grande acumula. É trabalho manual, fácil de errar, e polui o código.\n\nO **React Compiler**, que chegou à versão **1.0** na linha do React 19, resolve isso na origem: ele analisa os componentes durante o build e **insere a memorização sozinho**, onde ela é necessária.",
+                },
+                {
+                    type: "code",
+                    value: "// Você escreve assim\nfunction Lista({ itens, filtro }) {\n  const visiveis = itens.filter((i) => i.nome.includes(filtro));\n  return <ul>{visiveis.map((i) => <Linha key={i.id} item={i} />)}</ul>;\n}\n\n// O compilador gera o equivalente memorizado,\n// sem você escrever useMemo nem useCallback",
+                },
+                {
+                    type: "code",
+                    value: 'npm install --save-dev babel-plugin-react-compiler\n\n// vite.config.ts\nexport default defineConfig({\n  plugins: [\n    react({\n      babel: { plugins: [["babel-plugin-react-compiler", {}]] },\n    }),\n  ],\n});',
+                },
+                {
+                    type: "text",
+                    value: "## O que ele exige\n\nO compilador só consegue otimizar código que segue as **regras do React**: componentes puros, sem alterar props ou estado durante a renderização, sem efeito colateral no corpo do componente.\n\nQuando ele encontra algo que quebra as regras, ele **desiste daquele componente** em vez de gerar código errado. O plugin de ESLint do compilador aponta esses casos, e é a melhor forma de preparar um projeto.\n\n## O que muda no dia a dia\n\nEm um projeto que segue as regras, dá para remover boa parte das memorizações manuais. O código volta a ser o que a lógica pede, e a otimização deixa de ser decisão de quem escreve.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o React Compiler faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Insere a memorização automaticamente no build", isCorrect: true },
+                        { text: "Compila o JSX para JavaScript mais rápido", isCorrect: false },
+                        { text: "Remove os componentes que nunca são usados", isCorrect: false },
+                        {
+                            text: "Converte os componentes de classe em componentes função",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que o compilador exige do código?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Que ele siga as regras do React", isCorrect: true },
+                        { text: "Que ele esteja escrito em TypeScript", isCorrect: false },
+                        { text: "Que todos os componentes usem memo", isCorrect: false },
+                        { text: "Que não haja efeitos na aplicação", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que ele faz ao encontrar código que quebra as regras?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Desiste de otimizar aquele componente", isCorrect: true },
+                        { text: "Interrompe o build com um erro descritivo", isCorrect: false },
+                        { text: "Otimiza mesmo assim, com o risco de erro", isCorrect: false },
+                        { text: "Reescreve o componente para seguir as regras", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual ferramenta ajuda a preparar um projeto para o compilador?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O plugin de ESLint do compilador", isCorrect: true },
+                        { text: "O perfilador do React DevTools", isCorrect: false },
+                        { text: "O StrictMode no ambiente de desenvolvimento", isCorrect: false },
+                        { text: "O modo estrito do TypeScript no projeto", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que muda no código com o compilador ligado?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Dá para remover boa parte da memorização manual",
+                            isCorrect: true,
+                        },
+                        { text: "Os componentes deixam de precisar de props", isCorrect: false },
+                        { text: "Os efeitos passam a rodar em outra ordem", isCorrect: false },
+                        {
+                            text: "O estado passa a ser compartilhado entre eles por padrão",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Activity e prioridades",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Esconder sem descartar\n\nEsconder uma parte da tela com `display: none` mantém tudo montado, gastando recursos. Desmontar com uma condição perde o estado, e voltar exige remontar e buscar tudo de novo.\n\nO componente **`<Activity>`**, do React 19.2, oferece o meio-termo: em modo `hidden`, ele esconde os filhos, **desmonta os efeitos** e adia as atualizações, mas **preserva o estado**.",
+                },
+                {
+                    type: "code",
+                    value: '<Activity mode={abaAtiva === "perfil" ? "visible" : "hidden"}>\n  <Perfil />\n</Activity>\n\n<Activity mode={abaAtiva === "pedidos" ? "visible" : "hidden"}>\n  <Pedidos />\n</Activity>',
+                },
+                {
+                    type: "table",
+                    value: '[["Abordagem", "Estado", "Efeitos", "Custo ao voltar"], ["display none", "preservado", "ativos", "nenhum"], ["desmontar", "perdido", "desmontados", "remontar tudo"], ["Activity hidden", "preservado", "desmontados", "baixo"]]',
+                },
+                {
+                    type: "text",
+                    value: "O caso clássico é a navegação por abas: o formulário meio preenchido de uma aba continua lá quando a pessoa volta, e enquanto isso ele não mantém conexões nem temporizadores rodando.\n\n## Prioridades\n\nO `useTransition` marca uma atualização como **não urgente**. O React então prioriza o que é urgente, como o texto aparecendo enquanto se digita, e faz o resto sem travar a interface.",
+                },
+                {
+                    type: "code",
+                    value: "const [pendente, iniciarTransicao] = useTransition();\n\nfunction aoDigitar(texto: string) {\n  setTexto(texto);          // urgente: o campo responde na hora\n  iniciarTransicao(() => {\n    setFiltro(texto);       // não urgente: a lista pesada atualiza depois\n  });\n}",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que `<Activity mode='hidden'>` preserva?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O estado dos componentes escondidos", isCorrect: true },
+                        {
+                            text: "Os efeitos, que continuam ativos em segundo plano",
+                            isCorrect: false,
+                        },
+                        { text: "A posição de rolagem da página inteira", isCorrect: false },
+                        { text: "As requisições que estavam em andamento", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que acontece com os efeitos em modo hidden?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "São desmontados", isCorrect: true },
+                        {
+                            text: "Continuam rodando normalmente em segundo plano",
+                            isCorrect: false,
+                        },
+                        { text: "São pausados e retomados ao voltar a aparecer", isCorrect: false },
+                        { text: "Rodam com prioridade mais baixa que o normal", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual o problema de esconder com `display: none`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Tudo continua montado gastando recursos", isCorrect: true },
+                        { text: "O estado dos componentes acaba se perdendo", isCorrect: false },
+                        {
+                            text: "Os componentes precisam ser remontados ao voltar",
+                            isCorrect: false,
+                        },
+                        { text: "O navegador continua exibindo os elementos", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o `useTransition` marca?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Uma atualização como não urgente", isCorrect: true },
+                        { text: "Uma atualização que deve rodar primeiro", isCorrect: false },
+                        { text: "Um componente que não deve ser renderizado", isCorrect: false },
+                        { text: "Um efeito que roda fora da renderização", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual o caso clássico de uso do `<Activity>`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Navegação por abas com formulário preenchido", isCorrect: true },
+                        { text: "Listas com milhares de itens sendo exibidas", isCorrect: false },
+                        { text: "Componentes que fazem requisições ao servidor", isCorrect: false },
+                        { text: "Animações de entrada e saída de elementos", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Code splitting e listas grandes",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Carregar só o necessário\n\nUm aplicativo grande em um arquivo único faz a primeira tela esperar por código de páginas que talvez nunca sejam abertas. O `lazy` divide o build e carrega cada parte quando ela é pedida.",
+                },
+                {
+                    type: "code",
+                    value: 'import { lazy, Suspense } from "react";\n\nconst Relatorios = lazy(() => import("./Relatorios"));\nconst Editor = lazy(() => import("./Editor"));\n\n<Suspense fallback={<Carregando />}>\n  {aba === "relatorios" && <Relatorios />}\n  {aba === "editor" && <Editor />}\n</Suspense>',
+                },
+                {
+                    type: "text",
+                    value: "O corte natural é por **rota**: cada página vira um pedaço. Componentes pesados e pouco usados, como um editor de texto rico ou uma biblioteca de gráficos, também valem o corte.\n\nDividir demais tem custo próprio: cada pedaço é uma requisição, e dezenas de arquivos pequenos podem ser piores que um médio.",
+                },
+                {
+                    type: "text",
+                    value: "## Listas grandes\n\nRenderizar dez mil linhas cria dez mil nós no DOM, e o navegador engasga. A **virtualização** renderiza só o que está visível, mais uma pequena margem, e recicla os elementos conforme a rolagem.",
+                },
+                {
+                    type: "table",
+                    value: '[["Itens", "Abordagem"], ["até algumas centenas", "renderizar tudo"], ["milhares", "virtualizar"], ["muitos e vindos do servidor", "paginar ou rolagem infinita"]]',
+                },
+                {
+                    type: "text",
+                    value: "Antes de virtualizar, vale checar o mais simples: a pessoa realmente precisa ver dez mil linhas de uma vez? Paginação e busca costumam resolver melhor, e são mais fáceis de manter.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o `lazy` permite?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Carregar um componente só quando ele é pedido", isCorrect: true },
+                        {
+                            text: "Adiar a renderização de um componente muito pesado",
+                            isCorrect: false,
+                        },
+                        { text: "Executar o componente em segundo plano", isCorrect: false },
+                        { text: "Guardar o componente em cache no navegador", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual o corte mais natural para dividir o código?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Por rota, uma página por pedaço", isCorrect: true },
+                        { text: "Por componente, um arquivo para cada um", isCorrect: false },
+                        { text: "Por biblioteca usada em cada tela", isCorrect: false },
+                        { text: "Por tamanho, dividindo em partes iguais", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual o custo de dividir demais?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Cada pedaço vira uma requisição a mais", isCorrect: true },
+                        { text: "O build passa a demorar bem mais para rodar", isCorrect: false },
+                        { text: "Os componentes perdem o estado ao carregar", isCorrect: false },
+                        { text: "O navegador guarda menos coisas em cache", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que a virtualização faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Renderiza só o que está visível na tela", isCorrect: true },
+                        { text: "Carrega os itens da lista em segundo plano", isCorrect: false },
+                        { text: "Reduz o tamanho de cada item renderizado", isCorrect: false },
+                        {
+                            text: "Guarda a lista inteira na memória do navegador",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que checar antes de virtualizar uma lista?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Se a pessoa precisa mesmo ver tudo de uma vez", isCorrect: true },
+                        { text: "Se a lista cabe na memória do navegador", isCorrect: false },
+                        { text: "Se os itens têm chave estável definida", isCorrect: false },
+                        {
+                            text: "Se o componente de cada linha já está memorizado",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_7: Modulo = {
+    titulo: "Módulo 7 - Do projeto ao ar",
+    aulas: [
+        {
+            titulo: "React com TypeScript",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Tipando componentes\n\nA forma mais direta é tipar as props e deixar o retorno inferido. Não é preciso anotar o tipo do componente.",
+                },
+                {
+                    type: "code",
+                    value: "type Props = {\n  titulo: string;\n  itens: Produto[];\n  aoSelecionar: (p: Produto) => void;\n  children?: React.ReactNode;\n};\n\nfunction Lista({ titulo, itens, aoSelecionar, children }: Props) {\n  return <div>{children}</div>;\n}",
+                },
+                {
+                    type: "table",
+                    value: '[["Tipo", "Para que serve"], ["React.ReactNode", "qualquer coisa renderizável"], ["React.ReactElement", "um elemento JSX"], ["React.ComponentProps<\'button\'>", "as props de uma tag"], ["React.FormEvent", "o evento de um formulário"], ["React.Ref<T>", "uma referência a um elemento"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Herdando props de um elemento\n\nO padrão que evita listar dezenas de props em um componente de botão: herdar as props do elemento nativo e acrescentar as suas.",
+                },
+                {
+                    type: "code",
+                    value: 'type BotaoProps = React.ComponentProps<"button"> & {\n  variante?: "primario" | "secundario";\n};\n\nfunction Botao({ variante = "primario", ...resto }: BotaoProps) {\n  return <button className={`btn btn--${variante}`} {...resto} />;\n}\n\n// Agora aceita onClick, disabled, type e tudo mais\n<Botao variante="secundario" disabled onClick={f}>Cancelar</Botao>',
+                },
+                {
+                    type: "text",
+                    value: "## O useState com tipo\n\nA inferência resolve quase sempre. Anotar só é necessário quando o valor inicial não representa todos os estados possíveis, como um `null` que depois vira objeto.",
+                },
+                {
+                    type: "code",
+                    value: 'const [texto, setTexto] = useState("");            // string, inferido\nconst [user, setUser] = useState<Usuario | null>(null);   // precisa anotar',
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que costuma bastar para tipar um componente?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Tipar as props e deixar o retorno inferido", isCorrect: true },
+                        { text: "Anotar o componente com React.FC e as props", isCorrect: false },
+                        { text: "Declarar uma interface para o retorno também", isCorrect: false },
+                        { text: "Tipar cada elemento JSX devolvido por ele", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual tipo representa qualquer coisa renderizável?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "React.ReactNode", isCorrect: true },
+                        { text: "React.ReactElement, mais específico", isCorrect: false },
+                        { text: "JSX.Element, com o elemento devolvido", isCorrect: false },
+                        { text: "React.Component, a classe base do React", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como herdar as props de um elemento nativo?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Com React.ComponentProps do elemento", isCorrect: true },
+                        { text: "Estendendo a interface HTMLElement do DOM", isCorrect: false },
+                        { text: "Declarando cada prop nativa manualmente", isCorrect: false },
+                        { text: "Usando o operador de espalhamento nas props", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quando é preciso anotar o tipo do `useState`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Quando o inicial não cobre todos os estados", isCorrect: true },
+                        { text: "Sempre, o useState não infere sozinho", isCorrect: false },
+                        { text: "Quando o estado é usado em mais de um lugar", isCorrect: false },
+                        { text: "Quando o valor inicial é uma string vazia", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `...resto` faz nas props de um botão?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Repassa as demais props ao elemento nativo", isCorrect: true },
+                        { text: "Ignora as props que não foram declaradas", isCorrect: false },
+                        { text: "Cria um objeto com as props obrigatórias", isCorrect: false },
+                        {
+                            text: "Valida todas as props recebidas pelo componente",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Roteamento",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Várias telas em uma aplicação\n\nO React não traz roteamento: ele renderiza componentes. Uma biblioteca de rotas lê a URL e decide o que mostrar, mantendo o histórico do navegador funcionando.\n\nO **React Router** é a opção mais usada em aplicações puramente cliente.",
+                },
+                {
+                    type: "code",
+                    value: 'const router = createBrowserRouter([\n  {\n    path: "/",\n    element: <Layout />,\n    children: [\n      { index: true, element: <Home /> },\n      { path: "produtos", element: <Produtos /> },\n      { path: "produtos/:id", element: <Produto /> },\n      { path: "*", element: <NaoEncontrado /> },\n    ],\n  },\n]);\n\n// Lendo o parâmetro na tela\nconst { id } = useParams();',
+                },
+                {
+                    type: "text",
+                    value: "## Rotas aninhadas\n\nO `Layout` acima aparece em todas as páginas filhas, com um `<Outlet />` marcando onde a rota atual entra. É o mesmo raciocínio de composição do módulo 4, aplicado à navegação.\n\n## Links, não âncoras\n\nUsar `<a href>` recarrega a página inteira e perde todo o estado. O componente `<Link>` da biblioteca troca a tela sem recarregar.",
+                },
+                {
+                    type: "code",
+                    value: '// Errado: recarrega tudo\n<a href="/produtos">Produtos</a>\n\n// Certo: navegação no cliente\n<Link to="/produtos">Produtos</Link>\n\n// Navegando por código\nconst navegar = useNavigate();\nnavegar(`/produtos/${id}`);',
+                },
+                {
+                    type: "text",
+                    value: "## Estado na URL\n\nFiltro, ordenação e página atual pertencem à URL, não ao estado do componente. Assim o link pode ser compartilhado, o botão voltar funciona e recarregar a página não perde o contexto.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O React traz roteamento embutido?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Não, é preciso uma biblioteca", isCorrect: true },
+                        { text: "Sim, pelo componente Router do pacote react", isCorrect: false },
+                        { text: "Sim, desde a versão 19 do framework", isCorrect: false },
+                        { text: "Sim, mas apenas em aplicações de servidor", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que acontece ao usar `<a href>` em vez de `<Link>`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A página recarrega e o estado se perde", isCorrect: true },
+                        { text: "A navegação funciona igual, sem diferença", isCorrect: false },
+                        {
+                            text: "O roteador intercepta o clique automaticamente",
+                            isCorrect: false,
+                        },
+                        { text: "O histórico do navegador deixa de registrar", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o `<Outlet />` marca em um layout?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Onde a rota filha atual é renderizada", isCorrect: true },
+                        { text: "Onde os links de navegação vão aparecer", isCorrect: false },
+                        { text: "O ponto de saída da aplicação para outra rota", isCorrect: false },
+                        { text: "A área que será atualizada sem recarregar", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Onde filtro e ordenação devem morar?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Na URL, para poder compartilhar e voltar", isCorrect: true },
+                        { text: "No estado do componente que exibe a lista", isCorrect: false },
+                        { text: "Em um contexto compartilhado pela aplicação", isCorrect: false },
+                        { text: "No armazenamento local do navegador", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como se navega por código?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Com a função devolvida por useNavigate", isCorrect: true },
+                        { text: "Alterando o endereço com window.location", isCorrect: false },
+                        { text: "Renderizando um Link e clicando nele", isCorrect: false },
+                        { text: "Chamando o método push do componente Router", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Testes com Testing Library",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Testar o que a pessoa faz\n\nA **Testing Library** parte de um princípio: o teste deve interagir com a tela como um usuário interagiria. Ela desencoraja acessar estado interno ou implementação, porque isso quebra o teste a cada refatoração sem que nada tenha parado de funcionar.",
+                },
+                {
+                    type: "code",
+                    value: 'import { render, screen } from "@testing-library/react";\nimport userEvent from "@testing-library/user-event";\n\ntest("adiciona um item à lista", async () => {\n  const usuario = userEvent.setup();\n  render(<ListaDeTarefas />);\n\n  await usuario.type(screen.getByLabelText("Nova tarefa"), "Comprar pão");\n  await usuario.click(screen.getByRole("button", { name: "Adicionar" }));\n\n  expect(screen.getByText("Comprar pão")).toBeInTheDocument();\n});',
+                },
+                {
+                    type: "text",
+                    value: "## A ordem das consultas\n\nA biblioteca recomenda uma ordem de preferência, e ela não é arbitrária: quanto mais alto na lista, mais o teste se parece com o uso real e mais ele cobre acessibilidade de graça.",
+                },
+                {
+                    type: "table",
+                    value: '[["Preferência", "Consulta", "Por quê"], ["1", "getByRole", "é como leitores de tela navegam"], ["2", "getByLabelText", "é como se acha um campo"], ["3", "getByText", "é o que se lê na tela"], ["última", "getByTestId", "não reflete uso real"]]',
+                },
+                {
+                    type: "text",
+                    value: "## get, query e find\n\nTrês prefixos para três situações: `getBy` falha se não achar, `queryBy` devolve `null` e serve para afirmar ausência, e `findBy` espera o elemento aparecer, para o que é assíncrono.",
+                },
+                {
+                    type: "code",
+                    value: 'expect(screen.queryByText("Erro")).not.toBeInTheDocument();\nexpect(await screen.findByText("Salvo")).toBeInTheDocument();',
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual o princípio da Testing Library?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Interagir com a tela como um usuário faria", isCorrect: true },
+                        { text: "Verificar o estado interno de cada componente", isCorrect: false },
+                        {
+                            text: "Cobrir todas as linhas de código do componente",
+                            isCorrect: false,
+                        },
+                        { text: "Executar os testes sem renderizar a interface", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual consulta é a primeira na ordem de preferência?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "getByRole", isCorrect: true },
+                        { text: "getByText, pelo que aparece na tela", isCorrect: false },
+                        { text: "getByTestId, com um atributo próprio", isCorrect: false },
+                        { text: "getByLabelText, pelo rótulo do campo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que `getByRole` é preferida?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "É como leitores de tela navegam a página", isCorrect: true },
+                        { text: "Ela executa a busca bem mais rápido", isCorrect: false },
+                        { text: "Ela funciona mesmo sem renderizar a tela", isCorrect: false },
+                        { text: "Ela é a única que aceita expressões regulares", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual consulta usar para afirmar que algo não está na tela?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "queryBy, que devolve null", isCorrect: true },
+                        { text: "getBy, que falha quando não encontra", isCorrect: false },
+                        { text: "findBy, que espera o elemento aparecer", isCorrect: false },
+                        { text: "Qualquer uma, o resultado é o mesmo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual consulta usar para algo que aparece depois?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "findBy, que espera pelo elemento", isCorrect: true },
+                        { text: "getBy, repetindo a busca em um laço", isCorrect: false },
+                        { text: "queryBy, verificando se já apareceu", isCorrect: false },
+                        { text: "getAllBy, pegando todos os elementos", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Server Components e frameworks",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Componentes que rodam no servidor\n\nOs **React Server Components** rodam **apenas no servidor**. Eles podem consultar o banco direto, ler arquivos e usar segredos, e o JavaScript deles **nunca é enviado ao navegador**.\n\nÉ uma mudança grande no modelo: parte da árvore nunca chega ao cliente, e o pacote que a pessoa baixa fica menor.",
+                },
+                {
+                    type: "code",
+                    value: "// Componente de servidor: sem 'use client'\nasync function ListaProdutos() {\n  const produtos = await db.produto.findMany();   // direto no banco\n  return <ul>{produtos.map((p) => <li key={p.id}>{p.nome}</li>)}</ul>;\n}\n\n// Componente de cliente: precisa marcar\n\"use client\";\n\nfunction Contador() {\n  const [n, setN] = useState(0);\n  return <button onClick={() => setN(n + 1)}>{n}</button>;\n}",
+                },
+                {
+                    type: "table",
+                    value: '[["", "Servidor", "Cliente"], ["Estado e efeitos", "não", "sim"], ["Eventos de clique", "não", "sim"], ["Acesso a banco e segredos", "sim", "não"], ["JavaScript enviado", "nenhum", "sim"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Onde isso existe\n\nServer Components exigem um **framework** que cuide do build e do transporte: Next.js e React Router em modo framework são os caminhos mais comuns. Em uma aplicação criada só com Vite, eles não estão disponíveis.\n\n## Quando vale\n\nPara site com muito conteúdo e SEO importante, o ganho é grande. Para painel interno atrás de login, o modelo cliente puro continua mais simples e é uma escolha legítima.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Onde um Server Component roda?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Apenas no servidor", isCorrect: true },
+                        { text: "No servidor e depois de novo no cliente", isCorrect: false },
+                        { text: "No cliente, com os dados vindos do servidor", isCorrect: false },
+                        { text: "Nos dois, conforme a necessidade da tela", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que um Server Component não pode ter?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Estado, efeitos e eventos de clique", isCorrect: true },
+                        { text: "Acesso ao banco de dados da aplicação", isCorrect: false },
+                        { text: "Componentes filhos dentro do seu JSX", isCorrect: false },
+                        { text: "Chamadas assíncronas com await no corpo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quanto JavaScript de um Server Component vai ao navegador?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Nenhum", isCorrect: true },
+                        { text: "Apenas a parte que trata os eventos da tela", isCorrect: false },
+                        { text: "Todo ele, como qualquer outro componente", isCorrect: false },
+                        { text: "Só o necessário para hidratar a página", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `'use client'` marca?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Que o componente roda no navegador", isCorrect: true },
+                        { text: "Que o componente usa dados do cliente", isCorrect: false },
+                        { text: "Que o componente é renderizado sob demanda", isCorrect: false },
+                        { text: "Que o componente não deve ser memorizado", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que é preciso para usar Server Components?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um framework que cuide do build e transporte", isCorrect: true },
+                        {
+                            text: "Apenas ter a versão 19 do React instalada no projeto",
+                            isCorrect: false,
+                        },
+                        { text: "Um servidor Node rodando a aplicação", isCorrect: false },
+                        { text: "O React Compiler ligado no projeto", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Build, deploy e o projeto final",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Colocando no ar\n\nO build de uma aplicação React em Vite gera arquivos estáticos: HTML, JavaScript e CSS. Qualquer hospedagem de conteúdo estático serve, e o custo costuma ser próximo de zero.",
+                },
+                {
+                    type: "code",
+                    value: "npm run build\n# gera a pasta dist/\n\nnpm run preview\n# serve o build local, para conferir antes de publicar",
+                },
+                {
+                    type: "text",
+                    value: "## O detalhe que quebra em produção\n\nEm uma aplicação de página única, o servidor precisa devolver o `index.html` para **qualquer** rota. Sem isso, abrir `/produtos/42` direto no navegador devolve 404: o servidor procura um arquivo que não existe.\n\nCada hospedagem tem sua forma de configurar esse redirecionamento, e é o problema mais comum do primeiro deploy.",
+                },
+                {
+                    type: "text",
+                    value: "## Variáveis de ambiente\n\nNo Vite, apenas variáveis com o prefixo `VITE_` chegam ao código. E vale lembrar do óbvio que às vezes se esquece: **tudo que vai para o navegador é público**. Chave de API secreta não entra em aplicação cliente, em hipótese alguma.",
+                },
+                {
+                    type: "code",
+                    value: "# .env\nVITE_API_URL=https://api.exemplo.com\n\n// No código\nconst url = import.meta.env.VITE_API_URL;",
+                },
+                {
+                    type: "text",
+                    value: "## O projeto final\n\nPara fechar a trilha, construa um **gerenciador de tarefas** que exercite cada módulo:\n\n1. Componentes com props tipadas e listas com chave estável\n2. Estado com `useState` e `useReducer` para as transições da lista\n3. Um hook próprio guardando as tarefas no armazenamento local\n4. Context para o tema, com o alternador em qualquer profundidade\n5. Um formulário com Action e `useOptimistic` ao criar\n6. Rotas com filtro e ordenação na URL\n7. Testes com Testing Library cobrindo criar, concluir e filtrar\n\nCada item corresponde a um módulo desta trilha.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o build de uma aplicação React em Vite gera?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Arquivos estáticos de HTML, JS e CSS", isCorrect: true },
+                        { text: "Um servidor Node pronto para ser executado", isCorrect: false },
+                        { text: "Um contêiner com a aplicação já configurada", isCorrect: false },
+                        {
+                            text: "Um pacote instalável pelo gerenciador do sistema",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Por que abrir uma rota direto no navegador pode dar 404?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O servidor procura um arquivo que não existe", isCorrect: true },
+                        {
+                            text: "O roteador só funciona depois do primeiro clique",
+                            isCorrect: false,
+                        },
+                        { text: "A rota precisa ser cadastrada na hospedagem", isCorrect: false },
+                        { text: "O build não gera as páginas de cada rota", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como resolver esse problema de rotas?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Devolver o index.html para qualquer rota", isCorrect: true },
+                        { text: "Gerar um arquivo HTML para cada rota no build", isCorrect: false },
+                        { text: "Usar apenas rotas com a cerquilha na URL", isCorrect: false },
+                        { text: "Configurar o roteador para o modo de servidor", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quais variáveis chegam ao código em um projeto Vite?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "As que começam com VITE_", isCorrect: true },
+                        { text: "Todas as declaradas no arquivo .env", isCorrect: false },
+                        { text: "Apenas as declaradas no build de produção", isCorrect: false },
+                        { text: "As que forem importadas explicitamente", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que nunca deve ir para uma aplicação cliente?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Chave de API secreta", isCorrect: true },
+                        { text: "O endereço da API que será consumida", isCorrect: false },
+                        { text: "O nome do ambiente em que ela roda", isCorrect: false },
+                        { text: "A versão da aplicação que foi publicada", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+export const MODULOS: Modulo[] = [
+    MODULO_1,
+    MODULO_2,
+    MODULO_3,
+    MODULO_4,
+    MODULO_5,
+    MODULO_6,
+    MODULO_7,
+];
+
+async function seed() {
+    let [trilha] = await db.select().from(trails).where(eq(trails.name, NOME));
+    if (!trilha) {
+        [trilha] = await db
+            .insert(trails)
+            .values({
+                name: NOME,
+                trailLevel: LEVEL,
+                description: DESCRICAO,
+                workloadHours: CARGA_HORARIA,
+            })
+            .returning();
+        console.log("Trilha criada: " + NOME);
+    } else {
+        const existentes = await db.select().from(lessons).where(eq(lessons.trailId, trilha.id));
+        if (existentes.length > 0) {
+            console.log("Trilha já tem aulas, nada a fazer: " + NOME);
+            return;
+        }
+        await db
+            .update(trails)
+            .set({ workloadHours: CARGA_HORARIA, description: DESCRICAO, trailLevel: LEVEL })
+            .where(eq(trails.id, trilha.id));
+    }
+
+    let totalAulas = 0;
+    let totalQuestoes = 0;
+    for (let mi = 0; mi < MODULOS.length; mi++) {
+        const m = MODULOS[mi];
+        const [mod] = await db
+            .insert(modules)
+            .values({ trailId: trilha.id, title: m.titulo, position: mi + 1 })
+            .returning();
+        for (let li = 0; li < m.aulas.length; li++) {
+            const a = m.aulas[li];
+            const [lesson] = await db
+                .insert(lessons)
+                .values({
+                    trailId: trilha.id,
+                    moduleId: mod.id,
+                    title: a.titulo,
+                    content: null,
+                    contentBlocks: a.blocks,
+                    position: li + 1,
+                    published: true,
+                })
+                .returning();
+            for (let qi = 0; qi < a.questions.length; qi++) {
+                const q = a.questions[qi];
+                const [questao] = await db
+                    .insert(questions)
+                    .values({
+                        lessonId: lesson.id,
+                        statement: q.statement,
+                        difficulty: q.difficulty,
+                        position: qi + 1,
+                    })
+                    .returning();
+                await db.insert(questionOptions).values(
+                    q.options.map((o, k) => ({
+                        questionId: questao.id,
+                        text: o.text,
+                        isCorrect: o.isCorrect,
+                        position: k + 1,
+                    })),
+                );
+            }
+            totalAulas++;
+            totalQuestoes += a.questions.length;
+        }
+    }
+    console.log(
+        "Seed concluído: " +
+            MODULOS.length +
+            " módulos, " +
+            totalAulas +
+            " aulas, " +
+            totalQuestoes +
+            " questões.",
+    );
+}
+
+// Só semeia quando executado direto. Importado, expõe MODULOS/NOME sem rodar nada.
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+    seed()
+        .then(() => process.exit(0))
+        .catch((e) => {
+            console.error("Falha no seed:", e);
+            process.exit(1);
+        });
+}

--- a/backend/scripts/seed-trilha-spring-boot.ts
+++ b/backend/scripts/seed-trilha-spring-boot.ts
@@ -1,0 +1,3286 @@
+// Seed da trilha Spring Boot (Spring Boot 4.1). Conteúdo autoral.
+// A linha 4 saiu em novembro de 2025 sobre o Spring Framework 7, e a 4.1 de junho
+// de 2026 é o alvo recomendado: modularização, Java 25, versionamento de API,
+// HTTP Service Clients, conexões preguiçosas e mitigação de SSRF.
+//
+// Idempotente e nao destrutivo: se a trilha ja tiver aulas, nao faz nada.
+//
+// Rodar em prod: docker compose -f docker-compose.prod.yml run --rm -T --no-deps backend node scripts/seed-trilha-spring-boot.ts
+import { db } from "../db.ts";
+import { trails, modules, lessons, questions, questionOptions } from "../schema.ts";
+import { eq } from "drizzle-orm";
+import { pathToFileURL } from "node:url";
+
+export const NOME = "Spring Boot";
+const LEVEL: "iniciante" | "intermediario" | "avancado" = "intermediario";
+const DESCRICAO =
+    "Spring Boot 4.1 do primeiro projeto à produção: injeção de dependência e auto-configuração, REST com validação e tratamento de erros, JPA com relacionamentos e o problema N+1, Spring Security com JWT e autorização, testes com Mockito e Testcontainers, Actuator e observabilidade. Inclui o que a linha 4 trouxe: modularização, Java 25, versionamento de API e clientes HTTP declarativos.";
+const CARGA_HORARIA = 24;
+
+type Bloco = { type: "text" | "code" | "quote" | "table"; value: string };
+type Questao = {
+    statement: string;
+    difficulty: "facil" | "medio" | "dificil";
+    options: { text: string; isCorrect: boolean }[];
+};
+type Aula = { titulo: string; blocks: Bloco[]; questions: Questao[] };
+type Modulo = { titulo: string; aulas: Aula[] };
+
+const MODULO_1: Modulo = {
+    titulo: "Módulo 1 - O Spring e o primeiro projeto",
+    aulas: [
+        {
+            titulo: "O que é Spring e o que o Boot resolve",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Dois nomes, duas coisas\n\nO **Spring Framework** é a base: injeção de dependência, transações, acesso a dados, camada web. Ele existe desde 2003 e é o alicerce de boa parte do Java corporativo.\n\nO **Spring Boot** veio depois, em 2014, para resolver um problema do próprio Spring: configurar tudo dava um trabalho enorme. Ele traz **auto-configuração**, **starters** e um servidor embutido, e transforma dias de configuração em minutos.",
+                },
+                {
+                    type: "table",
+                    value: '[["O que o Boot resolve", "Como era antes"], ["auto-configuração", "XML ou classes de configuração à mão"], ["starters", "escolher e casar dezenas de versões"], ["servidor embutido", "publicar um WAR em um servidor externo"], ["padrões sensatos", "configurar tudo do zero"]]',
+                },
+                {
+                    type: "text",
+                    value: "## As versões desta trilha\n\nEsta trilha usa o **Spring Boot 4.1**, lançado em 10 de junho de 2026, sobre o **Spring Framework 7.0**.\n\nA linha 4 começou em novembro de 2025 e é uma virada grande: modularização do código, suporte de primeira classe ao **Java 25** mantendo compatibilidade com o Java 17, versionamento de API e clientes HTTP declarativos.",
+                },
+                {
+                    type: "quote",
+                    value: "O Boot não substitui o Spring: ele configura o Spring por você. Entender o que está por baixo é o que separa quem copia configuração de quem resolve problema.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual a relação entre Spring Framework e Spring Boot?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O Boot configura o Framework por você", isCorrect: true },
+                        {
+                            text: "O Boot é a versão mais nova, que substituiu o outro",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "São projetos independentes, sem relação entre eles",
+                            isCorrect: false,
+                        },
+                        { text: "O Framework é uma extensão opcional do Boot", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o Spring Boot trouxe de mais marcante?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Auto-configuração e servidor embutido", isCorrect: true },
+                        { text: "Um banco de dados já configurado no projeto", isCorrect: false },
+                        { text: "Uma linguagem própria para escrever serviços", isCorrect: false },
+                        { text: "Um substituto para a máquina virtual do Java", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual versão do Spring Boot esta trilha usa?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Spring Boot 4.1", isCorrect: true },
+                        { text: "Spring Boot 2.7", isCorrect: false },
+                        { text: "Spring Boot 3.2", isCorrect: false },
+                        { text: "Spring Boot 1.5", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Sobre qual versão do Framework o Spring Boot 4 roda?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Spring Framework 7.0", isCorrect: true },
+                        { text: "Spring Framework 6.2, da linha anterior", isCorrect: false },
+                        { text: "Spring Framework 5.3, ainda mantida", isCorrect: false },
+                        { text: "Ele não depende do Framework, é independente", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual versão do Java o Spring Boot 4 apoia em primeira classe?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Java 25", isCorrect: true },
+                        { text: "Java 17, que é a versão mínima aceita", isCorrect: false },
+                        { text: "Java 11, mantida por compatibilidade", isCorrect: false },
+                        { text: "Java 21, a versão anterior de longo prazo", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Criando o projeto",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O Spring Initializr\n\nO ponto de partida é o **start.spring.io**, um gerador que monta o projeto com as dependências escolhidas e as versões que funcionam juntas. A maioria dos editores tem o mesmo gerador integrado.",
+                },
+                {
+                    type: "code",
+                    value: "curl https://start.spring.io/starter.zip \\\n  -d dependencies=web,data-jpa,postgresql,validation \\\n  -d type=maven-project \\\n  -d javaVersion=25 \\\n  -d bootVersion=4.1.0 \\\n  -o loja.zip",
+                },
+                {
+                    type: "text",
+                    value: "## A classe principal\n\nO projeto gerado tem uma classe com `@SpringBootApplication`. Essa anotação junta três outras, e entender isso ajuda quando algo não é encontrado.",
+                },
+                {
+                    type: "code",
+                    value: "@SpringBootApplication\npublic class LojaApplication {\n    public static void main(String[] args) {\n        SpringApplication.run(LojaApplication.class, args);\n    }\n}\n\n// @SpringBootApplication equivale a:\n// @Configuration       esta classe declara beans\n// @EnableAutoConfiguration  ligue a auto-configuração\n// @ComponentScan       procure componentes a partir daqui",
+                },
+                {
+                    type: "text",
+                    value: "O `@ComponentScan` procura a partir do **pacote da classe principal e abaixo**. Uma classe em um pacote irmão não é encontrada, e esse é o motivo mais comum de um serviço não ser injetado em projeto novo.\n\n## Rodando",
+                },
+                {
+                    type: "code",
+                    value: "./mvnw spring-boot:run\n# ou\n./mvnw package && java -jar target/loja-0.0.1-SNAPSHOT.jar\n\n# O servidor embutido sobe na porta 8080",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o Spring Initializr resolve?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Monta o projeto com versões que funcionam juntas",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Gera o código das entidades e dos controllers do projeto",
+                            isCorrect: false,
+                        },
+                        { text: "Cria o banco de dados usado pela aplicação", isCorrect: false },
+                        { text: "Configura o servidor onde o projeto vai rodar", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quantas anotações o `@SpringBootApplication` reúne?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Três", isCorrect: true },
+                        { text: "Duas, configuração e escaneamento", isCorrect: false },
+                        { text: "Cinco, incluindo as de web e dados", isCorrect: false },
+                        { text: "Uma só, que liga tudo de uma vez", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Onde o `@ComponentScan` procura por componentes?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "No pacote da classe principal e abaixo", isCorrect: true },
+                        { text: "Em todo o projeto, sem restrição de pacote", isCorrect: false },
+                        { text: "Apenas no pacote onde a classe foi declarada", isCorrect: false },
+                        {
+                            text: "Nos pacotes listados no arquivo de configuração",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Por que um serviço em um pacote irmão não é injetado?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Ele fica fora do alcance do escaneamento", isCorrect: true },
+                        { text: "Ele precisa ser importado na classe principal", isCorrect: false },
+                        {
+                            text: "Ele exige uma anotação diferente de componente",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Ele precisa estar no mesmo arquivo do controller",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Em qual porta o servidor embutido sobe por padrão?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "8080", isCorrect: true },
+                        { text: "80", isCorrect: false },
+                        { text: "3000", isCorrect: false },
+                        { text: "8443", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Injeção de dependência",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O coração do Spring\n\nEm vez de cada classe criar as suas dependências, o Spring as **cria e entrega**. Esse é o princípio da inversão de controle, e é o que torna o código testável: em teste, você entrega uma implementação falsa no lugar da real.",
+                },
+                {
+                    type: "code",
+                    value: "// Acoplado: impossível testar sem banco de verdade\npublic class PedidoService {\n    private final PedidoRepository repo = new PedidoRepositoryJpa();\n}\n\n// Injetado: o Spring entrega, e o teste entrega outro\n@Service\npublic class PedidoService {\n    private final PedidoRepository repo;\n\n    public PedidoService(PedidoRepository repo) {\n        this.repo = repo;\n    }\n}",
+                },
+                {
+                    type: "text",
+                    value: "## Sempre por construtor\n\nExistem três formas de injetar: construtor, campo com `@Autowired` e método. A recomendação é **construtor**, e por razões concretas:\n\n- O campo pode ser `final`, então o objeto é imutável\n- Fica impossível criar o objeto sem as dependências\n- O teste instancia a classe direto, sem framework nenhum\n- Uma lista longa de parâmetros denuncia que a classe faz coisas demais\n\nCom um único construtor, o `@Autowired` é dispensável.",
+                },
+                {
+                    type: "table",
+                    value: '[["Anotação", "Para que serve"], ["@Component", "componente genérico"], ["@Service", "regra de negócio"], ["@Repository", "acesso a dados"], ["@RestController", "camada web"], ["@Configuration", "classe que declara beans"], ["@Bean", "método que produz um bean"]]',
+                },
+                {
+                    type: "text",
+                    value: "As quatro primeiras são a mesma coisa para o Spring: todas registram um bean. A diferença é **semântica**, e ajuda quem lê a saber a responsabilidade de cada classe.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que a injeção de dependência inverte?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Quem cria as dependências da classe", isCorrect: true },
+                        { text: "A ordem em que as classes são carregadas", isCorrect: false },
+                        { text: "A direção das chamadas entre as camadas", isCorrect: false },
+                        { text: "O sentido do fluxo de dados na aplicação", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual forma de injeção é recomendada?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Por construtor", isCorrect: true },
+                        { text: "Por campo, com a anotação Autowired", isCorrect: false },
+                        { text: "Por método setter, após a construção", isCorrect: false },
+                        { text: "Tanto faz, as três são equivalentes", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual vantagem a injeção por construtor traz ao teste?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "A classe pode ser instanciada sem o framework", isCorrect: true },
+                        { text: "O teste executa bem mais rápido que os outros", isCorrect: false },
+                        { text: "As dependências são criadas automaticamente", isCorrect: false },
+                        { text: "O Spring injeta objetos falsos por padrão", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a diferença entre `@Service` e `@Repository` para o Spring?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Nenhuma técnica, a diferença é semântica", isCorrect: true },
+                        { text: "O Repository ganha transações automáticas", isCorrect: false },
+                        { text: "O Service é criado antes do Repository", isCorrect: false },
+                        { text: "O Repository só funciona com JPA no projeto", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que uma lista longa de parâmetros no construtor denuncia?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Que a classe faz coisas demais", isCorrect: true },
+                        {
+                            text: "Que faltam anotações nos componentes injetados",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Que o escaneamento está encontrando duplicatas",
+                            isCorrect: false,
+                        },
+                        { text: "Que a classe deveria usar injeção por campo", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Configuração e perfis",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Configuração fora do código\n\nO Spring lê configuração de várias fontes, com uma ordem de precedência bem definida. Saber essa ordem resolve a dúvida clássica de por que um valor não está sendo aplicado.",
+                },
+                {
+                    type: "table",
+                    value: '[["Fonte", "Precedência"], ["argumentos da linha de comando", "a mais alta"], ["variáveis de ambiente", "alta"], ["application-{perfil}.yml", "média"], ["application.yml", "baixa"], ["valores padrão no código", "a mais baixa"]]',
+                },
+                {
+                    type: "code",
+                    value: "# application.yml\nspring:\n  application:\n    name: loja\n  datasource:\n    url: ${DB_URL:jdbc:postgresql://localhost:5432/loja}\n    username: ${DB_USER:postgres}\n    password: ${DB_PASSWORD}\n  jpa:\n    hibernate:\n      ddl-auto: validate\n\nloja:\n  taxa-entrega: 12.50\n  prazo-dias: 5",
+                },
+                {
+                    type: "text",
+                    value: "Repare no `${DB_URL:padrão}`: a variável de ambiente vence, e o valor depois dos dois-pontos é o padrão para desenvolvimento.\n\n## Perfis\n\nUm **perfil** é um conjunto de configuração para um ambiente. O arquivo `application-prod.yml` só é lido quando o perfil `prod` está ativo, e seus valores sobrescrevem os do arquivo base.",
+                },
+                {
+                    type: "code",
+                    value: 'java -jar loja.jar --spring.profiles.active=prod\nSPRING_PROFILES_ACTIVE=prod java -jar loja.jar\n\n// Um bean que só existe em um perfil\n@Configuration\n@Profile("dev")\npublic class DadosDeExemplo { }',
+                },
+                {
+                    type: "text",
+                    value: "## Configuração tipada\n\nEspalhar `@Value` pelo código funciona e não valida nada. `@ConfigurationProperties` agrupa a configuração em uma classe, com tipos e validação.",
+                },
+                {
+                    type: "code",
+                    value: '@ConfigurationProperties(prefix = "loja")\n@Validated\npublic record LojaProperties(\n    @NotNull BigDecimal taxaEntrega,\n    @Min(1) int prazoDias\n) {}',
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual fonte de configuração tem a maior precedência?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Os argumentos da linha de comando", isCorrect: true },
+                        { text: "As variáveis de ambiente do sistema", isCorrect: false },
+                        { text: "O arquivo application.yml do projeto", isCorrect: false },
+                        { text: "Os valores padrão declarados no código", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `${DB_URL:jdbc:...}` significa?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Usa a variável, e o padrão se ela não existir", isCorrect: true },
+                        { text: "Concatena a variável com o valor informado", isCorrect: false },
+                        {
+                            text: "Exige que a variável esteja definida no ambiente",
+                            isCorrect: false,
+                        },
+                        { text: "Usa sempre o valor após os dois-pontos", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quando `application-prod.yml` é lido?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Quando o perfil prod está ativo", isCorrect: true },
+                        { text: "Sempre, junto com o arquivo base do projeto", isCorrect: false },
+                        { text: "Quando a aplicação roda empacotada em um jar", isCorrect: false },
+                        { text: "Quando nenhum outro arquivo é encontrado", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a vantagem de `@ConfigurationProperties` sobre `@Value`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Agrupa a configuração com tipos e validação", isCorrect: true },
+                        {
+                            text: "Lê os valores bem mais rápido na inicialização",
+                            isCorrect: false,
+                        },
+                        { text: "Permite alterar a configuração em execução", isCorrect: false },
+                        {
+                            text: "Dispensa a declaração no arquivo de propriedades",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que a anotação `@Profile('dev')` faz em uma classe?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Só registra o bean naquele perfil", isCorrect: true },
+                        {
+                            text: "Define qual perfil será ativado na inicialização",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Impede que a classe rode em produção por engano",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Carrega o arquivo de configuração daquele perfil",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Auto-configuração e starters",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Como o Boot adivinha\n\nA **auto-configuração** funciona por condições: o Spring Boot olha o que está no classpath, o que já foi configurado e quais propriedades existem, e decide o que criar.\n\nSe o driver do PostgreSQL está presente e há uma URL de banco configurada, ele monta o pool de conexões. Se você declarou o seu, ele **recua** e usa o seu.",
+                },
+                {
+                    type: "code",
+                    value: '// É assim que a auto-configuração é escrita\n@AutoConfiguration\n@ConditionalOnClass(DataSource.class)\n@ConditionalOnProperty("spring.datasource.url")\npublic class DataSourceAutoConfiguration {\n\n    @Bean\n    @ConditionalOnMissingBean   // só cria se você não criou\n    public DataSource dataSource() { }\n}',
+                },
+                {
+                    type: "text",
+                    value: "O `@ConditionalOnMissingBean` é a chave do modelo: você nunca precisa desligar a auto-configuração, basta declarar o seu bean e ele vence.\n\n## Starters\n\nUm **starter** é um pacote que traz um conjunto de dependências compatíveis entre si. Em vez de escolher cinco bibliotecas e torcer para as versões casarem, você declara um.",
+                },
+                {
+                    type: "table",
+                    value: '[["Starter", "O que traz"], ["spring-boot-starter-web", "MVC, REST e servidor embutido"], ["spring-boot-starter-data-jpa", "JPA, Hibernate e transações"], ["spring-boot-starter-security", "autenticação e autorização"], ["spring-boot-starter-validation", "Bean Validation"], ["spring-boot-starter-test", "JUnit, Mockito e AssertJ"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Descobrindo o que foi configurado\n\nQuando algo aparece sem você ter pedido, ou não aparece quando deveria, o relatório de auto-configuração mostra exatamente o que foi decidido e por quê.",
+                },
+                {
+                    type: "code",
+                    value: "java -jar loja.jar --debug\n# imprime o relatório de condições avaliadas",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Em que a auto-configuração se baseia para decidir?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "No classpath, nos beans e nas propriedades", isCorrect: true },
+                        { text: "Apenas nas dependências declaradas no projeto", isCorrect: false },
+                        { text: "Em um arquivo de configuração gerado no build", isCorrect: false },
+                        { text: "Na versão do Java usada para compilar", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `@ConditionalOnMissingBean` garante?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O bean só é criado se você não criou o seu", isCorrect: true },
+                        { text: "O bean é criado apenas uma vez na aplicação", isCorrect: false },
+                        { text: "O bean é substituído quando outro é declarado", isCorrect: false },
+                        { text: "O bean falha se a dependência estiver ausente", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que é um starter?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um pacote com dependências compatíveis", isCorrect: true },
+                        { text: "Um modelo de projeto pronto para começar", isCorrect: false },
+                        { text: "Uma classe que inicializa a aplicação", isCorrect: false },
+                        {
+                            text: "Um perfil de configuração para desenvolvimento",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Como declarar o seu próprio bean afeta a auto-configuração?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A auto-configuração recua e usa o seu", isCorrect: true },
+                        { text: "Os dois beans são criados e coexistem", isCorrect: false },
+                        { text: "A aplicação falha por conflito de definição", isCorrect: false },
+                        { text: "É preciso desligar a auto-configuração antes", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como ver o que a auto-configuração decidiu?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Subindo a aplicação com a flag debug", isCorrect: true },
+                        { text: "Consultando um endpoint do Actuator", isCorrect: false },
+                        { text: "Lendo os arquivos gerados na pasta target", isCorrect: false },
+                        { text: "Habilitando o log em nível de rastreamento", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_2: Modulo = {
+    titulo: "Módulo 2 - Web e REST",
+    aulas: [
+        {
+            titulo: "Controllers e mapeamentos",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Recebendo requisições\n\nUm `@RestController` responde HTTP e devolve dados serializados, normalmente JSON. As anotações de mapeamento ligam verbo e caminho a um método.",
+                },
+                {
+                    type: "code",
+                    value: '@RestController\n@RequestMapping("/api/produtos")\npublic class ProdutoController {\n\n    private final ProdutoService service;\n\n    public ProdutoController(ProdutoService service) {\n        this.service = service;\n    }\n\n    @GetMapping\n    public Page<ProdutoResponse> listar(Pageable paginacao) {\n        return service.listar(paginacao);\n    }\n\n    @GetMapping("/{id}")\n    public ProdutoResponse buscar(@PathVariable Long id) {\n        return service.buscar(id);\n    }\n\n    @PostMapping\n    @ResponseStatus(HttpStatus.CREATED)\n    public ProdutoResponse criar(@RequestBody @Valid CriarProdutoRequest req) {\n        return service.criar(req);\n    }\n}',
+                },
+                {
+                    type: "table",
+                    value: '[["Anotação", "De onde vem o valor"], ["@PathVariable", "um trecho da URL"], ["@RequestParam", "a query string"], ["@RequestBody", "o corpo da requisição"], ["@RequestHeader", "um cabeçalho"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Controller e RestController\n\n`@Controller` devolve o **nome de uma view** para ser renderizada. `@RestController` é `@Controller` mais `@ResponseBody`: o retorno vira o corpo da resposta.\n\nEm API é sempre `@RestController`. Usar `@Controller` por engano faz o Spring procurar um template com o nome do que você devolveu, e o erro resultante confunde.",
+                },
+                {
+                    type: "text",
+                    value: "## Nunca devolva a entidade\n\nDevolver a entidade JPA direto vaza campos internos, expõe a estrutura da tabela e cria carregamento preguiçoso no meio da serialização. Use um record de resposta.",
+                },
+                {
+                    type: "code",
+                    value: "public record ProdutoResponse(Long id, String nome, BigDecimal preco) {\n    public static ProdutoResponse de(Produto p) {\n        return new ProdutoResponse(p.getId(), p.getNome(), p.getPreco());\n    }\n}",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual a diferença entre `@Controller` e `@RestController`?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "O Rest devolve o corpo, o outro o nome de uma view",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "O Rest só aceita requisições do tipo GET e POST",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O Controller não pode receber injeção de dependência",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O Rest exige que o retorno seja sempre um record",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "De onde `@PathVariable` tira o valor?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "De um trecho da URL", isCorrect: true },
+                        { text: "Da query string após a interrogação", isCorrect: false },
+                        { text: "Do corpo enviado na requisição", isCorrect: false },
+                        { text: "De um cabeçalho HTTP da chamada", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que não devolver a entidade JPA na resposta?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Vaza campos internos e dispara carregamento preguiçoso",
+                            isCorrect: true,
+                        },
+                        { text: "A entidade não pode ser convertida para JSON", isCorrect: false },
+                        {
+                            text: "O Spring recusa entidades JPA como retorno de um método",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "A serialização fica bem mais lenta que um record",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Para que serve `@ResponseStatus(HttpStatus.CREATED)`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Definir o código HTTP da resposta", isCorrect: true },
+                        { text: "Validar que o recurso foi mesmo criado", isCorrect: false },
+                        { text: "Registrar a criação no log da aplicação", isCorrect: false },
+                        { text: "Indicar que o método altera o banco de dados", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `@RequestBody` faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Converte o corpo da requisição em objeto", isCorrect: true },
+                        { text: "Valida o corpo antes de chegar ao método", isCorrect: false },
+                        { text: "Lê os parâmetros da query string da URL", isCorrect: false },
+                        { text: "Define o formato que a resposta terá", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Validação",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Bean Validation\n\nAs regras de formato ficam no objeto de entrada, como anotações. O `@Valid` no parâmetro do controller aciona a verificação **antes** de o método rodar.",
+                },
+                {
+                    type: "code",
+                    value: 'public record CriarProdutoRequest(\n    @NotBlank(message = "O nome é obrigatório")\n    @Size(max = 255)\n    String nome,\n\n    @NotNull\n    @DecimalMin(value = "0.0", inclusive = false)\n    BigDecimal preco,\n\n    @NotNull\n    Long categoriaId,\n\n    @Email\n    String emailContato\n) {}',
+                },
+                {
+                    type: "table",
+                    value: '[["Anotação", "Verifica"], ["@NotNull", "que não é nulo"], ["@NotBlank", "texto com conteúdo não vazio"], ["@NotEmpty", "coleção ou texto não vazio"], ["@Size", "tamanho entre mínimo e máximo"], ["@Positive e @Min", "valores numéricos"], ["@Pattern", "expressão regular"]]',
+                },
+                {
+                    type: "text",
+                    value: "## A confusão entre NotNull, NotEmpty e NotBlank\n\nElas parecem iguais e recusam coisas diferentes. Para texto vindo de formulário, `@NotBlank` é quase sempre a certa: ela recusa `null`, string vazia e string só com espaços.",
+                },
+                {
+                    type: "table",
+                    value: '[["Valor", "@NotNull", "@NotEmpty", "@NotBlank"], ["null", "recusa", "recusa", "recusa"], ["\\"\\"", "aceita", "recusa", "recusa"], ["\\"   \\"", "aceita", "aceita", "recusa"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Validação de negócio é outra coisa\n\nBean Validation cuida de **formato**. Regras que dependem do banco ou de outro serviço, como um email já cadastrado, pertencem ao service, não à anotação.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o `@Valid` no parâmetro aciona?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A validação antes de o método rodar", isCorrect: true },
+                        { text: "A conversão do corpo para o tipo do objeto", isCorrect: false },
+                        { text: "O registro dos erros no log da aplicação", isCorrect: false },
+                        {
+                            text: "A verificação das regras de negócio do service",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual anotação recusa uma string só com espaços?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "@NotBlank", isCorrect: true },
+                        { text: "@NotNull, que verifica o valor nulo", isCorrect: false },
+                        { text: "@NotEmpty, que verifica o tamanho", isCorrect: false },
+                        { text: "@Size, com o mínimo definido em um", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `@NotNull` aceita que `@NotEmpty` recusa?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A string vazia", isCorrect: true },
+                        { text: "A string com apenas espaços em branco", isCorrect: false },
+                        { text: "O valor nulo passado no campo", isCorrect: false },
+                        { text: "Uma coleção com um único elemento", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Onde uma regra que consulta o banco deve ficar?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "No service, não na anotação", isCorrect: true },
+                        { text: "Em uma anotação de validação personalizada", isCorrect: false },
+                        { text: "No controller, antes de chamar o service", isCorrect: false },
+                        { text: "No repository, junto com a consulta", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o Bean Validation cuida?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Do formato dos dados de entrada", isCorrect: true },
+                        { text: "Das regras de negócio da aplicação", isCorrect: false },
+                        { text: "Da autorização de quem fez a chamada", isCorrect: false },
+                        { text: "Da consistência dos dados no banco", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Tratamento de erros",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Uma resposta de erro consistente\n\nSem tratamento, cada exceção vira um 500 com um corpo padrão que expõe detalhes internos. O `@RestControllerAdvice` centraliza o tratamento e devolve a mesma estrutura para toda a API.",
+                },
+                {
+                    type: "code",
+                    value: '@RestControllerAdvice\npublic class TratadorDeErros {\n\n    @ExceptionHandler(RecursoNaoEncontrado.class)\n    public ProblemDetail naoEncontrado(RecursoNaoEncontrado e) {\n        var p = ProblemDetail.forStatus(HttpStatus.NOT_FOUND);\n        p.setTitle("Recurso não encontrado");\n        p.setDetail(e.getMessage());\n        return p;\n    }\n\n    @ExceptionHandler(MethodArgumentNotValidException.class)\n    public ProblemDetail invalido(MethodArgumentNotValidException e) {\n        var p = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);\n        p.setTitle("Dados inválidos");\n        p.setProperty("campos", e.getBindingResult().getFieldErrors().stream()\n            .collect(toMap(FieldError::getField, FieldError::getDefaultMessage)));\n        return p;\n    }\n}',
+                },
+                {
+                    type: "text",
+                    value: "## ProblemDetail\n\nO `ProblemDetail` implementa a **RFC 7807**, um formato padronizado de resposta de erro com `type`, `title`, `status`, `detail` e `instance`. Usá-lo evita que cada API invente o próprio formato, e clientes conhecidos já sabem lê-lo.",
+                },
+                {
+                    type: "code",
+                    value: '{\n  "type": "about:blank",\n  "title": "Dados inválidos",\n  "status": 400,\n  "campos": {\n    "nome": "O nome é obrigatório",\n    "preco": "deve ser maior que 0"\n  }\n}',
+                },
+                {
+                    type: "quote",
+                    value: "Nunca devolva a mensagem da exceção original ao cliente. Ela costuma trazer nome de tabela, consulta e caminho de arquivo.",
+                },
+                {
+                    type: "text",
+                    value: "## O que registrar\n\nErro esperado, como um recurso não encontrado, é log de nível informativo. Erro inesperado é log de erro **com a pilha**, e resposta genérica para quem chamou.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o `@RestControllerAdvice` centraliza?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O tratamento de exceções da API", isCorrect: true },
+                        { text: "A validação dos objetos de entrada", isCorrect: false },
+                        { text: "A configuração dos controllers do projeto", isCorrect: false },
+                        { text: "O registro das rotas da aplicação", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o `ProblemDetail` implementa?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um formato padronizado de resposta de erro", isCorrect: true },
+                        {
+                            text: "Um mecanismo de repetição automática da requisição",
+                            isCorrect: false,
+                        },
+                        { text: "Um contrato de validação dos campos", isCorrect: false },
+                        { text: "Um registro estruturado para o log", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que não devolver a mensagem da exceção original?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Ela expõe tabelas, consultas e caminhos internos",
+                            isCorrect: true,
+                        },
+                        { text: "Ela costuma estar em inglês para o usuário", isCorrect: false },
+                        {
+                            text: "Ela acaba deixando a resposta muito maior que o normal",
+                            isCorrect: false,
+                        },
+                        { text: "Ela impede que o cliente trate o erro sozinho", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual nível de log um recurso não encontrado merece?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Informativo, é um erro esperado", isCorrect: true },
+                        { text: "Erro, com a pilha completa registrada", isCorrect: false },
+                        { text: "Crítico, por indicar falha na aplicação", isCorrect: false },
+                        { text: "Nenhum, esse caso não precisa de log", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que acontece sem nenhum tratamento de erro?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Toda exceção vira um 500 com detalhes internos", isCorrect: true },
+                        {
+                            text: "A aplicação inteira para de responder às requisições",
+                            isCorrect: false,
+                        },
+                        { text: "O Spring devolve um 404 para qualquer falha", isCorrect: false },
+                        { text: "As exceções são registradas e ignoradas", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Versionamento de API e clientes HTTP",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Versionar API, novidade do Boot 4\n\nQuando uma API muda de forma incompatível, clientes antigos quebram. A saída sempre foi versionar, e cada equipe inventava a sua: caminho com `/v1`, cabeçalho próprio, parâmetro na query.\n\nO **Spring Framework 7**, base do Boot 4, trouxe **suporte de primeira classe a versionamento**, com a versão declarada no próprio mapeamento.",
+                },
+                {
+                    type: "code",
+                    value: '@RestController\n@RequestMapping("/api/produtos")\npublic class ProdutoController {\n\n    @GetMapping(version = "1.0")\n    public ProdutoV1 buscarV1(@PathVariable Long id) { }\n\n    @GetMapping(version = "2.0")\n    public ProdutoV2 buscarV2(@PathVariable Long id) { }\n}',
+                },
+                {
+                    type: "text",
+                    value: "A estratégia de onde a versão é lida, cabeçalho, caminho ou parâmetro, vira **configuração**, e o mesmo controller atende as duas sem duplicar rota nem escrever filtro.\n\n## HTTP Service Clients\n\nA outra novidade grande é o cliente HTTP **declarativo**. Em vez de montar a chamada na mão, você descreve a interface e o Spring gera a implementação.",
+                },
+                {
+                    type: "code",
+                    value: '@HttpExchange("/api/cep")\npublic interface CepClient {\n\n    @GetExchange("/{cep}")\n    Endereco buscar(@PathVariable String cep);\n\n    @PostExchange\n    Endereco cadastrar(@RequestBody NovoEndereco req);\n}\n\n// O Boot 4 registra a implementação sozinho:\n// basta injetar CepClient onde precisar',
+                },
+                {
+                    type: "text",
+                    value: "O ganho vai além de escrever menos: a interface **é** o contrato, e testar fica simples porque basta substituir a interface por uma implementação falsa.\n\nNo Spring Boot 4.1, esses clientes também ganharam proteção contra **SSRF**, o ataque em que uma URL controlada pelo atacante faz o servidor chamar um endereço interno.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o Spring Framework 7 trouxe para versionamento?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Suporte de primeira classe, no próprio mapeamento",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Um filtro já pronto para ler a versão vinda do cabeçalho",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Uma anotação que descontinua endpoints antigos",
+                            isCorrect: false,
+                        },
+                        { text: "Um gerador de documentação por versão da API", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Onde a estratégia de leitura da versão é definida?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Na configuração da aplicação", isCorrect: true },
+                        { text: "Em cada método anotado do controller", isCorrect: false },
+                        { text: "No cliente que faz a chamada à API", isCorrect: false },
+                        { text: "No arquivo de rotas do projeto", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que um HTTP Service Client é?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Uma interface que descreve as chamadas", isCorrect: true },
+                        { text: "Uma classe que monta as requisições na mão", isCorrect: false },
+                        { text: "Um proxy que intercepta chamadas de saída", isCorrect: false },
+                        { text: "Um servidor embutido para testes de API", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a vantagem do cliente declarativo em testes?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Basta trocar a interface por uma implementação falsa",
+                            isCorrect: true,
+                        },
+                        { text: "As chamadas passam a ser feitas em memória", isCorrect: false },
+                        {
+                            text: "O cliente valida o corpo da resposta automaticamente",
+                            isCorrect: false,
+                        },
+                        { text: "Os testes deixam de precisar de rede", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que é um ataque de SSRF?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Fazer o servidor chamar um endereço interno", isCorrect: true },
+                        { text: "Injetar código malicioso na resposta da API", isCorrect: false },
+                        {
+                            text: "Enviar requisições em massa para derrubar o servidor",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Interceptar a comunicação entre cliente e servidor",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Paginação, ordenação e boas práticas de API",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Nunca devolva a lista inteira\n\nUm endpoint que devolve todos os registros funciona bem com cem linhas e derruba a aplicação com um milhão. Paginação não é otimização, é requisito.\n\nO Spring Data resolve isso com o `Pageable`, que já lê os parâmetros da URL sozinho.",
+                },
+                {
+                    type: "code",
+                    value: '@GetMapping\npublic Page<ProdutoResponse> listar(\n    @PageableDefault(size = 20, sort = "nome") Pageable paginacao\n) {\n    return service.listar(paginacao);\n}\n\n// GET /api/produtos?page=0&size=20&sort=preco,desc',
+                },
+                {
+                    type: "text",
+                    value: "## Os códigos de resposta que importam\n\nUsar o código certo permite que o cliente trate a resposta sem ler o corpo.",
+                },
+                {
+                    type: "table",
+                    value: '[["Código", "Quando usar"], ["200", "deu certo e há corpo"], ["201", "recurso criado, com Location"], ["204", "deu certo e não há corpo"], ["400", "a requisição está errada"], ["401 e 403", "não autenticado e sem permissão"], ["404", "o recurso não existe"], ["409", "conflito, como duplicidade"], ["422", "entendi, mas a regra não permite"]]',
+                },
+                {
+                    type: "text",
+                    value: "A confusão mais comum é entre **401** e **403**: o primeiro é *não sei quem você é*, o segundo é *sei quem você é e você não pode*.\n\n## Idempotência\n\n`GET`, `PUT` e `DELETE` devem ser idempotentes: repetir a chamada leva ao mesmo estado. `POST` não é, e por isso duas submissões criam dois registros. Quando isso importa, uma chave de idempotência enviada pelo cliente resolve.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Por que paginação é requisito e não otimização?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Sem ela a aplicação cai quando a tabela cresce", isCorrect: true },
+                        { text: "Porque o Spring Data exige o uso do Pageable", isCorrect: false },
+                        {
+                            text: "Porque o JSON tem um limite de tamanho definido",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Porque o navegador não renderiza listas grandes",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual a diferença entre 401 e 403?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um é não autenticado, o outro é sem permissão", isCorrect: true },
+                        {
+                            text: "Um é erro do cliente e o outro é erro do servidor",
+                            isCorrect: false,
+                        },
+                        { text: "Um é temporário e o outro é permanente", isCorrect: false },
+                        { text: "Um vale para API e o outro para páginas web", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual código usar ao criar um recurso?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "201, com o cabeçalho Location", isCorrect: true },
+                        { text: "200, como em qualquer resposta de sucesso", isCorrect: false },
+                        { text: "204, indicando que não há corpo na resposta", isCorrect: false },
+                        { text: "202, indicando que foi aceito para processar", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que significa uma operação ser idempotente?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Repeti-la leva ao mesmo estado final", isCorrect: true },
+                        { text: "Ela pode ser executada por qualquer usuário", isCorrect: false },
+                        { text: "Ela não altera nenhum dado no banco", isCorrect: false },
+                        {
+                            text: "Ela devolve sempre a mesma resposta ao cliente",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual verbo HTTP não é idempotente?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "POST", isCorrect: true },
+                        { text: "PUT, que substitui o recurso inteiro", isCorrect: false },
+                        { text: "DELETE, que remove o recurso indicado", isCorrect: false },
+                        { text: "GET, que apenas consulta o recurso", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_3: Modulo = {
+    titulo: "Módulo 3 - Dados com JPA",
+    aulas: [
+        {
+            titulo: "Entidades e o Hibernate",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# JPA, Hibernate e Spring Data\n\nTrês nomes que se confundem:\n\n- **JPA** é a **especificação**: as anotações e a interface\n- **Hibernate** é a **implementação** mais usada dela\n- **Spring Data JPA** é a camada do Spring **em cima** disso, que gera os repositórios",
+                },
+                {
+                    type: "code",
+                    value: '@Entity\n@Table(name = "produtos")\npublic class Produto {\n\n    @Id\n    @GeneratedValue(strategy = GenerationType.IDENTITY)\n    private Long id;\n\n    @Column(nullable = false)\n    private String nome;\n\n    @Column(nullable = false, precision = 10, scale = 2)\n    private BigDecimal preco;\n\n    @ManyToOne(fetch = FetchType.LAZY)\n    @JoinColumn(name = "categoria_id")\n    private Categoria categoria;\n\n    @Enumerated(EnumType.STRING)\n    private StatusProduto status;\n\n    protected Produto() {}   // exigido pela JPA\n}',
+                },
+                {
+                    type: "text",
+                    value: "## Dois detalhes que causam bug em produção\n\n**`@Enumerated(EnumType.STRING)` não é opcional.** O padrão é `ORDINAL`, que grava a **posição** do valor no enum. Inserir um valor no meio do enum depois disso reescreve o significado de todos os registros já gravados, em silêncio.\n\n**`ddl-auto` nunca deve ser `update` em produção.** Ele altera o schema sozinho conforme as entidades, sem revisão e sem histórico. Em produção use `validate`, com as mudanças vindo de migrations.",
+                },
+                {
+                    type: "table",
+                    value: '[["ddl-auto", "O que faz", "Onde usar"], ["none", "não mexe no schema", "produção"], ["validate", "confere e falha se divergir", "produção"], ["update", "altera para casar com as entidades", "nunca"], ["create-drop", "recria a cada execução", "teste"]]',
+                },
+                {
+                    type: "quote",
+                    value: "Enum gravado como ordinal é uma bomba-relógio: funciona por meses e explode quando alguém acrescenta um valor no meio da lista.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual a relação entre JPA e Hibernate?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um é a especificação e o outro a implementação", isCorrect: true },
+                        { text: "São a mesma coisa, com dois nomes diferentes", isCorrect: false },
+                        {
+                            text: "O Hibernate é a versão nova que substituiu a JPA",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "A JPA é uma camada do Spring sobre o Hibernate",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Por que `@Enumerated(EnumType.STRING)` importa?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "O padrão grava a posição, que muda ao editar o enum",
+                            isCorrect: true,
+                        },
+                        { text: "O padrão não aceita enums com muitos valores", isCorrect: false },
+                        {
+                            text: "A string ocupa menos espaço na tabela do banco",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O padrão acaba impedindo a leitura do valor pelo Hibernate",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual valor de `ddl-auto` usar em produção?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "validate ou none", isCorrect: true },
+                        { text: "update, para acompanhar as entidades", isCorrect: false },
+                        { text: "create-drop, recriando a cada implantação", isCorrect: false },
+                        { text: "create, garantindo o schema correto", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que `ddl-auto: update` é perigoso?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Ele altera o schema sem revisão nem histórico", isCorrect: true },
+                        { text: "Ele apaga todos os dados a cada inicialização", isCorrect: false },
+                        { text: "Ele deixa a aplicação bem mais lenta ao subir", isCorrect: false },
+                        { text: "Ele impede o uso de migrations no projeto", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que a entidade precisa de um construtor sem argumentos?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A JPA o exige para instanciar a entidade", isCorrect: true },
+                        { text: "O Spring o usa para injetar as dependências", isCorrect: false },
+                        { text: "O Jackson o exige para converter em JSON", isCorrect: false },
+                        { text: "O banco o usa ao mapear as colunas", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Repositories e query methods",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Consultas geradas pelo nome\n\nO Spring Data cria a implementação do repositório em tempo de execução. Métodos declarados seguindo a convenção de nome viram consultas, sem que você escreva SQL.",
+                },
+                {
+                    type: "code",
+                    value: "public interface ProdutoRepository extends JpaRepository<Produto, Long> {\n\n    List<Produto> findByAtivoTrue();\n\n    List<Produto> findByCategoriaIdAndPrecoLessThan(Long categoriaId, BigDecimal teto);\n\n    Optional<Produto> findBySlug(String slug);\n\n    boolean existsBySlug(String slug);\n\n    Page<Produto> findByNomeContainingIgnoreCase(String termo, Pageable p);\n\n    long countByCategoriaId(Long categoriaId);\n}",
+                },
+                {
+                    type: "table",
+                    value: '[["Trecho do nome", "Vira"], ["findBy", "select"], ["And e Or", "condições combinadas"], ["LessThan e Between", "comparações"], ["Containing e StartingWith", "like"], ["OrderBy...Desc", "ordenação"], ["existsBy e countBy", "exists e count"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Onde a convenção deixa de compensar\n\nO nome cresce junto com a consulta, e chega um ponto em que ele fica ilegível. Nesse momento, `@Query` é mais claro.",
+                },
+                {
+                    type: "code",
+                    value: '@Query("""\n    select p from Produto p\n    join fetch p.categoria c\n    where p.ativo = true\n      and (:termo is null or lower(p.nome) like lower(concat(\'%\', :termo, \'%\')))\n    """)\nPage<Produto> buscar(@Param("termo") String termo, Pageable p);',
+                },
+                {
+                    type: "text",
+                    value: "## O retorno diz a intenção\n\n`Optional<T>` para o que pode não existir, `List<T>` para várias linhas, `Page<T>` quando há paginação e você quer o total, `Slice<T>` quando quer só saber se há mais. `Page` faz uma consulta extra de contagem; `Slice`, não.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Como o Spring Data implementa os métodos do repositório?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Gerando a implementação em tempo de execução", isCorrect: true },
+                        {
+                            text: "Exigindo que você escreva a consulta inteira em SQL",
+                            isCorrect: false,
+                        },
+                        { text: "Gerando o código-fonte durante a compilação", isCorrect: false },
+                        { text: "Copiando de uma classe base já implementada", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `findByNomeContainingIgnoreCase` gera?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um like sem diferenciar maiúsculas", isCorrect: true },
+                        { text: "Uma comparação exata do nome informado", isCorrect: false },
+                        { text: "Uma busca por texto completo no banco", isCorrect: false },
+                        { text: "Uma consulta que ignora o campo quando é nulo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quando trocar o nome longo por `@Query`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Quando o nome do método fica ilegível", isCorrect: true },
+                        { text: "Quando a consulta usa mais de uma tabela", isCorrect: false },
+                        { text: "Quando o retorno é uma página de resultados", isCorrect: false },
+                        { text: "Sempre, o nome nunca deve gerar a consulta", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a diferença entre `Page` e `Slice`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O Page faz uma consulta extra de contagem", isCorrect: true },
+                        { text: "O Slice não permite ordenar os resultados", isCorrect: false },
+                        {
+                            text: "O Page só funciona com consultas geradas por nome",
+                            isCorrect: false,
+                        },
+                        { text: "O Slice devolve todos os registros de uma vez", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual retorno usar para algo que pode não existir?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Optional", isCorrect: true },
+                        { text: "List, que fica vazia quando não encontra", isCorrect: false },
+                        { text: "O próprio tipo, devolvendo nulo se faltar", isCorrect: false },
+                        { text: "Page, com zero elementos no resultado", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Relacionamentos e o problema N+1",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Como as entidades se ligam\n\nOs quatro relacionamentos da JPA espelham os do banco. O lado que **tem a chave estrangeira** é o dono da relação.",
+                },
+                {
+                    type: "code",
+                    value: '@Entity\npublic class Pedido {\n    @ManyToOne(fetch = FetchType.LAZY)\n    private Cliente cliente;\n\n    @OneToMany(mappedBy = "pedido", cascade = CascadeType.ALL, orphanRemoval = true)\n    private List<ItemPedido> itens = new ArrayList<>();\n}',
+                },
+                {
+                    type: "text",
+                    value: "## Sempre LAZY em ManyToOne\n\nO padrão de `@ManyToOne` e `@OneToOne` é **EAGER**, o que significa que carregar um pedido traz o cliente junto, sempre, mesmo quando ninguém vai usá-lo. Em uma cadeia de entidades isso arrasta meio banco.\n\nDeclare `fetch = FetchType.LAZY` em todo `@ManyToOne`. O padrão da JPA aqui é uma escolha antiga e ruim.",
+                },
+                {
+                    type: "text",
+                    value: "# O problema N+1\n\nCom carregamento preguiçoso, percorrer uma lista acessando a relação dispara **uma consulta por item**. Cem pedidos viram 101 consultas.\n\nÉ o problema de desempenho mais comum em JPA, e o mais silencioso: em desenvolvimento com dez registros ninguém percebe.",
+                },
+                {
+                    type: "code",
+                    value: '// N+1: uma consulta por pedido\nList<Pedido> pedidos = repo.findAll();\nfor (Pedido p : pedidos) {\n    System.out.println(p.getCliente().getNome());\n}\n\n// Solução 1: join fetch na consulta\n@Query("select p from Pedido p join fetch p.cliente")\nList<Pedido> buscarComCliente();\n\n// Solução 2: entity graph, sem escrever a consulta\n@EntityGraph(attributePaths = {"cliente", "itens"})\nList<Pedido> findByStatus(StatusPedido status);',
+                },
+                {
+                    type: "quote",
+                    value: "Ligue spring.jpa.show-sql em desenvolvimento. O N+1 fica visível na hora: cem selects iguais em sequência no console.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual o padrão de carregamento de um `@ManyToOne`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "EAGER, e por isso deve ser trocado", isCorrect: true },
+                        { text: "LAZY, que é o comportamento desejado", isCorrect: false },
+                        { text: "Depende da configuração do Hibernate", isCorrect: false },
+                        { text: "Não há padrão, é preciso sempre declarar", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que caracteriza o problema N+1?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Uma consulta extra por item percorrido", isCorrect: true },
+                        { text: "Uma consulta que devolve linhas repetidas", isCorrect: false },
+                        { text: "Um relacionamento mapeado nos dois lados", isCorrect: false },
+                        { text: "Uma tabela sem índice na chave estrangeira", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que o N+1 costuma passar despercebido?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Com poucos registros o efeito não aparece", isCorrect: true },
+                        { text: "O Hibernate esconde as consultas geradas", isCorrect: false },
+                        { text: "Ele só acontece em bancos PostgreSQL", isCorrect: false },
+                        { text: "O erro aparece apenas no log de nível debug", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `@EntityGraph` permite?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Carregar relações sem escrever a consulta", isCorrect: true },
+                        { text: "Desenhar o modelo de entidades do projeto", isCorrect: false },
+                        { text: "Validar as relações mapeadas na inicialização", isCorrect: false },
+                        { text: "Gerar o schema a partir das entidades", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como tornar o N+1 visível em desenvolvimento?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Ligando a exibição do SQL gerado", isCorrect: true },
+                        { text: "Consultando o Actuator da aplicação", isCorrect: false },
+                        { text: "Medindo o tempo de cada requisição", isCorrect: false },
+                        { text: "Ativando o perfil de produção localmente", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Transações",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# @Transactional\n\nA anotação define o limite de uma transação: tudo dentro dela vale junto ou nada vale. O lugar dela é o **service**, onde a operação de negócio acontece, não o repositório.",
+                },
+                {
+                    type: "code",
+                    value: "@Service\npublic class PedidoService {\n\n    @Transactional\n    public Pedido criar(CriarPedidoRequest req) {\n        var pedido = new Pedido(req.clienteId());\n        pedido.adicionarItens(req.itens());\n        estoqueService.reservar(req.itens());   // mesma transação\n        return repo.save(pedido);\n    }\n\n    @Transactional(readOnly = true)\n    public Page<Pedido> listar(Pageable p) {\n        return repo.findAll(p);\n    }\n}",
+                },
+                {
+                    type: "text",
+                    value: "`readOnly = true` em consultas não é enfeite: o Hibernate pula a checagem de alterações no fim, o que reduz trabalho e memória em listagens grandes.\n\n## Rollback só em unchecked\n\nPor padrão, o Spring desfaz a transação em `RuntimeException` e `Error`, **não** em exceção verificada. Uma `IOException` lançada no meio deixa a transação confirmar, o que quase nunca é o desejado.",
+                },
+                {
+                    type: "code",
+                    value: "// Não desfaz: IOException é verificada\n@Transactional\npublic void processar() throws IOException { }\n\n// Desfaz\n@Transactional(rollbackFor = Exception.class)\npublic void processar() throws IOException { }",
+                },
+                {
+                    type: "text",
+                    value: "## A autoinvocação que não funciona\n\nO `@Transactional` funciona por proxy: o Spring envolve o bean. Chamar um método anotado **de dentro da mesma classe** não passa pelo proxy, e a transação simplesmente não começa.\n\nEste é o bug mais comum de transação em Spring, e não dá nenhum aviso.",
+                },
+                {
+                    type: "code",
+                    value: "@Service\npublic class Servico {\n    public void externo() {\n        interno();   // NÃO abre transação: não passa pelo proxy\n    }\n\n    @Transactional\n    public void interno() { }\n}",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Onde o `@Transactional` deve ficar?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "No service, na operação de negócio", isCorrect: true },
+                        { text: "No repository, junto do acesso ao banco", isCorrect: false },
+                        { text: "No controller, no início da requisição", isCorrect: false },
+                        { text: "Na entidade que será alterada", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `readOnly = true` traz de ganho?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O Hibernate pula a checagem de alterações", isCorrect: true },
+                        { text: "A consulta é executada em outra conexão", isCorrect: false },
+                        {
+                            text: "O resultado é guardado em cache automaticamente",
+                            isCorrect: false,
+                        },
+                        { text: "A transação é aberta com menos privilégios", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Em quais exceções o Spring desfaz a transação por padrão?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Nas não verificadas e nos erros", isCorrect: true },
+                        { text: "Em todas as exceções lançadas no método", isCorrect: false },
+                        { text: "Apenas nas exceções verificadas do Java", isCorrect: false },
+                        { text: "Somente quando o rollback é chamado na mão", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Por que chamar um método transacional da mesma classe não funciona?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "A chamada não passa pelo proxy do Spring", isCorrect: true },
+                        { text: "O método precisa ser público para funcionar", isCorrect: false },
+                        { text: "A transação anterior ainda está aberta", isCorrect: false },
+                        { text: "O Spring proíbe transações aninhadas", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que acontece quando a autoinvocação ocorre?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "A transação não começa, e sem nenhum aviso", isCorrect: true },
+                        { text: "O Spring lança uma exceção de configuração", isCorrect: false },
+                        { text: "A transação é aberta pelo método chamador", isCorrect: false },
+                        { text: "O método é executado duas vezes seguidas", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Migrations com Flyway",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O schema versionado\n\nCom `ddl-auto: validate`, alguém precisa criar as tabelas. Esse alguém é uma ferramenta de **migration**: o Flyway ou o Liquibase.\n\nCada mudança vira um arquivo SQL numerado, que roda uma vez e fica registrado. O banco passa a ter histórico, e todo ambiente chega ao mesmo estado.",
+                },
+                {
+                    type: "code",
+                    value: "src/main/resources/db/migration/\n  V1__cria_tabela_produtos.sql\n  V2__cria_tabela_categorias.sql\n  V3__adiciona_slug_em_produtos.sql\n  V4__indice_em_produtos_categoria_id.sql",
+                },
+                {
+                    type: "code",
+                    value: "-- V3__adiciona_slug_em_produtos.sql\nalter table produtos add column slug varchar(255);\nupdate produtos set slug = lower(replace(nome, ' ', '-'));\nalter table produtos alter column slug set not null;\ncreate unique index idx_produtos_slug on produtos (slug);",
+                },
+                {
+                    type: "text",
+                    value: "Repare na ordem: acrescentar a coluna aceitando nulo, preencher os registros existentes e só então exigir o valor. Criar direto como `not null` falha em qualquer tabela com dados.\n\n## Nunca edite uma migration aplicada\n\nO Flyway guarda um **checksum** de cada arquivo. Alterar um já aplicado faz a validação falhar na próxima inicialização, e a aplicação não sobe.\n\nIsso parece rigor excessivo até você lembrar que os outros ambientes já rodaram a versão antiga: a alteração nunca chegaria lá.",
+                },
+                {
+                    type: "table",
+                    value: '[["Situação", "O que fazer"], ["a migration ainda não foi aplicada", "pode editar"], ["já rodou só na sua máquina", "limpar o banco e recriar"], ["já rodou em outro ambiente", "criar uma migration nova"]]',
+                },
+            ],
+            questions: [
+                {
+                    statement: "Por que uma ferramenta de migration é necessária com `validate`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Alguém precisa criar e alterar o schema", isCorrect: true },
+                        { text: "O Hibernate não consegue validar sem ela", isCorrect: false },
+                        { text: "As entidades exigem um arquivo de mapeamento", isCorrect: false },
+                        { text: "O Spring Boot não sobe sem migrations", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que acontece ao editar uma migration já aplicada?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O checksum muda e a validação falha", isCorrect: true },
+                        { text: "A migration roda de novo com o conteúdo novo", isCorrect: false },
+                        { text: "O Flyway ignora a alteração em silêncio", isCorrect: false },
+                        { text: "O banco é recriado do zero na inicialização", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como acrescentar uma coluna obrigatória em tabela com dados?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Criar aceitando nulo, preencher e depois exigir",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Criar direto como não nula, com um valor padrão",
+                            isCorrect: false,
+                        },
+                        { text: "Apagar os dados antes de criar a coluna", isCorrect: false },
+                        { text: "Criar a coluna em uma tabela nova e copiar", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que fazer quando a migration já rodou em outro ambiente?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Criar uma migration nova", isCorrect: true },
+                        { text: "Editar a existente e avisar a equipe", isCorrect: false },
+                        { text: "Apagar o registro dela na tabela de histórico", isCorrect: false },
+                        { text: "Rodar o comando de reparo do Flyway", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o número no nome do arquivo define?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "A ordem em que as migrations rodam", isCorrect: true },
+                        { text: "A versão da aplicação naquele momento", isCorrect: false },
+                        { text: "A quantidade de comandos dentro do arquivo", isCorrect: false },
+                        { text: "O ambiente em que ela deve ser aplicada", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_4: Modulo = {
+    titulo: "Módulo 4 - Segurança",
+    aulas: [
+        {
+            titulo: "Spring Security e a cadeia de filtros",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Como o Security funciona\n\nO Spring Security se instala como uma **cadeia de filtros** antes de qualquer controller. Cada filtro tem uma responsabilidade: extrair credenciais, autenticar, verificar autorização, tratar erro.\n\nEntender que é uma cadeia explica por que um erro de segurança nunca chega ao seu código: ele acontece antes.",
+                },
+                {
+                    type: "code",
+                    value: '@Configuration\n@EnableWebSecurity\npublic class SecurityConfig {\n\n    @Bean\n    SecurityFilterChain filterChain(HttpSecurity http) throws Exception {\n        return http\n            .csrf(csrf -> csrf.disable())            // API stateless\n            .sessionManagement(s -> s.sessionCreationPolicy(STATELESS))\n            .authorizeHttpRequests(auth -> auth\n                .requestMatchers("/api/publico/**").permitAll()\n                .requestMatchers(HttpMethod.GET, "/api/produtos/**").permitAll()\n                .requestMatchers("/api/admin/**").hasRole("ADMIN")\n                .anyRequest().authenticated()\n            )\n            .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)\n            .build();\n    }\n}',
+                },
+                {
+                    type: "text",
+                    value: "## A ordem das regras importa\n\nAs regras são avaliadas **de cima para baixo**, e a primeira que casa vence. Pôr `anyRequest().authenticated()` antes das específicas faz com que nenhuma delas seja alcançada.\n\n## Desabilitar CSRF exige entender o porquê\n\nCSRF protege contra outro site fazer a requisição usando o **cookie** da vítima. Em API que autentica por token no cabeçalho o ataque não se aplica, porque o navegador não envia o cabeçalho sozinho.\n\nEm aplicação que usa sessão e cookie, desabilitar CSRF é abrir uma porta de verdade.",
+                },
+                {
+                    type: "table",
+                    value: '[["Método", "Verifica"], ["permitAll", "libera para qualquer um"], ["authenticated", "exige estar autenticado"], ["hasRole", "exige um papel específico"], ["hasAuthority", "exige uma permissão"], ["denyAll", "bloqueia sempre"]]',
+                },
+            ],
+            questions: [
+                {
+                    statement: "Como o Spring Security se instala na aplicação?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Como uma cadeia de filtros antes dos controllers",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Como uma anotação em cada um dos métodos protegidos",
+                            isCorrect: false,
+                        },
+                        { text: "Como um interceptador depois do controller", isCorrect: false },
+                        { text: "Como um proxy em volta de cada service", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Em que ordem as regras de autorização são avaliadas?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "De cima para baixo, a primeira que casa vence", isCorrect: true },
+                        { text: "Da mais específica para a mais genérica", isCorrect: false },
+                        { text: "Em ordem alfabética dos caminhos declarados", isCorrect: false },
+                        { text: "Todas são avaliadas e a mais restritiva vence", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Contra o que o CSRF protege?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Outro site usar o cookie da vítima na requisição",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Scripts maliciosos injetados na própria página",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Interceptação do tráfego entre cliente e servidor",
+                            isCorrect: false,
+                        },
+                        { text: "Tentativas repetidas de adivinhar a senha", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quando desabilitar CSRF é aceitável?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Em API que autentica por token no cabeçalho", isCorrect: true },
+                        { text: "Em qualquer API que devolva JSON ao cliente", isCorrect: false },
+                        { text: "Quando a aplicação usa HTTPS em produção", isCorrect: false },
+                        { text: "Sempre, o CSRF é uma proteção obsoleta", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que acontece ao pôr `anyRequest().authenticated()` primeiro?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "As regras seguintes nunca são alcançadas", isCorrect: true },
+                        { text: "Todas as regras passam a exigir autenticação", isCorrect: false },
+                        { text: "O Spring reordena as regras automaticamente", isCorrect: false },
+                        { text: "A configuração falha ao iniciar a aplicação", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Autenticação e senhas",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Quem é o usuário\n\nO Security precisa de duas peças: um `UserDetailsService` que sabe carregar o usuário e um `PasswordEncoder` que sabe verificar a senha.",
+                },
+                {
+                    type: "code",
+                    value: '@Service\npublic class UsuarioDetailsService implements UserDetailsService {\n\n    private final UsuarioRepository repo;\n\n    @Override\n    public UserDetails loadUserByUsername(String email) {\n        return repo.findByEmail(email)\n            .orElseThrow(() -> new UsernameNotFoundException("não encontrado"));\n    }\n}\n\n@Bean\nPasswordEncoder passwordEncoder() {\n    return new BCryptPasswordEncoder();\n}',
+                },
+                {
+                    type: "text",
+                    value: "## Senha nunca é guardada\n\nO que vai para o banco é o **hash**, gerado por um algoritmo lento de propósito. Bcrypt e Argon2 são os recomendados; MD5 e SHA são rápidos demais e por isso inadequados para senha.\n\nO `BCryptPasswordEncoder` já inclui o **salt** no resultado, então duas pessoas com a mesma senha têm hashes diferentes.",
+                },
+                {
+                    type: "code",
+                    value: "// Ao cadastrar\nusuario.setSenha(encoder.encode(senhaDigitada));\n\n// Ao autenticar: nunca compare hashes diretamente\nif (encoder.matches(senhaDigitada, usuario.getSenha())) { }",
+                },
+                {
+                    type: "quote",
+                    value: "Diga apenas email ou senha incorretos. Dizer qual dos dois falhou entrega ao atacante a lista de emails cadastrados.",
+                },
+                {
+                    type: "text",
+                    value: "## Delegação\n\nO `DelegatingPasswordEncoder`, que é o padrão do Spring Security, grava o algoritmo junto do hash, no formato `{bcrypt}$2a$...`. Isso permite migrar de algoritmo sem invalidar as senhas antigas: as novas usam o algoritmo novo e as antigas continuam sendo verificadas pelo anterior.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o `UserDetailsService` faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Carrega o usuário para o Security", isCorrect: true },
+                        { text: "Verifica se a senha informada está correta", isCorrect: false },
+                        { text: "Gera o token usado nas próximas requisições", isCorrect: false },
+                        { text: "Define quais permissões cada papel tem", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que MD5 e SHA são inadequados para senha?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Eles são rápidos demais, o que facilita a força bruta",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Eles não aceitam senhas que tenham caracteres especiais",
+                            isCorrect: false,
+                        },
+                        { text: "Eles produzem hashes de tamanho variável", isCorrect: false },
+                        { text: "Eles foram removidos das bibliotecas do Java", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o BCrypt inclui no resultado além do hash?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O salt", isCorrect: true },
+                        { text: "A data em que a senha foi criada", isCorrect: false },
+                        { text: "O identificador do usuário dono da senha", isCorrect: false },
+                        { text: "A quantidade de tentativas já realizadas", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como verificar se a senha digitada está correta?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Com o método matches do encoder", isCorrect: true },
+                        { text: "Comparando o hash gerado com o do banco", isCorrect: false },
+                        { text: "Descriptografando o hash guardado no banco", isCorrect: false },
+                        { text: "Consultando o banco pela senha informada", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Para que serve gravar o algoritmo junto do hash?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Permitir migrar de algoritmo sem invalidar as senhas",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Acelerar a verificação da senha durante a autenticação",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Impedir que o hash seja usado em outro sistema",
+                            isCorrect: false,
+                        },
+                        { text: "Identificar qual versão da aplicação o gerou", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "JWT e autenticação stateless",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Sessão contra token\n\nEm autenticação com **sessão**, o servidor guarda o estado e o cliente carrega apenas um identificador. Em autenticação com **token**, o próprio token carrega a informação e o servidor não guarda nada.\n\nA segunda escala melhor horizontalmente, porque qualquer instância valida o token sem consultar um repositório compartilhado.",
+                },
+                {
+                    type: "code",
+                    value: 'public String gerar(Usuario u) {\n    return JWT.create()\n        .withIssuer("loja")\n        .withSubject(u.getEmail())\n        .withClaim("papel", u.getPapel().name())\n        .withExpiresAt(Instant.now().plus(2, ChronoUnit.HOURS))\n        .sign(Algorithm.HMAC256(segredo));\n}',
+                },
+                {
+                    type: "text",
+                    value: "## O que um JWT é, e o que não é\n\nUm JWT é **assinado**, não criptografado. Qualquer pessoa lê o conteúdo dele: basta decodificar a base64. A assinatura garante que ninguém **alterou** o conteúdo, não que ninguém o leu.\n\nA consequência é direta: **nunca coloque dado sensível em um JWT**. Nada de CPF, telefone ou qualquer coisa que não possa ser pública.",
+                },
+                {
+                    type: "table",
+                    value: '[["", "Sessão", "JWT"], ["Estado no servidor", "sim", "não"], ["Escala horizontal", "exige repositório compartilhado", "direto"], ["Revogar acesso", "imediato", "difícil"], ["Tamanho no tráfego", "pequeno", "maior"]]',
+                },
+                {
+                    type: "text",
+                    value: "## O problema da revogação\n\nComo o servidor não guarda estado, **não há como invalidar um token** antes de ele expirar. Alguém que teve o acesso removido continua entrando até o token vencer.\n\nAs saídas usuais: expiração curta com um refresh token de vida longa, ou uma lista de tokens revogados, que reintroduz o estado que se queria evitar. Não existe solução limpa, e essa é a troca real do modelo stateless.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Um JWT é criptografado?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Não, ele é apenas assinado", isCorrect: true },
+                        { text: "Sim, o conteúdo dele é ilegível sem a chave", isCorrect: false },
+                        { text: "Sim, quando o algoritmo escolhido é o HMAC", isCorrect: false },
+                        { text: "Depende de a aplicação usar HTTPS ou não", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que a assinatura de um JWT garante?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Que o conteúdo não foi alterado", isCorrect: true },
+                        { text: "Que apenas o servidor consegue lê-lo", isCorrect: false },
+                        { text: "Que ele não pode ser usado duas vezes", isCorrect: false },
+                        { text: "Que ele expira no prazo configurado", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que nunca deve ir dentro de um JWT?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Dado sensível, que não possa ser público", isCorrect: true },
+                        {
+                            text: "O identificador do usuário que foi autenticado",
+                            isCorrect: false,
+                        },
+                        { text: "A data de expiração do próprio token", isCorrect: false },
+                        { text: "O papel que o usuário tem no sistema", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a principal desvantagem do modelo stateless?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Não há como revogar o token antes de expirar", isCorrect: true },
+                        {
+                            text: "O servidor precisa validar em um banco central",
+                            isCorrect: false,
+                        },
+                        { text: "O token só funciona em uma instância por vez", isCorrect: false },
+                        {
+                            text: "A autenticação fica bem mais lenta por requisição",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual a saída usual para o problema da revogação?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Expiração curta com um refresh token", isCorrect: true },
+                        { text: "Guardar a sessão do usuário no servidor", isCorrect: false },
+                        { text: "Trocar a chave de assinatura periodicamente", isCorrect: false },
+                        { text: "Exigir nova autenticação a cada requisição", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Autorização",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Quem pode fazer o quê\n\nA autorização por caminho, na cadeia de filtros, resolve o grosso. Para regras que dependem do dado, a anotação em cima do método é mais precisa.",
+                },
+                {
+                    type: "code",
+                    value: '@EnableMethodSecurity\n@Configuration\npublic class MethodSecurityConfig { }\n\n@Service\npublic class PedidoService {\n\n    @PreAuthorize("hasRole(\'ADMIN\')")\n    public void cancelar(Long id) { }\n\n    @PreAuthorize("hasRole(\'ADMIN\') or #email == authentication.name")\n    public Usuario buscarPorEmail(String email) { }\n\n    @PostAuthorize("returnObject.clienteId == authentication.principal.id")\n    public Pedido buscar(Long id) { }\n}',
+                },
+                {
+                    type: "text",
+                    value: 'O `@PreAuthorize` roda **antes** do método e evita o trabalho. O `@PostAuthorize` roda depois, quando a decisão depende do que foi devolvido, e por isso o método executa mesmo quando o acesso será negado.\n\n## Role e authority\n\nUm **role** é uma authority com o prefixo `ROLE_`. `hasRole("ADMIN")` procura por `ROLE_ADMIN`, enquanto `hasAuthority("ADMIN")` procura por `ADMIN` exato. Misturar os dois é a causa mais comum de um 403 inexplicável.',
+                },
+                {
+                    type: "text",
+                    value: "## A forma mais segura de todas\n\nMelhor que verificar a permissão é **escopar a consulta** pelo usuário. Assim o registro de outra pessoa nem aparece, e não há verificação para esquecer.",
+                },
+                {
+                    type: "code",
+                    value: "// Frágil: depende de lembrar da verificação\nPedido p = repo.findById(id).orElseThrow();\nif (!p.getClienteId().equals(usuarioAtual.getId())) throw new AcessoNegado();\n\n// Sólido: o pedido de outra pessoa não existe nesta consulta\nPedido p = repo.findByIdAndClienteId(id, usuarioAtual.getId()).orElseThrow();",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual a diferença entre `@PreAuthorize` e `@PostAuthorize`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um roda antes e o outro depois do método", isCorrect: true },
+                        {
+                            text: "Um vale para controllers e o outro para services",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Um verifica papel e o outro verifica permissão",
+                            isCorrect: false,
+                        },
+                        { text: "Um lança exceção e o outro devolve nulo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a desvantagem do `@PostAuthorize`?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "O método executa mesmo quando o acesso será negado",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Ele não consegue acessar o usuário que foi autenticado",
+                            isCorrect: false,
+                        },
+                        { text: "Ele só funciona em métodos que devolvem lista", isCorrect: false },
+                        { text: "Ele exige que a exceção seja tratada na mão", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `hasRole('ADMIN')` procura de fato?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "A authority ROLE_ADMIN", isCorrect: true },
+                        { text: "A authority ADMIN, exatamente como escrita", isCorrect: false },
+                        {
+                            text: "Qualquer authority que contenha a palavra ADMIN",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Um papel declarado na configuração do Security",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual a forma mais segura de proteger o acesso a um registro?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Escopar a consulta pelo usuário atual", isCorrect: true },
+                        { text: "Verificar o dono depois de buscar o registro", isCorrect: false },
+                        { text: "Anotar o método com PreAuthorize e o papel", isCorrect: false },
+                        { text: "Filtrar a lista devolvida antes de responder", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `@EnableMethodSecurity` habilita?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "As anotações de autorização nos métodos", isCorrect: true },
+                        { text: "A cadeia de filtros de segurança do Spring", isCorrect: false },
+                        { text: "A criptografia das senhas gravadas no banco", isCorrect: false },
+                        { text: "A autenticação por token nas requisições", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "CORS, segredos e cuidados de produção",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# CORS\n\nO navegador bloqueia requisições de um site para uma origem diferente, a menos que o servidor autorize. Esse é o **CORS**, e ele é uma proteção **do navegador**, não do servidor: um cliente que não seja navegador ignora tudo isso.",
+                },
+                {
+                    type: "code",
+                    value: '@Bean\nCorsConfigurationSource corsConfigurationSource() {\n    var config = new CorsConfiguration();\n    config.setAllowedOrigins(List.of("https://loja.com.br"));\n    config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE"));\n    config.setAllowedHeaders(List.of("Authorization", "Content-Type"));\n    config.setAllowCredentials(true);\n\n    var source = new UrlBasedCorsConfigurationSource();\n    source.registerCorsConfiguration("/api/**", config);\n    return source;\n}',
+                },
+                {
+                    type: "text",
+                    value: "Liberar `*` em produção anula a proteção, e a combinação de `*` com `allowCredentials` nem é aceita pela especificação.\n\n## Segredos\n\nSenha de banco e chave de assinatura **nunca** vão para o repositório. Elas entram por variável de ambiente ou por um gerenciador de segredos, e o `application.yml` referencia a variável.",
+                },
+                {
+                    type: "code",
+                    value: "spring:\n  datasource:\n    password: ${DB_PASSWORD}\napp:\n  jwt:\n    segredo: ${JWT_SECRET}",
+                },
+                {
+                    type: "text",
+                    value: "## A lista do que conferir antes de subir\n\n- Segredos fora do repositório, vindos do ambiente\n- HTTPS obrigatório, sem exceção\n- CORS restrito às origens que existem\n- Senhas com bcrypt ou argon2\n- Limite de tentativas de login\n- Log sem senha, token ou dado pessoal\n- Dependências verificadas contra vulnerabilidades conhecidas",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O CORS é uma proteção de quem?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Do navegador", isCorrect: true },
+                        { text: "Do servidor, que recusa as requisições", isCorrect: false },
+                        { text: "Do protocolo HTTP em si, na especificação", isCorrect: false },
+                        { text: "Do Spring Security, na cadeia de filtros", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que acontece com um cliente que não é navegador?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Ele ignora o CORS por completo", isCorrect: true },
+                        { text: "Ele é bloqueado pelo servidor da aplicação", isCorrect: false },
+                        { text: "Ele precisa enviar a origem no cabeçalho", isCorrect: false },
+                        { text: "Ele recebe um erro de origem não permitida", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual o problema de liberar `*` nas origens?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A proteção deixa de existir", isCorrect: true },
+                        { text: "O navegador passa a exigir HTTPS na chamada", isCorrect: false },
+                        { text: "As requisições ficam bem mais lentas", isCorrect: false },
+                        { text: "O Spring recusa a configuração ao iniciar", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Onde a senha do banco deve ficar?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Em variável de ambiente ou gerenciador de segredos",
+                            isCorrect: true,
+                        },
+                        { text: "No application.yml, junto do resto", isCorrect: false },
+                        {
+                            text: "Em um arquivo separado, guardado fora do repositório",
+                            isCorrect: false,
+                        },
+                        { text: "Criptografada dentro do próprio código", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que nunca deve aparecer no log?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Senha, token ou dado pessoal", isCorrect: true },
+                        { text: "O identificador da requisição atendida", isCorrect: false },
+                        { text: "O tempo que a requisição levou para responder", isCorrect: false },
+                        { text: "O caminho que foi chamado pelo cliente", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_5: Modulo = {
+    titulo: "Módulo 5 - Testes",
+    aulas: [
+        {
+            titulo: "JUnit e Mockito",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O teste mais barato\n\nO teste de unidade não sobe o Spring: ele instancia a classe direto e entrega dublês no lugar das dependências. Roda em milissegundos, e é onde a regra de negócio deve ser coberta.\n\nÉ aqui que a injeção **por construtor** se paga: sem ela, não há como instanciar a classe fora do framework.",
+                },
+                {
+                    type: "code",
+                    value: "@ExtendWith(MockitoExtension.class)\nclass PedidoServiceTest {\n\n    @Mock PedidoRepository repo;\n    @Mock EstoqueService estoque;\n    @InjectMocks PedidoService service;\n\n    @Test\n    void naoCriaPedidoSemEstoque() {\n        when(estoque.disponivel(1L, 5)).thenReturn(false);\n\n        assertThatThrownBy(() -> service.criar(new CriarPedido(1L, 5)))\n            .isInstanceOf(EstoqueInsuficiente.class);\n\n        verify(repo, never()).save(any());\n    }\n}",
+                },
+                {
+                    type: "table",
+                    value: '[["Anotação", "O que faz"], ["@Mock", "cria um dublê da dependência"], ["@InjectMocks", "injeta os dublês na classe testada"], ["when e thenReturn", "define o que o dublê responde"], ["verify", "confere se o método foi chamado"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Verificar demais engessa o teste\n\n`verify` em toda interação transforma o teste em uma cópia da implementação: qualquer refatoração o quebra, mesmo sem nada ter parado de funcionar.\n\nA regra que funciona: verifique **efeito colateral que importa**, como o `never()` acima garantindo que nada foi gravado. Para o resto, afirme o **resultado**.",
+                },
+                {
+                    type: "quote",
+                    value: "Teste que quebra a cada refatoração sem que nada tenha parado de funcionar não protege nada, e a equipe aprende a apagá-lo.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que um teste de unidade não faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Não sobe o contexto do Spring", isCorrect: true },
+                        { text: "Não instancia a classe que está sendo testada", isCorrect: false },
+                        { text: "Não verifica se os métodos foram chamados", isCorrect: false },
+                        { text: "Não usa dublês no lugar das dependências", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `@InjectMocks` faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Injeta os dublês na classe testada", isCorrect: true },
+                        { text: "Cria um dublê da classe que será testada", isCorrect: false },
+                        { text: "Registra a classe no contexto do Spring", isCorrect: false },
+                        { text: "Substitui a classe real por uma implementação", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que a injeção por construtor ajuda no teste?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Permite instanciar a classe fora do framework", isCorrect: true },
+                        { text: "Faz o Mockito criar os dublês sozinho", isCorrect: false },
+                        { text: "Torna as dependências opcionais no teste", isCorrect: false },
+                        {
+                            text: "Permite trocar a implementação durante a execução",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual o problema de usar `verify` em toda interação?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "O teste vira cópia da implementação e quebra em refatoração",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Os testes acabam passando a rodar muito mais devagar do que antes",
+                            isCorrect: false,
+                        },
+                        { text: "O Mockito recusa mais de uma verificação", isCorrect: false },
+                        { text: "As dependências deixam de ser injetadas", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que vale verificar com `verify`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Efeito colateral que importa, como não gravar", isCorrect: true },
+                        { text: "Toda e qualquer chamada feita às dependências", isCorrect: false },
+                        { text: "O valor devolvido pelo método testado", isCorrect: false },
+                        { text: "A ordem em que os métodos foram chamados", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Fatias de teste e o contexto completo",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Nem todo teste precisa de tudo\n\nSubir o contexto inteiro para testar um controller é caro: banco, segurança, filas, tudo. As **fatias de teste** sobem apenas a parte relevante.",
+                },
+                {
+                    type: "table",
+                    value: '[["Anotação", "O que sobe"], ["@WebMvcTest", "só a camada web"], ["@DataJpaTest", "só JPA e o banco"], ["@JsonTest", "só a serialização"], ["@RestClientTest", "só os clientes HTTP"], ["@SpringBootTest", "a aplicação inteira"]]',
+                },
+                {
+                    type: "code",
+                    value: '@WebMvcTest(ProdutoController.class)\nclass ProdutoControllerTest {\n\n    @Autowired MockMvc mvc;\n    @MockitoBean ProdutoService service;   // o service é dublê\n\n    @Test\n    void devolve404QuandoNaoExiste() throws Exception {\n        when(service.buscar(99L)).thenThrow(new RecursoNaoEncontrado("produto"));\n\n        mvc.perform(get("/api/produtos/99"))\n           .andExpect(status().isNotFound())\n           .andExpect(jsonPath("$.title").value("Recurso não encontrado"));\n    }\n}',
+                },
+                {
+                    type: "text",
+                    value: "O `@MockitoBean` substitui o bean real no contexto por um dublê. Ele veio no lugar do antigo `@MockBean`, que foi descontinuado.\n\n## O cache de contexto\n\nO Spring **reaproveita** o contexto entre classes de teste com a mesma configuração. Isso é o que mantém uma suíte grande viável.\n\nO efeito colateral: cada combinação diferente de configuração cria um contexto novo, e uma suíte com muitas variações passa mais tempo subindo contexto do que testando. Padronizar a configuração dos testes é uma otimização real.",
+                },
+                {
+                    type: "code",
+                    value: '@SpringBootTest\n@AutoConfigureMockMvc\n@ActiveProfiles("test")\nclass FluxoCompletoTest {\n    // sobe tudo: use para o caminho principal, não para cada caso\n}',
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que `@WebMvcTest` sobe?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Apenas a camada web", isCorrect: true },
+                        { text: "A aplicação inteira, com banco e segurança", isCorrect: false },
+                        { text: "A camada web e a de acesso a dados", isCorrect: false },
+                        { text: "Somente as classes anotadas no projeto", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `@MockitoBean` faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Substitui o bean real no contexto por um dublê", isCorrect: true },
+                        { text: "Cria um dublê fora do contexto do Spring", isCorrect: false },
+                        { text: "Registra um bean novo apenas para o teste", isCorrect: false },
+                        {
+                            text: "Verifica se o bean real foi injetado corretamente",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Por que o Spring reaproveita o contexto entre testes?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Subir o contexto é caro e lento", isCorrect: true },
+                        {
+                            text: "Para que os testes compartilhem o mesmo estado",
+                            isCorrect: false,
+                        },
+                        { text: "Porque cada contexto ocupa muita memória", isCorrect: false },
+                        {
+                            text: "Para garantir que a ordem dos testes não importe",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que faz o Spring criar um contexto novo?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Uma combinação diferente de configuração", isCorrect: true },
+                        { text: "Cada classe de teste, sempre, sem exceção", isCorrect: false },
+                        { text: "A presença de qualquer dublê no teste", isCorrect: false },
+                        { text: "O uso de um perfil ativo na classe", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quando usar `@SpringBootTest`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "No caminho principal, não em cada caso", isCorrect: true },
+                        { text: "Em todos os testes, para garantir realismo", isCorrect: false },
+                        { text: "Apenas quando o teste envolve o banco", isCorrect: false },
+                        { text: "Somente nos testes de unidade de service", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Testcontainers",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Testar contra o banco de verdade\n\nBanco em memória como o H2 é rápido e mente: ele não tem os tipos, as funções nem o comportamento do PostgreSQL. Um teste que passa nele pode falhar em produção por diferença de dialeto.\n\nO **Testcontainers** sobe um container real do banco durante o teste, e o descarta no fim.",
+                },
+                {
+                    type: "code",
+                    value: '@SpringBootTest\n@Testcontainers\nclass ProdutoRepositoryIT {\n\n    @Container\n    @ServiceConnection\n    static PostgreSQLContainer<?> postgres =\n        new PostgreSQLContainer<>("postgres:17-alpine");\n\n    @Autowired ProdutoRepository repo;\n\n    @Test\n    void buscaPorSlug() {\n        repo.save(new Produto("Caneca", "caneca", new BigDecimal("29.90")));\n        assertThat(repo.findBySlug("caneca")).isPresent();\n    }\n}',
+                },
+                {
+                    type: "text",
+                    value: "O `@ServiceConnection` é o que torna isso prático: ele configura a URL, o usuário e a senha da aplicação apontando para o container, sem nenhuma propriedade escrita à mão.\n\n## Além do banco\n\nO mesmo vale para Redis, Kafka, RabbitMQ e qualquer coisa que rode em container. O teste passa a exercitar a integração de verdade, e não uma imitação.",
+                },
+                {
+                    type: "table",
+                    value: '[["", "Banco em memória", "Testcontainers"], ["Fidelidade", "baixa", "é o banco real"], ["Velocidade", "muito rápido", "segundos para subir"], ["Precisa de Docker", "não", "sim"], ["Pega erro de dialeto", "não", "sim"]]',
+                },
+                {
+                    type: "text",
+                    value: "## O custo\n\nSubir container leva segundos, então não é para cada teste. O uso comum é: unidade para regra de negócio, fatia para a camada web, e Testcontainers para o que realmente toca o banco, marcados como teste de integração e rodados junto na CI.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual o problema de testar com banco em memória?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Ele não reproduz o comportamento do banco real", isCorrect: true },
+                        { text: "Ele é lento para subir a cada execução", isCorrect: false },
+                        {
+                            text: "Ele não aceita as migrations escritas para o projeto",
+                            isCorrect: false,
+                        },
+                        { text: "Ele exige Docker instalado na máquina", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o Testcontainers faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Sobe um container real durante o teste", isCorrect: true },
+                        { text: "Simula o banco de dados em memória", isCorrect: false },
+                        { text: "Conecta no banco usado em desenvolvimento", isCorrect: false },
+                        { text: "Gera dados de teste para as tabelas", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `@ServiceConnection` resolve?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Aponta a aplicação para o container sem configuração",
+                            isCorrect: true,
+                        },
+                        { text: "Garante que o container suba antes do teste", isCorrect: false },
+                        {
+                            text: "Reaproveita o mesmo container entre todas as classes",
+                            isCorrect: false,
+                        },
+                        { text: "Verifica se o serviço respondeu corretamente", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual o custo do Testcontainers?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Subir o container leva segundos", isCorrect: true },
+                        { text: "Ele não funciona em ambiente de integração", isCorrect: false },
+                        { text: "Ele exige uma licença para uso comercial", isCorrect: false },
+                        { text: "Ele só funciona com bancos relacionais", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Onde o Testcontainers se encaixa na pirâmide de testes?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "No que realmente toca o banco", isCorrect: true },
+                        { text: "Em todos os testes, por ser mais realista", isCorrect: false },
+                        { text: "Apenas nos testes da camada web", isCorrect: false },
+                        { text: "Nos testes de unidade dos services", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Testes de API",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Exercitando o endpoint\n\nO `MockMvc` chama o controller passando por toda a pilha web, incluindo conversão de JSON, validação e tratamento de erro, sem abrir uma porta de rede.",
+                },
+                {
+                    type: "code",
+                    value: '@Test\nvoid criaProdutoValido() throws Exception {\n    mvc.perform(post("/api/produtos")\n            .contentType(APPLICATION_JSON)\n            .content("""\n                { "nome": "Caneca", "preco": 29.90, "categoriaId": 1 }\n                """))\n       .andExpect(status().isCreated())\n       .andExpect(jsonPath("$.nome").value("Caneca"));\n}\n\n@Test\nvoid recusaPrecoNegativo() throws Exception {\n    mvc.perform(post("/api/produtos")\n            .contentType(APPLICATION_JSON)\n            .content("""\n                { "nome": "Caneca", "preco": -1, "categoriaId": 1 }\n                """))\n       .andExpect(status().isBadRequest())\n       .andExpect(jsonPath("$.campos.preco").exists());\n}',
+                },
+                {
+                    type: "text",
+                    value: "## Testando com segurança ligada\n\nCom Spring Security no classpath, todo endpoint passa a exigir autenticação, e testes que passavam começam a devolver 401. As anotações do módulo de teste resolvem isso sem desligar a segurança, o que seria testar outra aplicação.",
+                },
+                {
+                    type: "code",
+                    value: '@Test\n@WithMockUser(roles = "ADMIN")\nvoid adminPodeExcluir() throws Exception {\n    mvc.perform(delete("/api/produtos/1"))\n       .andExpect(status().isNoContent());\n}\n\n@Test\n@WithMockUser(roles = "CLIENTE")\nvoid clienteNaoPodeExcluir() throws Exception {\n    mvc.perform(delete("/api/produtos/1"))\n       .andExpect(status().isForbidden());\n}',
+                },
+                {
+                    type: "text",
+                    value: "O segundo teste é o mais importante dos dois: testar que **quem não pode não consegue** é o que realmente protege. É comum uma suíte cobrir só o caminho autorizado e deixar o buraco passar.",
+                },
+                {
+                    type: "quote",
+                    value: "Para cada permissão, escreva dois testes: um que confirma o acesso de quem pode, e um que confirma a negação de quem não pode.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o `MockMvc` exercita?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Toda a pilha web, sem abrir porta de rede", isCorrect: true },
+                        { text: "Apenas o método do controller, isoladamente", isCorrect: false },
+                        { text: "A aplicação inteira, com banco e filas", isCorrect: false },
+                        { text: "A serialização do JSON de resposta apenas", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que acontece com os testes quando o Security entra no projeto?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Os endpoints passam a exigir autenticação", isCorrect: true },
+                        { text: "Os testes deixam de compilar sem alteração", isCorrect: false },
+                        { text: "As fatias de teste deixam de funcionar", isCorrect: false },
+                        { text: "As requisições passam a exigir HTTPS", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `@WithMockUser` faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Executa o teste como um usuário autenticado", isCorrect: true },
+                        {
+                            text: "Desliga a segurança durante a execução daquele teste",
+                            isCorrect: false,
+                        },
+                        { text: "Cria um usuário real no banco de teste", isCorrect: false },
+                        { text: "Gera um token válido para a requisição", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual teste de permissão é mais importante?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O que confirma que quem não pode é bloqueado", isCorrect: true },
+                        { text: "O que confirma que quem pode consegue acessar", isCorrect: false },
+                        { text: "O que verifica o código HTTP da resposta", isCorrect: false },
+                        {
+                            text: "O que testa o caminho sem autenticação nenhuma",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Por que não desligar a segurança nos testes?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Seria testar uma aplicação diferente da real", isCorrect: true },
+                        { text: "O Spring não permite desligá-la em teste", isCorrect: false },
+                        { text: "Os testes ficariam mais lentos ao rodar", isCorrect: false },
+                        { text: "As anotações de teste deixariam de funcionar", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "O que testar",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Cobertura não é o objetivo\n\nCem por cento de cobertura com asserções fracas não protege nada, e é fácil de alcançar. O objetivo é que uma **mudança que quebra o comportamento** faça algum teste falhar.\n\nA pergunta útil não é *quanto está coberto*, é *o que aconteceria se eu apagasse esta linha*.",
+                },
+                {
+                    type: "table",
+                    value: '[["Camada", "Tipo de teste", "Quantidade"], ["regra de negócio", "unidade", "muitos"], ["repositório com consulta própria", "integração", "alguns"], ["endpoint", "fatia web", "alguns"], ["fluxo principal completo", "integração", "poucos"]]',
+                },
+                {
+                    type: "text",
+                    value: "## O que quase sempre vale testar\n\n- Toda regra de negócio com condição, e principalmente os **limites** dela\n- Todo caminho de erro que o sistema trata de propósito\n- Toda consulta escrita à mão, que o compilador não verifica\n- Toda permissão, nos dois sentidos\n- Todo bug corrigido, com um teste que falha antes da correção",
+                },
+                {
+                    type: "text",
+                    value: "## O que não vale\n\nGetter e setter, código gerado, e configuração do framework. Testar que o Spring injeta uma dependência é testar o Spring, não a sua aplicação.\n\nE evite testar detalhe de implementação: um teste que conhece a ordem interna das chamadas quebra na primeira melhoria do código.",
+                },
+                {
+                    type: "quote",
+                    value: "O melhor momento de escrever um teste é quando você acabou de encontrar um bug: ele documenta o caso e garante que não volta.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual o objetivo de uma suíte de testes?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Que uma quebra de comportamento faça algum teste falhar",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Alcançar cem por cento de cobertura de todo o código do projeto",
+                            isCorrect: false,
+                        },
+                        { text: "Executar em menos de um minuto na integração", isCorrect: false },
+                        { text: "Cobrir todas as classes com ao menos um teste", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual pergunta é mais útil que a cobertura?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O que aconteceria se eu apagasse esta linha", isCorrect: true },
+                        {
+                            text: "Quantos testes já existem escritos para esta classe",
+                            isCorrect: false,
+                        },
+                        { text: "Quanto tempo a suíte leva para rodar", isCorrect: false },
+                        { text: "Quantas asserções cada teste possui", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual tipo de teste deve ser o mais numeroso?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Os de unidade da regra de negócio", isCorrect: true },
+                        { text: "Os de integração do fluxo completo", isCorrect: false },
+                        { text: "Os da camada web com MockMvc", isCorrect: false },
+                        { text: "Os de repositório com Testcontainers", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que não vale a pena testar?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Getters, código gerado e configuração do framework",
+                            isCorrect: true,
+                        },
+                        { text: "Consultas escritas à mão no repositório", isCorrect: false },
+                        {
+                            text: "Os caminhos de erro que já são tratados de propósito no código",
+                            isCorrect: false,
+                        },
+                        { text: "Os limites das regras de negócio", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quando é um bom momento para escrever um teste?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Ao encontrar um bug, antes de corrigi-lo", isCorrect: true },
+                        { text: "Depois de a funcionalidade estar em produção", isCorrect: false },
+                        { text: "Quando a cobertura cai abaixo do limite", isCorrect: false },
+                        { text: "Antes de qualquer linha de código ser escrita", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_6: Modulo = {
+    titulo: "Módulo 6 - Produção",
+    aulas: [
+        {
+            titulo: "Actuator",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# A aplicação se explicando\n\nO **Actuator** expõe endpoints que respondem perguntas operacionais: a aplicação está saudável, quanto de memória está usando, quais propriedades estão valendo, quais beans existem.",
+                },
+                {
+                    type: "code",
+                    value: "management:\n  endpoints:\n    web:\n      exposure:\n        include: health,info,metrics,prometheus\n  endpoint:\n    health:\n      show-details: when-authorized\n  server:\n    port: 9090   # porta separada, não exposta ao público",
+                },
+                {
+                    type: "table",
+                    value: '[["Endpoint", "Responde"], ["/health", "a aplicação está de pé e íntegra"], ["/info", "versão e dados do build"], ["/metrics", "métricas da aplicação"], ["/prometheus", "as métricas no formato do Prometheus"], ["/env", "as propriedades em vigor"], ["/loggers", "níveis de log, alteráveis em execução"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Cuidado com o que é exposto\n\nO padrão expõe apenas `/health` e `/info` pela web, e isso é proposital. `/env` e `/heapdump` revelam configuração e memória, e não podem ficar públicos em hipótese alguma.\n\nA prática comum é pôr o Actuator em uma **porta separada**, acessível só pela rede interna.",
+                },
+                {
+                    type: "text",
+                    value: "## Liveness e readiness\n\nEm Kubernetes, dois sinais diferentes importam: **liveness** diz se o processo está vivo, e **readiness** diz se ele pode receber tráfego. Confundir os dois faz o orquestrador reiniciar containers que só estavam aquecendo.",
+                },
+                {
+                    type: "code",
+                    value: "GET /actuator/health/liveness\nGET /actuator/health/readiness",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o Actuator expõe?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Endpoints com informação operacional", isCorrect: true },
+                        { text: "A documentação da API para os clientes", isCorrect: false },
+                        { text: "Um painel de administração da aplicação", isCorrect: false },
+                        { text: "Os logs da aplicação em tempo real", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que `/env` não pode ser público?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Ele revela a configuração em vigor", isCorrect: true },
+                        { text: "Ele consome muita memória ao ser chamado", isCorrect: false },
+                        {
+                            text: "Ele permite alterar as propriedades da aplicação",
+                            isCorrect: false,
+                        },
+                        { text: "Ele expõe as rotas registradas no projeto", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a prática comum para o Actuator em produção?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Deixá-lo em uma porta separada e interna", isCorrect: true },
+                        { text: "Expor todos os endpoints com autenticação", isCorrect: false },
+                        { text: "Desligá-lo por completo no ambiente", isCorrect: false },
+                        { text: "Publicá-lo em um subdomínio próprio", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a diferença entre liveness e readiness?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Um diz se está vivo, o outro se pode receber tráfego",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Um deles é para o container e o outro é para a aplicação",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Um é verificado uma vez e o outro continuamente",
+                            isCorrect: false,
+                        },
+                        { text: "Um responde HTTP e o outro apenas um código", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que acontece ao confundir liveness com readiness?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "O orquestrador reinicia containers que só aqueciam",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "A aplicação inteira deixa de receber requisições novas",
+                            isCorrect: false,
+                        },
+                        { text: "O container nunca é considerado saudável", isCorrect: false },
+                        { text: "As métricas param de ser coletadas", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Observabilidade",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Três sinais\n\nObservabilidade se apoia em três tipos de dado, e cada um responde uma pergunta diferente:\n\n- **Métricas**: quantas requisições, quanto tempo, quantos erros\n- **Logs**: o que aconteceu em cada evento\n- **Traces**: por onde a requisição passou entre serviços",
+                },
+                {
+                    type: "code",
+                    value: '@Service\npublic class PedidoService {\n\n    private final Counter pedidosCriados;\n\n    public PedidoService(MeterRegistry registry) {\n        this.pedidosCriados = Counter.builder("pedidos.criados")\n            .description("Total de pedidos criados")\n            .register(registry);\n    }\n\n    @Observed(name = "pedido.criar")\n    public Pedido criar(CriarPedido req) {\n        pedidosCriados.increment();\n        return repo.save(new Pedido(req));\n    }\n}',
+                },
+                {
+                    type: "text",
+                    value: "## OpenTelemetry\n\nO **OpenTelemetry** é o padrão aberto para coletar esses três sinais. O ganho é não ficar preso a um fornecedor: a aplicação emite no formato padrão, e a ferramenta de destino é configuração.\n\nO Spring Boot 4.1 melhorou o suporte a ele, e a instrumentação automática cobre requisições web, chamadas de banco e clientes HTTP sem código nenhum.",
+                },
+                {
+                    type: "text",
+                    value: "## Log estruturado e correlação\n\nEm produção, log em JSON é consultável; log em texto solto exige expressão regular. E o **trace id** propagado no contexto é o que permite achar todas as linhas de uma mesma requisição, mesmo passando por vários serviços.",
+                },
+                {
+                    type: "code",
+                    value: "logging:\n  structured:\n    format:\n      console: ecs   # JSON estruturado\n\n# Cada linha sai com traceId e spanId,\n# preenchidos automaticamente pela instrumentação",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Quais são os três sinais da observabilidade?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Métricas, logs e traces", isCorrect: true },
+                        { text: "Erros, avisos e mensagens informativas", isCorrect: false },
+                        { text: "Requisições, respostas e tempo de resposta", isCorrect: false },
+                        { text: "Memória, processador e uso de disco", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que um trace responde?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Por onde a requisição passou entre serviços", isCorrect: true },
+                        { text: "Quantas requisições o serviço recebeu", isCorrect: false },
+                        {
+                            text: "O que exatamente aconteceu em cada evento registrado",
+                            isCorrect: false,
+                        },
+                        { text: "Quanto de memória cada serviço consumiu", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual o ganho de usar OpenTelemetry?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Não ficar preso a um fornecedor", isCorrect: true },
+                        {
+                            text: "Coletar os dados com menos impacto no desempenho",
+                            isCorrect: false,
+                        },
+                        { text: "Dispensar a instrumentação manual do código", isCorrect: false },
+                        { text: "Guardar os dados por mais tempo no destino", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que log em JSON é melhor em produção?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Ele é consultável sem expressão regular", isCorrect: true },
+                        { text: "Ele ocupa menos espaço em disco que o texto", isCorrect: false },
+                        { text: "Ele é gravado bem mais rápido pela aplicação", isCorrect: false },
+                        { text: "Ele pode ser lido diretamente por pessoas", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Para que serve o trace id nas linhas de log?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Achar todas as linhas de uma mesma requisição", isCorrect: true },
+                        {
+                            text: "Identificar qual das instâncias gerou cada linha",
+                            isCorrect: false,
+                        },
+                        { text: "Ordenar as linhas por horário de ocorrência", isCorrect: false },
+                        { text: "Marcar quais linhas são de erro no sistema", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Cache",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Guardando o que custa caro\n\nO Spring abstrai cache por anotações, e o provedor é configuração: mapa em memória, Redis, Caffeine. Trocar de provedor não muda o código.",
+                },
+                {
+                    type: "code",
+                    value: '@Service\npublic class CategoriaService {\n\n    @Cacheable("categorias")\n    public List<Categoria> listarAtivas() {\n        return repo.findByAtivoTrue();\n    }\n\n    @CacheEvict(value = "categorias", allEntries = true)\n    public Categoria salvar(Categoria c) {\n        return repo.save(c);\n    }\n\n    @Cacheable(value = "categoria", key = "#id")\n    public Categoria buscar(Long id) {\n        return repo.findById(id).orElseThrow();\n    }\n}',
+                },
+                {
+                    type: "table",
+                    value: '[["Anotação", "O que faz"], ["@Cacheable", "guarda o retorno e reaproveita"], ["@CacheEvict", "remove entradas do cache"], ["@CachePut", "atualiza sem pular o método"], ["@Caching", "combina várias das anteriores"]]',
+                },
+                {
+                    type: "text",
+                    value: "## As armadilhas\n\n**A anotação funciona por proxy.** Chamar um método `@Cacheable` de dentro da mesma classe não passa pelo proxy, e o cache não acontece. É a mesma armadilha do `@Transactional`.\n\n**Invalidar é a parte difícil.** Cache que não é limpo entrega dado velho, e é um bug que aparece longe da causa. Toda escrita que afeta o dado precisa do `@CacheEvict` correspondente.\n\n**Cachear o que muda toda hora piora.** O custo de gravar e invalidar supera o de simplesmente consultar.",
+                },
+                {
+                    type: "quote",
+                    value: "Cache é a otimização que mais cria bug estranho. Antes de cachear, meça: muitas vezes o problema é um índice faltando no banco.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que `@Cacheable` faz?",
+                    difficulty: "facil",
+                    options: [
+                        {
+                            text: "Guarda o retorno e reaproveita na próxima chamada",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Grava o resultado daquela chamada no banco de dados do projeto",
+                            isCorrect: false,
+                        },
+                        { text: "Executa o método em segundo plano", isCorrect: false },
+                        { text: "Repete a chamada quando ela falha", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que chamar um método cacheado da mesma classe não funciona?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "A chamada não passa pelo proxy do Spring", isCorrect: true },
+                        { text: "O cache só funciona em métodos públicos", isCorrect: false },
+                        { text: "A anotação precisa estar na classe também", isCorrect: false },
+                        { text: "O provedor de cache ainda não foi iniciado", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a parte difícil de trabalhar com cache?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Saber quando invalidar as entradas", isCorrect: true },
+                        { text: "Escolher o provedor certo para o projeto", isCorrect: false },
+                        { text: "Configurar o tempo de expiração das chaves", isCorrect: false },
+                        { text: "Serializar os objetos guardados no cache", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que acontece ao cachear dado que muda toda hora?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O custo de gravar e invalidar supera o ganho", isCorrect: true },
+                        { text: "O cache passa a ocupar memória demais", isCorrect: false },
+                        { text: "As entradas nunca chegam a ser reaproveitadas", isCorrect: false },
+                        { text: "O provedor recusa gravar a chave repetida", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que checar antes de cachear uma consulta lenta?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Se não falta um índice no banco", isCorrect: true },
+                        { text: "Se o provedor de cache está configurado", isCorrect: false },
+                        { text: "Se a consulta devolve muitos registros", isCorrect: false },
+                        { text: "Se o método é chamado com frequência", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Assíncrono e agendamento",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Trabalho fora da requisição\n\nEnviar email dentro da requisição faz o usuário esperar por algo que não precisa acontecer agora. O `@Async` devolve a resposta e continua o trabalho em outra thread.",
+                },
+                {
+                    type: "code",
+                    value: '@Configuration\n@EnableAsync\npublic class AsyncConfig {\n\n    @Bean\n    Executor taskExecutor() {\n        var executor = new ThreadPoolTaskExecutor();\n        executor.setCorePoolSize(4);\n        executor.setMaxPoolSize(10);\n        executor.setQueueCapacity(100);\n        executor.setThreadNamePrefix("app-async-");\n        executor.initialize();\n        return executor;\n    }\n}\n\n@Async\npublic CompletableFuture<Void> enviarBoasVindas(Usuario u) {\n    mailer.enviar(u.getEmail(), "Bem-vindo");\n    return CompletableFuture.completedFuture(null);\n}',
+                },
+                {
+                    type: "text",
+                    value: "Definir o executor é importante: sem ele, o Spring usa um que cria uma thread nova por chamada, sem limite. Sob carga isso derruba a aplicação.\n\nO Spring Boot 4.1 melhorou a **propagação de contexto** em métodos `@Async`, o que faz o trace id e o contexto de segurança acompanharem a thread nova. Antes, o log da tarefa assíncrona perdia a correlação com a requisição que a originou.",
+                },
+                {
+                    type: "text",
+                    value: "## Agendamento\n\n`@Scheduled` executa em intervalo ou por expressão cron. Em aplicação com **várias instâncias**, a tarefa roda em todas ao mesmo tempo, e é preciso um mecanismo de trava para garantir uma execução só.",
+                },
+                {
+                    type: "code",
+                    value: '@Scheduled(cron = "0 0 3 * * *", zone = "America/Sao_Paulo")\npublic void relatorioDiario() { }\n\n@Scheduled(fixedDelay = 60_000)\npublic void verificarPendencias() { }',
+                },
+                {
+                    type: "quote",
+                    value: "Async não é fila. Se o trabalho não pode se perder quando o processo cai, ele precisa de uma fila com persistência, não de outra thread.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que `@Async` faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Executa o método em outra thread", isCorrect: true },
+                        { text: "Adia a execução para um horário definido", isCorrect: false },
+                        { text: "Envia o trabalho para uma fila persistente", isCorrect: false },
+                        { text: "Repete o método quando ele falha", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que definir um executor próprio?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "O padrão cria threads sem limite e derruba sob carga",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "O padrão não funciona com métodos que devolvem valor",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "O executor é obrigatório para o @Async funcionar",
+                            isCorrect: false,
+                        },
+                        { text: "O padrão executa as tarefas em ordem inversa", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o Spring Boot 4.1 melhorou no assíncrono?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A propagação do contexto para a thread nova", isCorrect: true },
+                        { text: "O desempenho do pool de threads padrão", isCorrect: false },
+                        {
+                            text: "O tratamento das exceções nos métodos assíncronos",
+                            isCorrect: false,
+                        },
+                        { text: "A quantidade máxima de tarefas simultâneas", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que acontece com `@Scheduled` em várias instâncias?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "A tarefa roda em todas ao mesmo tempo", isCorrect: true },
+                        { text: "Apenas a primeira instância executa a tarefa", isCorrect: false },
+                        { text: "O Spring elege uma instância automaticamente", isCorrect: false },
+                        { text: "A tarefa é distribuída entre as instâncias", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quando `@Async` não é suficiente?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Quando o trabalho não pode se perder se o processo cair",
+                            isCorrect: true,
+                        },
+                        { text: "Quando a tarefa demora mais de um minuto", isCorrect: false },
+                        { text: "Quando o método precisa devolver um valor", isCorrect: false },
+                        {
+                            text: "Quando existe mais de uma tarefa rodando ao mesmo tempo",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Empacotamento e containers",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O jar executável\n\nO Spring Boot empacota tudo em um jar único, com as dependências e o servidor dentro. Não há servidor externo para instalar: `java -jar` sobe a aplicação.",
+                },
+                {
+                    type: "code",
+                    value: "./mvnw clean package\njava -jar target/loja-1.0.0.jar\n\n# Pulando os testes, quando a CI já os rodou\n./mvnw clean package -DskipTests",
+                },
+                {
+                    type: "text",
+                    value: "## Camadas na imagem\n\nCopiar o jar inteiro para a imagem Docker desperdiça cache: uma linha alterada no seu código invalida a camada que contém todas as dependências, que são a maior parte do tamanho.\n\nO Boot resolve isso com **jar em camadas**: dependências, dependências de snapshot e o seu código ficam separados. Como as dependências mudam pouco, a camada delas é reaproveitada entre builds.",
+                },
+                {
+                    type: "code",
+                    value: 'FROM eclipse-temurin:25-jre AS builder\nWORKDIR /app\nCOPY target/*.jar app.jar\nRUN java -Djarmode=tools -jar app.jar extract --layers --destination extracted\n\nFROM eclipse-temurin:25-jre\nWORKDIR /app\nCOPY --from=builder /app/extracted/dependencies/ ./\nCOPY --from=builder /app/extracted/spring-boot-loader/ ./\nCOPY --from=builder /app/extracted/application/ ./\nENTRYPOINT ["java", "-jar", "app.jar"]',
+                },
+                {
+                    type: "text",
+                    value: "## Imagem sem Dockerfile\n\nO próprio Boot constrói a imagem usando buildpacks, escolhendo a base e as configurações da JVM sozinho. Para a maioria dos projetos é melhor do que um Dockerfile escrito à mão.",
+                },
+                {
+                    type: "code",
+                    value: "./mvnw spring-boot:build-image",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o jar do Spring Boot contém?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "As dependências e o servidor embutido", isCorrect: true },
+                        { text: "Apenas as classes compiladas do projeto", isCorrect: false },
+                        { text: "O código-fonte junto com as classes", isCorrect: false },
+                        { text: "Um instalador para o servidor de aplicação", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual o problema de copiar o jar inteiro para a imagem?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Uma mudança no código invalida a camada das dependências",
+                            isCorrect: true,
+                        },
+                        { text: "A imagem final fica com o dobro do tamanho", isCorrect: false },
+                        {
+                            text: "O jar precisa ser todo extraído antes de poder ser executado",
+                            isCorrect: false,
+                        },
+                        { text: "As dependências deixam de ser encontradas", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o jar em camadas separa?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Dependências e o código da aplicação", isCorrect: true },
+                        { text: "As classes de teste e as de produção", isCorrect: false },
+                        { text: "Os recursos estáticos e o código Java", isCorrect: false },
+                        { text: "Cada módulo do projeto em uma camada", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que a camada de dependências é reaproveitada?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Elas mudam pouco entre um build e outro", isCorrect: true },
+                        { text: "Elas são baixadas de um cache remoto", isCorrect: false },
+                        { text: "O Docker as guarda em um volume próprio", isCorrect: false },
+                        { text: "Elas são compartilhadas entre os projetos", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `spring-boot:build-image` faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Constrói a imagem sem precisar de Dockerfile", isCorrect: true },
+                        { text: "Publica a imagem gerada em um registro remoto", isCorrect: false },
+                        { text: "Gera o Dockerfile a partir do projeto", isCorrect: false },
+                        { text: "Testa a imagem antes de empacotá-la", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_7: Modulo = {
+    titulo: "Módulo 7 - O Spring Boot 4",
+    aulas: [
+        {
+            titulo: "O que mudou na linha 4",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Uma virada de geração\n\nO **Spring Boot 4.0** saiu em 20 de novembro de 2025, sobre o **Spring Framework 7.0**. A equipe descreve como o começo de uma geração nova, com foco no Java 25 e no ecossistema atual.\n\nO **Spring Boot 4.1**, de junho de 2026, é o alvo recomendado para projeto novo.",
+                },
+                {
+                    type: "table",
+                    value: '[["Novidade do Boot 4", "O que resolve"], ["modularização do código", "jars menores e mais focados"], ["Java 25 em primeira classe", "recursos novos da linguagem"], ["versionamento de API", "evoluir sem quebrar clientes"], ["HTTP Service Clients", "cliente declarativo por interface"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Compatibilidade\n\nApesar do salto de versão maior, o Boot 4 mantém compatibilidade com **Java 17**. Não é preciso migrar a versão do Java junto, o que separa duas migrações que seriam arriscadas de fazer ao mesmo tempo.\n\n## O que exige atenção\n\nA modularização significa que alguns pacotes mudaram de artefato. Um projeto que dependia de uma classe interna pode precisar declarar uma dependência nova. Para código que usa as APIs públicas, a migração é tranquila.",
+                },
+                {
+                    type: "quote",
+                    value: "Migre uma coisa por vez: primeiro a versão do Spring Boot mantendo o Java, depois a versão do Java. Duas migrações juntas dobram a superfície de erro.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Quando o Spring Boot 4.0 foi lançado?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Em novembro de 2025", isCorrect: true },
+                        { text: "Em junho de 2026, junto com a versão 4.1", isCorrect: false },
+                        { text: "Em março de 2026, no primeiro trimestre", isCorrect: false },
+                        { text: "Em novembro de 2024, um ano antes", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a versão mínima de Java aceita pelo Boot 4?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Java 17", isCorrect: true },
+                        { text: "Java 25, que é a apoiada em primeira classe", isCorrect: false },
+                        { text: "Java 21, a versão anterior de longo prazo", isCorrect: false },
+                        { text: "Java 11, mantida por compatibilidade", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que a modularização do Boot 4 traz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Jars menores e mais focados", isCorrect: true },
+                        { text: "Um sistema de plugins para a aplicação", isCorrect: false },
+                        { text: "A separação entre código e configuração", isCorrect: false },
+                        { text: "A divisão do projeto em vários módulos Maven", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que pode exigir atenção ao migrar?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Pacotes que mudaram de artefato com a modularização",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "A reescrita de todas as anotações usadas no projeto",
+                            isCorrect: false,
+                        },
+                        { text: "A migração obrigatória para o Java 25", isCorrect: false },
+                        { text: "A troca do Maven pelo Gradle no build", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a estratégia recomendada de migração?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Uma coisa por vez, Spring antes do Java", isCorrect: true },
+                        { text: "Migrar o Spring e o Java na mesma alteração", isCorrect: false },
+                        { text: "Migrar o Java primeiro e o Spring depois", isCorrect: false },
+                        { text: "Reescrever o projeto do zero na versão nova", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Java 25 no dia a dia",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# A linguagem mudou muito\n\nQuem escreveu Java 8 e voltou agora encontra outra linguagem. Vários recursos que exigiam bibliotecas hoje são sintaxe, e o código de uma aplicação Spring fica bem mais curto.",
+                },
+                {
+                    type: "code",
+                    value: '// Record: dados imutáveis sem cerimônia\npublic record ProdutoResponse(Long id, String nome, BigDecimal preco) {}\n\n// var: o tipo vem da direita\nvar produtos = repo.findByAtivoTrue();\n\n// Texto em bloco\nvar consulta = """\n    select p from Produto p\n    where p.ativo = true\n    """;\n\n// Switch como expressão, com pattern matching\nvar descricao = switch (status) {\n    case PENDENTE -> "Aguardando pagamento";\n    case PAGO, ENVIADO -> "Em andamento";\n    case CANCELADO -> "Cancelado";\n};',
+                },
+                {
+                    type: "text",
+                    value: "## Sealed e pattern matching\n\nUma hierarquia **selada** declara quem pode estendê-la. O compilador então sabe todos os casos possíveis, e passa a **exigir** que o switch os trate todos, do mesmo jeito que uma união discriminada em outras linguagens.",
+                },
+                {
+                    type: "code",
+                    value: 'public sealed interface Resultado permits Sucesso, Falha {}\npublic record Sucesso(Pedido pedido) implements Resultado {}\npublic record Falha(String motivo) implements Resultado {}\n\n// O compilador cobra os dois casos\nvar mensagem = switch (resultado) {\n    case Sucesso(var pedido) -> "Pedido " + pedido.getId();\n    case Falha(var motivo) -> "Falhou: " + motivo;\n};',
+                },
+                {
+                    type: "text",
+                    value: "## Threads virtuais\n\nO recurso que mais muda o desempenho de uma aplicação web. Threads virtuais são leves o bastante para criar milhares delas, e uma thread bloqueada em entrada e saída deixa de segurar uma thread do sistema.\n\nEm uma aplicação que passa a maior parte do tempo esperando banco e chamadas HTTP, ligar isso muda a capacidade de atendimento com uma linha de configuração.",
+                },
+                {
+                    type: "code",
+                    value: "spring:\n  threads:\n    virtual:\n      enabled: true",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que um record oferece?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Dados imutáveis sem escrever cerimônia", isCorrect: true },
+                        { text: "Uma classe que gera o mapeamento para o banco", isCorrect: false },
+                        { text: "Um objeto que valida os próprios campos", isCorrect: false },
+                        { text: "Uma estrutura que substitui as interfaces", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que uma hierarquia selada permite ao compilador?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Saber todos os casos e exigir que sejam tratados",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Impedir que a classe seja instanciada diretamente",
+                            isCorrect: false,
+                        },
+                        { text: "Gerar as implementações das subclasses", isCorrect: false },
+                        { text: "Otimizar o código gerado para cada caso", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual o ganho das threads virtuais em aplicação web?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Uma thread bloqueada não segura uma thread do sistema",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "As requisições passam a ser todas processadas em paralelo",
+                            isCorrect: false,
+                        },
+                        { text: "O processador é usado de forma mais eficiente", isCorrect: false },
+                        { text: "A memória consumida por requisição diminui", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Em que tipo de aplicação as threads virtuais mais ajudam?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Na que passa o tempo esperando banco e HTTP", isCorrect: true },
+                        { text: "Na que faz cálculo pesado no processador", isCorrect: false },
+                        { text: "Na que processa arquivos grandes em memória", isCorrect: false },
+                        { text: "Na que roda tarefas agendadas periódicas", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como ligar threads virtuais no Spring Boot?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Com uma propriedade na configuração", isCorrect: true },
+                        { text: "Anotando cada controller da aplicação", isCorrect: false },
+                        { text: "Trocando o servidor embutido por outro", isCorrect: false },
+                        {
+                            text: "Configurando o executor de tarefas assíncronas",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "As novidades do Spring Boot 4.1",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# A primeira versão menor da linha 4\n\nO **Spring Boot 4.1**, de 10 de junho de 2026, roda sobre o Spring Framework 7.0.8 e é o alvo recomendado para projeto novo. Ele acrescenta várias peças que faltavam.",
+                },
+                {
+                    type: "table",
+                    value: '[["Novidade", "O que traz"], ["gRPC com auto-configuração", "serviços gRPC sem configuração manual"], ["proteção contra SSRF", "no cliente HTTP declarativo"], ["Kotlin 2.3", "suporte à versão nova da linguagem"], ["conexões preguiçosas", "o datasource conecta só quando precisa"], ["propagação em @Async", "contexto acompanha a thread nova"], ["OpenTelemetry", "suporte melhorado à instrumentação"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Conexões preguiçosas no datasource\n\nPor padrão, uma transação pega a conexão ao começar, mesmo que o método só vá consultar o banco no fim, ou nem consulte. Com a conexão preguiçosa, ela é obtida na **primeira consulta de verdade**.\n\nO ganho aparece em aplicação com muitas requisições curtas: o pool de conexões atende mais gente com o mesmo tamanho.",
+                },
+                {
+                    type: "text",
+                    value: "## Proteção contra SSRF\n\nUm ataque de **SSRF** faz o servidor buscar uma URL escolhida pelo atacante, alcançando endereços internos que não são acessíveis de fora. É especialmente perigoso em nuvem, onde endereços internos expõem credenciais da instância.\n\nO cliente HTTP do 4.1 traz mitigação embutida, o que fecha uma porta que antes dependia de cada equipe lembrar de fechar.",
+                },
+                {
+                    type: "quote",
+                    value: "Qualquer funcionalidade em que o usuário informa uma URL que o servidor vai buscar é um candidato a SSRF: importar de um link, webhook, avatar por URL.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Sobre qual versão do Framework o Boot 4.1 roda?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Spring Framework 7.0.8", isCorrect: true },
+                        { text: "Spring Framework 7.1, lançado junto", isCorrect: false },
+                        { text: "Spring Framework 6.2, ainda mantida", isCorrect: false },
+                        { text: "Spring Framework 8.0, em desenvolvimento", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que a conexão preguiçosa do datasource muda?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "A conexão é obtida só na primeira consulta real",
+                            isCorrect: true,
+                        },
+                        { text: "A conexão é mantida aberta por mais tempo", isCorrect: false },
+                        { text: "O pool passa a criar conexões sob demanda", isCorrect: false },
+                        {
+                            text: "As consultas são todas agrupadas antes de executar",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Onde o ganho da conexão preguiçosa aparece?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Em aplicação com muitas requisições curtas", isCorrect: true },
+                        { text: "Em consultas que devolvem muitos registros", isCorrect: false },
+                        { text: "Em transações que duram vários segundos", isCorrect: false },
+                        { text: "Em aplicações com um único usuário ativo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que SSRF é especialmente perigoso em nuvem?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Endereços internos podem expor credenciais da instância",
+                            isCorrect: true,
+                        },
+                        { text: "A rede da nuvem é mais lenta para responder", isCorrect: false },
+                        {
+                            text: "Os provedores de nuvem não permitem bloquear esses endereços",
+                            isCorrect: false,
+                        },
+                        { text: "As instâncias não têm firewall configurado", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual funcionalidade é candidata a SSRF?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Qualquer uma em que o usuário informa uma URL", isCorrect: true },
+                        {
+                            text: "Qualquer uma que receba o upload de um arquivo",
+                            isCorrect: false,
+                        },
+                        { text: "As que exigem autenticação por token", isCorrect: false },
+                        { text: "As que fazem consultas ao banco de dados", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Arquitetura em camadas",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Onde cada coisa mora\n\nUma aplicação Spring bem organizada tem responsabilidades separadas. A divisão mais comum tem três camadas, e o valor dela é que cada uma só conhece a de baixo.",
+                },
+                {
+                    type: "table",
+                    value: '[["Camada", "Responsabilidade", "Não deve"], ["controller", "receber e responder HTTP", "ter regra de negócio"], ["service", "a regra de negócio", "conhecer HTTP"], ["repository", "acesso a dados", "ter decisão de negócio"]]',
+                },
+                {
+                    type: "text",
+                    value: "## O sinal de que a divisão quebrou\n\nUm controller com `if` decidindo o que fazer, ou um service recebendo `HttpServletRequest`, são sinais de vazamento entre camadas. O efeito prático é que a regra fica impossível de testar sem subir a camada web.\n\n## Organizar por funcionalidade, não por tipo\n\nA estrutura por tipo agrupa todos os controllers, todos os services, todos os repositories. Ela é a mais ensinada e envelhece mal: mexer em uma funcionalidade exige abrir quatro pastas distantes.",
+                },
+                {
+                    type: "code",
+                    value: "// Por tipo: comum, e espalha cada mudança\ncom.loja/\n  controller/  ProdutoController, PedidoController, ClienteController\n  service/     ProdutoService, PedidoService, ClienteService\n  repository/  ...\n\n// Por funcionalidade: tudo de um assunto junto\ncom.loja/\n  produto/  ProdutoController, ProdutoService, ProdutoRepository, Produto\n  pedido/   PedidoController, PedidoService, PedidoRepository, Pedido\n  cliente/  ...",
+                },
+                {
+                    type: "text",
+                    value: "A segunda forma tem outra vantagem: ela mostra o **tamanho** de cada assunto. Uma pasta que cresceu demais é um candidato natural a virar um módulo separado, e essa informação some quando tudo está misturado por tipo.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que um controller não deve ter?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Regra de negócio", isCorrect: true },
+                        { text: "Injeção de dependências por construtor", isCorrect: false },
+                        { text: "Anotações de mapeamento de rota", isCorrect: false },
+                        { text: "Tratamento do código HTTP da resposta", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que um service recebendo `HttpServletRequest` indica?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Vazamento da camada web para o negócio", isCorrect: true },
+                        { text: "Que o service precisa de mais dependências", isCorrect: false },
+                        { text: "Que o controller está fino demais", isCorrect: false },
+                        { text: "Que falta um objeto de transferência de dados", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual o efeito prático de a regra vazar para o controller?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Ela fica impossível de testar sem a camada web", isCorrect: true },
+                        { text: "A aplicação passa a responder mais devagar", isCorrect: false },
+                        { text: "O Spring deixa de injetar as dependências", isCorrect: false },
+                        {
+                            text: "As transações acabam parando de funcionar corretamente",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual o problema de organizar por tipo?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Mexer em uma funcionalidade exige abrir várias pastas",
+                            isCorrect: true,
+                        },
+                        { text: "As classes ficam com nomes muito parecidos", isCorrect: false },
+                        {
+                            text: "O Spring acaba demorando mais para escanear os pacotes",
+                            isCorrect: false,
+                        },
+                        { text: "As camadas passam a depender umas das outras", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual vantagem extra a organização por funcionalidade traz?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Ela mostra o tamanho de cada assunto", isCorrect: true },
+                        { text: "Ela reduz a quantidade de classes do projeto", isCorrect: false },
+                        { text: "Ela dispensa a separação em camadas", isCorrect: false },
+                        { text: "Ela facilita a busca por nome de classe", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Projeto final e para onde ir",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Juntando tudo\n\nPara fechar a trilha, construa uma **API de pedidos** que exercite cada módulo:\n\n1. Projeto com os starters de web, JPA, validation e security\n2. Entidades com relacionamentos, migrations em Flyway e `ddl-auto: validate`\n3. Endpoints REST com validação, paginação e `ProblemDetail` nos erros\n4. Autenticação por JWT, com autorização por papel e consultas escopadas\n5. Testes de unidade no service, fatia web nos controllers e Testcontainers no repositório\n6. Actuator, métricas e log estruturado com trace id\n7. Imagem em camadas e um `docker-compose` com banco",
+                },
+                {
+                    type: "code",
+                    value: "@Service\n@Transactional\npublic class PedidoService {\n\n    private final PedidoRepository repo;\n    private final EstoqueService estoque;\n\n    public PedidoService(PedidoRepository repo, EstoqueService estoque) {\n        this.repo = repo;\n        this.estoque = estoque;\n    }\n\n    public PedidoResponse criar(CriarPedidoRequest req, Long clienteId) {\n        if (!estoque.disponivel(req.itens())) {\n            throw new EstoqueInsuficiente();\n        }\n        var pedido = repo.save(Pedido.novo(clienteId, req.itens()));\n        estoque.reservar(req.itens());\n        return PedidoResponse.de(pedido);\n    }\n\n    @Transactional(readOnly = true)\n    public Page<PedidoResponse> listarDoCliente(Long clienteId, Pageable p) {\n        return repo.findByClienteId(clienteId, p).map(PedidoResponse::de);\n    }\n}",
+                },
+                {
+                    type: "text",
+                    value: "Repare em três coisas do código acima: a injeção é por construtor, a listagem é escopada pelo cliente em vez de verificar permissão depois, e o `readOnly` está na consulta.\n\n## Para onde ir depois\n\n- **Aprofundar JPA**: consultas complexas, projeções, lote e o custo real de cada operação\n- **Mensageria**: Kafka ou RabbitMQ, para desacoplar serviços de verdade\n- **Arquitetura**: quando dividir em serviços, e o custo que isso cobra\n- **Ler o código do Spring**: as auto-configurações são legíveis, e entender uma delas ensina mais que dez tutoriais",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Por que a listagem é escopada pelo cliente?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "O pedido de outra pessoa não aparece na consulta",
+                            isCorrect: true,
+                        },
+                        { text: "Para que a consulta execute mais rápido", isCorrect: false },
+                        {
+                            text: "Porque o Spring Data exige um filtro na consulta",
+                            isCorrect: false,
+                        },
+                        {
+                            text: "Para reduzir a quantidade de dados na resposta",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Por que `readOnly = true` na listagem?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O Hibernate pula a checagem de alterações", isCorrect: true },
+                        { text: "A consulta passa a usar outra conexão do pool", isCorrect: false },
+                        {
+                            text: "O resultado é guardado em cache automaticamente",
+                            isCorrect: false,
+                        },
+                        { text: "A transação é aberta com menos privilégios", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual valor de `ddl-auto` o projeto final usa?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "validate, com as mudanças vindo de migrations", isCorrect: true },
+                        { text: "update, para acompanhar as entidades", isCorrect: false },
+                        {
+                            text: "create-drop, recriando todo o schema a cada build",
+                            isCorrect: false,
+                        },
+                        { text: "none, sem nenhuma verificação", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual tipo de teste cobre o repositório no projeto final?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Integração com Testcontainers", isCorrect: true },
+                        { text: "Unidade com dublês do Mockito", isCorrect: false },
+                        { text: "Fatia web com o MockMvc configurado", isCorrect: false },
+                        { text: "Nenhum, repositório não precisa de teste", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que aprender lendo as auto-configurações do Spring?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Como o framework decide o que criar e por quê", isCorrect: true },
+                        { text: "Quais dependências o projeto precisa declarar", isCorrect: false },
+                        { text: "Como escrever testes para a aplicação", isCorrect: false },
+                        { text: "Quais propriedades existem na configuração", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+export const MODULOS: Modulo[] = [
+    MODULO_1,
+    MODULO_2,
+    MODULO_3,
+    MODULO_4,
+    MODULO_5,
+    MODULO_6,
+    MODULO_7,
+];
+
+async function seed() {
+    let [trilha] = await db.select().from(trails).where(eq(trails.name, NOME));
+    if (!trilha) {
+        [trilha] = await db
+            .insert(trails)
+            .values({
+                name: NOME,
+                trailLevel: LEVEL,
+                description: DESCRICAO,
+                workloadHours: CARGA_HORARIA,
+            })
+            .returning();
+        console.log("Trilha criada: " + NOME);
+    } else {
+        const existentes = await db.select().from(lessons).where(eq(lessons.trailId, trilha.id));
+        if (existentes.length > 0) {
+            console.log("Trilha já tem aulas, nada a fazer: " + NOME);
+            return;
+        }
+        await db
+            .update(trails)
+            .set({ workloadHours: CARGA_HORARIA, description: DESCRICAO, trailLevel: LEVEL })
+            .where(eq(trails.id, trilha.id));
+    }
+
+    let totalAulas = 0;
+    let totalQuestoes = 0;
+    for (let mi = 0; mi < MODULOS.length; mi++) {
+        const m = MODULOS[mi];
+        const [mod] = await db
+            .insert(modules)
+            .values({ trailId: trilha.id, title: m.titulo, position: mi + 1 })
+            .returning();
+        for (let li = 0; li < m.aulas.length; li++) {
+            const a = m.aulas[li];
+            const [lesson] = await db
+                .insert(lessons)
+                .values({
+                    trailId: trilha.id,
+                    moduleId: mod.id,
+                    title: a.titulo,
+                    content: null,
+                    contentBlocks: a.blocks,
+                    position: li + 1,
+                    published: true,
+                })
+                .returning();
+            for (let qi = 0; qi < a.questions.length; qi++) {
+                const q = a.questions[qi];
+                const [questao] = await db
+                    .insert(questions)
+                    .values({
+                        lessonId: lesson.id,
+                        statement: q.statement,
+                        difficulty: q.difficulty,
+                        position: qi + 1,
+                    })
+                    .returning();
+                await db.insert(questionOptions).values(
+                    q.options.map((o, k) => ({
+                        questionId: questao.id,
+                        text: o.text,
+                        isCorrect: o.isCorrect,
+                        position: k + 1,
+                    })),
+                );
+            }
+            totalAulas++;
+            totalQuestoes += a.questions.length;
+        }
+    }
+    console.log(
+        "Seed concluído: " +
+            MODULOS.length +
+            " módulos, " +
+            totalAulas +
+            " aulas, " +
+            totalQuestoes +
+            " questões.",
+    );
+}
+
+// Só semeia quando executado direto. Importado, expõe MODULOS/NOME sem rodar nada.
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+    seed()
+        .then(() => process.exit(0))
+        .catch((e) => {
+            console.error("Falha no seed:", e);
+            process.exit(1);
+        });
+}

--- a/backend/scripts/seed-trilha-typescript.ts
+++ b/backend/scripts/seed-trilha-typescript.ts
@@ -1,0 +1,3089 @@
+// Seed da trilha TypeScript (TypeScript 7). Conteúdo autoral.
+// A versão 7 saiu em 8 de julho de 2026 com o compilador reescrito em Go, e é a
+// que a trilha ensina: strict e module esnext por padrão, target es5 e
+// moduleResolution node removidos, e o pacote @typescript/typescript6 para conviver.
+//
+// Idempotente e nao destrutivo: se a trilha ja tiver aulas, nao faz nada.
+//
+// Rodar em prod: docker compose -f docker-compose.prod.yml run --rm -T --no-deps backend node scripts/seed-trilha-typescript.ts
+import { db } from "../db.ts";
+import { trails, modules, lessons, questions, questionOptions } from "../schema.ts";
+import { eq } from "drizzle-orm";
+import { pathToFileURL } from "node:url";
+
+export const NOME = "TypeScript";
+const LEVEL: "iniciante" | "intermediario" | "avancado" = "intermediario";
+const DESCRICAO =
+    "TypeScript 7 do zero ao uso profissional: por que tipos existem, união e narrowing, interfaces e generics, os tipos que calculam com conditional e mapped types, validação na fronteira do sistema, configuração do compilador e migração de projetos JavaScript. Inclui o que o TypeScript 7 mudou com o compilador nativo em Go.";
+const CARGA_HORARIA = 20;
+
+type Bloco = { type: "text" | "code" | "quote" | "table"; value: string };
+type Questao = {
+    statement: string;
+    difficulty: "facil" | "medio" | "dificil";
+    options: { text: string; isCorrect: boolean }[];
+};
+type Aula = { titulo: string; blocks: Bloco[]; questions: Questao[] };
+type Modulo = { titulo: string; aulas: Aula[] };
+
+const MODULO_1: Modulo = {
+    titulo: "Módulo 1 - Por que o TypeScript existe",
+    aulas: [
+        {
+            titulo: "O problema que o TypeScript resolve",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Erros que só aparecem rodando\n\nJavaScript não checa tipo nenhum antes de executar. Um `undefined` onde deveria haver objeto, um número somado com texto, uma propriedade escrita errada: nada disso é apontado até a linha rodar, e às vezes ela só roda na mão do usuário.\n\nO **TypeScript** acrescenta um sistema de tipos que roda **antes**. Ele não muda o que o código faz, ele avisa o que não faz sentido.",
+                },
+                {
+                    type: "code",
+                    value: "// JavaScript: passa e quebra em produção\nfunction total(itens) {\n  return itens.reduce((soma, i) => soma + i.preco, 0);\n}\n\ntotal(null);           // TypeError na hora de rodar\ntotal([{ prec: 10 }]); // NaN, silencioso e pior ainda\n\n// TypeScript: os dois são apontados antes de rodar\nfunction total(itens: { preco: number }[]): number {\n  return itens.reduce((soma, i) => soma + i.preco, 0);\n}",
+                },
+                {
+                    type: "text",
+                    value: "## O que se ganha além do erro\n\nO benefício mais óbvio é achar bug cedo, mas quem usa no dia a dia costuma citar outros dois:\n\n- **Autocompletar que funciona**: o editor sabe o que existe em cada objeto\n- **Refatorar sem medo**: renomear um campo aponta todos os lugares que precisam mudar\n\nÉ documentação que o compilador verifica, então ela não fica desatualizada como um comentário.",
+                },
+                {
+                    type: "text",
+                    value: "Esta trilha usa o **TypeScript 7**, lançado em 8 de julho de 2026, que reescreveu o compilador em Go e mudou vários padrões de configuração.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o TypeScript acrescenta ao JavaScript?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Uma checagem de tipos antes de rodar", isCorrect: true },
+                        { text: "Um interpretador próprio bem mais rápido", isCorrect: false },
+                        { text: "Uma biblioteca de funções já prontas para uso", isCorrect: false },
+                        {
+                            text: "Um empacotador que junta os arquivos do projeto",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O TypeScript muda o comportamento do código em execução?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Não, ele só verifica antes", isCorrect: true },
+                        { text: "Sim, ele valida os tipos durante a execução", isCorrect: false },
+                        {
+                            text: "Sim, ele converte os valores para o tipo certo",
+                            isCorrect: false,
+                        },
+                        { text: "Sim, ele impede que a função rode com erro", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Além de achar bug, o que mais se ganha?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Autocompletar e refatoração confiáveis", isCorrect: true },
+                        { text: "Um código bem menor depois de compilado", isCorrect: false },
+                        { text: "Uma execução mais rápida no navegador", isCorrect: false },
+                        { text: "A eliminação da necessidade de testes", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que tipos são melhores que comentários como documentação?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O compilador verifica se ainda estão corretos", isCorrect: true },
+                        {
+                            text: "Eles ocupam bem menos espaço dentro do arquivo",
+                            isCorrect: false,
+                        },
+                        { text: "Eles são escritos em uma linguagem própria", isCorrect: false },
+                        { text: "Eles aparecem na documentação gerada", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual versão do TypeScript esta trilha usa?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "TypeScript 7", isCorrect: true },
+                        { text: "TypeScript 4.9", isCorrect: false },
+                        { text: "TypeScript 5.0", isCorrect: false },
+                        { text: "TypeScript 3.8", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Instalando o TypeScript 7 e o primeiro arquivo",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Instalando no projeto\n\nO TypeScript é uma dependência de desenvolvimento: ele só existe na sua máquina e na CI, nunca no que vai para produção. O que roda é o JavaScript que ele gera.",
+                },
+                {
+                    type: "code",
+                    value: "npm install --save-dev typescript\nnpx tsc --version\n# Version 7.0.2\n\n# Cria o tsconfig.json\nnpx tsc --init",
+                },
+                {
+                    type: "text",
+                    value: "## O primeiro arquivo\n\nArquivos `.ts` são JavaScript com anotações de tipo. Todo JavaScript válido é TypeScript válido, o que permite adotar aos poucos.",
+                },
+                {
+                    type: "code",
+                    value: 'const nome: string = "Ana";\nconst idade: number = 28;\nconst ativo: boolean = true;\n\nfunction saudacao(quem: string): string {\n  return `Olá, ${quem}!`;\n}\n\nconsole.log(saudacao(nome));\nconsole.log(saudacao(idade));  // Erro: number não é string',
+                },
+                {
+                    type: "code",
+                    value: "npx tsc            # compila conforme o tsconfig\nnpx tsc --watch    # recompila a cada alteração\nnpx tsc --noEmit   # só checa, não gera arquivo",
+                },
+                {
+                    type: "text",
+                    value: "## Rodando direto\n\nO Node moderno executa TypeScript sem etapa de build, apagando os tipos na hora. É o caminho mais simples para começar, e o `--noEmit` continua sendo como se checa o projeto inteiro.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Onde o TypeScript entra nas dependências do projeto?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Como dependência de desenvolvimento", isCorrect: true },
+                        {
+                            text: "Como dependência normal, que vai para produção",
+                            isCorrect: false,
+                        },
+                        { text: "Como dependência global, instalada no sistema", isCorrect: false },
+                        { text: "Como dependência opcional do empacotador", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Todo arquivo JavaScript é TypeScript válido?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Sim, e é o que permite adotar aos poucos", isCorrect: true },
+                        { text: "Não, é preciso anotar todos os tipos antes", isCorrect: false },
+                        { text: "Não, a sintaxe das duas é bem diferente", isCorrect: false },
+                        { text: "Só quando o arquivo não usa classes", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `tsc --noEmit` faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Checa os tipos sem gerar arquivo", isCorrect: true },
+                        { text: "Gera o JavaScript sem checar os tipos", isCorrect: false },
+                        { text: "Compila apenas os arquivos que mudaram", isCorrect: false },
+                        { text: "Remove os arquivos gerados anteriormente", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que roda em produção em um projeto TypeScript?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O JavaScript gerado", isCorrect: true },
+                        { text: "O próprio TypeScript, interpretado direto", isCorrect: false },
+                        { text: "Os dois, conforme o ambiente configurado", isCorrect: false },
+                        { text: "O TypeScript compilado para código nativo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `tsc --watch` faz?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Recompila a cada alteração de arquivo", isCorrect: true },
+                        { text: "Observa os erros em tempo de execução", isCorrect: false },
+                        { text: "Acompanha o uso de memória do compilador", isCorrect: false },
+                        { text: "Monitora as dependências desatualizadas", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "O tsconfig e os padrões do TypeScript 7",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O arquivo que manda\n\nO `tsconfig.json` diz ao compilador quais arquivos considerar e com qual rigor. Ele é o primeiro lugar a olhar quando o TypeScript aceita algo que deveria recusar.",
+                },
+                {
+                    type: "code",
+                    value: '{\n  "compilerOptions": {\n    "target": "es2023",\n    "module": "esnext",\n    "moduleResolution": "bundler",\n    "strict": true,\n    "noUncheckedIndexedAccess": true,\n    "outDir": "./dist",\n    "rootDir": "./src"\n  },\n  "include": ["src"],\n  "exclude": ["node_modules", "dist"]\n}',
+                },
+                {
+                    type: "text",
+                    value: "## Os padrões mudaram no TypeScript 7\n\nEsta é a parte que mais confunde quem vem de tutorial antigo. Vários padrões foram invertidos, e para melhor.",
+                },
+                {
+                    type: "table",
+                    value: '[["Opção", "Antes do TS 7", "No TS 7"], ["strict", "false", "**true**"], ["module", "commonjs", "**esnext**"], ["types", "todos, como [\\"*\\"]", "**vazio, []**"], ["rootDir", "inferido", "**./**"]]',
+                },
+                {
+                    type: "text",
+                    value: "A mudança de `types` merece atenção: antes, todo pacote em `node_modules/@types` era incluído automaticamente, o que trazia tipos globais que ninguém pediu e deixava a checagem mais lenta. Agora você declara o que quer.\n\n## O que foi removido\n\nO TypeScript 7 eliminou alvos e resoluções antigas: `target: es5` não existe mais, `moduleResolution: node` e `node10` saíram, e os formatos de módulo `amd`, `umd`, `systemjs` e `none` foram removidos. O `baseUrl` foi descontinuado.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual o valor padrão de `strict` no TypeScript 7?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "true", isCorrect: true },
+                        { text: "false, como era nas versões anteriores", isCorrect: false },
+                        { text: "Depende do alvo escolhido no tsconfig", isCorrect: false },
+                        { text: "Não existe mais essa opção no arquivo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que mudou no padrão da opção `types`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Deixou de incluir tudo e passou a vir vazio", isCorrect: true },
+                        { text: "Passou a incluir também os tipos do projeto", isCorrect: false },
+                        { text: "Deixou de existir e virou automática", isCorrect: false },
+                        { text: "Passou a aceitar apenas um pacote por vez", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual alvo de compilação foi removido no TypeScript 7?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O es5", isCorrect: true },
+                        { text: "O esnext, substituído pelo es2023", isCorrect: false },
+                        { text: "O es2015, o primeiro com módulos", isCorrect: false },
+                        { text: "O es2020, por falta de suporte", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual o padrão de `module` no TypeScript 7?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "esnext", isCorrect: true },
+                        { text: "commonjs, como era antes da versão 7", isCorrect: false },
+                        { text: "amd, para compatibilidade com o navegador", isCorrect: false },
+                        { text: "umd, que funciona nos dois ambientes", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que incluir todos os `@types` automaticamente era ruim?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Trazia tipos globais indesejados e deixava lento",
+                            isCorrect: true,
+                        },
+                        { text: "Aumentava o tamanho do JavaScript gerado", isCorrect: false },
+                        { text: "Impedia o uso de bibliotecas sem tipos", isCorrect: false },
+                        {
+                            text: "Fazia o compilador ignorar por completo o modo estrito",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Tipos primitivos e inferência",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Os tipos básicos\n\nO TypeScript tem os primitivos do JavaScript, escritos em minúsculo. `String` com maiúscula é o objeto envelopado e quase nunca é o que você quer.",
+                },
+                {
+                    type: "table",
+                    value: '[["Tipo", "Exemplo"], ["string", "\\"Ana\\""], ["number", "28 e 1.67, sem distinção"], ["boolean", "true"], ["bigint", "9007199254740993n"], ["symbol", "Symbol(\'id\')"], ["null e undefined", "os dois vazios do JavaScript"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Inferência\n\nNa maior parte do tempo você **não escreve o tipo**: o TypeScript o descobre pelo valor. Anotar o óbvio só polui o código.\n\nA regra que a comunidade segue: anote o que **entra e sai** de uma função, e deixe o resto inferido.",
+                },
+                {
+                    type: "code",
+                    value: 'const nome = "Ana";        // string, inferido\nlet total = 0;             // number, inferido\nconst ativo = true;        // boolean, inferido\n\n// Redundante: o tipo já era óbvio\nconst nome: string = "Ana";\n\n// Útil: a assinatura é o contrato\nfunction calcular(itens: number[], taxa: number): number {\n  return itens.reduce((a, b) => a + b, 0) * (1 + taxa);\n}',
+                },
+                {
+                    type: "text",
+                    value: "## const e let mudam a inferência\n\nUma sutileza que aparece o tempo todo: `const` com um literal infere o **tipo literal**, porque o valor nunca muda. Com `let`, o tipo é o amplo.",
+                },
+                {
+                    type: "code",
+                    value: 'const metodo = "GET";   // tipo é "GET", literal\nlet verbo = "GET";      // tipo é string, amplo\n\n// É por isso que isto funciona\nfunction buscar(metodo: "GET" | "POST") {}\nbuscar(metodo);   // ok, o tipo é exatamente "GET"\nbuscar(verbo);    // erro: string não cabe na união',
+                },
+            ],
+            questions: [
+                {
+                    statement: "Como se escreve o tipo de texto em TypeScript?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "string, em minúsculo", isCorrect: true },
+                        { text: "String, com a inicial maiúscula", isCorrect: false },
+                        { text: "text, como em algumas linguagens", isCorrect: false },
+                        { text: "char, para cada caractere do texto", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O TypeScript distingue inteiro de decimal?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Não, os dois são number", isCorrect: true },
+                        { text: "Sim, existem os tipos int e float", isCorrect: false },
+                        { text: "Sim, o decimal usa o tipo double", isCorrect: false },
+                        { text: "Só quando o modo estrito está ligado", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a regra prática sobre quando anotar o tipo?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Anotar o que entra e sai de uma função", isCorrect: true },
+                        { text: "Anotar todas as variáveis do arquivo", isCorrect: false },
+                        { text: "Anotar apenas quando o compilador reclamar", isCorrect: false },
+                        { text: "Nunca anotar, a inferência resolve tudo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual o tipo inferido de `const metodo = 'GET'`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: 'O literal "GET"', isCorrect: true },
+                        { text: "O tipo string, amplo como em qualquer texto", isCorrect: false },
+                        { text: "O tipo any, porque não foi anotado", isCorrect: false },
+                        { text: "Um tipo de união com todos os verbos", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que `let` infere um tipo mais amplo que `const`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Porque o valor ainda pode mudar depois", isCorrect: true },
+                        { text: "Porque let é mais antigo que const", isCorrect: false },
+                        { text: "Porque const guarda o valor em memória", isCorrect: false },
+                        { text: "Porque let não aceita valores literais", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Como o TypeScript roda: apagar tipos",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Type erasure\n\nO conceito mais importante para não se confundir: **os tipos somem na compilação**. O JavaScript gerado não tem nenhuma informação de tipo, e nada é verificado em execução.\n\nIsso significa que o TypeScript **não protege contra dado errado vindo de fora**. Uma resposta de API que você tipou como `Usuario` pode vir com qualquer coisa, e ninguém vai reclamar.",
+                },
+                {
+                    type: "code",
+                    value: "// O que você escreve\ninterface Usuario {\n  id: number;\n  nome: string;\n}\n\nfunction saudar(u: Usuario): string {\n  return `Olá, ${u.nome}`;\n}\n\n// O que é gerado: os tipos sumiram\nfunction saudar(u) {\n  return `Olá, ${u.nome}`;\n}",
+                },
+                {
+                    type: "quote",
+                    value: "Tipo é promessa de quem escreve, não garantia de quem executa. Dado que vem de fora precisa ser validado em execução.",
+                },
+                {
+                    type: "text",
+                    value: "## A consequência prática\n\nComo o tipo some, você não pode perguntar em execução se algo é `Usuario`. Para checar a forma de um dado externo, o caminho é validar campo a campo, ou usar uma biblioteca de validação que **também gera o tipo**, evitando descrever a mesma forma duas vezes.",
+                },
+                {
+                    type: "code",
+                    value: 'const resposta = await fetch("/api/usuario");\nconst dados = await resposta.json();\n// dados é any: o TypeScript não sabe nada sobre ele\n\n// Isto compila e mente\nconst usuario = dados as Usuario;\n\n// O caminho honesto: checar de verdade\nfunction ehUsuario(v: unknown): v is Usuario {\n  return (\n    typeof v === "object" && v !== null &&\n    "id" in v && typeof v.id === "number" &&\n    "nome" in v && typeof v.nome === "string"\n  );\n}',
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que acontece com os tipos na compilação?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Eles são apagados do resultado", isCorrect: true },
+                        { text: "Eles viram verificações em tempo de execução", isCorrect: false },
+                        { text: "Eles são guardados em um arquivo separado", isCorrect: false },
+                        { text: "Eles são convertidos em comentários no código", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O TypeScript protege contra dado errado vindo de uma API?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Não, nada é verificado em execução", isCorrect: true },
+                        { text: "Sim, ele valida a resposta antes de entregar", isCorrect: false },
+                        { text: "Sim, quando a interface está bem declarada", isCorrect: false },
+                        { text: "Sim, desde que o modo estrito esteja ligado", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `dados as Usuario` faz?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Afirma o tipo sem verificar nada", isCorrect: true },
+                        { text: "Converte o objeto para o formato de Usuario", isCorrect: false },
+                        { text: "Valida se o objeto tem os campos esperados", isCorrect: false },
+                        { text: "Cria uma cópia tipada do objeto original", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como checar de verdade a forma de um dado externo?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Validando campo a campo em execução", isCorrect: true },
+                        { text: "Declarando a interface com todos os campos", isCorrect: false },
+                        { text: "Usando o modo estrito no tsconfig do projeto", isCorrect: false },
+                        { text: "Anotando o retorno da função que busca", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a vantagem de uma biblioteca de validação que gera o tipo?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A forma é descrita uma vez só", isCorrect: true },
+                        { text: "A validação passa a rodar na compilação", isCorrect: false },
+                        { text: "O código gerado fica bem menor no fim", isCorrect: false },
+                        { text: "Os tipos deixam de ser apagados no build", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_2: Modulo = {
+    titulo: "Módulo 2 - Os tipos do dia a dia",
+    aulas: [
+        {
+            titulo: "Arrays, tuplas e objetos",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Arrays\n\nDuas formas escrevem a mesma coisa, e a comunidade prefere a primeira por ser mais curta.",
+                },
+                {
+                    type: "code",
+                    value: 'const nomes: string[] = ["Ana", "Bruno"];\nconst numeros: Array<number> = [1, 2, 3];\n\n// Array de objetos\nconst produtos: { nome: string; preco: number }[] = [\n  { nome: "Caneca", preco: 29.9 },\n];\n\n// Somente leitura: o array não pode ser alterado\nconst fixos: readonly string[] = ["a", "b"];\nfixos.push("c");   // erro',
+                },
+                {
+                    type: "text",
+                    value: "## Tuplas\n\nUma tupla é um array de **tamanho e tipos fixos por posição**. É o que descreve o retorno de um `useState` do React ou o par chave e valor de um `Object.entries`.",
+                },
+                {
+                    type: "code",
+                    value: 'const par: [string, number] = ["idade", 28];\n\n// Com nomes, que aparecem no autocompletar\nconst coord: [x: number, y: number] = [10, 20];\n\n// Opcional e resto\ntype Args = [nome: string, idade?: number, ...tags: string[]];',
+                },
+                {
+                    type: "text",
+                    value: "## Objetos e o excesso de propriedade\n\nO TypeScript recusa propriedade a mais em um **literal** de objeto, mas aceita se ele vier de uma variável. Essa assimetria surpreende, e existe para pegar erro de digitação onde ele é mais provável.",
+                },
+                {
+                    type: "code",
+                    value: 'type Produto = { nome: string; preco: number };\n\n// Erro: cor não existe em Produto\nconst a: Produto = { nome: "X", preco: 1, cor: "azul" };\n\n// Aceito: a checagem de excesso só vale para literais\nconst temp = { nome: "X", preco: 1, cor: "azul" };\nconst b: Produto = temp;',
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que uma tupla define além dos tipos?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O tamanho e a posição de cada item", isCorrect: true },
+                        { text: "A ordem em que os itens são percorridos", isCorrect: false },
+                        { text: "Os nomes que cada item terá no objeto", isCorrect: false },
+                        { text: "O valor padrão de cada posição do array", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `readonly string[]` impede?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Alterar o array, como um push", isCorrect: true },
+                        { text: "Ler qualquer item do array declarado", isCorrect: false },
+                        { text: "Criar o array com mais de um item", isCorrect: false },
+                        { text: "Passar o array para outra função", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que o TypeScript recusa propriedade a mais em um literal?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Para pegar erro de digitação onde é mais provável",
+                            isCorrect: true,
+                        },
+                        { text: "Porque o objeto ficaria maior na memória", isCorrect: false },
+                        {
+                            text: "Porque o tipo declarado não aceita nenhuma mudança",
+                            isCorrect: false,
+                        },
+                        { text: "Porque literais não podem ter tipo anotado", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Por que a mesma propriedade extra passa quando vem de uma variável?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "A checagem de excesso só vale para literais", isCorrect: true },
+                        { text: "A variável perde o tipo ao ser atribuída", isCorrect: false },
+                        { text: "O compilador ignora variáveis intermediárias", isCorrect: false },
+                        { text: "O tipo da variável é sempre inferido como any", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual forma de declarar array a comunidade prefere?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "string[]", isCorrect: true },
+                        { text: "Array<string>, que é mais explícita", isCorrect: false },
+                        { text: "[string], como em uma tupla", isCorrect: false },
+                        { text: "list<string>, no padrão de outras linguagens", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Union e narrowing",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Um valor, vários tipos possíveis\n\nA **união** diz que o valor é um de alguns tipos. Enquanto o TypeScript não souber qual, ele só permite o que é comum a todos.",
+                },
+                {
+                    type: "code",
+                    value: "function formatar(id: number | string): string {\n  return id.toUpperCase();   // erro: number não tem toUpperCase\n}",
+                },
+                {
+                    type: "text",
+                    value: "## Narrowing\n\n**Narrowing** é o TypeScript estreitar o tipo conforme o que o seu código verifica. Ele entende as verificações que você já escreveria de qualquer forma.",
+                },
+                {
+                    type: "code",
+                    value: 'function formatar(id: number | string): string {\n  if (typeof id === "string") {\n    return id.toUpperCase();   // aqui id é string\n  }\n  return id.toFixed(2);        // aqui só sobrou number\n}',
+                },
+                {
+                    type: "table",
+                    value: '[["Verificação", "Serve para"], ["typeof x === \'string\'", "primitivos"], ["x instanceof Date", "classes"], ["\'campo\' in x", "objetos com formas diferentes"], ["Array.isArray(x)", "arrays"], ["x === null", "separar o nulo"]]',
+                },
+                {
+                    type: "text",
+                    value: "## União discriminada\n\nO padrão mais útil de todos: um campo literal comum que identifica cada variante. O TypeScript usa esse campo para estreitar, e passa a exigir que você trate todos os casos.",
+                },
+                {
+                    type: "code",
+                    value: 'type Resultado =\n  | { status: "carregando" }\n  | { status: "ok"; dados: string[] }\n  | { status: "erro"; mensagem: string };\n\nfunction render(r: Resultado): string {\n  switch (r.status) {\n    case "carregando":\n      return "Aguarde...";\n    case "ok":\n      return r.dados.join(", ");   // dados só existe aqui\n    case "erro":\n      return r.mensagem;\n  }\n}',
+                },
+            ],
+            questions: [
+                {
+                    statement:
+                        "O que se pode fazer com um valor de tipo `number | string` antes de estreitar?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Apenas o que serve para os dois", isCorrect: true },
+                        { text: "Tudo que serve para qualquer um dos dois", isCorrect: false },
+                        { text: "Nada, é preciso estreitar sempre antes", isCorrect: false },
+                        { text: "Apenas convertê-lo para outro tipo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que é narrowing?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "O compilador estreitar o tipo conforme a verificação",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Converter o valor informado para um tipo bem mais específico",
+                            isCorrect: false,
+                        },
+                        { text: "Reduzir a quantidade de tipos de uma união", isCorrect: false },
+                        { text: "Remover os tipos que não são usados no código", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que caracteriza uma união discriminada?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Um campo literal comum que identifica a variante",
+                            isCorrect: true,
+                        },
+                        { text: "Um campo opcional presente em algumas delas", isCorrect: false },
+                        { text: "O uso de classes em vez de objetos simples", isCorrect: false },
+                        {
+                            text: "A quantidade igual de campos em cada uma das variantes",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Qual verificação estreita o tipo de uma classe?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "instanceof", isCorrect: true },
+                        { text: "typeof, que também funciona com classes", isCorrect: false },
+                        { text: "in, verificando um campo da classe", isCorrect: false },
+                        { text: "Array.isArray, para qualquer objeto", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a vantagem prática da união discriminada?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "O compilador cobra o tratamento de todos os casos",
+                            isCorrect: true,
+                        },
+                        { text: "Ela deixa o código gerado bem menor", isCorrect: false },
+                        {
+                            text: "Ela dispensa qualquer verificação de tipo no código",
+                            isCorrect: false,
+                        },
+                        { text: "Ela permite acessar todos os campos direto", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Literais, enum e const",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Tipos literais\n\nUm tipo pode ser um **valor exato**. Combinados em união, os literais criam conjuntos fechados sem precisar de enum.",
+                },
+                {
+                    type: "code",
+                    value: 'type Metodo = "GET" | "POST" | "PUT" | "DELETE";\ntype Tamanho = "p" | "m" | "g";\ntype Resposta = 200 | 404 | 500;\n\nfunction requisitar(url: string, metodo: Metodo) {}\n\nrequisitar("/api", "GET");    // ok\nrequisitar("/api", "GET ");   // erro: o espaço a mais não passa',
+                },
+                {
+                    type: "text",
+                    value: "## enum, e por que evitá-lo\n\nO `enum` existe desde o começo do TypeScript e é uma das poucas coisas que **gera código JavaScript**, quebrando a regra de que os tipos somem. Ele também tem comportamentos surpreendentes: o enum numérico aceita qualquer número.\n\nA recomendação atual da comunidade é preferir união de literais, ou um objeto com `as const` quando você precisa dos valores em execução.",
+                },
+                {
+                    type: "code",
+                    value: 'enum Status {\n  Ativo,\n  Inativo,\n}\nconst s: Status = 42;   // aceito, e não deveria ser\n\n// A alternativa: objeto com as const\nconst Status = {\n  Ativo: "ativo",\n  Inativo: "inativo",\n} as const;\n\ntype Status = (typeof Status)[keyof typeof Status];\n// tipo é "ativo" | "inativo"',
+                },
+                {
+                    type: "text",
+                    value: "## as const\n\nO `as const` congela um valor: objetos ficam `readonly` e os literais mantêm o tipo exato em vez de virarem `string`. É o que faz o padrão acima funcionar.",
+                },
+                {
+                    type: "code",
+                    value: 'const cores = ["azul", "verde"];\n// tipo: string[]\n\nconst cores = ["azul", "verde"] as const;\n// tipo: readonly ["azul", "verde"]\n\ntype Cor = (typeof cores)[number];   // "azul" | "verde"',
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que um tipo literal representa?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um valor exato, e não a categoria dele", isCorrect: true },
+                        { text: "Um valor que não pode ser alterado depois", isCorrect: false },
+                        { text: "Um valor escrito diretamente no código", isCorrect: false },
+                        { text: "Um tipo criado a partir de outro tipo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que o enum é a exceção à regra dos tipos apagados?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Ele gera código JavaScript no resultado", isCorrect: true },
+                        { text: "Ele é verificado durante a execução do código", isCorrect: false },
+                        { text: "Ele precisa ser importado em cada arquivo", isCorrect: false },
+                        { text: "Ele guarda os valores em uma tabela à parte", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual comportamento surpreendente o enum numérico tem?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Ele aceita qualquer número como valor", isCorrect: true },
+                        { text: "Ele começa a contagem a partir de um", isCorrect: false },
+                        { text: "Ele não pode ser usado dentro de uniões", isCorrect: false },
+                        { text: "Ele converte os valores para texto sozinho", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `as const` faz com um array?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Torna somente leitura e fixa os literais", isCorrect: true },
+                        { text: "Impede que ele seja passado a funções", isCorrect: false },
+                        { text: "Converte todos os itens para o mesmo tipo", isCorrect: false },
+                        { text: "Guarda o array em uma constante global", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que a comunidade recomenda no lugar do enum?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "União de literais ou objeto com as const", isCorrect: true },
+                        { text: "Classes com propriedades estáticas", isCorrect: false },
+                        { text: "Constantes soltas exportadas do módulo", isCorrect: false },
+                        { text: "Um tipo com todos os valores como opcionais", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Funções: parâmetros e retorno",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Tipando funções\n\nA assinatura é o contrato. Parâmetros opcionais levam interrogação e vêm depois dos obrigatórios; o resto é recolhido com `...`.",
+                },
+                {
+                    type: "code",
+                    value: "function criar(nome: string, idade?: number, ...tags: string[]): void {}\n\n// Tipo de uma função, para passar adiante\ntype Comparador = (a: number, b: number) => number;\n\nconst crescente: Comparador = (a, b) => a - b;\n// a e b não precisam de anotação: vêm do tipo",
+                },
+                {
+                    type: "text",
+                    value: "## Inferência contextual\n\nRepare que `crescente` não anota os parâmetros. Quando o TypeScript já sabe o tipo esperado pelo contexto, ele preenche o resto. É o que faz callbacks funcionarem sem anotação nenhuma.",
+                },
+                {
+                    type: "code",
+                    value: "const numeros = [3, 1, 2];\n\nnumeros.map((n) => n * 2);       // n é number, inferido\nnumeros.filter((n) => n > 1);    // idem\nnumeros.sort((a, b) => a - b);   // idem",
+                },
+                {
+                    type: "text",
+                    value: "## void e o retorno ignorado\n\n`void` significa que o retorno não interessa. Uma sutileza útil: uma função que **devolve algo** pode ser usada onde se espera `void`, porque o retorno simplesmente é ignorado. É o que permite `array.forEach(x => lista.push(x))` sem reclamação.",
+                },
+                {
+                    type: "code",
+                    value: "type Callback = () => void;\n\nconst cb: Callback = () => 42;   // ok, o 42 é ignorado\n\n// Diferente de never, que é o que nunca retorna\nfunction falhar(msg: string): never {\n  throw new Error(msg);\n}",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Onde ficam os parâmetros opcionais na assinatura?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Depois dos obrigatórios", isCorrect: true },
+                        { text: "Antes dos obrigatórios, para ficarem visíveis", isCorrect: false },
+                        { text: "Em qualquer posição, desde que anotados", isCorrect: false },
+                        { text: "Sempre por último, depois do parâmetro resto", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que é inferência contextual?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O tipo vir do contexto em que a função é usada", isCorrect: true },
+                        { text: "O tipo ser deduzido do corpo da função", isCorrect: false },
+                        { text: "O tipo ser copiado da função anterior", isCorrect: false },
+                        {
+                            text: "O tipo mudar conforme os argumentos que foram passados",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Uma função que devolve valor pode ser usada onde se espera `void`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Sim, o retorno é apenas ignorado", isCorrect: true },
+                        { text: "Não, o retorno precisa ser exatamente void", isCorrect: false },
+                        { text: "Sim, mas o valor precisa ser undefined", isCorrect: false },
+                        { text: "Só quando a função é uma arrow function", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a diferença entre `void` e `never`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O never indica que a função nunca retorna", isCorrect: true },
+                        { text: "O void aceita qualquer valor como retorno", isCorrect: false },
+                        { text: "O never é usado apenas em classes", isCorrect: false },
+                        { text: "O void só funciona com arrow functions", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como se declara o tipo de uma função?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Com uma seta entre parâmetros e retorno", isCorrect: true },
+                        { text: "Com a palavra function antes do nome", isCorrect: false },
+                        { text: "Com dois-pontos entre os parâmetros", isCorrect: false },
+                        { text: "Com a palavra type dentro dos parênteses", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "any, unknown, never e void",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Os quatro tipos especiais\n\nEsses quatro confundem por terem nomes parecidos e propósitos bem diferentes.",
+                },
+                {
+                    type: "table",
+                    value: '[["Tipo", "Significa", "Quando aparece"], ["any", "desliga a checagem", "quase nunca deveria"], ["unknown", "não sei ainda", "dado vindo de fora"], ["never", "nunca acontece", "função que lança"], ["void", "retorno sem valor", "função sem return"]]',
+                },
+                {
+                    type: "text",
+                    value: "## any é a saída de emergência\n\nCom `any` o TypeScript para de checar aquele valor **e tudo que sai dele**. Um `any` no meio do código apaga a segurança de todo o caminho por onde ele passa, silenciosamente.",
+                },
+                {
+                    type: "code",
+                    value: 'const dados: any = JSON.parse(texto);\ndados.qualquer.coisa.que.nao.existe;   // compila, e quebra rodando\n\n// unknown obriga a verificar antes de usar\nconst dados: unknown = JSON.parse(texto);\ndados.nome;   // erro: precisa estreitar primeiro\n\nif (typeof dados === "object" && dados !== null && "nome" in dados) {\n  console.log(dados.nome);   // agora sim\n}',
+                },
+                {
+                    type: "quote",
+                    value: "unknown é o any com responsabilidade: aceita qualquer valor na entrada, mas exige verificação antes do uso.",
+                },
+                {
+                    type: "text",
+                    value: "## never e a checagem de exaustão\n\n`never` é o tipo do que não pode acontecer. O uso mais valioso dele é garantir que você tratou **todos** os casos de uma união: se um caso novo for acrescentado depois, o compilador aponta o lugar esquecido.",
+                },
+                {
+                    type: "code",
+                    value: 'type Forma = { tipo: "circulo"; raio: number } | { tipo: "quadrado"; lado: number };\n\nfunction area(f: Forma): number {\n  switch (f.tipo) {\n    case "circulo":\n      return Math.PI * f.raio ** 2;\n    case "quadrado":\n      return f.lado ** 2;\n    default: {\n      // Se surgir uma forma nova, este atribuição falha\n      const impossivel: never = f;\n      return impossivel;\n    }\n  }\n}',
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que `any` faz com a checagem de tipos?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Desliga para aquele valor e o que sai dele", isCorrect: true },
+                        {
+                            text: "Aceita qualquer valor, mas ainda verifica o uso",
+                            isCorrect: false,
+                        },
+                        { text: "Converte o valor para o tipo mais próximo", isCorrect: false },
+                        { text: "Marca o valor para ser verificado depois", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a diferença entre `any` e `unknown`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O unknown exige verificação antes do uso", isCorrect: true },
+                        { text: "O any aceita bem mais tipos que o unknown", isCorrect: false },
+                        { text: "O unknown só funciona com objetos", isCorrect: false },
+                        { text: "O any é verificado durante a execução", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o tipo `never` representa?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Algo que nunca acontece", isCorrect: true },
+                        { text: "Um valor que ainda não foi definido", isCorrect: false },
+                        { text: "Um retorno vazio de uma função", isCorrect: false },
+                        { text: "Um valor que pode ser qualquer coisa", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Para que serve atribuir a uma variável `never` no default de um switch?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Garantir que todos os casos foram tratados", isCorrect: true },
+                        {
+                            text: "Impedir que o switch caia no caso padrão do fim",
+                            isCorrect: false,
+                        },
+                        { text: "Lançar uma exceção quando nada casa", isCorrect: false },
+                        { text: "Documentar que o caso é impossível", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual o tipo certo para o retorno de um `JSON.parse`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "unknown, para forçar a verificação", isCorrect: true },
+                        { text: "any, que é o padrão da própria função", isCorrect: false },
+                        { text: "object, já que sempre devolve um objeto", isCorrect: false },
+                        { text: "string, porque a entrada era texto", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_3: Modulo = {
+    titulo: "Módulo 3 - Modelando com tipos",
+    aulas: [
+        {
+            titulo: "Interface e type alias",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Duas formas de nomear uma forma\n\n`interface` e `type` fazem quase a mesma coisa. A escolha entre eles gera discussão maior do que merece, porque na prática as diferenças são poucas.",
+                },
+                {
+                    type: "code",
+                    value: "interface Usuario {\n  id: number;\n  nome: string;\n  email: string;\n}\n\ntype Usuario = {\n  id: number;\n  nome: string;\n  email: string;\n};",
+                },
+                {
+                    type: "table",
+                    value: '[["", "interface", "type"], ["Descreve objeto", "sim", "sim"], ["União e tupla", "não", "sim"], ["Estender", "com extends", "com interseção"], ["Declarar duas vezes", "junta as duas", "erro"], ["Tipos que calculam", "não", "sim"]]',
+                },
+                {
+                    type: "text",
+                    value: "## A diferença que decide\n\nA **fusão de declarações** é o que separa os dois na prática: declarar a mesma `interface` duas vezes junta os campos, e isso é como se estende tipos de bibliotecas de terceiros. Com `type`, redeclarar é erro.\n\nA regra que a maioria dos times adota: **interface para forma de objeto, type para o resto**.",
+                },
+                {
+                    type: "code",
+                    value: '// Acrescentando um campo a um tipo de biblioteca\ndeclare module "express" {\n  interface Request {\n    usuario?: Usuario;\n  }\n}\n\n// type é obrigatório aqui\ntype Resultado = Sucesso | Erro;\ntype Par = [string, number];\ntype Chaves = keyof Usuario;',
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que só o `type` consegue descrever?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Uniões e tuplas", isCorrect: true },
+                        { text: "Objetos com campos opcionais dentro", isCorrect: false },
+                        { text: "Formas que serão estendidas depois", isCorrect: false },
+                        { text: "Tipos usados em mais de um arquivo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que acontece ao declarar a mesma `interface` duas vezes?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "As declarações se juntam", isCorrect: true },
+                        { text: "A segunda substitui a primeira por completo", isCorrect: false },
+                        { text: "O compilador aponta um erro de duplicidade", isCorrect: false },
+                        { text: "A segunda é ignorada em completo silêncio", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Para que serve a fusão de declarações na prática?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Estender tipos de bibliotecas de terceiros", isCorrect: true },
+                        { text: "Dividir uma interface grande em arquivos", isCorrect: false },
+                        { text: "Permitir dois tipos com o mesmo nome", isCorrect: false },
+                        { text: "Sobrescrever campos herdados de outro tipo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual regra a maioria dos times adota?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Interface para objeto, type para o resto", isCorrect: true },
+                        { text: "Sempre type, por ser mais poderoso", isCorrect: false },
+                        { text: "Sempre interface, por ser bem mais rápido", isCorrect: false },
+                        { text: "Alternar conforme o tamanho do tipo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como uma `interface` estende outra?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Com a palavra extends", isCorrect: true },
+                        { text: "Com o operador de interseção", isCorrect: false },
+                        { text: "Com a palavra implements", isCorrect: false },
+                        { text: "Com dois-pontos após o nome", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Opcional, readonly e index signature",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Campos opcionais\n\nA interrogação marca o campo como opcional: ele pode faltar, e ao ler o tipo inclui `undefined`.",
+                },
+                {
+                    type: "code",
+                    value: 'interface Config {\n  url: string;\n  tempoLimite?: number;\n  cabecalhos?: Record<string, string>;\n}\n\nconst c: Config = { url: "/api" };   // ok\nc.tempoLimite.toFixed();             // erro: pode ser undefined\nc.tempoLimite?.toFixed();            // ok',
+                },
+                {
+                    type: "text",
+                    value: "## Opcional não é o mesmo que aceitar undefined\n\nUma distinção que aparece em revisão de código: `campo?: number` permite **omitir**, enquanto `campo: number | undefined` **exige** o campo, ainda que com valor indefinido. Em objeto de configuração você quer o primeiro; em resposta de API, muitas vezes o segundo.",
+                },
+                {
+                    type: "text",
+                    value: "## readonly\n\nMarca o campo como imutável depois de criado. Vale só na checagem: nada impede a alteração em execução, porque o tipo sumiu.",
+                },
+                {
+                    type: "code",
+                    value: "interface Ponto {\n  readonly x: number;\n  readonly y: number;\n}\n\nconst p: Ponto = { x: 1, y: 2 };\np.x = 10;   // erro na compilação",
+                },
+                {
+                    type: "text",
+                    value: "## Index signature\n\nQuando as chaves não são conhecidas de antemão, você descreve o formato delas. `Record<K, V>` é a forma curta e mais legível.",
+                },
+                {
+                    type: "code",
+                    value: "interface Dicionario {\n  [chave: string]: number;\n}\n\n// O mesmo, mais curto\ntype Dicionario = Record<string, number>;\n\n// Combinando chaves conhecidas com o resto\ninterface Resposta {\n  status: number;\n  [extra: string]: unknown;\n}",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que a interrogação faz em um campo?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Permite que ele seja omitido", isCorrect: true },
+                        { text: "Permite que ele receba qualquer tipo", isCorrect: false },
+                        { text: "Marca o campo como somente leitura", isCorrect: false },
+                        { text: "Indica que o campo pode ser nulo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Qual a diferença entre `campo?: number` e `campo: number | undefined`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O segundo exige o campo, mesmo indefinido", isCorrect: true },
+                        {
+                            text: "O primeiro aceita o null e o segundo não aceita",
+                            isCorrect: false,
+                        },
+                        { text: "O segundo só funciona em interfaces", isCorrect: false },
+                        { text: "Não há diferença prática entre os dois", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O `readonly` impede alteração em execução?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Não, ele só vale na checagem", isCorrect: true },
+                        { text: "Sim, o campo fica congelado no objeto", isCorrect: false },
+                        { text: "Sim, quando o modo estrito está ligado", isCorrect: false },
+                        { text: "Sim, o compilador gera um Object.freeze", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Para que serve uma index signature?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Descrever objetos com chaves desconhecidas", isCorrect: true },
+                        { text: "Criar um índice para uma busca mais rápida", isCorrect: false },
+                        { text: "Ordenar as chaves de um objeto", isCorrect: false },
+                        { text: "Impedir que chaves novas sejam criadas", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a forma curta de `{ [k: string]: number }`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Record<string, number>", isCorrect: true },
+                        { text: "Map<string, number>, da biblioteca padrão", isCorrect: false },
+                        { text: "Dictionary<string, number>, tipo interno", isCorrect: false },
+                        { text: "Index<string, number>, na sintaxe curta", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Interseção e composição",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Somando formas\n\nO `&` cria um tipo que tem **tudo** dos dois. É a forma de compor tipos pequenos em vez de escrever um grande.",
+                },
+                {
+                    type: "code",
+                    value: "type ComId = { id: number };\ntype ComDatas = { criadoEm: Date; atualizadoEm: Date };\ntype DadosUsuario = { nome: string; email: string };\n\ntype Usuario = ComId & ComDatas & DadosUsuario;\n\n// Reaproveitando nos outros\ntype Produto = ComId & ComDatas & { nome: string; preco: number };",
+                },
+                {
+                    type: "text",
+                    value: "## Interseção e união se confundem\n\nOs símbolos enganam quem vem de outras linguagens:\n\n- `A & B` é **e**: precisa satisfazer os dois, então tem os campos dos dois\n- `A | B` é **ou**: é um dos dois, então só dá para usar o que é comum\n\nA confusão vem de que a interseção **aumenta** os campos disponíveis, enquanto a união os reduz.",
+                },
+                {
+                    type: "code",
+                    value: "type A = { x: number; y: number };\ntype B = { y: number; z: number };\n\ntype E = A & B;   // tem x, y e z\ntype Ou = A | B;  // só y é garantido\n\nfunction f(v: Ou) {\n  v.y;   // ok\n  v.x;   // erro: pode ser um B\n}",
+                },
+                {
+                    type: "text",
+                    value: "## Quando a interseção não faz sentido\n\nInterseção de tipos incompatíveis gera `never`, um tipo que nenhum valor satisfaz. O compilador aceita a declaração e o erro só aparece quando alguém tenta usar.",
+                },
+                {
+                    type: "code",
+                    value: "type Impossivel = { a: string } & { a: number };\n// o campo a vira never: nada é string e number ao mesmo tempo",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que `A & B` produz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um tipo com os campos dos dois", isCorrect: true },
+                        { text: "Um tipo com os campos comuns aos dois", isCorrect: false },
+                        { text: "Um tipo que é um dos dois, não os dois", isCorrect: false },
+                        { text: "Um tipo sem nenhum campo em comum", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que se pode acessar em um valor do tipo `A | B`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Apenas o que existe nos dois", isCorrect: true },
+                        { text: "Tudo que existe em qualquer um deles", isCorrect: false },
+                        { text: "Nada, é preciso converter antes de usar", isCorrect: false },
+                        { text: "Apenas os campos que forem opcionais", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que interseção e união confundem?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "A interseção aumenta os campos e a união reduz", isCorrect: true },
+                        { text: "Os dois símbolos são muito parecidos", isCorrect: false },
+                        {
+                            text: "Os dois acabam produzindo o mesmo resultado final",
+                            isCorrect: false,
+                        },
+                        { text: "A união só funciona com tipos primitivos", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que acontece ao intersectar `{ a: string }` com `{ a: number }`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O campo vira never e nada satisfaz o tipo", isCorrect: true },
+                        { text: "O compilador aponta um erro na declaração", isCorrect: false },
+                        { text: "O último tipo declarado vence o conflito", isCorrect: false },
+                        { text: "O campo passa a aceitar os dois tipos", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a vantagem de compor tipos pequenos?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Reaproveitar as partes comuns entre eles", isCorrect: true },
+                        { text: "Reduzir o tamanho do código compilado", isCorrect: false },
+                        { text: "Acelerar a checagem feita pelo compilador", isCorrect: false },
+                        { text: "Permitir que os tipos sejam alterados depois", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Generics",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Tipos com parâmetro\n\nSem generics, uma função que funciona com qualquer tipo perde a informação: entra `string`, sai `any`. O **generic** guarda o tipo que entrou e o devolve na saída.",
+                },
+                {
+                    type: "code",
+                    value: '// Perde o tipo\nfunction primeiro(lista: any[]): any {\n  return lista[0];\n}\nconst n = primeiro([1, 2, 3]);   // any, e o editor não ajuda\n\n// Preserva\nfunction primeiro<T>(lista: T[]): T | undefined {\n  return lista[0];\n}\nconst n = primeiro([1, 2, 3]);        // number\nconst s = primeiro(["a", "b"]);       // string',
+                },
+                {
+                    type: "text",
+                    value: "O `<T>` é um **parâmetro de tipo**: ele é preenchido na chamada, quase sempre por inferência. Você raramente precisa escrever `primeiro<number>([1,2,3])`.\n\n## Em tipos e interfaces\n\nGenerics não são só de função. Eles descrevem estruturas que carregam outro tipo dentro.",
+                },
+                {
+                    type: "code",
+                    value: "interface Resposta<T> {\n  dados: T;\n  status: number;\n  erro?: string;\n}\n\ntype RespostaUsuario = Resposta<Usuario>;\ntype RespostaLista = Resposta<Produto[]>;\n\n// Vários parâmetros\nfunction par<A, B>(a: A, b: B): [A, B] {\n  return [a, b];\n}",
+                },
+                {
+                    type: "quote",
+                    value: "Se um parâmetro de tipo aparece uma vez só na assinatura, ele provavelmente não deveria existir: generic serve para ligar entrada e saída.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Que problema o generic resolve?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Preservar o tipo que entrou até a saída", isCorrect: true },
+                        { text: "Permitir que a função aceite mais tipos", isCorrect: false },
+                        { text: "Reduzir a quantidade de código escrito", isCorrect: false },
+                        { text: "Validar os argumentos em tempo de execução", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como o valor de `<T>` costuma ser definido?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Por inferência, a partir dos argumentos", isCorrect: true },
+                        {
+                            text: "Escrito explicitamente em toda e qualquer chamada",
+                            isCorrect: false,
+                        },
+                        { text: "Declarado uma vez no topo do arquivo", isCorrect: false },
+                        { text: "Definido no tsconfig do projeto", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Generics servem apenas para funções?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Não, também para tipos e interfaces", isCorrect: true },
+                        { text: "Sim, só funções podem ter parâmetro de tipo", isCorrect: false },
+                        { text: "Não, mas em interfaces são apenas decorativos", isCorrect: false },
+                        { text: "Sim, e apenas quando elas devolvem valor", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que indica que um generic talvez seja desnecessário?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Ele aparecer uma única vez na assinatura", isCorrect: true },
+                        { text: "Ele ser usado em mais de um dos parâmetros", isCorrect: false },
+                        { text: "O nome dele não ser a letra T", isCorrect: false },
+                        { text: "Ele ser inferido em vez de escrito", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `Resposta<Produto[]>` significa?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Uma resposta cujos dados são uma lista de produtos",
+                            isCorrect: true,
+                        },
+                        { text: "Uma lista de respostas contendo produtos", isCorrect: false },
+                        {
+                            text: "Uma resposta que pode conter um produto ou uma lista",
+                            isCorrect: false,
+                        },
+                        { text: "Um produto que contém uma resposta dentro", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Restrições em generics",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Limitando o que T pode ser\n\nUm generic sem restrição aceita qualquer tipo, e por isso você não pode acessar nada dentro dele. O `extends` impõe um mínimo.",
+                },
+                {
+                    type: "code",
+                    value: '// Erro: T pode ser qualquer coisa, e nem tudo tem length\nfunction tamanho<T>(v: T): number {\n  return v.length;\n}\n\n// Com restrição: T precisa ter length\nfunction tamanho<T extends { length: number }>(v: T): number {\n  return v.length;\n}\n\ntamanho("texto");     // ok\ntamanho([1, 2, 3]);   // ok\ntamanho(42);          // erro: number não tem length',
+                },
+                {
+                    type: "text",
+                    value: "## keyof\n\n`keyof T` é a união das chaves de `T`. Combinado com generics, ele permite escrever funções que acessam campos com segurança total.",
+                },
+                {
+                    type: "code",
+                    value: 'interface Usuario {\n  id: number;\n  nome: string;\n  email: string;\n}\n\ntype ChaveUsuario = keyof Usuario;   // "id" | "nome" | "email"\n\nfunction pegar<T, K extends keyof T>(obj: T, chave: K): T[K] {\n  return obj[chave];\n}\n\nconst u: Usuario = { id: 1, nome: "Ana", email: "a@b.c" };\n\nconst id = pegar(u, "id");       // number\nconst nome = pegar(u, "nome");   // string\npegar(u, "idade");               // erro: chave não existe',
+                },
+                {
+                    type: "text",
+                    value: "Repare no retorno `T[K]`: ele é o tipo do campo acessado, que muda conforme a chave passada. O editor sabe que `pegar(u, 'id')` é um número sem que você diga nada.\n\n## Valor padrão\n\nParâmetros de tipo aceitam padrão, útil quando o caso mais comum é sempre o mesmo.",
+                },
+                {
+                    type: "code",
+                    value: "interface Resposta<T = unknown> {\n  dados: T;\n  status: number;\n}\n\ntype Simples = Resposta;   // dados é unknown",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que `extends` faz em um parâmetro de tipo?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Impõe um mínimo que o tipo precisa ter", isCorrect: true },
+                        { text: "Faz o tipo herdar de outra interface", isCorrect: false },
+                        { text: "Permite que o tipo seja estendido depois", isCorrect: false },
+                        { text: "Cria uma cópia do tipo com mais campos", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `keyof Usuario` produz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A união das chaves do tipo", isCorrect: true },
+                        { text: "Um array com os nomes das chaves", isCorrect: false },
+                        { text: "Um objeto com as chaves e os tipos", isCorrect: false },
+                        { text: "A quantidade de campos que o tipo tem", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o retorno `T[K]` representa?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O tipo do campo acessado por aquela chave", isCorrect: true },
+                        { text: "Um array indexado pelo tipo da chave", isCorrect: false },
+                        { text: "O tipo da chave e não do valor", isCorrect: false },
+                        { text: "Um tipo genérico que aceita qualquer campo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que não se pode acessar `v.length` em um `T` sem restrição?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Porque T pode ser um tipo que não tem length", isCorrect: true },
+                        {
+                            text: "Porque generics não permitem acessar campo algum",
+                            isCorrect: false,
+                        },
+                        { text: "Porque length é uma propriedade privada", isCorrect: false },
+                        { text: "Porque o valor ainda não foi inicializado", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Para que serve um valor padrão em parâmetro de tipo?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Dispensar informá-lo no caso mais comum", isCorrect: true },
+                        { text: "Permitir que ele seja omitido na declaração", isCorrect: false },
+                        { text: "Garantir que o tipo nunca seja undefined", isCorrect: false },
+                        { text: "Definir um valor inicial para a variável", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_4: Modulo = {
+    titulo: "Módulo 4 - Tipos que calculam",
+    aulas: [
+        {
+            titulo: "Utility types",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Transformações que já vêm prontas\n\nO TypeScript traz um conjunto de tipos que derivam um tipo de outro. Eles evitam a duplicação mais comum de todas: escrever quase a mesma interface de novo com uma diferença pequena.",
+                },
+                {
+                    type: "table",
+                    value: '[["Utility", "O que faz"], ["Partial<T>", "todos os campos viram opcionais"], ["Required<T>", "todos viram obrigatórios"], ["Readonly<T>", "todos viram somente leitura"], ["Pick<T, K>", "só as chaves escolhidas"], ["Omit<T, K>", "todas menos as escolhidas"], ["Record<K, V>", "objeto de chaves K e valores V"], ["ReturnType<F>", "o que a função devolve"]]',
+                },
+                {
+                    type: "code",
+                    value: 'interface Usuario {\n  id: number;\n  nome: string;\n  email: string;\n  senha: string;\n}\n\n// O que a API devolve: sem a senha\ntype UsuarioPublico = Omit<Usuario, "senha">;\n\n// O que o formulário de edição aceita: tudo opcional, sem o id\ntype AtualizarUsuario = Partial<Omit<Usuario, "id">>;\n\n// O que o cadastro exige\ntype CriarUsuario = Pick<Usuario, "nome" | "email" | "senha">;',
+                },
+                {
+                    type: "text",
+                    value: "## Por que isso importa\n\nOs quatro tipos acima derivam de `Usuario`. Quando um campo é acrescentado lá, os quatro acompanham sozinhos. Escritos à mão, um deles seria esquecido na próxima alteração, e esse é exatamente o tipo de bug que o TypeScript deveria evitar.",
+                },
+                {
+                    type: "code",
+                    value: "// Extraindo tipos de funções e promessas\ntype Resultado = ReturnType<typeof buscarUsuario>;\ntype Dados = Awaited<ReturnType<typeof buscarUsuario>>;\ntype Params = Parameters<typeof criar>;",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que `Partial<T>` faz?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Torna todos os campos opcionais", isCorrect: true },
+                        { text: "Remove metade dos campos do tipo", isCorrect: false },
+                        { text: "Torna todos os campos somente leitura", isCorrect: false },
+                        { text: "Cria um tipo com apenas um campo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a diferença entre `Pick` e `Omit`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um escolhe as chaves e o outro as descarta", isCorrect: true },
+                        { text: "Um funciona com interfaces e o outro com type", isCorrect: false },
+                        { text: "Um mantém a ordem e o outro reordena", isCorrect: false },
+                        { text: "Um aceita uma chave e o outro várias", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a vantagem de derivar tipos em vez de escrevê-los à mão?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Eles acompanham a mudança do tipo de origem", isCorrect: true },
+                        { text: "Eles ocupam menos espaço no arquivo final", isCorrect: false },
+                        { text: "Eles são checados mais rápido pelo compilador", isCorrect: false },
+                        {
+                            text: "Eles permitem campos que não existem na origem",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que `ReturnType<typeof f>` devolve?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O tipo que a função f devolve", isCorrect: true },
+                        { text: "Os tipos dos parâmetros da função f", isCorrect: false },
+                        { text: "O tipo da própria função f", isCorrect: false },
+                        { text: "O valor devolvido pela função f", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Para que serve `Awaited<T>`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Extrair o tipo de dentro de uma promessa", isCorrect: true },
+                        { text: "Fazer o tipo esperar a execução terminar", isCorrect: false },
+                        { text: "Marcar a função como assíncrona", isCorrect: false },
+                        { text: "Converter um tipo comum em promessa", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Conditional types",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Tipos com if\n\nUm **conditional type** escolhe entre dois tipos conforme uma condição. A sintaxe é o ternário, aplicado a tipos.",
+                },
+                {
+                    type: "code",
+                    value: 'type EhString<T> = T extends string ? "sim" : "não";\n\ntype A = EhString<"oi">;   // "sim"\ntype B = EhString<42>;     // "não"\n\n// Um caso útil: descartar null e undefined\ntype SemNulo<T> = T extends null | undefined ? never : T;\ntype C = SemNulo<string | null>;   // string',
+                },
+                {
+                    type: "text",
+                    value: "## Distributividade\n\nO comportamento que mais surpreende: quando o tipo testado é uma **união** e aparece sozinho antes do `extends`, a condição é aplicada **a cada membro separadamente**, e os resultados voltam como união.\n\nÉ isso que faz `SemNulo<string | null>` devolver `string` em vez de `string | null`.",
+                },
+                {
+                    type: "code",
+                    value: "type Caixa<T> = T extends unknown ? T[] : never;\n\ntype D = Caixa<string | number>;\n// distribui: string[] | number[]\n\n// Para NÃO distribuir, envolva em colchetes\ntype Caixa2<T> = [T] extends [unknown] ? T[] : never;\ntype E = Caixa2<string | number>;\n// não distribui: (string | number)[]",
+                },
+                {
+                    type: "text",
+                    value: "## infer\n\nDentro de um conditional type, `infer` **captura** um pedaço do tipo em uma variável. É como os utility types de extração são construídos.",
+                },
+                {
+                    type: "code",
+                    value: "// Extraindo o tipo de dentro de um array\ntype Item<T> = T extends (infer U)[] ? U : never;\ntype F = Item<string[]>;   // string\n\n// Extraindo o retorno de uma função\ntype Retorno<T> = T extends (...args: any[]) => infer R ? R : never;\n\n// Extraindo de dentro de uma promessa\ntype Resolvido<T> = T extends Promise<infer U> ? U : T;",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual a sintaxe de um conditional type?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A do ternário, com extends na condição", isCorrect: true },
+                        { text: "A do if e else, com chaves em volta", isCorrect: false },
+                        { text: "A do switch, com um caso por tipo", isCorrect: false },
+                        { text: "A do operador de união escrito entre os dois", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que acontece quando o tipo testado é uma união?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "A condição é aplicada a cada membro", isCorrect: true },
+                        { text: "A condição é aplicada à união inteira", isCorrect: false },
+                        { text: "O compilador aponta erro de ambiguidade", isCorrect: false },
+                        { text: "Apenas o primeiro membro é considerado", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como se impede a distributividade?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Envolvendo os dois lados em colchetes", isCorrect: true },
+                        { text: "Usando never no lugar do unknown", isCorrect: false },
+                        { text: "Declarando o tipo como não genérico", isCorrect: false },
+                        { text: "Trocando o extends por uma interseção", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `infer` faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Captura um pedaço do tipo em uma variável", isCorrect: true },
+                        { text: "Deduz o tipo a partir de um valor", isCorrect: false },
+                        { text: "Força o compilador a inferir de novo", isCorrect: false },
+                        { text: "Declara um parâmetro de tipo como opcional", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `T extends (infer U)[] ? U : never` faz?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Extrai o tipo dos itens de um array", isCorrect: true },
+                        { text: "Verifica se o tipo é um array vazio", isCorrect: false },
+                        { text: "Converte qualquer tipo em um array", isCorrect: false },
+                        { text: "Devolve o tamanho do array informado", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Mapped types",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Percorrendo as chaves de um tipo\n\nUm **mapped type** cria um tipo novo aplicando uma transformação a cada chave de outro. É assim que `Partial` e `Readonly` são implementados, e você pode escrever os seus.",
+                },
+                {
+                    type: "code",
+                    value: "// É assim que Partial é definido\ntype Partial<T> = {\n  [K in keyof T]?: T[K];\n};\n\n// E Readonly\ntype Readonly<T> = {\n  readonly [K in keyof T]: T[K];\n};\n\n// Um seu: tudo vira string\ntype Stringificado<T> = {\n  [K in keyof T]: string;\n};",
+                },
+                {
+                    type: "text",
+                    value: "## Acrescentar e remover modificadores\n\nO `-` na frente de `?` ou `readonly` **remove** o modificador. É como `Required` funciona.",
+                },
+                {
+                    type: "code",
+                    value: "type Required<T> = {\n  [K in keyof T]-?: T[K];\n};\n\ntype Mutavel<T> = {\n  -readonly [K in keyof T]: T[K];\n};",
+                },
+                {
+                    type: "text",
+                    value: "## Renomeando chaves com `as`\n\nO `as` dentro do mapped type permite mudar o nome de cada chave. Combinado com template literal types, ele gera famílias inteiras de tipos.",
+                },
+                {
+                    type: "code",
+                    value: "interface Usuario {\n  nome: string;\n  idade: number;\n}\n\ntype Getters<T> = {\n  [K in keyof T as `get${Capitalize<string & K>}`]: () => T[K];\n};\n\ntype UsuarioGetters = Getters<Usuario>;\n// { getNome: () => string; getIdade: () => number }",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que um mapped type faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Transforma cada chave de outro tipo", isCorrect: true },
+                        { text: "Converte um tipo em um objeto Map", isCorrect: false },
+                        { text: "Mapeia valores para chaves diferentes", isCorrect: false },
+                        { text: "Percorre os valores de um objeto", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o `-?` faz em um mapped type?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Remove a opcionalidade das chaves", isCorrect: true },
+                        { text: "Torna todas as chaves opcionais", isCorrect: false },
+                        { text: "Remove as chaves que são opcionais", isCorrect: false },
+                        { text: "Inverte o tipo de cada chave", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Para que serve o `as` dentro de um mapped type?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Renomear as chaves geradas", isCorrect: true },
+                        { text: "Afirmar o tipo de cada valor", isCorrect: false },
+                        { text: "Converter o tipo para outro formato", isCorrect: false },
+                        { text: "Filtrar quais chaves serão incluídas", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como `Readonly<T>` é implementado?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Como um mapped type que acrescenta readonly", isCorrect: true },
+                        { text: "Como uma função interna do compilador", isCorrect: false },
+                        { text: "Como uma interseção com um tipo vazio", isCorrect: false },
+                        {
+                            text: "Como um conditional type aplicado sobre as chaves",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que `[K in keyof T]` percorre?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Cada chave do tipo T", isCorrect: true },
+                        { text: "Cada valor guardado no objeto T", isCorrect: false },
+                        { text: "Cada tipo da união chamada T", isCorrect: false },
+                        { text: "Cada item de um array do tipo T", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Template literal types",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Strings que o compilador entende\n\nUm **template literal type** monta tipos de texto a partir de outros tipos. Ele transforma padrões de nome, que antes eram convenção informal, em algo que o compilador verifica.",
+                },
+                {
+                    type: "code",
+                    value: 'type Metodo = "get" | "post";\ntype Recurso = "usuario" | "produto";\n\ntype Rota = `/${Recurso}`;\n// "/usuario" | "/produto"\n\ntype Handler = `${Metodo}${Capitalize<Recurso>}`;\n// "getUsuario" | "getProduto" | "postUsuario" | "postProduto"',
+                },
+                {
+                    type: "text",
+                    value: "Repare que a combinação é feita pelo compilador: duas uniões de dois membros geram quatro possibilidades. Escrever isso à mão não escala.\n\n## Os utilitários de texto\n\nQuatro tipos internos transformam o texto: `Uppercase`, `Lowercase`, `Capitalize` e `Uncapitalize`.",
+                },
+                {
+                    type: "code",
+                    value: 'type A = Uppercase<"abc">;      // "ABC"\ntype B = Capitalize<"nome">;    // "Nome"\ntype C = Lowercase<"ABC">;      // "abc"',
+                },
+                {
+                    type: "text",
+                    value: "## Um caso real\n\nO padrão mais comum é tipar um objeto de eventos ou de rotas, garantindo que o nome siga a convenção.",
+                },
+                {
+                    type: "code",
+                    value: 'type Evento = "click" | "focus" | "blur";\n\ntype Ouvintes = {\n  [E in Evento as `on${Capitalize<E>}`]?: (e: Event) => void;\n};\n// { onClick?: ...; onFocus?: ...; onBlur?: ... }\n\n// Extraindo com infer\ntype ParamRota<T> = T extends `${string}:${infer P}` ? P : never;\ntype X = ParamRota<"/usuarios/:id">;   // "id"',
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que um template literal type monta?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Tipos de texto a partir de outros tipos", isCorrect: true },
+                        { text: "Strings formatadas em tempo de execução", isCorrect: false },
+                        { text: "Modelos de HTML verificados na compilação", isCorrect: false },
+                        { text: "Constantes de texto exportadas do módulo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement:
+                        "Quantos tipos resultam da combinação de duas uniões de dois membros?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Quatro", isCorrect: true },
+                        { text: "Dois, um para cada união informada", isCorrect: false },
+                        { text: "Um só, com todos os textos juntos", isCorrect: false },
+                        { text: "Três, descartando a combinação repetida", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `Capitalize<'nome'>` produz?",
+                    difficulty: "facil",
+                    options: [
+                        { text: '"Nome"', isCorrect: true },
+                        { text: '"NOME"', isCorrect: false },
+                        { text: '"nome"', isCorrect: false },
+                        { text: '"nOME"', isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que se ganha ao tipar nomes com template literal?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "A convenção de nome passa a ser verificada", isCorrect: true },
+                        { text: "Os nomes ficam mais curtos no código", isCorrect: false },
+                        { text: "As strings são criadas em tempo de execução", isCorrect: false },
+                        { text: "O compilador gera os nomes automaticamente", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `T extends `${string}:${infer P}` ? P : never` extrai?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O trecho que vem depois dos dois-pontos", isCorrect: true },
+                        { text: "O trecho que aparece antes dos dois-pontos", isCorrect: false },
+                        { text: "A quantidade de dois-pontos no texto", isCorrect: false },
+                        { text: "O texto inteiro, sem os dois-pontos", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Quando parar de tipar",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Tipo também tem custo\n\nOs recursos dos módulos anteriores permitem descrever quase qualquer coisa no sistema de tipos. A pergunta que fica é **quanto** vale a pena.\n\nTipo complexo demais cobra em três moedas: leitura, mensagem de erro e tempo de compilação. Um tipo que ninguém do time entende é pior que um `unknown` bem colocado com validação em execução.",
+                },
+                {
+                    type: "code",
+                    value: '// Difícil de ler, difícil de manter, erro incompreensível\ntype Caminhos<T, P extends string = ""> = T extends object\n  ? { [K in keyof T & string]: Caminhos<T[K], P extends "" ? K : `${P}.${K}`> }[keyof T & string]\n  : P;\n\n// Muitas vezes basta\ntype Caminho = "usuario.nome" | "usuario.email" | "pedido.total";',
+                },
+                {
+                    type: "text",
+                    value: "## Os sinais de que passou do ponto\n\n- A mensagem de erro tem mais de dez linhas e não diz onde está o problema\n- Ninguém do time consegue alterar o tipo sem tentativa e erro\n- O editor fica lento ao abrir o arquivo\n- O tipo precisa de um comentário explicando como funciona",
+                },
+                {
+                    type: "quote",
+                    value: "Tipo existe para ajudar quem escreve o código. Quando ele vira o problema em vez da solução, simplificar é a resposta certa.",
+                },
+                {
+                    type: "text",
+                    value: "## O meio-termo que funciona\n\nUse tipos avançados onde eles se pagam: em biblioteca usada por muita gente, ou em um ponto do sistema onde o erro é caro. No código do dia a dia, tipos simples e explícitos ganham quase sempre.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Em que moedas um tipo complexo cobra?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Leitura, mensagem de erro e compilação", isCorrect: true },
+                        { text: "Memória, disco e tempo de execução", isCorrect: false },
+                        { text: "Tamanho do arquivo gerado no build", isCorrect: false },
+                        { text: "Compatibilidade com versões anteriores", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual é um sinal de que o tipo ficou complexo demais?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "A mensagem de erro não diz onde está o problema",
+                            isCorrect: true,
+                        },
+                        { text: "O tipo usa mais de um parâmetro genérico", isCorrect: false },
+                        { text: "O tipo é usado em mais de um arquivo", isCorrect: false },
+                        {
+                            text: "O tipo foi derivado de algum outro tipo existente",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Onde tipos avançados costumam se pagar?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Em biblioteca usada por muita gente", isCorrect: true },
+                        { text: "No código das telas de uma aplicação", isCorrect: false },
+                        { text: "Em scripts de automação pequenos", isCorrect: false },
+                        { text: "Em testes automatizados do projeto", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que costuma ser melhor que um tipo indecifrável?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um unknown com validação em execução", isCorrect: true },
+                        { text: "Um any bem documentado no comentário", isCorrect: false },
+                        { text: "Uma interface com todos os campos opcionais", isCorrect: false },
+                        { text: "Vários tipos pequenos com o mesmo nome", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Para quem o tipo existe?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Para quem escreve e lê o código", isCorrect: true },
+                        { text: "Para o compilador otimizar o resultado", isCorrect: false },
+                        { text: "Para a documentação gerada do projeto", isCorrect: false },
+                        { text: "Para o navegador validar os dados", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_5: Modulo = {
+    titulo: "Módulo 5 - TypeScript no mundo real",
+    aulas: [
+        {
+            titulo: "Módulos e import type",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Cada arquivo é um módulo\n\nUm arquivo com `import` ou `export` é um módulo, com escopo próprio. Sem nenhum dos dois, ele é tratado como script global, e tudo que ele declara colide com o resto do projeto.\n\nQuando um arquivo de tipos parece estar sendo ignorado, a primeira coisa a conferir é se ele exporta alguma coisa.",
+                },
+                {
+                    type: "code",
+                    value: 'export interface Usuario {\n  id: number;\n  nome: string;\n}\n\nexport type Papel = "admin" | "editor";\n\nexport function criar(u: Usuario): void {}\nexport default criar;',
+                },
+                {
+                    type: "text",
+                    value: "## import type\n\nImportar um tipo com `import type` deixa explícito que aquilo **some na compilação**. O compilador remove a linha inteira, e nenhum efeito colateral do módulo é disparado por engano.",
+                },
+                {
+                    type: "code",
+                    value: 'import type { Usuario } from "./tipos";\nimport { criar } from "./servico";\n\n// Misturando os dois na mesma linha\nimport { criar, type Usuario } from "./modulo";',
+                },
+                {
+                    type: "text",
+                    value: "Sem `import type`, um import usado apenas em posição de tipo pode acabar mantido no resultado por engano, arrastando o módulo inteiro. Em projeto grande isso vira dependência circular e tempo de carga que ninguém explica.\n\n## Caminhos\n\nCom `moduleResolution: bundler`, imports relativos dispensam a extensão. Em Node com módulos ES, a extensão `.js` é obrigatória mesmo no arquivo `.ts`, o que confunde quase todo mundo na primeira vez.",
+                },
+                {
+                    type: "code",
+                    value: '// Com bundler\nimport { criar } from "./servico";\n\n// Em Node com ESM: extensão .js, mesmo o arquivo sendo .ts\nimport { criar } from "./servico.js";',
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que torna um arquivo um módulo em TypeScript?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Ter ao menos um import ou export", isCorrect: true },
+                        { text: "Ter a extensão .ts em vez de .js", isCorrect: false },
+                        { text: "Estar dentro da pasta configurada em rootDir", isCorrect: false },
+                        { text: "Declarar ao menos uma interface exportável", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que acontece com um arquivo sem import nem export?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Ele é tratado como script global", isCorrect: true },
+                        { text: "Ele é ignorado pelo compilador por completo", isCorrect: false },
+                        { text: "Ele gera um erro de módulo inválido", isCorrect: false },
+                        { text: "Ele é compilado sem checagem de tipos", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `import type` garante?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Que a linha some na compilação", isCorrect: true },
+                        { text: "Que o tipo seja verificado com mais rigor", isCorrect: false },
+                        { text: "Que o módulo seja carregado antes dos outros", isCorrect: false },
+                        { text: "Que apenas tipos possam ser exportados de lá", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual problema um import de tipo mantido por engano pode causar?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Dependência circular e carga desnecessária", isCorrect: true },
+                        { text: "Erro de tipo em tempo de execução", isCorrect: false },
+                        { text: "Perda da checagem naquele arquivo", isCorrect: false },
+                        { text: "Duplicação do tipo dentro do resultado final", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Em Node com módulos ES, qual extensão o import usa?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: ".js, mesmo o arquivo sendo .ts", isCorrect: true },
+                        { text: ".ts, igual ao arquivo de origem", isCorrect: false },
+                        { text: "Nenhuma, a extensão é dispensada", isCorrect: false },
+                        { text: ".mjs, para indicar o formato do módulo", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Bibliotecas, @types e declarações",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Três situações\n\nAo instalar uma biblioteca, você cai em um de três casos:\n\n1. Ela **já vem com tipos**, e não há nada a fazer\n2. Os tipos moram em um pacote `@types`, publicado pela comunidade\n3. Não existe tipo nenhum, e você declara o que precisa",
+                },
+                {
+                    type: "code",
+                    value: "# Caso 1: os tipos vêm junto\nnpm install zod\n\n# Caso 2: pacote separado, sempre como dev\nnpm install express\nnpm install --save-dev @types/express",
+                },
+                {
+                    type: "text",
+                    value: "## Quando não há tipos\n\nUm arquivo `.d.ts` declara o formato de algo que existe mas o TypeScript não conhece. Ele só contém declarações e nunca gera código.",
+                },
+                {
+                    type: "code",
+                    value: '// tipos/biblioteca-antiga.d.ts\ndeclare module "biblioteca-antiga" {\n  export function calcular(a: number, b: number): number;\n  export const versao: string;\n}\n\n// Declarando algo global, como uma variável injetada no HTML\ndeclare global {\n  interface Window {\n    minhaConfig: { apiUrl: string };\n  }\n}\n\nexport {};',
+                },
+                {
+                    type: "text",
+                    value: "## A saída rápida, e o preço dela\n\nUma declaração vazia faz o import compilar, ao custo de o módulo inteiro virar `any`. Serve para destravar, mas deixa um buraco que ninguém enxerga depois.",
+                },
+                {
+                    type: "code",
+                    value: 'declare module "biblioteca-antiga";   // tudo vira any',
+                },
+            ],
+            questions: [
+                {
+                    statement: "Onde ficam os tipos de bibliotecas que não os trazem?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Em pacotes @types da comunidade", isCorrect: true },
+                        { text: "No próprio TypeScript, que já os conhece", isCorrect: false },
+                        { text: "Em um arquivo gerado pelo compilador", isCorrect: false },
+                        { text: "Na pasta node_modules da biblioteca", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como um pacote `@types` deve ser instalado?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Como dependência de desenvolvimento", isCorrect: true },
+                        { text: "Como dependência normal do projeto", isCorrect: false },
+                        { text: "Globalmente, para valer em todos os projetos", isCorrect: false },
+                        { text: "Junto da biblioteca, no mesmo comando", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que um arquivo `.d.ts` contém?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Apenas declarações, sem gerar código", isCorrect: true },
+                        { text: "O código já compilado de uma biblioteca", isCorrect: false },
+                        { text: "Os testes de tipo do projeto", isCorrect: false },
+                        { text: "A configuração do compilador", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual o preço de `declare module 'x';` sem corpo?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O módulo inteiro vira any", isCorrect: true },
+                        { text: "O módulo deixa de poder ser importado", isCorrect: false },
+                        { text: "O compilador ignora o arquivo que o usa", isCorrect: false },
+                        { text: "A biblioteca precisa ser reinstalada", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Para que serve `declare global`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Acrescentar tipos ao escopo global", isCorrect: true },
+                        { text: "Tornar um tipo visível em outros projetos", isCorrect: false },
+                        { text: "Declarar variáveis usadas em todo o arquivo", isCorrect: false },
+                        { text: "Importar tipos sem escrever o import", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Type guards e validação de dados externos",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# A fronteira do sistema\n\nTudo que entra de fora, resposta de API, corpo de requisição, arquivo lido, é `unknown` na prática, mesmo que o tipo diga outra coisa. A **fronteira** é onde a validação precisa acontecer.\n\nDepois dela, o resto do código pode confiar nos tipos.",
+                },
+                {
+                    type: "text",
+                    value: "## Type predicate\n\nUma função que devolve `v is Tipo` ensina o compilador a estreitar. Ela é a ponte entre a verificação em execução e o tipo em compilação.",
+                },
+                {
+                    type: "code",
+                    value: 'interface Usuario {\n  id: number;\n  nome: string;\n}\n\nfunction ehUsuario(v: unknown): v is Usuario {\n  return (\n    typeof v === "object" && v !== null &&\n    "id" in v && typeof (v as Usuario).id === "number" &&\n    "nome" in v && typeof (v as Usuario).nome === "string"\n  );\n}\n\nconst dados: unknown = await resposta.json();\n\nif (ehUsuario(dados)) {\n  console.log(dados.nome);   // aqui é Usuario de verdade\n}',
+                },
+                {
+                    type: "text",
+                    value: "## O risco do predicate escrito à mão\n\nO compilador **acredita** no que você declarou: se o corpo da função esquecer de checar um campo, o tipo mente e o erro reaparece longe dali.\n\nPor isso a prática mais comum hoje é usar uma biblioteca de validação que **gera o tipo a partir do esquema**. A forma é descrita uma vez, e a verificação e o tipo nunca divergem.",
+                },
+                {
+                    type: "code",
+                    value: 'import { z } from "zod";\n\nconst UsuarioSchema = z.object({\n  id: z.number(),\n  nome: z.string(),\n  email: z.string().email(),\n});\n\n// O tipo sai do esquema, não é escrito de novo\ntype Usuario = z.infer<typeof UsuarioSchema>;\n\nconst dados = UsuarioSchema.parse(await resposta.json());\n// Se não bater, lança. Se passar, dados é Usuario e é verdade.',
+                },
+                {
+                    type: "quote",
+                    value: "Valide na borda, confie no miolo. Espalhar verificação por todo o código é sinal de que a fronteira não está clara.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que uma função com retorno `v is Tipo` faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Ensina o compilador a estreitar o tipo", isCorrect: true },
+                        { text: "Converte o valor para o tipo informado", isCorrect: false },
+                        { text: "Valida o valor durante a compilação", isCorrect: false },
+                        { text: "Lança exceção quando o tipo não bate", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual o risco de um type predicate escrito à mão?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "O compilador acredita mesmo se a checagem estiver errada",
+                            isCorrect: true,
+                        },
+                        {
+                            text: "Ele acaba deixando a execução do código muito mais lenta que o normal",
+                            isCorrect: false,
+                        },
+                        { text: "Ele não funciona com tipos genéricos", isCorrect: false },
+                        { text: "Ele precisa ser repetido em cada arquivo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a vantagem de gerar o tipo a partir de um esquema?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A verificação e o tipo nunca divergem", isCorrect: true },
+                        { text: "O esquema passa a ser validado na compilação", isCorrect: false },
+                        { text: "O código gerado fica bem menor", isCorrect: false },
+                        { text: "Os tipos deixam de ser apagados", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Onde a validação deve acontecer?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Na fronteira, onde o dado entra", isCorrect: true },
+                        { text: "Em cada função que usa o dado", isCorrect: false },
+                        { text: "No momento em que o dado é exibido", isCorrect: false },
+                        { text: "Apenas nos testes automatizados", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual o tipo real de uma resposta de `json()`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Desconhecido, ainda que anotado", isCorrect: true },
+                        { text: "O tipo declarado na anotação da função", isCorrect: false },
+                        { text: "Sempre um objeto com campos de texto", isCorrect: false },
+                        { text: "O tipo inferido do endpoint chamado", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Classes e o operador satisfies",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Classes com tipos\n\nClasses em TypeScript ganham modificadores de visibilidade e propriedades declaradas no construtor, o que reduz muito a repetição.",
+                },
+                {
+                    type: "code",
+                    value: 'class Conta {\n  // Declarar no construtor cria e atribui de uma vez\n  constructor(\n    public readonly id: number,\n    private saldo: number,\n  ) {}\n\n  depositar(valor: number): void {\n    if (valor <= 0) throw new Error("valor inválido");\n    this.saldo += valor;\n  }\n\n  get extrato(): number {\n    return this.saldo;\n  }\n}',
+                },
+                {
+                    type: "table",
+                    value: '[["Modificador", "Quem enxerga", "Existe em execução"], ["public", "todos", "sim"], ["protected", "a classe e as filhas", "não, só na checagem"], ["private", "só a classe", "não, só na checagem"], ["#campo", "só a classe", "sim, é do JavaScript"]]',
+                },
+                {
+                    type: "text",
+                    value: "Repare na última linha: `private` do TypeScript **some na compilação**, então nada impede o acesso em execução. O `#campo` é privado de verdade, porque é um recurso do próprio JavaScript.\n\n## O operador satisfies\n\nEle verifica que um valor **satisfaz** um tipo, sem alargar a inferência. É a resposta para o dilema entre anotar e não anotar.",
+                },
+                {
+                    type: "code",
+                    value: 'type Config = Record<string, string | number>;\n\n// Anotando: perde o detalhe, tudo vira string | number\nconst a: Config = { porta: 3000, host: "local" };\na.porta.toFixed();   // erro: pode ser string\n\n// Sem anotar: não valida nada\nconst b = { porta: 3000, host: "local" };\n\n// Com satisfies: valida e mantém os tipos exatos\nconst c = { porta: 3000, host: "local" } satisfies Config;\nc.porta.toFixed();   // ok, porta é number\nc.hoost;             // erro de digitação apontado',
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que declarar a propriedade no construtor evita?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Declarar e atribuir o campo separadamente", isCorrect: true },
+                        { text: "A necessidade de tipar os parâmetros", isCorrect: false },
+                        { text: "Que a classe precise declarar um construtor", isCorrect: false },
+                        { text: "Que o campo apareça no objeto criado", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O `private` do TypeScript protege em execução?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Não, ele some na compilação", isCorrect: true },
+                        { text: "Sim, o campo fica inacessível de fora", isCorrect: false },
+                        { text: "Sim, ele vira um campo com sustenido", isCorrect: false },
+                        { text: "Sim, quando o modo estrito está ligado", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual forma dá privacidade de verdade?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O campo com sustenido do JavaScript", isCorrect: true },
+                        { text: "O modificador private do TypeScript", isCorrect: false },
+                        { text: "O modificador protected na classe", isCorrect: false },
+                        { text: "A palavra readonly antes do campo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `satisfies` faz que a anotação não faz?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Valida sem alargar os tipos inferidos", isCorrect: true },
+                        { text: "Verifica o valor em tempo de execução", isCorrect: false },
+                        { text: "Converte o valor para o tipo informado", isCorrect: false },
+                        { text: "Permite campos que o tipo não declara", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que acontece ao anotar um objeto com um tipo amplo?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Os tipos exatos de cada campo se perdem", isCorrect: true },
+                        { text: "Os campos a mais passam a ser sempre aceitos", isCorrect: false },
+                        { text: "O objeto vira somente leitura", isCorrect: false },
+                        { text: "A inferência é desligada no arquivo", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Lendo as mensagens do compilador",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Erros que parecem impenetráveis\n\nAs mensagens do TypeScript ficam longas quando os tipos são grandes, e a informação útil quase sempre está no **fim**, não no começo.\n\nA estratégia que funciona: leia de baixo para cima. A última linha costuma dizer exatamente qual campo, de qual tipo, não é compatível com qual outro.",
+                },
+                {
+                    type: "code",
+                    value: "Argument of type '{ nome: string; idade: string; }' is not assignable\nto parameter of type 'Usuario'.\n  Types of property 'idade' are incompatible.\n    Type 'string' is not assignable to type 'number'.\n\n// A última linha é a resposta: idade veio como texto",
+                },
+                {
+                    type: "table",
+                    value: '[["Mensagem", "O que costuma ser"], ["Object is possibly \'undefined\'", "falta checar antes de usar"], ["Property does not exist on type", "erro de digitação ou tipo errado"], ["Type \'X\' is not assignable to \'Y\'", "o campo apontado no fim não bate"], ["No overload matches this call", "argumentos na ordem ou tipo errados"], ["Excessive stack depth", "tipo recursivo sem fim"]]',
+                },
+                {
+                    type: "text",
+                    value: "## Duas ferramentas de investigação\n\nQuando o tipo não é o que você esperava, pergunte ao compilador em vez de adivinhar. Passar o mouse sobre a variável no editor mostra o tipo resolvido, e um tipo auxiliar força a exibição.",
+                },
+                {
+                    type: "code",
+                    value: '// Forçando o editor a mostrar o tipo expandido\ntype Expandir<T> = { [K in keyof T]: T[K] } & {};\n\ntype Opaco = Partial<Omit<Usuario, "senha">>;\ntype Claro = Expandir<Opaco>;   // agora o editor mostra os campos\n\n// Afirmando uma expectativa no próprio código\nconst _checagem: Usuario = objeto;   // falha aqui se não bater',
+                },
+                {
+                    type: "quote",
+                    value: "Quando o erro não fizer sentido, simplifique: reduza o caso a três linhas. Quase sempre o problema aparece antes de você terminar de reduzir.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Onde está a informação útil em um erro longo do TypeScript?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Nas últimas linhas da mensagem", isCorrect: true },
+                        { text: "Na primeira linha, que resume tudo", isCorrect: false },
+                        { text: "No meio, onde os tipos são listados", isCorrect: false },
+                        { text: "Distribuída por igual em toda a mensagem", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que 'Object is possibly undefined' costuma indicar?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Falta checar o valor antes de usar", isCorrect: true },
+                        { text: "O objeto não foi importado corretamente", isCorrect: false },
+                        { text: "O tipo declarado está incompleto", isCorrect: false },
+                        { text: "A variável foi declarada duas vezes", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que 'Property does not exist on type' costuma ser?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Erro de digitação ou tipo errado", isCorrect: true },
+                        { text: "Uma propriedade privada acessada de fora", isCorrect: false },
+                        { text: "Um campo opcional que não foi informado", isCorrect: false },
+                        { text: "Um módulo que não foi importado ainda", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Como descobrir o tipo real de uma variável?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Passando o mouse sobre ela no editor", isCorrect: true },
+                        { text: "Imprimindo o valor com um console.log", isCorrect: false },
+                        { text: "Lendo o JavaScript que foi gerado", isCorrect: false },
+                        { text: "Consultando o arquivo de configuração", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual estratégia ajuda quando o erro não faz sentido?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Reduzir o caso a poucas linhas", isCorrect: true },
+                        { text: "Anotar o tipo explicitamente em tudo", isCorrect: false },
+                        { text: "Desligar o modo estrito temporariamente", isCorrect: false },
+                        { text: "Atualizar a versão do TypeScript", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_6: Modulo = {
+    titulo: "Módulo 6 - Configuração e ferramentas",
+    aulas: [
+        {
+            titulo: "As flags do modo estrito",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O que strict liga\n\n`strict: true`, que é o padrão desde o TypeScript 7, é um atalho para um conjunto de flags. Vale saber o que cada uma faz, porque elas explicam a maior parte dos erros que aparecem ao ligar o modo estrito em um projeto antigo.",
+                },
+                {
+                    type: "table",
+                    value: '[["Flag", "O que passa a exigir"], ["strictNullChecks", "tratar null e undefined"], ["noImplicitAny", "anotar o que não é inferido"], ["strictFunctionTypes", "compatibilidade de parâmetros"], ["strictPropertyInitialization", "inicializar campo de classe"], ["useUnknownInCatchVariables", "erro do catch como unknown"]]',
+                },
+                {
+                    type: "text",
+                    value: "## strictNullChecks é a que muda tudo\n\nSem ela, `null` e `undefined` cabem em qualquer tipo, e o compilador não avisa nada. Com ela ligada, você é obrigado a tratar o caso vazio, e é daí que vem a maior parte do valor do TypeScript.",
+                },
+                {
+                    type: "code",
+                    value: '// Sem strictNullChecks: compila e quebra rodando\nfunction nome(u: Usuario | null): string {\n  return u.nome;\n}\n\n// Com strictNullChecks: o compilador cobra\nfunction nome(u: Usuario | null): string {\n  if (!u) return "anônimo";\n  return u.nome;\n}',
+                },
+                {
+                    type: "text",
+                    value: "## Duas flags fora do strict que valem a pena\n\n`noUncheckedIndexedAccess` faz o acesso por índice devolver `T | undefined`, o que é a verdade: `lista[10]` pode não existir. É rigorosa e pega uma classe inteira de bug.\n\n`exactOptionalPropertyTypes` distingue campo ausente de campo com valor `undefined`.",
+                },
+                {
+                    type: "code",
+                    value: "const lista = [1, 2, 3];\n\n// Sem a flag: o tipo é number, e é mentira\nconst x = lista[10];\nx.toFixed();   // compila, e quebra rodando\n\n// Com noUncheckedIndexedAccess: number | undefined\nconst y = lista[10];\ny?.toFixed();  // o compilador cobra o cuidado",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que `strict: true` representa?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um atalho para um conjunto de flags", isCorrect: true },
+                        { text: "Uma checagem extra feita depois das outras", isCorrect: false },
+                        { text: "Um modo que impede o uso do tipo any", isCorrect: false },
+                        { text: "Uma verificação em tempo de execução", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `strictNullChecks` passa a exigir?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Tratar os casos de null e undefined", isCorrect: true },
+                        { text: "Anotar o tipo de todas as variáveis", isCorrect: false },
+                        { text: "Inicializar todos os campos de classe", isCorrect: false },
+                        { text: "Declarar o retorno de todas as funções", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `noUncheckedIndexedAccess` muda?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "O acesso por índice passa a incluir undefined", isCorrect: true },
+                        { text: "O índice precisa ser sempre um número", isCorrect: false },
+                        { text: "Arrays passam a ser somente leitura", isCorrect: false },
+                        {
+                            text: "O acesso fora do tamanho passa a lançar exceção",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "Por que `lista[10]` ter tipo `number` é uma mentira?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "A posição pode não existir no array", isCorrect: true },
+                        { text: "O array pode ter tipos misturados dentro", isCorrect: false },
+                        { text: "O índice pode ser uma string em execução", isCorrect: false },
+                        {
+                            text: "O valor pode ter sido alterado por outra função",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que `useUnknownInCatchVariables` faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O erro capturado chega como unknown", isCorrect: true },
+                        { text: "Impede que exceções sejam capturadas", isCorrect: false },
+                        { text: "Converte o erro para o tipo Error", isCorrect: false },
+                        { text: "Exige um bloco finally em todo try", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "TypeScript com Node e no navegador",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Dois ambientes, duas configurações\n\nO TypeScript precisa saber o que existe no ambiente. `lib` define quais APIs da linguagem ele conhece, e os tipos do ambiente vêm de pacotes.",
+                },
+                {
+                    type: "code",
+                    value: '// Para Node\n{\n  "compilerOptions": {\n    "lib": ["es2023"],\n    "module": "nodenext",\n    "moduleResolution": "nodenext",\n    "types": ["node"]\n  }\n}\n\n// Para o navegador\n{\n  "compilerOptions": {\n    "lib": ["es2023", "dom", "dom.iterable"],\n    "module": "esnext",\n    "moduleResolution": "bundler"\n  }\n}',
+                },
+                {
+                    type: "text",
+                    value: 'Sem `dom` no `lib`, o compilador não conhece `document` nem `fetch` no navegador. Sem `types: ["node"]`, ele não conhece `process` nem `Buffer`. Esse é o erro mais comum de configuração inicial.\n\n## Rodando sem build\n\nO Node moderno executa arquivos `.ts` apagando os tipos, sem checar nada. Isso é ótimo para desenvolver, e não substitui a checagem: `tsc --noEmit` continua sendo o que roda na CI.',
+                },
+                {
+                    type: "code",
+                    value: "node app.ts        # roda, sem checar tipos\nnpx tsc --noEmit   # checa, sem rodar",
+                },
+                {
+                    type: "text",
+                    value: "## No navegador\n\nO navegador não entende TypeScript. Um empacotador como Vite ou esbuild apaga os tipos e monta o resultado. Eles também **não checam** os tipos, pela mesma razão de desempenho, então a checagem fica em um passo próprio.",
+                },
+                {
+                    type: "quote",
+                    value: "Quase toda ferramenta moderna apaga os tipos sem verificá-los. Se a CI não roda tsc --noEmit, ninguém está checando nada.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que a opção `lib` define?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Quais APIs o compilador conhece", isCorrect: true },
+                        { text: "Quais bibliotecas serão instaladas", isCorrect: false },
+                        { text: "Onde os arquivos gerados serão salvos", isCorrect: false },
+                        { text: "Quais pastas entram na compilação", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que falta quando `document` não é reconhecido?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A entrada dom no lib", isCorrect: true },
+                        { text: "O pacote @types/browser instalado", isCorrect: false },
+                        { text: "A opção target apontando para o navegador", isCorrect: false },
+                        { text: "O módulo configurado como esnext", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O Node checa os tipos ao rodar um arquivo `.ts`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Não, ele apenas apaga os tipos", isCorrect: true },
+                        { text: "Sim, e falha quando algum tipo não bate", isCorrect: false },
+                        { text: "Sim, mas apenas os tipos exportados", isCorrect: false },
+                        { text: "Depende da versão do Node instalada", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Os empacotadores como Vite checam os tipos?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Não, eles apenas os apagam", isCorrect: true },
+                        { text: "Sim, é parte do processo de build", isCorrect: false },
+                        { text: "Sim, quando o modo estrito está ligado", isCorrect: false },
+                        { text: "Apenas nos arquivos que foram alterados", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Onde a checagem de tipos deve acontecer no projeto?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Em um passo próprio, com tsc --noEmit", isCorrect: true },
+                        { text: "No momento em que o código é executado", isCorrect: false },
+                        { text: "Durante o empacotamento para produção", isCorrect: false },
+                        { text: "No editor apenas, enquanto se escreve", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Lint, formatação e CI",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# O que o compilador não faz\n\nO TypeScript verifica tipos, não estilo nem prática ruim. Essa parte fica com o linter, e as duas ferramentas se complementam em vez de competir.",
+                },
+                {
+                    type: "table",
+                    value: '[["Ferramenta", "Responde"], ["tsc", "os tipos batem?"], ["ESLint", "o código segue as regras?"], ["Prettier", "a formatação está uniforme?"], ["Vitest ou Jest", "o comportamento está certo?"]]',
+                },
+                {
+                    type: "code",
+                    value: 'npm install --save-dev eslint typescript-eslint\n\n// eslint.config.js\nimport tseslint from "typescript-eslint";\n\nexport default tseslint.config(\n  ...tseslint.configs.recommendedTypeChecked,\n  {\n    languageOptions: {\n      parserOptions: { projectService: true },\n    },\n  },\n);',
+                },
+                {
+                    type: "text",
+                    value: "## Regras que usam tipo\n\nO conjunto `recommendedTypeChecked` liga regras que consultam o **verificador de tipos**, e não só a sintaxe. São elas que pegam coisas como promessa não aguardada ou comparação que nunca é verdadeira, e nenhum linter puramente sintático conseguiria.",
+                },
+                {
+                    type: "text",
+                    value: "## Na CI\n\nTrês passos cobrem o essencial, e devem falhar a CI quando algum não passa.",
+                },
+                {
+                    type: "code",
+                    value: '{\n  "scripts": {\n    "typecheck": "tsc --noEmit",\n    "lint": "eslint .",\n    "test": "vitest run"\n  }\n}',
+                },
+            ],
+            questions: [
+                {
+                    statement: "O que o TypeScript não verifica?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Estilo e práticas ruins de código", isCorrect: true },
+                        { text: "A compatibilidade entre tipos declarados", isCorrect: false },
+                        { text: "A existência dos campos acessados", isCorrect: false },
+                        { text: "O retorno das funções anotadas", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que as regras com checagem de tipo conseguem pegar?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Promessa não aguardada e comparação impossível", isCorrect: true },
+                        {
+                            text: "Linhas de código com mais de oitenta caracteres",
+                            isCorrect: false,
+                        },
+                        { text: "Variáveis declaradas e não utilizadas", isCorrect: false },
+                        { text: "Aspas simples em vez de aspas duplas", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual comando faz a checagem de tipos na CI?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "tsc --noEmit", isCorrect: true },
+                        { text: "eslint . com a configuração recomendada", isCorrect: false },
+                        { text: "prettier --check em todos os arquivos", isCorrect: false },
+                        { text: "npm run build, que compila o projeto", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a responsabilidade do Prettier?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "A formatação uniforme do código", isCorrect: true },
+                        { text: "As regras de qualidade do código", isCorrect: false },
+                        { text: "A verificação dos tipos declarados", isCorrect: false },
+                        { text: "A execução dos testes automatizados", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Linter e compilador competem entre si?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Não, cada um responde uma pergunta", isCorrect: true },
+                        { text: "Sim, o linter substitui a checagem de tipos", isCorrect: false },
+                        { text: "Sim, é preciso escolher um dos dois", isCorrect: false },
+                        { text: "Sim, quando as regras usam o verificador", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Migrando um projeto JavaScript",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Migração acontece aos poucos\n\nTentar converter tudo de uma vez costuma acabar em um ramo abandonado depois de duas semanas. A migração que dá certo é incremental, e o TypeScript foi desenhado para isso.",
+                },
+                {
+                    type: "text",
+                    value: "## O caminho que funciona\n\n1. Instalar o TypeScript e criar o `tsconfig.json` com `allowJs: true`\n2. Ligar `checkJs` e ver o que aparece, sem renomear nada ainda\n3. Renomear arquivo por arquivo, começando pelas **folhas**, que são as que ninguém importa\n4. Ligar as flags estritas uma a uma\n5. Só então proibir `any` no linter",
+                },
+                {
+                    type: "code",
+                    value: '{\n  "compilerOptions": {\n    "allowJs": true,\n    "checkJs": false,\n    "strict": false,\n    "noEmit": true\n  }\n}',
+                },
+                {
+                    type: "text",
+                    value: "## Por que começar pelas folhas\n\nUm arquivo que importa outro herda os tipos dele. Convertendo primeiro o que está no fim da cadeia, cada arquivo seguinte já encontra tipos prontos. No sentido contrário, você tipa contra `any` e refaz depois.\n\n## O escape controlado\n\nDurante a migração, silenciar um erro pontual é legítimo. O importante é que ele seja **visível** e **temporário**.",
+                },
+                {
+                    type: "code",
+                    value: "// @ts-expect-error: o tipo desta lib será corrigido na issue 412\nconst x = libAntiga.metodo();\n\n// Prefira @ts-expect-error a @ts-ignore:\n// se o erro sumir, o expect-error passa a falhar e você remove a linha",
+                },
+                {
+                    type: "quote",
+                    value: "Migração com prazo e sem plano vira strict desligado para sempre. Ligar uma flag por semana entrega mais do que uma reescrita que nunca termina.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Por qual tipo de arquivo começar a migração?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Pelas folhas, que ninguém importa", isCorrect: true },
+                        { text: "Pelos arquivos de entrada da aplicação", isCorrect: false },
+                        { text: "Pelos arquivos com mais linhas de código", isCorrect: false },
+                        { text: "Pelos arquivos de teste do projeto", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Para que serve `allowJs: true`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Permitir os dois tipos de arquivo juntos", isCorrect: true },
+                        { text: "Converter os arquivos JavaScript sozinho", isCorrect: false },
+                        { text: "Desligar a checagem de tipos do projeto", isCorrect: false },
+                        { text: "Gerar arquivos JavaScript na compilação", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a vantagem de `@ts-expect-error` sobre `@ts-ignore`?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Ele falha quando o erro deixa de existir", isCorrect: true },
+                        { text: "Ele silencia mais tipos de erro que o outro", isCorrect: false },
+                        { text: "Ele registra o erro no log da compilação", isCorrect: false },
+                        { text: "Ele funciona em blocos de várias linhas", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `checkJs` faz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Checa também os arquivos JavaScript", isCorrect: true },
+                        { text: "Converte os arquivos JavaScript em TypeScript", isCorrect: false },
+                        { text: "Permite importar JavaScript sem tipos", isCorrect: false },
+                        { text: "Verifica apenas a sintaxe dos arquivos", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que converter tudo de uma vez costuma falhar?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O ramo fica grande demais e é abandonado", isCorrect: true },
+                        { text: "O compilador não aceita muitos arquivos", isCorrect: false },
+                        { text: "Os tipos gerados ficam inconsistentes", isCorrect: false },
+                        { text: "A equipe precisa parar de escrever código", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Organizando tipos em projeto grande",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Onde os tipos moram\n\nEm projeto pequeno, tipo junto do código que o usa resolve. Conforme o projeto cresce, três perguntas aparecem: onde declarar, quando compartilhar e quando duplicar.",
+                },
+                {
+                    type: "text",
+                    value: "## Perto de quem usa\n\nA regra que envelhece melhor: o tipo mora junto do módulo que o **produz**, e é exportado de lá. Uma pasta `types/` central vira depósito e cria dependência de todo mundo para todo mundo.\n\nA exceção legítima são os tipos de domínio compartilhados de verdade, e os tipos gerados a partir do banco ou de um esquema de API.",
+                },
+                {
+                    type: "code",
+                    value: "src/\n  usuarios/\n    usuario.ts          # o tipo Usuario mora aqui, exportado\n    usuario.service.ts\n    usuario.controller.ts\n  pedidos/\n    pedido.ts\n    pedido.service.ts\n  compartilhado/\n    resultado.ts        # tipos usados por todo o sistema",
+                },
+                {
+                    type: "text",
+                    value: "## Duplicar às vezes é o certo\n\nDois tipos com os mesmos campos hoje não são o mesmo tipo. O `Usuario` que a API devolve e o `Usuario` do formulário se parecem agora e vão divergir: um ganha `token`, o outro ganha `confirmarSenha`.\n\nUnir os dois cedo demais produz um tipo cheio de campos opcionais que não descreve bem nenhum dos dois.",
+                },
+                {
+                    type: "code",
+                    value: "// Melhor separados, ainda que pareçam iguais\ntype UsuarioAPI = { id: number; nome: string; email: string };\ntype FormularioUsuario = { nome: string; email: string; senha: string };\n\n// Do que um tipo que serve mal aos dois\ntype Usuario = {\n  id?: number;\n  nome: string;\n  email: string;\n  senha?: string;\n};",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Onde um tipo deve morar, como regra?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Junto do módulo que o produz", isCorrect: true },
+                        { text: "Em uma pasta types central do projeto", isCorrect: false },
+                        { text: "No arquivo que mais o utiliza", isCorrect: false },
+                        { text: "Em um pacote separado do repositório", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual o problema de uma pasta `types/` central?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Ela cria dependência de todos para todos", isCorrect: true },
+                        {
+                            text: "Ela acaba deixando a compilação bem mais lenta",
+                            isCorrect: false,
+                        },
+                        { text: "Ela impede o uso de tipos genéricos", isCorrect: false },
+                        { text: "Ela obriga a exportar todos os tipos", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quando duplicar um tipo é o certo?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Quando os dois vão divergir com o tempo", isCorrect: true },
+                        { text: "Quando eles estão em módulos diferentes", isCorrect: false },
+                        { text: "Quando um deles tem campos opcionais", isCorrect: false },
+                        { text: "Quando o tipo é usado em mais de um lugar", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que acontece ao unir dois tipos cedo demais?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Surge um tipo cheio de campos opcionais", isCorrect: true },
+                        { text: "Os dois módulos passam a se importar", isCorrect: false },
+                        { text: "O compilador aponta um conflito de nomes", isCorrect: false },
+                        { text: "A checagem fica mais lenta no projeto", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual exceção justifica um lugar compartilhado para tipos?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Tipos de domínio usados por todo o sistema", isCorrect: true },
+                        { text: "Tipos que aparecem em mais de dois arquivos", isCorrect: false },
+                        { text: "Tipos com mais de cinco campos declarados", isCorrect: false },
+                        { text: "Tipos que usam parâmetros genéricos", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+const MODULO_7: Modulo = {
+    titulo: "Módulo 7 - O TypeScript 7",
+    aulas: [
+        {
+            titulo: "O compilador reescrito em Go",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Por que reescrever\n\nO compilador do TypeScript sempre foi escrito em TypeScript, rodando sobre Node. Isso tinha uma elegância: a ferramenta era escrita na linguagem que ela compila.\n\nO custo apareceu com a escala. Em bases grandes, uma verificação completa passava de dois minutos, e o editor demorava para responder. O **TypeScript 7**, lançado em 8 de julho de 2026, trocou essa base por uma **implementação nativa em Go**.",
+                },
+                {
+                    type: "table",
+                    value: '[["Projeto", "Antes", "Com o TS 7", "Ganho"], ["VS Code", "125,7s", "10,6s", "11,9x"], ["Sentry", "139,8s", "15,7s", "8,9x"], ["Bluesky", "24,3s", "2,8s", "8,7x"]]',
+                },
+                {
+                    type: "text",
+                    value: "O ganho fica entre **8x e 12x** em verificação completa, e o consumo de memória caiu entre 6% e 26%.\n\n## Por que Go\n\nA escolha foi discutida na comunidade, já que Rust era a aposta de muita gente. A equipe explicou que Go permitia uma **tradução mais direta** do compilador existente, preservando a estrutura e o comportamento, além de trazer paralelismo com pouco atrito. Reescrever do zero em outra arquitetura teria levado anos e mudado o comportamento de formas difíceis de rastrear.",
+                },
+                {
+                    type: "text",
+                    value: "## O que muda para quem usa\n\nQuase nada na linguagem. Os tipos, a sintaxe e as regras de checagem continuam iguais. O que muda é o tempo: o editor responde na hora, e a checagem na CI deixa de ser o passo mais lento.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Em que linguagem o compilador do TypeScript 7 foi escrito?",
+                    difficulty: "facil",
+                    options: [
+                        { text: "Go", isCorrect: true },
+                        { text: "Rust, a aposta de boa parte da comunidade", isCorrect: false },
+                        { text: "C++, pela proximidade com o sistema", isCorrect: false },
+                        { text: "TypeScript, como nas versões anteriores", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual o ganho de velocidade na verificação completa?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Entre oito e doze vezes", isCorrect: true },
+                        { text: "Cerca de duas vezes, em média", isCorrect: false },
+                        { text: "Entre trinta e cinquenta vezes", isCorrect: false },
+                        { text: "Depende do tamanho do projeto, sem média", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que a equipe escolheu Go em vez de Rust?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Permitia traduzir o compilador de forma mais direta",
+                            isCorrect: true,
+                        },
+                        { text: "Go é mais rápido que Rust em qualquer caso", isCorrect: false },
+                        { text: "Rust não tem suporte a paralelismo", isCorrect: false },
+                        {
+                            text: "Go já era usado em várias outras ferramentas da equipe",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+                {
+                    statement: "O que muda na linguagem com o compilador novo?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Quase nada, as regras seguem as mesmas", isCorrect: true },
+                        { text: "A sintaxe foi simplificada em vários pontos", isCorrect: false },
+                        { text: "Os tipos passaram a existir em execução", isCorrect: false },
+                        { text: "As interfaces foram substituídas por type", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que motivou a reescrita?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O tempo de verificação em bases grandes", isCorrect: true },
+                        { text: "A dificuldade de escrever novos recursos", isCorrect: false },
+                        { text: "A dependência do Node para rodar", isCorrect: false },
+                        { text: "A falta de gente que soubesse TypeScript", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Os padrões novos e o que quebrou",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Uma limpeza que estava atrasada\n\nAlém do compilador, o TypeScript 7 aproveitou a virada de versão maior para inverter padrões antigos e remover suporte a alvos que quase ninguém usa mais.\n\nO efeito prático é que um `tsconfig.json` copiado de tutorial antigo pode simplesmente não funcionar.",
+                },
+                {
+                    type: "table",
+                    value: '[["Mudança", "Antes", "Agora"], ["strict", "false", "true"], ["module", "commonjs", "esnext"], ["types", "todos os @types", "vazio"], ["rootDir", "inferido", "./"], ["target es5", "suportado", "removido"], ["moduleResolution node", "suportado", "removido"]]',
+                },
+                {
+                    type: "text",
+                    value: "## O que foi removido\n\n- **`target: es5`**: gerar código para navegadores sem suporte a ES2015 deixou de fazer sentido\n- **`moduleResolution: node` e `node10`**: a resolução antiga do Node saiu; ficam `node16`, `nodenext` e `bundler`\n- **Formatos de módulo `amd`, `umd`, `systemjs` e `none`**: anteriores aos módulos ES\n- **`baseUrl`**: descontinuado em favor de `paths` com caminhos relativos",
+                },
+                {
+                    type: "text",
+                    value: "## Ao atualizar\n\nO caminho é ligar o novo e rodar a checagem. `strict: true` costuma revelar erros reais que estavam escondidos, e por isso vale tratar a atualização como duas etapas: primeiro fazer compilar com as opções antigas explícitas, depois ligar as novas uma a uma.",
+                },
+                {
+                    type: "code",
+                    value: '// Etapa 1: preservar o comportamento antigo, explicitamente\n{\n  "compilerOptions": {\n    "strict": false,\n    "module": "commonjs",\n    "target": "es2020"\n  }\n}\n\n// Etapa 2: ligar uma flag por vez e corrigir o que aparecer',
+                },
+            ],
+            questions: [
+                {
+                    statement: "Por que um tsconfig antigo pode não funcionar no TypeScript 7?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Opções foram removidas e padrões invertidos", isCorrect: true },
+                        { text: "O formato do arquivo mudou para YAML", isCorrect: false },
+                        { text: "O arquivo passou a se chamar de outro jeito", isCorrect: false },
+                        { text: "As opções agora ficam no package.json", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Quais resoluções de módulo restaram?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "node16, nodenext e bundler", isCorrect: true },
+                        { text: "node, node10 e o antigo classic", isCorrect: false },
+                        { text: "commonjs, amd e esnext", isCorrect: false },
+                        { text: "classic, node e bundler", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que `target: es5` foi removido?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "Gerar para navegadores sem ES2015 não faz mais sentido",
+                            isCorrect: true,
+                        },
+                        { text: "O compilador em Go não consegue gerá-lo", isCorrect: false },
+                        {
+                            text: "Ele acabava deixando o código gerado muito maior do que precisa",
+                            isCorrect: false,
+                        },
+                        { text: "Ele conflitava com o módulo esnext", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que substituiu o `baseUrl`?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "A opção paths com caminhos relativos", isCorrect: true },
+                        { text: "A opção rootDir, que virou obrigatória", isCorrect: false },
+                        { text: "A resolução bundler, que dispensa caminhos", isCorrect: false },
+                        { text: "Os imports com caminho absoluto", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual a estratégia recomendada ao atualizar?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Fixar o comportamento antigo e ligar uma flag por vez",
+                            isCorrect: true,
+                        },
+                        { text: "Ligar todas as opções novas de uma só vez", isCorrect: false },
+                        { text: "Reescrever o tsconfig do zero com o init", isCorrect: false },
+                        {
+                            text: "Manter as duas versões instaladas para sempre no projeto",
+                            isCorrect: false,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Convivendo com o TypeScript 6",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Nem todo projeto atualiza junto\n\nEm um repositório com vários pacotes, ou com uma biblioteca que ainda não suporta a versão nova, é preciso conviver com as duas por um tempo.\n\nA equipe do TypeScript previu isso e publicou o pacote **`@typescript/typescript6`**, que instala a versão 6 com o executável **`tsc6`**. Os dois convivem no mesmo projeto sem conflito de nome.",
+                },
+                {
+                    type: "code",
+                    value: 'npm install --save-dev typescript @typescript/typescript6\n\n{\n  "scripts": {\n    "typecheck": "tsc --noEmit",\n    "typecheck:legado": "tsc6 --noEmit -p tsconfig.legado.json"\n  }\n}',
+                },
+                {
+                    type: "text",
+                    value: "## A linha do tempo\n\nO **TypeScript 6.0** foi a última versão sobre o compilador antigo, publicada no começo de 2026, e serve de ponte: ela traz avisos sobre o que vai ser removido no 7, permitindo preparar o projeto antes de dar o salto.\n\nA sequência que menos dói é passar pelo 6 antes de ir para o 7, e não pular direto de uma versão 5.",
+                },
+                {
+                    type: "table",
+                    value: '[["Versão", "Compilador", "Papel"], ["5.x", "TypeScript", "a linha anterior"], ["6.0", "TypeScript", "última da base antiga, ponte"], ["7.0", "Go", "a linha atual"]]',
+                },
+                {
+                    type: "quote",
+                    value: "Atualizar por etapas custa mais tempo de calendário e menos tempo de depuração. Em projeto grande a segunda moeda é a cara.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual pacote permite usar a versão 6 lado a lado?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "@typescript/typescript6", isCorrect: true },
+                        { text: "typescript-legacy, publicado à parte", isCorrect: false },
+                        { text: "typescript@6, na mesma linha de instalação", isCorrect: false },
+                        { text: "@types/typescript6, com os tipos antigos", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual o nome do executável da versão 6 nesse pacote?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "tsc6", isCorrect: true },
+                        { text: "tsc-legacy, indicando a versão antiga", isCorrect: false },
+                        { text: "tsc --v6, com a flag de versão", isCorrect: false },
+                        { text: "typescript6, o nome do pacote", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual o papel do TypeScript 6.0?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Ser a última da base antiga e servir de ponte", isCorrect: true },
+                        {
+                            text: "Ser a primeira versão a usar o compilador em Go",
+                            isCorrect: false,
+                        },
+                        { text: "Ser uma versão apenas de correção de falhas", isCorrect: false },
+                        { text: "Ser a versão de suporte estendido do 5.x", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual sequência de atualização dói menos?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Passar pelo 6 antes de ir para o 7", isCorrect: true },
+                        { text: "Pular direto do 5 para o 7 de uma vez", isCorrect: false },
+                        { text: "Manter o 5 e esperar o 8 ser lançado", isCorrect: false },
+                        { text: "Instalar as três versões ao mesmo tempo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que a versão 6 traz que ajuda a preparar o salto?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Avisos sobre o que será removido no 7", isCorrect: true },
+                        { text: "O compilador em Go em modo experimental", isCorrect: false },
+                        { text: "Um conversor automático do tsconfig", isCorrect: false },
+                        { text: "A checagem em paralelo dos arquivos", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Quando a checagem fica lenta",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Mesmo rápido, dá para atrapalhar\n\nO compilador em Go resolveu a maior parte do problema de desempenho, mas escolhas de tipagem ainda pesam. Em projeto grande vale saber medir antes de adivinhar.",
+                },
+                {
+                    type: "code",
+                    value: "npx tsc --noEmit --diagnostics\n# Files, Lines, Nodes, Identifiers, Check time, Total time\n\nnpx tsc --noEmit --generateTrace trace/\n# gera um rastro para abrir no perfilador do navegador",
+                },
+                {
+                    type: "text",
+                    value: "## Os três culpados mais comuns\n\n**Tipos recursivos profundos**, que o compilador precisa expandir passo a passo. Uma união gerada por recursão sobre uma string longa é o caso clássico.\n\n**Uniões enormes**, com centenas de membros. Cada comparação percorre a união inteira.\n\n**Inferência em cadeia longa**, quando o tipo de um valor depende de outro, que depende de outro. Anotar explicitamente um ponto do meio corta o trabalho pela metade.",
+                },
+                {
+                    type: "code",
+                    value: '// Custa caro: o compilador expande caractere a caractere\ntype Split<S extends string> = S extends `${infer A},${infer B}`\n  ? [A, ...Split<B>]\n  : [S];\n\n// Barato e quase sempre suficiente\ntype Campos = "nome" | "email" | "idade";',
+                },
+                {
+                    type: "text",
+                    value: "## Ajudando o compilador\n\nAnotar o retorno de funções exportadas evita que o compilador precise inferir a mesma cadeia toda vez. Em bibliotecas isso também deixa a interface pública estável: uma mudança interna não altera o tipo que os outros enxergam.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Qual flag mostra o tempo gasto na checagem?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "--diagnostics", isCorrect: true },
+                        { text: "--verbose, com a saída detalhada", isCorrect: false },
+                        { text: "--profile, com o perfil de execução", isCorrect: false },
+                        { text: "--stats, com as estatísticas do projeto", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual tipo costuma pesar mais na checagem?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Tipos recursivos profundos", isCorrect: true },
+                        { text: "Interfaces com muitos campos declarados", isCorrect: false },
+                        { text: "Tipos importados de outros arquivos", isCorrect: false },
+                        { text: "Uniões de dois ou três literais", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Por que uma união enorme custa caro?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Cada comparação percorre todos os membros", isCorrect: true },
+                        { text: "Ela ocupa muita memória no arquivo gerado", isCorrect: false },
+                        { text: "Ela impede a inferência nos outros tipos", isCorrect: false },
+                        { text: "Ela precisa ser reordenada a cada uso", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que anotar o retorno de funções exportadas ajuda?",
+                    difficulty: "dificil",
+                    options: [
+                        {
+                            text: "Evita reinferir a cadeia e estabiliza a interface",
+                            isCorrect: true,
+                        },
+                        { text: "Reduz o tamanho do JavaScript gerado", isCorrect: false },
+                        {
+                            text: "Permite que a função seja usada sem nenhum import",
+                            isCorrect: false,
+                        },
+                        { text: "Faz o compilador pular a checagem do corpo", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que `--generateTrace` produz?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Um rastro para abrir em um perfilador", isCorrect: true },
+                        { text: "Um log de todos os erros encontrados", isCorrect: false },
+                        { text: "Um relatório dos tipos usados no projeto", isCorrect: false },
+                        { text: "Uma lista dos arquivos mais lentos", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+        {
+            titulo: "Projeto final e para onde ir",
+            blocks: [
+                {
+                    type: "text",
+                    value: "# Juntando tudo\n\nPara fechar a trilha, escreva um **cliente de API tipado de ponta a ponta**. Ele exercita cada módulo:\n\n1. `tsconfig.json` estrito, com `noUncheckedIndexedAccess` ligado\n2. Tipos de domínio derivados uns dos outros com `Pick`, `Omit` e `Partial`\n3. Uma união discriminada para o resultado: carregando, sucesso ou erro\n4. Uma função genérica de requisição que preserva o tipo da resposta\n5. Validação na fronteira, com um esquema que gera o tipo\n6. Template literal types para as rotas, garantindo a convenção\n7. `tsc --noEmit`, ESLint com regras que usam tipo, e testes",
+                },
+                {
+                    type: "code",
+                    value: 'type Resultado<T> =\n  | { estado: "carregando" }\n  | { estado: "ok"; dados: T }\n  | { estado: "erro"; mensagem: string };\n\nasync function requisitar<T>(\n  rota: `/api/${string}`,\n  validar: (v: unknown) => T,\n): Promise<Resultado<T>> {\n  try {\n    const r = await fetch(rota);\n    if (!r.ok) return { estado: "erro", mensagem: `HTTP ${r.status}` };\n    return { estado: "ok", dados: validar(await r.json()) };\n  } catch (e) {\n    return { estado: "erro", mensagem: e instanceof Error ? e.message : "falhou" };\n  }\n}',
+                },
+                {
+                    type: "text",
+                    value: "Repare que o `catch` trata `e` como `unknown`, que é o padrão do modo estrito, e verifica antes de acessar `message`. Esse é o tipo de cuidado que a trilha inteira construiu.\n\n## Para onde ir depois\n\nO caminho mais comum é aplicar TypeScript em um framework: **React** com tipos é onde a maior parte do TypeScript profissional acontece, e a trilha de React desta plataforma continua daqui.\n\nNo back-end, vale olhar TypeScript com Node e um framework de API. E se o assunto for tipos avançados, o exercício que mais ensina é ler os tipos de uma biblioteca que você já usa.",
+                },
+            ],
+            questions: [
+                {
+                    statement: "Por que o `catch` trata o erro como `unknown`?",
+                    difficulty: "medio",
+                    options: [
+                        {
+                            text: "É o padrão do modo estrito, e qualquer coisa pode ser lançada",
+                            isCorrect: true,
+                        },
+                        { text: "Porque o erro sempre é um objeto Error", isCorrect: false },
+                        {
+                            text: "Porque o tipo do erro capturado não pode ser anotado de forma alguma",
+                            isCorrect: false,
+                        },
+                        { text: "Porque o try não permite tipar o bloco", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que a união discriminada do resultado garante?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Que todos os estados sejam tratados", isCorrect: true },
+                        { text: "Que a requisição nunca falhe no meio", isCorrect: false },
+                        { text: "Que os dados venham sempre preenchidos", isCorrect: false },
+                        { text: "Que o estado seja verificado em execução", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que o parâmetro genérico `T` preserva na função de requisição?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "O tipo da resposta até quem chamou", isCorrect: true },
+                        {
+                            text: "O tipo da rota informada no primeiro argumento",
+                            isCorrect: false,
+                        },
+                        { text: "O formato do erro devolvido pela API", isCorrect: false },
+                        { text: "A validação aplicada aos dados recebidos", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "O que a rota tipada como `/api/${string}` garante?",
+                    difficulty: "dificil",
+                    options: [
+                        { text: "Que o caminho comece pelo prefixo esperado", isCorrect: true },
+                        { text: "Que a rota exista no servidor da API", isCorrect: false },
+                        {
+                            text: "Que o caminho seja escapado antes de ser usado",
+                            isCorrect: false,
+                        },
+                        { text: "Que a resposta venha no formato JSON", isCorrect: false },
+                    ],
+                },
+                {
+                    statement: "Qual exercício mais ensina sobre tipos avançados?",
+                    difficulty: "medio",
+                    options: [
+                        { text: "Ler os tipos de uma biblioteca que você usa", isCorrect: true },
+                        { text: "Escrever tipos recursivos do zero", isCorrect: false },
+                        { text: "Converter um projeto bem grande de uma vez só", isCorrect: false },
+                        { text: "Decorar a lista de utility types", isCorrect: false },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+export const MODULOS: Modulo[] = [
+    MODULO_1,
+    MODULO_2,
+    MODULO_3,
+    MODULO_4,
+    MODULO_5,
+    MODULO_6,
+    MODULO_7,
+];
+
+async function seed() {
+    let [trilha] = await db.select().from(trails).where(eq(trails.name, NOME));
+    if (!trilha) {
+        [trilha] = await db
+            .insert(trails)
+            .values({
+                name: NOME,
+                trailLevel: LEVEL,
+                description: DESCRICAO,
+                workloadHours: CARGA_HORARIA,
+            })
+            .returning();
+        console.log("Trilha criada: " + NOME);
+    } else {
+        const existentes = await db.select().from(lessons).where(eq(lessons.trailId, trilha.id));
+        if (existentes.length > 0) {
+            console.log("Trilha já tem aulas, nada a fazer: " + NOME);
+            return;
+        }
+        await db
+            .update(trails)
+            .set({ workloadHours: CARGA_HORARIA, description: DESCRICAO, trailLevel: LEVEL })
+            .where(eq(trails.id, trilha.id));
+    }
+
+    let totalAulas = 0;
+    let totalQuestoes = 0;
+    for (let mi = 0; mi < MODULOS.length; mi++) {
+        const m = MODULOS[mi];
+        const [mod] = await db
+            .insert(modules)
+            .values({ trailId: trilha.id, title: m.titulo, position: mi + 1 })
+            .returning();
+        for (let li = 0; li < m.aulas.length; li++) {
+            const a = m.aulas[li];
+            const [lesson] = await db
+                .insert(lessons)
+                .values({
+                    trailId: trilha.id,
+                    moduleId: mod.id,
+                    title: a.titulo,
+                    content: null,
+                    contentBlocks: a.blocks,
+                    position: li + 1,
+                    published: true,
+                })
+                .returning();
+            for (let qi = 0; qi < a.questions.length; qi++) {
+                const q = a.questions[qi];
+                const [questao] = await db
+                    .insert(questions)
+                    .values({
+                        lessonId: lesson.id,
+                        statement: q.statement,
+                        difficulty: q.difficulty,
+                        position: qi + 1,
+                    })
+                    .returning();
+                await db.insert(questionOptions).values(
+                    q.options.map((o, k) => ({
+                        questionId: questao.id,
+                        text: o.text,
+                        isCorrect: o.isCorrect,
+                        position: k + 1,
+                    })),
+                );
+            }
+            totalAulas++;
+            totalQuestoes += a.questions.length;
+        }
+    }
+    console.log(
+        "Seed concluído: " +
+            MODULOS.length +
+            " módulos, " +
+            totalAulas +
+            " aulas, " +
+            totalQuestoes +
+            " questões.",
+    );
+}
+
+// Só semeia quando executado direto. Importado, expõe MODULOS/NOME sem rodar nada.
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+    seed()
+        .then(() => process.exit(0))
+        .catch((e) => {
+            console.error("Falha no seed:", e);
+            process.exit(1);
+        });
+}


### PR DESCRIPTION
Três trilhas que fecham as duas stacks mais pedidas: JavaScript já existia mas parava na linguagem, e Java existia sem nenhum framework.

## As versões, com duas surpresas

Confirmei cada uma na fonte antes de escrever, e o cenário mudou bastante:

| Stack | Versão | Lançamento | O que muda |
|---|---|---|---|
| TypeScript | **7.0** (patch 7.0.2) | 08/07/2026 | compilador nativo em Go, 8x a 12x mais rápido |
| React | **19.2** (patch 19.2.8) | 01/10/2025 | React Compiler 1.0 estável |
| Spring Boot | **4.1** | 10/06/2026 | sobre Spring Framework 7.0.8 |

O **TypeScript 7 saiu do preview há três semanas** e inverteu padrões que todo tutorial antigo ensina: `strict` e `module: esnext` viraram padrão, `types` deixou de incluir tudo, e `target: es5` e `moduleResolution: node` foram **removidos**. Um `tsconfig.json` copiado de material de 2024 simplesmente não funciona.

O **Spring Boot pulou para a linha 4** em novembro de 2025, sobre o Spring Framework 7. Ele mantém compatibilidade com Java 17, então dá para migrar o Spring sem migrar o Java junto.

## O que cada trilha cobre

Todas seguem o formato atual: **7 módulos, 35 aulas, 175 questões, 5 por aula**.

**TypeScript**, intermediário, 20 horas. Por que tipos existem, união e narrowing, interfaces e generics, os tipos que calculam com conditional e mapped types, validação na fronteira, configuração do compilador e migração de projeto JavaScript. O módulo 7 é sobre a versão 7: o compilador em Go, os padrões novos, o pacote `@typescript/typescript6` para conviver, e como medir quando a checagem fica lenta.

**React**, intermediário, 24 horas. JSX e componentes, estado e a lição de que ele é uma foto e não uma variável, efeitos e os quatro casos em que não se deve usar efeito, composição com hooks próprios e context, as Actions do React 19, desempenho com o React Compiler, testes e Server Components. Do 19.2 entram `useEffectEvent` e `<Activity>`.

**Spring Boot**, intermediário, 24 horas. Injeção de dependência e auto-configuração, REST com validação e `ProblemDetail`, JPA com relacionamentos e o N+1, Security com JWT, testes com Mockito e Testcontainers, Actuator e observabilidade. Da linha 4: modularização, Java 25 com records e threads virtuais, versionamento de API e HTTP Service Clients. Do 4.1: conexões preguiçosas, propagação de contexto em `@Async` e mitigação de SSRF.

## Decisões de conteúdo

**Ensinar a armadilha.** Cada trilha insiste nos pontos onde a documentação é clara mas a prática engana: `any` apagando a segurança do caminho todo, o estado do React sendo uma foto da renderização, o `key` com índice quebrando lista com estado, o `@Enumerated` que grava a posição do enum, o `@Transactional` que não funciona em autoinvocação, o `useFormStatus` que só funciona dentro do formulário.

**Um módulo por versão nova.** As três trilhas terminam com um módulo dedicado ao que a versão atual trouxe, em vez de espalhar as novidades como notas de rodapé. Isso também facilita a revisão quando a próxima versão sair.

**As três emitem certificado** e ficam **fora de roadmap**, como as demais trilhas de linguagem e framework.

## Verificado em dev

- 3 trilhas, 21 módulos, 105 aulas, 525 questões, 5 questões em toda aula
- toda questão com 4 alternativas e exatamente uma correta: **0 fora do padrão**
- nenhuma alternativa correta é a mais longa do grupo, nas 525
- sem emoji e sem travessão nas 105 aulas
- `seed-detalhes-trilhas` e `seed-conquistas-trilhas` rodados: 3 conquistas criadas
- `tsc --noEmit`, eslint e prettier limpos

## Para rodar em produção

    node scripts/seed-trilha-typescript.ts
    node scripts/seed-trilha-react.ts
    node scripts/seed-trilha-spring-boot.ts
    node scripts/seed-detalhes-trilhas.ts
    node scripts/seed-conquistas-trilhas.ts

Todos idempotentes, e nenhum roadmap é alterado.