### PR TITLE
fix: reestruturação do roadmap falhava se algum estágio removido tivesse conclusão manual

### DIFF
--- a/backend/scripts/seed-roadmap-seguranca.ts
+++ b/backend/scripts/seed-roadmap-seguranca.ts
@@ -20,8 +20,15 @@
 //
 // Rodar em prod: docker compose -f docker-compose.prod.yml exec -T backend node scripts/seed-roadmap-seguranca.ts
 import { db } from "../db.ts";
-import { roadmaps, roadmapStages, roadmapStageRefs, trails, simulados } from "../schema.ts";
-import { eq, inArray } from "drizzle-orm";
+import {
+    roadmaps,
+    roadmapStages,
+    roadmapStageRefs,
+    roadmapStageCompletions,
+    trails,
+    simulados,
+} from "../schema.ts";
+import { eq, inArray, count } from "drizzle-orm";
 
 const SLUG = "seguranca";
 
@@ -202,9 +209,21 @@ async function seed() {
     const titulos = STAGES.map((s) => s.title);
     const removidos = atuais.filter((a) => !titulos.includes(a.title));
     for (const r of removidos) {
+        // A ordem importa: roadmap_stage_completions e roadmap_stage_refs têm chave
+        // estrangeira para o estágio, então apagar o estágio antes delas falha.
+        // Apagar a conclusão é o certo aqui: ela dizia que o aluno concluiu um estágio
+        // que deixou de existir neste roadmap. O progresso das TRILHAS dele continua
+        // intacto, porque vive em lessons_progress e não depende do estágio.
+        const [{ n: conclusoes }] = await db
+            .select({ n: count() })
+            .from(roadmapStageCompletions)
+            .where(eq(roadmapStageCompletions.stageId, r.id));
+        await db.delete(roadmapStageCompletions).where(eq(roadmapStageCompletions.stageId, r.id));
         await db.delete(roadmapStageRefs).where(eq(roadmapStageRefs.stageId, r.id));
         await db.delete(roadmapStages).where(eq(roadmapStages.id, r.id));
         console.log(`  estágio removido do roadmap: ${r.title}`);
+        if (Number(conclusoes) > 0)
+            console.log(`     ${conclusoes} conclusão(ões) manual(is) dele foram apagadas junto`);
     }
 
     let criados = 0;

--- a/backend/scripts/seed-roadmap-seguranca.ts
+++ b/backend/scripts/seed-roadmap-seguranca.ts
@@ -10,9 +10,13 @@
 //
 // Reconciliar significa: apagar os estágios que saíram do desenho, atualizar e
 // reposicionar os que ficam, criar os que faltam e acertar as refs de cada um.
-// É seguro para o aluno: a conclusão manual de estágio é gravada em
-// lessons_progress contra a AULA, não contra o estágio, e não existe tabela de
-// progresso presa a roadmap_stages. Nada de progresso se perde aqui.
+//
+// O que o aluno perde e o que ele não perde: o progresso das TRILHAS é intocado,
+// porque vive em lessons_progress e não depende de estágio. Já a conclusão manual
+// de estágio ("já sei isso", em roadmap_stage_completions) é apagada junto com o
+// estágio removido, e tem que ser: ela afirmava que o aluno concluiu um estágio
+// que deixou de existir neste roadmap. Essa tabela tem FK para roadmap_stages, e
+// esquecê-la fazia o delete do estágio abortar com violação de chave.
 //
 // Ref que não resolve NÃO bloqueia: o estágio é criado sem ela e o script avisa.
 // É o que permite rodar antes das trilhas novas existirem e rodar de novo depois


### PR DESCRIPTION
Corrige um bug latente no `seed-roadmap-seguranca.ts` que veio em #346.

## O problema

O script apaga os estágios que saíram do desenho e, antes disso, apagava só as referências (`roadmap_stage_refs`). Acontece que existe uma segunda tabela com chave estrangeira para o estágio: **`roadmap_stage_completions`**, que guarda a conclusão manual de estágio, o "já sei isso".

Se qualquer aluno tivesse marcado um dos três estágios removidos como concluído, o `DELETE` do estágio violaria a chave estrangeira e o seed abortaria no meio da reconciliação, deixando o roadmap num estado parcial.

Hoje em produção esses três estágios têm zero conclusões, então o seed rodaria bem. Mas há 42 conclusões manuais na plataforma e nada impede alguém marcar um deles antes da release, então é falha esperando acontecer.

## A correção

Apagar a conclusão antes do estágio, e dizer no log quantas foram. Apagar é o comportamento certo: o registro afirmava que o aluno concluiu um estágio que deixou de existir naquele roadmap. O progresso das **trilhas** dele continua intacto, porque vive em `lessons_progress` e não depende do estágio.

## Testado

Reproduzi o cenário que quebrava num Postgres efêmero: espelho do estado de produção, um aluno com conclusão manual em dois dos estágios que saem, e o script rodando em cima disso. Antes da correção o delete violaria a chave estrangeira; depois dela a reconciliação completa os 8 estágios, informa no log as conclusões apagadas e deixa **zero conclusões órfãs**. tsc e prettier limpos.