### PR TITLE
feat: pergunta de próxima trilha do roadmap ao concluir uma trilha

### DIFF
--- a/backend/src/controllers/RoadmapController.ts
+++ b/backend/src/controllers/RoadmapController.ts
@@ -3,6 +3,7 @@ import {
     concluirEstagio,
     listarRoadmaps,
     obterRoadmap,
+    proximaTrilhaAposConcluir,
     listarRoadmapsAdmin,
     obterRoadmapStudio,
     criarRoadmap,
@@ -37,6 +38,14 @@ export const getRoadmap = async (req: Request, res: Response, next: NextFunction
         const roadmap = await obterRoadmap(slug, req.userId);
         if (!roadmap) return res.status(404).json({ erro: "Roadmap não encontrado" });
         res.json(roadmap);
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const getProximaTrilha = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        res.json(await proximaTrilhaAposConcluir(req.userId!, String(req.params.trailId)));
     } catch (err) {
         next(err);
     }

--- a/backend/src/routes/roadmap.routes.ts
+++ b/backend/src/routes/roadmap.routes.ts
@@ -14,12 +14,14 @@ import {
     createStageRef,
     deleteStageRef,
     completeStage,
+    getProximaTrilha,
 } from "../controllers/RoadmapController.ts";
 
 const router = Router();
 
 // Leitura (qualquer logado)
 router.get("/roadmaps", autenticar, listRoadmaps);
+router.get("/roadmaps/proxima-trilha/:trailId", autenticar, getProximaTrilha);
 
 // Gestão pelo estúdio (admin). Vem antes de "/roadmaps/:slug" e usa o prefixo
 // "/studio" para não colidir com a rota de detalhe do aluno.

--- a/backend/src/services/roadmap.service.ts
+++ b/backend/src/services/roadmap.service.ts
@@ -43,7 +43,10 @@ const SEM_CONCLUSAO: Conclusao = {
 // com status "passed" (não xpEarned, que é específico do desafio do dia).
 async function carregarConclusao(userId: string): Promise<Conclusao> {
     const [aulas, sims, des] = await Promise.all([
-        db.select({ id: lessonProgress.lessonId }).from(lessonProgress).where(eq(lessonProgress.userId, userId)),
+        db
+            .select({ id: lessonProgress.lessonId })
+            .from(lessonProgress)
+            .where(eq(lessonProgress.userId, userId)),
         db
             .select({ id: simuladoAttempts.simuladoId })
             .from(simuladoAttempts)
@@ -51,7 +54,12 @@ async function carregarConclusao(userId: string): Promise<Conclusao> {
         db
             .select({ id: challengeSubmissions.challengeId })
             .from(challengeSubmissions)
-            .where(and(eq(challengeSubmissions.userId, userId), eq(challengeSubmissions.status, "passed"))),
+            .where(
+                and(
+                    eq(challengeSubmissions.userId, userId),
+                    eq(challengeSubmissions.status, "passed"),
+                ),
+            ),
     ]);
     return {
         lessons: new Set(aulas.map((r) => r.id)),
@@ -130,10 +138,15 @@ function statusPorProgresso(feitos: number, total: number): StatusRoadmap {
 
 // Resolve cada ref para dados de exibição (título + o que o front precisa pra rotear).
 async function resolverRefs(refs: { refType: RefType; refId: string }[]) {
-    const idsDe = (t: RefType) => [...new Set(refs.filter((r) => r.refType === t).map((r) => r.refId))];
+    const idsDe = (t: RefType) => [
+        ...new Set(refs.filter((r) => r.refType === t).map((r) => r.refId)),
+    ];
     const [tr, md, ls, sm, ch] = await Promise.all([
         idsDe("trail").length
-            ? db.select({ id: trails.id, name: trails.name }).from(trails).where(inArray(trails.id, idsDe("trail")))
+            ? db
+                  .select({ id: trails.id, name: trails.name })
+                  .from(trails)
+                  .where(inArray(trails.id, idsDe("trail")))
             : Promise.resolve([] as { id: string; name: string }[]),
         idsDe("module").length
             ? db
@@ -163,12 +176,12 @@ async function resolverRefs(refs: { refType: RefType; refId: string }[]) {
     const info = new Map<string, Record<string, unknown>>();
     for (const r of tr) info.set("trail:" + r.id, { title: r.name, trailId: r.id });
     for (const r of md) info.set("module:" + r.id, { title: r.title, trailId: r.trailId });
-    for (const r of ls) info.set("lesson:" + r.id, { title: r.title, trailId: r.trailId, lessonId: r.id });
+    for (const r of ls)
+        info.set("lesson:" + r.id, { title: r.title, trailId: r.trailId, lessonId: r.id });
     for (const r of sm) info.set("simulado:" + r.id, { title: r.name, slug: r.slug });
     for (const r of ch) info.set("challenge:" + r.id, { title: r.title, number: r.number });
     return info;
 }
-
 
 async function estagiosConcluidosManualmente(userId: string) {
     const rows = await db
@@ -194,12 +207,18 @@ export async function listarRoadmaps(userId?: string) {
         .orderBy(asc(roadmapStages.position));
     const etapaIds = etapas.map((e) => e.id);
     const refs = etapaIds.length
-        ? await db.select().from(roadmapStageRefs).where(inArray(roadmapStageRefs.stageId, etapaIds))
+        ? await db
+              .select()
+              .from(roadmapStageRefs)
+              .where(inArray(roadmapStageRefs.stageId, etapaIds))
         : [];
 
     let conclusao = SEM_CONCLUSAO;
     let manuais = new Set<string>();
-    let aulas = { porTrail: new Map<string, AulaContainer[]>(), porModule: new Map<string, AulaContainer[]>() };
+    let aulas = {
+        porTrail: new Map<string, AulaContainer[]>(),
+        porModule: new Map<string, AulaContainer[]>(),
+    };
     if (userId) {
         conclusao = await carregarConclusao(userId);
         manuais = await estagiosConcluidosManualmente(userId);
@@ -218,7 +237,10 @@ export async function listarRoadmaps(userId?: string) {
     const etapaConcluida = (stageId: string) => {
         if (manuais.has(stageId)) return true;
         const rs = refsPorEtapa.get(stageId) ?? [];
-        return rs.length > 0 && rs.every((r) => refConcluido(r.refType as RefType, r.refId, conclusao, aulas));
+        return (
+            rs.length > 0 &&
+            rs.every((r) => refConcluido(r.refType as RefType, r.refId, conclusao, aulas))
+        );
     };
 
     return lista.map((r) => {
@@ -266,7 +288,10 @@ export async function obterRoadmap(slug: string, userId?: string) {
 
     let conclusao = SEM_CONCLUSAO;
     let manuais = new Set<string>();
-    let aulas = { porTrail: new Map<string, AulaContainer[]>(), porModule: new Map<string, AulaContainer[]>() };
+    let aulas = {
+        porTrail: new Map<string, AulaContainer[]>(),
+        porModule: new Map<string, AulaContainer[]>(),
+    };
     if (userId) {
         conclusao = await carregarConclusao(userId);
         manuais = await estagiosConcluidosManualmente(userId);
@@ -275,7 +300,9 @@ export async function obterRoadmap(slug: string, userId?: string) {
             refs.filter((r) => r.refType === "module").map((r) => r.refId),
         );
     }
-    const infoRef = await resolverRefs(refs.map((r) => ({ refType: r.refType as RefType, refId: r.refId })));
+    const infoRef = await resolverRefs(
+        refs.map((r) => ({ refType: r.refType as RefType, refId: r.refId })),
+    );
 
     const refsPorEtapa = new Map<string, typeof refs>();
     for (const r of refs) {
@@ -288,7 +315,9 @@ export async function obterRoadmap(slug: string, userId?: string) {
         const rs = refsPorEtapa.get(e.id) ?? [];
         const completed =
             (userId && manuais.has(e.id)) ||
-            (userId && rs.length > 0 && rs.every((r) => refConcluido(r.refType as RefType, r.refId, conclusao, aulas)));
+            (userId &&
+                rs.length > 0 &&
+                rs.every((r) => refConcluido(r.refType as RefType, r.refId, conclusao, aulas)));
         return {
             id: e.id,
             phase: e.phase,
@@ -336,6 +365,69 @@ export async function obterRoadmap(slug: string, userId?: string) {
     };
 }
 
+// Depois de concluir uma trilha: em qual roadmap ela vive e qual é a próxima
+// trilha dele. Com a trilha em mais de um roadmap, vale o de maior progresso do
+// usuário (desempate pela posição do roadmap). Só oferece etapa destravada; no
+// fim do roadmap (ou sem etapa elegível), proximaTrilha volta nula.
+export async function proximaTrilhaAposConcluir(userId: string, trailId: string) {
+    const candidatos = await db
+        .selectDistinct({ slug: roadmaps.slug, position: roadmaps.position })
+        .from(roadmapStageRefs)
+        .innerJoin(roadmapStages, eq(roadmapStages.id, roadmapStageRefs.stageId))
+        .innerJoin(roadmaps, eq(roadmaps.id, roadmapStages.roadmapId))
+        .where(
+            and(
+                eq(roadmapStageRefs.refType, "trail"),
+                eq(roadmapStageRefs.refId, trailId),
+                eq(roadmaps.published, true),
+            ),
+        );
+    if (!candidatos.length) return { roadmap: null, proximaTrilha: null };
+
+    const detalhes: NonNullable<Awaited<ReturnType<typeof obterRoadmap>>>[] = [];
+    for (const c of [...candidatos].sort((a, b) => a.position - b.position)) {
+        const d = await obterRoadmap(c.slug, userId);
+        if (d) detalhes.push(d);
+    }
+    if (!detalhes.length) return { roadmap: null, proximaTrilha: null };
+
+    // A próxima etapa elegível de cada roadmap: depois da etapa desta trilha,
+    // destravada, não concluída e com uma trilha para apontar.
+    const refDaProxima = (d: (typeof detalhes)[number]) => {
+        const idx = d.stages.findIndex((s) =>
+            s.refs.some((r) => r.refType === "trail" && r.refId === trailId),
+        );
+        if (idx < 0) return null;
+        const etapa = d.stages
+            .slice(idx + 1)
+            .find((s) => !s.completed && !s.locked && s.refs.some((r) => r.refType === "trail"));
+        return etapa?.refs.find((r) => r.refType === "trail") ?? null;
+    };
+
+    // Prefere um roadmap que tenha o que oferecer; entre eles (e no fallback
+    // sem oferta), o de maior progresso do usuário, já ordenados por posição.
+    const comProxima = detalhes
+        .map((d) => ({ d, ref: refDaProxima(d) }))
+        .filter((x) => x.ref !== null);
+    const escolhaEntre = comProxima.length ? comProxima : detalhes.map((d) => ({ d, ref: null }));
+    const { d: escolhido, ref: refTrilha } = escolhaEntre.reduce((melhor, x) =>
+        x.d.progress.stagesDone > melhor.d.progress.stagesDone ? x : melhor,
+    );
+
+    let proximaTrilha = null;
+    if (refTrilha) {
+        const [t] = await db
+            .select({ id: trails.id, name: trails.name, level: trails.trailLevel })
+            .from(trails)
+            .where(eq(trails.id, refTrilha.refId));
+        proximaTrilha = t ?? null;
+    }
+    return {
+        roadmap: { slug: escolhido.slug, name: escolhido.name },
+        proximaTrilha,
+    };
+}
+
 // ============================ CRUD (admin) ============================
 
 type DadosCriarRoadmap = z.infer<typeof createRoadmapSchema>;
@@ -361,10 +453,7 @@ export async function concluirEstagio(stageId: string, userId: string) {
         .from(roadmapStages)
         .where(eq(roadmapStages.id, stageId));
     if (!etapa) throw new AppError(404, "Estágio não encontrado");
-    await db
-        .insert(roadmapStageCompletions)
-        .values({ stageId, userId })
-        .onConflictDoNothing();
+    await db.insert(roadmapStageCompletions).values({ stageId, userId }).onConflictDoNothing();
 
     // As trilhas e módulos do estágio também ficam concluídos: progresso manual, sem XP.
     const refs = await db
@@ -424,7 +513,9 @@ export async function obterRoadmapStudio(id: string) {
               .where(inArray(roadmapStageRefs.stageId, etapaIds))
               .orderBy(asc(roadmapStageRefs.position))
         : [];
-    const info = await resolverRefs(refs.map((r) => ({ refType: r.refType as RefType, refId: r.refId })));
+    const info = await resolverRefs(
+        refs.map((r) => ({ refType: r.refType as RefType, refId: r.refId })),
+    );
 
     const refsPorEtapa = new Map<string, typeof refs>();
     for (const r of refs) {
@@ -456,12 +547,19 @@ export async function obterRoadmapStudio(id: string) {
 export async function criarRoadmap(dados: DadosCriarRoadmap) {
     const slug = (dados.slug?.trim() || gerarSlug(dados.name)).slice(0, 80);
     if (!slug) throw new AppError(400, "Não foi possível gerar um slug a partir do nome");
-    const [existe] = await db.select({ id: roadmaps.id }).from(roadmaps).where(eq(roadmaps.slug, slug));
+    const [existe] = await db
+        .select({ id: roadmaps.id })
+        .from(roadmaps)
+        .where(eq(roadmaps.slug, slug));
     if (existe) throw new AppError(409, "Já existe um roadmap com esse slug");
 
     let position = dados.position;
     if (position === undefined) {
-        const [ult] = await db.select({ p: roadmaps.position }).from(roadmaps).orderBy(desc(roadmaps.position)).limit(1);
+        const [ult] = await db
+            .select({ p: roadmaps.position })
+            .from(roadmaps)
+            .orderBy(desc(roadmaps.position))
+            .limit(1);
         position = ult ? ult.p + 1 : 1;
     }
     const [rm] = await db
@@ -487,7 +585,10 @@ export async function atualizarRoadmap(id: string, dados: DadosAtualizarRoadmap)
     const sets: Partial<typeof roadmaps.$inferInsert> = {};
     if (dados.slug !== undefined) {
         const s = dados.slug.trim();
-        const [outro] = await db.select({ id: roadmaps.id }).from(roadmaps).where(eq(roadmaps.slug, s));
+        const [outro] = await db
+            .select({ id: roadmaps.id })
+            .from(roadmaps)
+            .where(eq(roadmaps.slug, s));
         if (outro && outro.id !== id) throw new AppError(409, "Já existe um roadmap com esse slug");
         sets.slug = s;
     }
@@ -522,7 +623,10 @@ export async function excluirRoadmap(id: string) {
 }
 
 export async function criarEstagio(roadmapId: string, dados: DadosCriarEstagio) {
-    const [rm] = await db.select({ id: roadmaps.id }).from(roadmaps).where(eq(roadmaps.id, roadmapId));
+    const [rm] = await db
+        .select({ id: roadmaps.id })
+        .from(roadmaps)
+        .where(eq(roadmaps.id, roadmapId));
     if (!rm) throw new AppError(404, "Roadmap não encontrado");
 
     let position = dados.position;
@@ -550,7 +654,10 @@ export async function criarEstagio(roadmapId: string, dados: DadosCriarEstagio) 
 }
 
 export async function atualizarEstagio(id: string, dados: DadosAtualizarEstagio) {
-    const [st] = await db.select({ id: roadmapStages.id }).from(roadmapStages).where(eq(roadmapStages.id, id));
+    const [st] = await db
+        .select({ id: roadmapStages.id })
+        .from(roadmapStages)
+        .where(eq(roadmapStages.id, id));
     if (!st) throw new AppError(404, "Estágio não encontrado");
 
     const sets: Partial<typeof roadmapStages.$inferInsert> = {};
@@ -561,12 +668,19 @@ export async function atualizarEstagio(id: string, dados: DadosAtualizarEstagio)
     if (dados.position !== undefined) sets.position = dados.position;
     if (Object.keys(sets).length === 0) throw new AppError(400, "Nada para atualizar");
 
-    const [atualizado] = await db.update(roadmapStages).set(sets).where(eq(roadmapStages.id, id)).returning();
+    const [atualizado] = await db
+        .update(roadmapStages)
+        .set(sets)
+        .where(eq(roadmapStages.id, id))
+        .returning();
     return atualizado;
 }
 
 export async function excluirEstagio(id: string) {
-    const [st] = await db.select({ id: roadmapStages.id }).from(roadmapStages).where(eq(roadmapStages.id, id));
+    const [st] = await db
+        .select({ id: roadmapStages.id })
+        .from(roadmapStages)
+        .where(eq(roadmapStages.id, id));
     if (!st) throw new AppError(404, "Estágio não encontrado");
     await db.transaction(async (tx) => {
         await tx.delete(roadmapStageRefs).where(eq(roadmapStageRefs.stageId, id));
@@ -575,7 +689,10 @@ export async function excluirEstagio(id: string) {
 }
 
 export async function adicionarRef(stageId: string, dados: DadosCriarRef) {
-    const [st] = await db.select({ id: roadmapStages.id }).from(roadmapStages).where(eq(roadmapStages.id, stageId));
+    const [st] = await db
+        .select({ id: roadmapStages.id })
+        .from(roadmapStages)
+        .where(eq(roadmapStages.id, stageId));
     if (!st) throw new AppError(404, "Estágio não encontrado");
 
     // Valida que o conteúdo referenciado existe, para nunca criar um ref pendurado.
@@ -602,7 +719,10 @@ export async function adicionarRef(stageId: string, dados: DadosCriarRef) {
 }
 
 export async function removerRef(id: string) {
-    const [ref] = await db.select({ id: roadmapStageRefs.id }).from(roadmapStageRefs).where(eq(roadmapStageRefs.id, id));
+    const [ref] = await db
+        .select({ id: roadmapStageRefs.id })
+        .from(roadmapStageRefs)
+        .where(eq(roadmapStageRefs.id, id));
     if (!ref) throw new AppError(404, "Referência não encontrada");
     await db.delete(roadmapStageRefs).where(eq(roadmapStageRefs.id, id));
 }

--- a/backend/tests/roadmap.test.ts
+++ b/backend/tests/roadmap.test.ts
@@ -114,7 +114,21 @@ async function montarRoadmap(adminToken: string) {
         });
         stageIds.push(st.body.id as string);
     }
-    return { slug: rm.body.slug as string, stageIds, lessonIds };
+    return {
+        slug: rm.body.slug as string,
+        stageIds,
+        lessonIds,
+        trailIds: [trilha.body.id as string, trilha2.body.id as string],
+    };
+}
+
+async function concluirAulaPeloQuiz(lessonId: string, token: string) {
+    const aula = await get(`/lessons/${lessonId}`, token);
+    const answers = aula.body.questions.map((q: any) => ({
+        questionId: q.id,
+        optionId: q.options.find((o: any) => o.text === "certa").id,
+    }));
+    await post(`/lessons/${lessonId}/quiz`, token, { answers });
 }
 
 before(async () => {
@@ -186,5 +200,49 @@ describe("Roadmap: conclusão manual de estágio", () => {
             aluno.token,
         );
         assert.equal(r.status, 404);
+    });
+});
+
+describe("Roadmap: próxima trilha após concluir", () => {
+    test("aponta a próxima trilha do roadmap; no fim, devolve nula", async () => {
+        const admin = await criarUsuarioLogado(true);
+        const { lessonIds, trailIds } = await montarRoadmap(admin.token);
+        const aluno = await criarUsuarioLogado();
+
+        // Antes de concluir a primeira trilha, a etapa seguinte está travada:
+        // nada a oferecer.
+        const travado = await get(`/roadmaps/proxima-trilha/${trailIds[0]}`, aluno.token);
+        assert.equal(travado.status, 200);
+        assert.equal(travado.body.roadmap.name, "Backend");
+        assert.equal(travado.body.proximaTrilha, null);
+
+        for (const lessonId of lessonIds) {
+            await concluirAulaPeloQuiz(lessonId, aluno.token);
+        }
+
+        const r = await get(`/roadmaps/proxima-trilha/${trailIds[0]}`, aluno.token);
+        assert.equal(r.status, 200);
+        assert.equal(r.body.roadmap.name, "Backend");
+        assert.equal(r.body.proximaTrilha.name, "Logica 2");
+        assert.equal(r.body.proximaTrilha.id, trailIds[1]);
+
+        // A última trilha do roadmap não tem próxima.
+        const fim = await get(`/roadmaps/proxima-trilha/${trailIds[1]}`, aluno.token);
+        assert.equal(fim.body.roadmap.name, "Backend");
+        assert.equal(fim.body.proximaTrilha, null);
+    });
+
+    test("trilha fora de qualquer roadmap devolve roadmap nulo", async () => {
+        const admin = await criarUsuarioLogado(true);
+        const avulsa = await post("/trails", admin.token, {
+            name: "Avulsa",
+            level: "iniciante",
+            description: "Trilha sem roadmap nenhum.",
+        });
+        const aluno = await criarUsuarioLogado();
+        const r = await get(`/roadmaps/proxima-trilha/${avulsa.body.id}`, aluno.token);
+        assert.equal(r.status, 200);
+        assert.equal(r.body.roadmap, null);
+        assert.equal(r.body.proximaTrilha, null);
     });
 });

--- a/frontend/src/pages/Aula/index.tsx
+++ b/frontend/src/pages/Aula/index.tsx
@@ -23,6 +23,7 @@ import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 import { BlocosConteudo, md, TextoMath } from '../../components/BlocosConteudo';
 import { getTrailLang } from '../../utils/trailLang';
+import { proximaTrilhaRoadmap, type ProximaTrilhaRoadmap } from '../../services/roadmaps';
 
 import { NAV_PRINCIPAL as NAV } from '../../data/nav';
 
@@ -36,6 +37,29 @@ export function Aula() {
   const [aula, setAula] = useState<LessonDetail | null>(null);
   const [carregando, setCarregando] = useState(true);
   const [erro, setErro] = useState('');
+  const [proximaRoadmap, setProximaRoadmap] = useState<ProximaTrilhaRoadmap | null>(null);
+  const [perguntaTrilha, setPerguntaTrilha] = useState(false);
+  const [buscandoProxima, setBuscandoProxima] = useState(false);
+
+  // Ao concluir a trilha, pergunta se a pessoa quer emendar a próxima do
+  // roadmap; trilha fora de roadmap (ou roadmap no fim) segue para a lista.
+  async function aoConcluirTrilha() {
+    if (buscandoProxima) return;
+    setBuscandoProxima(true);
+    try {
+      const r = proximaRoadmap ?? (await proximaTrilhaRoadmap(trailId!));
+      setProximaRoadmap(r);
+      if (r.roadmap && r.proximaTrilha) {
+        setPerguntaTrilha(true);
+        return;
+      }
+    } catch (err) {
+      console.error('Falha ao buscar a próxima trilha do roadmap.', err);
+    } finally {
+      setBuscandoProxima(false);
+    }
+    navigate('/trilhas');
+  }
 
   useEffect(() => {
     let ativo = true;
@@ -105,13 +129,61 @@ export function Aula() {
         {!carregando && !erro && trilha && aula && (
           <div className="lesson">
             <SidebarTrilha trilha={trilha} aulaAtualId={aula.id} />
-            <ConteudoAula trilha={trilha} aula={aula} onConcluir={() => navigate('/trilhas')} />
+            <ConteudoAula trilha={trilha} aula={aula} onConcluir={aoConcluirTrilha} />
+          </div>
+        )}
+
+        {perguntaTrilha && proximaRoadmap?.roadmap && proximaRoadmap.proximaTrilha && (
+          <div className="solve-next-scrim" onClick={() => setPerguntaTrilha(false)}>
+            <div
+              className="solve-next"
+              role="dialog"
+              aria-label="Próxima trilha do roadmap"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <span className="solve-next__check">
+                <Check size={22} />
+              </span>
+              <h3 className="solve-next__titulo">Trilha concluída!</h3>
+              <p className="solve-next__sub">
+                Quer seguir para a próxima trilha do roadmap {proximaRoadmap.roadmap.name}?
+              </p>
+              <div className="solve-next__alvo">
+                <span className="solve-next__nome">{proximaRoadmap.proximaTrilha.name}</span>
+                <span className="solve-next__nivel">
+                  {NIVEL_LABEL[proximaRoadmap.proximaTrilha.level]}
+                </span>
+              </div>
+              <div className="solve-next__acoes">
+                <button
+                  className="solve-next__ficar"
+                  onClick={() => {
+                    setPerguntaTrilha(false);
+                    navigate('/trilhas');
+                  }}
+                >
+                  Agora não
+                </button>
+                <button
+                  className="solve-next__ir"
+                  onClick={() => navigate(`/trilhas/${proximaRoadmap.proximaTrilha!.id}`)}
+                >
+                  Ir para a próxima
+                </button>
+              </div>
+            </div>
           </div>
         )}
       </div>
     </div>
   );
 }
+
+const NIVEL_LABEL: Record<string, string> = {
+  iniciante: 'Iniciante',
+  intermediario: 'Intermediário',
+  avancado: 'Avançado',
+};
 
 function SidebarTrilha({ trilha, aulaAtualId }: { trilha: TrailDetail; aulaAtualId: string }) {
   const [aberto, setAberto] = useState(false);

--- a/frontend/src/services/roadmaps.ts
+++ b/frontend/src/services/roadmaps.ts
@@ -64,6 +64,16 @@ export async function obterRoadmap(slug: string) {
   return data;
 }
 
+export interface ProximaTrilhaRoadmap {
+  roadmap: { slug: string; name: string } | null;
+  proximaTrilha: { id: string; name: string; level: Nivel } | null;
+}
+
+export async function proximaTrilhaRoadmap(trailId: string) {
+  const { data } = await api.get<ProximaTrilhaRoadmap>(`/roadmaps/proxima-trilha/${trailId}`);
+  return data;
+}
+
 // ===================== ADMIN (estúdio) =====================
 
 export async function concluirEstagio(stageId: string) {

--- a/frontend/src/styles/desafio.css
+++ b/frontend/src/styles/desafio.css
@@ -1280,3 +1280,12 @@
 .solve-next__ir:hover {
   filter: brightness(1.05);
 }
+.solve-next__nivel {
+  flex: none;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--accent);
+  background: var(--accent-soft);
+  padding: 2px 9px;
+  border-radius: 999px;
+}


### PR DESCRIPTION
## O que muda

Continuação natural da pergunta de próximo desafio: o botão **Concluir trilha**, na última aula, agora pergunta se a pessoa quer seguir para a próxima trilha do roadmap, mostrando o nome do roadmap, a trilha seguinte e o nível. "Ir para a próxima" navega direto; "Agora não" segue para a lista de trilhas, como antes.

(Este commit tinha sido empurrado na branch do #315 depois do merge; entra aqui por cherry-pick, sem mudança nenhuma em relação ao que foi testado.)

## Como funciona

- Rota nova `GET /roadmaps/proxima-trilha/:trailId`: descobre em quais roadmaps publicados a trilha vive e devolve a próxima etapa elegível (depois da etapa da trilha, destravada, não concluída e com trilha para apontar), reusando a lógica de conclusão e cadeado que o roadmap já tinha.
- Trilha em mais de um roadmap: prefere um roadmap que tenha o que oferecer e, entre eles, o de maior progresso do usuário (desempate pela posição do roadmap). Isso resolve em tempo real o que a regra do catálogo protege no conteúdo (trilha não crava a próxima, porque pode viver em vários roadmaps).
- Sem oferta (trilha fora de roadmap, fim do caminho, etapa seguinte travada): sem pergunta, comportamento antigo.
- Sem migração; frontend reusa o visual do diálogo dos desafios.

## Validação

- Integração: 112 testes, com 2 novos (a rota aponta a próxima após concluir de verdade pelo quiz, devolve nula antes do destravamento e no fim do roadmap; trilha avulsa devolve roadmap nulo).
- Navegador em dev: concluída a última aula de Protocolos da Web (5 de 5 no quiz), o diálogo ofereceu Fundamentos de LLMs do roadmap Engenharia de IA e a navegação abriu a trilha nova. Fluxo repetido para confirmar.
- prettier e tsc limpos nos dois lados.