### PR TITLE
feat: redireciona ensinadev.com para o .com.br

### DIFF
--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,3 +1,10 @@
+# O .com é redirecionado para o .com.br, que segue como domínio canônico.
+# Exige que ensinadev.com aponte (A) para esta VPS, senão o Caddy não emite o
+# certificado e fica tentando o desafio da Let's Encrypt em vão.
+ensinadev.com, www.ensinadev.com {
+	redir https://ensinadev.com.br{uri} permanent
+}
+
 ensinadev.com.br, www.ensinadev.com.br {
 	# API: tudo sob /api vai para o backend, removendo o prefixo /api
 	handle_path /api/* {


### PR DESCRIPTION
O domínio **ensinadev.com** foi registrado e passa a redirecionar para o **ensinadev.com.br**, que segue como domínio canônico do app.

## A mudança

Um bloco novo no Caddyfile, antes do bloco atual:

```
ensinadev.com, www.ensinadev.com {
	redir https://ensinadev.com.br{uri} permanent
}
```

- **301 (permanent)**, que é o certo quando o .com.br continua sendo o canônico: buscadores transferem a autoridade e navegadores passam a ir direto.
- `{uri}` preserva caminho e query, então `ensinadev.com/trilhas?x=1` cai em `ensinadev.com.br/trilhas?x=1`.
- Cobre apex e www.
- O Caddy emite o certificado do domínio novo sozinho no primeiro acesso, então não há passo manual de SSL.

Configuração validada com `caddy validate` (Valid configuration).

## Pré-requisito de DNS (antes do deploy)

Hoje `ensinadev.com` resolve para 2.57.91.91 (página de estacionamento do registrador). Precisa apontar para a VPS **antes** deste deploy, senão o Caddy não consegue completar o desafio da Let's Encrypt e fica tentando emitir o certificado em vão (o .com.br continua funcionando normalmente nesse meio tempo).

No painel do domínio, alterar o registro A:

| Tipo | Nome | Conteúdo atual | Novo conteúdo |
|------|------|----------------|---------------|
| A | @ | 2.57.91.91 | 76.13.174.73 |

O CNAME de `www` apontando para `ensinadev.com` pode ficar como está, porque acompanha o apex.

## Depois do deploy

Verificar:

```
curl -sI https://ensinadev.com | head -3        # 301 para https://ensinadev.com.br/
curl -sI https://www.ensinadev.com/trilhas | head -3
```

Nada muda no backend: o redirecionamento acontece no Caddy, então nenhuma requisição chega à API com origem .com e não há ajuste de CORS.