### PR TITLE
chore: um endereço canônico só e redirecionamento em 301

### DIFF
--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,11 +1,27 @@
-# O .com é redirecionado para o .com.br, que segue como domínio canônico.
+# O domínio canônico é ensinadev.com.br, sem www. Todos os outros endereços
+# apenas redirecionam para ele.
+#
+# Antes o www servia o site em paralelo, e isso custava caro de dois jeitos: os
+# robôs de link guardam o preview por URL, então www e raiz viravam duas
+# entradas de cache independentes (uma podia estar boa e a outra vazia), e a
+# busca via o mesmo conteúdo em dois endereços, o que divide o sinal do domínio.
+#
+# Os blocos http:// existem de propósito. Sem eles o Caddy cria sozinho o
+# redirecionamento de http para https usando 308, que é correto pelo protocolo
+# mas é de 2015: robô de link antigo às vezes não reconhece esse código e
+# desiste. O `permanent` do redir abaixo responde 301, que todo mundo entende.
 # Exige que ensinadev.com aponte (A) para esta VPS, senão o Caddy não emite o
 # certificado e fica tentando o desafio da Let's Encrypt em vão.
-ensinadev.com, www.ensinadev.com {
+http://ensinadev.com.br, http://www.ensinadev.com.br,
+http://ensinadev.com, http://www.ensinadev.com {
 	redir https://ensinadev.com.br{uri} permanent
 }
 
-ensinadev.com.br, www.ensinadev.com.br {
+https://www.ensinadev.com.br, https://ensinadev.com, https://www.ensinadev.com {
+	redir https://ensinadev.com.br{uri} permanent
+}
+
+https://ensinadev.com.br {
 	# API: tudo sob /api vai para o backend, removendo o prefixo /api
 	handle_path /api/* {
 		reverse_proxy backend:3001


### PR DESCRIPTION
## Por quê

Enviando o mesmo site no WhatsApp, `https://ensinadev.com.br` monta o card e `www.ensinadev.com.br` não monta. Mesma página, mesmo servidor, mesmo HTML.

A causa é que hoje os dois endereços servem o site em paralelo. Robô de link guarda o preview por URL, então www e raiz são duas entradas de cache independentes: uma pode estar boa e a outra vazia desde antes das tags existirem. E, para a busca, o mesmo conteúdo em dois endereços divide o sinal do domínio.

## O que muda

O `ensinadev.com.br` passa a ser o único endereço que serve o site. O `www`, o `.com` e o `www.com` só redirecionam para ele, preservando o caminho.

Os blocos `http://` são explícitos de propósito. Sem eles o Caddy monta sozinho o redirecionamento de http para https usando **308**, que é correto pelo protocolo mas é de 2015, e robô de link antigo às vezes não reconhece o código e desiste. Como quem digita um endereço sem `https://` cai justamente nesse caminho, o `permanent` do `redir` passa a responder **301**, que todo mundo entende.

## Testado

Validado e executado com a mesma imagem que roda em produção (`caddy:latest`), não só lido:

`caddy validate` retorna "Valid configuration".

Subi o Caddy num container e medi os códigos de resposta na porta 80. Os quatro hosts respondem **301** para `https://ensinadev.com.br`, preservando o caminho (testei com `/trilhas`):

| Host | Resposta |
|---|---|
| www.ensinadev.com.br | 301 para https://ensinadev.com.br/trilhas |
| ensinadev.com.br | 301 para https://ensinadev.com.br/trilhas |
| ensinadev.com | 301 para https://ensinadev.com.br/trilhas |
| www.ensinadev.com | 301 para https://ensinadev.com.br/trilhas |

E inspecionei a configuração adaptada para garantir que o site segue de pé: no servidor de 443, só `ensinadev.com.br` carrega o conjunto real (proxy da API, arquivos estáticos, compressão); os outros três carregam apenas o redirecionamento.

## O que isto não resolve

Não descacheia o `www` na hora. Para descobrir o redirecionamento o robô precisaria buscar a página, e é justamente isso que ele não está fazendo enquanto tiver resposta guardada. O ganho é impedir que o problema volte, para qualquer pessoa que compartilhe o link, e consolidar o domínio para a busca. Enquanto isso, compartilhar usando `https://ensinadev.com.br` funciona hoje.