### PR TITLE
feat: plano trimestral e analisador ATS de currículo

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -18,3 +18,12 @@ CERT_RESPONSAVEL=
 ABACATEPAY_API_KEY=
 ABACATEPAY_WEBHOOK_SECRET=
 ABACATEPAY_PRODUCT_PIX_AUTO=
+
+# Analisador de currículo. Sem ATS_IA_MODO o motor determinístico roda sozinho.
+# "api" usa a chave abaixo (o padrão aponta para o DeepSeek, que fala o protocolo
+# da Anthropic); "cli" usa o Claude Code instalado na máquina e só vale local.
+ATS_IA_MODO=off
+ATS_API_KEY=
+# ATS_API_BASE_URL=https://api.deepseek.com/anthropic
+# ATS_MODELO=deepseek-v4-pro
+# ATS_LIMITE_MENSAL=30

--- a/backend/app.ts
+++ b/backend/app.ts
@@ -13,6 +13,7 @@ import certificateRoutes from "./src/routes/certificate.routes.ts";
 import apoioRoutes from "./src/routes/apoio.routes.ts";
 import comunidadeRoutes from "./src/routes/comunidade.routes.ts";
 import labRoutes from "./src/routes/lab.routes.ts";
+import atsRoutes from "./src/routes/ats.routes.ts";
 import { errorMiddleware } from "./src/middlewares/error.ts";
 import { apiLimiter } from "./src/middlewares/rateLimit.ts";
 import helmet from "helmet";
@@ -30,6 +31,7 @@ app.use("/me/avatar", express.json({ limit: "6mb" }));
 app.use("/me/cover", express.json({ limit: "6mb" }));
 app.use("/me/fundo", express.json({ limit: "14mb" }));
 app.use("/comunidade/imagem", express.json({ limit: "6mb" }));
+app.use("/curriculo/analises", express.json({ limit: "8mb" }));
 app.use(express.json());
 app.use(helmet({ frameguard: { action: "deny" } }));
 app.use(
@@ -62,6 +64,7 @@ app.use(certificateRoutes);
 app.use(apoioRoutes);
 app.use(comunidadeRoutes);
 app.use(labRoutes);
+app.use(atsRoutes);
 app.use(adminRoutes);
 
 app.get("/health", (_req, res) => res.json({ status: "ok" }));

--- a/backend/drizzle/0048_plano_trimestral.sql
+++ b/backend/drizzle/0048_plano_trimestral.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."subscription_plan" ADD VALUE 'trimestral' BEFORE 'anual';

--- a/backend/drizzle/0049_analise_curriculo.sql
+++ b/backend/drizzle/0049_analise_curriculo.sql
@@ -1,0 +1,20 @@
+CREATE TYPE "public"."resume_analysis_engine" AS ENUM('heuristica', 'ia');--> statement-breakpoint
+CREATE TABLE "resume_analyses" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"job_title" varchar(160),
+	"score" integer NOT NULL,
+	"verdict" varchar(80) NOT NULL,
+	"description" text NOT NULL,
+	"engine" "resume_analysis_engine" NOT NULL,
+	"summary" jsonb NOT NULL,
+	"breakdown" jsonb NOT NULL,
+	"keywords_found" jsonb NOT NULL,
+	"keywords_partial" jsonb NOT NULL,
+	"keywords_missing" jsonb NOT NULL,
+	"suggestions" jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "resume_analyses" ADD CONSTRAINT "resume_analyses_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "resume_analyses_user_id_idx" ON "resume_analyses" USING btree ("user_id");

--- a/backend/drizzle/meta/0048_snapshot.json
+++ b/backend/drizzle/meta/0048_snapshot.json
@@ -1,0 +1,3914 @@
+{
+  "id": "3b013fcc-9f2e-485d-b8dd-39f9a031504a",
+  "prevId": "0be1bf59-4565-4096-8977-6deb956629e9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.achievements": {
+      "name": "achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "criteria_type": {
+          "name": "criteria_type",
+          "type": "achievement_criteria",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "achievements_name_unique": {
+          "name": "achievements_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.certificates": {
+      "name": "certificates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_name": {
+          "name": "student_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpf": {
+          "name": "cpf",
+          "type": "varchar(11)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trail_name": {
+          "name": "trail_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workload_hours": {
+          "name": "workload_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "certificates_trail_id_idx": {
+          "name": "certificates_trail_id_idx",
+          "columns": [
+            {
+              "expression": "trail_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "certificates_user_id_users_id_fk": {
+          "name": "certificates_user_id_users_id_fk",
+          "tableFrom": "certificates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "certificates_trail_id_trails_id_fk": {
+          "name": "certificates_trail_id_trails_id_fk",
+          "tableFrom": "certificates",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "certificates_code_unique": {
+          "name": "certificates_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        },
+        "certificates_user_id_trail_id_unique": {
+          "name": "certificates_user_id_trail_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "trail_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge_submissions": {
+      "name": "challenge_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "challenge_language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "challenge_submission_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "passed_count": {
+          "name": "passed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_count": {
+          "name": "total_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xp_earned": {
+          "name": "xp_earned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "challenge_submissions_user_id_idx": {
+          "name": "challenge_submissions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "challenge_submissions_challenge_id_idx": {
+          "name": "challenge_submissions_challenge_id_idx",
+          "columns": [
+            {
+              "expression": "challenge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "challenge_submissions_user_id_users_id_fk": {
+          "name": "challenge_submissions_user_id_users_id_fk",
+          "tableFrom": "challenge_submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "challenge_submissions_challenge_id_challenges_id_fk": {
+          "name": "challenge_submissions_challenge_id_challenges_id_fk",
+          "tableFrom": "challenge_submissions",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge_tests": {
+      "name": "challenge_tests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_output": {
+          "name": "expected_output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "challenge_tests_challenge_id_idx": {
+          "name": "challenge_tests_challenge_id_idx",
+          "columns": [
+            {
+              "expression": "challenge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "challenge_tests_challenge_id_challenges_id_fk": {
+          "name": "challenge_tests_challenge_id_challenges_id_fk",
+          "tableFrom": "challenge_tests",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenges": {
+      "name": "challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "challenge_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stdin'"
+        },
+        "entry_point": {
+          "name": "entry_point",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_blocks": {
+          "name": "statement_blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "question_difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'facil'"
+        },
+        "starter_code": {
+          "name": "starter_code",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_date": {
+          "name": "active_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "challenges_number_unique": {
+          "name": "challenges_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "number"
+          ]
+        },
+        "challenges_active_date_unique": {
+          "name": "challenges_active_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "active_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_comments": {
+      "name": "community_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_comments_post_id_idx": {
+          "name": "community_comments_post_id_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_comments_user_id_idx": {
+          "name": "community_comments_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_comments_post_id_community_posts_id_fk": {
+          "name": "community_comments_post_id_community_posts_id_fk",
+          "tableFrom": "community_comments",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_comments_user_id_users_id_fk": {
+          "name": "community_comments_user_id_users_id_fk",
+          "tableFrom": "community_comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_likes": {
+      "name": "community_likes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_likes_user_id_idx": {
+          "name": "community_likes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_likes_post_id_community_posts_id_fk": {
+          "name": "community_likes_post_id_community_posts_id_fk",
+          "tableFrom": "community_likes",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_likes_user_id_users_id_fk": {
+          "name": "community_likes_user_id_users_id_fk",
+          "tableFrom": "community_likes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "community_likes_post_id_user_id_unique": {
+          "name": "community_likes_post_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_post_tags": {
+      "name": "community_post_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_post_tags_post_id_community_posts_id_fk": {
+          "name": "community_post_tags_post_id_community_posts_id_fk",
+          "tableFrom": "community_post_tags",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "community_post_tags_post_id_tag_unique": {
+          "name": "community_post_tags_post_id_tag_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_id",
+            "tag"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_posts": {
+      "name": "community_posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "community_post_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'post'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_language": {
+          "name": "code_language",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_posts_user_id_idx": {
+          "name": "community_posts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_posts_user_id_users_id_fk": {
+          "name": "community_posts_user_id_users_id_fk",
+          "tableFrom": "community_posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comunicado_respostas": {
+      "name": "comunicado_respostas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "comunicado_id": {
+          "name": "comunicado_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "comunicado_resposta_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "comunicado_respostas_user_id_idx": {
+          "name": "comunicado_respostas_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comunicado_respostas_comunicado_id_comunicados_id_fk": {
+          "name": "comunicado_respostas_comunicado_id_comunicados_id_fk",
+          "tableFrom": "comunicado_respostas",
+          "tableTo": "comunicados",
+          "columnsFrom": [
+            "comunicado_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "comunicado_respostas_user_id_users_id_fk": {
+          "name": "comunicado_respostas_user_id_users_id_fk",
+          "tableFrom": "comunicado_respostas",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "comunicado_respostas_comunicado_id_user_id_unique": {
+          "name": "comunicado_respostas_comunicado_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "comunicado_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comunicados": {
+      "name": "comunicados",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "comunicado_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.glossary": {
+      "name": "glossary",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "term": {
+          "name": "term",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "varchar(400)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "glossary_term_unique": {
+          "name": "glossary_term_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "term"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.languages": {
+      "name": "languages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "languages_name_unique": {
+          "name": "languages_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons_progress": {
+      "name": "lessons_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "manual": {
+          "name": "manual",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "lessons_progress_lesson_id_idx": {
+          "name": "lessons_progress_lesson_id_idx",
+          "columns": [
+            {
+              "expression": "lesson_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lessons_progress_user_id_users_id_fk": {
+          "name": "lessons_progress_user_id_users_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_progress_lesson_id_lessons_id_fk": {
+          "name": "lessons_progress_lesson_id_lessons_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lessons_progress_user_id_lesson_id_unique": {
+          "name": "lessons_progress_user_id_lesson_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "lesson_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons": {
+      "name": "lessons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_blocks": {
+          "name": "content_blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "duration_min": {
+          "name": "duration_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview": {
+          "name": "preview",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lessons_trail_id_idx": {
+          "name": "lessons_trail_id_idx",
+          "columns": [
+            {
+              "expression": "trail_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lessons_module_id_idx": {
+          "name": "lessons_module_id_idx",
+          "columns": [
+            {
+              "expression": "module_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lessons_trail_id_trails_id_fk": {
+          "name": "lessons_trail_id_trails_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_module_id_modules_id_fk": {
+          "name": "lessons_module_id_modules_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "modules",
+          "columnsFrom": [
+            "module_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.modules": {
+      "name": "modules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "modules_trail_id_idx": {
+          "name": "modules_trail_id_idx",
+          "columns": [
+            {
+              "expression": "trail_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "modules_trail_id_trails_id_fk": {
+          "name": "modules_trail_id_trails_id_fk",
+          "tableFrom": "modules",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_accounts": {
+      "name": "oauth_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_accounts_user_id_idx": {
+          "name": "oauth_accounts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_accounts_user_id_users_id_fk": {
+          "name": "oauth_accounts_user_id_users_id_fk",
+          "tableFrom": "oauth_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_accounts_provider_provider_id_unique": {
+          "name": "oauth_accounts_provider_provider_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "provider_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_answers": {
+      "name": "question_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_option_id": {
+          "name": "selected_option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "question_answers_question_id_idx": {
+          "name": "question_answers_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "question_answers_selected_option_id_idx": {
+          "name": "question_answers_selected_option_id_idx",
+          "columns": [
+            {
+              "expression": "selected_option_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "question_answers_user_id_users_id_fk": {
+          "name": "question_answers_user_id_users_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_question_id_questions_id_fk": {
+          "name": "question_answers_question_id_questions_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_selected_option_id_question_options_id_fk": {
+          "name": "question_answers_selected_option_id_question_options_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "question_options",
+          "columnsFrom": [
+            "selected_option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "question_answers_user_id_question_id_unique": {
+          "name": "question_answers_user_id_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_options": {
+      "name": "question_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "question_options_question_id_idx": {
+          "name": "question_options_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "question_options_question_id_questions_id_fk": {
+          "name": "question_options_question_id_questions_id_fk",
+          "tableFrom": "question_options",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "question_difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'facil'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "questions_lesson_id_idx": {
+          "name": "questions_lesson_id_idx",
+          "columns": [
+            {
+              "expression": "lesson_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "questions_lesson_id_lessons_id_fk": {
+          "name": "questions_lesson_id_lessons_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ranking_snapshots": {
+      "name": "ranking_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ranking_snapshots_user_id_users_id_fk": {
+          "name": "ranking_snapshots_user_id_users_id_fk",
+          "tableFrom": "ranking_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ranking_snapshots_user_id_snapshot_date_unique": {
+          "name": "ranking_snapshots_user_id_snapshot_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "snapshot_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmap_stage_completions": {
+      "name": "roadmap_stage_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "roadmap_stage_completions_stage_id_idx": {
+          "name": "roadmap_stage_completions_stage_id_idx",
+          "columns": [
+            {
+              "expression": "stage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "roadmap_stage_completions_user_id_users_id_fk": {
+          "name": "roadmap_stage_completions_user_id_users_id_fk",
+          "tableFrom": "roadmap_stage_completions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "roadmap_stage_completions_stage_id_roadmap_stages_id_fk": {
+          "name": "roadmap_stage_completions_stage_id_roadmap_stages_id_fk",
+          "tableFrom": "roadmap_stage_completions",
+          "tableTo": "roadmap_stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roadmap_stage_completions_user_id_stage_id_unique": {
+          "name": "roadmap_stage_completions_user_id_stage_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "stage_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmap_stage_refs": {
+      "name": "roadmap_stage_refs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_type": {
+          "name": "ref_type",
+          "type": "roadmap_ref_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "roadmap_stage_refs_stage_id_idx": {
+          "name": "roadmap_stage_refs_stage_id_idx",
+          "columns": [
+            {
+              "expression": "stage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "roadmap_stage_refs_stage_id_roadmap_stages_id_fk": {
+          "name": "roadmap_stage_refs_stage_id_roadmap_stages_id_fk",
+          "tableFrom": "roadmap_stage_refs",
+          "tableTo": "roadmap_stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmap_stages": {
+      "name": "roadmap_stages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "roadmap_id": {
+          "name": "roadmap_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "roadmap_phase",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "roadmap_stages_roadmap_id_idx": {
+          "name": "roadmap_stages_roadmap_id_idx",
+          "columns": [
+            {
+              "expression": "roadmap_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "roadmap_stages_roadmap_id_roadmaps_id_fk": {
+          "name": "roadmap_stages_roadmap_id_roadmaps_id_fk",
+          "tableFrom": "roadmap_stages",
+          "tableTo": "roadmaps",
+          "columnsFrom": [
+            "roadmap_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmaps": {
+      "name": "roadmaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "trail_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "premium": {
+          "name": "premium",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roadmaps_slug_unique": {
+          "name": "roadmaps_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_attempt_answers": {
+      "name": "simulado_attempt_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "simulado_attempt_answers_question_id_idx": {
+          "name": "simulado_attempt_answers_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulado_attempt_answers_option_id_idx": {
+          "name": "simulado_attempt_answers_option_id_idx",
+          "columns": [
+            {
+              "expression": "option_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "simulado_attempt_answers_attempt_id_simulado_attempts_id_fk": {
+          "name": "simulado_attempt_answers_attempt_id_simulado_attempts_id_fk",
+          "tableFrom": "simulado_attempt_answers",
+          "tableTo": "simulado_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempt_answers_question_id_simulado_questions_id_fk": {
+          "name": "simulado_attempt_answers_question_id_simulado_questions_id_fk",
+          "tableFrom": "simulado_attempt_answers",
+          "tableTo": "simulado_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempt_answers_option_id_simulado_options_id_fk": {
+          "name": "simulado_attempt_answers_option_id_simulado_options_id_fk",
+          "tableFrom": "simulado_attempt_answers",
+          "tableTo": "simulado_options",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulado_attempt_answers_attempt_id_question_id_option_id_unique": {
+          "name": "simulado_attempt_answers_attempt_id_question_id_option_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "attempt_id",
+            "question_id",
+            "option_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_attempt_questions": {
+      "name": "simulado_attempt_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "simulado_attempt_questions_question_id_idx": {
+          "name": "simulado_attempt_questions_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "simulado_attempt_questions_attempt_id_simulado_attempts_id_fk": {
+          "name": "simulado_attempt_questions_attempt_id_simulado_attempts_id_fk",
+          "tableFrom": "simulado_attempt_questions",
+          "tableTo": "simulado_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempt_questions_question_id_simulado_questions_id_fk": {
+          "name": "simulado_attempt_questions_question_id_simulado_questions_id_fk",
+          "tableFrom": "simulado_attempt_questions",
+          "tableTo": "simulado_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulado_attempt_questions_attempt_id_question_id_unique": {
+          "name": "simulado_attempt_questions_attempt_id_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "attempt_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_attempts": {
+      "name": "simulado_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "simulado_id": {
+          "name": "simulado_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passed": {
+          "name": "passed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personalizado": {
+          "name": "personalizado",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "topicos": {
+          "name": "topicos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "simulado_attempts_user_id_idx": {
+          "name": "simulado_attempts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulado_attempts_simulado_id_idx": {
+          "name": "simulado_attempts_simulado_id_idx",
+          "columns": [
+            {
+              "expression": "simulado_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "simulado_attempts_user_id_users_id_fk": {
+          "name": "simulado_attempts_user_id_users_id_fk",
+          "tableFrom": "simulado_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempts_simulado_id_simulados_id_fk": {
+          "name": "simulado_attempts_simulado_id_simulados_id_fk",
+          "tableFrom": "simulado_attempts",
+          "tableTo": "simulados",
+          "columnsFrom": [
+            "simulado_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_options": {
+      "name": "simulado_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "simulado_options_question_id_idx": {
+          "name": "simulado_options_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "simulado_options_question_id_simulado_questions_id_fk": {
+          "name": "simulado_options_question_id_simulado_questions_id_fk",
+          "tableFrom": "simulado_options",
+          "tableTo": "simulado_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_questions": {
+      "name": "simulado_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "simulado_id": {
+          "name": "simulado_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "simulado_questions_simulado_id_idx": {
+          "name": "simulado_questions_simulado_id_idx",
+          "columns": [
+            {
+              "expression": "simulado_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "simulado_questions_simulado_id_simulados_id_fk": {
+          "name": "simulado_questions_simulado_id_simulados_id_fk",
+          "tableFrom": "simulado_questions",
+          "tableTo": "simulados",
+          "columnsFrom": [
+            "simulado_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulados": {
+      "name": "simulados",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_count": {
+          "name": "question_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pass_percent": {
+          "name": "pass_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulados_slug_unique": {
+          "name": "simulados_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "subscription_plan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "subscription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pendente'"
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gateway": {
+          "name": "gateway",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'abacatepay'"
+        },
+        "gateway_id": {
+          "name": "gateway_id",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_user_id_idx": {
+          "name": "subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_user_id_users_id_fk": {
+          "name": "subscriptions_user_id_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tokens": {
+      "name": "tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'refresh'"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tokens_user_id_idx": {
+          "name": "tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tokens_user_id_users_id_fk": {
+          "name": "tokens_user_id_users_id_fk",
+          "tableFrom": "tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tokens_token_hash_unique": {
+          "name": "tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_reviews": {
+      "name": "trail_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stars": {
+          "name": "stars",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trail_reviews_trail_id_idx": {
+          "name": "trail_reviews_trail_id_idx",
+          "columns": [
+            {
+              "expression": "trail_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trail_reviews_trail_id_trails_id_fk": {
+          "name": "trail_reviews_trail_id_trails_id_fk",
+          "tableFrom": "trail_reviews",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trail_reviews_user_id_users_id_fk": {
+          "name": "trail_reviews_user_id_users_id_fk",
+          "tableFrom": "trail_reviews",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trail_reviews_user_id_trail_id_unique": {
+          "name": "trail_reviews_user_id_trail_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "trail_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_tags": {
+      "name": "trail_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "trail_tags_tag_id_idx": {
+          "name": "trail_tags_tag_id_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trail_tags_trail_id_trails_id_fk": {
+          "name": "trail_tags_trail_id_trails_id_fk",
+          "tableFrom": "trail_tags",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trail_tags_tag_id_tags_id_fk": {
+          "name": "trail_tags_tag_id_tags_id_fk",
+          "tableFrom": "trail_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trail_tags_trail_id_tag_id_unique": {
+          "name": "trail_tags_trail_id_tag_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trail_id",
+            "tag_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trails": {
+      "name": "trails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "trail_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "what_you_learn": {
+          "name": "what_you_learn",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prerequisites": {
+          "name": "prerequisites",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workload_hours": {
+          "name": "workload_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_achievements": {
+      "name": "user_achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "achievement_id": {
+          "name": "achievement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "notified": {
+          "name": "notified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_achievements_achievement_id_idx": {
+          "name": "user_achievements_achievement_id_idx",
+          "columns": [
+            {
+              "expression": "achievement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_achievements_user_id_users_id_fk": {
+          "name": "user_achievements_user_id_users_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_achievements_achievement_id_achievements_id_fk": {
+          "name": "user_achievements_achievement_id_achievements_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "achievements",
+          "columnsFrom": [
+            "achievement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_achievements_user_id_achievement_id_unique": {
+          "name": "user_achievements_user_id_achievement_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "achievement_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_follows": {
+      "name": "user_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "following_id": {
+          "name": "following_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_follows_following_id_idx": {
+          "name": "user_follows_following_id_idx",
+          "columns": [
+            {
+              "expression": "following_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_follows_follower_id_users_id_fk": {
+          "name": "user_follows_follower_id_users_id_fk",
+          "tableFrom": "user_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_follows_following_id_users_id_fk": {
+          "name": "user_follows_following_id_users_id_fk",
+          "tableFrom": "user_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "following_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_follows_follower_id_following_id_unique": {
+          "name": "user_follows_follower_id_following_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "follower_id",
+            "following_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username_changed_at": {
+          "name": "username_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occupation": {
+          "name": "occupation",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github": {
+          "name": "github",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin": {
+          "name": "linkedin",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "failed_login_attempts": {
+          "name": "failed_login_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_goal_kind": {
+          "name": "weekly_goal_kind",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_goal_target": {
+          "name": "weekly_goal_target",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accent": {
+          "name": "accent",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "background_url": {
+          "name": "background_url",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "background_dim": {
+          "name": "background_dim",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.achievement_criteria": {
+      "name": "achievement_criteria",
+      "schema": "public",
+      "values": [
+        "xp_total",
+        "lessons_completed",
+        "questions_correct",
+        "special",
+        "streak_days",
+        "challenges_facil",
+        "challenges_medio",
+        "challenges_dificil",
+        "trail_completed"
+      ]
+    },
+    "public.challenge_kind": {
+      "name": "challenge_kind",
+      "schema": "public",
+      "values": [
+        "stdin",
+        "function"
+      ]
+    },
+    "public.challenge_language": {
+      "name": "challenge_language",
+      "schema": "public",
+      "values": [
+        "javascript",
+        "python",
+        "csharp",
+        "java"
+      ]
+    },
+    "public.challenge_submission_status": {
+      "name": "challenge_submission_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "passed",
+        "failed",
+        "error",
+        "timeout"
+      ]
+    },
+    "public.community_post_kind": {
+      "name": "community_post_kind",
+      "schema": "public",
+      "values": [
+        "duvida",
+        "solucao",
+        "conquista",
+        "post"
+      ]
+    },
+    "public.comunicado_kind": {
+      "name": "comunicado_kind",
+      "schema": "public",
+      "values": [
+        "aviso",
+        "pesquisa"
+      ]
+    },
+    "public.comunicado_resposta_status": {
+      "name": "comunicado_resposta_status",
+      "schema": "public",
+      "values": [
+        "respondido",
+        "dispensado"
+      ]
+    },
+    "public.question_difficulty": {
+      "name": "question_difficulty",
+      "schema": "public",
+      "values": [
+        "facil",
+        "medio",
+        "dificil"
+      ]
+    },
+    "public.roadmap_phase": {
+      "name": "roadmap_phase",
+      "schema": "public",
+      "values": [
+        "fundamentos",
+        "core",
+        "avancado",
+        "deploy"
+      ]
+    },
+    "public.roadmap_ref_type": {
+      "name": "roadmap_ref_type",
+      "schema": "public",
+      "values": [
+        "trail",
+        "module",
+        "lesson",
+        "simulado",
+        "challenge"
+      ]
+    },
+    "public.subscription_plan": {
+      "name": "subscription_plan",
+      "schema": "public",
+      "values": [
+        "mensal",
+        "trimestral",
+        "anual",
+        "pix_auto"
+      ]
+    },
+    "public.subscription_status": {
+      "name": "subscription_status",
+      "schema": "public",
+      "values": [
+        "pendente",
+        "ativa",
+        "cancelada"
+      ]
+    },
+    "public.trail_level": {
+      "name": "trail_level",
+      "schema": "public",
+      "values": [
+        "iniciante",
+        "intermediario",
+        "avancado"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin",
+        "moderator"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/0049_snapshot.json
+++ b/backend/drizzle/meta/0049_snapshot.json
@@ -1,0 +1,4052 @@
+{
+  "id": "893221fa-b9d1-421d-a167-1181844d2316",
+  "prevId": "3b013fcc-9f2e-485d-b8dd-39f9a031504a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.achievements": {
+      "name": "achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "criteria_type": {
+          "name": "criteria_type",
+          "type": "achievement_criteria",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "achievements_name_unique": {
+          "name": "achievements_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.certificates": {
+      "name": "certificates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_name": {
+          "name": "student_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpf": {
+          "name": "cpf",
+          "type": "varchar(11)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trail_name": {
+          "name": "trail_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workload_hours": {
+          "name": "workload_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "certificates_trail_id_idx": {
+          "name": "certificates_trail_id_idx",
+          "columns": [
+            {
+              "expression": "trail_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "certificates_user_id_users_id_fk": {
+          "name": "certificates_user_id_users_id_fk",
+          "tableFrom": "certificates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "certificates_trail_id_trails_id_fk": {
+          "name": "certificates_trail_id_trails_id_fk",
+          "tableFrom": "certificates",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "certificates_code_unique": {
+          "name": "certificates_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        },
+        "certificates_user_id_trail_id_unique": {
+          "name": "certificates_user_id_trail_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "trail_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge_submissions": {
+      "name": "challenge_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "challenge_language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "challenge_submission_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "passed_count": {
+          "name": "passed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_count": {
+          "name": "total_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xp_earned": {
+          "name": "xp_earned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "challenge_submissions_user_id_idx": {
+          "name": "challenge_submissions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "challenge_submissions_challenge_id_idx": {
+          "name": "challenge_submissions_challenge_id_idx",
+          "columns": [
+            {
+              "expression": "challenge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "challenge_submissions_user_id_users_id_fk": {
+          "name": "challenge_submissions_user_id_users_id_fk",
+          "tableFrom": "challenge_submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "challenge_submissions_challenge_id_challenges_id_fk": {
+          "name": "challenge_submissions_challenge_id_challenges_id_fk",
+          "tableFrom": "challenge_submissions",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge_tests": {
+      "name": "challenge_tests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_output": {
+          "name": "expected_output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "challenge_tests_challenge_id_idx": {
+          "name": "challenge_tests_challenge_id_idx",
+          "columns": [
+            {
+              "expression": "challenge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "challenge_tests_challenge_id_challenges_id_fk": {
+          "name": "challenge_tests_challenge_id_challenges_id_fk",
+          "tableFrom": "challenge_tests",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenges": {
+      "name": "challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "challenge_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stdin'"
+        },
+        "entry_point": {
+          "name": "entry_point",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_blocks": {
+          "name": "statement_blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "question_difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'facil'"
+        },
+        "starter_code": {
+          "name": "starter_code",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_date": {
+          "name": "active_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "challenges_number_unique": {
+          "name": "challenges_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "number"
+          ]
+        },
+        "challenges_active_date_unique": {
+          "name": "challenges_active_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "active_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_comments": {
+      "name": "community_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_comments_post_id_idx": {
+          "name": "community_comments_post_id_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_comments_user_id_idx": {
+          "name": "community_comments_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_comments_post_id_community_posts_id_fk": {
+          "name": "community_comments_post_id_community_posts_id_fk",
+          "tableFrom": "community_comments",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_comments_user_id_users_id_fk": {
+          "name": "community_comments_user_id_users_id_fk",
+          "tableFrom": "community_comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_likes": {
+      "name": "community_likes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_likes_user_id_idx": {
+          "name": "community_likes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_likes_post_id_community_posts_id_fk": {
+          "name": "community_likes_post_id_community_posts_id_fk",
+          "tableFrom": "community_likes",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_likes_user_id_users_id_fk": {
+          "name": "community_likes_user_id_users_id_fk",
+          "tableFrom": "community_likes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "community_likes_post_id_user_id_unique": {
+          "name": "community_likes_post_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_post_tags": {
+      "name": "community_post_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_post_tags_post_id_community_posts_id_fk": {
+          "name": "community_post_tags_post_id_community_posts_id_fk",
+          "tableFrom": "community_post_tags",
+          "tableTo": "community_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "community_post_tags_post_id_tag_unique": {
+          "name": "community_post_tags_post_id_tag_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_id",
+            "tag"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_posts": {
+      "name": "community_posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "community_post_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'post'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_language": {
+          "name": "code_language",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_posts_user_id_idx": {
+          "name": "community_posts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_posts_user_id_users_id_fk": {
+          "name": "community_posts_user_id_users_id_fk",
+          "tableFrom": "community_posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comunicado_respostas": {
+      "name": "comunicado_respostas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "comunicado_id": {
+          "name": "comunicado_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "comunicado_resposta_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "comunicado_respostas_user_id_idx": {
+          "name": "comunicado_respostas_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comunicado_respostas_comunicado_id_comunicados_id_fk": {
+          "name": "comunicado_respostas_comunicado_id_comunicados_id_fk",
+          "tableFrom": "comunicado_respostas",
+          "tableTo": "comunicados",
+          "columnsFrom": [
+            "comunicado_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "comunicado_respostas_user_id_users_id_fk": {
+          "name": "comunicado_respostas_user_id_users_id_fk",
+          "tableFrom": "comunicado_respostas",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "comunicado_respostas_comunicado_id_user_id_unique": {
+          "name": "comunicado_respostas_comunicado_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "comunicado_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comunicados": {
+      "name": "comunicados",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "comunicado_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.glossary": {
+      "name": "glossary",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "term": {
+          "name": "term",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "varchar(400)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "glossary_term_unique": {
+          "name": "glossary_term_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "term"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.languages": {
+      "name": "languages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "languages_name_unique": {
+          "name": "languages_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons_progress": {
+      "name": "lessons_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "manual": {
+          "name": "manual",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "lessons_progress_lesson_id_idx": {
+          "name": "lessons_progress_lesson_id_idx",
+          "columns": [
+            {
+              "expression": "lesson_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lessons_progress_user_id_users_id_fk": {
+          "name": "lessons_progress_user_id_users_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_progress_lesson_id_lessons_id_fk": {
+          "name": "lessons_progress_lesson_id_lessons_id_fk",
+          "tableFrom": "lessons_progress",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lessons_progress_user_id_lesson_id_unique": {
+          "name": "lessons_progress_user_id_lesson_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "lesson_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons": {
+      "name": "lessons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_blocks": {
+          "name": "content_blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "duration_min": {
+          "name": "duration_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview": {
+          "name": "preview",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lessons_trail_id_idx": {
+          "name": "lessons_trail_id_idx",
+          "columns": [
+            {
+              "expression": "trail_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lessons_module_id_idx": {
+          "name": "lessons_module_id_idx",
+          "columns": [
+            {
+              "expression": "module_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lessons_trail_id_trails_id_fk": {
+          "name": "lessons_trail_id_trails_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lessons_module_id_modules_id_fk": {
+          "name": "lessons_module_id_modules_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "modules",
+          "columnsFrom": [
+            "module_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.modules": {
+      "name": "modules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "modules_trail_id_idx": {
+          "name": "modules_trail_id_idx",
+          "columns": [
+            {
+              "expression": "trail_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "modules_trail_id_trails_id_fk": {
+          "name": "modules_trail_id_trails_id_fk",
+          "tableFrom": "modules",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_accounts": {
+      "name": "oauth_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_accounts_user_id_idx": {
+          "name": "oauth_accounts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_accounts_user_id_users_id_fk": {
+          "name": "oauth_accounts_user_id_users_id_fk",
+          "tableFrom": "oauth_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_accounts_provider_provider_id_unique": {
+          "name": "oauth_accounts_provider_provider_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "provider_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_answers": {
+      "name": "question_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_option_id": {
+          "name": "selected_option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "question_answers_question_id_idx": {
+          "name": "question_answers_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "question_answers_selected_option_id_idx": {
+          "name": "question_answers_selected_option_id_idx",
+          "columns": [
+            {
+              "expression": "selected_option_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "question_answers_user_id_users_id_fk": {
+          "name": "question_answers_user_id_users_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_question_id_questions_id_fk": {
+          "name": "question_answers_question_id_questions_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "question_answers_selected_option_id_question_options_id_fk": {
+          "name": "question_answers_selected_option_id_question_options_id_fk",
+          "tableFrom": "question_answers",
+          "tableTo": "question_options",
+          "columnsFrom": [
+            "selected_option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "question_answers_user_id_question_id_unique": {
+          "name": "question_answers_user_id_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_options": {
+      "name": "question_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "question_options_question_id_idx": {
+          "name": "question_options_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "question_options_question_id_questions_id_fk": {
+          "name": "question_options_question_id_questions_id_fk",
+          "tableFrom": "question_options",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "question_difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'facil'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "questions_lesson_id_idx": {
+          "name": "questions_lesson_id_idx",
+          "columns": [
+            {
+              "expression": "lesson_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "questions_lesson_id_lessons_id_fk": {
+          "name": "questions_lesson_id_lessons_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ranking_snapshots": {
+      "name": "ranking_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ranking_snapshots_user_id_users_id_fk": {
+          "name": "ranking_snapshots_user_id_users_id_fk",
+          "tableFrom": "ranking_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ranking_snapshots_user_id_snapshot_date_unique": {
+          "name": "ranking_snapshots_user_id_snapshot_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "snapshot_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resume_analyses": {
+      "name": "resume_analyses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_title": {
+          "name": "job_title",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "engine": {
+          "name": "engine",
+          "type": "resume_analysis_engine",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "breakdown": {
+          "name": "breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keywords_found": {
+          "name": "keywords_found",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keywords_partial": {
+          "name": "keywords_partial",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keywords_missing": {
+          "name": "keywords_missing",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestions": {
+          "name": "suggestions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "resume_analyses_user_id_idx": {
+          "name": "resume_analyses_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "resume_analyses_user_id_users_id_fk": {
+          "name": "resume_analyses_user_id_users_id_fk",
+          "tableFrom": "resume_analyses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmap_stage_completions": {
+      "name": "roadmap_stage_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "roadmap_stage_completions_stage_id_idx": {
+          "name": "roadmap_stage_completions_stage_id_idx",
+          "columns": [
+            {
+              "expression": "stage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "roadmap_stage_completions_user_id_users_id_fk": {
+          "name": "roadmap_stage_completions_user_id_users_id_fk",
+          "tableFrom": "roadmap_stage_completions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "roadmap_stage_completions_stage_id_roadmap_stages_id_fk": {
+          "name": "roadmap_stage_completions_stage_id_roadmap_stages_id_fk",
+          "tableFrom": "roadmap_stage_completions",
+          "tableTo": "roadmap_stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roadmap_stage_completions_user_id_stage_id_unique": {
+          "name": "roadmap_stage_completions_user_id_stage_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "stage_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmap_stage_refs": {
+      "name": "roadmap_stage_refs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_type": {
+          "name": "ref_type",
+          "type": "roadmap_ref_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "roadmap_stage_refs_stage_id_idx": {
+          "name": "roadmap_stage_refs_stage_id_idx",
+          "columns": [
+            {
+              "expression": "stage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "roadmap_stage_refs_stage_id_roadmap_stages_id_fk": {
+          "name": "roadmap_stage_refs_stage_id_roadmap_stages_id_fk",
+          "tableFrom": "roadmap_stage_refs",
+          "tableTo": "roadmap_stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmap_stages": {
+      "name": "roadmap_stages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "roadmap_id": {
+          "name": "roadmap_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "roadmap_phase",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "roadmap_stages_roadmap_id_idx": {
+          "name": "roadmap_stages_roadmap_id_idx",
+          "columns": [
+            {
+              "expression": "roadmap_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "roadmap_stages_roadmap_id_roadmaps_id_fk": {
+          "name": "roadmap_stages_roadmap_id_roadmaps_id_fk",
+          "tableFrom": "roadmap_stages",
+          "tableTo": "roadmaps",
+          "columnsFrom": [
+            "roadmap_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmaps": {
+      "name": "roadmaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "trail_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "premium": {
+          "name": "premium",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roadmaps_slug_unique": {
+          "name": "roadmaps_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_attempt_answers": {
+      "name": "simulado_attempt_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "simulado_attempt_answers_question_id_idx": {
+          "name": "simulado_attempt_answers_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulado_attempt_answers_option_id_idx": {
+          "name": "simulado_attempt_answers_option_id_idx",
+          "columns": [
+            {
+              "expression": "option_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "simulado_attempt_answers_attempt_id_simulado_attempts_id_fk": {
+          "name": "simulado_attempt_answers_attempt_id_simulado_attempts_id_fk",
+          "tableFrom": "simulado_attempt_answers",
+          "tableTo": "simulado_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempt_answers_question_id_simulado_questions_id_fk": {
+          "name": "simulado_attempt_answers_question_id_simulado_questions_id_fk",
+          "tableFrom": "simulado_attempt_answers",
+          "tableTo": "simulado_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempt_answers_option_id_simulado_options_id_fk": {
+          "name": "simulado_attempt_answers_option_id_simulado_options_id_fk",
+          "tableFrom": "simulado_attempt_answers",
+          "tableTo": "simulado_options",
+          "columnsFrom": [
+            "option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulado_attempt_answers_attempt_id_question_id_option_id_unique": {
+          "name": "simulado_attempt_answers_attempt_id_question_id_option_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "attempt_id",
+            "question_id",
+            "option_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_attempt_questions": {
+      "name": "simulado_attempt_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "simulado_attempt_questions_question_id_idx": {
+          "name": "simulado_attempt_questions_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "simulado_attempt_questions_attempt_id_simulado_attempts_id_fk": {
+          "name": "simulado_attempt_questions_attempt_id_simulado_attempts_id_fk",
+          "tableFrom": "simulado_attempt_questions",
+          "tableTo": "simulado_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempt_questions_question_id_simulado_questions_id_fk": {
+          "name": "simulado_attempt_questions_question_id_simulado_questions_id_fk",
+          "tableFrom": "simulado_attempt_questions",
+          "tableTo": "simulado_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulado_attempt_questions_attempt_id_question_id_unique": {
+          "name": "simulado_attempt_questions_attempt_id_question_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "attempt_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_attempts": {
+      "name": "simulado_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "simulado_id": {
+          "name": "simulado_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passed": {
+          "name": "passed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personalizado": {
+          "name": "personalizado",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "topicos": {
+          "name": "topicos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "simulado_attempts_user_id_idx": {
+          "name": "simulado_attempts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "simulado_attempts_simulado_id_idx": {
+          "name": "simulado_attempts_simulado_id_idx",
+          "columns": [
+            {
+              "expression": "simulado_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "simulado_attempts_user_id_users_id_fk": {
+          "name": "simulado_attempts_user_id_users_id_fk",
+          "tableFrom": "simulado_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "simulado_attempts_simulado_id_simulados_id_fk": {
+          "name": "simulado_attempts_simulado_id_simulados_id_fk",
+          "tableFrom": "simulado_attempts",
+          "tableTo": "simulados",
+          "columnsFrom": [
+            "simulado_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_options": {
+      "name": "simulado_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "simulado_options_question_id_idx": {
+          "name": "simulado_options_question_id_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "simulado_options_question_id_simulado_questions_id_fk": {
+          "name": "simulado_options_question_id_simulado_questions_id_fk",
+          "tableFrom": "simulado_options",
+          "tableTo": "simulado_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulado_questions": {
+      "name": "simulado_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "simulado_id": {
+          "name": "simulado_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "simulado_questions_simulado_id_idx": {
+          "name": "simulado_questions_simulado_id_idx",
+          "columns": [
+            {
+              "expression": "simulado_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "simulado_questions_simulado_id_simulados_id_fk": {
+          "name": "simulado_questions_simulado_id_simulados_id_fk",
+          "tableFrom": "simulado_questions",
+          "tableTo": "simulados",
+          "columnsFrom": [
+            "simulado_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.simulados": {
+      "name": "simulados",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_count": {
+          "name": "question_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pass_percent": {
+          "name": "pass_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "simulados_slug_unique": {
+          "name": "simulados_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "subscription_plan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "subscription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pendente'"
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gateway": {
+          "name": "gateway",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'abacatepay'"
+        },
+        "gateway_id": {
+          "name": "gateway_id",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_user_id_idx": {
+          "name": "subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_user_id_users_id_fk": {
+          "name": "subscriptions_user_id_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tokens": {
+      "name": "tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'refresh'"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tokens_user_id_idx": {
+          "name": "tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tokens_user_id_users_id_fk": {
+          "name": "tokens_user_id_users_id_fk",
+          "tableFrom": "tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tokens_token_hash_unique": {
+          "name": "tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_reviews": {
+      "name": "trail_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stars": {
+          "name": "stars",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trail_reviews_trail_id_idx": {
+          "name": "trail_reviews_trail_id_idx",
+          "columns": [
+            {
+              "expression": "trail_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trail_reviews_trail_id_trails_id_fk": {
+          "name": "trail_reviews_trail_id_trails_id_fk",
+          "tableFrom": "trail_reviews",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trail_reviews_user_id_users_id_fk": {
+          "name": "trail_reviews_user_id_users_id_fk",
+          "tableFrom": "trail_reviews",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trail_reviews_user_id_trail_id_unique": {
+          "name": "trail_reviews_user_id_trail_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "trail_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_tags": {
+      "name": "trail_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "trail_tags_tag_id_idx": {
+          "name": "trail_tags_tag_id_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trail_tags_trail_id_trails_id_fk": {
+          "name": "trail_tags_trail_id_trails_id_fk",
+          "tableFrom": "trail_tags",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "trail_tags_tag_id_tags_id_fk": {
+          "name": "trail_tags_tag_id_tags_id_fk",
+          "tableFrom": "trail_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trail_tags_trail_id_tag_id_unique": {
+          "name": "trail_tags_trail_id_tag_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trail_id",
+            "tag_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trails": {
+      "name": "trails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "trail_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "what_you_learn": {
+          "name": "what_you_learn",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prerequisites": {
+          "name": "prerequisites",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workload_hours": {
+          "name": "workload_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_achievements": {
+      "name": "user_achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "achievement_id": {
+          "name": "achievement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "notified": {
+          "name": "notified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_achievements_achievement_id_idx": {
+          "name": "user_achievements_achievement_id_idx",
+          "columns": [
+            {
+              "expression": "achievement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_achievements_user_id_users_id_fk": {
+          "name": "user_achievements_user_id_users_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_achievements_achievement_id_achievements_id_fk": {
+          "name": "user_achievements_achievement_id_achievements_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "achievements",
+          "columnsFrom": [
+            "achievement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_achievements_user_id_achievement_id_unique": {
+          "name": "user_achievements_user_id_achievement_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "achievement_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_follows": {
+      "name": "user_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "following_id": {
+          "name": "following_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_follows_following_id_idx": {
+          "name": "user_follows_following_id_idx",
+          "columns": [
+            {
+              "expression": "following_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_follows_follower_id_users_id_fk": {
+          "name": "user_follows_follower_id_users_id_fk",
+          "tableFrom": "user_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_follows_following_id_users_id_fk": {
+          "name": "user_follows_following_id_users_id_fk",
+          "tableFrom": "user_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "following_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_follows_follower_id_following_id_unique": {
+          "name": "user_follows_follower_id_following_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "follower_id",
+            "following_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username_changed_at": {
+          "name": "username_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occupation": {
+          "name": "occupation",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github": {
+          "name": "github",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin": {
+          "name": "linkedin",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "failed_login_attempts": {
+          "name": "failed_login_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_goal_kind": {
+          "name": "weekly_goal_kind",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_goal_target": {
+          "name": "weekly_goal_target",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accent": {
+          "name": "accent",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "background_url": {
+          "name": "background_url",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "background_dim": {
+          "name": "background_dim",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.achievement_criteria": {
+      "name": "achievement_criteria",
+      "schema": "public",
+      "values": [
+        "xp_total",
+        "lessons_completed",
+        "questions_correct",
+        "special",
+        "streak_days",
+        "challenges_facil",
+        "challenges_medio",
+        "challenges_dificil",
+        "trail_completed"
+      ]
+    },
+    "public.challenge_kind": {
+      "name": "challenge_kind",
+      "schema": "public",
+      "values": [
+        "stdin",
+        "function"
+      ]
+    },
+    "public.challenge_language": {
+      "name": "challenge_language",
+      "schema": "public",
+      "values": [
+        "javascript",
+        "python",
+        "csharp",
+        "java"
+      ]
+    },
+    "public.challenge_submission_status": {
+      "name": "challenge_submission_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "passed",
+        "failed",
+        "error",
+        "timeout"
+      ]
+    },
+    "public.community_post_kind": {
+      "name": "community_post_kind",
+      "schema": "public",
+      "values": [
+        "duvida",
+        "solucao",
+        "conquista",
+        "post"
+      ]
+    },
+    "public.comunicado_kind": {
+      "name": "comunicado_kind",
+      "schema": "public",
+      "values": [
+        "aviso",
+        "pesquisa"
+      ]
+    },
+    "public.comunicado_resposta_status": {
+      "name": "comunicado_resposta_status",
+      "schema": "public",
+      "values": [
+        "respondido",
+        "dispensado"
+      ]
+    },
+    "public.question_difficulty": {
+      "name": "question_difficulty",
+      "schema": "public",
+      "values": [
+        "facil",
+        "medio",
+        "dificil"
+      ]
+    },
+    "public.resume_analysis_engine": {
+      "name": "resume_analysis_engine",
+      "schema": "public",
+      "values": [
+        "heuristica",
+        "ia"
+      ]
+    },
+    "public.roadmap_phase": {
+      "name": "roadmap_phase",
+      "schema": "public",
+      "values": [
+        "fundamentos",
+        "core",
+        "avancado",
+        "deploy"
+      ]
+    },
+    "public.roadmap_ref_type": {
+      "name": "roadmap_ref_type",
+      "schema": "public",
+      "values": [
+        "trail",
+        "module",
+        "lesson",
+        "simulado",
+        "challenge"
+      ]
+    },
+    "public.subscription_plan": {
+      "name": "subscription_plan",
+      "schema": "public",
+      "values": [
+        "mensal",
+        "trimestral",
+        "anual",
+        "pix_auto"
+      ]
+    },
+    "public.subscription_status": {
+      "name": "subscription_status",
+      "schema": "public",
+      "values": [
+        "pendente",
+        "ativa",
+        "cancelada"
+      ]
+    },
+    "public.trail_level": {
+      "name": "trail_level",
+      "schema": "public",
+      "values": [
+        "iniciante",
+        "intermediario",
+        "avancado"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin",
+        "moderator"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -337,6 +337,13 @@
       "when": 1785334056771,
       "tag": "0047_stale_invisible_woman",
       "breakpoints": true
+    },
+    {
+      "idx": 48,
+      "version": "7",
+      "when": 1785447776287,
+      "tag": "0048_plano_trimestral",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -344,6 +344,13 @@
       "when": 1785447776287,
       "tag": "0048_plano_trimestral",
       "breakpoints": true
+    },
+    {
+      "idx": 49,
+      "version": "7",
+      "when": 1785448530740,
+      "tag": "0049_analise_curriculo",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
+                "@anthropic-ai/sdk": "^0.115.0",
                 "@types/cookie-parser": "^1.4.10",
                 "@types/cors": "^2.8.19",
                 "@types/ws": "^8.18.1",
@@ -25,6 +26,7 @@
                 "pdfkit": "^0.19.1",
                 "pg": "^8.21.0",
                 "qrcode": "^1.5.4",
+                "unpdf": "^1.8.0",
                 "ws": "^8.21.1",
                 "zod": "^4.4.3"
             },
@@ -45,6 +47,36 @@
                 "prettier": "^3.9.3",
                 "typescript": "^6.0.3",
                 "typescript-eslint": "^8.62.0"
+            }
+        },
+        "node_modules/@anthropic-ai/sdk": {
+            "version": "0.115.0",
+            "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.115.0.tgz",
+            "integrity": "sha512-BJrFIVyjNuU8lfDyIJTvlRYzgQg+zEl78BxE7fq8esULsGz9IRQvGtW5spq3tydmtjQb/GFdooKGdGsetpx+lQ==",
+            "license": "MIT",
+            "dependencies": {
+                "json-schema-to-ts": "^3.1.1",
+                "standardwebhooks": "^1.0.0"
+            },
+            "bin": {
+                "anthropic-ai-sdk": "bin/cli"
+            },
+            "peerDependencies": {
+                "zod": "^3.25.0 || ^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "zod": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@babel/runtime": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+            "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
             }
         },
         "node_modules/@drizzle-team/brocli": {
@@ -1164,6 +1196,12 @@
             "engines": {
                 "node": ">=10"
             }
+        },
+        "node_modules/@stablelib/base64": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+            "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+            "license": "MIT"
         },
         "node_modules/@swc/helpers": {
             "version": "0.5.23",
@@ -2612,6 +2650,12 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/fast-sha256": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+            "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+            "license": "Unlicense"
+        },
         "node_modules/fdir": {
             "version": "6.5.0",
             "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -3030,6 +3074,19 @@
             "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/json-schema-to-ts": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+            "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.18.3",
+                "ts-algebra": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=16"
+            }
         },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
@@ -3997,6 +4054,16 @@
                 "node": ">= 10.x"
             }
         },
+        "node_modules/standardwebhooks": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+            "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+            "license": "MIT",
+            "dependencies": {
+                "@stablelib/base64": "^1.0.0",
+                "fast-sha256": "^1.3.0"
+            }
+        },
         "node_modules/statuses": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -4063,6 +4130,12 @@
             "engines": {
                 "node": ">=0.6"
             }
+        },
+        "node_modules/ts-algebra": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+            "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+            "license": "MIT"
         },
         "node_modules/ts-api-utils": {
             "version": "2.5.0",
@@ -4699,6 +4772,23 @@
             "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
             "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
             "license": "MIT"
+        },
+        "node_modules/unpdf": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/unpdf/-/unpdf-1.8.0.tgz",
+            "integrity": "sha512-jQlkckbe5nKxRHQdbvo9IKHlU6Cjq00UlxxB8lrCIxvS2o5IbAL1wM+4a1Yc3+BIohg9p5AsoaftwO+G4Aq/qQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=22"
+            },
+            "peerDependencies": {
+                "@napi-rs/canvas": "^0.1.69 || ^1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@napi-rs/canvas": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/unpipe": {
             "version": "1.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,6 +16,7 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
+        "@anthropic-ai/sdk": "^0.115.0",
         "@types/cookie-parser": "^1.4.10",
         "@types/cors": "^2.8.19",
         "@types/ws": "^8.18.1",
@@ -32,6 +33,7 @@
         "pdfkit": "^0.19.1",
         "pg": "^8.21.0",
         "qrcode": "^1.5.4",
+        "unpdf": "^1.8.0",
         "ws": "^8.21.1",
         "zod": "^4.4.3"
     },

--- a/backend/schema.ts
+++ b/backend/schema.ts
@@ -682,7 +682,12 @@ export const certificates = pgTable(
     ],
 );
 
-export const subscriptionPlan = pgEnum("subscription_plan", ["mensal", "anual", "pix_auto"]);
+export const subscriptionPlan = pgEnum("subscription_plan", [
+    "mensal",
+    "trimestral",
+    "anual",
+    "pix_auto",
+]);
 export const subscriptionStatus = pgEnum("subscription_status", ["pendente", "ativa", "cancelada"]);
 
 // Apoio ao projeto. Cada pagamento vira uma linha; apoiador ativo = alguma

--- a/backend/schema.ts
+++ b/backend/schema.ts
@@ -711,6 +711,33 @@ export const subscriptions = pgTable(
     (table) => [index("subscriptions_user_id_idx").on(table.userId)],
 );
 
+export const resumeAnalysisEngine = pgEnum("resume_analysis_engine", ["heuristica", "ia"]);
+
+// Análise de currículo contra uma vaga. Nem o PDF nem o texto extraído ficam
+// aqui: é dado pessoal que não precisamos depois que a análise sai.
+export const resumeAnalyses = pgTable(
+    "resume_analyses",
+    {
+        id: uuid("id").primaryKey().defaultRandom(),
+        userId: uuid("user_id")
+            .references(() => users.id)
+            .notNull(),
+        jobTitle: varchar("job_title", { length: 160 }),
+        score: integer("score").notNull(),
+        verdict: varchar("verdict", { length: 80 }).notNull(),
+        description: text("description").notNull(),
+        engine: resumeAnalysisEngine("engine").notNull(),
+        summary: jsonb("summary").notNull(),
+        breakdown: jsonb("breakdown").notNull(),
+        keywordsFound: jsonb("keywords_found").notNull(),
+        keywordsPartial: jsonb("keywords_partial").notNull(),
+        keywordsMissing: jsonb("keywords_missing").notNull(),
+        suggestions: jsonb("suggestions").notNull(),
+        createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    },
+    (table) => [index("resume_analyses_user_id_idx").on(table.userId)],
+);
+
 export const communityPostKind = pgEnum("community_post_kind", [
     "duvida",
     "solucao",

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -42,6 +42,18 @@ const envSchema = z.object({
     ABACATEPAY_API_KEY: z.string().optional(),
     ABACATEPAY_WEBHOOK_SECRET: z.string().optional(),
     ABACATEPAY_PRODUCT_PIX_AUTO: z.string().optional(),
+    // Analisador de currículo. Sem modo de IA roda só o motor determinístico;
+    // "cli" usa o Claude Code da máquina (local) e "api" usa a chave (produção).
+    ATS_IA_MODO: z.enum(["off", "cli", "api"]).default("off"),
+    ATS_API_KEY: z.string().optional(),
+    // O modo "api" fala o protocolo da Anthropic, e o DeepSeek expõe um endpoint
+    // nesse formato. Apagar a base URL manda as chamadas para a Anthropic.
+    ATS_API_BASE_URL: z.string().url().default("https://api.deepseek.com/anthropic"),
+    ATS_MODELO: z.string().default("deepseek-v4-pro"),
+    ATS_MODELO_CLI: z.string().default("opus"),
+    // O v4-pro passa de 100s em currículo grande, então a margem é generosa.
+    ATS_TIMEOUT_S: z.coerce.number().int().positive().default(180),
+    ATS_LIMITE_MENSAL: z.coerce.number().int().positive().default(30),
     // Dados do emissor impressos no certificado. Sem os três, a emissão fica desligada.
     CERT_RAZAO_SOCIAL: z.string().optional(),
     CERT_CNPJ: z.string().optional(),

--- a/backend/src/controllers/ApoioController.ts
+++ b/backend/src/controllers/ApoioController.ts
@@ -13,7 +13,7 @@ import {
     assinaturasAdmin,
 } from "../services/apoiador.service.ts";
 
-const cobrancaSchema = z.object({ plan: z.enum(["mensal", "anual"]) });
+const cobrancaSchema = z.object({ plan: z.enum(["mensal", "trimestral", "anual"]) });
 const accentSchema = z.object({ accent: z.string().regex(/^#[0-9A-Fa-f]{6}$/).nullable() });
 const veuSchema = z.object({ dim: z.number().int().min(0).max(100) });
 

--- a/backend/src/controllers/AtsController.ts
+++ b/backend/src/controllers/AtsController.ts
@@ -1,0 +1,44 @@
+import type { Request, Response, NextFunction } from "express";
+import { z } from "zod";
+import { analisarCurriculo, analiseAts, historicoAts, statusAts } from "../services/ats.service.ts";
+
+const analiseSchema = z.object({
+    vaga: z.string(),
+    tituloVaga: z.string().max(160).nullish(),
+    pdf: z.string(),
+});
+
+export const getAtsStatus = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        res.json(await statusAts(req.userId!));
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const createAnalise = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const { vaga, tituloVaga, pdf } = analiseSchema.parse(req.body);
+        res.status(201).json(
+            await analisarCurriculo(req.userId!, { vaga, tituloVaga, pdfBase64: pdf }),
+        );
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const listAnalises = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        res.json(await historicoAts(req.userId!));
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const getAnalise = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        res.json(await analiseAts(req.userId!, String(req.params.id)));
+    } catch (err) {
+        next(err);
+    }
+};

--- a/backend/src/middlewares/rateLimit.ts
+++ b/backend/src/middlewares/rateLimit.ts
@@ -81,14 +81,18 @@ export const desafioRunLimiter = criarLimiter(
     "Muitas execuções seguidas. Aguarde um instante e tente de novo.",
 );
 
-export const uploadLimiter = criarLimiter(
-    30,
-    "Muitos envios de imagem. Aguarde alguns minutos.",
-);
+export const uploadLimiter = criarLimiter(30, "Muitos envios de imagem. Aguarde alguns minutos.");
 
 // Publicar na comunidade (post ou comentário) é escrita de conteúdo; teto por
 // janela para conter spam/flood sem atrapalhar quem participa normalmente.
 export const comunidadeEscritaLimiter = criarLimiter(
     40,
     "Você está publicando rápido demais. Aguarde alguns minutos.",
+);
+
+// Cada análise lê um PDF e pode chamar o modelo; o teto mensal por apoiador está
+// no service, e este é só a barreira de rajada.
+export const analiseCurriculoLimiter = criarLimiter(
+    10,
+    "Muitas análises seguidas. Aguarde alguns minutos.",
 );

--- a/backend/src/routes/ats.routes.ts
+++ b/backend/src/routes/ats.routes.ts
@@ -1,0 +1,18 @@
+import { Router } from "express";
+import { autenticar } from "../middlewares/auth.ts";
+import { analiseCurriculoLimiter } from "../middlewares/rateLimit.ts";
+import {
+    createAnalise,
+    getAnalise,
+    getAtsStatus,
+    listAnalises,
+} from "../controllers/AtsController.ts";
+
+const router = Router();
+
+router.get("/curriculo/status", autenticar, getAtsStatus);
+router.get("/curriculo/analises", autenticar, listAnalises);
+router.get("/curriculo/analises/:id", autenticar, getAnalise);
+router.post("/curriculo/analises", autenticar, analiseCurriculoLimiter, createAnalise);
+
+export default router;

--- a/backend/src/services/apoiador.service.ts
+++ b/backend/src/services/apoiador.service.ts
@@ -14,9 +14,13 @@ import {
 
 export const PLANOS = {
     mensal: { valorCents: 500, dias: 30, descricao: "Apoio mensal ao Ensina Dev" },
+    trimestral: { valorCents: 1400, dias: 90, descricao: "Apoio trimestral ao Ensina Dev" },
     anual: { valorCents: 5000, dias: 365, descricao: "Apoio anual ao Ensina Dev" },
     pix_auto: { valorCents: 500, dias: 30, descricao: "Apoio mensal recorrente ao Ensina Dev" },
 } as const;
+
+// Planos que o usuário escolhe na tela; pix_auto nasce de outro fluxo.
+export type PlanoAvulso = "mensal" | "trimestral" | "anual";
 
 export const ACCENTS = ["#2D6BF5", "#7C3AED", "#DB2777", "#E0532F", "#1C8F5A", "#B7791F"];
 
@@ -132,7 +136,7 @@ export async function statusApoio(userId: string) {
     };
 }
 
-export async function criarCobranca(userId: string, plan: "mensal" | "anual") {
+export async function criarCobranca(userId: string, plan: PlanoAvulso) {
     const [pendentes] = await db
         .select({ n: count() })
         .from(subscriptions)

--- a/backend/src/services/ats.service.ts
+++ b/backend/src/services/ats.service.ts
@@ -1,0 +1,224 @@
+// Analisador de currículo contra uma vaga, benefício de apoiador. Nada do
+// currículo é guardado: o banco fica só com o resultado da análise.
+
+import { and, desc, eq, gt, sql } from "drizzle-orm";
+import { db } from "../../db.ts";
+import { resumeAnalyses } from "../../schema.ts";
+import { AppError } from "../errors/AppError.ts";
+import { env } from "../config/env.ts";
+import { apoiadorAtivo } from "./apoiador.service.ts";
+import { analisar, type ItemResumo, type ResultadoAnalise } from "./ats/heuristica.ts";
+import { iaAtiva, refinar, type Refinamento } from "./ats/ia.ts";
+import { extrairTextoPdf } from "./ats/pdf.ts";
+
+const MIN_VAGA = 120;
+const MAX_VAGA = 20000;
+const MAX_PDF_BYTES = 5 * 1024 * 1024;
+// Currículo maior que isso é quase sempre texto duplicado pelo layout do PDF.
+const MAX_CURRICULO = 20000;
+
+export interface EntradaAnalise {
+    vaga: string;
+    tituloVaga?: string | null;
+    pdfBase64: string;
+}
+
+export async function statusAts(userId: string) {
+    const [apoiador, usadas] = await Promise.all([
+        apoiadorAtivo(userId),
+        analisesNoPeriodo(userId),
+    ]);
+    return {
+        liberado: apoiador,
+        usadas,
+        limite: env.ATS_LIMITE_MENSAL,
+        restantes: Math.max(0, env.ATS_LIMITE_MENSAL - usadas),
+        ia: iaAtiva(),
+    };
+}
+
+export async function analisarCurriculo(userId: string, entrada: EntradaAnalise) {
+    if (!(await apoiadorAtivo(userId))) {
+        throw new AppError(403, "A análise de currículo é um benefício de apoiador.");
+    }
+
+    const usadas = await analisesNoPeriodo(userId);
+    if (usadas >= env.ATS_LIMITE_MENSAL) {
+        throw new AppError(
+            429,
+            `Você já fez ${env.ATS_LIMITE_MENSAL} análises nos últimos 30 dias. O limite volta conforme as análises antigas saem da janela.`,
+        );
+    }
+
+    const vaga = entrada.vaga.trim();
+    if (vaga.length < MIN_VAGA) {
+        throw new AppError(
+            400,
+            "Cole a descrição da vaga inteira: com poucas linhas a análise não diz nada.",
+        );
+    }
+    if (vaga.length > MAX_VAGA) {
+        throw new AppError(400, "Essa descrição de vaga é longa demais. Cole só o texto da vaga.");
+    }
+
+    const curriculo = (await extrairTextoPdf(decodificarPdf(entrada.pdfBase64))).slice(
+        0,
+        MAX_CURRICULO,
+    );
+
+    const base = analisar(vaga, curriculo);
+    const resultado = mesclar(base, await refinar(vaga, curriculo, base));
+
+    const [linha] = await db
+        .insert(resumeAnalyses)
+        .values({
+            userId,
+            jobTitle: entrada.tituloVaga?.trim().slice(0, 160) || null,
+            score: resultado.score,
+            verdict: resultado.veredito,
+            description: resultado.descricao,
+            engine: resultado.motor,
+            summary: resultado.resumo,
+            breakdown: resultado.detalhe,
+            keywordsFound: resultado.encontradas,
+            keywordsPartial: resultado.parciais,
+            keywordsMissing: resultado.ausentes,
+            suggestions: resultado.sugestoes,
+        })
+        .returning({ id: resumeAnalyses.id, createdAt: resumeAnalyses.createdAt });
+
+    return {
+        id: linha.id,
+        criadaEm: linha.createdAt,
+        restantes: Math.max(0, env.ATS_LIMITE_MENSAL - usadas - 1),
+        ...resultado,
+    };
+}
+
+export async function historicoAts(userId: string) {
+    const linhas = await db
+        .select({
+            id: resumeAnalyses.id,
+            tituloVaga: resumeAnalyses.jobTitle,
+            score: resumeAnalyses.score,
+            veredito: resumeAnalyses.verdict,
+            motor: resumeAnalyses.engine,
+            criadaEm: resumeAnalyses.createdAt,
+        })
+        .from(resumeAnalyses)
+        .where(eq(resumeAnalyses.userId, userId))
+        .orderBy(desc(resumeAnalyses.createdAt))
+        .limit(50);
+    return linhas;
+}
+
+export async function analiseAts(userId: string, id: string) {
+    const [linha] = await db
+        .select()
+        .from(resumeAnalyses)
+        .where(and(eq(resumeAnalyses.id, id), eq(resumeAnalyses.userId, userId)))
+        .limit(1);
+    if (!linha) throw new AppError(404, "Análise não encontrada.");
+
+    return {
+        id: linha.id,
+        tituloVaga: linha.jobTitle,
+        criadaEm: linha.createdAt,
+        score: linha.score,
+        veredito: linha.verdict,
+        descricao: linha.description,
+        motor: linha.engine,
+        resumo: linha.summary,
+        detalhe: linha.breakdown,
+        encontradas: linha.keywordsFound,
+        parciais: linha.keywordsPartial,
+        ausentes: linha.keywordsMissing,
+        sugestoes: linha.suggestions,
+    };
+}
+
+// Janela móvel de 30 dias, e não mês do calendário: quem assina dia 28 não perde
+// o limite dois dias depois.
+function analisesNoPeriodo(userId: string): Promise<number> {
+    return db
+        .select({ n: sql<number>`count(*)::int` })
+        .from(resumeAnalyses)
+        .where(
+            and(
+                eq(resumeAnalyses.userId, userId),
+                gt(resumeAnalyses.createdAt, new Date(Date.now() - 30 * 86400000)),
+            ),
+        )
+        .then(([linha]) => Number(linha?.n ?? 0));
+}
+
+function decodificarPdf(entrada: string): Buffer {
+    const base64 = entrada.includes(",") ? entrada.slice(entrada.indexOf(",") + 1) : entrada;
+    const pdf = Buffer.from(base64, "base64");
+    if (pdf.length === 0) {
+        throw new AppError(400, "Envie o currículo em PDF.");
+    }
+    if (pdf.length > MAX_PDF_BYTES) {
+        throw new AppError(413, "O PDF passa de 5 MB. Exporte o currículo com menos imagens.");
+    }
+    if (pdf.subarray(0, 5).toString("latin1") !== "%PDF-") {
+        throw new AppError(400, "O arquivo enviado não é um PDF.");
+    }
+    return pdf;
+}
+
+// A nota e o detalhe continuam vindo da heurística; da IA entram só o texto das
+// sugestões e em qual lista cada palavra-chave cai.
+function mesclar(base: ResultadoAnalise, refinamento: Refinamento | null): ResultadoAnalise {
+    if (!refinamento) return base;
+
+    const universo = [...base.encontradas, ...base.parciais, ...base.ausentes];
+    const conjunto = (lista: string[]) => new Set(lista.map((t) => t.toLowerCase()));
+    const iaEncontradas = conjunto(refinamento.encontradas);
+    const iaParciais = conjunto(refinamento.parciais);
+    const iaAusentes = conjunto(refinamento.ausentes);
+    const eramEncontradas = conjunto(base.encontradas);
+    const eramAusentes = conjunto(base.ausentes);
+
+    const encontradas: string[] = [];
+    const parciais: string[] = [];
+    const ausentes: string[] = [];
+    for (const termo of universo) {
+        const chave = termo.toLowerCase();
+        if (iaEncontradas.has(chave)) encontradas.push(termo);
+        else if (iaAusentes.has(chave)) ausentes.push(termo);
+        else if (iaParciais.has(chave)) parciais.push(termo);
+        // Termo que a IA não citou fica onde a heurística tinha posto.
+        else if (eramEncontradas.has(chave)) encontradas.push(termo);
+        else if (eramAusentes.has(chave)) ausentes.push(termo);
+        else parciais.push(termo);
+    }
+
+    return {
+        ...base,
+        motor: "ia",
+        sugestoes: refinamento.sugestoes.length > 0 ? refinamento.sugestoes : base.sugestoes,
+        encontradas,
+        parciais,
+        ausentes,
+        resumo: atualizarResumoPalavras(base.resumo, encontradas.length, universo.length),
+    };
+}
+
+function atualizarResumoPalavras(
+    resumo: ItemResumo[],
+    encontradas: number,
+    total: number,
+): ItemResumo[] {
+    if (resumo.length === 0) return resumo;
+    const razao = total === 0 ? 0 : encontradas / total;
+    const [primeiro, ...resto] = resumo;
+    return [
+        {
+            ...primeiro,
+            valor: `${encontradas}/${total}`,
+            tom: razao >= 0.75 ? "bom" : razao >= 0.5 ? "atencao" : "ruim",
+        },
+        ...resto,
+    ];
+}

--- a/backend/src/services/ats/dicionario.ts
+++ b/backend/src/services/ats/dicionario.ts
@@ -1,0 +1,226 @@
+// Termos que o analisador reconhece. A ordem daqui é a ordem em que as
+// palavras-chave aparecem na tela. `tecnica` marca o que conta na nota de
+// habilidades técnicas: processo (Scrum, code review) e idioma ficam de fora
+// dessa conta, mas ainda valem como palavra-chave da vaga.
+
+export interface TermoTecnico {
+    exibicao: string;
+    apelidos: string[];
+    tecnica: boolean;
+}
+
+export const TERMOS: TermoTecnico[] = [
+    // Front-end
+    { exibicao: "React", apelidos: ["react", "react.js", "reactjs"], tecnica: true },
+    { exibicao: "Next.js", apelidos: ["next.js", "nextjs", "next js"], tecnica: true },
+    { exibicao: "Vue", apelidos: ["vue", "vue.js", "vuejs"], tecnica: true },
+    { exibicao: "Angular", apelidos: ["angular", "angularjs"], tecnica: true },
+    { exibicao: "TypeScript", apelidos: ["typescript"], tecnica: true },
+    { exibicao: "JavaScript", apelidos: ["javascript", "ecmascript"], tecnica: true },
+    { exibicao: "HTML", apelidos: ["html", "html5"], tecnica: true },
+    { exibicao: "CSS", apelidos: ["css", "css3"], tecnica: true },
+    {
+        exibicao: "Tailwind CSS",
+        apelidos: ["tailwind css", "tailwind", "tailwindcss"],
+        tecnica: true,
+    },
+    { exibicao: "SASS", apelidos: ["sass", "scss"], tecnica: true },
+    { exibicao: "Redux", apelidos: ["redux"], tecnica: true },
+    { exibicao: "Webpack", apelidos: ["webpack"], tecnica: true },
+    { exibicao: "Vite", apelidos: ["vite"], tecnica: true },
+    { exibicao: "React Native", apelidos: ["react native"], tecnica: true },
+    { exibicao: "Flutter", apelidos: ["flutter"], tecnica: true },
+
+    // Linguagens e frameworks de back-end
+    { exibicao: "Node.js", apelidos: ["node.js", "nodejs", "node js", "node"], tecnica: true },
+    { exibicao: "Express", apelidos: ["express", "express.js", "expressjs"], tecnica: true },
+    { exibicao: "NestJS", apelidos: ["nestjs", "nest.js"], tecnica: true },
+    { exibicao: "C#", apelidos: ["c#", "csharp", "c sharp"], tecnica: true },
+    { exibicao: ".NET", apelidos: [".net", "dotnet", "dot net", ".net core"], tecnica: true },
+    {
+        exibicao: "ASP.NET Core",
+        apelidos: ["asp.net core", "asp.net", "aspnet", "asp net"],
+        tecnica: true,
+    },
+    {
+        exibicao: "Entity Framework",
+        apelidos: ["entity framework", "ef core", "efcore"],
+        tecnica: true,
+    },
+    { exibicao: "Java", apelidos: ["java"], tecnica: true },
+    { exibicao: "Spring Boot", apelidos: ["spring boot", "springboot", "spring"], tecnica: true },
+    { exibicao: "Python", apelidos: ["python"], tecnica: true },
+    { exibicao: "Django", apelidos: ["django"], tecnica: true },
+    { exibicao: "Flask", apelidos: ["flask"], tecnica: true },
+    { exibicao: "FastAPI", apelidos: ["fastapi", "fast api"], tecnica: true },
+    { exibicao: "PHP", apelidos: ["php"], tecnica: true },
+    { exibicao: "Laravel", apelidos: ["laravel"], tecnica: true },
+    { exibicao: "Ruby", apelidos: ["ruby"], tecnica: true },
+    { exibicao: "Ruby on Rails", apelidos: ["ruby on rails", "rails"], tecnica: true },
+    { exibicao: "Go", apelidos: ["golang"], tecnica: true },
+    { exibicao: "Kotlin", apelidos: ["kotlin"], tecnica: true },
+
+    // APIs e integração
+    {
+        exibicao: "APIs REST",
+        apelidos: ["apis rest", "api rest", "rest", "restful", "apis restful"],
+        tecnica: true,
+    },
+    { exibicao: "GraphQL", apelidos: ["graphql"], tecnica: true },
+    { exibicao: "gRPC", apelidos: ["grpc"], tecnica: true },
+    { exibicao: "WebSocket", apelidos: ["websocket", "websockets"], tecnica: true },
+    { exibicao: "OpenAPI", apelidos: ["openapi", "swagger"], tecnica: true },
+    { exibicao: "JWT", apelidos: ["jwt", "json web token"], tecnica: true },
+    { exibicao: "OAuth", apelidos: ["oauth", "oauth2", "oauth 2.0"], tecnica: true },
+
+    // Dados e mensageria
+    { exibicao: "SQL", apelidos: ["sql"], tecnica: true },
+    { exibicao: "PostgreSQL", apelidos: ["postgresql", "postgres", "postgre"], tecnica: true },
+    { exibicao: "MySQL", apelidos: ["mysql"], tecnica: true },
+    { exibicao: "SQL Server", apelidos: ["sql server", "sqlserver"], tecnica: true },
+    { exibicao: "Oracle", apelidos: ["oracle"], tecnica: true },
+    { exibicao: "MongoDB", apelidos: ["mongodb", "mongo"], tecnica: true },
+    { exibicao: "Redis", apelidos: ["redis"], tecnica: true },
+    { exibicao: "Elasticsearch", apelidos: ["elasticsearch", "elastic search"], tecnica: true },
+    { exibicao: "Prisma", apelidos: ["prisma"], tecnica: true },
+    { exibicao: "RabbitMQ", apelidos: ["rabbitmq", "rabbit mq"], tecnica: true },
+    { exibicao: "Kafka", apelidos: ["kafka", "apache kafka"], tecnica: true },
+    {
+        exibicao: "Mensageria",
+        apelidos: ["mensageria", "messaging", "message broker", "filas"],
+        tecnica: true,
+    },
+
+    // Cloud, infra e DevOps
+    { exibicao: "AWS", apelidos: ["aws", "amazon web services"], tecnica: true },
+    { exibicao: "Azure", apelidos: ["azure", "microsoft azure"], tecnica: true },
+    { exibicao: "GCP", apelidos: ["gcp", "google cloud", "google cloud platform"], tecnica: true },
+    { exibicao: "Cloud", apelidos: ["cloud", "nuvem", "computacao em nuvem"], tecnica: true },
+    { exibicao: "Docker", apelidos: ["docker"], tecnica: true },
+    { exibicao: "Kubernetes", apelidos: ["kubernetes", "k8s"], tecnica: true },
+    { exibicao: "Terraform", apelidos: ["terraform"], tecnica: true },
+    {
+        exibicao: "CI/CD",
+        apelidos: ["ci/cd", "ci cd", "cicd", "integracao continua"],
+        tecnica: true,
+    },
+    { exibicao: "GitHub Actions", apelidos: ["github actions"], tecnica: true },
+    { exibicao: "Jenkins", apelidos: ["jenkins"], tecnica: true },
+    { exibicao: "Linux", apelidos: ["linux", "unix"], tecnica: true },
+    { exibicao: "Nginx", apelidos: ["nginx"], tecnica: true },
+    { exibicao: "Git", apelidos: ["git"], tecnica: true },
+    {
+        exibicao: "Observabilidade",
+        apelidos: ["observabilidade", "observability", "tracing"],
+        tecnica: false,
+    },
+
+    // Testes e qualidade
+    { exibicao: "Jest", apelidos: ["jest"], tecnica: true },
+    { exibicao: "Vitest", apelidos: ["vitest"], tecnica: true },
+    { exibicao: "Cypress", apelidos: ["cypress"], tecnica: true },
+    { exibicao: "Playwright", apelidos: ["playwright"], tecnica: true },
+    { exibicao: "Selenium", apelidos: ["selenium"], tecnica: true },
+    { exibicao: "Testing Library", apelidos: ["testing library"], tecnica: true },
+    { exibicao: "JUnit", apelidos: ["junit"], tecnica: true },
+    { exibicao: "xUnit", apelidos: ["xunit", "nunit"], tecnica: true },
+    { exibicao: "pytest", apelidos: ["pytest"], tecnica: true },
+    { exibicao: "PHPUnit", apelidos: ["phpunit"], tecnica: true },
+    {
+        exibicao: "Testes",
+        apelidos: ["testes", "teste", "testes automatizados", "tests"],
+        tecnica: false,
+    },
+    { exibicao: "TDD", apelidos: ["tdd", "test driven development"], tecnica: false },
+
+    // Arquitetura
+    { exibicao: "SOLID", apelidos: ["solid"], tecnica: true },
+    {
+        exibicao: "Clean Architecture",
+        apelidos: ["clean architecture", "arquitetura limpa"],
+        tecnica: true,
+    },
+    {
+        exibicao: "DDD",
+        apelidos: ["ddd", "domain driven design", "domain-driven design"],
+        tecnica: true,
+    },
+    {
+        exibicao: "Orientação a Objetos",
+        apelidos: [
+            "orientacao a objetos",
+            "object oriented",
+            "oop",
+            "programacao orientada a objetos",
+        ],
+        tecnica: true,
+    },
+    {
+        exibicao: "Microserviços",
+        apelidos: ["microservicos", "microsservicos", "microservices"],
+        tecnica: true,
+    },
+    {
+        exibicao: "Escalabilidade",
+        apelidos: ["escalabilidade", "scalability", "escalavel"],
+        tecnica: false,
+    },
+
+    // Segurança
+    { exibicao: "OWASP", apelidos: ["owasp", "owasp top 10"], tecnica: true },
+    {
+        exibicao: "Segurança de aplicações",
+        apelidos: [
+            "seguranca de aplicacoes",
+            "application security",
+            "appsec",
+            "security by design",
+        ],
+        tecnica: true,
+    },
+    { exibicao: "LGPD", apelidos: ["lgpd", "gdpr"], tecnica: false },
+
+    // Dados e IA
+    {
+        exibicao: "Inteligência Artificial",
+        apelidos: ["inteligencia artificial", "llm", "llms"],
+        tecnica: true,
+    },
+    {
+        exibicao: "Machine Learning",
+        apelidos: ["machine learning", "aprendizado de maquina"],
+        tecnica: true,
+    },
+    { exibicao: "Data Science", apelidos: ["data science", "ciencia de dados"], tecnica: true },
+    { exibicao: "Power BI", apelidos: ["power bi", "powerbi"], tecnica: true },
+    { exibicao: "ETL", apelidos: ["etl"], tecnica: true },
+
+    // Produto, processo e idioma
+    { exibicao: "Scrum", apelidos: ["scrum"], tecnica: false },
+    {
+        exibicao: "Ágil",
+        apelidos: ["agile", "metodologias ageis", "metodologia agil"],
+        tecnica: false,
+    },
+    { exibicao: "Kanban", apelidos: ["kanban"], tecnica: false },
+    { exibicao: "Code review", apelidos: ["code review", "revisao de codigo"], tecnica: false },
+    { exibicao: "Figma", apelidos: ["figma"], tecnica: false },
+    {
+        exibicao: "Responsivo",
+        apelidos: ["responsivo", "responsiva", "responsividade", "responsive"],
+        tecnica: false,
+    },
+    {
+        exibicao: "Performance",
+        apelidos: ["performance", "core web vitals", "desempenho"],
+        tecnica: false,
+    },
+    {
+        exibicao: "Acessibilidade",
+        apelidos: ["acessibilidade", "accessibility", "a11y"],
+        tecnica: false,
+    },
+    { exibicao: "WCAG", apelidos: ["wcag"], tecnica: true },
+    { exibicao: "Inglês", apelidos: ["ingles", "english"], tecnica: false },
+    { exibicao: "Espanhol", apelidos: ["espanhol", "spanish"], tecnica: false },
+];

--- a/backend/src/services/ats/heuristica.ts
+++ b/backend/src/services/ats/heuristica.ts
@@ -1,0 +1,433 @@
+// Motor determinístico do analisador: mesma entrada, mesma saída, sem rede.
+// É ele quem produz a nota; a IA, quando ligada, só reescreve as sugestões e
+// revisa a classificação das palavras-chave.
+
+import { TERMOS } from "./dicionario.ts";
+import {
+    PALAVRAS_VAZIAS,
+    contemPalavra,
+    contemSolto,
+    normalizar,
+    tokenizar,
+    tokenizarOriginal,
+} from "./normalizar.ts";
+
+export type Tom = "bom" | "atencao" | "ruim";
+export type Prioridade = "alta" | "media" | "baixa";
+export type StatusPalavra = "encontrada" | "parcial" | "ausente";
+export type Motor = "heuristica" | "ia";
+
+export interface ItemResumo {
+    rotulo: string;
+    valor: string;
+    tom: Tom;
+    icone: string;
+}
+
+export interface ItemDetalhe {
+    rotulo: string;
+    icone: string;
+    pct: number;
+}
+
+export interface Sugestao {
+    prioridade: Prioridade;
+    titulo: string;
+    texto: string;
+}
+
+export interface ResultadoAnalise {
+    score: number;
+    veredito: string;
+    descricao: string;
+    motor: Motor;
+    resumo: ItemResumo[];
+    detalhe: ItemDetalhe[];
+    encontradas: string[];
+    parciais: string[];
+    ausentes: string[];
+    sugestoes: Sugestao[];
+}
+
+// Somam 1.
+const PESO_PALAVRAS = 0.35;
+const PESO_TECNICO = 0.2;
+const PESO_EXPERIENCIA = 0.2;
+const PESO_FORMACAO = 0.1;
+const PESO_FORMATACAO = 0.15;
+
+const MAX_PALAVRAS = 21;
+
+const ORDEM_PRIORIDADE: Record<Prioridade, number> = { alta: 0, media: 1, baixa: 2 };
+
+interface Candidata {
+    exibicao: string;
+    apelidos: string[];
+    tecnica: boolean;
+}
+
+interface Classificada extends Candidata {
+    status: StatusPalavra;
+}
+
+export function analisar(vaga: string, curriculo: string): ResultadoAnalise {
+    const vagaNorm = normalizar(vaga ?? "");
+    const curriculoNorm = normalizar(curriculo ?? "");
+
+    const classificadas = extrairPalavras(vaga ?? "", vagaNorm).map((c) => ({
+        ...c,
+        status: classificar(c, curriculoNorm),
+    }));
+
+    const encontradas = classificadas
+        .filter((k) => k.status === "encontrada")
+        .map((k) => k.exibicao);
+    const parciais = classificadas.filter((k) => k.status === "parcial").map((k) => k.exibicao);
+    const ausentes = classificadas.filter((k) => k.status === "ausente").map((k) => k.exibicao);
+
+    const pctPalavras = coberturaPct(classificadas);
+    const pctTecnico = coberturaPct(classificadas.filter((k) => k.tecnica));
+    const experiencia = notaExperiencia(curriculo ?? "", curriculoNorm);
+    const pctFormacao = notaFormacao(curriculoNorm);
+    const formatacao = notaFormatacao(curriculo ?? "", curriculoNorm);
+
+    const score = Math.min(
+        100,
+        Math.max(
+            0,
+            Math.round(
+                pctPalavras * PESO_PALAVRAS +
+                    pctTecnico * PESO_TECNICO +
+                    experiencia.pct * PESO_EXPERIENCIA +
+                    pctFormacao * PESO_FORMACAO +
+                    formatacao.pct * PESO_FORMATACAO,
+            ),
+        ),
+    );
+
+    const { veredito, descricao } = vereditoPara(score);
+    const razaoPalavras =
+        classificadas.length === 0 ? 0 : encontradas.length / classificadas.length;
+
+    return {
+        score,
+        veredito,
+        descricao,
+        motor: "heuristica",
+        resumo: [
+            {
+                rotulo: "Palavras-chave",
+                valor: `${encontradas.length}/${classificadas.length}`,
+                tom: tomPorRazao(razaoPalavras),
+                icone: "key",
+            },
+            {
+                rotulo: "Formatação ATS",
+                valor: formatacao.rotulo,
+                tom: tomPorPct(formatacao.pct),
+                icone: "layout",
+            },
+            {
+                rotulo: "Verbos de ação",
+                valor: experiencia.rotuloVerbos,
+                tom: experiencia.tomVerbos,
+                icone: "bolt",
+            },
+        ],
+        detalhe: [
+            { rotulo: "Palavras-chave da vaga", icone: "key", pct: pctPalavras },
+            { rotulo: "Experiência profissional", icone: "briefcase", pct: experiencia.pct },
+            { rotulo: "Habilidades técnicas", icone: "code", pct: pctTecnico },
+            { rotulo: "Formação acadêmica", icone: "cap", pct: pctFormacao },
+            { rotulo: "Formatação e legibilidade ATS", icone: "layout", pct: formatacao.pct },
+        ],
+        encontradas,
+        parciais,
+        ausentes,
+        sugestoes: montarSugestoes(classificadas, curriculoNorm, experiencia, formatacao.pct),
+    };
+}
+
+function extrairPalavras(vagaBruta: string, vagaNorm: string): Candidata[] {
+    const candidatas: Candidata[] = [];
+    const vistas = new Set<string>();
+
+    for (const termo of TERMOS) {
+        if (!termo.apelidos.some((a) => contemPalavra(vagaNorm, a))) continue;
+        const chave = normalizar(termo.exibicao);
+        if (vistas.has(chave)) continue;
+        vistas.add(chave);
+        candidatas.push({
+            exibicao: termo.exibicao,
+            apelidos: termo.apelidos,
+            tecnica: termo.tecnica,
+        });
+    }
+
+    // Fallback para o que o dicionário não cobre. Só passa ALL-CAPS (OWASP) ou
+    // camelCase (MongoDB): palavra comum, mesmo Capitalizada por começar frase, fica fora.
+    for (const linha of vagaBruta.split(/[\r\n]+/)) {
+        if (candidatas.length >= MAX_PALAVRAS) break;
+        const semMarcador = linha.replace(/^[\s\-*•·–]+/, "");
+        if (semMarcador === linha.trimStart()) continue; // não é linha de bullet
+
+        for (const original of tokenizarOriginal(semMarcador)) {
+            if (candidatas.length >= MAX_PALAVRAS) break;
+
+            const token = original.replace(/^[.,;:()"'!?]+|[.,;:()"'!?]+$/g, "");
+            const norm = normalizar(token);
+            if (norm.length < 3 || PALAVRAS_VAZIAS.has(norm)) continue;
+            if (/^[\d.+/]+$/.test(norm) || !pareceSiglaOuTecnologia(token)) continue;
+            // "APIs" ao lado de "APIs REST" é a mesma palavra-chave contada duas vezes.
+            if (
+                candidatas.some((c) =>
+                    c.apelidos.some((a) => a === norm || a.split(" ").includes(norm)),
+                )
+            )
+                continue;
+            if (vistas.has(norm)) continue;
+
+            vistas.add(norm);
+            candidatas.push({ exibicao: token, apelidos: [norm], tecnica: false });
+        }
+    }
+
+    return candidatas.slice(0, MAX_PALAVRAS);
+}
+
+function classificar(c: Candidata, curriculoNorm: string): StatusPalavra {
+    if (c.apelidos.some((a) => contemPalavra(curriculoNorm, a))) return "encontrada";
+    if (c.apelidos.some((a) => a.length >= 3 && contemSolto(curriculoNorm, a))) return "parcial";
+    return "ausente";
+}
+
+function pareceSiglaOuTecnologia(token: string): boolean {
+    const letras = [...token].filter((c) => /\p{L}/u.test(c));
+    if (letras.length < 2) return false;
+    const todasMaiusculas = letras.every((c) => c === c.toUpperCase() && c !== c.toLowerCase());
+    const maiusculaInterna = [...token.slice(1)].some(
+        (c) => c === c.toUpperCase() && c !== c.toLowerCase(),
+    );
+    return todasMaiusculas || maiusculaInterna;
+}
+
+function coberturaPct(palavras: Classificada[]): number {
+    if (palavras.length === 0) return 0;
+    const soma = palavras.reduce(
+        (t, k) => t + (k.status === "encontrada" ? 1 : k.status === "parcial" ? 0.5 : 0),
+        0,
+    );
+    return Math.round((soma / palavras.length) * 100);
+}
+
+interface NotaExperiencia {
+    pct: number;
+    rotuloVerbos: string;
+    tomVerbos: Tom;
+    verbos: number;
+    razaoMetricas: number;
+    anos: number;
+}
+
+function notaExperiencia(bruto: string, norm: string): NotaExperiencia {
+    let anos = 0;
+    for (const m of norm.matchAll(/(\d+)\s*\+?\s*(anos|ano|years|year)/g)) {
+        anos = Math.max(anos, Number(m[1]));
+    }
+    const notaAnos =
+        anos >= 5
+            ? 100
+            : anos === 4
+              ? 90
+              : anos === 3
+                ? 80
+                : anos === 2
+                  ? 65
+                  : anos === 1
+                    ? 50
+                    : 30;
+
+    const tokens = tokenizar(bruto);
+    const verbos = tokens.filter((t) => VERBOS_ACAO.has(t)).length;
+    const notaVerbos =
+        verbos >= 8 ? 100 : verbos >= 5 ? 85 : verbos >= 3 ? 70 : verbos >= 1 ? 55 : 35;
+
+    const linhas = bruto
+        .split(/[\r\n]+/)
+        .map((l) => l.trim())
+        .filter((l) => l.length > 0);
+    const bullets = linhas.filter((l) => /^[-•*·–]/.test(l));
+    const consideradas = bullets.length > 0 ? bullets : linhas;
+    const comNumero = consideradas.filter((l) => /\d/.test(l)).length;
+
+    return {
+        pct: Math.min(100, Math.max(0, Math.round(notaAnos * 0.55 + notaVerbos * 0.45))),
+        rotuloVerbos: verbos >= 5 ? "Forte" : verbos >= 2 ? "Médio" : "Fraco",
+        tomVerbos: verbos >= 5 ? "bom" : verbos >= 2 ? "atencao" : "ruim",
+        verbos,
+        razaoMetricas: consideradas.length === 0 ? 0 : comNumero / consideradas.length,
+        anos,
+    };
+}
+
+function notaFormacao(norm: string): number {
+    const acertos = PALAVRAS_FORMACAO.filter((k) => contemPalavra(norm, k)).length;
+    return acertos >= 3 ? 95 : acertos === 2 ? 85 : acertos === 1 ? 70 : 35;
+}
+
+function notaFormatacao(bruto: string, norm: string): { pct: number; rotulo: string } {
+    let nota = 0;
+
+    const titulos = TITULOS_PADRAO.filter((h) => contemPalavra(norm, h)).length;
+    nota += Math.min(30, titulos * 10);
+
+    if (/[-•*]/.test(bruto)) nota += 25;
+
+    const palavras = tokenizar(bruto).length;
+    if (palavras >= 200 && palavras <= 1200) nota += 25;
+    else if ((palavras >= 120 && palavras < 200) || (palavras > 1200 && palavras <= 1800))
+        nota += 15;
+    else nota += 5;
+
+    // Caractere estranho em excesso é resquício de layout que o ATS não lê.
+    const estranhos = [...bruto].filter(caractereEstranho).length;
+    const razao = bruto.length === 0 ? 1 : estranhos / bruto.length;
+    nota += razao < 0.02 ? 20 : razao < 0.06 ? 12 : 4;
+
+    nota = Math.min(100, Math.max(0, nota));
+    return { pct: nota, rotulo: nota >= 75 ? "Boa" : nota >= 50 ? "Regular" : "Fraca" };
+}
+
+function caractereEstranho(c: string): boolean {
+    if (/[\p{L}\p{N}\s]/u.test(c)) return false;
+    return !".,;:-–()/@+%#&'\"!?•*_".includes(c);
+}
+
+function montarSugestoes(
+    palavras: Classificada[],
+    curriculoNorm: string,
+    experiencia: NotaExperiencia,
+    pctFormatacao: number,
+): Sugestao[] {
+    const sugestoes: Sugestao[] = [];
+
+    const tecnicasAusentes = palavras
+        .filter((k) => k.tecnica && k.status === "ausente")
+        .map((k) => k.exibicao);
+    if (tecnicasAusentes.length > 0) {
+        sugestoes.push({
+            prioridade: "alta",
+            titulo: "Inclua as tecnologias que a vaga pede",
+            texto: `A vaga cita ${tecnicasAusentes.slice(0, 3).join(", ")} e nada disso aparece no seu currículo. Se você já trabalhou com essas tecnologias, cite-as nas habilidades e, principalmente, na experiência em que você as usou.`,
+        });
+    }
+
+    const parcialCentral = palavras.find((k) => k.tecnica && k.status === "parcial")?.exibicao;
+    if (parcialCentral) {
+        sugestoes.push({
+            prioridade: "alta",
+            titulo: `Deixe ${parcialCentral} explícito`,
+            texto: `${parcialCentral} aparece de forma vaga no seu currículo, mas é um requisito central da vaga. Cite o nome por extenso em uma experiência recente e descreva o que você construiu com ele.`,
+        });
+    }
+
+    if (experiencia.verbos < 3) {
+        sugestoes.push({
+            prioridade: "media",
+            titulo: "Comece cada entrega com um verbo de ação",
+            texto: 'Suas descrições contam pouco sobre o que você fez. Troque frases como "responsável pelo módulo de pagamentos" por "desenvolvi o módulo de pagamentos", "reduzi", "automatizei", "liderei".',
+        });
+    }
+
+    if (experiencia.razaoMetricas < 0.5) {
+        sugestoes.push({
+            prioridade: "media",
+            titulo: "Quantifique os resultados",
+            texto: `Só ${Math.round(experiencia.razaoMetricas * 100)}% das suas entregas têm número. Métrica é o que separa "melhorei a performance" de "reduzi o tempo de carregamento em 35%" na leitura do recrutador.`,
+        });
+    }
+
+    if (experiencia.anos === 0) {
+        sugestoes.push({
+            prioridade: "baixa",
+            titulo: "Deixe o tempo de experiência visível",
+            texto: "Não encontramos um tempo de atuação declarado. Coloque o período de cada cargo (mês/ano de início e fim) e, no resumo, quantos anos você tem na área.",
+        });
+    }
+
+    const titulos = TITULOS_PADRAO.filter((h) => contemPalavra(curriculoNorm, h)).length;
+    if (titulos < 3 || pctFormatacao < 75) {
+        sugestoes.push({
+            prioridade: "baixa",
+            titulo: "Padronize os títulos das seções",
+            texto: 'Use nomes convencionais como "Experiência", "Formação" e "Habilidades". O ATS separa o currículo por esses títulos e ignora seções que não reconhece.',
+        });
+    }
+
+    return sugestoes
+        .sort((a, b) => ORDEM_PRIORIDADE[a.prioridade] - ORDEM_PRIORIDADE[b.prioridade])
+        .slice(0, 5);
+}
+
+function tomPorRazao(razao: number): Tom {
+    return razao >= 0.75 ? "bom" : razao >= 0.5 ? "atencao" : "ruim";
+}
+
+function tomPorPct(pct: number): Tom {
+    return pct >= 75 ? "bom" : pct >= 50 ? "atencao" : "ruim";
+}
+
+function vereditoPara(score: number): { veredito: string; descricao: string } {
+    if (score >= 80) {
+        return {
+            veredito: "Ótima compatibilidade",
+            descricao:
+                "Seu currículo está muito bem alinhado com a vaga. Pequenos ajustes deixam ele ainda mais forte.",
+        };
+    }
+    if (score >= 60) {
+        return {
+            veredito: "Boa compatibilidade",
+            descricao:
+                "Seu currículo conversa bem com a vaga, mas ajustes em palavras-chave e formatação ainda elevam a nota.",
+        };
+    }
+    if (score >= 40) {
+        return {
+            veredito: "Compatibilidade parcial",
+            descricao:
+                "Seu currículo atende parte dos requisitos. Reforce as palavras-chave e as experiências mais próximas do que a vaga pede.",
+        };
+    }
+    return {
+        veredito: "Baixa compatibilidade",
+        descricao:
+            "Seu currículo ainda está distante do que a vaga pede. Revise palavras-chave, habilidades técnicas e formatação.",
+    };
+}
+
+// prettier-ignore
+const VERBOS_ACAO = new Set([
+    "desenvolvi", "implementei", "criei", "construi", "liderei", "gerenciei", "otimizei",
+    "reduzi", "aumentei", "melhorei", "automatizei", "projetei", "entreguei", "mantive",
+    "colaborei", "coordenei", "integrei", "refatorei", "modernizei", "migrei", "publiquei",
+    "atuei", "participei", "conduzi", "estruturei", "padronizei", "monitorei", "escalei",
+    "developed", "implemented", "created", "built", "led", "managed", "optimized", "reduced",
+    "increased", "improved", "automated", "designed", "delivered", "maintained", "collaborated",
+    "coordinated", "integrated", "refactored", "launched", "shipped",
+]);
+
+// prettier-ignore
+const PALAVRAS_FORMACAO = [
+    "formacao", "graduacao", "bacharelado", "tecnologo", "licenciatura", "pos", "mestrado",
+    "doutorado", "faculdade", "universidade", "curso", "tecnico", "ciencia da computacao",
+    "engenharia", "sistemas de informacao", "analise e desenvolvimento", "education",
+    "bachelor", "degree", "university",
+];
+
+// prettier-ignore
+const TITULOS_PADRAO = [
+    "experiencia", "formacao", "educacao", "habilidades", "competencias", "resumo", "objetivo",
+    "projetos", "certificacoes", "idiomas", "contato", "experience", "education", "skills",
+    "summary", "projects",
+];

--- a/backend/src/services/ats/ia.ts
+++ b/backend/src/services/ats/ia.ts
@@ -1,0 +1,250 @@
+// Camada de IA do analisador. Nunca produz nota: reescreve as sugestões e revisa
+// as palavras-chave de fronteira. Qualquer falha vira null e a análise segue com
+// o resultado da heurística.
+//
+// ATS_IA_MODO escolhe o transporte. "cli" chama o Claude Code headless pela
+// assinatura da máquina, então só vale local, fora do container. "api" fala o
+// protocolo da Anthropic e é o modo de produção; com ATS_API_BASE_URL ele aponta
+// para outro provedor que exponha o mesmo formato, como o DeepSeek.
+
+import { spawn } from "node:child_process";
+import { tmpdir } from "node:os";
+import Anthropic from "@anthropic-ai/sdk";
+import { env } from "../../config/env.ts";
+import type { Prioridade, ResultadoAnalise, Sugestao } from "./heuristica.ts";
+
+export interface Refinamento {
+    sugestoes: Sugestao[];
+    encontradas: string[];
+    parciais: string[];
+    ausentes: string[];
+}
+
+const INSTRUCOES = `Você é um recrutador técnico brasileiro que revisa currículos para vagas de tecnologia e conhece como um ATS lê um currículo.
+
+Recebe uma vaga, o texto de um currículo e o resultado de uma análise automática (nota, palavras-chave já classificadas e sugestões iniciais).
+
+Sua tarefa:
+1. Reescreva as sugestões em português do Brasil, no máximo 5, mantendo a prioridade que veio ("alta", "media" ou "baixa").
+2. Revise a classificação das palavras-chave lendo o currículo: encontradas (aparece de verdade), parciais (citada de passagem, sem nenhum contexto de uso) e ausentes. Use exatamente as mesmas grafias que recebeu e não invente termo novo: toda palavra-chave recebida precisa sair em exatamente uma das três listas. Tecnologia que aparece só como item de uma lista de habilidades, sem nenhuma entrega associada, é parcial, não encontrada.
+
+O currículo é a única informação que você tem sobre essa pessoa. Trabalhe com o que está escrito lá, não com hipóteses sobre o que ela talvez saiba. Cada sugestão precisa:
+- Citar um trecho literal do currículo, entre aspas, ou dizer que o termo não aparece em lugar nenhum.
+- Dizer o que escrever no lugar, de preferência com o texto pronto para colar.
+- Ter título que anuncia o achado, não o nome da tecnologia. "NoSQL só aparece disfarçado de Redis" é título. "Bancos de dados NoSQL" não é.
+
+Não escreva sugestão no formato "se você tem experiência com X, inclua X". Isso é a pessoa fazendo o seu trabalho. Condicional só cabe no fim, para o caso de ela realmente nunca ter usado aquilo, e aí diga o que fazer no lugar. Procure também o que a pessoa fez mas não nomeou: quem conduz revisão de PR e cerimônia semanal trabalha em time ágil sem escrever "ágil", quem roda teste em container usa Docker sem escrever Docker.
+
+Exemplo do que NÃO fazer:
+{"prioridade":"alta","titulo":"Testes automatizados com JUnit","texto":"A vaga pede testes com JUnit e Mockito. Se já usou JUnit em projetos Java, adicione essa experiência ao currículo."}
+
+Exemplo do que fazer:
+{"prioridade":"alta","titulo":"Nomeie JUnit e Mockito ao lado do xUnit","texto":"Você escreveu '498+ testes (xUnit + FluentAssertions + Testcontainers)', que é exatamente o que a vaga quer, só que com outro nome. Escreva a equivalência no item de testes: 'xUnit + Moq (equivalente a JUnit + Mockito)'. O filtro procura a string JUnit e hoje não acha nada."}
+
+Como escrever: frase direta, do jeito que uma pessoa falaria. Nada de emoji, de travessão (— ou –) e de reticências no meio da frase. Onde caberia travessão, use vírgula, dois-pontos, parênteses ou ponto final. Evite os vícios de texto de IA: abrir com "Além disso", "Vale destacar", "É importante ressaltar", fechar com resumo do que acabou de dizer, ou encher de adjetivo. Vá ao ponto e pare quando terminar.
+
+Não recalcule a nota. Responda só com o objeto JSON, sem texto em volta:
+{"sugestoes":[{"prioridade":"alta|media|baixa","titulo":"...","texto":"..."}],"encontradas":["..."],"parciais":["..."],"ausentes":["..."]}`;
+
+const ESQUEMA = {
+    type: "object",
+    properties: {
+        sugestoes: {
+            type: "array",
+            items: {
+                type: "object",
+                properties: {
+                    prioridade: { type: "string", enum: ["alta", "media", "baixa"] },
+                    titulo: { type: "string" },
+                    texto: { type: "string" },
+                },
+                required: ["prioridade", "titulo", "texto"],
+                additionalProperties: false,
+            },
+        },
+        encontradas: { type: "array", items: { type: "string" } },
+        parciais: { type: "array", items: { type: "string" } },
+        ausentes: { type: "array", items: { type: "string" } },
+    },
+    required: ["sugestoes", "encontradas", "parciais", "ausentes"],
+    additionalProperties: false,
+} as const;
+
+export function iaAtiva(): boolean {
+    if (env.ATS_IA_MODO === "cli") return true;
+    return env.ATS_IA_MODO === "api" && Boolean(env.ATS_API_KEY);
+}
+
+export async function refinar(
+    vaga: string,
+    curriculo: string,
+    base: ResultadoAnalise,
+): Promise<Refinamento | null> {
+    if (!iaAtiva()) return null;
+
+    const mensagem = montarMensagem(vaga, curriculo, base);
+    try {
+        const texto = env.ATS_IA_MODO === "cli" ? await viaCli(mensagem) : await viaApi(mensagem);
+        return texto ? interpretar(texto) : null;
+    } catch (err) {
+        console.error("Refinamento da análise de currículo falhou:", err);
+        return null;
+    }
+}
+
+function montarMensagem(vaga: string, curriculo: string, base: ResultadoAnalise): string {
+    const sugestoes = base.sugestoes
+        .map((s) => `- [${s.prioridade}] ${s.titulo}: ${s.texto}`)
+        .join("\n");
+    return `=== VAGA ===
+${vaga}
+
+=== CURRÍCULO ===
+${curriculo}
+
+=== ANÁLISE AUTOMÁTICA ===
+Nota geral: ${base.score}
+Palavras-chave encontradas: ${base.encontradas.join(", ") || "(nenhuma)"}
+Palavras-chave parciais: ${base.parciais.join(", ") || "(nenhuma)"}
+Palavras-chave ausentes: ${base.ausentes.join(", ") || "(nenhuma)"}
+Sugestões iniciais:
+${sugestoes}`;
+}
+
+let cliente: Anthropic | null = null;
+
+async function viaApi(mensagem: string): Promise<string | null> {
+    cliente ??= new Anthropic({
+        apiKey: env.ATS_API_KEY,
+        baseURL: env.ATS_API_BASE_URL,
+        timeout: env.ATS_TIMEOUT_S * 1000,
+    });
+
+    // Fora da Anthropic, o endpoint compatível costuma ignorar ou recusar esses
+    // dois: o DeepSeek só aceita `effort` em output_config e já vem com o próprio
+    // modo de raciocínio ligado. Sem o schema a saída deixa de ser JSON garantido,
+    // e é o parser tolerante (o mesmo do modo cli) que segura.
+    const soAnthropic = !env.ATS_API_BASE_URL.includes("api.anthropic.com")
+        ? {}
+        : {
+              thinking: { type: "adaptive" as const },
+              output_config: { format: { type: "json_schema" as const, schema: ESQUEMA } },
+          };
+
+    const resposta = await cliente.messages.create({
+        model: env.ATS_MODELO,
+        max_tokens: 8000,
+        // As instruções são idênticas em toda análise; o cache corta o custo delas.
+        system: [{ type: "text", text: INSTRUCOES, cache_control: { type: "ephemeral" } }],
+        messages: [{ role: "user", content: mensagem }],
+        ...soAnthropic,
+    });
+
+    if (resposta.stop_reason === "refusal") {
+        console.error("Refinamento recusado pelo modelo:", resposta.stop_details);
+        return null;
+    }
+    const bloco = resposta.content.find((b) => b.type === "text");
+    return bloco?.type === "text" ? bloco.text : null;
+}
+
+function viaCli(mensagem: string): Promise<string | null> {
+    return new Promise((resolve) => {
+        const args = ["-p", "--output-format", "json"];
+        if (env.ATS_MODELO_CLI) args.push("--model", env.ATS_MODELO_CLI);
+
+        // cwd neutro: de dentro do projeto o CLI carregaria o CLAUDE.md do repositório.
+        const processo = spawn("claude", args, { cwd: tmpdir(), stdio: ["pipe", "pipe", "pipe"] });
+
+        let saida = "";
+        let erro = "";
+        const prazo = setTimeout(() => processo.kill("SIGKILL"), env.ATS_TIMEOUT_S * 1000);
+
+        processo.stdout.on("data", (d) => (saida += d));
+        processo.stderr.on("data", (d) => (erro += d));
+        processo.on("error", (e) => {
+            clearTimeout(prazo);
+            console.error("Não foi possível executar o Claude Code:", e.message);
+            resolve(null);
+        });
+        processo.on("close", (codigo) => {
+            clearTimeout(prazo);
+            if (codigo !== 0) {
+                console.error(`Claude Code saiu com código ${codigo}:`, erro.slice(0, 300));
+                return resolve(null);
+            }
+            resolve(extrairResultadoCli(saida));
+        });
+
+        processo.stdin.end(`${INSTRUCOES}\n\n${mensagem}`);
+    });
+}
+
+// O modo headless embrulha a resposta num envelope; o texto vem em "result".
+function extrairResultadoCli(saida: string): string | null {
+    if (!saida.trim()) return null;
+    try {
+        const envelope = JSON.parse(saida) as { is_error?: boolean; result?: unknown };
+        if (envelope.is_error) return null;
+        return typeof envelope.result === "string" ? envelope.result : null;
+    } catch {
+        return saida;
+    }
+}
+
+const PRIORIDADES = new Set<Prioridade>(["alta", "media", "baixa"]);
+
+// O prompt pede para não usar travessão nem emoji, mas nem todo modelo obedece.
+// Aqui a regra deixa de depender disso.
+function limpar(texto: string): string {
+    return (
+        texto
+            // Entre números é faixa ("10–20", "2h–35min"), não pontuação: vira hífen.
+            .replace(/(\d\p{L}*)\s*[—–]\s*(\d)/gu, "$1-$2")
+            .replace(/\s*[—–]\s*/g, ", ")
+            .replace(/\p{Extended_Pictographic}/gu, "")
+            .replace(/\s{2,}/g, " ")
+            .replace(/[,\s]+$/, "")
+            .trim()
+    );
+}
+
+// Recorta do primeiro { ao último }: o modo api devolve JSON puro pelo schema,
+// mas o cli pode vir com prosa em volta.
+function interpretar(texto: string): Refinamento | null {
+    const inicio = texto.indexOf("{");
+    const fim = texto.lastIndexOf("}");
+    if (inicio < 0 || fim <= inicio) return null;
+
+    let bruto: Record<string, unknown>;
+    try {
+        bruto = JSON.parse(texto.slice(inicio, fim + 1)) as Record<string, unknown>;
+    } catch (err) {
+        console.error("Resposta do refinamento não é JSON válido:", err);
+        return null;
+    }
+
+    const sugestoes = (Array.isArray(bruto.sugestoes) ? bruto.sugestoes : [])
+        .map((s) => s as Record<string, unknown>)
+        .filter((s) => typeof s.titulo === "string" && s.titulo.trim().length > 0)
+        .map<Sugestao>((s) => ({
+            prioridade: PRIORIDADES.has(s.prioridade as Prioridade)
+                ? (s.prioridade as Prioridade)
+                : "media",
+            titulo: limpar(String(s.titulo)),
+            texto: typeof s.texto === "string" ? limpar(s.texto) : "",
+        }))
+        .filter((s) => s.titulo.length > 0)
+        .slice(0, 5);
+
+    return {
+        sugestoes,
+        encontradas: listaDeTextos(bruto.encontradas),
+        parciais: listaDeTextos(bruto.parciais),
+        ausentes: listaDeTextos(bruto.ausentes),
+    };
+}
+
+function listaDeTextos(valor: unknown): string[] {
+    return Array.isArray(valor) ? valor.filter((v): v is string => typeof v === "string") : [];
+}

--- a/backend/src/services/ats/normalizar.ts
+++ b/backend/src/services/ats/normalizar.ts
@@ -1,0 +1,67 @@
+// Todo o casamento acontece sobre o texto normalizado, para "inglês" no
+// currículo casar com "ingles" na vaga. O original só serve para exibir.
+
+export function normalizar(texto: string): string {
+    if (!texto) return "";
+    return texto
+        .toLowerCase()
+        .normalize("NFD")
+        .replace(/\p{Diacritic}/gu, "")
+        .normalize("NFC");
+}
+
+// Ponto, barra e cerquilha entram no token para preservar "next.js", "ci/cd" e "c#".
+const PALAVRA = /[\p{L}\p{N}][\p{L}\p{N}.+/#]*/gu;
+
+export function tokenizar(texto: string): string[] {
+    return normalizar(texto).match(PALAVRA) ?? [];
+}
+
+export function tokenizarOriginal(texto: string): string[] {
+    return texto ? (texto.match(PALAVRA) ?? []) : [];
+}
+
+function escaparRegex(texto: string): string {
+    return texto.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function contemPalavra(textoNormalizado: string, termo: string): boolean {
+    const alvo = normalizar(termo).trim();
+    if (!alvo) return false;
+    return new RegExp(`(?<![\\p{L}\\p{N}])${escaparRegex(alvo)}(?![\\p{L}\\p{N}])`, "u").test(
+        textoNormalizado,
+    );
+}
+
+// Sem fronteira de palavra: é o que caracteriza a menção fraca (parcial).
+export function contemSolto(textoNormalizado: string, termo: string): boolean {
+    const alvo = normalizar(termo).trim();
+    return alvo.length > 0 && textoNormalizado.includes(alvo);
+}
+
+// Filtram o fallback de extração, que pega tokens soltos das linhas de requisito.
+// prettier-ignore
+export const PALAVRAS_VAZIAS = new Set([
+    // Português
+    "a", "o", "as", "os", "um", "uma", "uns", "umas", "de", "do", "da", "dos", "das", "em",
+    "no", "na", "nos", "nas", "por", "para", "com", "sem", "sob", "sobre", "ate", "e", "ou",
+    "que", "se", "ao", "aos", "como", "mais", "menos", "muito", "muita", "ser", "ter", "estar",
+    "sua", "seu", "suas", "seus", "nosso", "nossa", "nossos", "nossas", "vaga", "pessoa",
+    "time", "times", "cultura", "boa", "bom", "leitura", "nivel", "experiencia", "conhecimento",
+    "vivencia", "dominio", "fluxo", "anos", "ano", "partir", "designs", "interfaces",
+    "aplicacoes", "garantir", "colaborar", "manter", "desenvolver", "implementar", "escrever",
+    "construir", "integrar", "buscamos", "produto", "back", "junior", "pleno", "senior",
+    "estagio", "trainee", "remoto", "hibrido", "presencial", "intermediario", "documentacao",
+    "responsabilidades", "requisitos", "diferenciais", "automatizados", "consumo",
+    "versionamento", "desenvolvimento", "responsivas", "web", "performaticas", "acessiveis",
+    "agil", "core", "library", "testing", "media", "alta", "baixa", "complexidade", "solucoes",
+    "solucao", "codigo", "limpo", "cobertura", "unitarios", "integracao", "qualidade", "seguro",
+    "seguros", "autonoma", "autonomo", "forma", "participar", "alem", "sustentacao",
+    "incidentes", "producao", "processos", "negocios", "negocio", "parceiros", "ferramentas",
+    "tecnologias", "backend", "frontend", "fullstack", "transacionais", "comprovada", "solida",
+    "bons", "principios", "design", "orientado", "objetos", "reviews", "atuar", "salario",
+    "beneficios", "clt", "pj", "vale", "plano", "saude",
+    // Inglês
+    "the", "an", "of", "in", "on", "for", "with", "and", "or", "to", "as", "is", "are", "be",
+    "by", "at", "from", "this", "that", "your", "our", "we", "you", "it",
+]);

--- a/backend/src/services/ats/pdf.ts
+++ b/backend/src/services/ats/pdf.ts
@@ -1,0 +1,33 @@
+import { extractText, getDocumentProxy } from "unpdf";
+import { AppError } from "../../errors/AppError.ts";
+
+// Abaixo disso o PDF é escaneado ou só imagem: a nota sairia inventada.
+const MINIMO_CARACTERES = 200;
+
+export async function extrairTextoPdf(pdf: Buffer): Promise<string> {
+    let texto: string;
+    try {
+        const documento = await getDocumentProxy(new Uint8Array(pdf));
+        const extraido = await extractText(documento, { mergePages: true });
+        texto = extraido.text;
+    } catch (err) {
+        console.error("Falha ao ler o PDF do currículo:", err);
+        throw new AppError(
+            422,
+            "Não conseguimos ler esse PDF. Confira se o arquivo não está corrompido.",
+        );
+    }
+
+    if (texto.replace(/\s/g, "").length < MINIMO_CARACTERES) {
+        throw new AppError(
+            422,
+            "Esse PDF não tem texto selecionável (parece uma imagem ou um currículo escaneado). Exporte o currículo como PDF de texto e envie de novo.",
+        );
+    }
+
+    return texto
+        .split(/\r?\n/)
+        .map((l) => l.replace(/[ \t]+/g, " ").trim())
+        .filter((l) => l.length > 0)
+        .join("\n");
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -93,6 +93,7 @@ const Comunidade = lazy(() =>
   import('./pages/Comunidade').then((m) => ({ default: m.Comunidade })),
 );
 const Apoie = lazy(() => import('./pages/Apoie').then((m) => ({ default: m.Apoie })));
+const Curriculo = lazy(() => import('./pages/Curriculo').then((m) => ({ default: m.Curriculo })));
 const CompletarPerfil = lazy(() =>
   import('./pages/CompletarPerfil').then((m) => ({ default: m.CompletarPerfil })),
 );
@@ -394,6 +395,14 @@ function AppRoutes() {
             element={
               <PrivateRoute>
                 <Apoie />
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path="/curriculo"
+            element={
+              <PrivateRoute>
+                <Curriculo />
               </PrivateRoute>
             }
           />

--- a/frontend/src/components/UserMenu.tsx
+++ b/frontend/src/components/UserMenu.tsx
@@ -94,6 +94,16 @@ export function UserMenu({ initials, level, name, email }: UserMenuProps) {
           >
             Conquistas
           </button>
+          {user?.apoiador && (
+            <button
+              type="button"
+              role="menuitem"
+              className="user-menu__item"
+              onClick={() => go('/curriculo')}
+            >
+              Analisar currículo
+            </button>
+          )}
           <button
             type="button"
             role="menuitem"

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -9,4 +9,5 @@
 @import './styles/roadmap.css';
 @import './styles/landing.css';
 @import './styles/lab.css';
+@import './styles/curriculo.css';
 @import './styles/mobile.css';

--- a/frontend/src/pages/Apoie/index.tsx
+++ b/frontend/src/pages/Apoie/index.tsx
@@ -38,6 +38,7 @@ const GRATIS = [
 ];
 
 const PREMIUM = [
+  'Analisador de currículo para as vagas que você quer',
   'Selo de apoiador no perfil e no ranking',
   'Estatísticas avançadas de progresso',
   'Cor e imagem de fundo personalizadas',

--- a/frontend/src/pages/Apoie/index.tsx
+++ b/frontend/src/pages/Apoie/index.tsx
@@ -21,6 +21,7 @@ import {
   definirVeuFundo,
   type StatusApoio,
   type CobrancaPix,
+  type PlanoAvulso,
 } from '../../services/apoio';
 import { aplicarFundo, aplicarVeu } from '../../utils/accent';
 import { urlImagem } from '../../utils/urlImagem';
@@ -43,6 +44,34 @@ const PREMIUM = [
   'Aquele carinho de manter o projeto vivo',
 ];
 
+// Quanto mais longo o compromisso, menor o valor por mês.
+const CICLOS: {
+  id: PlanoAvulso;
+  aba: string;
+  selo?: string;
+  preco: string;
+  periodo: string;
+  botao: string;
+}[] = [
+  { id: 'mensal', aba: 'Mensal', preco: 'R$ 5', periodo: '/mês', botao: 'Assinar por R$ 5/mês' },
+  {
+    id: 'trimestral',
+    aba: 'Trimestral',
+    selo: 'R$ 4,67/mês',
+    preco: 'R$ 14',
+    periodo: '/trimestre',
+    botao: 'Assinar por R$ 14/trimestre',
+  },
+  {
+    id: 'anual',
+    aba: 'Anual',
+    selo: '2 meses grátis',
+    preco: 'R$ 50',
+    periodo: '/ano',
+    botao: 'Assinar por R$ 50/ano',
+  },
+];
+
 const TIPOS_IMG = ['image/png', 'image/jpeg', 'image/webp'];
 // A original nunca sobe: o recorte comprime antes. Aqui só barra exagero.
 const MAX_IMG = 10 * 1024 * 1024;
@@ -58,7 +87,7 @@ function lerArquivo(file: File): Promise<string> {
 
 export function Apoie() {
   const { user: authUser, atualizarUsuario } = useAuth();
-  const [ciclo, setCiclo] = useState<'mensal' | 'anual'>('mensal');
+  const [ciclo, setCiclo] = useState<PlanoAvulso>('mensal');
   const [status, setStatus] = useState<StatusApoio | null>(null);
   const [cobranca, setCobranca] = useState<CobrancaPix | null>(null);
   const [gerando, setGerando] = useState(false);
@@ -76,6 +105,7 @@ export function Apoie() {
 
   const displayName = authUser?.name ?? '';
   const initials = getInitials(displayName || 'A');
+  const cicloAtual = CICLOS.find((c) => c.id === ciclo) ?? CICLOS[0];
 
   async function carregarStatus() {
     try {
@@ -297,18 +327,15 @@ export function Apoie() {
 
             {!apoiador && (
               <div className="apoie__ciclos">
-                <button
-                  className={`apoie__ciclo${ciclo === 'mensal' ? ' apoie__ciclo--on' : ''}`}
-                  onClick={() => setCiclo('mensal')}
-                >
-                  Mensal
-                </button>
-                <button
-                  className={`apoie__ciclo${ciclo === 'anual' ? ' apoie__ciclo--on' : ''}`}
-                  onClick={() => setCiclo('anual')}
-                >
-                  Anual <span className="apoie__gratis-tag">2 meses grátis</span>
-                </button>
+                {CICLOS.map((c) => (
+                  <button
+                    key={c.id}
+                    className={`apoie__ciclo${ciclo === c.id ? ' apoie__ciclo--on' : ''}`}
+                    onClick={() => setCiclo(c.id)}
+                  >
+                    {c.aba} {c.selo && <span className="apoie__gratis-tag">{c.selo}</span>}
+                  </button>
+                ))}
               </div>
             )}
           </div>
@@ -445,8 +472,8 @@ export function Apoie() {
                   PREMIUM
                 </div>
                 <div className="apoie__preco-linha">
-                  <span className="apoie__preco">{ciclo === 'mensal' ? 'R$ 5' : 'R$ 50'}</span>
-                  <span className="apoie__preco-sub">{ciclo === 'mensal' ? '/mês' : '/ano'}</span>
+                  <span className="apoie__preco">{cicloAtual.preco}</span>
+                  <span className="apoie__preco-sub">{cicloAtual.periodo}</span>
                 </div>
                 <p className="apoie__plano-desc">Cancele quando quiser. Sem fidelidade.</p>
                 <hr className="rule" />
@@ -462,11 +489,7 @@ export function Apoie() {
                   ))}
                 </div>
                 <button className="btn btn--accent btn--block" onClick={assinar} disabled={gerando}>
-                  {gerando
-                    ? 'Gerando...'
-                    : ciclo === 'mensal'
-                      ? 'Assinar por R$ 5/mês'
-                      : 'Assinar por R$ 50/ano'}
+                  {gerando ? 'Gerando...' : cicloAtual.botao}
                 </button>
                 <p className="apoie__nota">Você continua com tudo de graça se não assinar.</p>
               </div>

--- a/frontend/src/pages/AssinaturasAdmin/index.tsx
+++ b/frontend/src/pages/AssinaturasAdmin/index.tsx
@@ -61,6 +61,7 @@ function montarSerie(
 
 const PLANO: Record<string, string> = {
   mensal: 'Mensal',
+  trimestral: 'Trimestral',
   anual: 'Anual',
   pix_auto: 'Pix Automático',
 };

--- a/frontend/src/pages/Curriculo/index.tsx
+++ b/frontend/src/pages/Curriculo/index.tsx
@@ -1,0 +1,484 @@
+import { useEffect, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useAuth } from '../../contexts/AuthContext';
+import { Logo } from '../../components/Logo';
+import { MobileMenu } from '../../components/MobileMenu';
+import { UserMenu } from '../../components/UserMenu';
+import { ThemeToggle } from '../../components/ThemeToggle';
+import { Flame, Check, X, Alert, Info, Zap, DocLines, Redo, Star } from '../../components/Icons';
+import { getInitials } from '../../utils/initials';
+import { NAV_PRINCIPAL as NAV } from '../../data/nav';
+import {
+  analisarCurriculo,
+  listarAnalises,
+  obterAnalise,
+  obterStatusCurriculo,
+  type Analise,
+  type Prioridade,
+  type ResumoAnalise,
+  type StatusCurriculo,
+  type Tom,
+} from '../../services/curriculo';
+
+const MAX_PDF = 5 * 1024 * 1024;
+const MIN_VAGA = 120;
+
+const ROTULO_PRIORIDADE: Record<Prioridade, string> = {
+  alta: 'Prioridade alta',
+  media: 'Média',
+  baixa: 'Refinamento',
+};
+
+// A análise com IA passa de um minuto e meio, e uma barra parada nesse tempo
+// passa a impressão de travamento.
+const ETAPAS = [
+  'Lendo o PDF do currículo...',
+  'Extraindo as palavras-chave da vaga...',
+  'Comparando com o seu currículo...',
+  'Procurando o que você fez mas não nomeou...',
+  'Montando as sugestões...',
+];
+const SEGUNDOS_POR_ETAPA = 22;
+
+function corDaNota(score: number): string {
+  if (score >= 80) return 'var(--success)';
+  if (score >= 60) return 'var(--gold)';
+  if (score >= 40) return 'var(--bronze)';
+  return 'var(--av-red)';
+}
+
+function classeTom(tom: Tom): string {
+  return tom === 'bom'
+    ? 'cur__tom--bom'
+    : tom === 'atencao'
+      ? 'cur__tom--atencao'
+      : 'cur__tom--ruim';
+}
+
+function lerArquivo(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(new Error('Falha ao ler o arquivo'));
+    reader.readAsDataURL(file);
+  });
+}
+
+function Anel({ score }: { score: number }) {
+  const raio = 78;
+  const volta = 2 * Math.PI * raio;
+  return (
+    <div className="cur__anel">
+      <svg viewBox="0 0 180 180" role="img" aria-label={`Nota ${score} de 100`}>
+        <circle className="cur__anel-trilho" cx="90" cy="90" r={raio} />
+        <circle
+          className="cur__anel-valor"
+          cx="90"
+          cy="90"
+          r={raio}
+          stroke={corDaNota(score)}
+          strokeDasharray={`${(score / 100) * volta} ${volta}`}
+        />
+      </svg>
+      <div className="cur__anel-texto">
+        <strong style={{ color: corDaNota(score) }}>{score}</strong>
+        <span>de 100</span>
+      </div>
+    </div>
+  );
+}
+
+export function Curriculo() {
+  const { user: authUser } = useAuth();
+  const [status, setStatus] = useState<StatusCurriculo | null>(null);
+  const [historico, setHistorico] = useState<ResumoAnalise[]>([]);
+  const [analise, setAnalise] = useState<Analise | null>(null);
+  const [tituloVaga, setTituloVaga] = useState('');
+  const [vaga, setVaga] = useState('');
+  const [arquivo, setArquivo] = useState<File | null>(null);
+  const [analisando, setAnalisando] = useState(false);
+  const [etapa, setEtapa] = useState(0);
+  const [erro, setErro] = useState('');
+  const inputPdf = useRef<HTMLInputElement>(null);
+
+  const displayName = authUser?.name ?? '';
+  const initials = getInitials(displayName || 'A');
+
+  useEffect(() => {
+    void carregar();
+  }, []);
+
+  useEffect(() => {
+    if (!analisando) return;
+    const t = setInterval(
+      () => setEtapa((e) => Math.min(e + 1, ETAPAS.length - 1)),
+      SEGUNDOS_POR_ETAPA * 1000,
+    );
+    return () => clearInterval(t);
+  }, [analisando]);
+
+  async function carregar() {
+    try {
+      const s = await obterStatusCurriculo();
+      setStatus(s);
+      if (s.liberado) setHistorico(await listarAnalises());
+    } catch (e) {
+      console.error('Falha ao carregar o analisador de currículo:', e);
+    }
+  }
+
+  function escolherArquivo(file: File | undefined) {
+    if (!file) return;
+    if (file.type !== 'application/pdf') {
+      setErro('O currículo precisa estar em PDF.');
+      return;
+    }
+    if (file.size > MAX_PDF) {
+      setErro('O PDF passa de 5 MB. Exporte o currículo com menos imagens.');
+      return;
+    }
+    setErro('');
+    setArquivo(file);
+  }
+
+  async function analisar() {
+    if (analisando || !arquivo) return;
+    setErro('');
+    setEtapa(0);
+    setAnalisando(true);
+    try {
+      const pdf = await lerArquivo(arquivo);
+      const resultado = await analisarCurriculo({
+        vaga,
+        tituloVaga: tituloVaga.trim() || undefined,
+        pdf,
+      });
+      setAnalise(resultado);
+      void carregar();
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    } catch (e) {
+      const resposta = e as { response?: { data?: { erro?: string; message?: string } } };
+      setErro(
+        resposta.response?.data?.erro ??
+          resposta.response?.data?.message ??
+          'Não foi possível analisar agora. Tente de novo em instantes.',
+      );
+      console.error('Falha ao analisar o currículo:', e);
+    } finally {
+      setAnalisando(false);
+    }
+  }
+
+  async function abrirAnalise(id: string) {
+    try {
+      setAnalise(await obterAnalise(id));
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    } catch (e) {
+      console.error('Falha ao abrir a análise:', e);
+    }
+  }
+
+  function novaAnalise() {
+    setAnalise(null);
+    setArquivo(null);
+    setErro('');
+    if (inputPdf.current) inputPdf.current.value = '';
+  }
+
+  const vagaCurta = vaga.trim().length < MIN_VAGA;
+
+  return (
+    <div className="home-shell">
+      <div className="home">
+        <header className="topbar">
+          <MobileMenu />
+          <Logo variant="solid" size={20} to="/home" />
+          <nav className="nav">
+            {NAV.map((item) => (
+              <Link key={item.to} to={item.to} className="nav__item">
+                {item.label}
+              </Link>
+            ))}
+          </nav>
+          <div className="topbar__spacer" />
+          <div className="streak-pill">
+            <Flame size={16} /> {authUser?.streak ?? 0}
+          </div>
+          <ThemeToggle inline />
+          <UserMenu
+            initials={initials}
+            level={authUser?.level ?? 1}
+            name={displayName}
+            email={authUser?.email}
+          />
+        </header>
+
+        <div className="cur">
+          <div className="cur__cabecalho">
+            <div>
+              <h1 className="cur__titulo">Analisador de currículo</h1>
+              <p className="cur__sub">
+                Cole a descrição da vaga, envie seu currículo em PDF e veja a nota de
+                compatibilidade com ATS, as palavras-chave que faltam e o que ajustar antes de se
+                candidatar.
+              </p>
+            </div>
+            {status?.liberado && (
+              <div className="cur__cota">
+                <strong>{status.restantes}</strong>
+                <span>
+                  {status.restantes === 1 ? 'análise restante' : 'análises restantes'}
+                  <br />
+                  nos últimos 30 dias
+                </span>
+              </div>
+            )}
+          </div>
+
+          {status && !status.liberado && (
+            <div className="card cur__paywall">
+              <span className="cur__paywall-icone">
+                <Star size={18} />
+              </span>
+              <div>
+                <h2>A análise de currículo é um benefício de apoiador</h2>
+                <p>
+                  Por R$ 5 por mês você libera o analisador e ajuda a manter a plataforma inteira de
+                  graça para todo mundo.
+                </p>
+              </div>
+              <Link className="btn btn--accent" to="/apoie">
+                Quero apoiar
+              </Link>
+            </div>
+          )}
+
+          {erro && <div className="auth__alert">{erro}</div>}
+
+          {status?.liberado && !analise && (
+            <div className="card cur__form">
+              <label className="cur__campo">
+                <span className="cur__rotulo">Título da vaga (opcional)</span>
+                <input
+                  className="input"
+                  value={tituloVaga}
+                  maxLength={160}
+                  placeholder="Back-end Pleno na Nubank"
+                  onChange={(e) => setTituloVaga(e.target.value)}
+                />
+                <span className="cur__dica">Só para você reconhecer a análise no histórico.</span>
+              </label>
+
+              <label className="cur__campo">
+                <span className="cur__rotulo">Descrição da vaga</span>
+                <textarea
+                  className="input cur__textarea"
+                  value={vaga}
+                  rows={12}
+                  placeholder="Cole aqui a vaga inteira: requisitos, diferenciais e responsabilidades."
+                  onChange={(e) => setVaga(e.target.value)}
+                />
+                <span className="cur__dica">
+                  {vagaCurta
+                    ? `Faltam ${MIN_VAGA - vaga.trim().length} caracteres. Quanto mais completa a vaga, melhor a análise.`
+                    : `${vaga.trim().length} caracteres`}
+                </span>
+              </label>
+
+              <div className="cur__campo">
+                <span className="cur__rotulo">Seu currículo em PDF</span>
+                <input
+                  ref={inputPdf}
+                  type="file"
+                  accept="application/pdf"
+                  hidden
+                  onChange={(e) => escolherArquivo(e.target.files?.[0])}
+                />
+                <button
+                  type="button"
+                  className={`cur__dropzone${arquivo ? ' cur__dropzone--ok' : ''}`}
+                  onClick={() => inputPdf.current?.click()}
+                >
+                  <DocLines size={22} />
+                  {arquivo ? (
+                    <>
+                      <strong>{arquivo.name}</strong>
+                      <span>{(arquivo.size / 1024).toFixed(0)} KB · clique para trocar</span>
+                    </>
+                  ) : (
+                    <>
+                      <strong>Escolher arquivo</strong>
+                      <span>PDF de texto, até 5 MB</span>
+                    </>
+                  )}
+                </button>
+                <span className="cur__dica">
+                  Precisa ser um PDF exportado como texto. Currículo escaneado ou print não dá para
+                  ler.
+                </span>
+              </div>
+
+              <button
+                className="btn btn--accent btn--block"
+                onClick={analisar}
+                disabled={analisando || !arquivo || vagaCurta}
+              >
+                {analisando ? ETAPAS[etapa] : 'Analisar currículo'}
+              </button>
+              {analisando && (
+                <p className="cur__espera">
+                  A análise costuma levar perto de dois minutos. Pode deixar a aba aberta.
+                </p>
+              )}
+            </div>
+          )}
+
+          {analise && (
+            <div className="cur__resultado">
+              <aside className="card cur__placar">
+                <Anel score={analise.score} />
+                <h2 style={{ color: corDaNota(analise.score) }}>{analise.veredito}</h2>
+                <p>{analise.descricao}</p>
+                <hr className="rule" />
+                <div className="cur__resumo">
+                  {analise.resumo.map((item) => (
+                    <div key={item.rotulo} className="cur__resumo-item">
+                      <span>{item.rotulo}</span>
+                      <strong className={classeTom(item.tom)}>{item.valor}</strong>
+                    </div>
+                  ))}
+                </div>
+                <button className="btn btn--ghost btn--block" onClick={novaAnalise}>
+                  <Redo size={15} /> Analisar outro currículo
+                </button>
+              </aside>
+
+              <div className="cur__colunas">
+                <section className="card">
+                  <h3 className="cur__secao">Compatibilidade por seção</h3>
+                  {analise.detalhe.map((item) => (
+                    <div key={item.rotulo} className="cur__barra">
+                      <div className="cur__barra-topo">
+                        <span>{item.rotulo}</span>
+                        <strong style={{ color: corDaNota(item.pct) }}>{item.pct}%</strong>
+                      </div>
+                      <div className="cur__barra-trilho">
+                        <div
+                          className="cur__barra-valor"
+                          style={{ width: `${item.pct}%`, background: corDaNota(item.pct) }}
+                        />
+                      </div>
+                    </div>
+                  ))}
+                </section>
+
+                <section className="card">
+                  <h3 className="cur__secao">
+                    Palavras-chave
+                    <span className="cur__secao-nota">
+                      {analise.encontradas.length}/
+                      {analise.encontradas.length +
+                        analise.parciais.length +
+                        analise.ausentes.length}{' '}
+                      encontradas
+                    </span>
+                  </h3>
+                  <GrupoPalavras titulo="Encontradas" tipo="ok" termos={analise.encontradas} />
+                  <GrupoPalavras titulo="Vagas" tipo="parcial" termos={analise.parciais} />
+                  <GrupoPalavras titulo="Ausentes" tipo="fora" termos={analise.ausentes} />
+                </section>
+
+                <section className="card">
+                  <h3 className="cur__secao">
+                    O que ajustar
+                    {analise.motor === 'ia' && (
+                      <span className="cur__selo-ia">Revisado por IA</span>
+                    )}
+                  </h3>
+                  {analise.sugestoes.map((s) => (
+                    <article
+                      key={s.titulo}
+                      className={`cur__sugestao cur__sugestao--${s.prioridade}`}
+                    >
+                      <span className="cur__sugestao-icone">
+                        {s.prioridade === 'alta' ? (
+                          <Alert size={16} />
+                        ) : s.prioridade === 'media' ? (
+                          <Zap size={16} />
+                        ) : (
+                          <Info size={16} />
+                        )}
+                      </span>
+                      <div>
+                        <h4>
+                          {s.titulo}
+                          <span className="cur__prioridade">{ROTULO_PRIORIDADE[s.prioridade]}</span>
+                        </h4>
+                        <p>{s.texto}</p>
+                      </div>
+                    </article>
+                  ))}
+                </section>
+              </div>
+            </div>
+          )}
+
+          {status?.liberado && historico.length > 0 && (
+            <section className="card cur__historico">
+              <h3 className="cur__secao">Análises anteriores</h3>
+              <div className="cur__historico-lista">
+                {historico.map((h) => (
+                  <button
+                    key={h.id}
+                    className="cur__historico-item"
+                    onClick={() => abrirAnalise(h.id)}
+                  >
+                    <strong style={{ color: corDaNota(h.score) }}>{h.score}</strong>
+                    <span className="cur__historico-vaga">
+                      {h.tituloVaga || 'Vaga sem título'}
+                      <small>
+                        {new Date(h.criadaEm).toLocaleDateString('pt-BR', {
+                          day: '2-digit',
+                          month: 'short',
+                          year: 'numeric',
+                        })}
+                      </small>
+                    </span>
+                    <span className="cur__historico-veredito">{h.veredito}</span>
+                  </button>
+                ))}
+              </div>
+            </section>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function GrupoPalavras({
+  titulo,
+  tipo,
+  termos,
+}: {
+  titulo: string;
+  tipo: 'ok' | 'parcial' | 'fora';
+  termos: string[];
+}) {
+  if (termos.length === 0) return null;
+  return (
+    <div className="cur__grupo">
+      <div className={`cur__grupo-titulo cur__grupo-titulo--${tipo}`}>
+        {titulo} <span>{termos.length}</span>
+      </div>
+      <div className="cur__chips">
+        {termos.map((t) => (
+          <span key={t} className={`cur__chip cur__chip--${tipo}`}>
+            {tipo === 'ok' ? <Check size={12} /> : tipo === 'fora' ? <X size={12} /> : null}
+            {t}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/services/apoio.ts
+++ b/frontend/src/services/apoio.ts
@@ -2,9 +2,12 @@ import api from './api';
 
 export const ACCENTS = ['#2D6BF5', '#7C3AED', '#DB2777', '#E0532F', '#1C8F5A', '#B7791F'];
 
+export type PlanoAvulso = 'mensal' | 'trimestral' | 'anual';
+export type Plano = PlanoAvulso | 'pix_auto';
+
 export interface StatusApoio {
   apoiador: boolean;
-  plano: 'mensal' | 'anual' | 'pix_auto' | null;
+  plano: Plano | null;
   expiresAt: string | null;
   cancelada: boolean;
   disponivel: boolean;
@@ -23,7 +26,7 @@ export async function obterStatusApoio() {
   return data;
 }
 
-export async function criarCobranca(plan: 'mensal' | 'anual') {
+export async function criarCobranca(plan: PlanoAvulso) {
   const { data } = await api.post<CobrancaPix>('/apoie/cobranca', { plan });
   return data;
 }
@@ -74,7 +77,7 @@ export interface AssinaturasAdminData {
   porDia: { d: string; cents: number }[];
   assinaturas: {
     id: string;
-    plan: 'mensal' | 'anual' | 'pix_auto';
+    plan: Plano;
     status: 'pendente' | 'ativa' | 'cancelada';
     amountCents: number;
     paidAt: string | null;

--- a/frontend/src/services/curriculo.ts
+++ b/frontend/src/services/curriculo.ts
@@ -1,0 +1,82 @@
+import api from './api';
+
+export type Tom = 'bom' | 'atencao' | 'ruim';
+export type Prioridade = 'alta' | 'media' | 'baixa';
+export type Motor = 'heuristica' | 'ia';
+
+export interface ItemResumo {
+  rotulo: string;
+  valor: string;
+  tom: Tom;
+  icone: string;
+}
+
+export interface ItemDetalhe {
+  rotulo: string;
+  icone: string;
+  pct: number;
+}
+
+export interface Sugestao {
+  prioridade: Prioridade;
+  titulo: string;
+  texto: string;
+}
+
+export interface Analise {
+  id: string;
+  criadaEm: string;
+  tituloVaga?: string | null;
+  score: number;
+  veredito: string;
+  descricao: string;
+  motor: Motor;
+  resumo: ItemResumo[];
+  detalhe: ItemDetalhe[];
+  encontradas: string[];
+  parciais: string[];
+  ausentes: string[];
+  sugestoes: Sugestao[];
+  restantes?: number;
+}
+
+export interface StatusCurriculo {
+  liberado: boolean;
+  usadas: number;
+  limite: number;
+  restantes: number;
+  ia: boolean;
+}
+
+export interface ResumoAnalise {
+  id: string;
+  tituloVaga: string | null;
+  score: number;
+  veredito: string;
+  motor: Motor;
+  criadaEm: string;
+}
+
+export async function obterStatusCurriculo() {
+  const { data } = await api.get<StatusCurriculo>('/curriculo/status');
+  return data;
+}
+
+export async function analisarCurriculo(entrada: {
+  vaga: string;
+  tituloVaga?: string;
+  pdf: string;
+}) {
+  const { data } = await api.post<Analise>('/curriculo/analises', entrada);
+  return data;
+}
+
+export async function listarAnalises() {
+  const { data } = await api.get<ResumoAnalise[]>('/curriculo/analises');
+  return data;
+}
+
+export async function obterAnalise(id: string) {
+  const { data } = await api.get<Analise>(`/curriculo/analises/${id}`);
+  return data;
+}

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -5949,6 +5949,16 @@ a.logo {
   .apoie__planos {
     grid-template-columns: 1fr;
   }
+  /* Com três ciclos a pílula não cabe na largura do celular: vira coluna. */
+  .apoie__ciclos {
+    display: flex;
+    flex-direction: column;
+    align-self: center;
+    border-radius: 16px;
+  }
+  .apoie__ciclo {
+    justify-content: center;
+  }
 }
 
 .prg-periodo--lock {

--- a/frontend/src/styles/curriculo.css
+++ b/frontend/src/styles/curriculo.css
@@ -1,0 +1,473 @@
+/* Analisador de currículo (ATS) */
+
+.cur {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  max-width: 1140px;
+  margin: 0 auto;
+  padding: 30px 26px 56px;
+  color: var(--text);
+}
+.cur__cabecalho {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+}
+.cur__titulo {
+  margin: 0 0 6px;
+  font-size: 30px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+.cur__sub {
+  margin: 0;
+  max-width: 620px;
+  color: var(--muted);
+  line-height: 1.6;
+}
+.cur__cota {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  background: var(--surface);
+  white-space: nowrap;
+}
+.cur__cota strong {
+  font-size: 26px;
+  line-height: 1;
+  color: var(--accent);
+}
+.cur__cota span {
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--muted);
+}
+
+.cur__paywall {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  padding: 22px 24px;
+}
+.cur__paywall-icone {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 42px;
+  height: 42px;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+.cur__paywall h2 {
+  margin: 0 0 4px;
+  font-size: 17px;
+}
+.cur__paywall p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.5;
+}
+.cur__paywall .btn {
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+/* ---------- formulário ---------- */
+
+.cur__form {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 24px;
+}
+.cur__campo {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.cur__rotulo {
+  font-size: 13px;
+  font-weight: 700;
+}
+.cur__dica {
+  font-size: 12px;
+  color: var(--muted);
+}
+.cur__textarea {
+  min-height: 220px;
+  resize: vertical;
+  font-family: inherit;
+  line-height: 1.6;
+}
+.cur__dropzone {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 26px;
+  border: 1.5px dashed var(--border-strong);
+  border-radius: var(--r-lg);
+  background: var(--surface-2);
+  color: var(--muted);
+  font-family: inherit;
+  cursor: pointer;
+}
+.cur__dropzone:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.cur__dropzone strong {
+  color: var(--text);
+  font-size: 14px;
+}
+.cur__dropzone span {
+  font-size: 12px;
+}
+.cur__dropzone--ok {
+  border-style: solid;
+  border-color: var(--success);
+  color: var(--success);
+}
+.cur__espera {
+  margin: -8px 0 0;
+  text-align: center;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+/* ---------- resultado ---------- */
+
+.cur__resultado {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: 20px;
+  align-items: start;
+}
+.cur__placar {
+  position: sticky;
+  top: 20px;
+  padding: 24px;
+  text-align: center;
+}
+.cur__placar h2 {
+  margin: 18px 0 8px;
+  font-size: 20px;
+}
+.cur__placar p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.6;
+}
+.cur__anel {
+  position: relative;
+  width: 180px;
+  margin: 0 auto;
+}
+.cur__anel svg {
+  display: block;
+  width: 100%;
+  transform: rotate(-90deg);
+}
+.cur__anel-trilho,
+.cur__anel-valor {
+  fill: none;
+  stroke-width: 14;
+}
+.cur__anel-trilho {
+  stroke: var(--surface-2);
+}
+.cur__anel-valor {
+  stroke-linecap: round;
+  transition: stroke-dasharray 0.6s ease;
+}
+.cur__anel-texto {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+.cur__anel-texto strong {
+  font-size: 52px;
+  line-height: 1;
+  letter-spacing: -0.03em;
+}
+.cur__anel-texto span {
+  font-size: 12px;
+  color: var(--muted);
+}
+.cur__resumo {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 18px;
+  text-align: left;
+}
+.cur__resumo-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 13px;
+}
+.cur__resumo-item span {
+  color: var(--muted);
+}
+.cur__tom--bom {
+  color: var(--success);
+}
+.cur__tom--atencao {
+  color: var(--gold);
+}
+.cur__tom--ruim {
+  color: var(--av-red);
+}
+
+.cur__colunas {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+.cur__colunas .card {
+  padding: 22px 24px;
+}
+.cur__secao {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 0 0 18px;
+  font-size: 16px;
+}
+.cur__secao-nota {
+  margin-left: auto;
+  font-size: 12px;
+  font-weight: 400;
+  color: var(--muted);
+}
+.cur__selo-ia {
+  padding: 3px 9px;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.cur__barra + .cur__barra {
+  margin-top: 14px;
+}
+.cur__barra-topo {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 6px;
+  font-size: 13px;
+}
+.cur__barra-trilho {
+  height: 8px;
+  border-radius: 999px;
+  background: var(--surface-2);
+  overflow: hidden;
+}
+.cur__barra-valor {
+  height: 100%;
+  border-radius: 999px;
+  transition: width 0.6s ease;
+}
+
+.cur__grupo + .cur__grupo {
+  margin-top: 18px;
+}
+.cur__grupo-titulo {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin-bottom: 9px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.cur__grupo-titulo span {
+  padding: 1px 7px;
+  border-radius: 999px;
+  background: var(--surface-2);
+  color: var(--muted);
+  letter-spacing: 0;
+}
+.cur__grupo-titulo--ok {
+  color: var(--success);
+}
+.cur__grupo-titulo--parcial {
+  color: var(--gold);
+}
+.cur__grupo-titulo--fora {
+  color: var(--av-red);
+}
+.cur__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+.cur__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 11px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  font-size: 13px;
+}
+.cur__chip--ok {
+  border-color: color-mix(in srgb, var(--success) 35%, transparent);
+  background: var(--success-soft);
+  color: var(--success);
+}
+.cur__chip--parcial {
+  border-color: color-mix(in srgb, var(--gold) 40%, transparent);
+  background: color-mix(in srgb, var(--gold) 12%, transparent);
+  color: var(--gold);
+}
+.cur__chip--fora {
+  border-color: color-mix(in srgb, var(--av-red) 30%, transparent);
+  background: color-mix(in srgb, var(--av-red) 10%, transparent);
+  color: var(--av-red);
+}
+
+.cur__sugestao {
+  display: flex;
+  gap: 14px;
+  padding: 16px 18px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  background: var(--surface-2);
+}
+.cur__sugestao + .cur__sugestao {
+  margin-top: 12px;
+}
+.cur__sugestao h4 {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 9px;
+  margin: 0 0 5px;
+  font-size: 15px;
+}
+.cur__sugestao p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.65;
+}
+.cur__sugestao-icone {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--r-md);
+}
+.cur__prioridade {
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.cur__sugestao--alta .cur__sugestao-icone,
+.cur__sugestao--alta .cur__prioridade {
+  background: color-mix(in srgb, var(--av-red) 14%, transparent);
+  color: var(--av-red);
+}
+.cur__sugestao--media .cur__sugestao-icone,
+.cur__sugestao--media .cur__prioridade {
+  background: color-mix(in srgb, var(--gold) 16%, transparent);
+  color: var(--gold);
+}
+.cur__sugestao--baixa .cur__sugestao-icone,
+.cur__sugestao--baixa .cur__prioridade {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+/* ---------- histórico ---------- */
+
+.cur__historico {
+  padding: 22px 24px;
+}
+.cur__historico-lista {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.cur__historico-item {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--surface-2);
+  color: inherit;
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.cur__historico-item:hover {
+  border-color: var(--accent);
+}
+.cur__historico-item > strong {
+  min-width: 36px;
+  font-size: 20px;
+}
+.cur__historico-vaga {
+  display: flex;
+  flex-direction: column;
+  font-size: 14px;
+  font-weight: 500;
+}
+.cur__historico-vaga small {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 400;
+}
+.cur__historico-veredito {
+  margin-left: auto;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+@media (max-width: 900px) {
+  .cur__cabecalho {
+    flex-direction: column;
+    gap: 14px;
+  }
+  .cur__resultado {
+    grid-template-columns: 1fr;
+  }
+  .cur__placar {
+    position: static;
+  }
+  .cur__paywall {
+    flex-wrap: wrap;
+  }
+  .cur__paywall .btn {
+    margin-left: 0;
+    width: 100%;
+  }
+  .cur__historico-veredito {
+    display: none;
+  }
+}


### PR DESCRIPTION
Dois assuntos: um ciclo novo de apoio e o analisador de currículo, que é o primeiro benefício de peso do plano.

## Plano trimestral

Terceiro ciclo entre o mensal e o anual, por R$ 14 a cada 90 dias, o que dá R$ 4,67 por mês. A escada fica coerente: quanto mais longo o compromisso, menor o valor mensal, e a taxa fixa do gateway é paga uma vez em vez de três.

A tela de apoio passa a montar os ciclos a partir de uma lista, em vez de dois botões escritos à mão. No celular a pílula vira coluna, porque três opções não cabem na largura.

## Analisador de currículo

Cola a descrição da vaga, envia o currículo em PDF e recebe nota de 0 a 100 de compatibilidade com ATS, detalhe por seção, as palavras-chave encontradas, vagas e ausentes, e até cinco sugestões do que ajustar antes de se candidatar.

**A nota nunca sai de um modelo.** Ela vem de um motor determinístico que roda sempre, sem rede: extrai as palavras-chave da vaga a partir de um dicionário curado mais as siglas das linhas de requisito, classifica cada uma contra o currículo e calcula cinco notas de seção com pesos fixos. Mesma entrada, mesma saída.

Depois dele o modelo entra para reescrever as sugestões com o contexto do currículo e revisar as palavras-chave que ficaram na fronteira. Se essa chamada falhar por qualquer motivo, a análise sai igual, só com o motor marcado como `heuristica` na resposta.

O transporte fala o protocolo da Anthropic e aponta para o DeepSeek por padrão. Tem também um modo que chama o Claude Code instalado na máquina, sem chave, para rodar local.

Travessão e emoji saem do texto por limpeza determinística depois da resposta, porque nem todo modelo respeita a instrução do prompt.

### Privacidade

Nem o PDF nem o texto extraído do currículo ficam no banco. Persiste só o resultado da análise e um título de vaga opcional, que a pessoa digita para reconhecer a análise no histórico.

### Acesso e limites

Benefício de apoiador ativo, de qualquer plano. Teto de análises por pessoa numa janela móvel de 30 dias, configurável, mais limitador de rajada na rota. PDF até 5 MB, e PDF sem texto selecionável é recusado com mensagem explicando o motivo em vez de gerar nota sobre currículo vazio.

## Rotas

| Método | Rota | Descrição |
|---|---|---|
| GET | `/curriculo/status` | Liberado, usadas, limite e se a IA está ligada |
| POST | `/curriculo/analises` | Cria a análise (vaga + PDF em base64) |
| GET | `/curriculo/analises` | Histórico |
| GET | `/curriculo/analises/:id` | Análise completa |

## Configuração em produção

O `.env` precisa de `ATS_IA_MODO=api` e `ATS_API_KEY`. O resto tem padrão no código e está documentado no `.env.example`. Sem `ATS_IA_MODO`, o motor determinístico roda sozinho e a funcionalidade continua de pé.

## Migrations

`0048` adiciona o valor `trimestral` ao enum de plano. `0049` cria a tabela `resume_analyses`.

## Testado localmente

Análise completa pela interface nos temas claro e escuro, com currículo e vaga reais. Heurística sozinha e com refinamento. Histórico, cota e gate de apoiador. Caminhos de erro: vaga curta, arquivo que não é PDF, PDF sem texto e usuário sem apoio. Paywall e menu do usuário nos dois estados. Troca de ciclo no /apoie e validação do plano na API, incluindo confirmar que nenhuma cobrança órfã é criada quando o gateway falha.

Fica de fora da conferência o layout dos três ciclos no celular, que precisa de olhada no responsivo.