### PR TITLE
feat: painel de usuários do Estúdio com análises e busca paginada

### DIFF
--- a/backend/src/controllers/AdminController.ts
+++ b/backend/src/controllers/AdminController.ts
@@ -12,7 +12,12 @@ export const getVisaoGeral = async (_req: Request, res: Response, next: NextFunc
 export const getUsuariosCrm = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const q = typeof req.query.q === "string" ? req.query.q : undefined;
-        res.json(await usuariosCrm(q));
+        const pagina = Math.max(1, Number(req.query.pagina) || 1);
+        const porPagina = Math.min(100, Math.max(5, Number(req.query.porPagina) || 20));
+        const ordenarPor =
+            typeof req.query.ordenarPor === "string" ? req.query.ordenarPor : undefined;
+        const direcao = req.query.direcao === "asc" ? "asc" : "desc";
+        res.json(await usuariosCrm(q, pagina, porPagina, ordenarPor, direcao));
     } catch (err) {
         next(err);
     }

--- a/backend/src/services/admin.service.ts
+++ b/backend/src/services/admin.service.ts
@@ -1,6 +1,6 @@
 import { db } from "../../db.ts";
-import { sql } from "drizzle-orm";
-import { calcularXp } from "../domain/xp.ts";
+import { sql, type SQL } from "drizzle-orm";
+import { calcularXp, XP_POR_AULA, XP_POR_QUESTAO } from "../domain/xp.ts";
 
 // Linha de atividade unificada (aula, simulado, desafio, conquista). Serve para
 // derivar "última atividade" e "usuários ativos" sem uma coluna de last-seen.
@@ -53,6 +53,40 @@ export async function visaoGeral() {
         `)
     ).rows as { dia: string; n: number }[];
 
+    // Alunos distintos com aula concluída em cada trilha (o gráfico decide o corte).
+    const porTrilha = (
+        await db.execute(sql`
+            select t.name nome, count(distinct lp.user_id)::int n
+            from lessons_progress lp
+            join lessons l on l.id = lp.lesson_id
+            join trails t on t.id = l.trail_id
+            group by t.name
+            order by n desc, t.name
+        `)
+    ).rows as { nome: string; n: number }[];
+
+    // Funil de onboarding por coorte de ano de cadastro: onde cada safra de
+    // usuários para no caminho registro -> prática. O "todos" é somado no cliente.
+    const funilPorAno = (
+        await db.execute(sql`
+            select
+                to_char(u.created_at, 'YYYY') ano,
+                count(*)::int registrados,
+                count(*) filter (where username is not null and username <> '')::int com_username,
+                count(*) filter (where exists (
+                    select 1 from lessons_progress lp where lp.user_id = u.id
+                ))::int concluiu_aula,
+                count(*) filter (where exists (
+                    select 1 from challenge_submissions cs where cs.user_id = u.id and cs.xp_earned > 0
+                ) or exists (
+                    select 1 from simulado_attempts sa where sa.user_id = u.id
+                ))::int praticou
+            from users u
+            group by ano
+            order by ano
+        `)
+    ).rows as Record<string, any>[];
+
     return {
         usuarios: usuarios.total,
         perfilCompleto: usuarios.perfil_completo,
@@ -67,20 +101,58 @@ export async function visaoGeral() {
         trilhas: conteudo.trilhas,
         aulasTotal: conteudo.aulas_total,
         cadastrosPorDia: cadastros,
+        usuariosPorTrilha: porTrilha,
+        funilPorAno: funilPorAno.map((f) => ({
+            ano: f.ano as string,
+            registrados: f.registrados as number,
+            comUsername: f.com_username as number,
+            concluiuAula: f.concluiu_aula as number,
+            praticou: f.praticou as number,
+        })),
     };
 }
 
 // Métricas por usuário para o CRM, agregadas em uma query só (sem N+1).
 // A busca por nome/username/email é feita no servidor.
-export async function usuariosCrm(busca?: string) {
+// Colunas ordenáveis do CRM (whitelist: o nome vem da query string). O XP é
+// derivado, então a ordenação reproduz a fórmula do domínio em SQL.
+const ORDENACOES: Record<string, SQL> = {
+    name: sql`u.name`,
+    criadoEm: sql`u.created_at`,
+    aulas: sql`coalesce(ap.n, 0)`,
+    trilhas: sql`coalesce(ta.n, 0)`,
+    simulados: sql`coalesce(sa.n, 0)`,
+    desafios: sql`coalesce(ds.n, 0)`,
+    conquistas: sql`coalesce(cq.n, 0)`,
+    xp: sql`(coalesce(ap.n, 0) * ${XP_POR_AULA} + coalesce(ac.n, 0) * ${XP_POR_QUESTAO} + coalesce(ds.xp, 0))`,
+    ultimaAtividade: sql`la.ultima`,
+};
+
+export async function usuariosCrm(
+    busca?: string,
+    pagina = 1,
+    porPagina = 20,
+    ordenarPor = "criadoEm",
+    direcao: "asc" | "desc" = "desc",
+) {
     const termo = busca?.trim();
     const filtro = termo
         ? sql`where u.name ilike ${`%${termo}%`} or u.username ilike ${`%${termo}%`} or u.email ilike ${`%${termo}%`}`
         : sql``;
+
+    const [{ total }] = (
+        await db.execute(sql`select count(*)::int total from users u ${filtro}`)
+    ).rows as { total: number }[];
+
+    const ordem = ORDENACOES[ordenarPor] ?? ORDENACOES.criadoEm;
+    const sentido = direcao === "asc" ? sql`asc nulls first` : sql`desc nulls last`;
+    const offset = (Math.max(1, pagina) - 1) * porPagina;
+
     const { rows } = await db.execute(sql`
         select
             u.id, u.name, u.username, u.email, u.created_at,
             (u.password_hash is null) as social,
+            oa.provider,
             coalesce(ap.n, 0)::int aulas,
             coalesce(ac.n, 0)::int questoes,
             coalesce(ds.n, 0)::int desafios,
@@ -113,16 +185,21 @@ export async function usuariosCrm(busca?: string) {
         left join (
             select user_id, max(ts) ultima from (${ATIVIDADE}) z group by user_id
         ) la on la.user_id = u.id
+        left join (
+            select user_id, min(provider) provider from oauth_accounts group by user_id
+        ) oa on oa.user_id = u.id
         ${filtro}
-        order by u.created_at desc
+        order by ${ordem} ${sentido}, u.created_at desc
+        limit ${porPagina} offset ${offset}
     `);
 
-    return (rows as Record<string, any>[]).map((r) => ({
+    const usuarios = (rows as Record<string, any>[]).map((r) => ({
         id: r.id as string,
         name: r.name as string,
         username: (r.username as string | null) ?? null,
         email: r.email as string,
         origem: r.social ? "social" : "email",
+        provider: (r.provider as string | null) ?? null,
         criadoEm: r.created_at as string,
         ultimaAtividade: (r.ultima_atividade as string | null) ?? null,
         aulas: r.aulas as number,
@@ -133,4 +210,6 @@ export async function usuariosCrm(busca?: string) {
         questoesCertas: r.questoes as number,
         xp: calcularXp({ aulas: r.aulas, questoes: r.questoes, desafiosXp: r.desafios_xp }),
     }));
+
+    return { rows: usuarios, total };
 }

--- a/frontend/src/pages/Usuarios/FunilOnboarding.tsx
+++ b/frontend/src/pages/Usuarios/FunilOnboarding.tsx
@@ -1,0 +1,147 @@
+import { useState } from 'react';
+import type { VisaoGeral } from '../../services/admin';
+
+type Coorte = VisaoGeral['funilPorAno'][number];
+type Modo = 'barras' | 'funil';
+
+// Funil do registro à prática, com dois estilos (barras alinhadas ou funil
+// centrado estilo Power BI) e filtro por coorte de ano de cadastro.
+export function FunilOnboarding({ porAno }: { porAno: VisaoGeral['funilPorAno'] }) {
+  const [anoSel, setAnoSel] = useState<string>('todos');
+  const [modo, setModo] = useState<Modo>('barras');
+  const [hover, setHover] = useState<number | null>(null);
+
+  const coorte: Omit<Coorte, 'ano'> =
+    anoSel === 'todos'
+      ? porAno.reduce(
+          (acc, f) => ({
+            registrados: acc.registrados + f.registrados,
+            comUsername: acc.comUsername + f.comUsername,
+            concluiuAula: acc.concluiuAula + f.concluiuAula,
+            praticou: acc.praticou + f.praticou,
+          }),
+          { registrados: 0, comUsername: 0, concluiuAula: 0, praticou: 0 },
+        )
+      : (porAno.find((f) => f.ano === anoSel) ?? {
+          registrados: 0,
+          comUsername: 0,
+          concluiuAula: 0,
+          praticou: 0,
+        });
+
+  const etapas = [
+    { label: 'Registrados', n: coorte.registrados },
+    { label: 'Completaram o perfil', n: coorte.comUsername },
+    { label: 'Concluíram uma aula', n: coorte.concluiuAula },
+    { label: 'Praticaram', n: coorte.praticou },
+  ];
+  const max = etapas[0].n || 1;
+  const ativo = hover != null ? etapas[hover] : null;
+  const conversaoDe = (i: number) =>
+    i > 0 && etapas[i - 1].n > 0 ? Math.round((etapas[i].n / etapas[i - 1].n) * 100) : null;
+
+  return (
+    <div className="painel-graf">
+      <div className="painel-graf__head">
+        <div className="painel-graf__titulo">Funil de onboarding</div>
+        <div className="painel-graf__controles">
+          <div className="painel-graf__periodos">
+            {(['barras', 'funil'] as Modo[]).map((m) => (
+              <button
+                key={m}
+                className={`painel-graf__periodo${modo === m ? ' is-ativo' : ''}`}
+                onClick={() => setModo(m)}
+              >
+                {m === 'barras' ? 'Barras' : 'Funil'}
+              </button>
+            ))}
+          </div>
+          <div className="painel-graf__periodos">
+            <button
+              className={`painel-graf__periodo${anoSel === 'todos' ? ' is-ativo' : ''}`}
+              onClick={() => setAnoSel('todos')}
+            >
+              Tudo
+            </button>
+            {porAno.map((f) => (
+              <button
+                key={f.ano}
+                className={`painel-graf__periodo${anoSel === f.ano ? ' is-ativo' : ''}`}
+                onClick={() => setAnoSel(f.ano)}
+              >
+                {f.ano}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+      <div className="painel-graf__leitura">
+        {ativo ? (
+          <>
+            <b>{ativo.n}</b> na etapa {ativo.label.toLowerCase()} ·{' '}
+            {Math.round((ativo.n / max) * 100)}% do topo
+            {conversaoDe(hover!) != null && <> ({conversaoDe(hover!)}% da anterior)</>}
+          </>
+        ) : (
+          <span>
+            Usuários {anoSel === 'todos' ? 'da base' : `registrados em ${anoSel}`} em cada etapa
+            (praticar = desafio ou simulado)
+          </span>
+        )}
+      </div>
+
+      {modo === 'barras' ? (
+        <div className="painel-funil">
+          {etapas.map((e, i) => {
+            const pct = Math.round((e.n / max) * 100);
+            const conversao = conversaoDe(i);
+            return (
+              <div
+                key={e.label}
+                className="painel-funil__etapa"
+                onMouseEnter={() => setHover(i)}
+                onMouseLeave={() => setHover(null)}
+              >
+                <div className="painel-funil__topo">
+                  <span className="painel-funil__label">{e.label}</span>
+                  <span className="painel-funil__valor">
+                    {e.n} · {pct}%
+                    {conversao != null && (
+                      <span className="painel-funil__conv"> ({conversao}% da anterior)</span>
+                    )}
+                  </span>
+                </div>
+                <div className="painel-funil__barra">
+                  <div className="painel-funil__fill" style={{ width: `${Math.max(pct, 1)}%` }} />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="painel-funilbi">
+          {etapas.map((e, i) => {
+            const pct = Math.max(Math.round((e.n / max) * 100), 3);
+            const dentro = pct >= 14;
+            return (
+              <div
+                key={e.label}
+                className="painel-funilbi__linha"
+                onMouseEnter={() => setHover(i)}
+                onMouseLeave={() => setHover(null)}
+              >
+                <span className="painel-funilbi__label">{e.label}</span>
+                <div className="painel-funilbi__area">
+                  <div className="painel-funilbi__bar" style={{ width: `${pct}%` }}>
+                    {dentro && <span className="painel-funilbi__valor">{e.n}</span>}
+                  </div>
+                  {!dentro && <span className="painel-funilbi__valor-fora">{e.n}</span>}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/Usuarios/GraficoCrescimento.tsx
+++ b/frontend/src/pages/Usuarios/GraficoCrescimento.tsx
@@ -15,9 +15,9 @@ const PERIODOS = [
   { chave: 'max', label: 'Máx', dias: Infinity },
 ] as const;
 
-const W = 820;
-const H = 240;
-const PADL = 44;
+const W = 1240;
+const H = 300;
+const PADL = 48;
 const PADR = 14;
 const PADT = 16;
 const PADB = 26;
@@ -67,11 +67,18 @@ export function GraficoCrescimento({ cadastros }: { cadastros: Cadastro[] }) {
       const v = Math.round(vmin + (spanV * i) / 3);
       return { v, y: py(v) };
     });
-    const nLab = Math.min(5, Math.max(2, pts.length));
-    const xlabs = Array.from({ length: nLab }, (_, i) => {
+    const nLab = Math.min(6, Math.max(2, pts.length));
+    const candidatos = Array.from({ length: nLab }, (_, i) => {
       const p = pts[Math.round((i * (pts.length - 1)) / (nLab - 1))];
       return { t: p.t, x: p.x };
     });
+    // Datas irregulares podem cair coladas; mantém 90px entre rótulos, preferindo a data final.
+    const xlabs = candidatos.reduce<{ t: number; x: number }[]>((acc, l, i) => {
+      const ultimo = acc[acc.length - 1];
+      if (!ultimo || l.x - ultimo.x >= 90) return [...acc, l];
+      if (i === candidatos.length - 1) return [...acc.slice(0, -1), l];
+      return acc;
+    }, []);
 
     return { pts, linha, area, ticks, xlabs };
   }, [cadastros, periodo]);

--- a/frontend/src/pages/Usuarios/GraficoMensal.tsx
+++ b/frontend/src/pages/Usuarios/GraficoMensal.tsx
@@ -1,0 +1,118 @@
+import { useMemo, useState } from 'react';
+
+// Registros novos por mês: barras de uma série só (a cor é fixa; o mês identifica).
+const W = 1240;
+const H = 220;
+const PADL = 48;
+const PADR = 14;
+const PADT = 18;
+const PADB = 30;
+
+const fmtMes = (chave: string) => {
+  const [ano, mes] = chave.split('-').map(Number);
+  const nome = new Date(ano, mes - 1, 1).toLocaleDateString('pt-BR', { month: 'short' });
+  return nome.replace('.', '');
+};
+
+export function GraficoMensal({ cadastros }: { cadastros: { dia: string; n: number }[] }) {
+  const [hover, setHover] = useState<number | null>(null);
+  const [anoSel, setAnoSel] = useState<string | null>(null);
+
+  const { anos, porMes } = useMemo(() => {
+    const mapa = new Map<string, number>();
+    for (const c of cadastros) {
+      const chave = c.dia.slice(0, 7);
+      mapa.set(chave, (mapa.get(chave) ?? 0) + c.n);
+    }
+    const todos = [...mapa.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([chave, n]) => ({ chave, n }));
+    return { anos: [...new Set(todos.map((m) => m.chave.slice(0, 4)))], porMes: todos };
+  }, [cadastros]);
+
+  const ano = anoSel ?? anos.at(-1) ?? '';
+  const meses = porMes.filter((m) => m.chave.startsWith(ano));
+
+  if (porMes.length === 0) return null;
+
+  const max = Math.max(...meses.map((m) => m.n));
+  const areaW = W - PADL - PADR;
+  const areaH = H - PADT - PADB;
+  const passo = areaW / meses.length;
+  const larg = Math.min(72, passo * 0.6);
+  const py = (v: number) => PADT + (1 - v / max) * areaH;
+
+  const ticks = Array.from({ length: 3 }, (_, i) => Math.round((max * (i + 1)) / 3));
+  const ativo = hover != null ? meses[hover] : null;
+
+  return (
+    <div className="painel-graf">
+      <div className="painel-graf__head">
+        <div className="painel-graf__titulo">Registros por mês</div>
+        <div className="painel-graf__periodos">
+          {anos.map((a) => (
+            <button
+              key={a}
+              className={`painel-graf__periodo${a === ano ? ' is-ativo' : ''}`}
+              onClick={() => {
+                setAnoSel(a);
+                setHover(null);
+              }}
+            >
+              {a}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="painel-graf__leitura">
+        {ativo ? (
+          <>
+            <b>{ativo.n}</b> novos usuários em {fmtMes(ativo.chave)} de {ano}
+          </>
+        ) : (
+          <span>Quantos usuários novos entraram em cada mês de {ano}</span>
+        )}
+      </div>
+      <svg className="painel-graf__svg" viewBox={`0 0 ${W} ${H}`} onMouseLeave={() => setHover(null)}>
+        {ticks.map((v) => (
+          <g key={v}>
+            <line className="painel-graf__grid" x1={PADL} y1={py(v)} x2={W - PADR} y2={py(v)} />
+            <text className="painel-graf__ylab" x={PADL - 8} y={py(v) + 4} textAnchor="end">
+              {v}
+            </text>
+          </g>
+        ))}
+        {meses.map((m, i) => {
+          const x = PADL + i * passo + (passo - larg) / 2;
+          const y = py(m.n);
+          const alturaBarra = H - PADB - y;
+          return (
+            <g key={m.chave} onMouseEnter={() => setHover(i)}>
+              <rect
+                x={PADL + i * passo}
+                y={PADT}
+                width={passo}
+                height={areaH}
+                fill="transparent"
+              />
+              <rect
+                className={`painel-barra${hover != null && hover !== i ? ' is-apagada' : ''}`}
+                x={x}
+                y={y}
+                width={larg}
+                height={Math.max(alturaBarra, 2)}
+                rx="4"
+              />
+              <text className="painel-barra__valor" x={x + larg / 2} y={y - 6} textAnchor="middle">
+                {m.n}
+              </text>
+              <text className="painel-graf__xlab" x={x + larg / 2} y={H - 8} textAnchor="middle">
+                {fmtMes(m.chave)}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+    </div>
+  );
+}

--- a/frontend/src/pages/Usuarios/GraficoTrilhas.tsx
+++ b/frontend/src/pages/Usuarios/GraficoTrilhas.tsx
@@ -1,0 +1,120 @@
+import { useMemo, useState } from 'react';
+
+// Donut de alunos por trilha: top 5 + "Outras" (paleta categórica fixa validada;
+// a fatia de agregação é sempre neutra). Identidade vem da legenda, não só da cor.
+const CORES = ['var(--viz-1)', 'var(--viz-2)', 'var(--viz-3)', 'var(--viz-4)', 'var(--viz-5)'];
+const COR_OUTRAS = 'var(--muted)';
+
+const TAM = 220;
+const R = 82;
+const ESPESSURA = 30;
+const CENTRO = TAM / 2;
+
+interface Props {
+  dados: { nome: string; n: number }[];
+}
+
+export function GraficoTrilhas({ dados }: Props) {
+  const [hover, setHover] = useState<number | null>(null);
+
+  const fatias = useMemo(() => {
+    const comAlunos = dados.filter((d) => d.n > 0);
+    const top = comAlunos.slice(0, 5);
+    const resto = comAlunos.slice(5);
+    const outras = resto.reduce((s, d) => s + d.n, 0);
+    const lista = [
+      ...top.map((d, i) => ({ nome: d.nome, n: d.n, cor: CORES[i], outras: false })),
+      ...(outras > 0
+        ? [{ nome: `Outras (${resto.length})`, n: outras, cor: COR_OUTRAS, outras: true }]
+        : []),
+    ];
+    const total = lista.reduce((s, d) => s + d.n, 0);
+    if (total === 0) return { lista: [], total: 0 };
+
+    let acumulado = 0;
+    const circ = 2 * Math.PI * R;
+    return {
+      total,
+      lista: lista.map((d) => {
+        const frac = d.n / total;
+        const seg = {
+          ...d,
+          frac,
+          dash: `${Math.max(frac * circ - 2, 0.5)} ${circ}`,
+          offset: -acumulado * circ,
+        };
+        acumulado += frac;
+        return seg;
+      }),
+    };
+  }, [dados]);
+
+  const ativo = hover != null ? fatias.lista[hover] : null;
+
+  if (fatias.total === 0) {
+    return (
+      <div className="painel-graf">
+        <div className="painel-graf__titulo">Alunos por trilha</div>
+        <p className="track__desc">Nenhuma aula concluída ainda.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="painel-graf">
+      <div className="painel-graf__titulo">Alunos por trilha</div>
+      <div className="painel-graf__leitura">
+        {ativo ? (
+          <>
+            <b>{ativo.n}</b> alunos em {ativo.nome} ({Math.round(ativo.frac * 100)}%)
+          </>
+        ) : (
+          <span>Alunos com aula concluída em cada trilha (quem estuda duas conta nas duas)</span>
+        )}
+      </div>
+      <div className="painel-donut">
+        <svg viewBox={`0 0 ${TAM} ${TAM}`} className="painel-donut__svg">
+          {fatias.lista.map((f, i) => (
+            <circle
+              key={f.nome}
+              className={`painel-donut__fatia${hover != null && hover !== i ? ' is-apagada' : ''}`}
+              cx={CENTRO}
+              cy={CENTRO}
+              r={R}
+              fill="none"
+              stroke={f.cor}
+              strokeWidth={ESPESSURA}
+              strokeDasharray={f.dash}
+              strokeDashoffset={f.offset}
+              transform={`rotate(-90 ${CENTRO} ${CENTRO})`}
+              onMouseEnter={() => setHover(i)}
+              onMouseLeave={() => setHover(null)}
+            />
+          ))}
+          <text className="painel-donut__num" x={CENTRO} y={CENTRO - 4} textAnchor="middle">
+            {fatias.total}
+          </text>
+          <text className="painel-donut__sub" x={CENTRO} y={CENTRO + 16} textAnchor="middle">
+            participações
+          </text>
+        </svg>
+        <ul className="painel-donut__legenda">
+          {fatias.lista.map((f, i) => (
+            <li
+              key={f.nome}
+              className="painel-donut__item"
+              onMouseEnter={() => setHover(i)}
+              onMouseLeave={() => setHover(null)}
+            >
+              <span className="painel-donut__cor" style={{ background: f.cor }} />
+              <span className="painel-donut__nome">{f.nome}</span>
+              <span className="painel-donut__valor">
+                {f.n} · {Math.round(f.frac * 100)}%
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Usuarios/index.tsx
+++ b/frontend/src/pages/Usuarios/index.tsx
@@ -1,9 +1,15 @@
-import { useMemo, useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { EstudioTopbar } from '../../components/EstudioTopbar';
+import { ChevronLeft, ChevronRight } from '../../components/Icons';
 import { useRequisicao } from '../../hooks/useRequisicao';
 import { obterVisaoGeral, listarUsuariosCrm, type UsuarioCrm } from '../../services/admin';
 import { GraficoCrescimento } from './GraficoCrescimento';
+import { GraficoMensal } from './GraficoMensal';
+import { GraficoTrilhas } from './GraficoTrilhas';
+import { FunilOnboarding } from './FunilOnboarding';
 import '../../styles/painel.css';
+
+const POR_PAGINA = 20;
 
 const fmtData = (s: string | null) =>
   s ? new Date(s).toLocaleDateString('pt-BR', { day: '2-digit', month: '2-digit', year: '2-digit' }) : '—';
@@ -43,33 +49,35 @@ export function Usuarios() {
   const { dados: overview } = useRequisicao(obterVisaoGeral, []);
   const [busca, setBusca] = useState('');
   const [buscaDeb, setBuscaDeb] = useState('');
+  const [pagina, setPagina] = useState(1);
   const [ordem, setOrdem] = useState<{ col: Coluna; desc: boolean }>({ col: 'criadoEm', desc: true });
 
   useEffect(() => {
-    const id = setTimeout(() => setBuscaDeb(busca), 350);
+    const id = setTimeout(() => {
+      setBuscaDeb(busca);
+      setPagina(1);
+    }, 350);
     return () => clearTimeout(id);
   }, [busca]);
 
-  const { dados: usuariosData, carregando } = useRequisicao(
-    () => listarUsuariosCrm(buscaDeb),
-    [buscaDeb],
+  const { dados: paginaCrm, carregando } = useRequisicao(
+    () =>
+      listarUsuariosCrm({
+        busca: buscaDeb,
+        pagina,
+        porPagina: POR_PAGINA,
+        ordenarPor: ordem.col,
+        direcao: ordem.desc ? 'desc' : 'asc',
+      }),
+    [buscaDeb, pagina, ordem],
   );
 
-  const filtrados = useMemo(() => {
-    const base = usuariosData ?? [];
-    const { col, desc } = ordem;
-    return base.toSorted((a, b) => {
-      const va = a[col] ?? '';
-      const vb = b[col] ?? '';
-      const cmp =
-        typeof va === 'number' && typeof vb === 'number'
-          ? va - vb
-          : String(va).localeCompare(String(vb));
-      return desc ? -cmp : cmp;
-    });
-  }, [usuariosData, ordem]);
+  const usuarios = paginaCrm?.rows ?? [];
+  const total = paginaCrm?.total ?? 0;
+  const totalPaginas = Math.max(1, Math.ceil(total / POR_PAGINA));
 
   function ordenarPor(col: Coluna) {
+    setPagina(1);
     setOrdem((o) => (o.col === col ? { col, desc: !o.desc } : { col, desc: true }));
   }
 
@@ -96,7 +104,7 @@ export function Usuarios() {
     <div className="home painel-page">
       <EstudioTopbar crumb={<b>Usuários</b>} />
 
-      <div className="estudio-home">
+      <div className="estudio-home estudio-home--painel">
         <div className="estudio-home__head">
           <div>
             <h1 className="estudio-home__title">Usuários</h1>
@@ -116,6 +124,15 @@ export function Usuarios() {
 
         {overview && <GraficoCrescimento cadastros={overview.cadastrosPorDia} />}
 
+        {overview && <GraficoMensal cadastros={overview.cadastrosPorDia} />}
+
+        {overview && (
+          <div className="painel-duplo">
+            <GraficoTrilhas dados={overview.usuariosPorTrilha} />
+            <FunilOnboarding porAno={overview.funilPorAno} />
+          </div>
+        )}
+
         <div className="painel-toolbar">
           <input
             className="estudio-form__input"
@@ -124,58 +141,93 @@ export function Usuarios() {
             value={busca}
             onChange={(e) => setBusca(e.target.value)}
           />
-          <span className="painel-toolbar__contagem">{filtrados.length} usuários</span>
+          <span className="painel-toolbar__contagem">
+            {total} usuário{total === 1 ? '' : 's'}
+          </span>
         </div>
 
-        {carregando ? (
-          <p className="track__desc">Carregando...</p>
-        ) : (
-          <div className="painel-tabela-wrap">
-            <table className="painel-tabela">
-              <thead>
-                <tr>
-                  <Th col="name" label="Usuário" ordem={ordem} onClick={ordenarPor} />
-                  <th>Origem</th>
-                  <Th col="aulas" label="Aulas" ordem={ordem} onClick={ordenarPor} />
-                  <Th col="trilhas" label="Trilhas" ordem={ordem} onClick={ordenarPor} />
-                  <Th col="simulados" label="Simul." ordem={ordem} onClick={ordenarPor} />
-                  <Th col="desafios" label="Desaf." ordem={ordem} onClick={ordenarPor} />
-                  <Th col="conquistas" label="Conq." ordem={ordem} onClick={ordenarPor} />
-                  <Th col="xp" label="XP" ordem={ordem} onClick={ordenarPor} />
-                  <Th col="ultimaAtividade" label="Últ. atividade" ordem={ordem} onClick={ordenarPor} />
+        <div className="painel-tabela-wrap">
+          <table className="painel-tabela">
+            <thead>
+              <tr>
+                <Th col="name" label="Usuário" ordem={ordem} onClick={ordenarPor} />
+                <th>Origem</th>
+                <Th col="aulas" label="Aulas" ordem={ordem} onClick={ordenarPor} />
+                <Th col="trilhas" label="Trilhas" ordem={ordem} onClick={ordenarPor} />
+                <Th col="simulados" label="Simul." ordem={ordem} onClick={ordenarPor} />
+                <Th col="desafios" label="Desaf." ordem={ordem} onClick={ordenarPor} />
+                <Th col="conquistas" label="Conq." ordem={ordem} onClick={ordenarPor} />
+                <Th col="xp" label="XP" ordem={ordem} onClick={ordenarPor} />
+                <Th col="ultimaAtividade" label="Últ. atividade" ordem={ordem} onClick={ordenarPor} />
+                <Th col="criadoEm" label="Cadastro" ordem={ordem} onClick={ordenarPor} />
+              </tr>
+            </thead>
+            <tbody className={carregando ? 'painel-tabela__body is-carregando' : 'painel-tabela__body'}>
+              {usuarios.map((u) => (
+                <tr key={u.id}>
+                  <td>
+                    <div className="painel-user__nome">{u.name}</div>
+                    <div className="painel-user__sub">
+                      {u.username ? (
+                        `@${u.username}`
+                      ) : (
+                        <span className="painel-user__semuser">sem username</span>
+                      )}
+                    </div>
+                  </td>
+                  <td>
+                    <span className={`painel-tag painel-tag--${u.origem}`}>
+                      {u.origem !== 'social'
+                        ? 'Email'
+                        : u.provider === 'github'
+                          ? 'GitHub'
+                          : u.provider === 'google'
+                            ? 'Google'
+                            : 'Social'}
+                    </span>
+                  </td>
+                  <td className="num">{u.aulas}</td>
+                  <td className="num">{u.trilhas}</td>
+                  <td className="num">{u.simulados}</td>
+                  <td className="num">{u.desafios}</td>
+                  <td className="num">{u.conquistas}</td>
+                  <td className="num">{u.xp}</td>
+                  <td>{fmtData(u.ultimaAtividade)}</td>
+                  <td>{fmtData(u.criadoEm)}</td>
                 </tr>
-              </thead>
-              <tbody>
-                {filtrados.map((u) => (
-                  <tr key={u.id}>
-                    <td>
-                      <div className="painel-user__nome">{u.name}</div>
-                      <div className="painel-user__sub">
-                        {u.username ? (
-                          `@${u.username}`
-                        ) : (
-                          <span className="painel-user__semuser">sem username</span>
-                        )}
-                      </div>
-                    </td>
-                    <td>
-                      <span className={`painel-tag painel-tag--${u.origem}`}>
-                        {u.origem === 'social' ? 'Social' : 'Email'}
-                      </span>
-                    </td>
-                    <td className="num">{u.aulas}</td>
-                    <td className="num">{u.trilhas}</td>
-                    <td className="num">{u.simulados}</td>
-                    <td className="num">{u.desafios}</td>
-                    <td className="num">{u.conquistas}</td>
-                    <td className="num">{u.xp}</td>
-                    <td>{fmtData(u.ultimaAtividade)}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+              ))}
+              {!carregando && usuarios.length === 0 && (
+                <tr>
+                  <td colSpan={10} className="painel-tabela__vazia">
+                    Nenhum usuário encontrado.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="painel-pag">
+          <span className="painel-pag__info">
+            Página {pagina} de {totalPaginas}
+          </span>
+          <div className="painel-pag__botoes">
+            <button
+              className="painel-pag__btn"
+              disabled={pagina <= 1 || carregando}
+              onClick={() => setPagina((p) => Math.max(1, p - 1))}
+            >
+              <ChevronLeft size={14} /> Anterior
+            </button>
+            <button
+              className="painel-pag__btn"
+              disabled={pagina >= totalPaginas || carregando}
+              onClick={() => setPagina((p) => Math.min(totalPaginas, p + 1))}
+            >
+              Próxima <ChevronRight size={14} />
+            </button>
           </div>
-        )}
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/services/admin.ts
+++ b/frontend/src/services/admin.ts
@@ -14,6 +14,14 @@ export interface VisaoGeral {
   trilhas: number;
   aulasTotal: number;
   cadastrosPorDia: { dia: string; n: number }[];
+  usuariosPorTrilha: { nome: string; n: number }[];
+  funilPorAno: {
+    ano: string;
+    registrados: number;
+    comUsername: number;
+    concluiuAula: number;
+    praticou: number;
+  }[];
 }
 
 export interface UsuarioCrm {
@@ -22,6 +30,7 @@ export interface UsuarioCrm {
   username: string | null;
   email: string;
   origem: 'email' | 'social';
+  provider: string | null;
   criadoEm: string;
   ultimaAtividade: string | null;
   aulas: number;
@@ -38,9 +47,26 @@ export async function obterVisaoGeral() {
   return data;
 }
 
-export async function listarUsuariosCrm(busca?: string) {
-  const { data } = await api.get<UsuarioCrm[]>('/admin/users', {
-    params: busca ? { q: busca } : undefined,
+export interface PaginaUsuariosCrm {
+  rows: UsuarioCrm[];
+  total: number;
+}
+
+export async function listarUsuariosCrm(params: {
+  busca?: string;
+  pagina: number;
+  porPagina: number;
+  ordenarPor: string;
+  direcao: 'asc' | 'desc';
+}) {
+  const { data } = await api.get<PaginaUsuariosCrm>('/admin/users', {
+    params: {
+      ...(params.busca ? { q: params.busca } : {}),
+      pagina: params.pagina,
+      porPagina: params.porPagina,
+      ordenarPor: params.ordenarPor,
+      direcao: params.direcao,
+    },
   });
   return data;
 }

--- a/frontend/src/styles/painel.css
+++ b/frontend/src/styles/painel.css
@@ -233,3 +233,256 @@
   border-color: var(--accent);
   color: var(--accent);
 }
+
+/* ==== Painel largo, gráficos novos e paginação ==== */
+
+/* Paleta categórica dos gráficos (validada contra as superfícies clara e escura;
+   a fatia de agregação "Outras" usa sempre o cinza --muted). */
+:root {
+  --viz-1: #5b50d6;
+  --viz-2: #0b8f7c;
+  --viz-3: #c77d0a;
+  --viz-4: #c2417a;
+  --viz-5: #587a29;
+}
+[data-theme='dark'] {
+  --viz-1: #8b82e8;
+  --viz-2: #2ba391;
+  --viz-3: #c6841a;
+  --viz-4: #d4568f;
+  --viz-5: #7fa13f;
+}
+
+.estudio-home--painel {
+  max-width: 1400px;
+}
+
+.painel-duplo {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+  margin-bottom: 20px;
+}
+@media (max-width: 980px) {
+  .painel-duplo {
+    grid-template-columns: 1fr;
+  }
+}
+
+.painel-donut {
+  display: flex;
+  align-items: center;
+  gap: 22px;
+}
+.painel-donut__svg {
+  width: 210px;
+  flex-shrink: 0;
+}
+.painel-donut__fatia {
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+.painel-donut__fatia.is-apagada {
+  opacity: 0.3;
+}
+.painel-donut__num {
+  fill: var(--text);
+  font-size: 30px;
+  font-weight: 800;
+}
+.painel-donut__sub {
+  fill: var(--muted);
+  font-size: 12px;
+}
+.painel-donut__legenda {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+  flex: 1;
+}
+.painel-donut__item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  cursor: default;
+}
+.painel-donut__cor {
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+.painel-donut__nome {
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.painel-donut__valor {
+  margin-left: auto;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.painel-funil {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.painel-funil__topo {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 4px;
+  font-size: 13px;
+}
+.painel-funil__label {
+  color: var(--text);
+  font-weight: 600;
+}
+.painel-funil__valor {
+  color: var(--muted);
+}
+.painel-funil__conv {
+  opacity: 0.8;
+}
+.painel-funil__barra {
+  height: 14px;
+  border-radius: 5px;
+  background: var(--surface-2);
+  overflow: hidden;
+}
+.painel-funil__fill {
+  height: 100%;
+  border-radius: 5px;
+  background: var(--accent);
+  opacity: 0.85;
+  transition: width 0.3s;
+}
+
+.painel-tabela__body.is-carregando {
+  opacity: 0.45;
+}
+.painel-tabela__vazia {
+  text-align: center;
+  color: var(--muted);
+  padding: 24px 0;
+}
+
+.painel-pag {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 14px;
+}
+.painel-pag__info {
+  font-size: 13px;
+  color: var(--muted);
+}
+.painel-pag__botoes {
+  display: flex;
+  gap: 8px;
+}
+.painel-pag__btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 7px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.painel-pag__btn:hover:not(:disabled) {
+  border-color: var(--accent);
+}
+.painel-pag__btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.painel-barra {
+  fill: var(--accent);
+  opacity: 0.85;
+  transition: opacity 0.15s;
+}
+.painel-barra.is-apagada {
+  opacity: 0.35;
+}
+.painel-barra__valor {
+  fill: var(--muted);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.painel-funil__fill--central {
+  margin: 0 auto;
+  height: 22px;
+  border-radius: 6px;
+}
+
+.painel-graf__controles {
+  display: flex;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+/* Funil estilo Power BI: rótulo à esquerda, barras centradas com o valor dentro */
+.painel-funilbi {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.painel-funilbi__linha {
+  display: grid;
+  grid-template-columns: 168px 1fr;
+  align-items: center;
+  gap: 10px;
+}
+.painel-funilbi__label {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--text);
+  text-align: right;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.painel-funilbi__area {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 34px;
+}
+.painel-funilbi__bar {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: width 0.3s;
+  min-width: 8px;
+}
+.painel-funilbi__valor {
+  color: #fff;
+  font-size: 13px;
+  font-weight: 700;
+}
+.painel-funilbi__valor-fora {
+  position: absolute;
+  left: 50%;
+  transform: translateX(calc(-50% + 60px));
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 700;
+}


### PR DESCRIPTION
Reformulação da tela Estúdio > Usuários pra aguentar a base atual (1.600+ usuários) e responder mais perguntas de análise.

## Layout

- Container alargado de 760px pra 1400px (modificador `estudio-home--painel`): margens laterais enxutas, os 6 cards numa linha, tabela na largura toda.
- Gráfico "Usuários ao longo do tempo" maior (1240x300) e com deduplicação de rótulos no eixo x (datas coladas não colidem mais).

## Lista de usuários

- **Paginação server-side** (20 por página) com total e botões Anterior/Próxima: a página não carrega mais a base inteira.
- **Ordenação server-side** em todas as colunas (whitelist de colunas no service; o XP ordena pela fórmula do domínio reproduzida em SQL, usando as constantes de `domain/xp.ts`).
- Busca por nome/username/email (debounce) integrada à paginação.
- Coluna nova de **Cadastro** e a **Origem agora mostra o provedor social** (GitHub/Google via join em `oauth_accounts`; "Social" genérico quando não há registro): diagnóstico de casos de login social direto na tabela.

## Análises novas (overview)

- **Registros por mês**: barras com valor por mês e filtro por ano.
- **Alunos por trilha**: donut top 5 + "Outras", legenda com contagem e %, centro com o total de participações (aluno em duas trilhas conta nas duas, e o texto diz isso). Paleta categórica nova validada por contraste e daltonismo contra as superfícies clara e escura (variáveis `--viz-1..5`).
- **Funil de onboarding**: Registrados > Completaram o perfil > Concluíram uma aula > Praticaram, com % do topo e conversão por etapa; **filtro por coorte de ano de cadastro** (o backend agrega o funil por ano) e **dois estilos de visualização** alternáveis: barras alinhadas ou funil centrado estilo Power BI (valor dentro da barra).

Sem migração e sem mudança de rota nova: só `GET /admin/users` ganhou parâmetros (pagina, porPagina, ordenarPor, direcao) e o `GET /admin/overview` ganhou os agregados novos.

Validado no dev no navegador (busca, ordenação, paginação, os dois temas e os dois estilos do funil); tsc limpo em backend e frontend contra a develop pura.