### PR TITLE
fix: erro de imagem no perfil aparecia fora da tela

### DIFF
--- a/frontend/src/contexts/ToastContext.tsx
+++ b/frontend/src/contexts/ToastContext.tsx
@@ -14,6 +14,9 @@ interface ToastCtx {
 
 const Ctx = createContext<ToastCtx>({ mostrar: () => {} });
 
+// A barra de progresso é animada por esta mesma duração.
+const TOAST_MS = 4500;
+
 export function useToast() {
   return useContext(Ctx);
 }
@@ -26,7 +29,7 @@ export function ToastProvider({ children }: { children: ReactNode }) {
   const mostrar = useCallback((msg: string, tipo: Tipo = 'sucesso') => {
     const id = idSeq++;
     setToasts((prev) => [...prev, { id, msg, tipo }]);
-    setTimeout(() => setToasts((prev) => prev.filter((t) => t.id !== id)), 3200);
+    setTimeout(() => setToasts((prev) => prev.filter((t) => t.id !== id)), TOAST_MS);
   }, []);
 
   return (
@@ -35,10 +38,15 @@ export function ToastProvider({ children }: { children: ReactNode }) {
       <div className="toasts">
         {toasts.map((t) => (
           <div key={t.id} className={`toast toast--${t.tipo}`}>
-            <span className="toast__icon">
-              {t.tipo === 'sucesso' ? <Check size={13} /> : <X size={11} />}
-            </span>
-            <span>{t.msg}</span>
+            <div className="toast__linha">
+              <span className="toast__icon">
+                {t.tipo === 'sucesso' ? <Check size={15} /> : <X size={13} />}
+              </span>
+              <span className="toast__msg">{t.msg}</span>
+            </div>
+            <div className="toast__barra">
+              <div className="toast__progresso" style={{ animationDuration: `${TOAST_MS}ms` }} />
+            </div>
           </div>
         ))}
       </div>

--- a/frontend/src/pages/Perfil/index.tsx
+++ b/frontend/src/pages/Perfil/index.tsx
@@ -10,6 +10,7 @@ import {
 import { Link, useNavigate } from 'react-router-dom';
 import api from '../../services/api';
 import { useAuth } from '../../contexts/AuthContext';
+import { useToast } from '../../contexts/ToastContext';
 import { Logo } from '../../components/Logo';
 import { MobileMenu } from '../../components/MobileMenu';
 import { UserMenu } from '../../components/UserMenu';
@@ -126,6 +127,7 @@ export function Perfil() {
     linkedin: '',
     x: '',
   });
+  const { mostrar } = useToast();
   const [salvando, setSalvando] = useState(false);
   const [erro, setErro] = useState('');
   const [enviandoFoto, setEnviandoFoto] = useState(false);
@@ -211,9 +213,11 @@ export function Perfil() {
       setEditando(false);
       // A URL canônica do perfil carrega o username; se ele mudou, acompanha.
       if (data.username) navigate(`/${data.username}`, { replace: true });
+      mostrar('Perfil atualizado.');
     } catch (e) {
+      console.error('Falha ao salvar o perfil', e);
       const msg = (e as { response?: { data?: { erro?: string } } })?.response?.data?.erro;
-      setErro(msg ?? 'Não foi possível salvar as alterações.');
+      mostrar(msg ?? 'Não foi possível salvar as alterações.', 'erro');
     } finally {
       setSalvando(false);
     }
@@ -222,11 +226,11 @@ export function Perfil() {
   // Valida o arquivo escolhido e abre o recortador; o envio acontece após o corte.
   async function escolherImagem(file: File, tipo: 'avatar' | 'cover') {
     if (!TIPOS_IMG.includes(file.type)) {
-      setErro('Use uma imagem PNG, JPG ou WEBP.');
+      mostrar('Use uma imagem PNG, JPG ou WEBP.', 'erro');
       return;
     }
     if (file.size > MAX_IMG) {
-      setErro('Imagem muito grande (máximo 4MB).');
+      mostrar('Imagem muito grande (máximo 4MB).', 'erro');
       return;
     }
     setErro('');
@@ -248,8 +252,9 @@ export function Perfil() {
       setPerfil((prev) => (prev ? { ...prev, ...data } : data));
       if (avatar) atualizarUsuario({ avatarUrl: data.avatarUrl });
     } catch (e) {
+      console.error('Falha ao enviar a imagem do perfil', e);
       const msg = (e as { response?: { data?: { erro?: string } } })?.response?.data?.erro;
-      setErro(msg ?? 'Não foi possível enviar a imagem.');
+      mostrar(msg ?? 'Não foi possível enviar a imagem.', 'erro');
     } finally {
       setBusy(false);
     }
@@ -264,8 +269,9 @@ export function Perfil() {
       setPerfil((prev) => (prev ? { ...prev, ...data } : data));
       if (rota === '/me/avatar') atualizarUsuario({ avatarUrl: data.avatarUrl });
     } catch (e) {
+      console.error('Falha ao remover a imagem do perfil', e);
       const msg = (e as { response?: { data?: { erro?: string } } })?.response?.data?.erro;
-      setErro(msg ?? 'Não foi possível remover a imagem.');
+      mostrar(msg ?? 'Não foi possível remover a imagem.', 'erro');
     } finally {
       setBusy(false);
     }
@@ -738,7 +744,7 @@ export function Perfil() {
               </div>
             </div>
 
-            {erro && (
+            {erro && !perfil && (
               <div className="auth__alert" style={{ marginTop: 16 }}>
                 {erro}
               </div>

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -4356,29 +4356,66 @@
 }
 .toast {
   display: flex;
-  align-items: center;
-  gap: 10px;
-  min-width: 220px;
-  max-width: 360px;
-  padding: 13px 16px;
-  border-radius: 12px;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 320px;
+  max-width: 440px;
+  padding: 16px 18px 14px;
+  border-radius: 14px;
   background: var(--surface);
   border: 1px solid var(--border);
   box-shadow: var(--shadow);
-  font-size: 14px;
+  font-size: 15px;
   font-weight: 600;
   color: var(--text);
   animation: toast-in 0.2s ease;
 }
+.toast__linha {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.toast__msg {
+  line-height: 1.35;
+}
 .toast__icon {
-  width: 24px;
-  height: 24px;
-  border-radius: 7px;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
   flex-shrink: 0;
   display: flex;
   align-items: center;
   justify-content: center;
   color: #fff;
+}
+.toast__barra {
+  height: 4px;
+  border-radius: 999px;
+  background: var(--surface-2);
+  overflow: hidden;
+}
+.toast__progresso {
+  height: 100%;
+  width: 100%;
+  border-radius: 999px;
+  transform-origin: left center;
+  animation-name: toast-progresso;
+  animation-timing-function: linear;
+  animation-fill-mode: forwards;
+}
+.toast--sucesso .toast__progresso {
+  background: var(--success);
+}
+.toast--erro .toast__progresso {
+  background: var(--av-red);
+}
+@keyframes toast-progresso {
+  from {
+    transform: scaleX(1);
+  }
+  to {
+    transform: scaleX(0);
+  }
 }
 .toast--sucesso .toast__icon {
   background: var(--success);


### PR DESCRIPTION
Um usuário relatou que, ao escolher uma imagem maior que o permitido no perfil, "o seletor só fecha e não aparece erro nenhum", enquanto imagem menor funciona.

## O que estava acontecendo

A validação sempre funcionou e a mensagem era gerada, mas o bloco de erro é renderizado no **rodapé** da página, enquanto os botões de foto e capa ficam no **topo**. Medindo na página: o alerta aparecia na posição 1245px com a viewport terminando em 905px, ou seja, 340px abaixo da dobra. O usuário via só o seletor de arquivo fechar.

O mesmo valia para o erro de tipo inválido (GIF, por exemplo) e para o erro ao salvar o perfil, já que o botão "Salvar alterações" também fica no topo.

## Correção

Os avisos de imagem e de salvar passam a sair em **toast**, que é fixo no canto superior direito e independe de scroll. O bloco do rodapé ficou reservado ao caso de falha ao carregar o perfil, quando não há mais nada na tela.

Também foram adicionados `console.error` nos catch de imagem e de salvar, que antes engoliam o erro original.

## Toast maior e com barra de tempo

Aproveitando a mudança, o componente de toast (compartilhado com desafios e estúdio) ganhou:

- corpo maior (mínimo de 320px, texto de 15px, ícone de 28px) para caber mensagens completas;
- barra de progresso que encolhe linearmente até o toast sumir, com a mesma constante de duração do timer (uma variável só controla os dois);
- duração de 3,2s para 4,5s, tempo mais confortável de leitura.

## Testes no navegador (dev)

- Imagem de 5MB: toast vermelho "Imagem muito grande (máximo 4MB)" visível com a página no topo.
- GIF: toast "Use uma imagem PNG, JPG ou WEBP".
- PNG válido de 3KB: recortador abre normalmente, sem toast de erro.
- Barra de progresso medida ao vivo encolhendo: 247, 194, 139, 87 e 34 pixels, sumindo junto com o toast.