### PR TITLE
feat: indicador de carregamento na análise de currículo

### DIFF
--- a/frontend/src/pages/Curriculo/index.tsx
+++ b/frontend/src/pages/Curriculo/index.tsx
@@ -322,8 +322,16 @@ export function Curriculo() {
                 className="btn btn--accent btn--block"
                 onClick={analisar}
                 disabled={analisando || !arquivo || vagaCurta}
+                aria-busy={analisando}
               >
-                {analisando ? ETAPAS[etapa] : 'Analisar currículo'}
+                {analisando ? (
+                  <>
+                    <span className="cur__girando" aria-hidden="true" />
+                    {ETAPAS[etapa]}
+                  </>
+                ) : (
+                  'Analisar currículo'
+                )}
               </button>
               {analisando && (
                 <p className="cur__espera">

--- a/frontend/src/styles/curriculo.css
+++ b/frontend/src/styles/curriculo.css
@@ -136,6 +136,25 @@
   border-color: var(--success);
   color: var(--success);
 }
+.cur__girando {
+  flex-shrink: 0;
+  width: 15px;
+  height: 15px;
+  border: 2px solid color-mix(in srgb, var(--on-accent) 35%, transparent);
+  border-top-color: var(--on-accent);
+  border-radius: 50%;
+  animation: cur-girar 0.7s linear infinite;
+}
+@keyframes cur-girar {
+  to {
+    transform: rotate(360deg);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .cur__girando {
+    animation-duration: 2.4s;
+  }
+}
 .cur__espera {
   margin: -8px 0 0;
   text-align: center;


### PR DESCRIPTION
A análise leva perto de dois minutos e, até agora, o único sinal de que algo estava acontecendo era o texto do botão trocando de frase a cada 22 segundos. Entre uma troca e outra a tela parecia parada.

Agora aparece um círculo girando ao lado da frase da etapa, dentro do próprio botão. O botão também passa a marcar `aria-busy` enquanto a análise roda.

Com `prefers-reduced-motion`, o giro fica lento em vez de parar. Quem tem a preferência ligada continua vendo que a análise está em andamento, que é justamente a informação que o indicador existe para dar.

O spinner ficou em `curriculo.css`, porque hoje é a única tela do projeto com espera longa o bastante para precisar dele. Se aparecer um segundo caso, vale promover para componente.

Conferido rodando uma análise real: o círculo aparece junto com a primeira frase, acompanha a troca das cinco etapas e some quando o resultado carrega.