### PR TITLE
fix: cartões de apoio na mesma altura e CORS restrito em dev

### DIFF
--- a/backend/app.ts
+++ b/backend/app.ts
@@ -34,12 +34,14 @@ app.use("/comunidade/imagem", express.json({ limit: "6mb" }));
 app.use("/curriculo/analises", express.json({ limit: "8mb" }));
 app.use(express.json());
 app.use(helmet({ frameguard: { action: "deny" } }));
-app.use(
-    cors({
-        origin: env.NODE_ENV === "production" ? env.FRONTEND_URL : true,
-        credentials: true,
-    }),
-);
+// Refletir a origem que chega, junto com credentials, deixaria qualquer site
+// chamar a API autenticado como quem estivesse logado.
+const ORIGENS =
+    env.NODE_ENV === "production"
+        ? [env.FRONTEND_URL]
+        : [env.FRONTEND_URL, /^http:\/\/localhost:\d+$/, /^http:\/\/127\.0\.0\.1:\d+$/];
+
+app.use(cors({ origin: ORIGENS, credentials: true }));
 
 // Imagens enviadas pelos usuarios. Libera o carregamento cross-origin para o
 // front (em dev fica em outra origem que o backend).

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -5725,12 +5725,17 @@ a.logo {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 20px;
-  align-items: start;
 }
 .apoie__plano {
   position: relative;
+  display: flex;
+  flex-direction: column;
   overflow: hidden;
   padding: 24px;
+}
+/* Absorve a sobra para os botões dos dois cartões fecharem na mesma linha. */
+.apoie__plano .apoie__lista {
+  flex: 1;
 }
 .apoie__plano--premium {
   border: 2px solid var(--accent);
@@ -5824,7 +5829,7 @@ a.logo {
 }
 .apoie__atual {
   width: 100%;
-  height: 46px;
+  height: 50px; /* igual a .btn--block */
   border: 1px solid var(--border-strong);
   border-radius: 12px;
   background: var(--surface-2);


### PR DESCRIPTION
## Cartões da tela de apoio

O cartão do grátis e o do premium ficavam de alturas diferentes, porque o premium tem o subtítulo da lista e, desde o analisador de currículo, um item a mais. A grade deixa de alinhar pelo topo, a lista de cada cartão absorve a sobra e os dois botões fecham na mesma linha.

O botão do grátis também estava 4px mais baixo que o do premium: `.apoie__atual` tinha 46px contra os 50px do `.btn--block`.

Antes e depois no mesmo estado da tela: os dois cartões agora terminam na mesma altura, com botão e rodapé alinhados.

## CORS

O CodeQL apontou `js/cors-permissive-configuration` em `backend/app.ts`. Em desenvolvimento a origem era `true`, ou seja, a API refletia qualquer origem que chegasse, e junto com `credentials: true` isso permite que qualquer site faça chamada autenticada como quem estiver logado no navegador.

Passa a valer uma lista fechada: em produção só o `FRONTEND_URL`, e em desenvolvimento o `FRONTEND_URL` mais `localhost` e `127.0.0.1` em qualquer porta.

Conferido localmente: requisição com origem `http://localhost:5173` volta com o header de liberação, e requisição de origem estranha volta sem header nenhum.